### PR TITLE
Reset conversations

### DIFF
--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.db import models
 from django.db.models import JSONField
 from django.urls import reverse
-from telebot import TeleBot, apihelper
+from telebot import TeleBot, apihelper, types
 
 from apps.experiments.models import Experiment, ExperimentSession
 from apps.utils.models import BaseModel
@@ -13,6 +13,8 @@ from apps.web.meta import absolute_url
 
 
 class ExperimentChannel(BaseModel):
+    RESET_COMMAND = "/reset"
+
     PLATFORM = (("telegram", "telegram"), ("web", "web"), ("whatsapp", "whatsapp"))
     name = models.CharField(max_length=40, help_text="The name of this channel")
     experiment = models.ForeignKey(Experiment, on_delete=models.CASCADE, null=True, blank=True)
@@ -45,6 +47,7 @@ def _set_telegram_webhook(experiment_channel: ExperimentChannel):
         webhook_url = None
 
     tele_bot.set_webhook(webhook_url, secret_token=settings.TELEGRAM_SECRET_TOKEN)
+    tele_bot.set_my_commands(commands=[types.BotCommand(ExperimentChannel.RESET_COMMAND, "Restart chat")])
 
 
 # TODO: Remove this model

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -40,7 +40,7 @@ def _set_telegram_webhook(experiment_channel: ExperimentChannel):
     """
     Set the webhook at Telegram to allow message forwarding to this platform
     """
-    tele_bot = TeleBot(experiment_channel.extra_data.get("bot_token", ""), parse_mode=None)
+    tele_bot = TeleBot(experiment_channel.extra_data.get("bot_token", ""), threaded=False)
     if experiment_channel.active:
         webhook_url = absolute_url(reverse("channels:new_telegram_message", args=[experiment_channel.external_id]))
     else:

--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -1,10 +1,7 @@
 from typing import List, Optional
 
-from langchain import ConversationChain
-from langchain.callbacks import get_openai_callback
 from langchain.chat_models import ChatOpenAI
 from langchain.memory import ConversationBufferMemory
-from langchain.prompts import SystemMessagePromptTemplate
 from langchain.schema import AIMessage, HumanMessage
 
 from apps.chat.conversation import Conversation

--- a/apps/chat/message_handlers.py
+++ b/apps/chat/message_handlers.py
@@ -20,8 +20,6 @@ from apps.chat.bots import get_bot_from_session
 from apps.chat.exceptions import AudioSynthesizeException, MessageHandlerException
 from apps.experiments.models import ExperimentSession, SessionStatus
 
-RESET_COMMAND = "/ocs-reset"
-
 
 class MESSAGE_TYPES(Enum):
     TEXT = "text"
@@ -268,7 +266,7 @@ class MessageHandler:
         )
 
     def _is_reset_conversation_request(self):
-        return self.message_text == RESET_COMMAND
+        return self.message_text == ExperimentChannel.RESET_COMMAND
 
 
 class WebMessageHandler(MessageHandler):

--- a/apps/chat/message_handlers.py
+++ b/apps/chat/message_handlers.py
@@ -9,6 +9,7 @@ import boto3
 import requests
 from botocore.client import Config
 from django.conf import settings
+from django.utils import timezone
 from telebot import TeleBot
 from telebot.util import smart_split
 from twilio.rest import Client
@@ -18,6 +19,8 @@ from apps.channels.models import ExperimentChannel
 from apps.chat.bots import get_bot_from_session
 from apps.chat.exceptions import AudioSynthesizeException, MessageHandlerException
 from apps.experiments.models import ExperimentSession, SessionStatus
+
+RESET_COMMAND = "/ocs-reset"
 
 
 class MESSAGE_TYPES(Enum):
@@ -160,6 +163,10 @@ class MessageHandler:
             self.experiment_session.status = SessionStatus.ACTIVE
             self.experiment_session.save()
 
+            if self._is_reset_conversation_request():
+                # Why not include webchats? They can be reset by creating a new chat.
+                return
+
         response = None
         if self.message_content_type == MESSAGE_TYPES.TEXT:
             response = self._get_llm_response(self.message_text)
@@ -225,22 +232,32 @@ class MessageHandler:
         self.experiment_session = ExperimentSession.objects.filter(
             experiment=self.experiment,
             external_chat_id=str(self.chat_id),
-        ).first()
-        if not self.experiment_session:
-            self._create_experiment_session()
-        elif not self.experiment_session.experiment_channel:
-            # This branch will only be entered for channel sessions that were created by the data migration.
-            # These sessions doesn't have experiment channels associated with them, so we need to make sure that
-            # they have experiment channels here. For new chats/sessions, the channel is added when they're
-            # created in _create_experiment_session.
-            # See this PR: https://github.com/czue/gpt-playground/pull/67
-            # If you see this comment in or after November 2023, you can remove this code. Do update the data
-            # migration (apps/channels/migrations/0005_create_channel_sessions.py) to link experiment channels
-            # to the channel sessions when removing this code
-            self.experiment_session.experiment_channel = self.channel
-            self.experiment_session.save()
+        ).last()
 
-    def _create_experiment_session(self):
+        if not self.experiment_session:
+            self._create_new_experiment_session()
+        else:
+            if self._is_reset_conversation_request() and self.experiment_session.user_already_engaged():
+                self._reset_session()
+            if not self.experiment_session.experiment_channel:
+                # This branch will only be entered for channel sessions that were created by the data migration.
+                # These sessions doesn't have experiment channels associated with them, so we need to make sure that
+                # they have experiment channels here. For new chats/sessions, the channel is added when they're
+                # created in _create_new_experiment_session.
+                # See this PR: https://github.com/czue/gpt-playground/pull/67
+                # If you see this comment in or after November 2023, you can remove this code. Do update the data
+                # migration (apps/channels/migrations/0005_create_channel_sessions.py) to link experiment channels
+                # to the channel sessions when removing this code
+                self.experiment_session.experiment_channel = self.channel
+                self.experiment_session.save()
+
+    def _reset_session(self):
+        """Resets the session by ending the current `experiment_session` and creating a new one"""
+        self.experiment_session.ended_at = timezone.now()
+        self.experiment_session.save()
+        self._create_new_experiment_session()
+
+    def _create_new_experiment_session(self):
         self.experiment_session = ExperimentSession.objects.create(
             user=None,
             participant=None,
@@ -249,6 +266,9 @@ class MessageHandler:
             external_chat_id=self.chat_id,
             experiment_channel=self.channel,
         )
+
+    def _is_reset_conversation_request(self):
+        return self.message_text == RESET_COMMAND
 
 
 class WebMessageHandler(MessageHandler):

--- a/apps/chat/tests/test_message_handlers.py
+++ b/apps/chat/tests/test_message_handlers.py
@@ -126,8 +126,10 @@ class TelegramMessageHandlerTest(TestCase):
 
     @patch("apps.chat.message_handlers.TelegramMessageHandler.send_text_to_user")
     @patch("apps.chat.bots.TopicBot._call_predict", return_value="OK")
-    @patch("apps.chat.bots.ChatOpenAI")
-    def test_reset_command_creates_new_experiment_session(self, openai_mock, _call_predict, _send_text_to_user_mock):
+    @patch("apps.chat.bots.create_conversation")
+    def test_reset_command_creates_new_experiment_session(
+        self, create_conversation, _call_predict, _send_text_to_user_mock
+    ):
         """The reset command should create a new session when the user conversed with the bot"""
         telegram_chat_id = 00000
         message_handler = self._get_telegram_message_handler(self.experiment_channel)
@@ -144,8 +146,10 @@ class TelegramMessageHandlerTest(TestCase):
 
     @patch("apps.chat.message_handlers.TelegramMessageHandler.send_text_to_user")
     @patch("apps.chat.bots.TopicBot._call_predict", return_value="OK")
-    @patch("apps.chat.bots.ChatOpenAI")
-    def test_reset_conversation_does_not_create_new_session(self, openai_mock, _call_predict, _send_text_to_user_mock):
+    @patch("apps.chat.bots.create_conversation")
+    def test_reset_conversation_does_not_create_new_session(
+        self, create_conversation, _call_predict, _send_text_to_user_mock
+    ):
         """The reset command should not create a new session when the user haven't conversed with the bot yet"""
         telegram_chat_id = 00000
         message_handler = self._get_telegram_message_handler(self.experiment_channel)

--- a/apps/chat/tests/test_message_handlers.py
+++ b/apps/chat/tests/test_message_handlers.py
@@ -126,7 +126,8 @@ class TelegramMessageHandlerTest(TestCase):
 
     @patch("apps.chat.message_handlers.TelegramMessageHandler.send_text_to_user")
     @patch("apps.chat.bots.TopicBot._call_predict", return_value="OK")
-    def test_reset_command_creates_new_experiment_session(self, _call_predict, _send_text_to_user_mock):
+    @patch("apps.chat.bots.ChatOpenAI")
+    def test_reset_command_creates_new_experiment_session(self, openai_mock, _call_predict, _send_text_to_user_mock):
         """The reset command should create a new session when the user conversed with the bot"""
         telegram_chat_id = 00000
         message_handler = self._get_telegram_message_handler(self.experiment_channel)
@@ -143,7 +144,8 @@ class TelegramMessageHandlerTest(TestCase):
 
     @patch("apps.chat.message_handlers.TelegramMessageHandler.send_text_to_user")
     @patch("apps.chat.bots.TopicBot._call_predict", return_value="OK")
-    def test_reset_conversation_does_not_create_new_session(self, _call_predict, _send_text_to_user_mock):
+    @patch("apps.chat.bots.ChatOpenAI")
+    def test_reset_conversation_does_not_create_new_session(self, openai_mock, _call_predict, _send_text_to_user_mock):
         """The reset command should not create a new session when the user haven't conversed with the bot yet"""
         telegram_chat_id = 00000
         message_handler = self._get_telegram_message_handler(self.experiment_channel)

--- a/apps/chat/tests/test_message_handlers.py
+++ b/apps/chat/tests/test_message_handlers.py
@@ -5,7 +5,7 @@ from mock import Mock, patch
 from telebot import types
 
 from apps.channels.models import ExperimentChannel
-from apps.chat.message_handlers import TelegramMessageHandler
+from apps.chat.message_handlers import RESET_COMMAND, TelegramMessageHandler
 from apps.experiments.models import ConsentForm, Experiment, ExperimentSession, Prompt
 from apps.users.models import CustomUser
 
@@ -88,8 +88,8 @@ class TelegramMessageHandlerTest(TestCase):
         self.assertEqual(experiment_sessions_count, 1)
 
         # Second message
-        # First we mock the _create_experiment_session so we can verify that it was not called
-        message_handler._create_experiment_session = Mock()
+        # First we mock the _create_new_experiment_session so we can verify that it was not called
+        message_handler._create_new_experiment_session = Mock()
 
         # Now let's simulate the incoming message
         message = _telegram_message(chat_id=self.telegram_chat_id)
@@ -101,7 +101,7 @@ class TelegramMessageHandlerTest(TestCase):
         ).count()
         self.assertEqual(experiment_sessions_count, 1)
 
-        message_handler._create_experiment_session.assert_not_called()
+        message_handler._create_new_experiment_session.assert_not_called()
 
     @patch("apps.chat.message_handlers.TelegramMessageHandler.send_text_to_user")
     @patch("apps.chat.message_handlers.TelegramMessageHandler._get_llm_response")
@@ -124,13 +124,48 @@ class TelegramMessageHandlerTest(TestCase):
         self.assertTrue(ExperimentSession.objects.filter(external_chat_id=00000).exists())
         self.assertTrue(ExperimentSession.objects.filter(external_chat_id=11111).exists())
 
+    @patch("apps.chat.message_handlers.TelegramMessageHandler.send_text_to_user")
+    @patch("apps.chat.bots.TopicBot._call_predict", return_value="OK")
+    def test_reset_command_creates_new_experiment_session(self, _call_predict, _send_text_to_user_mock):
+        """The reset command should create a new session when the user conversed with the bot"""
+        telegram_chat_id = 00000
+        message_handler = self._get_telegram_message_handler(self.experiment_channel)
+        normal_message = _telegram_message(chat_id=telegram_chat_id)
+        message_handler.new_user_message(normal_message)
+
+        message_handler = self._get_telegram_message_handler(self.experiment_channel)
+        reset_message = _telegram_message(chat_id=telegram_chat_id, message_text=RESET_COMMAND)
+        message_handler.new_user_message(reset_message)
+        sessions = ExperimentSession.objects.filter(external_chat_id=telegram_chat_id).all()
+        self.assertEqual(len(sessions), 2)
+        self.assertIsNotNone(sessions[0].ended_at)
+        self.assertIsNone(sessions[1].ended_at)
+
+    @patch("apps.chat.message_handlers.TelegramMessageHandler.send_text_to_user")
+    @patch("apps.chat.bots.TopicBot._call_predict", return_value="OK")
+    def test_reset_conversation_does_not_create_new_session(self, _call_predict, _send_text_to_user_mock):
+        """The reset command should not create a new session when the user haven't conversed with the bot yet"""
+        telegram_chat_id = 00000
+        message_handler = self._get_telegram_message_handler(self.experiment_channel)
+
+        message1 = _telegram_message(chat_id=telegram_chat_id, message_text=RESET_COMMAND)
+        message_handler.new_user_message(message1)
+
+        message2 = _telegram_message(chat_id=telegram_chat_id, message_text=RESET_COMMAND)
+        message_handler.new_user_message(message2)
+
+        sessions = ExperimentSession.objects.filter(external_chat_id=telegram_chat_id).all()
+        self.assertEqual(len(sessions), 1)
+        # The reset command should not be saved in the history
+        self.assertEqual(sessions[0].chat.get_langchain_messages(), [])
+
     def _get_telegram_message_handler(self, experiment_channel: ExperimentChannel) -> TelegramMessageHandler:
         message_handler = TelegramMessageHandler(channel=experiment_channel)
         message_handler.telegram_bot = Mock()
         return message_handler
 
 
-def _telegram_message(chat_id: int) -> types.Message:
+def _telegram_message(chat_id: int, message_text: str = "Hi there") -> types.Message:
     message_data = {
         "update_id": 432101234,
         "message": {
@@ -151,7 +186,7 @@ def _telegram_message(chat_id: int) -> types.Message:
                 "type": "private",
             },
             "date": 1690376696,
-            "text": "Hi there",
+            "text": message_text,
         },
     }
     json_data = json.dumps(message_data)

--- a/apps/chat/tests/test_message_handlers.py
+++ b/apps/chat/tests/test_message_handlers.py
@@ -137,7 +137,7 @@ class TelegramMessageHandlerTest(TestCase):
         message_handler.new_user_message(normal_message)
 
         message_handler = self._get_telegram_message_handler(self.experiment_channel)
-        reset_message = _telegram_message(chat_id=telegram_chat_id, message_text=RESET_COMMAND)
+        reset_message = _telegram_message(chat_id=telegram_chat_id, message_text=ExperimentChannel.RESET_COMMAND)
         message_handler.new_user_message(reset_message)
         sessions = ExperimentSession.objects.filter(external_chat_id=telegram_chat_id).all()
         self.assertEqual(len(sessions), 2)
@@ -154,10 +154,10 @@ class TelegramMessageHandlerTest(TestCase):
         telegram_chat_id = 00000
         message_handler = self._get_telegram_message_handler(self.experiment_channel)
 
-        message1 = _telegram_message(chat_id=telegram_chat_id, message_text=RESET_COMMAND)
+        message1 = _telegram_message(chat_id=telegram_chat_id, message_text=ExperimentChannel.RESET_COMMAND)
         message_handler.new_user_message(message1)
 
-        message2 = _telegram_message(chat_id=telegram_chat_id, message_text=RESET_COMMAND)
+        message2 = _telegram_message(chat_id=telegram_chat_id, message_text=ExperimentChannel.RESET_COMMAND)
         message_handler.new_user_message(message2)
 
         sessions = ExperimentSession.objects.filter(external_chat_id=telegram_chat_id).all()

--- a/apps/chat/tests/test_message_handlers.py
+++ b/apps/chat/tests/test_message_handlers.py
@@ -5,7 +5,7 @@ from mock import Mock, patch
 from telebot import types
 
 from apps.channels.models import ExperimentChannel
-from apps.chat.message_handlers import RESET_COMMAND, TelegramMessageHandler
+from apps.chat.message_handlers import TelegramMessageHandler
 from apps.experiments.models import ConsentForm, Experiment, ExperimentSession, Prompt
 from apps.users.models import CustomUser
 

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -5,10 +5,9 @@ from django.conf import settings
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.urls import reverse
-from django.utils import timezone
 from django.utils.translation import gettext
 
-from apps.chat.models import Chat
+from apps.chat.models import Chat, ChatMessage
 from apps.teams.models import BaseTeamModel, Team
 from apps.utils.models import BaseModel
 from apps.web.meta import absolute_url
@@ -344,6 +343,9 @@ class ExperimentSession(BaseModel):
                 "experiments:start_experiment_session", args=[self.team.slug, self.experiment.public_id, self.public_id]
             )
         )
+
+    def user_already_engaged(self) -> bool:
+        return ChatMessage.objects.filter(chat=self.chat, message_type="human").exists()
 
     def get_pre_survey_link(self):
         return self.experiment.pre_survey.get_link(self.participant, self)


### PR DESCRIPTION
Issue #17

The flow:

![image](https://github.com/dimagi/open-chat-studio/assets/64970009/723599e1-e5fe-4c15-be80-6f405011b178)

- Resetting conversations simply creates new experiment sessions which has no chat history.
- The reset command is not saved in the chat history
- Webchats are not able to reset conversations, since they have the luxury of simply creating a new one