### PR TITLE
More auditing

### DIFF
--- a/apps/experiments/model_audit_fields.py
+++ b/apps/experiments/model_audit_fields.py
@@ -44,3 +44,5 @@ EXPERIMENT_CHANNEL_FIELDS = [
     "platform",
     "messaging_provider",
 ]
+
+NO_ACTIVITY_CONFIG_FIELDS = ["message_for_bot", "name", "max_pings", "ping_after"]

--- a/apps/experiments/model_audit_fields.py
+++ b/apps/experiments/model_audit_fields.py
@@ -33,3 +33,6 @@ CONSENT_FORM_FIELDS = [
     "confirmation_text",
     "team",
 ]
+
+TEAM_FIELDS = ["name", "slug", "members"]
+MEMBERSHIP_FIELDS = ["team", "user", "role"]

--- a/apps/experiments/model_audit_fields.py
+++ b/apps/experiments/model_audit_fields.py
@@ -45,5 +45,7 @@ EXPERIMENT_CHANNEL_FIELDS = [
     "messaging_provider",
 ]
 
-NO_ACTIVITY_CONFIG_FIELDS = ["message_for_bot", "name", "max_pings", "ping_after"]
-MESSAGING_PROVIDER_FIELDS = ["type", "name", "config"]
+NO_ACTIVITY_CONFIG_FIELDS = ["message_for_bot", "name", "max_pings", "ping_after", "team"]
+MESSAGING_PROVIDER_FIELDS = ["type", "name", "team"]
+VOICE_PROVIDER_FIELDS = ["type", "name", "team"]
+LLM_PROVIDER_FIELDS = ["team", "type", "name", "llm_models"]

--- a/apps/experiments/model_audit_fields.py
+++ b/apps/experiments/model_audit_fields.py
@@ -46,3 +46,4 @@ EXPERIMENT_CHANNEL_FIELDS = [
 ]
 
 NO_ACTIVITY_CONFIG_FIELDS = ["message_for_bot", "name", "max_pings", "ping_after"]
+MESSAGING_PROVIDER_FIELDS = ["type", "name", "config"]

--- a/apps/experiments/model_audit_fields.py
+++ b/apps/experiments/model_audit_fields.py
@@ -1,3 +1,5 @@
+from django.contrib.auth.models import AbstractUser
+
 PROMPT_FIELDS = ["owner", "name", "description", "prompt", "input_formatter", "team"]
 
 EXPERIMENT_FIELDS = [
@@ -49,3 +51,6 @@ NO_ACTIVITY_CONFIG_FIELDS = ["message_for_bot", "name", "max_pings", "ping_after
 MESSAGING_PROVIDER_FIELDS = ["type", "name", "team"]
 VOICE_PROVIDER_FIELDS = ["type", "name", "team"]
 LLM_PROVIDER_FIELDS = ["team", "type", "name", "llm_models"]
+
+# The auditing library struggles with dates. Let's ignore them for now
+CUSTOM_USER_FIELDS = [f.attname for f in AbstractUser._meta.fields if f.attname not in ["last_login", "date_joined"]]

--- a/apps/experiments/model_audit_fields.py
+++ b/apps/experiments/model_audit_fields.py
@@ -36,3 +36,11 @@ CONSENT_FORM_FIELDS = [
 
 TEAM_FIELDS = ["name", "slug", "members"]
 MEMBERSHIP_FIELDS = ["team", "user", "role"]
+EXPERIMENT_CHANNEL_FIELDS = [
+    "name",
+    "experiment",
+    "active",
+    "extra_data",
+    "platform",
+    "messaging_provider",
+]

--- a/apps/experiments/model_audit_fields.py
+++ b/apps/experiments/model_audit_fields.py
@@ -1,5 +1,3 @@
-from django.contrib.auth.models import AbstractUser
-
 PROMPT_FIELDS = ["owner", "name", "description", "prompt", "input_formatter", "team"]
 
 EXPERIMENT_FIELDS = [
@@ -36,8 +34,6 @@ CONSENT_FORM_FIELDS = [
     "team",
 ]
 
-TEAM_FIELDS = ["name", "slug", "members"]
-MEMBERSHIP_FIELDS = ["team", "user", "role"]
 EXPERIMENT_CHANNEL_FIELDS = [
     "name",
     "experiment",
@@ -48,9 +44,3 @@ EXPERIMENT_CHANNEL_FIELDS = [
 ]
 
 NO_ACTIVITY_CONFIG_FIELDS = ["message_for_bot", "name", "max_pings", "ping_after", "team"]
-MESSAGING_PROVIDER_FIELDS = ["type", "name", "team"]
-VOICE_PROVIDER_FIELDS = ["type", "name", "team"]
-LLM_PROVIDER_FIELDS = ["team", "type", "name", "llm_models"]
-
-# The auditing library struggles with dates. Let's ignore them for now
-CUSTOM_USER_FIELDS = [f.attname for f in AbstractUser._meta.fields if f.attname not in ["last_login", "date_joined"]]

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -37,6 +37,10 @@ class ConsentFormObjectManager(AuditingManager):
     pass
 
 
+class NoActivityMessageConfigObjectManager(AuditingManager):
+    pass
+
+
 @audit_fields(*model_audit_fields.PROMPT_FIELDS, audit_special_queryset_writes=True)
 class Prompt(BaseTeamModel):
     """
@@ -249,9 +253,11 @@ class SyntheticVoice(BaseModel):
         return f"{self.language}, {self.gender}: {prefix}{self.name}"
 
 
+@audit_fields(*model_audit_fields.NO_ACTIVITY_CONFIG_FIELDS, audit_special_queryset_writes=True)
 class NoActivityMessageConfig(BaseTeamModel):
     """Configuration for when the user doesn't respond to the bot's message"""
 
+    objects = NoActivityMessageConfigObjectManager()
     message_for_bot = models.CharField(help_text="This message will be sent to the LLM along with the message history")
     name = models.CharField(max_length=64)
     max_pings = models.IntegerField()

--- a/apps/service_providers/model_audit_fields.py
+++ b/apps/service_providers/model_audit_fields.py
@@ -1,0 +1,3 @@
+MESSAGING_PROVIDER_FIELDS = ["type", "name", "team"]
+VOICE_PROVIDER_FIELDS = ["type", "name", "team"]
+LLM_PROVIDER_FIELDS = ["team", "type", "name", "llm_models"]

--- a/apps/service_providers/models.py
+++ b/apps/service_providers/models.py
@@ -9,7 +9,7 @@ from field_audit.models import AuditingManager
 from pydantic import ValidationError
 
 from apps.channels.models import ChannelPlatform
-from apps.experiments import model_audit_fields
+from apps.service_providers import model_audit_fields
 from apps.teams.models import BaseTeamModel
 
 from . import forms, llm_service, messaging_service, speech_service

--- a/apps/service_providers/models.py
+++ b/apps/service_providers/models.py
@@ -20,6 +20,14 @@ class MessagingProviderObjectManager(AuditingManager):
     pass
 
 
+class VoiceProviderObjectManager(AuditingManager):
+    pass
+
+
+class LlmProviderObjectManagerObjectManager(AuditingManager):
+    pass
+
+
 class LlmProviderType(models.TextChoices):
     openai = "openai", _("OpenAI")
     azure = "azure", _("Azure OpenAI")
@@ -50,7 +58,9 @@ class LlmProviderType(models.TextChoices):
         raise ServiceProviderConfigError(self, "No chat model configured")
 
 
+@audit_fields(*model_audit_fields.LLM_PROVIDER_FIELDS, audit_special_queryset_writes=True)
 class LlmProvider(BaseTeamModel):
+    objects = LlmProviderObjectManagerObjectManager()
     team = models.ForeignKey("teams.Team", on_delete=models.CASCADE)
     type = models.CharField(max_length=255, choices=LlmProviderType.choices)
     name = models.CharField(max_length=255)
@@ -102,7 +112,9 @@ class VoiceProviderType(models.TextChoices):
         raise ServiceProviderConfigError(self, "No voice service configured")
 
 
+@audit_fields(*model_audit_fields.VOICE_PROVIDER_FIELDS, audit_special_queryset_writes=True)
 class VoiceProvider(BaseTeamModel):
+    objects = VoiceProviderObjectManager()
     type = models.CharField(max_length=255, choices=VoiceProviderType.choices)
     name = models.CharField(max_length=255)
     config = encrypt(models.JSONField(default=dict))

--- a/apps/teams/model_audit_fields.py
+++ b/apps/teams/model_audit_fields.py
@@ -1,0 +1,2 @@
+TEAM_FIELDS = ["name", "slug", "members"]
+MEMBERSHIP_FIELDS = ["team", "user", "role"]

--- a/apps/teams/models.py
+++ b/apps/teams/models.py
@@ -11,7 +11,7 @@ from waffle import get_setting
 from waffle.models import CACHE_EMPTY, AbstractUserFlag
 from waffle.utils import get_cache, keyfmt
 
-from apps.experiments import model_audit_fields
+from apps.teams import model_audit_fields
 from apps.utils.models import BaseModel
 from apps.web.meta import absolute_url
 

--- a/apps/teams/tests/test_view_mixins.py
+++ b/apps/teams/tests/test_view_mixins.py
@@ -5,7 +5,7 @@ from django.views import View
 
 from apps.teams.middleware import TeamsMiddleware
 from apps.teams.mixins import LoginAndTeamRequiredMixin
-from apps.teams.models import Team
+from apps.teams.models import Membership, Team
 from apps.teams.roles import ROLE_ADMIN, ROLE_MEMBER
 from apps.users.models import CustomUser
 
@@ -30,13 +30,13 @@ class TeamMixinTest(TestCase):
 
         cls.sox_admin = CustomUser.objects.create(username="tito@redsox.com")
         cls.sox_member = CustomUser.objects.create(username="papi@redsox.com")
-        cls.sox.members.add(cls.sox_admin, through_defaults={"role": ROLE_ADMIN})
-        cls.sox.members.add(cls.sox_member, through_defaults={"role": ROLE_MEMBER})
+        Membership.objects.create(user=cls.sox_admin, role=ROLE_ADMIN, team=cls.sox)
+        Membership.objects.create(user=cls.sox_member, role=ROLE_MEMBER, team=cls.sox)
 
         cls.yanks_admin = CustomUser.objects.create(username="joe.torre@yankees.com")
         cls.yanks_member = CustomUser.objects.create(username="derek.jeter@yankees.com")
-        cls.yanks.members.add(cls.yanks_admin, through_defaults={"role": ROLE_ADMIN})
-        cls.yanks.members.add(cls.yanks_member, through_defaults={"role": ROLE_MEMBER})
+        Membership.objects.create(user=cls.yanks_admin, role=ROLE_ADMIN, team=cls.yanks)
+        Membership.objects.create(user=cls.yanks_member, role=ROLE_MEMBER, team=cls.yanks)
 
     def _get_request(self, user=None):
         request = self.factory.get("/team/")  # the url here is ignored

--- a/apps/users/model_audit_fields.py
+++ b/apps/users/model_audit_fields.py
@@ -1,0 +1,4 @@
+from django.contrib.auth.models import AbstractUser
+
+# The auditing library struggles with dates. Let's ignore them for now
+CUSTOM_USER_FIELDS = [f.attname for f in AbstractUser._meta.fields if f.attname not in ["last_login", "date_joined"]]

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -1,16 +1,25 @@
 import hashlib
 
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import AbstractUser, UserManager
 from django.db import models
+from field_audit import audit_fields
+from field_audit.models import AuditingManager
 
+from apps.experiments.model_audit_fields import CUSTOM_USER_FIELDS
 from apps.web.storage_backends import get_public_media_storage
 
 
+class AuditedUserObjectManager(UserManager, AuditingManager):
+    pass
+
+
+@audit_fields(*CUSTOM_USER_FIELDS, audit_special_queryset_writes=True)
 class CustomUser(AbstractUser):
     """
     Add additional fields to the user model here.
     """
 
+    objects = AuditedUserObjectManager()
     avatar = models.FileField(upload_to="profile-pictures/", blank=True, storage=get_public_media_storage)
     language = models.CharField(max_length=10, blank=True, null=True)
 

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -5,7 +5,7 @@ from django.db import models
 from field_audit import audit_fields
 from field_audit.models import AuditingManager
 
-from apps.experiments.model_audit_fields import CUSTOM_USER_FIELDS
+from apps.users.model_audit_fields import CUSTOM_USER_FIELDS
 from apps.web.storage_backends import get_public_media_storage
 
 


### PR DESCRIPTION
Addresses #144

For a smooth experience, go through the PR commit-wise.

All went well, except for the `Membership`model. I had to update the tests, since `team.members.add(...)` does not play well with the auditing library, which is a suboptimality. For now, simply creating a `Membership` object will suffice.

I ran into another issue when I tried to audit the `CustomUser` object. The audit library struggles with datetime serialization. I'll look into it. I have an idea where the issue occurs