### PR TITLE
refactor audio transcription to use service providers

### DIFF
--- a/apps/channels/audio.py
+++ b/apps/channels/audio.py
@@ -1,12 +1,6 @@
 from io import BytesIO
 
-import openai
 from pydub import AudioSegment
-
-
-def get_transcript(audio: BytesIO) -> str:
-    transcript = openai.Audio.transcribe(model="whisper-1", file=audio)
-    return transcript["text"]
 
 
 def convert_ogg_to_wav(ogg_audio: BytesIO) -> BytesIO:

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -185,9 +185,9 @@ class ChannelBase:
 
     def _reply_voice_message(self, text: str):
         voice_provider = self.experiment.voice_provider
-        voice_service = voice_provider.get_voice_service()
+        speech_service = voice_provider.get_speech_service()
         try:
-            voice_audio, duration = voice_service.synthesize_voice(text, self.experiment.synthetic_voice)
+            voice_audio, duration = speech_service.synthesize_voice(text, self.experiment.synthetic_voice)
             self.send_voice_to_user(voice_audio, duration)
         except AudioSynthesizeException as e:
             logging.exception(e)
@@ -207,9 +207,9 @@ class ChannelBase:
         if llm_service.supports_transcription:
             return llm_service.transcribe_audio(audio)
         elif self.experiment.voice_provider:
-            voice_service = self.experiment.voice_provider.get_voice_service()
-            if voice_service.supports_transcription:
-                return voice_service.transcribe_audio(audio)
+            speech_service = self.experiment.voice_provider.get_speech_service()
+            if speech_service.supports_transcription:
+                return speech_service.transcribe_audio(audio)
 
     def _get_llm_response(self, text: str) -> str:
         """

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -173,6 +173,7 @@ class ChannelBase:
             response = self._get_llm_response(self.message_text)
             self.send_text_to_user(response)
         elif self.message_content_type == MESSAGE_TYPES.VOICE:
+            # TODO: Error handling
             transcript = self._get_voice_transcript()
             response = self._get_llm_response(transcript)
             if self.voice_replies_supported and self.experiment.synthetic_voice:

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -198,10 +198,18 @@ class ChannelBase:
         self.transcription_started()
 
         audio_file = self.get_message_audio()
-        transcript = audio.get_transcript(audio_file)
-
+        transcript = self._transcribe_audio(audio_file)
         self.transcription_finished(transcript)
         return transcript
+
+    def _transcribe_audio(self, audio: BytesIO) -> str:
+        llm_service = self.experiment.llm_provider_new.get_llm_service()
+        if llm_service.supports_transcription:
+            return llm_service.transcribe_audio(audio)
+        elif self.experiment.voice_provider:
+            voice_service = self.experiment.voice_provider.get_voice_service()
+            if voice_service.supports_transcription:
+                return voice_service.transcribe_audio(audio)
 
     def _get_llm_response(self, text: str) -> str:
         """

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -309,7 +309,8 @@ class Experiment(BaseTeamModel):
         return self.name
 
     def get_chat_model(self):
-        return self.llm_provider_new.get_chat_model(self.llm, self.temperature)
+        service = self.llm_provider_new.get_llm_service()
+        return service.get_chat_model(self.llm, self.temperature)
 
     def get_absolute_url(self):
         return reverse("experiments:single_experiment_home", args=[self.team.slug, self.id])

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -21,7 +21,7 @@ def get_response_for_webchat_task(experiment_session_id: int, message_text: str)
 
 @shared_task
 def get_prompt_builder_response_task(team_id: int, user_id, data_dict: dict) -> str:
-    llm_provider = LlmProvider.objects.get(id=data_dict["provider"])
+    llm_service = LlmProvider.objects.get(id=data_dict["provider"]).get_llm_service()
     messages_history = data_dict["messages"]
 
     user = CustomUser.objects.get(id=user_id)
@@ -47,7 +47,7 @@ def get_prompt_builder_response_task(team_id: int, user_id, data_dict: dict) -> 
     bot = TopicBot(
         prompt=dummy_prompt,
         source_material=sourece_material_material,
-        llm=llm_provider.get_chat_model(data_dict["model"], float(data_dict["temperature"])),
+        llm=llm_service.get_chat_model(data_dict["model"], float(data_dict["temperature"])),
         safety_layers=None,
         chat=None,
         messages_history=messages_history,

--- a/apps/service_providers/llm_service.py
+++ b/apps/service_providers/llm_service.py
@@ -1,0 +1,47 @@
+from typing import Type
+
+import openai
+import pydantic
+from langchain.chat_models import ChatOpenAI
+from langchain.chat_models.base import BaseChatModel
+from langchain.llms import AzureOpenAI
+
+
+class LlmService(pydantic.BaseModel):
+    _type: str
+    _chat_model_cls: Type[BaseChatModel]
+    supports_transcription: bool = False
+
+    def get_chat_model(self, llm_model: str, temperature: float) -> BaseChatModel:
+        return self._chat_model_cls(model=llm_model, temperature=temperature)
+
+    def transcribe_audio(self, audio: bytes) -> str:
+        raise NotImplementedError
+
+
+class OpenAILlmService(LlmService):
+    _type = "openai"
+    _chat_model_cls = ChatOpenAI
+    supports_transcription: bool = True
+
+    openai_api_key: str
+    openai_api_base: str = None
+    openai_organization: str = None
+
+    def transcribe_audio(self, audio: bytes) -> str:
+        transcript = openai.Audio.transcribe(
+            model="whisper-1",
+            file=audio,
+            api_key=self.openai_api_key,
+            api_base=self.openai_api_base,
+            organization=self.openai_organization,
+        )
+        return transcript["text"]
+
+
+class AzureLlmService(LlmService):
+    _type = "openai"
+    _chat_model_cls = AzureOpenAI
+
+    openai_api_key: str
+    openai_api_base: str

--- a/apps/service_providers/llm_service.py
+++ b/apps/service_providers/llm_service.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 from typing import Type
 
 import openai
@@ -15,7 +16,7 @@ class LlmService(pydantic.BaseModel):
     def get_chat_model(self, llm_model: str, temperature: float) -> BaseChatModel:
         return self._chat_model_cls(model=llm_model, temperature=temperature)
 
-    def transcribe_audio(self, audio: bytes) -> str:
+    def transcribe_audio(self, audio: BytesIO) -> str:
         raise NotImplementedError
 
 
@@ -28,7 +29,7 @@ class OpenAILlmService(LlmService):
     openai_api_base: str = None
     openai_organization: str = None
 
-    def transcribe_audio(self, audio: bytes) -> str:
+    def transcribe_audio(self, audio: BytesIO) -> str:
         transcript = openai.Audio.transcribe(
             model="whisper-1",
             file=audio,

--- a/apps/service_providers/models.py
+++ b/apps/service_providers/models.py
@@ -3,8 +3,6 @@ from typing import Type
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from django_cryptography.fields import encrypt
-from langchain.chat_models import ChatOpenAI
-from langchain.llms import AzureOpenAI
 
 from apps.teams.models import BaseTeamModel
 
@@ -91,5 +89,5 @@ class VoiceProvider(BaseTeamModel):
     def type_enum(self):
         return VoiceProviderType(self.type)
 
-    def get_voice_service(self):
+    def get_voice_service(self) -> voice_service.VoiceSynthesizer:
         return self.type_enum.get_voice_service(self.config)

--- a/apps/service_providers/models.py
+++ b/apps/service_providers/models.py
@@ -6,7 +6,7 @@ from django_cryptography.fields import encrypt
 
 from apps.teams.models import BaseTeamModel
 
-from . import forms, llm_service, voice_service
+from . import forms, llm_service, speech_service
 
 
 class LlmProviderType(models.TextChoices):
@@ -65,12 +65,12 @@ class VoiceProviderType(models.TextChoices):
                 return forms.AzureVoiceConfigForm
         raise Exception(f"No config form configured for {self}")
 
-    def get_voice_service(self, config: dict):
+    def get_speech_service(self, config: dict):
         match self:
             case VoiceProviderType.aws:
-                return voice_service.AWSVoiceSynthesizer(**config)
+                return speech_service.AWSSpeechService(**config)
             case VoiceProviderType.azure:
-                return voice_service.AzureVoiceSynthesizer(**config)
+                return speech_service.AzureSpeechService(**config)
         raise Exception(f"No voice service configured for {self}")
 
 
@@ -89,5 +89,5 @@ class VoiceProvider(BaseTeamModel):
     def type_enum(self):
         return VoiceProviderType(self.type)
 
-    def get_voice_service(self) -> voice_service.VoiceSynthesizer:
-        return self.type_enum.get_voice_service(self.config)
+    def get_speech_service(self) -> speech_service.SpeechService:
+        return self.type_enum.get_speech_service(self.config)

--- a/apps/service_providers/speech_service.py
+++ b/apps/service_providers/speech_service.py
@@ -24,7 +24,7 @@ class SpeechService(pydantic.BaseModel):
         except Exception as e:
             raise AudioSynthesizeException(f"Unable to synthesize audio with {self._type}: {e}") from e
 
-    def transcribe_audio(self, audio: bytes) -> str:
+    def transcribe_audio(self, audio: BytesIO) -> str:
         raise NotImplementedError
 
     def _synthesize_voice(self, text, synthetic_voice) -> Tuple[BytesIO, float]:
@@ -106,12 +106,12 @@ class AzureSpeechService(SpeechService):
                         msg += ". Error details: {}".format(cancellation_details.error_details)
                 raise AudioSynthesizeException(msg)
 
-    def transcribe_audio(self, audio: bytes) -> str:
+    def transcribe_audio(self, audio: BytesIO) -> str:
         speech_config = speechsdk.SpeechConfig(subscription=self.azure_subscription_key, region=self.azure_region)
         speech_config.speech_recognition_language = "en-US"
 
         with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_file:
-            temp_file.write(audio)
+            temp_file.write(audio.getbuffer())
             temp_file.seek(0)
 
             audio_config = speechsdk.audio.AudioConfig(filename=temp_file.name)

--- a/apps/service_providers/speech_service.py
+++ b/apps/service_providers/speech_service.py
@@ -13,7 +13,7 @@ from apps.chat.exceptions import AudioSynthesizeException
 from apps.experiments.models import SyntheticVoice
 
 
-class VoiceSynthesizer(pydantic.BaseModel):
+class SpeechService(pydantic.BaseModel):
     _type: str
     supports_transcription = False
 
@@ -31,7 +31,7 @@ class VoiceSynthesizer(pydantic.BaseModel):
         raise NotImplementedError
 
 
-class AWSVoiceSynthesizer(VoiceSynthesizer):
+class AWSSpeechService(SpeechService):
     _type = SyntheticVoice.AWS
     aws_access_key_id: str
     aws_secret_access_key: str
@@ -62,7 +62,7 @@ class AWSVoiceSynthesizer(VoiceSynthesizer):
             return BytesIO(audio_data), duration_seconds
 
 
-class AzureVoiceSynthesizer(VoiceSynthesizer):
+class AzureSpeechService(SpeechService):
     _type = SyntheticVoice.Azure
     supports_transcription = True
     azure_subscription_key: str

--- a/apps/service_providers/tests/test_llm_service.py
+++ b/apps/service_providers/tests/test_llm_service.py
@@ -1,0 +1,11 @@
+from apps.service_providers.llm_service import AzureLlmService, OpenAILlmService
+
+
+def test_open_ai_service():
+    service = OpenAILlmService(openai_api_key="test")
+    assert service.supports_transcription
+
+
+def test_azure_ai_service():
+    service = AzureLlmService(openai_api_key="test", openai_api_base="https://api.openai.com/v1")
+    assert not service.supports_transcription

--- a/apps/service_providers/tests/test_voice_providers.py
+++ b/apps/service_providers/tests/test_voice_providers.py
@@ -76,7 +76,7 @@ def _test_voice_provider_error(provider_type: VoiceProviderType, data):
     assert not form.is_valid()
 
     with pytest.raises(ValidationError):
-        provider_type.get_voice_service(data)
+        provider_type.get_speech_service(data)
 
 
 def _test_voice_provider(team, provider_type: VoiceProviderType, data):
@@ -97,9 +97,9 @@ def _test_voice_provider(team, provider_type: VoiceProviderType, data):
         name="test", neural=True, language="English", language_code="en", gender="female", service=service
     )
 
-    voice_service = provider.get_voice_service()
+    speech_service = provider.get_speech_service()
     # bypass pydantic validation
     mock_synthesize = mock.Mock(return_value=(None, 0.0))
-    object.__setattr__(voice_service, "_synthesize_voice", mock_synthesize)
-    voice_service.synthesize_voice("test", voice)
+    object.__setattr__(speech_service, "_synthesize_voice", mock_synthesize)
+    speech_service.synthesize_voice("test", voice)
     assert mock_synthesize.call_count == 1

--- a/templates/teams/manage_team.html
+++ b/templates/teams/manage_team.html
@@ -28,7 +28,7 @@
 </section>
 {% if not create %}
 {% include 'teams/components/service_providers.html' with provider_type="llm" title="LLM Providers" %}
-{% include 'teams/components/service_providers.html' with provider_type="voice" title="Voice Providers" %}
+{% include 'teams/components/service_providers.html' with provider_type="voice" title="Speech Providers" %}
 <section class="app-card">
   <h3 class="pg-subtitle">{% translate "Team Members" %}</h3>
   <div class='table-responsive'>


### PR DESCRIPTION
Audio transcription was being done by OpenAI directly using the Open AI API environment variable.

Both Open AI and Azure support transcription but for Azure you need to use the 'speech api'. Since we already have the speech service set up I've refactored the services to optionally provide transcription as well.

If an experiment is using OpenAI for LLM it will use Open AI for transcription.
If it is using Azure then it must also provide an Azure Speech Provider for the transcription.