### PR TITLE
support cancellation of generation

### DIFF
--- a/apps/assistants/models.py
+++ b/apps/assistants/models.py
@@ -51,5 +51,8 @@ class OpenAiAssistant(BaseTeamModel):
     def formatted_tools(self):
         return [{"type": tool} for tool in self.builtin_tools]
 
+    def get_llm_service(self):
+        return self.llm_provider.get_llm_service()
+
     def get_assistant(self):
         return self.llm_provider.get_llm_service().get_assistant(self.assistant_id, as_agent=True)

--- a/apps/assistants/models.py
+++ b/apps/assistants/models.py
@@ -51,8 +51,5 @@ class OpenAiAssistant(BaseTeamModel):
     def formatted_tools(self):
         return [{"type": tool} for tool in self.builtin_tools]
 
-    def get_llm_service(self):
-        return self.llm_provider.get_llm_service()
-
     def get_assistant(self):
         return self.llm_provider.get_llm_service().get_assistant(self.assistant_id, as_agent=True)

--- a/apps/service_providers/llm_service/callbacks.py
+++ b/apps/service_providers/llm_service/callbacks.py
@@ -1,5 +1,6 @@
 import threading
 from typing import Any
+from uuid import UUID
 
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.language_models import BaseLanguageModel
@@ -33,3 +34,17 @@ class TokenCountingCallbackHandler(BaseCallbackHandler):
 
         with self._lock:
             self.completion_tokens += self.model.get_num_tokens_from_messages(messages)
+
+    def on_llm_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run when LLM errors and collect token usage."""
+        response = kwargs.get("response", None)
+        if not response:
+            return
+        self.on_llm_end(response)

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -145,9 +145,13 @@ class ExperimentRunnable(BaseExperimentRunnable):
 
         output = ""
         for token in chain.stream(input, config):
-            output += token
+            output += self._parse_output(token)
             if self._chat_is_cancelled():
                 return output
+        return output
+
+    def _parse_output(self, output):
+        return output
 
     def _chat_is_cancelled(self):
         if self.cancelled:
@@ -216,14 +220,8 @@ class SimpleExperimentRunnable(ExperimentRunnable):
 
 
 class AgentExperimentRunnable(ExperimentRunnable):
-    def _get_output_check_cancellation(self, input, config):
-        chain = self._build_chain()
-        output = ""
-        for step in chain.stream(input, config):
-            if "output" in step:
-                output += step["output"]
-            if self._chat_is_cancelled():
-                return output
+    def _parse_output(self, output):
+        return output.get("output", "")
 
     def _build_chain(self) -> Runnable[dict[str, Any], dict]:
         assert self.experiment.tools_enabled

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -160,6 +160,8 @@ class ExperimentRunnable(BaseExperimentRunnable):
         self.last_cancel_check = time.time()
 
         self.session.chat.refresh_from_db(fields=["metadata"])
+        # temporary mechanism to cancel the chat
+        # TODO: change this to something specific to the current chat message
         if self.session.chat.metadata.get("cancelled", False):
             self.cancelled = True
 

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -22,14 +22,11 @@ ASSISTANT_ID = "test_assistant_id"
 
 
 @pytest.fixture()
-def chat(team_with_users):
-    return Chat.objects.create(team=team_with_users)
-
-
-@pytest.fixture()
-def session(chat):
-    session = ExperimentSessionFactory(chat=chat)
-    local_assistant = OpenAiAssistantFactory(assistant_id=ASSISTANT_ID)
+def session():
+    chat = Chat()
+    chat.save = lambda: None
+    session = ExperimentSessionFactory.build(chat=chat)
+    local_assistant = OpenAiAssistantFactory.build(id=1, assistant_id=ASSISTANT_ID)
     session.experiment.assistant = local_assistant
     return session
 
@@ -37,7 +34,6 @@ def session(chat):
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
 @patch("openai.resources.beta.Threads.create_and_run")
-@pytest.mark.django_db()
 def test_assistant_conversation_new_chat(create_and_run, retrieve_run, list_messages, session):
     chat = session.chat
     assert chat.get_metadata(chat.MetadataKeys.OPENAI_THREAD_ID) is None
@@ -50,7 +46,7 @@ def test_assistant_conversation_new_chat(create_and_run, retrieve_run, list_mess
         ASSISTANT_ID, run.id, thread_id, [{"assistant": "ai response"}]
     )
 
-    assistant = AssistantExperimentRunnable(experiment=session.experiment, session=session)
+    assistant = _get_assistant_mocked_history_recording(session)
     result = assistant.invoke("test")
     assert result.output == "ai response"
     assert chat.get_metadata(chat.MetadataKeys.OPENAI_THREAD_ID) == thread_id
@@ -60,7 +56,6 @@ def test_assistant_conversation_new_chat(create_and_run, retrieve_run, list_mess
 @patch("openai.resources.beta.threads.messages.Messages.create")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
 @patch("openai.resources.beta.threads.runs.Runs.create")
-@pytest.mark.django_db()
 def test_assistant_conversation_existing_chat(create_run, retrieve_run, create_message, list_messages, session):
     thread_id = "test_thread_id"
     chat = session.chat
@@ -73,7 +68,7 @@ def test_assistant_conversation_existing_chat(create_run, retrieve_run, create_m
         ASSISTANT_ID, run.id, thread_id, [{"assistant": "ai response"}]
     )
 
-    assistant = AssistantExperimentRunnable(experiment=session.experiment, session=session)
+    assistant = _get_assistant_mocked_history_recording(session)
     result = assistant.invoke("test")
 
     assert create_message.call_args.args == (thread_id,)
@@ -84,7 +79,6 @@ def test_assistant_conversation_existing_chat(create_run, retrieve_run, create_m
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
 @patch("openai.resources.beta.Threads.create_and_run")
-@pytest.mark.django_db()
 def test_assistant_conversation_input_formatting(create_and_run, retrieve_run, list_messages, session):
     session.experiment.input_formatter = "foo {input} bar"
 
@@ -99,37 +93,32 @@ def test_assistant_conversation_input_formatting(create_and_run, retrieve_run, l
         ASSISTANT_ID, run.id, thread_id, [{"assistant": "ai response"}]
     )
 
-    assistant = AssistantExperimentRunnable(experiment=session.experiment, session=session)
+    assistant = _get_assistant_mocked_history_recording(session)
     result = assistant.invoke("test")
     assert result.output == "ai response"
     assert create_and_run.call_args.kwargs["thread"]["messages"][0]["content"] == "foo test bar"
 
 
-@pytest.mark.django_db()
 def test_assistant_runnable_raises_error(session):
     experiment = session.experiment
 
     error = openai.BadRequestError("test", response=mock.Mock(), body={})
     with mock_experiment_llm(experiment, [error]):
-        assistant = AssistantExperimentRunnable(experiment=experiment, session=session)
-
+        assistant = _get_assistant_mocked_history_recording(session)
         with pytest.raises(openai.BadRequestError):
             assistant.invoke("test")
 
 
-@pytest.mark.django_db()
 def test_assistant_runnable_handles_cancellation_status(session):
     experiment = session.experiment
 
     error = ValueError("unexpected status: cancelled")
     with mock_experiment_llm(experiment, [error]):
-        assistant = AssistantExperimentRunnable(experiment=experiment, session=session)
-
+        assistant = _get_assistant_mocked_history_recording(session)
         with pytest.raises(GenerationCancelled):
             assistant.invoke("test")
 
 
-@pytest.mark.django_db()
 @pytest.mark.parametrize(
     ("responses", "exception", "output"),
     [
@@ -165,20 +154,25 @@ def test_assistant_runnable_handles_cancellation_status(session):
     ],
 )
 def test_assistant_runnable_cancels_existing_run(responses, exception, output, session):
-    experiment = session.experiment
-
     thread_id = "thread_abc"
     session.chat.set_metadata(session.chat.MetadataKeys.OPENAI_THREAD_ID, thread_id)
-    assistant = AssistantExperimentRunnable(experiment=experiment, session=session)
+
+    assistant = _get_assistant_mocked_history_recording(session)
     cancel_run = mock.Mock()
     assistant.__dict__["_cancel_run"] = cancel_run
-    with mock_experiment_llm(experiment, responses):
+    with mock_experiment_llm(session.experiment, responses):
         with exception:
             result = assistant.invoke("test")
 
     if output:
         assert result.output == "normal response"
         cancel_run.assert_called_once()
+
+
+def _get_assistant_mocked_history_recording(session):
+    assistant = AssistantExperimentRunnable(experiment=session.experiment, session=session)
+    assistant.__dict__["_save_message_to_history"] = lambda *args, **kwargs: None
+    return assistant
 
 
 def _create_thread_messages(assistant_id, run_id, thread_id, messages: list[dict[str, str]]):

--- a/apps/service_providers/tests/test_runnables_cancellation.py
+++ b/apps/service_providers/tests/test_runnables_cancellation.py
@@ -1,0 +1,53 @@
+import pytest
+
+from apps.service_providers.llm_service.runnables import (
+    ChainOutput,
+    GenerationCancelled,
+    SimpleExperimentRunnable,
+)
+from apps.utils.factories.experiment import ExperimentSessionFactory
+from apps.utils.langchain import FakeLlm, FakeLlmService
+
+
+@pytest.fixture()
+def fake_llm():
+    return FakeLlm(responses=[["This", " is", " a", " test", " message"]], token_counts=[30, 20, 10])
+
+
+@pytest.fixture()
+def session(fake_llm):
+    session = ExperimentSessionFactory()
+    session.experiment.get_llm_service = lambda: FakeLlmService(llm=fake_llm)
+    session.experiment.tools_enabled = True
+    return session
+
+
+@pytest.mark.django_db()
+def test_simple(session, fake_llm):
+    runnable = SimpleExperimentRunnable(session=session, experiment=session.experiment)
+    _test_runnable(runnable, session)
+
+
+def _test_runnable(runnable, session):
+    original_build = runnable._build_chain
+
+    def _new_build():
+        chain = original_build()
+        orig_stream = chain.stream
+
+        def _stream(*args, **kwargs):
+            """Simulate a cancellation after the 2nd token."""
+            for i, token in enumerate(orig_stream(*args, **kwargs)):
+                if i == 2:
+                    session.chat.metadata = {"cancelled": True}
+                    session.chat.save(update_fields=["metadata"])
+                yield token
+
+        chain.__dict__["stream"] = _stream
+        return chain
+
+    runnable.__dict__["_build_chain"] = _new_build
+
+    with pytest.raises(GenerationCancelled) as exc_info:
+        runnable.invoke("hi")
+    assert exc_info.value.output == ChainOutput(output="This is a", prompt_tokens=30, completion_tokens=20)

--- a/apps/utils/langchain.py
+++ b/apps/utils/langchain.py
@@ -81,9 +81,10 @@ class FakeAssistant(RunnableSerializable[dict, OutputType]):
     i: int = 0
 
     def invoke(self, input: dict, config: RunnableConfig | None = None) -> OutputType:
-        return OpenAIAssistantFinish(
-            return_values={"output": self._get_next_response()}, log="", thread_id="123", run_id="456"
-        )
+        response = self._get_next_response()
+        if isinstance(response, BaseException):
+            raise response
+        return OpenAIAssistantFinish(return_values={"output": response}, log="", thread_id="123", run_id="456")
 
     def _get_next_response(self):
         response = self.responses[self.i]
@@ -95,7 +96,7 @@ class FakeAssistant(RunnableSerializable[dict, OutputType]):
 
 
 @contextmanager
-def mock_experiment_llm(experiment, responses: list[str], token_counts: list[int] = None):
+def mock_experiment_llm(experiment, responses: list[Any], token_counts: list[int] = None):
     original = experiment.get_llm_service
 
     experiment.get_llm_service = lambda: FakeLlmService(

--- a/apps/utils/langchain.py
+++ b/apps/utils/langchain.py
@@ -5,8 +5,9 @@ from unittest import mock
 
 from langchain.agents.openai_assistant.base import OpenAIAssistantFinish, OutputType
 from langchain_community.chat_models import FakeListChatModel
-from langchain_core.messages import BaseMessage
-from langchain_core.outputs import ChatGenerationChunk
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.runnables import RunnableConfig, RunnableSerializable
 
 from apps.service_providers.llm_service import LlmService
@@ -19,13 +20,33 @@ class FakeLlm(FakeListChatModel):
     token_i: int = 0
     calls: list = []
 
-    def _call(self, messages: list[BaseMessage], *args, **kwargs) -> str:
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        output = self._call(messages, stop=stop, run_manager=run_manager, **kwargs)
+        if isinstance(output, BaseMessage):
+            message = output
+        else:
+            message = AIMessage(content=output)
+
+        generation = ChatGeneration(message=message)
+        return ChatResult(generations=[generation])
+
+    def _call(self, messages: list[BaseMessage], *args, **kwargs) -> str | BaseMessage:
         self.calls.append(mock.call(messages, *args, **kwargs))
         return super()._call(messages, *args, **kwargs)
 
     def _stream(self, messages: list[BaseMessage], *args, **kwargs) -> Iterator[ChatGenerationChunk]:
-        self.calls.append(mock.call(messages, *args, **kwargs))
-        return super()._stream(messages, *args, **kwargs)
+        response = self._call(messages, *args, **kwargs)
+        if isinstance(response, BaseMessage):
+            yield ChatGenerationChunk(message=response)
+        else:
+            for c in response:
+                yield ChatGenerationChunk(message=AIMessageChunk(content=c))
 
     def get_num_tokens_from_messages(self, messages: list) -> int:
         token_counts = self.token_counts[self.token_i]


### PR DESCRIPTION
Part 1 of #268

(best reviewed by commit)

This updates the bot runnables to stream their outputs and detect if the output should be cancelled or not.

The implementation is slightly different for the different runnable types based on how they function:

* simple runnable
  * Just stream the tokens and check after each token if cancellation is necessary
* agent runnable
  * stream the steps and check after each step if cancellation is necessary. Agents don't stream individual tokens, only steps
* assistant runnable
  * let OpenAI tell us if another run is running and then cancel that run. Also handle the state when a run get's cancelled during processing.

Setting the cancellation status has been left for a future PR. The current mechanism uses the 'chat.metadata' dict to store a cancellation status.

## Safety

This is pretty well covered by tests and I have tested it locally. The cancellation checks are only executed every 1s so it won't add much load to the DB.
