### PR TITLE
Move the logic to check channel utlization to the views

### DIFF
--- a/apps/channels/forms.py
+++ b/apps/channels/forms.py
@@ -1,10 +1,4 @@
-from typing import ClassVar
-
 from django import forms
-from django.forms import ValidationError
-from django.urls import reverse
-from django.utils.html import format_html
-from django.utils.translation import gettext as _
 
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.service_providers.models import MessagingProvider, MessagingProviderType
@@ -41,46 +35,15 @@ class ChannelForm(forms.ModelForm):
         return super().save()
 
 
-class ChannelFormBase(forms.Form):
-    """
-    Base class for channel-specific forms.
-
-    Attributes:
-        channel_identifier_key (ClassVar): The key used to identify a specific channel in the `extra_data` json
-            field on an `ExperimentChannel` instance. Subclasses need to specify this key and it will differ for
-            each channel type (Telegram, Whatsapp etc..)
-    """
-
-    channel_identifier_key: ClassVar
-
-    def clean(self):
-        cleaned_data = super().clean()
-        filter_params = {f"extra_data__{self.channel_identifier_key}": cleaned_data[self.channel_identifier_key]}
-
-        channel = ExperimentChannel.objects.filter(**filter_params).first()
-        if channel:
-            experiment = channel.experiment
-            url = reverse(
-                "experiments:single_experiment_home",
-                kwargs={"team_slug": experiment.team.slug, "experiment_id": experiment.id},
-            )
-            messsage = format_html(_("This channel is already used in <a href={}><u>another experiment</u></a>"), url)
-            raise ValidationError(messsage, code="invalid")
-        return cleaned_data
-
-
-class TelegramChannelForm(ChannelFormBase):
-    channel_identifier_key = "bot_token"
+class TelegramChannelForm(forms.Form):
     bot_token = forms.CharField(label="Bot Token", max_length=100)
 
 
-class WhatsappChannelForm(ChannelFormBase):
-    channel_identifier_key = "number"
+class WhatsappChannelForm(forms.Form):
     number = forms.CharField(label="Number", max_length=100)
 
 
-class FacebookChannelForm(ChannelFormBase):
-    channel_identifier_key = "page_id"
+class FacebookChannelForm(forms.Form):
     page_id = forms.CharField(label="Page ID", max_length=100)
     page_access_token = forms.CharField(label="Page Access Token")
     verify_token = forms.CharField(

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -127,7 +127,7 @@ class ExperimentChannel(BaseModel):
     def check_usage_by_another_experiment(platform: ChannelPlatform, identifier: str, new_experiment: Experiment):
         """
         Checks if another experiment (one that is not the same as `new_experiment`) already uses the channel specified by its `identifier`
-        and `platform`. Raises `ChannelAlreadyUtilized` error when another experiment uses it.
+        and `platform`. Raises `ChannelAlreadyUtilizedException` error when another experiment uses it.
         """
 
         filter_params = {f"extra_data__{platform.channel_identifier_key}": identifier}

--- a/apps/channels/tests/test_forms.py
+++ b/apps/channels/tests/test_forms.py
@@ -28,11 +28,3 @@ def test_channel_form_reveals_provider_types(team, platform, expected_widget_cls
     form_queryset = form.fields["messaging_provider"].queryset
     assert form_queryset.count() == MessagingProvider.objects.filter(team=team).count()
     assert form_queryset.first() == message_provider
-
-
-def test_channel_base_form(db):
-    channel = ExperimentChannelFactory()
-    invalid_form = TelegramChannelForm({"bot_token": channel.extra_data["bot_token"]})
-    valid_form = TelegramChannelForm({"bot_token": "123123"})
-    assert invalid_form.is_valid() is False
-    assert valid_form.is_valid() is True

--- a/apps/channels/tests/test_models.py
+++ b/apps/channels/tests/test_models.py
@@ -1,0 +1,25 @@
+import pytest
+
+from apps.channels.models import ExperimentChannel
+from apps.experiments.exceptions import ChannelAlreadyUtilizedException
+from apps.utils.factories.channels import ExperimentChannelFactory
+from apps.utils.factories.experiment import ExperimentFactory
+
+
+def test_new_integration_does_not_raise_exception(db):
+    channel = ExperimentChannelFactory()
+    new_experiment = ExperimentFactory()
+
+    ExperimentChannel.check_usage_by_another_experiment(
+        channel.platform, identifier="321", new_experiment=new_experiment
+    )
+
+
+def test_duplicate_integration_raises_exception(db):
+    channel = ExperimentChannelFactory()
+    new_experiment = ExperimentFactory()
+
+    with pytest.raises(ChannelAlreadyUtilizedException):
+        ExperimentChannel.check_usage_by_another_experiment(
+            channel.platform, identifier=channel.extra_data["bot_token"], new_experiment=new_experiment
+        )

--- a/apps/experiments/exceptions.py
+++ b/apps/experiments/exceptions.py
@@ -1,0 +1,9 @@
+class ViewException(Exception):
+    def __init__(self, html_message):
+        self.html_message = html_message
+        super().__init__(self.html_message)
+
+
+class ChannelAlreadyUtilizedException(ViewException):
+    def __init__(self, html_message):
+        super().__init__(html_message)


### PR DESCRIPTION
Fixes an issue with [this change](https://github.com/dimagi/open-chat-studio/pull/188) where the user cannot update an existing channel