### PR TITLE
implement access control for chats

### DIFF
--- a/apps/experiments/decorators.py
+++ b/apps/experiments/decorators.py
@@ -79,7 +79,9 @@ def verify_session_access_cookie(view):
 
     @wraps(view)
     def _inner(request, *args, **kwargs):
-        if request.user.is_authenticated and request.user.has_perm("chat.view_chat"):
+        if request.user.is_authenticated and (
+            request.experiment_session.user_id == request.user.id or request.user.has_perm("chat.view_chat")
+        ):
             return view(request, *args, **kwargs)
 
         try:

--- a/apps/experiments/decorators.py
+++ b/apps/experiments/decorators.py
@@ -91,8 +91,7 @@ def verify_session_access_cookie(view):
         except (signing.BadSignature, KeyError):
             raise Http404()
 
-        access_data = access_value
-        if not _validate_access_cookie_data(request.experiment_session, access_data):
+        if not _validate_access_cookie_data(request.experiment_session, access_value):
             raise Http404()
 
         return view(request, *args, **kwargs)

--- a/apps/experiments/decorators.py
+++ b/apps/experiments/decorators.py
@@ -91,7 +91,6 @@ def verify_session_access_cookie(view):
         except (signing.BadSignature, KeyError):
             raise Http404()
 
-        # access_data = json.loads(access_value)
         access_data = access_value
         if not _validate_access_cookie_data(request.experiment_session, access_data):
             raise Http404()

--- a/apps/experiments/tests/test_session_flow.py
+++ b/apps/experiments/tests/test_session_flow.py
@@ -1,0 +1,84 @@
+import pytest
+from django.contrib.auth.models import Permission
+from django.urls import reverse
+
+from apps.experiments.decorators import CHAT_SESSION_ACCESS_COOKIE
+from apps.experiments.models import Participant
+from apps.utils.factories.experiment import ExperimentSessionFactory
+
+
+@pytest.fixture()
+def session():
+    session = ExperimentSessionFactory()
+    participant = Participant.objects.create(team=session.team, identifier="test@test.com")
+    session.participant = participant
+    session.save()
+    return session
+
+
+@pytest.mark.django_db()
+def test_session_flow_with_access_cookie(client, session):
+    response = client.post(
+        reverse(
+            "experiments:start_experiment_session",
+            args=[session.experiment.team.slug, session.experiment.public_id, session.public_id],
+        ),
+        data={
+            "consent_agreement": "on",
+            "experiment_id": session.experiment.id,
+            "participant_id": session.participant.id,
+        },
+    )
+    assert response.status_code == 302
+    assert CHAT_SESSION_ACCESS_COOKIE in client.cookies
+
+    if session.experiment.pre_survey:
+        next_url = reverse(
+            "experiments:experiment_pre_survey",
+            args=[session.experiment.team.slug, session.experiment.public_id, session.public_id],
+        )
+    else:
+        next_url = reverse(
+            "experiments:experiment_chat",
+            args=[session.experiment.team.slug, session.experiment.public_id, session.public_id],
+        )
+    assert response.headers["Location"] == next_url
+
+    response = client.get(next_url)
+    assert response.status_code == 200
+
+    # making a request without the chat_session_access cookie should 404
+    del client.cookies[CHAT_SESSION_ACCESS_COOKIE]
+    response = client.get(next_url)
+    assert response.status_code == 404
+
+    # unless the request is for an authenticated user with the view_chat permission
+    client.login(username=session.experiment.owner.username, password="password")
+    session.experiment.owner.user_permissions.add(Permission.objects.get(codename="view_chat"))
+    response = client.get(next_url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db()
+def test_access_cookie_not_set_on_session_start_get(client, session):
+    response = client.get(
+        reverse(
+            "experiments:start_experiment_session",
+            args=[session.experiment.team.slug, session.experiment.public_id, session.public_id],
+        ),
+    )
+    assert response.status_code == 200
+    assert CHAT_SESSION_ACCESS_COOKIE not in client.cookies
+
+
+@pytest.mark.django_db()
+def test_access_cookie_not_set_on_session_start_with_inavlid_form(client, session):
+    response = client.post(
+        reverse(
+            "experiments:start_experiment_session",
+            args=[session.experiment.team.slug, session.experiment.public_id, session.public_id],
+        ),
+        data={},
+    )
+    assert response.status_code == 200
+    assert CHAT_SESSION_ACCESS_COOKIE not in client.cookies


### PR DESCRIPTION
Resolves #168 

This uses a signed cookie to verify access to chat sessions for web requests that are not authenticated.

Access is provided for 6 months. If the cookie is not present or expired the user will receive a 404 page.

Access is granted to authenticated users if they have the 'chat.view_chat' permission.