### PR TITLE
[Proposal] Make it easier to test telegram

### DIFF
--- a/apps/web/meta.py
+++ b/apps/web/meta.py
@@ -20,4 +20,7 @@ def absolute_url(relative_url: str, is_secure: bool = settings.USE_HTTPS_IN_ABSO
     """
     Returns the complete absolute url for a given path - for use in emails or API integrations.
     """
+    if settings.DEBUG and settings.SITE_URL_ROOT:
+        return f"{settings.SITE_URL_ROOT}{relative_url}"
+
     return f"{get_server_root(is_secure)}{relative_url}"

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -426,4 +426,5 @@ DJANGO_TABLES2_ROW_ATTRS = {
     "id": lambda record: f"record-{record.id}",
 }
 
+# This is only used for development purposes
 SITE_URL_ROOT = os.environ.get("SITE_URL_ROOT")

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -425,3 +425,5 @@ DJANGO_TABLES2_ROW_ATTRS = {
     "class": "border-b border-gray-200 hover:bg-gray-100",
     "id": lambda record: f"record-{record.id}",
 }
+
+SITE_URL_ROOT = os.environ.get("SITE_URL_ROOT")

--- a/tasks.py
+++ b/tasks.py
@@ -83,13 +83,14 @@ def setup_dev_env(c: Context):
 def ngrok_url(c: Context):
     #  You need to have ngrok installed on your system
     c.run("ngrok http 8000", echo=True, asynchronous=True)
-    time.sleep(2)
     while True:
-        response = requests.get("http://localhost:4040/api/tunnels")
-        if response.status_code == 200:
-            break
-        time.sleep(1)
-        print("Trying to a public address from ngrok")
+        try:
+            response = requests.get("http://localhost:4040/api/tunnels")
+            if response.status_code == 200:
+                break
+        except Exception:
+            time.sleep(1)
+            print("Trying to a public address from ngrok")
 
     public_url = response.json()["tunnels"][0]["public_url"].split("https://")[1]
     print(f"Public address found: {public_url}")

--- a/tasks.py
+++ b/tasks.py
@@ -97,10 +97,9 @@ def ngrok_url(c: Context):
 
 
 @task
-def runserver(c: Context, telegram=False):
+def runserver(c: Context, public=False):
     runserver_command = "python manage.py runserver"
-    public_url = None
-    if telegram:
+    if public:
         public_url = ngrok_url(c)
         runserver_command = f"SITE_URL_ROOT={public_url} {runserver_command}"
     c.run(runserver_command, echo=True, pty=True)

--- a/tasks.py
+++ b/tasks.py
@@ -102,4 +102,4 @@ def runserver(c: Context, telegram=False):
     if telegram:
         public_url = ngrok_url(c)
         runserver_command = f"SITE_URL_ROOT={public_url} {runserver_command}"
-    c.run(runserver_command, echo=True)
+    c.run(runserver_command, echo=True, pty=True)

--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,7 @@
+import time
 from pathlib import Path
 
+import requests
 from invoke import Context, Exit, call, task
 from termcolor import cprint
 
@@ -75,3 +77,29 @@ def setup_dev_env(c: Context):
 
     cprint("\nCreating superuser", "green")
     c.run("python manage.py createsuperuser", echo=True, pty=True)
+
+
+@task
+def ngrok_url(c: Context):
+    c.run("ngrok http 8000", echo=True, asynchronous=True)
+    time.sleep(2)
+    while True:
+        response = requests.get("http://localhost:4040/api/tunnels")
+        if response.status_code == 200:
+            break
+        time.sleep(1)
+        print("Trying to a public address from ngrok")
+
+    public_url = response.json()["tunnels"][0]["public_url"].split("https://")[1]
+    print(f"Public address found: {public_url}")
+    return public_url
+
+
+@task
+def runserver(c: Context, telegram=False):
+    runserver_command = "python manage.py runserver"
+    public_url = None
+    if telegram:
+        public_url = ngrok_url(c)
+        runserver_command = f"SITE_URL_ROOT={public_url} {runserver_command}"
+    c.run(runserver_command, echo=True)

--- a/tasks.py
+++ b/tasks.py
@@ -81,6 +81,7 @@ def setup_dev_env(c: Context):
 
 @task
 def ngrok_url(c: Context):
+    #  You need to have ngrok installed on your system
     c.run("ngrok http 8000", echo=True, asynchronous=True)
     time.sleep(2)
     while True:


### PR DESCRIPTION
See [this wiki](https://github.com/dimagi/open-chat-studio/wiki/Experiment-Channels#note-to-developers) for the steps to test telegram channels in the dev environment. It's a pain. I propose the following implementation that adds two invoke commands. If `runserver ` is run with the `--public` flag, it will use ngrok to get a public url for the dev machine and run the server with that URL. It will give this url to external services when registering webhooks (in Telegram's case) so they can actually talk back to the server.

Suggestions for other approaches are super welcome