### PR TITLE
Fix bot sending messages to users

### DIFF
--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -85,7 +85,12 @@ class OneOffReminderTool(CustomBaseTool):
 
 def create_periodic_task(experiment_session: ExperimentSession, message: str, **kwargs):
     task_kwargs = json.dumps(
-        {"chat_ids": [experiment_session.external_chat_id], "message": message, "is_bot_instruction": False}
+        {
+            "chat_ids": [experiment_session.external_chat_id],
+            "message": message,
+            "is_bot_instruction": False,
+            "experiment_public_id": str(experiment_session.experiment.public_id),
+        }
     )
     PeriodicTask.objects.create(
         name=f"reminder-{experiment_session.id}-{uuid.uuid4()}",

--- a/apps/chat/tasks.py
+++ b/apps/chat/tasks.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime, timedelta
 from typing import List
+from uuid import UUID
 
 import pytz
 from celery.app import shared_task
@@ -28,7 +29,7 @@ def periodic_tasks(self):
 
 
 @shared_task
-def send_bot_message_to_users(message: str, chat_ids: List[str], is_bot_instruction: bool):
+def send_bot_message_to_users(message: str, chat_ids: List[str], is_bot_instruction: bool, experiment_public_id: UUID):
     """This sends `message` to the sessions related to `chat_ids` as the bot.
 
     If `is_bot_instruction` is true, the message will be interpreted as an instruction for the bot. For each
@@ -36,7 +37,9 @@ def send_bot_message_to_users(message: str, chat_ids: List[str], is_bot_instruct
     response will be saved to the chat history.
     """
     experiment_sessions = (
-        ExperimentSession.objects.filter(external_chat_id__in=chat_ids)
+        ExperimentSession.objects.filter(
+            external_chat_id__in=chat_ids, experiment__public_id=UUID(experiment_public_id)
+        )
         .prefetch_related(
             "experiment",
         )

--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -5,9 +5,7 @@ from apps.experiments.models import Experiment
 
 
 def experiment_to_message_export_rows(experiment: Experiment):
-    for session in experiment.sessions.prefetch_related(
-        "chat", "chat__messages", "participant", "channel_session__experiment_channel"
-    ):
+    for session in experiment.sessions.prefetch_related("chat", "chat__messages", "participant", "experiment_channel"):
         for message in session.chat.messages.all():
             yield [
                 message.id,

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -379,7 +379,7 @@ class ExperimentSession(BaseTeamModel):
         return ChatMessage.objects.filter(chat=self.chat, message_type="human").exists()
 
     def get_platform_name(self) -> str:
-        return self.channel_session.experiment_channel.get_platform_display()
+        return self.experiment_channel.get_platform_display()
 
     def get_pre_survey_link(self):
         return self.experiment.pre_survey.get_link(self.participant, self)


### PR DESCRIPTION
The function that sends messages from the bot to a range of users does take the specific bot into consideration. Consequently, it will send the message to **all** chat with the specified chat id.

To reproduce the issue:
1. Create two telegram bots
2. Create two experiments (one experiment should have tools enabled) and link bot 1 to experiment 1 and bot 2 to experiment
3. Talk to both
4. In the experiment with tools enabled, ask the bot to send to a ping message in the near future (say, 30 seconds from now)

This PR fixes that by restricting the target audience of the message to a specific bot / experiment. This PR also fixes chat downloads that doesn't seem to work after the channel sessions were moved to the experiment session table