### PR TITLE
Turn.io - Support sending voice messages

### DIFF
--- a/apps/channels/audio.py
+++ b/apps/channels/audio.py
@@ -3,23 +3,6 @@ from io import BytesIO
 from pydub import AudioSegment
 
 
-def convert_audio_to_wav(audio: BytesIO, source_format="ogg") -> BytesIO:
-    """
-    OpenAI doesn't support .ogg filetypes, so we need to convert to wav (supported). We do this in-memory
-    """
-    audio = AudioSegment.from_file(audio, format=source_format)
-    # Convert to mono
-    audio = audio.set_channels(1)
-
-    # Export to WAV
-    wav_audio = BytesIO()
-    audio.export(wav_audio, format="wav")
-    wav_audio.seek(0)
-    wav_audio.name = "some_name.wav"
-
-    return wav_audio
-
-
 def convert_audio(audio: BytesIO, target_format: str, source_format="ogg") -> BytesIO:
     audio = AudioSegment.from_file(audio, format=source_format)
     # Convert to mono

--- a/apps/channels/audio.py
+++ b/apps/channels/audio.py
@@ -18,3 +18,15 @@ def convert_audio_to_wav(audio: BytesIO, source_format="ogg") -> BytesIO:
     wav_audio.name = "some_name.wav"
 
     return wav_audio
+
+
+def convert_audio(audio: BytesIO, target_format: str, source_format="ogg") -> BytesIO:
+    audio = AudioSegment.from_file(audio, format=source_format)
+    # Convert to mono
+    audio = audio.set_channels(1)
+
+    new_audio = BytesIO()
+    audio.export(new_audio, format=target_format)
+    new_audio.seek(0)
+    new_audio.name = f"some_name.{target_format}"
+    return new_audio

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -442,7 +442,7 @@ class TelegramChannel(ChannelBase):
     def get_message_audio(self) -> BytesIO:
         file_url = self.telegram_bot.get_file_url(self.message.voice.file_id)
         ogg_audio = BytesIO(requests.get(file_url).content)
-        return audio.convert_audio_to_wav(ogg_audio)
+        return audio.convert_audio(ogg_audio, target_format="wav", source_format="ogg")
 
     def new_bot_message(self, bot_message: str):
         """Handles a message coming from the bot. Call this to send bot messages to the user"""
@@ -541,7 +541,7 @@ class FacebookMessengerChannel(ChannelBase, BaseMessenger):
     def get_message_audio(self) -> BytesIO:
         raw_data = requests.get(self.message.media_url).content
         mp4_audio = BytesIO(raw_data)
-        return audio.convert_audio_to_wav(mp4_audio, source_format="mp4")
+        return audio.convert_audio(mp4_audio, target_format="wav", source_format="mp4")
 
     def transcription_finished(self, transcript: str):
         self.send_text_to_user(f'I heard: "{transcript}"')

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -504,39 +504,10 @@ class WhatsappChannel(ChannelBase):
         """
         Uploads the synthesized voice to AWS and send the public link to twilio
         """
-        s3_client = boto3.client(
-            "s3",
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-            region_name=settings.AWS_S3_REGION,
-            config=Config(signature_version="s3v4"),
-        )
-        file_path = f"{self.chat_id}/{uuid.uuid4()}.mp3"
-        audio_bytes = voice_audio.getvalue()
-        s3_client.upload_fileobj(
-            BytesIO(audio_bytes),
-            settings.WHATSAPP_S3_AUDIO_BUCKET,
-            file_path,
-            ExtraArgs={
-                "Expires": datetime.utcnow() + timedelta(minutes=7),
-                "Metadata": {
-                    "DurationSeconds": str(duration),
-                },
-                "ContentType": "audio/mpeg",
-            },
-        )
-        public_url = s3_client.generate_presigned_url(
-            "get_object",
-            Params={
-                "Bucket": settings.WHATSAPP_S3_AUDIO_BUCKET,
-                "Key": file_path,
-            },
-            ExpiresIn=360,
-        )
         from_number = self.experiment_channel.extra_data["number"]
         to_number = self.chat_id
         self.messaging_service.send_whatsapp_voice_message(
-            media_url=public_url, from_number=from_number, to_number=to_number
+            voice_audio=voice_audio, duration=duration, from_number=from_number, to_number=to_number
         )
 
 

--- a/apps/service_providers/messaging_service.py
+++ b/apps/service_providers/messaging_service.py
@@ -88,11 +88,12 @@ class TwilioService(MessagingService):
 class TurnIOService(MessagingService):
     _type: ClassVar[str] = "turnio"
     supported_platforms: ClassVar[list] = [ChannelPlatform.WHATSAPP]
+    voice_replies_supported: ClassVar[bool] = True
 
     auth_token: str
 
     @property
-    def client(self) -> Client:
+    def client(self) -> TurnClient:
         return TurnClient(token=self.auth_token)
 
     def send_whatsapp_text_message(self, message: str, from_number: str, to_number):

--- a/apps/service_providers/messaging_service.py
+++ b/apps/service_providers/messaging_service.py
@@ -82,7 +82,7 @@ class TwilioService(MessagingService):
     def get_message_audio(self, message: TwilioMessage) -> BytesIO:
         auth = (self.account_sid, self.auth_token)
         ogg_audio = BytesIO(requests.get(message.media_url, auth=auth).content)
-        return audio.convert_audio_to_wav(ogg_audio)
+        return audio.convert_audio(ogg_audio, target_format="wav", source_format="ogg")
 
 
 class TurnIOService(MessagingService):
@@ -109,4 +109,4 @@ class TurnIOService(MessagingService):
     def get_message_audio(self, message: TurnWhatsappMessage) -> BytesIO:
         response = self.client.media.get_media(message.media_id)
         ogg_audio = BytesIO(response.content)
-        return audio.convert_audio_to_wav(ogg_audio)
+        return audio.convert_audio(ogg_audio, target_format="wav", source_format="ogg")

--- a/apps/service_providers/messaging_service.py
+++ b/apps/service_providers/messaging_service.py
@@ -100,7 +100,11 @@ class TurnIOService(MessagingService):
         self.client.messages.send_text(to_number, message)
 
     def send_whatsapp_voice_message(self, voice_audio: BytesIO, duration: int, from_number: str, to_number: str):
-        pass
+        from apps.channels.audio import convert_audio
+
+        voice_audio = convert_audio(voice_audio, target_format="ogg", source_format="mp3")
+        media_id = self.client.media.upload_media(voice_audio.read(), content_type="audio/ogg")
+        self.client.messages.send_audio(whatsapp_id=to_number, media_id=media_id)
 
     def get_message_audio(self, message: TurnWhatsappMessage) -> BytesIO:
         response = self.client.media.get_media(message.media_id)

--- a/apps/service_providers/messaging_service.py
+++ b/apps/service_providers/messaging_service.py
@@ -44,20 +44,23 @@ class TwilioService(MessagingService):
     def client(self) -> Client:
         return Client(self.account_sid, self.auth_token)
 
-    def send_whatsapp_text_message(self, message: str, from_number: str, to_number):
-        self.client.messages.create(from_=f"whatsapp:{from_number}", body=message, to=f"whatsapp:{to_number}")
-
-    def send_whatsapp_voice_message(self, voice_audio: BytesIO, duration: int, from_number: str, to_number):
-        s3_client = boto3.client(
+    @property
+    def s3_client(self):
+        return boto3.client(
             "s3",
             aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
             region_name=settings.AWS_S3_REGION,
             config=Config(signature_version="s3v4"),
         )
-        file_path = f"{self.chat_id}/{uuid.uuid4()}.mp3"
+
+    def send_whatsapp_text_message(self, message: str, from_number: str, to_number):
+        self.client.messages.create(from_=f"whatsapp:{from_number}", body=message, to=f"whatsapp:{to_number}")
+
+    def send_whatsapp_voice_message(self, voice_audio: BytesIO, duration: int, from_number: str, to_number):
+        file_path = f"{uuid.uuid4()}.mp3"
         audio_bytes = voice_audio.getvalue()
-        s3_client.upload_fileobj(
+        self.s3_client.upload_fileobj(
             BytesIO(audio_bytes),
             settings.WHATSAPP_S3_AUDIO_BUCKET,
             file_path,
@@ -69,7 +72,7 @@ class TwilioService(MessagingService):
                 "ContentType": "audio/mpeg",
             },
         )
-        public_url = s3_client.generate_presigned_url(
+        public_url = self.s3_client.generate_presigned_url(
             "get_object",
             Params={
                 "Bucket": settings.WHATSAPP_S3_AUDIO_BUCKET,

--- a/apps/utils/factories/experiment.py
+++ b/apps/utils/factories/experiment.py
@@ -1,7 +1,7 @@
 import factory
 
 from apps.experiments import models
-from apps.utils.factories.service_provider_factories import LlmProviderFactory
+from apps.utils.factories.service_provider_factories import LlmProviderFactory, VoiceProviderFactory
 from apps.utils.factories.team import TeamFactory
 from apps.utils.factories.user import UserFactory
 
@@ -36,6 +36,18 @@ class SourceMaterialFactory(factory.django.DjangoModelFactory):
     team = factory.SubFactory(TeamFactory)
 
 
+class SyntheticVoiceFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.SyntheticVoice
+
+    name = factory.Faker("name")
+    neural = True
+    language = "English"
+    language_code = "en"
+    gender = "male"
+    service = "AWS"
+
+
 class ExperimentFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Experiment
@@ -49,6 +61,8 @@ class ExperimentFactory(factory.django.DjangoModelFactory):
     llm_provider = factory.SubFactory(LlmProviderFactory, team=factory.SelfAttribute("..team"))
     pre_survey = factory.SubFactory(SurveyFactory, team=factory.SelfAttribute("..team"))
     public_id = factory.Faker("uuid4")
+    synthetic_voice = factory.SubFactory(SyntheticVoiceFactory)
+    voice_provider = factory.SubFactory(VoiceProviderFactory)
 
 
 class ExperimentSessionFactory(factory.django.DjangoModelFactory):

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -39,4 +39,4 @@ taskbadger
 tiktoken
 fbmessenger
 django-field-audit>=1.2.7
-turn-python>=0.1.0
+turn-python>=0.2.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -380,7 +380,7 @@ tqdm==4.66.1
     # via
     #   huggingface-hub
     #   openai
-turn-python==0.1.0
+turn-python==0.2.0
     # via -r requirements/requirements.in
 twilio==8.10.1
     # via -r requirements/requirements.in


### PR DESCRIPTION
This PR is build on top of [this one](https://github.com/dimagi/open-chat-studio/pull/237). In this PR relies on [this turn-python](https://github.com/dimagi/turn-python/pull/4) one, so will finish this one off once that's ready.

The whatsapp service providers now implement their own ways of sending voice messages to users. I also replaced the `convert_audio_to_wav` with a more generic `convert_audio` method.