### PR TITLE
rename views to make it clearer what each does

### DIFF
--- a/apps/experiments/decorators.py
+++ b/apps/experiments/decorators.py
@@ -115,7 +115,7 @@ def _validate_access_cookie_data(experiment_session, access_data):
 def _redirect_for_state(request, experiment_session, team_slug):
     view_args = [team_slug, experiment_session.experiment.public_id, experiment_session.public_id]
     if experiment_session.status in [SessionStatus.SETUP, SessionStatus.PENDING]:
-        return HttpResponseRedirect(reverse("experiments:start_experiment_session", args=view_args))
+        return HttpResponseRedirect(reverse("experiments:start_session_from_invite", args=view_args))
     elif experiment_session.status == SessionStatus.PENDING_PRE_SURVEY:
         return HttpResponseRedirect(reverse("experiments:experiment_pre_survey", args=view_args))
     elif experiment_session.status == SessionStatus.ACTIVE:

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -461,7 +461,8 @@ class ExperimentSession(BaseTeamModel):
     def get_invite_url(self) -> str:
         return absolute_url(
             reverse(
-                "experiments:start_experiment_session", args=[self.team.slug, self.experiment.public_id, self.public_id]
+                "experiments:start_session_from_invite",
+                args=[self.team.slug, self.experiment.public_id, self.public_id],
             )
         )
 

--- a/apps/experiments/tests/test_session_access_cookie.py
+++ b/apps/experiments/tests/test_session_access_cookie.py
@@ -73,7 +73,7 @@ def test_access_permitted_for_session_user(client, session):
 def test_access_cookie_not_set_on_session_start_get(client, session):
     response = client.get(
         reverse(
-            "experiments:start_experiment_session",
+            "experiments:start_session_from_invite",
             args=[session.experiment.team.slug, session.experiment.public_id, session.public_id],
         ),
     )
@@ -85,7 +85,7 @@ def test_access_cookie_not_set_on_session_start_get(client, session):
 def test_access_cookie_not_set_on_session_start_with_inavalid_form(client, session):
     response = client.post(
         reverse(
-            "experiments:start_experiment_session",
+            "experiments:start_session_from_invite",
             args=[session.experiment.team.slug, session.experiment.public_id, session.public_id],
         ),
         data={},
@@ -97,7 +97,7 @@ def test_access_cookie_not_set_on_session_start_with_inavalid_form(client, sessi
 def _start_session(client, session):
     response = client.post(
         reverse(
-            "experiments:start_experiment_session",
+            "experiments:start_session_from_invite",
             args=[session.experiment.team.slug, session.experiment.public_id, session.public_id],
         ),
         data={

--- a/apps/experiments/urls.py
+++ b/apps/experiments/urls.py
@@ -75,8 +75,8 @@ urlpatterns = [
     # public links
     path(
         "e/<slug:experiment_id>/s/<slug:session_id>/",
-        views.start_experiment_session,
-        name="start_experiment_session",
+        views.start_session_from_invite,
+        name="start_session_from_invite",
     ),
     path(
         "e/<slug:experiment_id>/s/<slug:session_id>/pre-survey/",

--- a/apps/experiments/urls.py
+++ b/apps/experiments/urls.py
@@ -110,7 +110,7 @@ urlpatterns = [
         name="experiment_session_pagination_view",
     ),
     # public link
-    path("e/<slug:experiment_id>/start/", views.start_experiment, name="start_experiment"),
+    path("e/<slug:experiment_id>/start/", views.start_session_public, name="start_session_public"),
 ]
 
 urlpatterns.extend(make_crud_urls(views, "SafetyLayer", "safety"))

--- a/apps/experiments/urls.py
+++ b/apps/experiments/urls.py
@@ -43,7 +43,11 @@ urlpatterns = [
     path("e/<int:experiment_id>/", views.single_experiment_home, name="single_experiment_home"),
     path("e/<int:pk>/edit/", views.EditExperiment.as_view(), name="edit"),
     path("e/<int:pk>/delete/", views.delete_experiment, name="delete"),
-    path("e/<int:experiment_id>/start_session/", views.start_session, name="start_session"),
+    path(
+        "e/<int:experiment_id>/start_authed_web_session/",
+        views.start_authed_web_session,
+        name="start_authed_web_session",
+    ),
     path("e/<int:experiment_id>/create_channel/", views.create_channel, name="create_channel"),
     path("e/<int:experiment_id>/update_channel/<int:channel_id>/", views.update_delete_channel, name="update_channel"),
     path(

--- a/apps/experiments/views/__init__.py
+++ b/apps/experiments/views/__init__.py
@@ -28,7 +28,7 @@ from .experiment import (  # noqa: F401
     send_invitation,
     single_experiment_home,
     start_experiment_session,
-    start_session,
+    start_authed_web_session,
     start_session_public,
     update_delete_channel,
 )

--- a/apps/experiments/views/__init__.py
+++ b/apps/experiments/views/__init__.py
@@ -27,9 +27,9 @@ from .experiment import (  # noqa: F401
     poll_messages,
     send_invitation,
     single_experiment_home,
-    start_experiment,
     start_experiment_session,
     start_session,
+    start_session_public,
     update_delete_channel,
 )
 from .no_activity import (  # noqa: F401

--- a/apps/experiments/views/__init__.py
+++ b/apps/experiments/views/__init__.py
@@ -27,8 +27,8 @@ from .experiment import (  # noqa: F401
     poll_messages,
     send_invitation,
     single_experiment_home,
-    start_experiment_session,
     start_authed_web_session,
+    start_session_from_invite,
     start_session_public,
     update_delete_channel,
 )

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -668,11 +668,11 @@ def start_session_from_invite(request, team_slug: str, experiment_id: str, sessi
     initial = {
         "experiment_id": experiment.id,
     }
-    if experiment_session.participant:
-        initial["participant_id"] = experiment_session.participant.id
-        initial["identifier"] = experiment_session.participant.identifier
-    elif not request.user.is_anonymous:
-        initial["identifier"] = request.user.email
+    if not experiment_session.participant:
+        raise Http404()
+
+    initial["participant_id"] = experiment_session.participant.id
+    initial["identifier"] = experiment_session.participant.identifier
 
     if request.method == "POST":
         form = ConsentForm(consent, request.POST, initial=initial)

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -517,7 +517,7 @@ def poll_messages(request, team_slug: str, experiment_id: int, session_id: int):
     )
 
 
-def start_experiment(request, team_slug: str, experiment_id: str):
+def start_session_public(request, team_slug: str, experiment_id: str):
     try:
         experiment = get_object_or_404(Experiment, public_id=experiment_id, is_active=True, team=request.team)
     except ValidationError:

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -660,7 +660,7 @@ def _record_consent_and_redirect(request, team_slug: str, experiment_session: Ex
 
 
 @experiment_session_view(allowed_states=[SessionStatus.SETUP, SessionStatus.PENDING])
-def start_experiment_session(request, team_slug: str, experiment_id: str, session_id: str):
+def start_session_from_invite(request, team_slug: str, experiment_id: str, session_id: str):
     experiment = get_object_or_404(Experiment, public_id=experiment_id, team=request.team)
     experiment_session = get_object_or_404(ExperimentSession, experiment=experiment, public_id=session_id)
     consent = experiment.consent_form

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -413,7 +413,7 @@ def _check_and_process_seed_message(session: ExperimentSession):
 
 @require_POST
 @login_and_team_required
-def start_session(request, team_slug: str, experiment_id: int):
+def start_authed_web_session(request, team_slug: str, experiment_id: int):
     experiment = get_object_or_404(Experiment, id=experiment_id, team=request.team)
     experiment_channel = _ensure_experiment_channel_exists(
         experiment=experiment, platform="web", name=f"{experiment.id}-web"

--- a/locust/locustfile.py
+++ b/locust/locustfile.py
@@ -62,7 +62,7 @@ class BotUser(HttpUser):
         logging.debug("===================== %s: %s =====================", chat_id, len(messages))
         csrftoken = self._get_csrf(f"/a/{team}/experiments/e/{experiment_id}/")
         with self.client.post(
-            f"/a/{team}/experiments/e/{experiment_id}/start_session/",
+            f"/a/{team}/experiments/e/{experiment_id}/start_authed_web_session/",
             headers={"X-CSRFToken": csrftoken},
             cookies={"csrftoken": csrftoken},
             allow_redirects=False,

--- a/templates/experiments/components/experiment_actions_column.html
+++ b/templates/experiments/components/experiment_actions_column.html
@@ -1,4 +1,4 @@
-<form method="post" action="{% url 'experiments:start_session' record.team.slug record.id %}" class="inline">
+<form method="post" action="{% url 'experiments:start_authed_web_session' record.team.slug record.id %}" class="inline">
   {% csrf_token %}
   <button type="submit" class="btn btn-sm" title="New Session">
     <i class="fa-solid fa-file-circle-plus"></i>

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -20,7 +20,7 @@
           {% if experiment.is_active %}
             <div class="tooltip" data-tip="Public Link">
               <a class="btn btn-primary join-item rounded-l-full"
-                 href="{% url 'experiments:start_experiment' team.slug experiment.public_id %}" target="_blank">
+                 href="{% url 'experiments:start_session_public' team.slug experiment.public_id %}" target="_blank">
                 <i class="fa-solid fa-link"></i>
               </a>
             </div>

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -26,7 +26,7 @@
             </div>
           {% endif %}
           <div class="tooltip" data-tip="Start Web Session">
-            <form method="post" action="{% url 'experiments:start_session' team.slug experiment.id %}" class="inline">
+            <form method="post" action="{% url 'experiments:start_authed_web_session' team.slug experiment.id %}" class="inline">
               {% csrf_token %}
               <button type="submit" class="btn btn-primary join-item">
                 <i class="fa-solid fa-file-circle-plus"></i>


### PR DESCRIPTION
* 'start_experiment' -> 'start_session_public'
  * public shareable link
* 'start_session' -> 'start_authed_web_session'
  * web user clicks 'start session'
* 'start_experiment_session' -> 'start_session_from_invite'
  * emailed invite link

Also small change to require participants for 'invite' sessions. This is already a requirement when sending the invitations: https://github.com/dimagi/open-chat-studio/blob/ff1c1a7bb09ca83031ddc0da69a2e02fc3ec3d71/apps/experiments/email.py#L10-L11