### PR TITLE
misc changes to invitation flow and related UIs

### DIFF
--- a/apps/teams/forms.py
+++ b/apps/teams/forms.py
@@ -127,9 +127,15 @@ class InvitationForm(forms.ModelForm):
     class Meta:
         model = Invitation
         fields = ("email", "groups")
+        widgets = {
+            "groups": forms.CheckboxSelectMultiple(),
+        }
 
 
 class MembershipForm(forms.ModelForm):
     class Meta:
         model = Membership
         fields = ("groups",)
+        widgets = {
+            "groups": forms.CheckboxSelectMultiple(),
+        }

--- a/apps/teams/forms.py
+++ b/apps/teams/forms.py
@@ -30,6 +30,9 @@ class TeamSignupForm(SignupForm):
         else:
             del self.fields["terms_agreement"]
 
+        if "email" in kwargs.get("initial", {}):
+            self.fields["email"].widget.attrs = {"readonly": "readonly"}
+
     def clean(self):
         cleaned_data = super().clean()
         if not self.errors:

--- a/apps/teams/forms.py
+++ b/apps/teams/forms.py
@@ -71,8 +71,8 @@ class TeamSignupForm(SignupForm):
             if invite.is_accepted:
                 raise forms.ValidationError(
                     _(
-                        "It looks like that invitation link has expired. "
-                        "Please request a new invitation or sign in to continue."
+                        "The invitation has already been accepted. "
+                        "Please sign in to continue or request a new invitation."
                     )
                 )
 

--- a/apps/teams/forms.py
+++ b/apps/teams/forms.py
@@ -114,8 +114,11 @@ class InvitationForm(forms.ModelForm):
 
     def clean_email(self):
         email = self.cleaned_data["email"]
+        if Membership.objects.filter(team=self.team, user__email=email).exists():
+            raise ValidationError(_("A user with that email is already a member of this team."))
+
         # confirm no other pending invitations for this email
-        if Invitation.objects.filter(team=self.team, email=email, is_accepted=False):
+        if Invitation.objects.filter(team=self.team, email=email, is_accepted=False).exists():
             raise ValidationError(
                 _(
                     'There is already a pending invitation for {}. You can resend it by clicking "Resend Invitation".'

--- a/apps/teams/forms.py
+++ b/apps/teams/forms.py
@@ -114,11 +114,11 @@ class InvitationForm(forms.ModelForm):
 
     def clean_email(self):
         email = self.cleaned_data["email"]
-        if Membership.objects.filter(team=self.team, user__email=email).exists():
+        if Membership.objects.filter(team=self.team, user__email__iexact=email).exists():
             raise ValidationError(_("A user with that email is already a member of this team."))
 
         # confirm no other pending invitations for this email
-        if Invitation.objects.filter(team=self.team, email=email, is_accepted=False).exists():
+        if Invitation.objects.filter(team=self.team, email__iexact=email, is_accepted=False).exists():
             raise ValidationError(
                 _(
                     'There is already a pending invitation for {}. You can resend it by clicking "Resend Invitation".'

--- a/apps/teams/views/invitation_views.py
+++ b/apps/teams/views/invitation_views.py
@@ -51,6 +51,15 @@ def accept_invitation(request, invitation_id):
 
 
 class SignupAfterInvite(SignupView):
+    def get(self, request, *args, **kwargs):
+        if self.invitation.is_accepted:
+            messages.warning(
+                self.request,
+                _("The invitation has already been accepted. Please sign in to continue or request a new invitation."),
+            )
+            return redirect("web:home")
+        return super().get(request, *args, **kwargs)
+
     def is_open(self):
         """Allow signups from invitations even if public signups are closed."""
         return True
@@ -60,12 +69,7 @@ class SignupAfterInvite(SignupView):
         from ..models import Invitation
 
         invitation_id = self.kwargs["invitation_id"]
-
-        invitation = get_object_or_404(Invitation, id=invitation_id)
-        if invitation.is_accepted:
-            messages.error(self.request, _("Sorry, it looks like that invitation link has expired."))
-            return redirect("web:home")
-        return invitation
+        return get_object_or_404(Invitation, id=invitation_id)
 
     def get_initial(self):
         initial = super().get_initial()

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -197,7 +197,7 @@ else:
 ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_SUBJECT_PREFIX = ""
-ACCOUNT_CONFIRM_EMAIL_ON_GET = True
+ACCOUNT_CONFIRM_EMAIL_ON_GET = False
 ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_USERNAME_REQUIRED = False
 ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE = False
@@ -210,7 +210,7 @@ ACCOUNT_FORMS = {
 
 # User signup configuration: change to "mandatory" to require users to confirm email before signing in.
 # or "optional" to send confirmation emails but not require them
-ACCOUNT_EMAIL_VERIFICATION = env("ACCOUNT_EMAIL_VERIFICATION", default="none")
+ACCOUNT_EMAIL_VERIFICATION = env("ACCOUNT_EMAIL_VERIFICATION", default="mandatory")
 
 ALLAUTH_2FA_ALWAYS_REVEAL_BACKUP_TOKENS = False
 

--- a/templates/account/base.html
+++ b/templates/account/base.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% block body %}
   <div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-    <div class="max-w-md w-full space-y-8">
+    <div class="max-w-lg w-full space-y-8">
       {% block content %}
       {% endblock content %}
     </div>

--- a/templates/account/email_confirm.html
+++ b/templates/account/email_confirm.html
@@ -2,28 +2,38 @@
 {% load i18n %}
 {% load account %}
 {% block content %}
-  <h1 class="pg-title">{% translate "Confirm E-mail Address" %}</h1>
   {% if confirmation %}
     {% user_display confirmation.email_address.user as user_display %}
-    <p class="pg-content">
-      {% blocktranslate with confirmation.email_address.email as email %}
-        Please confirm that <a href="mailto:{{ email }}">{{ email }}</a>
-        is an e-mail address for user {{ user_display }}.
-      {% endblocktranslate %}
+    <p class="pg-content text-center">
+      <i class="fa-solid fa-circle-check fa-beat mb-4 text-success" style="--fa-beat-scale: 2.0; --fa-animation-iteration-count: 1;"></i>
+      <br/>
+      <a href="mailto:{{ confirmation.email_address.email }}">{{ confirmation.email_address.email }}</a>
     </p>
-    <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+    <p class="pg-content text-center">
+      {% translate "Thanks for verifying your email address." %}<br/>
+      {% translate "You will be redirected shortly." %}
+    </p>
+    <form method="post" action="{% url 'account_confirm_email' confirmation.key %}" id="confirmation_form">
       {% csrf_token %}
-      <div class="mt-2">
-        <button class="pg-button-primary" type="submit">{% translate 'Confirm' %}</button>
-      </div>
     </form>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        document.getElementById("confirmation_form").submit();
+      });
+    </script>
   {% else %}
     {% url 'account_email' as email_url %}
-    <p class="pg-content">
-      {% blocktranslate %}
-        This e-mail confirmation link expired or is invalid.
-        Please <a href="{{ email_url }}">issue a new e-mail confirmation request</a>.
-      {% endblocktranslate %}
-    </p>
+    <div class="prose max-w-none lg:prose-lg">
+      <p>
+        {% blocktranslate %}
+          This e-mail confirmation link expired or the email address has already been confirmed.
+        {% endblocktranslate %}
+      </p>
+      <p>
+        {% blocktranslate %}
+          If you are not able to log in, you can <a href="{{ email_url }}">request a new e-mail confirmation link</a>.
+        {% endblocktranslate %}
+      </p>
+    </div>
   {% endif %}
 {% endblock %}

--- a/templates/teams/accept_invite.html
+++ b/templates/teams/accept_invite.html
@@ -45,7 +45,7 @@
             {% endif %}
           {% else %}
             <p class="pg-subtitle">
-              {% translate "Sorry, it looks like that invitation has already been accepted or expired." %}
+              {% translate "That invitation has already been accepted, signing in." %}
             </p>
             <p>
               {% translate "If you think this is a mistake, ask your team administrator to invite you again!" %}


### PR DESCRIPTION
After digging into some issues users have had with the email confirmation flow I _think_ it is because the confirmation link is getting loaded prior to the browser rendering it e.g. by email clients or some other process. Since we had it set up to confirm the email on GET, by the time the user loaded the link in the browser the email address was already confirmed and the user got shown the error message.

I have changed it to require a POST request for confirmation. To keep the flow smooth I've set up a small JS event handler to automatically submit the form when the page is loaded in a browser.

I also made various text changes to the messaging to make it less confusing if they do happen to access the confirmation link again.

Other changes:
* Change user groups form to use check boxes instead of multi-select
* Check for existing team membership before creating new invitations