### PR TITLE
Use is_team_admin instead of checking legacy membership roles

### DIFF
--- a/apps/teams/views/manage_team_views.py
+++ b/apps/teams/views/manage_team_views.py
@@ -44,7 +44,7 @@ def manage_team(request, team_slug):
             messages.error(request, "Sorry you don't have permission to do that.")
     if team_form is None:
         team_form = TeamChangeForm(instance=team)
-    if request.team_membership.role != "admin":
+    if request.team_membership.is_team_admin:
         set_form_fields_disabled(team_form, True)
 
     return render(

--- a/templates/teams/components/invitation_row.html
+++ b/templates/teams/components/invitation_row.html
@@ -3,7 +3,7 @@
   <td>{{ invitation.email }}</td>
   <td>{{ invitation.created_at }}</td>
   <td>{{ invitation.groups.all|join:", " }}</td>
-{% if request.team_membership.role == 'admin' %}
+{% if request.team_membership.is_team_admin %}
   <td class="pg-inline-buttons pg-justify-content-end">
     <form hx-post="{% url 'single_team:resend_invitation' request.team.slug invitation.id %}" hx-target="this" hx-swap="outerHTML">
       {% csrf_token %}

--- a/templates/teams/components/team_invitations.html
+++ b/templates/teams/components/team_invitations.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load form_tags %}
 <div id="invitation-form-and-table">
-  {% if request.team_membership.role == 'admin' %}
+  {% if request.team_membership.is_team_admin %}
   <section class="app-card">
     <h3 class="pg-subtitle">{% translate "Invite Team Members" %}</h3>
     <form hx-post="{% url 'single_team:send_invitation' request.team.slug %}" hx-target="#invitation-form-and-table">
@@ -24,7 +24,7 @@
             <th>{% translate "Email" %}</th>
             <th>{% translate "Invited" %}</th>
             <th>{% translate "Roles" %}</th>
-            {% if request.team_membership.role == 'admin' %}<th></th>{% endif %}
+            {% if request.team_membership.is_team_admin %}<th></th>{% endif %}
           </tr>
           </thead>
           <tbody>

--- a/templates/teams/manage_team.html
+++ b/templates/teams/manage_team.html
@@ -20,7 +20,7 @@
   <form method="post">
     {% csrf_token %}
     {% render_form_fields team_form %}
-    {% if create or request.team_membership.role == 'admin' %}
+    {% if create or request.team_membership.is_team_admin %}
       <div class="pg-inline-buttons">
         <input class="pg-button-secondary" type="submit" value="{% translate 'Save Details' %}">
       </div>
@@ -47,7 +47,7 @@
       {% for membership in team.sorted_memberships.all %}
         <tr>
           <td>
-            {% if request.team_membership.is_admin or request.team_membership == membership %}
+            {% if request.team_membership.is_team_admin or request.team_membership == membership %}
               <a class="link" href="{% url 'single_team:team_membership_details' request.team.slug membership.pk %}">{{ membership.user }}</a>
             {% else %}
               {{ membership.user }}
@@ -61,7 +61,7 @@
   </div>
 </section>
 {% include 'teams/components/team_invitations.html' %}
-{% if request.team_membership.role == 'admin' %}
+{% if request.team_membership.is_team_admin %}
   <section class="app-card">
     <h3 class="pg-subtitle">
       {% translate "Danger Zone" %}


### PR DESCRIPTION
Resolves #154 

I justed called the `is_team_admin` (which checks model access levels instead) to check for admin status instead of the legacy team role. If I'm not mistaken @snopoke, we're not using the membership role for anything useful anymore?