### PR TITLE
Validate source material presence

### DIFF
--- a/apps/experiments/tests/test_views.py
+++ b/apps/experiments/tests/test_views.py
@@ -1,0 +1,57 @@
+import pytest
+from django.urls import reverse
+
+from apps.experiments.models import Experiment
+from apps.experiments.views.experiment import _source_material_is_missing
+from apps.utils.factories import experiment as experiment_factory
+
+
+def test_create_experiment_success(db, client):
+    source_material = experiment_factory.SourceMaterialFactory()
+    user = source_material.owner
+    team = source_material.team
+    consent_form = experiment_factory.ConsentFormFactory(team=team)
+    prompt = experiment_factory.PromptFactory(team=team)
+    client.force_login(user)
+
+    post_data = {
+        "name": "some name",
+        "description": "Some description",
+        "chatbot_prompt": prompt.id,
+        "source_material": source_material.id if source_material else "",
+        "consent_form": consent_form.id,
+        "temperature": 0.7,
+        "llm": "gpt-3.5",
+    }
+
+    client.post(reverse("experiments:new", args=[team.slug]), data=post_data)
+    experiment = Experiment.objects.filter(owner=user).first()
+    assert experiment is not None
+
+
+@pytest.mark.parametrize(
+    "create_source_material,promp_str",
+    [
+        (True, "You're an assistant"),
+        (True, "Answer questions from this source: {source_material}"),
+        (False, "You're an assistant"),
+    ],
+)
+def test_experiment_does_not_require_source_material(db, create_source_material, promp_str):
+    """Tests the `_source_material_is_missing` method"""
+    material = None
+    if create_source_material:
+        material = experiment_factory.SourceMaterialFactory()
+    experiment = experiment_factory.ExperimentFactory(chatbot_prompt__prompt=promp_str, source_material=material)
+    assert _source_material_is_missing(experiment) is False
+
+
+@pytest.mark.parametrize(
+    "source_material,promp_str",
+    [
+        (None, "Answer questions from this source: {source_material}"),
+    ],
+)
+def test_source_material_is_missing(db, source_material, promp_str):
+    experiment = experiment_factory.ExperimentFactory(chatbot_prompt__prompt=promp_str, source_material=source_material)
+    assert _source_material_is_missing(experiment) is True

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -116,22 +116,8 @@ class CreateExperiment(ExperimentViewMixin, CreateView):
     def get_success_url(self):
         return reverse("experiments:single_experiment_home", args=[self.request.team.slug, self.object.pk])
 
-    def get_form(self):
-        form = super().get_form()
-        _apply_related_model_querysets(self.request.team, form)
-        _apply_voice_provider_alpine_attrs(form)
-        return form
 
-    def form_valid(self, form):
-        form.instance.team = self.request.team
-        form.instance.owner = self.request.user
-        if not _prompt_has_source_material(form.instance):
-            messages.error(request=self.request, message="The prompt expects source material, but none were specified")
-            return render(self.request, self.template_name, self.get_context_data())
-        return super().form_valid(form)
-
-
-class EditExperiment(UpdateView):
+class EditExperiment(ExperimentViewMixin, UpdateView):
     model = Experiment
     fields = [
         "name",
@@ -167,22 +153,8 @@ class EditExperiment(UpdateView):
     def get_queryset(self):
         return Experiment.objects.filter(team=self.request.team)
 
-    def get_form(self):
-        form = super().get_form()
-        _apply_related_model_querysets(self.request.team, form)
-        _apply_voice_provider_alpine_attrs(form)
-        return form
-
     def get_success_url(self):
         return reverse("experiments:single_experiment_home", args=[self.request.team.slug, self.object.pk])
-
-    def form_valid(self, form):
-        form.instance.team = self.request.team
-        form.instance.owner = self.request.user
-        if not _prompt_has_source_material(form.instance):
-            messages.error(request=self.request, message="The prompt expects source material, but none were specified")
-            return render(self.request, self.template_name, self.get_context_data())
-        return super().form_valid(form)
 
 
 def _source_material_is_missing(experiment: Experiment) -> bool:

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -72,8 +72,6 @@ class ExperimentViewMixin:
         return form
 
     def form_valid(self, form):
-        form.instance.team = self.request.team
-        form.instance.owner = self.request.user
         if _source_material_is_missing(form.instance):
             messages.error(request=self.request, message="The prompt expects source material, but none were specified")
             return render(self.request, self.template_name, self.get_context_data())
@@ -115,6 +113,11 @@ class CreateExperiment(ExperimentViewMixin, CreateView):
 
     def get_success_url(self):
         return reverse("experiments:single_experiment_home", args=[self.request.team.slug, self.object.pk])
+
+    def form_valid(self, form):
+        form.instance.team = self.request.team
+        form.instance.owner = self.request.user
+        return super().form_valid(form)
 
 
 class EditExperiment(ExperimentViewMixin, UpdateView):

--- a/apps/utils/factories/experiment.py
+++ b/apps/utils/factories/experiment.py
@@ -1,0 +1,47 @@
+import factory
+
+from apps.experiments.models import ConsentForm, Experiment, Prompt, SourceMaterial
+from apps.utils.factories.team import TeamFactory
+from apps.utils.factories.user import UserFactory
+
+
+class PromptFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Prompt
+
+    owner = factory.SubFactory(UserFactory)
+    name = "Some name"
+    description = "This is a description"
+    team = factory.SubFactory(TeamFactory)
+
+
+class ConsentFormFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ConsentForm
+
+    name = "Consent form"
+    consent_text = "Do you give consent?"
+    is_default = True
+    team = factory.SubFactory(TeamFactory)
+
+
+class SourceMaterialFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = SourceMaterial
+
+    owner = factory.SubFactory(UserFactory)
+    topic = "Some source"
+    description = "Some description"
+    material = "material"
+    team = factory.SubFactory(TeamFactory)
+
+
+class ExperimentFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Experiment
+
+    owner = factory.SubFactory(UserFactory)
+    name = factory.Faker("name")
+    chatbot_prompt = factory.SubFactory(PromptFactory)
+    consent_form = factory.SubFactory(ConsentFormFactory)
+    team = factory.LazyAttribute(lambda obj: obj.chatbot_prompt.team)

--- a/apps/utils/factories/team.py
+++ b/apps/utils/factories/team.py
@@ -9,6 +9,7 @@ class TeamFactory(factory.django.DjangoModelFactory):
         model = Team
 
     name = factory.Faker("text", max_nb_chars=20)
+    slug = factory.Sequence(lambda x: f"team-{x}")
 
 
 class MembershipFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
This is a proposed solution to https://github.com/dimagi/open-chat-studio/issues/127 and a replacement for [this approach](https://github.com/dimagi/open-chat-studio/pull/128). This "new" way notifies users when they try to update an experiement that requires source material (in the prompt), but forgot to add any. An error message will show when they try to save:

![Screenshot from 2023-11-13 11-18-44](https://github.com/dimagi/open-chat-studio/assets/64970009/a2650aed-2994-4fad-bef5-46e2aa6367a9)
