### PR TITLE
Show channel on Experiment Review page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *~
 db.sqlite3
 .sass-cache/
-celerybeat-schedule
+celerybeat*
 gpt_playground/localsettings.py
 gpt_playground/local.py
 static_root/

--- a/apps/channels/const.py
+++ b/apps/channels/const.py
@@ -1,9 +1,0 @@
-WEB = "web"
-TELEGRAM = "telegram"
-WHATSAPP = "whatsapp"
-
-PLATFORM_DISPLAY_NAME = {
-    WEB: "Web",
-    TELEGRAM: "Telegram",
-    WHATSAPP: "WhatsApp",
-}

--- a/apps/channels/const.py
+++ b/apps/channels/const.py
@@ -1,0 +1,10 @@
+
+WEB = 'web'
+TELEGRAM = 'telegram'
+WHATSAPP = 'whatsapp'
+
+PLATFORM_DISPLAY_NAME = {
+    WEB: "Web",
+    TELEGRAM: "Telegram",
+    WHATSAPP: "WhatsApp",
+}

--- a/apps/channels/const.py
+++ b/apps/channels/const.py
@@ -1,7 +1,6 @@
-
-WEB = 'web'
-TELEGRAM = 'telegram'
-WHATSAPP = 'whatsapp'
+WEB = "web"
+TELEGRAM = "telegram"
+WHATSAPP = "whatsapp"
 
 PLATFORM_DISPLAY_NAME = {
     WEB: "Web",

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -10,10 +10,21 @@ from telebot import TeleBot, apihelper
 from apps.experiments.models import Experiment, ExperimentSession
 from apps.utils.models import BaseModel
 from apps.web.meta import absolute_url
+from apps.channels.const import (
+    WEB,
+    TELEGRAM,
+    WHATSAPP,
+    PLATFORM_DISPLAY_NAME,
+)
 
 
 class ExperimentChannel(BaseModel):
-    PLATFORM = (("telegram", "telegram"), ("web", "web"), ("whatsapp", "whatsapp"))
+    PLATFORM = (
+        (TELEGRAM, TELEGRAM),
+        (WEB, WEB),
+        (WHATSAPP, WHATSAPP)
+    )
+
     name = models.CharField(max_length=40, help_text="The name of this channel")
     experiment = models.ForeignKey(Experiment, on_delete=models.CASCADE, null=True, blank=True)
     active = models.BooleanField(default=True)
@@ -32,6 +43,10 @@ class ExperimentChannel(BaseModel):
         except apihelper.ApiTelegramException:
             token = self.extra_data.get("bot_token", "")
             logging.error(f"Unable set Telegram webhook with token '{token}'")
+
+    @property
+    def channel_display_name(self):
+        return PLATFORM_DISPLAY_NAME[self.platform]
 
 
 def _set_telegram_webhook(experiment_channel: ExperimentChannel):

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -19,11 +19,7 @@ from apps.channels.const import (
 
 
 class ExperimentChannel(BaseModel):
-    PLATFORM = (
-        (TELEGRAM, TELEGRAM),
-        (WEB, WEB),
-        (WHATSAPP, WHATSAPP)
-    )
+    PLATFORM = ((TELEGRAM, TELEGRAM), (WEB, WEB), (WHATSAPP, WHATSAPP))
 
     name = models.CharField(max_length=40, help_text="The name of this channel")
     experiment = models.ForeignKey(Experiment, on_delete=models.CASCADE, null=True, blank=True)

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -10,7 +10,10 @@ from telebot import TeleBot, apihelper
 from apps.experiments.models import Experiment, ExperimentSession
 from apps.utils.models import BaseModel
 from apps.web.meta import absolute_url
-from apps.channels.const import PLATFORM_DISPLAY_NAME, TELEGRAM, WEB, WHATSAPP
+
+WEB = "web"
+TELEGRAM = "telegram"
+WHATSAPP = "whatsapp"
 
 
 class ExperimentChannel(BaseModel):
@@ -34,10 +37,6 @@ class ExperimentChannel(BaseModel):
         except apihelper.ApiTelegramException:
             token = self.extra_data.get("bot_token", "")
             logging.error(f"Unable set Telegram webhook with token '{token}'")
-
-    @property
-    def channel_display_name(self):
-        return PLATFORM_DISPLAY_NAME[self.platform]
 
 
 def _set_telegram_webhook(experiment_channel: ExperimentChannel):

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -10,12 +10,7 @@ from telebot import TeleBot, apihelper
 from apps.experiments.models import Experiment, ExperimentSession
 from apps.utils.models import BaseModel
 from apps.web.meta import absolute_url
-from apps.channels.const import (
-    WEB,
-    TELEGRAM,
-    WHATSAPP,
-    PLATFORM_DISPLAY_NAME,
-)
+from apps.channels.const import PLATFORM_DISPLAY_NAME, TELEGRAM, WEB, WHATSAPP
 
 
 class ExperimentChannel(BaseModel):

--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -47,6 +47,7 @@ def experiment_to_csv(experiment: Experiment) -> io.StringIO:
             "Participant Public ID",
         ]
     )
+
     for row in experiment_to_message_export_rows(experiment):
         writer.writerow(row)
     return csv_in_memory

--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -5,13 +5,16 @@ from apps.experiments.models import Experiment
 
 
 def experiment_to_message_export_rows(experiment: Experiment):
-    for session in experiment.sessions.prefetch_related("chat", "chat__messages", "participant"):
+    for session in experiment.sessions.prefetch_related(
+        "chat", "chat__messages", "participant", "channel_session__experiment_channel"
+    ):
         for message in session.chat.messages.all():
             yield [
                 message.id,
                 message.created_at,
                 message.message_type,
                 message.content,
+                session.get_channel(),
                 message.chat.id,
                 # message.chat.name,
                 str(message.chat.user),
@@ -33,6 +36,7 @@ def experiment_to_csv(experiment: Experiment) -> io.StringIO:
             "Message Date",
             "Message Type",
             "Message Content",
+            "Platform",
             "Chat ID",
             "Chat User",
             "Session ID",

--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -14,7 +14,7 @@ def experiment_to_message_export_rows(experiment: Experiment):
                 message.created_at,
                 message.message_type,
                 message.content,
-                session.get_channel(),
+                session.get_platform_name(),
                 message.chat.id,
                 # message.chat.name,
                 str(message.chat.user),

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -322,7 +322,7 @@ class ExperimentSession(BaseModel):
             )
         )
 
-    def get_channel(self) -> str:
+    def get_platform_name(self) -> str:
         return self.channel_session.experiment_channel.channel_display_name
 
     def get_pre_survey_link(self):

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext
 
+from apps.channels.models import ExperimentChannel
 from apps.chat.models import Chat
 from apps.teams.models import BaseTeamModel, Team
 from apps.utils.models import BaseModel
@@ -323,7 +324,7 @@ class ExperimentSession(BaseModel):
         )
 
     def get_platform_name(self) -> str:
-        return self.channel_session.experiment_channel.channel_display_name
+        return ExperimentChannel.get_platform_display(self.channel_session.experiment_channel.platform)
 
     def get_pre_survey_link(self):
         return self.experiment.pre_survey.get_link(self.participant, self)

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -322,6 +322,9 @@ class ExperimentSession(BaseModel):
             )
         )
 
+    def get_channel(self) -> str:
+        return self.channel_session.experiment_channel.channel_display_name
+
     def get_pre_survey_link(self):
         return self.experiment.pre_survey.get_link(self.participant, self)
 

--- a/templates/experiments/components/experiment_details.html
+++ b/templates/experiments/components/experiment_details.html
@@ -28,7 +28,7 @@
       <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
         <dt class="text-sm font-medium leading-6 text-gray-900">Platform</dt>
         <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
-          {{ experiment_session.get_channel }}
+          {{ experiment_session.get_platform_name }}
         </dd>
       </div>
     </dl>

--- a/templates/experiments/components/experiment_details.html
+++ b/templates/experiments/components/experiment_details.html
@@ -25,6 +25,12 @@
         <dt class="text-sm font-medium leading-6 text-gray-900">Experiment</dt>
         <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">{{ experiment_session.experiment.name }}</dd>
       </div>
+      <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+        <dt class="text-sm font-medium leading-6 text-gray-900">Platform</dt>
+        <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+          {{ experiment_session.get_channel }}
+        </dd>
+      </div>
     </dl>
   </div>
 </div>


### PR DESCRIPTION
This PR addresses the first point on [this issue](https://github.com/dimagi/open-chat-studio/issues/6), namely to display the channel name on the _Experiment Review_ page. See screenshow below.

![image](https://github.com/dimagi/open-chat-studio/assets/44245062/42f8f84d-9e12-47d5-81a0-b4b8b373bde7)

In addition the platform name is also included when exporting the chat data.