### PR TITLE
update django-field-audit to 1.2.8

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -127,7 +127,7 @@ django-cryptography==1.1
     # via -r requirements/requirements.in
 django-environ==0.11.2
     # via -r requirements/requirements.in
-django-field-audit==1.2.7
+django-field-audit==1.2.8
     # via -r requirements/requirements.in
 django-hijack==3.4.2
     # via -r requirements/requirements.in


### PR DESCRIPTION
* v1.2.8 - 2024-01-24
    Use Django's timezone.now instead of datetime.now to ensure the correct timezone is used when creating audit events.

https://github.com/dimagi/django-field-audit/blob/main/CHANGELOG.md#v128---2024-01-24