### PR TITLE
Disable threaded mode for the TeleBot

### DIFF
--- a/apps/chat/message_handlers.py
+++ b/apps/chat/message_handlers.py
@@ -282,7 +282,7 @@ class TelegramMessageHandler(MessageHandler):
     voice_replies_supported = True
 
     def initialize(self):
-        self.telegram_bot = TeleBot(self.channel.extra_data["bot_token"], parse_mode=None)
+        self.telegram_bot = TeleBot(self.channel.extra_data["bot_token"], threaded=False)
 
     @property
     def chat_id(self) -> int:


### PR DESCRIPTION
Just bringing the change to this repo as well

### Context
Fix for the threading issue. Looks like the telegram bot is using threading internally for polling and stuff, not for sending messages to telegram, so we're actually not using threads, which means it's safe to turn off. Local testing shows it works