### PR TITLE
Notify user when they try to format the user input in the prompt string

### DIFF
--- a/apps/experiments/views/prompt.py
+++ b/apps/experiments/views/prompt.py
@@ -59,8 +59,7 @@ class PromptViewMixin:
     def form_valid(self, form):
         if "{input}" in form.data["prompt"]:
             error_message = (
-                """Unexpected {input} key found in the prompmt. Use the input formatter to format"""
-                """the user input"""
+                """Unexpected {input} key found in the prompt. Use the input formatter to format the user input"""
             )
             messages.error(request=self.request, message=error_message)
             return render(self.request, self.template_name, self.get_context_data())

--- a/apps/experiments/views/prompt.py
+++ b/apps/experiments/views/prompt.py
@@ -58,7 +58,10 @@ class PromptTableView(SingleTableView):
 class PromptViewMixin:
     def form_valid(self, form):
         if "{input}" in form.data["prompt"]:
-            error_message = "Unexpected {input} key. Use the input formatter to format the user input"
+            error_message = (
+                """Unexpected {input} key found in the prompmt. Use the input formatter to format"""
+                """the user input"""
+            )
             messages.error(request=self.request, message=error_message)
             return render(self.request, self.template_name, self.get_context_data())
         return super().form_valid(form)


### PR DESCRIPTION
This is in response to [this sentry error](https://dimagi.sentry.io/issues/4664550002/?alert_rule_id=14063552&alert_timestamp=1700802704064&alert_type=email&environment=production&notification_uuid=eaaaec44-1a6d-49fc-9887-d96b70d4117c&project=4505001320316928&referrer=alert_email). The user tried to format the user input in the prompt string, instead of using the input formatter.

This change shows an error message when the user includes the `{input}` key in the prompt string.

![image](https://github.com/dimagi/open-chat-studio/assets/64970009/32f65047-4c57-42af-9948-7065034f53d4)

While this change is preventative, it's still not very clear how to use the `{input}` key to format the user input I think. Since we're using `{source_material}` in the prompt string, I can imagine it being a bit confusing to have to use the `{input}` key in the input formatter when the user doesn't have any context on how these keys/fields are being used.

We should rethink the help text or add a short section at the top giving some context or an example? Not 100% sure what would be best. Suggestions welcome cc @bderenzi @snopoke 
