### PR TITLE
Add Anthropic Support

### DIFF
--- a/apps/chat/agent/agent.py
+++ b/apps/chat/agent/agent.py
@@ -15,6 +15,11 @@ class AgentExecuter:
     track of the session in which the agent is being executed.
 
     To learn more about LangChain agents, see the docs: https://docs.langchain.com/docs/components/agents
+
+    # TODO: use
+    https://python.langchain.com/docs/integrations/chat/anthropic_functions
+    when we implement this for anthropic
+
     """
 
     def __init__(self, llm: BaseLanguageModel, memory: ConversationBufferMemory, experiment_session: ExperimentSession):

--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -227,9 +227,9 @@ class SafetyBot:
         result = self._call_predict(self.prompt.format(input_str))
         print(f"response: {result}")
         print("========== end safety bot analysis =========")
-        if result.lower().startswith("safe"):
+        if result.strip().lower().startswith("safe"):
             return True
-        elif result.lower().startswith("unsafe"):
+        elif result.strip().lower().startswith("unsafe"):
             return False
         else:
             return False

--- a/apps/chat/conversation.py
+++ b/apps/chat/conversation.py
@@ -67,7 +67,7 @@ class Conversation:
         self.executer.memory.chat_memory.messages = messages
 
     def predict(self, input: str) -> Tuple[str, int, int]:
-        if not isinstance(self.executer, AgentExecuter) and isinstance(self.executer.llm, ChatAnthropic):
+        if not self._is_agent and isinstance(self.executer.llm, ChatAnthropic):
             # Langchain has no inbuilt functionality to return prompt or
             # completion tokens for Anthropic's models
             # https://python.langchain.com/docs/modules/model_io/llms/token_usage_tracking
@@ -77,7 +77,7 @@ class Conversation:
             response = self.executer.predict(input=input)
             formatted_prompt = self.executer.prompt.format_prompt(
                 input=input,
-                history=self.memory.buffer_as_messages,
+                history=self.executer.memory.buffer_as_messages,
             ).to_string()
             prompt_tokens = get_num_tokens_anthropic(formatted_prompt)
             completion_tokens = get_num_tokens_anthropic(response)

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -293,7 +293,7 @@ class Experiment(BaseTeamModel):
         default=False,
         help_text=(
             "If checked, this bot will be able to use prebuilt tools (set reminders etc). This uses more tokens, "
-            "so it will cost more."
+            "so it will cost more. This doesn't currently work with Anthropic models."
         ),
     )
 

--- a/apps/service_providers/forms.py
+++ b/apps/service_providers/forms.py
@@ -70,6 +70,17 @@ class AzureOpenAIConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
     )
 
 
+class AnthropicConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
+    obfuscate_fields = ["anthropic_api_key"]
+
+    anthropic_api_key = forms.CharField(label=_("Anthropic API Key"))
+    anthropic_api_base = forms.URLField(
+        label="API URL",
+        help_text="Base URL path for API requests e.g. 'https://api.anthropic.com'",
+        initial="https://api.anthropic.com",
+    )
+
+
 def obfuscate_value(value):
     if value and isinstance(value, str):
         return value[:4] + "*" * (len(value) - 4)

--- a/apps/service_providers/llm_service.py
+++ b/apps/service_providers/llm_service.py
@@ -2,7 +2,7 @@ from io import BytesIO
 from typing import ClassVar
 
 import pydantic
-from langchain.chat_models import AzureChatOpenAI, ChatOpenAI
+from langchain.chat_models import AzureChatOpenAI, ChatAnthropic, ChatOpenAI
 from langchain.chat_models.base import BaseChatModel
 from openai import OpenAI
 from openai._base_client import SyncAPIClient
@@ -65,5 +65,20 @@ class AzureLlmService(LlmService):
             openai_api_version=self.openai_api_version,
             openai_api_key=self.openai_api_key,
             deployment_name=llm_model,
+            temperature=temperature,
+        )
+
+
+class AnthropicLlmService(LlmService):
+    _type = "anthropic"
+
+    anthropic_api_key: str
+    anthropic_api_base: str
+
+    def get_chat_model(self, llm_model: str, temperature: float) -> BaseChatModel:
+        return ChatAnthropic(
+            anthropic_api_key=self.anthropic_api_key,
+            anthropic_api_url=self.anthropic_api_base,
+            model=llm_model,
             temperature=temperature,
         )

--- a/apps/service_providers/models.py
+++ b/apps/service_providers/models.py
@@ -16,6 +16,7 @@ from .exceptions import ServiceProviderConfigError
 class LlmProviderType(models.TextChoices):
     openai = "openai", _("OpenAI")
     azure = "azure", _("Azure OpenAI")
+    anthropic = "anthropic", _("Anthropic")
 
     @property
     def form_cls(self) -> Type[forms.ProviderTypeConfigForm]:
@@ -24,6 +25,8 @@ class LlmProviderType(models.TextChoices):
                 return forms.OpenAIConfigForm
             case LlmProviderType.azure:
                 return forms.AzureOpenAIConfigForm
+            case LlmProviderType.anthropic:
+                return forms.AnthropicConfigForm
         raise Exception(f"No config form configured for {self}")
 
     def get_llm_service(self, config: dict):
@@ -33,6 +36,8 @@ class LlmProviderType(models.TextChoices):
                     return llm_service.OpenAILlmService(**config)
                 case LlmProviderType.azure:
                     return llm_service.AzureLlmService(**config)
+                case LlmProviderType.anthropic:
+                    return llm_service.AnthropicLlmService(**config)
         except ValidationError as e:
             raise ServiceProviderConfigError(self, str(e)) from e
         raise ServiceProviderConfigError(self, "No chat model configured")

--- a/apps/service_providers/tests/test_llm_service.py
+++ b/apps/service_providers/tests/test_llm_service.py
@@ -1,4 +1,4 @@
-from apps.service_providers.llm_service import AzureLlmService, OpenAILlmService
+from apps.service_providers.llm_service import AnthropicLlmService, AzureLlmService, OpenAILlmService
 
 
 def test_open_ai_service():
@@ -10,4 +10,9 @@ def test_azure_ai_service():
     service = AzureLlmService(
         openai_api_key="test", openai_api_base="https://api.openai.com/v1", openai_api_version="v1"
     )
+    assert not service.supports_transcription
+
+
+def test_anthropic_service():
+    service = AnthropicLlmService(anthropic_api_key="test", anthropic_api_base="https://api.anthropic.com")
     assert not service.supports_transcription

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -26,7 +26,9 @@ factory-boy==3.3.0
 faker==20.0.0
     # via factory-boy
 filelock==3.13.1
-    # via virtualenv
+    # via
+    #   -c requirements/requirements.txt
+    #   virtualenv
 freezegun==1.2.2
     # via -r requirements/dev-requirements.in
 identify==2.5.31

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,3 +1,4 @@
+anthropic
 boto3
 Django
 django-allauth

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,8 +17,11 @@ amqp==5.2.0
     # via kombu
 annotated-types==0.6.0
     # via pydantic
+anthropic==0.10.0
+    # via -r requirements/requirements.in
 anyio==3.7.1
     # via
+    #   anthropic
     #   httpcore
     #   langchain
     #   openai
@@ -91,7 +94,9 @@ dataclasses-json==0.6.2
 defusedxml==0.7.1
     # via python3-openid
 distro==1.8.0
-    # via openai
+    # via
+    #   anthropic
+    #   openai
 django==4.2.7
     # via
     #   -r requirements/requirements.in
@@ -151,10 +156,14 @@ fbmessenger==6.0.0
     # via -r requirements/requirements.in
 ffmpeg==1.4
     # via -r requirements/requirements.in
+filelock==3.13.1
+    # via huggingface-hub
 frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
+fsspec==2023.12.2
+    # via huggingface-hub
 greenlet==3.0.1
     # via sqlalchemy
 h11==0.14.0
@@ -163,8 +172,11 @@ httpcore==0.17.3
     # via httpx
 httpx==0.24.1
     # via
+    #   anthropic
     #   openai
     #   taskbadger
+huggingface-hub==0.20.2
+    # via tokenizers
 idna==3.4
     # via
     #   anyio
@@ -216,6 +228,7 @@ openai==1.2.4
 packaging==23.2
     # via
     #   djangorestframework-api-key
+    #   huggingface-hub
     #   marshmallow
 pandas==2.1.3
     # via -r requirements/requirements.in
@@ -228,6 +241,7 @@ pycparser==2.21
 pydantic==2.5.0
     # via
     #   -r requirements/requirements.in
+    #   anthropic
     #   langchain
     #   langsmith
     #   openai
@@ -264,6 +278,7 @@ pytz==2023.3.post1
 pyyaml==6.0.1
     # via
     #   drf-spectacular
+    #   huggingface-hub
     #   langchain
 qrcode==7.4.2
     # via django-allauth-2fa
@@ -280,6 +295,7 @@ requests==2.31.0
     #   django-allauth
     #   django-anymail
     #   fbmessenger
+    #   huggingface-hub
     #   langchain
     #   langsmith
     #   pytelegrambotapi
@@ -304,6 +320,7 @@ six==1.16.0
     # via python-dateutil
 sniffio==1.3.0
     # via
+    #   anthropic
     #   anyio
     #   httpcore
     #   httpx
@@ -317,10 +334,14 @@ tenacity==8.2.3
     # via langchain
 tiktoken==0.5.2
     # via -r requirements/requirements.in
+tokenizers==0.15.0
+    # via anthropic
 tomlkit==0.11.8
     # via taskbadger
 tqdm==4.66.1
-    # via openai
+    # via
+    #   huggingface-hub
+    #   openai
 twilio==8.10.1
     # via -r requirements/requirements.in
 typer[all]==0.9.0
@@ -329,6 +350,8 @@ typer[all]==0.9.0
     #   typer
 typing-extensions==4.8.0
     # via
+    #   anthropic
+    #   huggingface-hub
     #   openai
     #   pydantic
     #   pydantic-core


### PR DESCRIPTION
Fixes: https://github.com/dimagi/open-chat-studio/issues/150

A few know bugs:
- Anthropic doesn't allow an 'Assistant' message to come first in the Prompt builder: https://github.com/dimagi/open-chat-studio/issues/211
- Agents aren't currently supported. Functions work a bit differently in Claude than in ChatGPT: https://python.langchain.com/docs/integrations/chat/anthropic_functions

This is mentioned in the code, but token counting works a bit differently in Claude (and the API doesn't return token counts like OpenAI does). I solved this by counting the tokens manually, but this could probably use some work when we update the call from `predict` to `invoke` ([which returns the input and output](https://python.langchain.com/docs/use_cases/tool_use/agents#invoke-agent)).