### PR TITLE
FIX: Include leading zero on the dates in history tab

### DIFF
--- a/templates/experiments/prompt_builder.html
+++ b/templates/experiments/prompt_builder.html
@@ -82,7 +82,7 @@
             visibleSidebar: undefined,
             history: [
                 {
-                    date: "{% now 'l j M Y' %}",
+                    date: "{% now 'l d M Y' %}",
                     events: [
                         {
                             history_id: 0,
@@ -154,7 +154,7 @@
     })
     .then(response => response.json())
     .then(fetchedData => {
-        const currentDate = "{% now 'l j M Y' %}";
+        const currentDate = "{% now 'l d M Y' %}";
         const existingHistory = Alpine.store('promptBuilder').history;
 
         // Save current editor


### PR DESCRIPTION
The backend generates dates with a leading zero. We need the frontend to do that as well so that current dates get filed together. Before this fix, you would have 

```
SATURDAY 7 OCT 2023
now      Current editor

SATURDAY 07 OCT 2023
09:25    Some previous state 
```

Now they are correctly merged.