### PR TITLE
Show webhook URL for Twilio as well

### DIFF
--- a/apps/channels/forms.py
+++ b/apps/channels/forms.py
@@ -1,11 +1,8 @@
 from django import forms
-from django.urls import reverse
 
 from apps.channels.models import ChannelPlatform, ExperimentChannel
-from apps.experiments.models import Experiment
 from apps.service_providers.models import MessagingProvider, MessagingProviderType
 from apps.teams.models import Team
-from apps.web.meta import absolute_url
 
 
 class ChannelForm(forms.ModelForm):
@@ -41,12 +38,7 @@ class ChannelForm(forms.ModelForm):
 class ExtraFormBase(forms.Form):
     def get_success_message(self, channel: ExperimentChannel):
         """The message to be displayed when the channel is successfully linked"""
-        if channel.messaging_provider and channel.messaging_provider.type == MessagingProviderType.turnio:
-            webhook_url = absolute_url(
-                reverse("channels:new_turn_message", kwargs={"experiment_id": channel.experiment.public_id}),
-                is_secure=True,
-            )
-            return f"Use the following URL when setting up the webhook in Turn.io: {webhook_url}"
+        return f"Use the following URL when setting up the webhook: {channel.webhook_url}"
 
 
 class TelegramChannelForm(ExtraFormBase):
@@ -55,26 +47,24 @@ class TelegramChannelForm(ExtraFormBase):
 
 class WhatsappChannelForm(ExtraFormBase):
     number = forms.CharField(label="Number", max_length=100)
-
-
-class TurnIOForm(ExtraFormBase):
-    number = forms.CharField(label="Number", max_length=100)
     webook_url = forms.CharField(
         widget=forms.TextInput(attrs={"readonly": "readonly"}),
         label="Webhook URL",
         disabled=True,
-        help_text="Use this as the URL when setting up the webhook in Turn.io",
+        help_text="Use this as the URL when setting up the webhook",
     )
 
-    def __init__(self, channel: ExperimentChannel, *args, **kwargs):
-        webhook_url = absolute_url(
-            reverse("channels:new_turn_message", kwargs={"experiment_id": channel.experiment.public_id}),
-            is_secure=True,
-        )
+    def __init__(self, *args, **kwargs):
         initial = kwargs.get("initial", {})
-        initial.setdefault("webook_url", webhook_url)
-        kwargs["initial"] = initial
-        return super().__init__(*args, **kwargs)
+        channel: ExperimentChannel = kwargs.pop("channel", None)
+        if channel:
+            initial["webook_url"] = channel.webhook_url
+            kwargs["initial"] = initial
+
+        super().__init__(*args, **kwargs)
+        if not channel:
+            # We only show the webhook URL field when there is something to show
+            self.fields["webook_url"].widget = forms.HiddenInput()
 
 
 class FacebookChannelForm(ExtraFormBase):

--- a/apps/channels/forms.py
+++ b/apps/channels/forms.py
@@ -51,6 +51,7 @@ class WhatsappChannelForm(ExtraFormBase):
         widget=forms.TextInput(attrs={"readonly": "readonly"}),
         label="Webhook URL",
         disabled=True,
+        required=False,
         help_text="Use this as the URL when setting up the webhook",
     )
 

--- a/apps/channels/tests/test_models.py
+++ b/apps/channels/tests/test_models.py
@@ -1,9 +1,12 @@
 import pytest
+from django.urls import reverse
 
 from apps.channels.models import ExperimentChannel
 from apps.experiments.exceptions import ChannelAlreadyUtilizedException
+from apps.service_providers.models import MessagingProviderType
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentFactory
+from apps.utils.factories.service_provider_factories import MessagingProviderFactory
 
 
 def test_new_integration_does_not_raise_exception(db):
@@ -23,3 +26,20 @@ def test_duplicate_integration_raises_exception(db):
         ExperimentChannel.check_usage_by_another_experiment(
             channel.platform, identifier=channel.extra_data["bot_token"], new_experiment=new_experiment
         )
+
+
+def test_channel_webhook_url(db):
+    # Setup providers
+    twilio_provider = MessagingProviderFactory(type=MessagingProviderType.twilio)
+    turnio_provider = MessagingProviderFactory(type=MessagingProviderType.turnio)
+
+    # Setup channels with their respective providers
+    no_provider_channel = ExperimentChannelFactory()
+    twilio_channel = ExperimentChannelFactory(messaging_provider=twilio_provider)
+    turnio_channel = ExperimentChannelFactory(messaging_provider=turnio_provider)
+
+    # Let's check out each one's webhook url
+    assert no_provider_channel.webhook_url is None
+    assert reverse("channels:new_whatsapp_message") in twilio_channel.webhook_url
+    turnio_uri = reverse("channels:new_turn_message", kwargs={"experiment_id": turnio_channel.experiment.public_id})
+    assert turnio_uri in turnio_channel.webhook_url


### PR DESCRIPTION
Sometimes I question my own sanity. We should be showing the webhook URL for twilio channels as well, making the TurnIO form redundant.