### PR TITLE
refactor resource handling in preparation for parallel runs and agents

### DIFF
--- a/apps/analysis/core.py
+++ b/apps/analysis/core.py
@@ -19,11 +19,13 @@ class StepContext(Generic[PipeOut]):
 
     data: PipeOut
     name: str = "start"
+    persist: bool = True
+    is_multiple: bool = False
     metadata: dict = dataclasses.field(default_factory=dict)
 
     @classmethod
     def initial(cls, data: PipeOut = None):
-        return cls(data, "start", {})
+        return cls(data)
 
     def clone_with(self, data: PipeOut = None):
         if data is None:
@@ -208,12 +210,13 @@ class BaseStep(Generic[PipeIn, PipeOut]):
                 self.preflight_check(context)
 
                 self.log.debug(f"Params: {self._params}")
-                output, metadata = self.run(self._params, context.data)
-                return StepContext(output, self.name, metadata)
+                result = self.run(self._params, context.data)
+                result.name = self.name
+                return result
         finally:
             self.log.info(f"Step {self.name} complete")
 
-    def run(self, params: Params, data: PipeIn) -> tuple[PipeOut, dict]:
+    def run(self, params: Params, data: PipeIn) -> StepContext[PipeOut]:
         """Run the step and return the output data and metadata."""
         raise NotImplementedError
 

--- a/apps/analysis/core.py
+++ b/apps/analysis/core.py
@@ -37,6 +37,10 @@ class StepContext(Generic[PipeOut]):
             data = self.data
         return dataclasses.replace(self, data=data)
 
+    @property
+    def should_split(self):
+        return self.is_multiple and isinstance(self.data, list)
+
 
 @dataclasses.dataclass
 class PipelineContext:

--- a/apps/analysis/serializers.py
+++ b/apps/analysis/serializers.py
@@ -12,7 +12,7 @@ from apps.analysis.models import Resource, ResourceMetadata
 def create_resource_for_data(team, data: Any, name: str) -> Resource:
     serializer = get_serializer(data)
     metadata = serializer.get_metadata(data)
-    time_suffix = timezone.now().replace(tzinfo=None).isoformat(timespec="milliseconds")
+    time_suffix = timezone.now().replace(tzinfo=None).strftime("%Y%m%d_%H%M%S")
     resource = Resource(
         team=team,
         name=f"{name} {time_suffix}",

--- a/apps/analysis/steps/filters.py
+++ b/apps/analysis/steps/filters.py
@@ -97,9 +97,9 @@ class TimeseriesFilter(TimeseriesStep):
     input_type = pd.DataFrame
     output_type = pd.DataFrame
 
-    def run(self, params: TimeseriesFilterParams, data: pd.DataFrame) -> tuple[pd.DataFrame, dict]:
+    def run(self, params: TimeseriesFilterParams, data: pd.DataFrame) -> StepContext[pd.DataFrame]:
         self.log.info(f"Initial timeseries data from {data.index.min()} to {data.index.max()} ({len(data)} rows)")
         mask = data.index.isin(pd.date_range(params.start, params.end, inclusive="left"))
         result = data.loc[mask]
         self.log.info(f"Filtered timeseries data from {params.start} to {params.end} ({len(result)} rows)")
-        return result, {}
+        return StepContext(result)

--- a/apps/analysis/steps/filters.py
+++ b/apps/analysis/steps/filters.py
@@ -10,6 +10,7 @@ from pydantic import Field, PositiveInt
 
 from apps.analysis.core import BaseStep, Params, ParamsForm, StepContext, required
 from apps.analysis.exceptions import StepError
+from apps.analysis.steps.utils import format_truncated_date
 
 
 class DurationUnit(IntEnum):
@@ -49,6 +50,10 @@ class TimeseriesFilterParams(Params):
     @property
     def end(self):
         return self.range_tuple[1]
+
+    def period_name(self):
+        truncate_to = self.duration_unit.name
+        return f"{format_truncated_date(self.start, truncate_to)}--{format_truncated_date(self.end, truncate_to)}"
 
     def filter(self, date: datetime) -> bool:
         start, end = self.range_tuple
@@ -102,5 +107,5 @@ class TimeseriesFilter(TimeseriesStep):
         mask = data.index.isin(pd.date_range(params.start, params.end, inclusive="left"))
         result = data.loc[mask]
         self.log.info(f"Filtered timeseries data from {params.start} to {params.end} ({len(result)} rows)")
-        self.create_resource(result, "filtered")
+        self.create_resource(result, params.period_name())
         return StepContext(result)

--- a/apps/analysis/steps/filters.py
+++ b/apps/analysis/steps/filters.py
@@ -102,4 +102,5 @@ class TimeseriesFilter(TimeseriesStep):
         mask = data.index.isin(pd.date_range(params.start, params.end, inclusive="left"))
         result = data.loc[mask]
         self.log.info(f"Filtered timeseries data from {params.start} to {params.end} ({len(result)} rows)")
+        self.create_resource(result, "filtered")
         return StepContext(result)

--- a/apps/analysis/steps/loaders.py
+++ b/apps/analysis/steps/loaders.py
@@ -41,7 +41,7 @@ class ResourceTextLoader(BaseLoader[str]):
             data = file.read()
             lines = len(data.splitlines())
             self.log.info(f"Loaded {lines} lines of text")
-            return StepContext(data, persist=False)
+            return StepContext(data)
 
 
 class ResourceDataframeLoader(BaseLoader[pd.DataFrame]):
@@ -53,7 +53,7 @@ class ResourceDataframeLoader(BaseLoader[pd.DataFrame]):
         with params.resource.file.open("r") as file:
             data = parser(file)
             self.log.info(f"Loaded {len(data)} rows")
-            return StepContext(data, persist=False)
+            return StepContext(data)
 
     def _get_parser(self, type_: ResourceType):
         if type_ == ResourceType.CSV:

--- a/apps/analysis/steps/loaders.py
+++ b/apps/analysis/steps/loaders.py
@@ -3,7 +3,7 @@ from functools import cached_property
 
 import pandas as pd
 
-from apps.analysis.core import BaseStep, Params, PipeOut, required
+from apps.analysis.core import BaseStep, Params, PipeOut, StepContext, required
 from apps.analysis.models import Resource, ResourceType
 
 
@@ -36,24 +36,24 @@ class ResourceTextLoader(BaseLoader[str]):
     param_schema = ResourceLoaderParams
     output_type = str
 
-    def load(self, params: ResourceLoaderParams) -> tuple[str, dict]:
+    def load(self, params: ResourceLoaderParams) -> StepContext[str]:
         with params.resource.file.open("r") as file:
             data = file.read()
             lines = len(data.splitlines())
             self.log.info(f"Loaded {lines} lines of text")
-            return data, {"persist_output": False}
+            return StepContext(data, persist=False)
 
 
 class ResourceDataframeLoader(BaseLoader[pd.DataFrame]):
     param_schema = ResourceLoaderParams
     output_type = pd.DataFrame
 
-    def load(self, params: ResourceLoaderParams) -> tuple[pd.DataFrame, dict]:
+    def load(self, params: ResourceLoaderParams) -> StepContext[pd.DataFrame]:
         parser = self._get_parser(params.resource.type)
         with params.resource.file.open("r") as file:
             data = parser(file)
             self.log.info(f"Loaded {len(data)} rows")
-            return data, {"persist_output": False}
+            return StepContext(data, persist=False)
 
     def _get_parser(self, type_: ResourceType):
         if type_ == ResourceType.CSV:

--- a/apps/analysis/steps/parsers.py
+++ b/apps/analysis/steps/parsers.py
@@ -41,7 +41,7 @@ class WhatsappParser(BaseStep[str, pd.DataFrame]):
             splits = list(filter(None, splits))
             if not splits:
                 self.log.info("No WhatsApp messages found")
-                return StepContext(pd.DataFrame(), persist=False)
+                return StepContext(pd.DataFrame())
 
             self.log.debug("Unable to parse WhatsApp data:\n" + "\n".join(data.splitlines()[:3]))
             raise StepError("Unable to parse WhatsApp data")
@@ -50,6 +50,7 @@ class WhatsappParser(BaseStep[str, pd.DataFrame]):
         df = pd.DataFrame(data=messages)
         df.set_index("date", inplace=True)
         self.log.info(f"Loaded messages from {df.index.min()} to {df.index.max()} ({len(df)} messages)")
+        self.create_resource(df, "whatsapp_messages")
         return StepContext(df)
 
     def _get_message(self, head, tail):

--- a/apps/analysis/steps/processors.py
+++ b/apps/analysis/steps/processors.py
@@ -11,7 +11,7 @@ from pydantic import model_validator
 
 import apps.analysis.exceptions
 from apps.analysis import core
-from apps.analysis.core import ParamsForm, required
+from apps.analysis.core import ParamsForm, StepContext, required
 
 
 class PromptParams(core.Params):
@@ -54,11 +54,11 @@ class LlmCompletionStep(core.BaseStep[Any, str]):
     input_type = Any
     output_type = str
 
-    def run(self, params: LlmCompletionStepParams, data: Any) -> tuple[str, dict]:
+    def run(self, params: LlmCompletionStepParams, data: Any) -> StepContext[str]:
         llm: BaseChatModel = self.pipeline_context.llm_service.get_chat_model(params.llm_model, 1.0)
         prompt = params.prompt_template.format_prompt(data=data)
         result = llm.invoke(prompt)
-        return result.content, {"persist_output": False}
+        return StepContext(result.content, persist=False)
 
 
 class AssistantParams(PromptParams):
@@ -95,7 +95,7 @@ class AssistantStep(core.BaseStep[Any, str]):
 
         self.client = self.pipeline_context.llm_service.get_raw_client()
 
-    def run(self, params: AssistantParams, data: Any) -> tuple[str, dict]:
+    def run(self, params: AssistantParams, data: Any) -> StepContext[str]:
         result = AssistantOutput()
         prompt = params.prompt_template.format_prompt(data=data)
         thread = self.client.beta.threads.create(
@@ -122,7 +122,7 @@ class AssistantStep(core.BaseStep[Any, str]):
 
         result.response = self._process_messages(result, thread.id)
         # TODO: Record files
-        return result.response, {"thread_id": thread.id, "run_id": run.id}
+        return StepContext(result.response, persist=False, metadata={"thread_id": thread.id, "run_id": run.id})
 
     def _process_messages(self, result: AssistantOutput, thread_id: str) -> str:
         messages = list(self.client.beta.threads.messages.list(thread_id=thread_id, order="asc"))

--- a/apps/analysis/steps/processors.py
+++ b/apps/analysis/steps/processors.py
@@ -58,7 +58,7 @@ class LlmCompletionStep(core.BaseStep[Any, str]):
         llm: BaseChatModel = self.pipeline_context.llm_service.get_chat_model(params.llm_model, 1.0)
         prompt = params.prompt_template.format_prompt(data=data)
         result = llm.invoke(prompt)
-        return StepContext(result.content, persist=False)
+        return StepContext(result.content)
 
 
 class AssistantParams(PromptParams):
@@ -122,7 +122,7 @@ class AssistantStep(core.BaseStep[Any, str]):
 
         result.response = self._process_messages(result, thread.id)
         # TODO: Record files
-        return StepContext(result.response, persist=False, metadata={"thread_id": thread.id, "run_id": run.id})
+        return StepContext(result.response, metadata={"thread_id": thread.id, "run_id": run.id})
 
     def _process_messages(self, result: AssistantOutput, thread_id: str) -> str:
         messages = list(self.client.beta.threads.messages.list(thread_id=thread_id, order="asc"))

--- a/apps/analysis/steps/splitters.py
+++ b/apps/analysis/steps/splitters.py
@@ -7,6 +7,7 @@ from pandas.core.resample import TimeGrouper
 
 from apps.analysis.core import BaseStep, Params, ParamsForm, StepContext, required
 from apps.analysis.exceptions import StepError
+from apps.analysis.steps.utils import format_truncated_date
 
 
 class TimeGroup(StrEnum):
@@ -19,8 +20,8 @@ class TimeGroup(StrEnum):
     quarterly = "Q"
     yearly = "Y"
 
-    def get_group_value(self, timestamp) -> pd.Period:
-        return timestamp.to_period(self.value)
+    def get_group_name(self, timestamp) -> str:
+        return format_truncated_date(timestamp, self.name)
 
 
 class TimeseriesSplitterParams(Params):
@@ -57,7 +58,7 @@ class TimeseriesSplitter(BaseStep[pd.DataFrame, dict[pd.Period, pd.DataFrame]]):
             if params.ignore_empty_groups and not len(group):
                 continue
             groups.append(group)
-            name = str(params.time_group.get_group_value(origin))
+            name = params.time_group.get_group_name(origin)
             names.append(name)
             self.create_resource(group, f"split_{name}")
 

--- a/apps/analysis/steps/splitters.py
+++ b/apps/analysis/steps/splitters.py
@@ -5,8 +5,8 @@ import pandas as pd
 from pandas.api import types as ptypes
 from pandas.core.resample import TimeGrouper
 
-from ..core import BaseStep, Params, ParamsForm, StepContext, required
-from ..exceptions import StepError
+from apps.analysis.core import BaseStep, Params, ParamsForm, StepContext, required
+from apps.analysis.exceptions import StepError
 
 
 class TimeGroup(StrEnum):
@@ -57,9 +57,12 @@ class TimeseriesSplitter(BaseStep[pd.DataFrame, dict[pd.Period, pd.DataFrame]]):
             if params.ignore_empty_groups and not len(group):
                 continue
             groups.append(group)
-            names.append(str(params.time_group.get_group_value(origin)))
+            name = str(params.time_group.get_group_value(origin))
+            names.append(name)
+            self.create_resource(group, f"split_{name}")
 
         self.log.info(f"Split timeseries data into {len(groups)} groups")
         for i, (name, group) in enumerate(zip(names, groups)):
             self.log.info(f"    Group {i + 1}: {name} ({len(group)} rows)")
+
         return StepContext(groups, is_multiple=True, metadata={"names": names})

--- a/apps/analysis/steps/splitters.py
+++ b/apps/analysis/steps/splitters.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from enum import StrEnum
 from typing import Literal
 
@@ -50,7 +49,7 @@ class TimeseriesSplitter(BaseStep[pd.DataFrame, dict[pd.Period, pd.DataFrame]]):
         if not ptypes.is_datetime64_any_dtype(context.data.index):
             raise StepError("Dataframe must have a datetime index")
 
-    def run(self, params: TimeseriesSplitterParams, data: pd.DataFrame) -> tuple[list[pd.DataFrame], dict]:
+    def run(self, params: TimeseriesSplitterParams, data: pd.DataFrame) -> StepContext[list[pd.DataFrame]]:
         grouped = data.groupby(params.grouper)
         groups = []
         names = []
@@ -63,4 +62,4 @@ class TimeseriesSplitter(BaseStep[pd.DataFrame, dict[pd.Period, pd.DataFrame]]):
         self.log.info(f"Split timeseries data into {len(groups)} groups")
         for i, (name, group) in enumerate(zip(names, groups)):
             self.log.info(f"    Group {i + 1}: {name} ({len(group)} rows)")
-        return groups, {"names": names, "output_multiple": True}
+        return StepContext(groups, is_multiple=True, metadata={"names": names})

--- a/apps/analysis/steps/utils.py
+++ b/apps/analysis/steps/utils.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+import pandas as pd
+
+
+def format_truncated_date(date: datetime, truncate_to: str):
+    match truncate_to:
+        case "seconds" | "secondly":
+            return date.isoformat(timespec="seconds")
+        case "minutes" | "minutely":
+            return date.isoformat(timespec="minutes")
+        case "hours" | "hourly":
+            return date.isoformat(timespec="hours")
+        case "days" | "daily":
+            return date.date().isoformat()
+        case "weeks" | "weekly":
+            return date.date().strftime("%Y-W%W")
+        case "months" | "monthly":
+            return date.date().strftime("%Y-%m")
+        case "quarters" | "quarterly":
+            quarter = pd.Timestamp(date).quarter
+            year = date.date().strftime("%Y")
+            return f"{year}-Q{quarter}"
+        case "years" | "yearly":
+            return date.date().strftime("%Y")

--- a/apps/analysis/tasks.py
+++ b/apps/analysis/tasks.py
@@ -42,7 +42,7 @@ def run_context(run):
     log_stream = RunLogStream(run)
     params = run.group.params
     params["llm_model"] = run.group.analysis.llm_model
-    pipeline_context = PipelineContext(run, log=Logger(log_stream), params=params)
+    pipeline_context = PipelineContext(run, log=Logger(log_stream), params=params, create_resources=True)
 
     with run_status_context(run, raise_errors=True):
         yield pipeline_context
@@ -89,13 +89,6 @@ def run_pipeline(group: RunGroup, pipeline_id: str, pipeline_factory, context=No
 
 def process_pipeline_output(run, result: StepContext):
     if result.is_multiple and isinstance(result.data, list):
-        result_data = result.data
-        run.output_summary = f"{len(result_data)} chunks created"
+        run.output_summary = f"{len(result.data)} groups created"
     else:
-        result_data = [result.data]
         run.output_summary = get_serializer(result.data).get_summary(result.data)
-
-    if result.persist:
-        for i, data in enumerate(result_data):
-            resource = create_resource_for_data(run.group.team, data, f"{result.name} Output {i}")
-            run.resources.add(resource)

--- a/apps/analysis/tasks.py
+++ b/apps/analysis/tasks.py
@@ -88,15 +88,15 @@ def run_pipeline(group: RunGroup, pipeline_id: str, pipeline_factory, context=No
         return result
 
 
-def process_pipeline_output(run, result):
-    if result.metadata.get("output_multiple", False) and isinstance(result.data, list):
+def process_pipeline_output(run, result: StepContext):
+    if result.is_multiple and isinstance(result.data, list):
         result_data = result.data
         result.output_summary = f"{len(result_data)} chunks created"
     else:
         result_data = [result.data]
         run.output_summary = get_serializer(result.data).get_summary(result.data)
 
-    if result.metadata.get("persist_output", True):
+    if result.persist:
         for i, data in enumerate(result_data):
             resource = create_resource_for_data(run.group.team, data, f"{result.name} Output {i}")
             run.resources.add(resource)

--- a/apps/analysis/tasks.py
+++ b/apps/analysis/tasks.py
@@ -40,10 +40,9 @@ def run_status_context(run, raise_errors=False):
 def run_context(run):
     """Context manager to create the pipeline context and manage run status."""
     log_stream = RunLogStream(run)
-    llm_service = run.group.analysis.llm_provider.get_llm_service()
     params = run.group.params
     params["llm_model"] = run.group.analysis.llm_model
-    pipeline_context = PipelineContext(llm_service, logger=Logger(log_stream), params=params)
+    pipeline_context = PipelineContext(run, log=Logger(log_stream), params=params)
 
     with run_status_context(run, raise_errors=True):
         yield pipeline_context
@@ -65,7 +64,7 @@ class RunLogStream(LogStream):
 
 @shared_task
 def run_analysis(run_group_id: int):
-    group = RunGroup.objects.get(id=run_group_id)
+    group = RunGroup.objects.select_related("team", "analysis", "analysis__llm_provider").get(id=run_group_id)
 
     with run_status_context(group):
         source_result = run_pipeline(group, group.analysis.source, get_source_pipeline)
@@ -91,7 +90,7 @@ def run_pipeline(group: RunGroup, pipeline_id: str, pipeline_factory, context=No
 def process_pipeline_output(run, result: StepContext):
     if result.is_multiple and isinstance(result.data, list):
         result_data = result.data
-        result.output_summary = f"{len(result_data)} chunks created"
+        run.output_summary = f"{len(result_data)} chunks created"
     else:
         result_data = [result.data]
         run.output_summary = get_serializer(result.data).get_summary(result.data)

--- a/apps/analysis/tasks.py
+++ b/apps/analysis/tasks.py
@@ -69,7 +69,7 @@ def run_analysis(run_group_id: int):
     with run_status_context(group):
         source_result = run_pipeline(group, group.analysis.source, get_source_pipeline)
 
-        if source_result.metadata.get("output_multiple", False) and isinstance(source_result.data, list):
+        if source_result.should_split:
             results = [source_result.clone_with(data) for data in source_result.data]
         else:
             results = [source_result]
@@ -88,7 +88,7 @@ def run_pipeline(group: RunGroup, pipeline_id: str, pipeline_factory, context=No
 
 
 def process_pipeline_output(run, result: StepContext):
-    if result.is_multiple and isinstance(result.data, list):
+    if result.should_split:
         run.output_summary = f"{len(result.data)} groups created"
     else:
         run.output_summary = get_serializer(result.data).get_summary(result.data)

--- a/apps/analysis/tests/demo_steps.py
+++ b/apps/analysis/tests/demo_steps.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from apps.analysis.core import BaseStep, Params, required
+from apps.analysis.core import BaseStep, Params, StepContext, required
 
 
 class FactorSay(Params):
@@ -13,10 +13,10 @@ class Multiply(BaseStep[int, int]):
     input_type = int
     output_type = int
 
-    def run(self, params: FactorSay, data: int) -> tuple[int, dict]:
+    def run(self, params: FactorSay, data: int) -> StepContext[int]:
         if params.say:
             self.log.debug(params.say)
-        return data * params.factor, {"some": "metadata"}
+        return StepContext(data * params.factor, metadata={"some": "metadata"})
 
 
 class Divide(BaseStep[int, int]):
@@ -24,10 +24,10 @@ class Divide(BaseStep[int, int]):
     input_type = int
     output_type = int
 
-    def run(self, params: FactorSay, data: int) -> tuple[int, dict]:
+    def run(self, params: FactorSay, data: int) -> StepContext[int]:
         if params.say:
             self.log.debug(params.say)
-        return data / params.factor, {}
+        return StepContext(data / params.factor)
 
 
 class SetFactor(BaseStep[Any, Any]):
@@ -35,30 +35,30 @@ class SetFactor(BaseStep[Any, Any]):
     input_type = Any
     output_type = Any
 
-    def run(self, params: FactorSay, data: Any) -> tuple[Any, dict]:
+    def run(self, params: FactorSay, data: Any) -> StepContext[Any]:
         self.pipeline_context.params["factor"] = params.factor
-        return data, {}
+        return StepContext(data)
 
 
 class StrInt(BaseStep[str, int]):
     input_type = str
     output_type = int
 
-    def run(self, params: Params, data: str) -> tuple[int, dict]:
-        return int(data), {}
+    def run(self, params: Params, data: str) -> StepContext[int]:
+        return StepContext(int(data))
 
 
 class IntStr(BaseStep[int, str]):
     input_type = int
     output_type = str
 
-    def run(self, params: Params, data: int) -> tuple[str, dict]:
-        return str(data), {}
+    def run(self, params: Params, data: int) -> StepContext[str]:
+        return StepContext(str(data))
 
 
 class StrReverse(BaseStep[str, str]):
     input_type = str
     output_type = str
 
-    def run(self, params: Params, data: str) -> tuple[str, dict]:
-        return data[::-1], {}
+    def run(self, params: Params, data: str) -> StepContext[str]:
+        return StepContext(data[::-1])

--- a/apps/analysis/tests/test_pipelines.py
+++ b/apps/analysis/tests/test_pipelines.py
@@ -11,14 +11,14 @@ from .demo_steps import Divide, FactorSay, IntStr, Multiply, SetFactor, StrInt
     [
         (
             Pipeline([Multiply(params=FactorSay(factor=3)), Divide(params=FactorSay(factor=2))]),
-            PipelineContext(None),
+            PipelineContext(),
             StepContext[int](10),
             15,
         ),
         # params passed from previous step
         (
             Pipeline([SetFactor(params=FactorSay(factor=3)), Multiply()]),
-            PipelineContext(None),
+            PipelineContext(),
             StepContext[int](2),
             6,
         ),
@@ -31,7 +31,7 @@ from .demo_steps import Divide, FactorSay, IntStr, Multiply, SetFactor, StrInt
                     Divide(),  # / 4  (param from previous step)
                 ]
             ),
-            PipelineContext(None, params={"factor": 2}),
+            PipelineContext(params={"factor": 2}),
             StepContext[int](2),
             3,
         ),
@@ -52,7 +52,7 @@ def test_pipeline(pipeline: Pipeline, pipeline_context, context, output):
 )
 def test_params(params, context, expected):
     step = Divide(params)
-    step.initialize(PipelineContext(None, params=context))
+    step.initialize(PipelineContext(params=context))
     assert step._params == expected
 
 

--- a/apps/analysis/tests/test_resource_dataframe_loader.py
+++ b/apps/analysis/tests/test_resource_dataframe_loader.py
@@ -12,7 +12,7 @@ from apps.analysis.steps.loaders import ResourceDataframeLoader, ResourceLoaderP
 @pytest.fixture
 def resource_dataframe_loader():
     step = ResourceDataframeLoader()
-    step.initialize(PipelineContext(None))
+    step.initialize(PipelineContext())
     return step
 
 

--- a/apps/analysis/tests/test_resource_dataframe_loader.py
+++ b/apps/analysis/tests/test_resource_dataframe_loader.py
@@ -47,9 +47,9 @@ def get_params(resource):
 def test_resource_dataframe_loader(resource_type, raw_data, expected, resource_dataframe_loader):
     resource = make_resource(resource_type, raw_data)
     params = get_params(resource)
-    data, _ = resource_dataframe_loader.load(params)
-    assert isinstance(data, pd.DataFrame)
-    assert data.to_csv(index=False) == expected
+    result = resource_dataframe_loader.load(params)
+    assert isinstance(result.data, pd.DataFrame)
+    assert result.data.to_csv(index=False) == expected
 
 
 def test_resource_dataframe_loader_raises_error_with_invalid_resource_type(resource_dataframe_loader):

--- a/apps/analysis/tests/test_steps.py
+++ b/apps/analysis/tests/test_steps.py
@@ -13,5 +13,5 @@ from .demo_steps import Divide, FactorSay, Multiply
     ],
 )
 def test_call(step: Step, context, output):
-    step.initialize(PipelineContext(None))
+    step.initialize(PipelineContext())
     assert step(context).data == output

--- a/apps/analysis/tests/test_timeseries_filter.py
+++ b/apps/analysis/tests/test_timeseries_filter.py
@@ -7,7 +7,7 @@ from apps.analysis.core import PipelineContext
 from apps.analysis.steps.filters import DurationUnit, TimeseriesFilter, TimeseriesFilterParams
 
 
-def _make_params(duration_unit, duration_value, anchor_type, anchor_point=None):
+def _make_params(duration_unit, duration_value, anchor_type="this", anchor_point=None):
     return TimeseriesFilterParams(
         duration_unit=duration_unit,
         duration_value=duration_value,
@@ -102,6 +102,22 @@ def _make_params(duration_unit, duration_value, anchor_type, anchor_point=None):
 def test_timeseries_filter_params(params, start, end):
     assert params.start == datetime.fromisoformat(start)
     assert params.end == datetime.fromisoformat(end)
+
+
+@pytest.mark.parametrize(
+    "unit, value, expected",
+    [
+        (DurationUnit.minutes, 7, "2022-04-01T15:36--2022-04-01T15:43"),
+        (DurationUnit.hours, 7, "2022-04-01T15--2022-04-01T22"),
+        (DurationUnit.days, 7, "2022-04-01--2022-04-08"),
+        (DurationUnit.weeks, 7, "2022-W13--2022-W20"),
+        (DurationUnit.months, 7, "2022-04--2022-11"),
+        (DurationUnit.years, 7, "2022--2029"),
+    ],
+)
+def test_timeseries_filter_params_period_name(unit, value, expected):
+    params = _make_params(unit, value, anchor_point="2022-04-01T15:36:45.123456")
+    assert params.period_name() == expected
 
 
 @pytest.fixture

--- a/apps/analysis/tests/test_timeseries_filter.py
+++ b/apps/analysis/tests/test_timeseries_filter.py
@@ -125,16 +125,16 @@ def test_timeseries_filter_with_valid_params(timeseries_filter, timeseries_data)
         anchor_type="this",
         anchor_point=datetime.fromisoformat("2021-01-02"),
     )
-    filtered_data, _ = timeseries_filter.run(params, timeseries_data)
-    assert len(filtered_data) == 7
-    assert filtered_data["value"].tolist() == list(range(1, 8))
+    result = timeseries_filter.run(params, timeseries_data)
+    assert len(result.data) == 7
+    assert result.data["value"].tolist() == list(range(1, 8))
 
 
 def test_timeseries_filter_with_empty_data(timeseries_filter):
     params = TimeseriesFilterParams(duration_unit=DurationUnit.days, duration_value=7, anchor_type="this")
     empty_data = pd.DataFrame()
-    filtered_data, _ = timeseries_filter.run(params, empty_data)
-    assert len(filtered_data) == 0
+    result = timeseries_filter.run(params, empty_data)
+    assert len(result.data) == 0
 
 
 def test_timeseries_filter_with_future_dates(timeseries_filter, timeseries_data):
@@ -144,5 +144,5 @@ def test_timeseries_filter_with_future_dates(timeseries_filter, timeseries_data)
         anchor_type="this",
         anchor_point=datetime.now() + timedelta(days=10),
     )
-    filtered_data, _ = timeseries_filter.run(params, timeseries_data)
-    assert len(filtered_data) == 0
+    result = timeseries_filter.run(params, timeseries_data)
+    assert len(result.data) == 0

--- a/apps/analysis/tests/test_timeseries_filter.py
+++ b/apps/analysis/tests/test_timeseries_filter.py
@@ -114,7 +114,7 @@ def timeseries_data():
 @pytest.fixture
 def timeseries_filter():
     step = TimeseriesFilter()
-    step.initialize(PipelineContext(None))
+    step.initialize(PipelineContext())
     return step
 
 

--- a/apps/analysis/tests/test_timeseries_splitter.py
+++ b/apps/analysis/tests/test_timeseries_splitter.py
@@ -1,8 +1,6 @@
-from datetime import datetime
-
 import pandas as pd
 import pytest
-from pandas import DataFrame, date_range
+from pandas import DataFrame, Period, Timestamp, date_range
 
 from apps.analysis.core import PipelineContext, StepContext
 from apps.analysis.exceptions import StepError
@@ -85,3 +83,21 @@ def test_timeseries_splitter_ignores_empty_groups(ignore_empty, group_count, tim
     data = DataFrame(index=dates, data={"value": range(len(dates))})
     result = timeseries_splitter.run(params, data)
     assert len(result.data) == group_count
+
+
+@pytest.mark.parametrize(
+    "time_group, expected",
+    [
+        (TimeGroup.secondly, "2022-03-07T15:22:05"),
+        (TimeGroup.minutely, "2022-03-07T15:22"),
+        (TimeGroup.hourly, "2022-03-07T15"),
+        (TimeGroup.daily, "2022-03-07"),
+        (TimeGroup.weekly, "2022-W10"),
+        (TimeGroup.monthly, "2022-03"),
+        (TimeGroup.quarterly, "2022-Q1"),
+        (TimeGroup.yearly, "2022"),
+    ],
+)
+def test_time_group_get_group_name(time_group, expected):
+    timestamp = Timestamp("2022-03-07 15:22:05")
+    assert time_group.get_group_name(timestamp) == expected

--- a/apps/analysis/tests/test_timeseries_splitter.py
+++ b/apps/analysis/tests/test_timeseries_splitter.py
@@ -35,9 +35,9 @@ def test_timeseries_splitter_splits_data_into_correct_groups(
     time_group, expected_groups, group_lengths, timeseries_splitter, timeseries_data
 ):
     params = TimeseriesSplitterParams(time_group=time_group, origin="start")
-    groups, _ = timeseries_splitter.run(params, timeseries_data)
-    assert len(groups) == expected_groups
-    assert [len(group) for group in groups] == group_lengths
+    result = timeseries_splitter.run(params, timeseries_data)
+    assert len(result.data) == expected_groups
+    assert [len(group) for group in result.data] == group_lengths
 
 
 @pytest.mark.parametrize(
@@ -56,10 +56,10 @@ def test_timeseries_splitter_splits_data_into_correct_groups_with_origin(origin,
     data = DataFrame(index=dates, data={"value": range(len(dates))})
 
     params = TimeseriesSplitterParams(time_group=TimeGroup.hourly, origin=origin)
-    groups, _ = timeseries_splitter.run(params, data)
-    assert len(groups) == 2
-    assert list(groups[0].index) == [pd.Timestamp(d) for d in expected_groups[0]]
-    assert list(groups[1].index) == [pd.Timestamp(d) for d in expected_groups[1]]
+    result = timeseries_splitter.run(params, data)
+    assert len(result.data) == 2
+    assert list(result.data[0].index) == [pd.Timestamp(d) for d in expected_groups[0]]
+    assert list(result.data[1].index) == [pd.Timestamp(d) for d in expected_groups[1]]
 
 
 def test_timeseries_splitter_raises_error_with_non_datetime_index(timeseries_splitter):
@@ -83,5 +83,5 @@ def test_timeseries_splitter_ignores_empty_groups(ignore_empty, group_count, tim
         pd.Timestamp("2021-01-04"),
     ]
     data = DataFrame(index=dates, data={"value": range(len(dates))})
-    groups, _ = timeseries_splitter.run(params, data)
-    assert len(groups) == group_count
+    result = timeseries_splitter.run(params, data)
+    assert len(result.data) == group_count

--- a/apps/analysis/tests/test_timeseries_splitter.py
+++ b/apps/analysis/tests/test_timeseries_splitter.py
@@ -12,7 +12,7 @@ from apps.analysis.steps.splitters import TimeGroup, TimeseriesSplitter, Timeser
 @pytest.fixture
 def timeseries_splitter():
     step = TimeseriesSplitter()
-    step.initialize(PipelineContext(None))
+    step.initialize(PipelineContext())
     return step
 
 

--- a/apps/analysis/tests/test_whatsapp_parser.py
+++ b/apps/analysis/tests/test_whatsapp_parser.py
@@ -40,7 +40,8 @@ def test_whatsapp_parser_parses_valid_log(whatsapp_parser, valid_whatsapp_log):
         remove_deleted_messages=False, remove_system_messages=False, remove_media_omitted_messages=False
     )
     whatsapp_parser.initialize(PipelineContext(None, params=params.model_dump()))
-    df, _ = whatsapp_parser.run(params, valid_whatsapp_log)
+    result = whatsapp_parser.run(params, valid_whatsapp_log)
+    df = result.data
     assert len(df) == 5
     _check_message(df, "2021-01-01 00:00", "system", "System Message")
     _check_message(df, "2021-01-01 00:01", "User1", "Hello World")
@@ -50,7 +51,8 @@ def test_whatsapp_parser_parses_valid_log(whatsapp_parser, valid_whatsapp_log):
 
 
 def test_whatsapp_parser_message_filtering(whatsapp_parser, valid_whatsapp_log):
-    df, _ = whatsapp_parser.run(whatsapp_parser._params, valid_whatsapp_log)
+    result = whatsapp_parser.run(whatsapp_parser._params, valid_whatsapp_log)
+    df = result.data
     assert len(df) == 2
     _check_message(df, "2021-01-01 00:01", "User1", "Hello World")
     _check_message(df, "2021-01-21 00:03", "User1", "Let's meet at 10:00\nWe can meet at the cafe")
@@ -58,7 +60,8 @@ def test_whatsapp_parser_message_filtering(whatsapp_parser, valid_whatsapp_log):
 
 def test_whatsapp_parser_parses_valid_log_unicode_rtl(whatsapp_parser, valid_whatsapp_log_unicode_rtl):
     params = Params()
-    df, _ = whatsapp_parser.run(params, valid_whatsapp_log_unicode_rtl)
+    result = whatsapp_parser.run(params, valid_whatsapp_log_unicode_rtl)
+    df = result.data
     assert not df.empty
     _check_message(df, "2023-03-11 21:27", "User1", "Hello")
     _check_message(df, "2023-03-11 21:28", "User2", "Hi\nHow are you?")
@@ -85,5 +88,5 @@ def test_whatsapp_parser_handles_invalid_log(whatsapp_parser):
 
 def test_whatsapp_parser_handles_empty_log(whatsapp_parser):
     params = Params()
-    df, _ = whatsapp_parser.run(params, "")
-    assert df.empty
+    result = whatsapp_parser.run(params, "")
+    assert result.data.empty

--- a/apps/analysis/tests/test_whatsapp_parser.py
+++ b/apps/analysis/tests/test_whatsapp_parser.py
@@ -12,7 +12,7 @@ from apps.analysis.steps.parsers import WhatsappParser, WhatsappParserParams
 @pytest.fixture
 def whatsapp_parser():
     step = WhatsappParser()
-    step.initialize(PipelineContext(None))
+    step.initialize(PipelineContext())
     return step
 
 
@@ -39,7 +39,7 @@ def test_whatsapp_parser_parses_valid_log(whatsapp_parser, valid_whatsapp_log):
     params = WhatsappParserParams(
         remove_deleted_messages=False, remove_system_messages=False, remove_media_omitted_messages=False
     )
-    whatsapp_parser.initialize(PipelineContext(None, params=params.model_dump()))
+    whatsapp_parser.initialize(PipelineContext(params=params.model_dump()))
     result = whatsapp_parser.run(params, valid_whatsapp_log)
     df = result.data
     assert len(df) == 5


### PR DESCRIPTION
This refactors how resources are created during pipeline runs. Each step can now manage their own resources and resources are included in the result context.

This means that later steps have access to resources created in previous steps and will allow the assistant step to create resources from files generated by the assistant.

This also paves the way for parallel runs which require persistence between tasks.

🐡 (Best reviewed by commit)