### PR TITLE
Audio fix:Convert synthesized audio to a supported format

### DIFF
--- a/apps/channels/tests/test_whatsapp_integration.py
+++ b/apps/channels/tests/test_whatsapp_integration.py
@@ -9,6 +9,7 @@ from apps.channels.models import ChannelPlatform
 from apps.channels.tasks import handle_turn_message, handle_twilio_message
 from apps.chat.channels import MESSAGE_TYPES
 from apps.service_providers.models import MessagingProviderType
+from apps.service_providers.speech_service import SynthesizedAudio
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.service_provider_factories import MessagingProviderFactory
 
@@ -81,7 +82,7 @@ class TestTwilio:
         message_type,
     ):
         """Test that the twilio integration can use the WhatsappChannel implementation"""
-        synthesize_voice_mock.return_value = (BytesIO(b"123"), 10)
+        synthesize_voice_mock.return_value = SynthesizedAudio(audio=BytesIO(b"123"), duration=10, format="mp3")
         with patch("apps.service_providers.messaging_service.TwilioService.s3_client"), patch(
             "apps.service_providers.messaging_service.TwilioService.client"
         ):

--- a/apps/channels/tests/test_whatsapp_integration.py
+++ b/apps/channels/tests/test_whatsapp_integration.py
@@ -96,6 +96,40 @@ class TestTwilio:
             # elif message_type == "audio": TODO: Figure out why this is not passing in the github workflows
             #     s3_client_mock.generate_presigned_url.assert_called()
 
+    @pytest.mark.usefixtures("_twilio_whatsapp_channel")
+    @pytest.mark.parametrize(
+        "synthesized_audio_format",
+        ["wav", "mp3"],
+    )
+    @patch("apps.service_providers.messaging_service.audio.convert_audio")
+    @patch("apps.chat.channels.ChannelBase._get_voice_transcript")
+    @patch("apps.service_providers.speech_service.SpeechService.synthesize_voice")
+    @patch("apps.chat.channels.WhatsappChannel._get_llm_response")
+    def test_convert_audio_to_supported_format(
+        self,
+        get_llm_response_mock,
+        synthesize_voice_mock,
+        _get_voice_transcript,
+        convert_audio_mock,
+        synthesized_audio_format,
+    ):
+        """Test that the synthesized audio is converted to mp3 before being sent to Twilio"""
+        synthesize_voice_mock.return_value = SynthesizedAudio(
+            audio=BytesIO(b"123"), duration=10, format=synthesized_audio_format
+        )
+        _get_voice_transcript.return_value = "Hi"
+        convert_audio_mock.return_value = BytesIO(b"123")
+
+        with patch("apps.service_providers.messaging_service.TwilioService.s3_client"), patch(
+            "apps.service_providers.messaging_service.TwilioService.client"
+        ):
+            get_llm_response_mock.return_value = "Hi"
+            handle_twilio_message(message_data=twilio_messages.audio_message())
+            if synthesized_audio_format == "mp3":
+                convert_audio_mock.assert_not_called()
+            else:
+                convert_audio_mock.assert_called()
+
 
 class TestTurnio:
     @pytest.mark.parametrize(
@@ -143,3 +177,32 @@ class TestTurnio:
         handle_turn_message(experiment_id=turnio_whatsapp_channel.experiment.public_id, message_data=incoming_message)
         _handle_unsupported_message.assert_called()
         _handle_supported_message.assert_not_called()
+
+    @pytest.mark.parametrize("synthesized_audio_format", ["wav", "ogg", "mp3"])
+    @patch("apps.service_providers.messaging_service.audio.convert_audio")
+    @patch("apps.chat.channels.ChannelBase._get_voice_transcript")
+    @patch("apps.service_providers.speech_service.SpeechService.synthesize_voice")
+    @patch("apps.chat.channels.WhatsappChannel._get_llm_response")
+    def test_audio_is_always_converted(
+        self,
+        _get_llm_response,
+        synthesize_voice_mock,
+        get_voice_transcript_mock,
+        convert_audio_mock,
+        db,
+        turnio_whatsapp_channel,
+        synthesized_audio_format,
+    ):
+        """Test that the synthesized audio is always converted to ogg format with the libopus codec"""
+        synthesize_voice_mock.return_value = SynthesizedAudio(
+            audio=BytesIO(b"123"), duration=10, format=synthesized_audio_format
+        )
+        _get_llm_response.return_value = "Hi"
+        get_voice_transcript_mock.return_value = "Hi"
+        convert_audio_mock.return_value = BytesIO(b"123")
+
+        with patch("apps.service_providers.messaging_service.TurnIOService.client"):
+            handle_turn_message(
+                experiment_id=turnio_whatsapp_channel.experiment.public_id, message_data=turnio_messages.audio_message()
+            )
+            convert_audio_mock.assert_called()

--- a/apps/channels/tests/test_whatsapp_integration.py
+++ b/apps/channels/tests/test_whatsapp_integration.py
@@ -101,7 +101,7 @@ class TestTwilio:
         "synthesized_audio_format",
         ["wav", "mp3"],
     )
-    @patch("apps.service_providers.messaging_service.audio.convert_audio")
+    @patch("apps.service_providers.messaging_service.convert_audio")
     @patch("apps.chat.channels.ChannelBase._get_voice_transcript")
     @patch("apps.service_providers.speech_service.SpeechService.synthesize_voice")
     @patch("apps.chat.channels.WhatsappChannel._get_llm_response")
@@ -179,7 +179,7 @@ class TestTurnio:
         _handle_supported_message.assert_not_called()
 
     @pytest.mark.parametrize("synthesized_audio_format", ["wav", "ogg", "mp3"])
-    @patch("apps.service_providers.messaging_service.audio.convert_audio")
+    @patch("apps.service_providers.messaging_service.convert_audio")
     @patch("apps.chat.channels.ChannelBase._get_voice_transcript")
     @patch("apps.service_providers.speech_service.SpeechService.synthesize_voice")
     @patch("apps.chat.channels.WhatsappChannel._get_llm_response")

--- a/apps/channels/tests/test_whatsapp_integration.py
+++ b/apps/channels/tests/test_whatsapp_integration.py
@@ -101,7 +101,7 @@ class TestTwilio:
         "synthesized_audio_format",
         ["wav", "mp3"],
     )
-    @patch("apps.service_providers.messaging_service.convert_audio")
+    @patch("apps.channels.audio.convert_audio")
     @patch("apps.chat.channels.ChannelBase._get_voice_transcript")
     @patch("apps.service_providers.speech_service.SpeechService.synthesize_voice")
     @patch("apps.chat.channels.WhatsappChannel._get_llm_response")
@@ -179,7 +179,7 @@ class TestTurnio:
         _handle_supported_message.assert_not_called()
 
     @pytest.mark.parametrize("synthesized_audio_format", ["wav", "ogg", "mp3"])
-    @patch("apps.service_providers.messaging_service.convert_audio")
+    @patch("apps.channels.audio.convert_audio")
     @patch("apps.chat.channels.ChannelBase._get_voice_transcript")
     @patch("apps.service_providers.speech_service.SpeechService.synthesize_voice")
     @patch("apps.chat.channels.WhatsappChannel._get_llm_response")

--- a/apps/service_providers/messaging_service.py
+++ b/apps/service_providers/messaging_service.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from turn import TurnClient
 from twilio.rest import Client
 
-from apps.channels.audio import convert_audio
+from apps.channels import audio
 from apps.channels.datamodels import TurnWhatsappMessage, TwilioMessage
 from apps.channels.models import ChannelPlatform
 from apps.chat.channels import MESSAGE_TYPES
@@ -64,7 +64,7 @@ class TwilioService(MessagingService):
     def send_whatsapp_voice_message(self, synthetic_voice: SynthesizedAudio, from_number: str, to_number):
         voice_audio = synthetic_voice.audio
         if synthetic_voice.format != "mp3":
-            voice_audio = convert_audio(
+            voice_audio = audio.convert_audio(
                 synthetic_voice.audio, target_format="mp3", source_format=synthetic_voice.format
             )
 
@@ -95,7 +95,7 @@ class TwilioService(MessagingService):
     def get_message_audio(self, message: TwilioMessage) -> BytesIO:
         auth = (self.account_sid, self.auth_token)
         ogg_audio = BytesIO(requests.get(message.media_url, auth=auth).content)
-        return convert_audio(ogg_audio, target_format="wav", source_format="ogg")
+        return audio.convert_audio(ogg_audio, target_format="wav", source_format="ogg")
 
 
 class TurnIOService(MessagingService):
@@ -115,7 +115,7 @@ class TurnIOService(MessagingService):
 
     def send_whatsapp_voice_message(self, synthetic_voice: SynthesizedAudio, from_number: str, to_number: str):
         # OGG must use the opus codec: https://whatsapp.turn.io/docs/api/media#uploading-media
-        voice_audio = convert_audio(
+        voice_audio = audio.convert_audio(
             synthetic_voice.audio, target_format="ogg", source_format=synthetic_voice.format, codec="libopus"
         )
         media_id = self.client.media.upload_media(voice_audio.read(), content_type="audio/ogg")
@@ -124,4 +124,4 @@ class TurnIOService(MessagingService):
     def get_message_audio(self, message: TurnWhatsappMessage) -> BytesIO:
         response = self.client.media.get_media(message.media_id)
         ogg_audio = BytesIO(response.content)
-        return convert_audio(ogg_audio, target_format="wav", source_format="ogg")
+        return audio.convert_audio(ogg_audio, target_format="wav", source_format="ogg")

--- a/apps/service_providers/messaging_service.py
+++ b/apps/service_providers/messaging_service.py
@@ -15,6 +15,7 @@ from apps.channels import audio
 from apps.channels.datamodels import TurnWhatsappMessage, TwilioMessage
 from apps.channels.models import ChannelPlatform
 from apps.chat.channels import MESSAGE_TYPES
+from apps.service_providers.speech_service import SynthesizedAudio
 
 
 class MessagingService(pydantic.BaseModel):
@@ -26,7 +27,7 @@ class MessagingService(pydantic.BaseModel):
     def send_whatsapp_text_message(self, message: str, from_number: str, to_number):
         raise NotImplementedError
 
-    def send_whatsapp_voice_message(self, media_url: str, from_number: str, to_number):
+    def send_whatsapp_voice_message(self, synthetic_voice: SynthesizedAudio, from_number: str, to_number: str):
         raise NotImplementedError
 
     def get_message_audio(self, message: TwilioMessage | TurnWhatsappMessage):
@@ -60,7 +61,13 @@ class TwilioService(MessagingService):
     def send_whatsapp_text_message(self, message: str, from_number: str, to_number):
         self.client.messages.create(from_=f"whatsapp:{from_number}", body=message, to=f"whatsapp:{to_number}")
 
-    def send_whatsapp_voice_message(self, voice_audio: BytesIO, duration: int, from_number: str, to_number):
+    def send_whatsapp_voice_message(self, synthetic_voice: SynthesizedAudio, from_number: str, to_number):
+        voice_audio = synthetic_voice.audio
+        if synthetic_voice.format != "mp3":
+            voice_audio = audio.convert_audio(
+                synthetic_voice.audio, target_format="mp3", source_format=synthetic_voice.format
+            )
+
         file_path = f"{uuid.uuid4()}.mp3"
         audio_bytes = voice_audio.getvalue()
         self.s3_client.upload_fileobj(
@@ -70,7 +77,7 @@ class TwilioService(MessagingService):
             ExtraArgs={
                 "Expires": datetime.utcnow() + timedelta(minutes=7),
                 "Metadata": {
-                    "DurationSeconds": str(duration),
+                    "DurationSeconds": str(synthetic_voice.duration),
                 },
                 "ContentType": "audio/mpeg",
             },
@@ -106,11 +113,11 @@ class TurnIOService(MessagingService):
     def send_whatsapp_text_message(self, message: str, from_number: str, to_number):
         self.client.messages.send_text(to_number, message)
 
-    def send_whatsapp_voice_message(self, voice_audio: BytesIO, duration: int, from_number: str, to_number: str):
-        from apps.channels.audio import convert_audio
-
+    def send_whatsapp_voice_message(self, synthetic_voice: SynthesizedAudio, from_number: str, to_number: str):
         # OGG must use the opus codec: https://whatsapp.turn.io/docs/api/media#uploading-media
-        voice_audio = convert_audio(voice_audio, target_format="ogg", source_format="mp3", codec="libopus")
+        voice_audio = audio.convert_audio(
+            synthetic_voice.audio, target_format="ogg", source_format=synthetic_voice.format, codec="libopus"
+        )
         media_id = self.client.media.upload_media(voice_audio.read(), content_type="audio/ogg")
         self.client.messages.send_audio(whatsapp_id=to_number, media_id=media_id)
 

--- a/apps/service_providers/speech_service.py
+++ b/apps/service_providers/speech_service.py
@@ -8,6 +8,7 @@ import boto3
 import pydantic
 from pydub import AudioSegment
 
+from apps.channels.audio import convert_audio
 from apps.chat.exceptions import AudioSynthesizeException
 from apps.experiments.models import SyntheticVoice
 
@@ -96,7 +97,9 @@ class AzureSpeechService(SpeechService):
                 with open(temp_file.name, "rb") as f:
                     file_content = f.read()
 
-                return BytesIO(file_content), duration_seconds
+                return convert_audio(
+                    audio=BytesIO(file_content), target_format="mp3", source_format="wav"
+                ), duration_seconds
             elif result.reason == speechsdk.ResultReason.Canceled:
                 cancellation_details = result.cancellation_details
                 msg = f"Azure speech synthesis failed: {cancellation_details.reason.name}"

--- a/apps/service_providers/speech_service.py
+++ b/apps/service_providers/speech_service.py
@@ -1,5 +1,6 @@
 import tempfile
 from contextlib import closing
+from dataclasses import dataclass
 from io import BytesIO
 from typing import ClassVar
 
@@ -8,16 +9,22 @@ import boto3
 import pydantic
 from pydub import AudioSegment
 
-from apps.channels.audio import convert_audio
 from apps.chat.exceptions import AudioSynthesizeException
 from apps.experiments.models import SyntheticVoice
+
+
+@dataclass
+class SynthesizedAudio:
+    audio: BytesIO
+    duration: float
+    format: str
 
 
 class SpeechService(pydantic.BaseModel):
     _type: ClassVar[str]
     supports_transcription: ClassVar[bool] = False
 
-    def synthesize_voice(self, text: str, synthetic_voice: SyntheticVoice) -> tuple[BytesIO, float]:
+    def synthesize_voice(self, text: str, synthetic_voice: SyntheticVoice) -> SynthesizedAudio:
         assert synthetic_voice.service == self._type
         try:
             return self._synthesize_voice(text, synthetic_voice)
@@ -27,7 +34,7 @@ class SpeechService(pydantic.BaseModel):
     def transcribe_audio(self, audio: BytesIO) -> str:
         raise NotImplementedError
 
-    def _synthesize_voice(self, text, synthetic_voice) -> tuple[BytesIO, float]:
+    def _synthesize_voice(self, text, synthetic_voice) -> SynthesizedAudio:
         raise NotImplementedError
 
 
@@ -37,7 +44,7 @@ class AWSSpeechService(SpeechService):
     aws_secret_access_key: str
     aws_region: str
 
-    def _synthesize_voice(self, text: str, synthetic_voice: SyntheticVoice) -> tuple[BytesIO, float]:
+    def _synthesize_voice(self, text: str, synthetic_voice: SyntheticVoice) -> SynthesizedAudio:
         """
         Calls AWS Polly to convert the text to speech using the synthetic_voice
         """
@@ -59,7 +66,7 @@ class AWSSpeechService(SpeechService):
         duration_seconds = len(audio_segment) / 1000  # Convert milliseconds to seconds
 
         with closing(audio_stream):
-            return BytesIO(audio_data), duration_seconds
+            return SynthesizedAudio(audio=BytesIO(audio_data), duration=duration_seconds, format="mp3")
 
 
 class AzureSpeechService(SpeechService):
@@ -68,7 +75,7 @@ class AzureSpeechService(SpeechService):
     azure_subscription_key: str
     azure_region: str
 
-    def _synthesize_voice(self, text: str, synthetic_voice: SyntheticVoice) -> tuple[BytesIO, float]:
+    def _synthesize_voice(self, text: str, synthetic_voice: SyntheticVoice) -> SynthesizedAudio:
         """
         Calls Azure's cognitive speech services to convert the text to speech using the synthetic_voice
         """
@@ -97,9 +104,7 @@ class AzureSpeechService(SpeechService):
                 with open(temp_file.name, "rb") as f:
                     file_content = f.read()
 
-                return convert_audio(
-                    audio=BytesIO(file_content), target_format="mp3", source_format="wav"
-                ), duration_seconds
+                return SynthesizedAudio(audio=BytesIO(file_content), duration=duration_seconds, format="wav")
             elif result.reason == speechsdk.ResultReason.Canceled:
                 cancellation_details = result.cancellation_details
                 msg = f"Azure speech synthesis failed: {cancellation_details.reason.name}"

--- a/apps/service_providers/speech_service.py
+++ b/apps/service_providers/speech_service.py
@@ -9,6 +9,7 @@ import boto3
 import pydantic
 from pydub import AudioSegment
 
+from apps.channels.audio import convert_audio
 from apps.chat.exceptions import AudioSynthesizeException
 from apps.experiments.models import SyntheticVoice
 
@@ -18,6 +19,15 @@ class SynthesizedAudio:
     audio: BytesIO
     duration: float
     format: str
+
+    def get_audio_bytes(self, format: str, codec: str | None = None) -> bytes:
+        """Returns the audio bytes in the specified `format` and `codec`. A conversion will always be triggered
+        when `codec` is specified to ensure that this codec was used.
+        """
+        audio = self.audio
+        if self.format != format or codec is not None:
+            audio = convert_audio(audio=self.audio, target_format=format, source_format=self.format, codec=codec)
+        return audio.getvalue()
 
 
 class SpeechService(pydantic.BaseModel):

--- a/apps/service_providers/tests/test_synthesized_audio.py
+++ b/apps/service_providers/tests/test_synthesized_audio.py
@@ -8,7 +8,7 @@ from apps.service_providers.speech_service import SynthesizedAudio
 
 @pytest.mark.parametrize(
     ("source_format", "target_format", "codec", "conversion_expected"),
-    [("mp3", "ogg", None, True), ("mp3", "mp3", None, False), ("mp3", "ogg", "libopus", True)],
+    [("mp3", "ogg", None, True), ("mp3", "mp3", None, False), ("ogg", "ogg", "libopus", True)],
 )
 def test_synthesized_audio(source_format, target_format, codec, conversion_expected):
     audio = SynthesizedAudio(audio=BytesIO(b"123"), duration=10.0, format=source_format)

--- a/apps/service_providers/tests/test_synthesized_audio.py
+++ b/apps/service_providers/tests/test_synthesized_audio.py
@@ -1,0 +1,23 @@
+from io import BytesIO
+from unittest import mock
+
+import pytest
+
+from apps.service_providers.speech_service import SynthesizedAudio
+
+
+@pytest.mark.parametrize(
+    ("source_format", "target_format", "codec", "conversion_expected"),
+    [("mp3", "ogg", None, True), ("mp3", "mp3", None, False), ("mp3", "ogg", "libopus", True)],
+)
+def test_synthesized_audio(source_format, target_format, codec, conversion_expected):
+    audio = SynthesizedAudio(audio=BytesIO(b"123"), duration=10.0, format=source_format)
+
+    with mock.patch("apps.service_providers.speech_service.convert_audio") as convert_audio:
+        convert_audio.return_value = BytesIO(b"321")
+        audio.get_audio_bytes(target_format, codec)
+
+        if conversion_expected:
+            convert_audio.assert_called()
+        else:
+            convert_audio.assert_not_called()

--- a/apps/service_providers/tests/test_voice_providers.py
+++ b/apps/service_providers/tests/test_voice_providers.py
@@ -5,6 +5,7 @@ import pytest
 from apps.experiments.models import SyntheticVoice
 from apps.service_providers.exceptions import ServiceProviderConfigError
 from apps.service_providers.models import VoiceProvider, VoiceProviderType
+from apps.service_providers.speech_service import SynthesizedAudio
 
 
 def test_aws_voice_provider(team_with_users):
@@ -100,7 +101,7 @@ def _test_voice_provider(team, provider_type: VoiceProviderType, data):
 
     speech_service = provider.get_speech_service()
     # bypass pydantic validation
-    mock_synthesize = mock.Mock(return_value=(None, 0.0))
+    mock_synthesize = mock.Mock(return_value=(SynthesizedAudio(audio=None, duration=0.0, format="mp3")))
     object.__setattr__(speech_service, "_synthesize_voice", mock_synthesize)
     speech_service.synthesize_voice("test", voice)
     assert mock_synthesize.call_count == 1


### PR DESCRIPTION
This addresses the issue where Azure's synthesized audio is in wav format, so when this voice provider is used with the Twilio messaging provider - which supports only mp3 - stuff breaks.

This PR adds a `SynthesizedAudio` dataclass to hold info pertaining to synthesized audio. This info is used to convert the audio to a supported format for the messaging service. We could have simply converted the synthesized audio from Azure to mp3 before returning it to the `BaseChannel` class, but it doesn't feel very robust, since then we have to remember that all synthesized audio must be in mp3 format (or document it and trust that people will read and rember this detail). Another approach could be to check if it's mp3 just before returning and raise an error if it's not, but blehg. I instead opted for the approach of returning the synthesized audio info (the raw audio, duration and format) so that each messaging provider can convert is as needed.

Tested this locally and it works