### PR TITLE
catch exception and return 404 response

### DIFF
--- a/apps/teams/helpers.py
+++ b/apps/teams/helpers.py
@@ -26,10 +26,7 @@ def get_next_unique_team_slug(team_name: str) -> str:
 def get_team_for_request(request, view_kwargs):
     team_slug = view_kwargs.get("team_slug", None)
     if team_slug:
-        try:
-            return Team.objects.get(slug=team_slug)
-        except Team.DoesNotExist:
-            return None
+        return Team.objects.filter(slug=team_slug).first()
 
     if not request.user.is_authenticated:
         return

--- a/apps/teams/helpers.py
+++ b/apps/teams/helpers.py
@@ -26,7 +26,10 @@ def get_next_unique_team_slug(team_name: str) -> str:
 def get_team_for_request(request, view_kwargs):
     team_slug = view_kwargs.get("team_slug", None)
     if team_slug:
-        return get_object_or_404(Team, slug=team_slug)
+        try:
+            return Team.objects.get(slug=team_slug)
+        except Team.DoesNotExist:
+            return None
 
     if not request.user.is_authenticated:
         return

--- a/apps/teams/tests/test_teams_middleware.py
+++ b/apps/teams/tests/test_teams_middleware.py
@@ -45,6 +45,12 @@ class TeamsAuthTest(TestCase):
         self.assertEqual(404, response.status_code)
         self._assertRequestHasTeam(response, self.yanks, None, None)
 
+    def test_team_view_missing_team(self):
+        self._login(self.sox_admin)
+        response = self.client.get(reverse("single_team:manage_team", args=["missing"]))
+        self.assertEqual(404, response.status_code)
+        self._assertRequestHasTeam(response, None, None)
+
     def test_team_admin_view(self):
         self._login(self.sox_admin)
         invite = self._create_invitation()


### PR DESCRIPTION
For some reason the Http404 exception is not
being handled when raised from middleware