### PR TITLE
Handle unsupported message types

### DIFF
--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -39,9 +39,11 @@ class TwilioMessage(BaseModel):
     @classmethod
     def determine_content_type(cls, value):
         if not value:
+            # Normal test messages doesn't have a content type
             return MESSAGE_TYPES.TEXT
         if value and value == "audio/ogg":
             return MESSAGE_TYPES.VOICE
+        raise UnsupportedMessageTypeException()
 
     @property
     def chat_id(self) -> str:
@@ -108,6 +110,7 @@ class FacebookMessage(BaseModel):
             return MESSAGE_TYPES.TEXT
         if value and value == "audio":
             return MESSAGE_TYPES.VOICE
+        raise UnsupportedMessageTypeException()
 
     @property
     def chat_id(self) -> str:

--- a/apps/channels/tests/test_facebook_integration.py
+++ b/apps/channels/tests/test_facebook_integration.py
@@ -91,6 +91,12 @@ class FacebookChannelTest(TestCase):
         assert facebook_message.user_id == "6785984231"
         assert facebook_message.media_url == media_url
 
+    @patch("apps.channels.tasks.FacebookMessengerChannel.new_user_message")
+    def test_unsupported_message_type_raises_exception(self, new_user_message):
+        message = _facebook_image_message(self.page_id, attachment_url="https://example.com/my-audio")
+        handle_facebook_message(team_slug=self.team.slug, message_data=message)
+        new_user_message.assert_not_called()
+
 
 def _facebook_text_message(page_id: str, message: str):
     data = {
@@ -133,6 +139,32 @@ def _facebook_audio_message(page_id: str, attachment_url: str):
                         "message": {
                             "mid": "m_IAx--vsBAYF3FYqN0LQN3sU3K_suxsIcKASSDHASD",
                             "attachments": [{"type": "audio", "payload": {"url": attachment_url}}],
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+    return json.dumps(data)
+
+
+def _facebook_image_message(page_id: str, attachment_url: str):
+    data = {
+        "object": "page",
+        "entry": [
+            {
+                "id": page_id,
+                "time": 1699260776574,
+                "messaging": [
+                    {
+                        "sender": {"id": "6785984231"},
+                        "recipient": {
+                            "id": page_id,
+                        },
+                        "timestamp": 1699259349974,
+                        "message": {
+                            "mid": "m_IAx--vsBAYF3FYqN0LQN3sU3K_suxsIcKASSDHASD",
+                            "attachments": [{"type": "image", "payload": {"url": attachment_url}}],
                         },
                     }
                 ],


### PR DESCRIPTION
Addresses [this issue](https://dimagi.sentry.io/share/issue/e35a652364334717bb13ae8f46160430/). We simply return when someone sends an unsupported message type. A better approach probably is to ask the bot to formulate a good response here.