### PR TITLE
change polling to avoid getting duplicate messages

### DIFF
--- a/templates/experiments/chat/chat_message_response.html
+++ b/templates/experiments/chat/chat_message_response.html
@@ -17,7 +17,7 @@
         Please try again, and wait a few minutes if this keeps happening.
       </p>
     {% else %}
-      <span class="loading-dots">Thinking</span>
+      <span class="loading loading-dots loading-sm"></span>
     {% endif %}
   </div>
 </div>

--- a/templates/experiments/chat/chat_ui.html
+++ b/templates/experiments/chat/chat_ui.html
@@ -28,9 +28,14 @@
 {% include 'experiments/chat/input_bar.html' %}
 {% include 'experiments/chat/end_experiment_modal.html' %}
 <script>
+  let refreshTimer = null;
+  const pollInterval = 60000;
+
   function scrollToBottom() {
     const chatUI = document.getElementById('message-list');
     chatUI.scrollTop = chatUI.scrollHeight;
+    cancelPolling();
+    refreshTimer = setTimeout(pollBackend, pollInterval);
   }
 
   function appendMessage(messageHTML) {
@@ -51,6 +56,9 @@
     var url = messageListDiv.getAttribute('data-url');
     const lastMessage = messageListDiv.lastElementChild
     const lastDateTime = lastMessage.getAttribute('data-last-message-datetime')
+    if (!lastDateTime) {
+      return;
+    }
     url = url + "?since=" + lastDateTime
     console.log(url);
     fetch(url)
@@ -64,12 +72,16 @@
       });
   }
 
-  const pollInterval = 60000;
-  setInterval(pollBackend, pollInterval);
+  function cancelPolling() {
+    if (refreshTimer) {
+      clearTimeout(refreshTimer);
+    }
+  }
 
   // Scroll to the bottom of the chat after initial load
   window.addEventListener('load', scrollToBottom);
 
   // Scroll to the bottom of the chat after every htmx request
   document.body.addEventListener('htmx:afterOnLoad', scrollToBottom);
+  document.body.addEventListener('htmx:beforeRequest', cancelPolling);
 </script>


### PR DESCRIPTION
There was a race condition where the poll would execute at the same time as a new message was added so the message would get added twice, once from htmx and once from the poll.

This is a minimal change to prevent that by cancelling the poll before an HTMX request is sent and then starting it again after.