### PR TITLE
Ignore chat member updates. This throws exceptions and are not useful

### DIFF
--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -20,6 +20,10 @@ def handle_telegram_message(self, message_data: str, channel_external_id: uuid):
         return
 
     update = types.Update.de_json(message_data)
+    if update.my_chat_member:
+        # This is a chat member update that we don't care about.
+        # See https://core.telegram.org/bots/api-changelog#march-9-2021
+        return
     message_handler = TelegramChannel(experiment_channel=experiment_channel)
     update_taskbadger_data(self, message_handler, update.message)
     message_handler.new_user_message(update.message)


### PR DESCRIPTION
Fix for [these kinds](https://dimagi.sentry.io/issues/4783082870/?project=4505001320316928&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=1&utc=true) of exceptions. We don't care about chat member updates, since there's no message from a user in there, so we can safely discard it