### PR TITLE
Fix: Ignore all non-user messages from Turn.io

### DIFF
--- a/apps/channels/admin.py
+++ b/apps/channels/admin.py
@@ -6,13 +6,7 @@ from apps.channels.models import ExperimentChannel
 
 @admin.register(ExperimentChannel)
 class ExperimentChannelAdmin(admin.ModelAdmin):
-    list_display = (
-        "name",
-        "team",
-        "platform",
-        "deleted",
-        "external_id",
-    )
+    list_display = ("name", "team", "platform", "deleted", "external_id", "messaging_provider")
     search_fields = ("name", "external_id")
     list_filter = (
         "platform",
@@ -24,6 +18,11 @@ class ExperimentChannelAdmin(admin.ModelAdmin):
         "created_at",
         "updated_at",
     )
+
+    @admin.display(description="Messaging Provider")
+    def messaging_provider(self, obj):
+        if obj.messaging_provider:
+            return obj.messaging_provider.name
 
     @admin.display(description="Team")
     def team(self, obj):

--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -125,7 +125,7 @@ class TurnWhatsappMessage(BaseModel):
             from_number=message_data["contacts"][0]["wa_id"],
             body=body,
             content_type=message_type,
-            media_id=message[message_type].get("id"),
+            media_id=message.get(message_type, {}).get("id", None),
             content_type_unparsed=message_type,
         )
 

--- a/apps/channels/tests/message_examples/turnio_messages.py
+++ b/apps/channels/tests/message_examples/turnio_messages.py
@@ -41,21 +41,21 @@ def text_message():
     }
 
 
-def audio_message():
+def voice_message():
     return {
         "contacts": [{"profile": {"name": "User"}, "wa_id": "27456897512"}],
         "messages": [
             {
                 "_vnd": {
                     "v1": {
-                        "author": {"id": "27456897512", "name": "Chris Smit", "type": "OWNER"},
+                        "author": {"id": "27456897512", "name": "John Doe", "type": "OWNER"},
                         "card_uuid": "None",
                         "chat": {
                             "assigned_to": "None",
-                            "contact_uuid": "eeb51508-4ff0-4ca4-9bf8-69e548b1ceb3",
+                            "contact_uuid": "ef59c32dsd9-289d-474e-aab1-e0dsss19f1f4",
                             "inserted_at": "2024-01-25T09:02:46.684610Z",
                             "owner": "+27456897512",
-                            "permalink": "https://whatsapp.turn.io/app/c/08a64841-10df-4c11-b81f-4ec36d616c1c",
+                            "permalink": "https://whatsapp.turn.io/app/c/ef59c32dsd9-289d-474e-aab1-e0dsss19f1f4",
                             "state": "OPEN",
                             "state_reason": "Re-opened by inbound message.",
                             "unread_count": 31,

--- a/apps/channels/tests/message_examples/turnio_messages.py
+++ b/apps/channels/tests/message_examples/turnio_messages.py
@@ -41,6 +41,64 @@ def text_message():
     }
 
 
+def outbound_message():
+    """An outbound message is one that the bot sends to the user. Depending on how the user configures the webhook,
+    Turn.io might forward any outbound messages to the server as well.
+    """
+
+    return {
+        "_vnd": {
+            "v1": {
+                "author": {"id": "ef59c32dsd9-289d-474e-aab1-e0dsss19f1f4", "name": "Dev token", "type": "SYSTEM"},
+                "card_uuid": None,
+                "chat": {
+                    "assigned_to": None,
+                    "contact_uuid": "eeb51508-4ff0-4ca4-9bf8-69e548b1ceb3",
+                    "inserted_at": "2024-01-25T09:02:46.684610Z",
+                    "owner": "+0723456789",
+                    "permalink": "https://whatsapp.turn.io/app/c/08a64841-10df-4c11-b81f-4ec36d616c1c",
+                    "state": "OPEN",
+                    "state_reason": "Re-opened by inbound message.",
+                    "unread_count": 54,
+                    "updated_at": "2024-03-12T09:16:38.690961Z",
+                    "uuid": "ef59c32dsd9-289d-474e-aab1-e0dsss19f1f4",
+                },
+                "direction": "outbound",
+                "faq_uuid": None,
+                "in_reply_to": None,
+                "inserted_at": "2024-03-12T09:16:38.678761Z",
+                "labels": [],
+                "last_status": None,
+                "last_status_timestamp": None,
+                "on_fallback_channel": False,
+                "rendered_content": None,
+                "uuid": "761bcbf9-53b1-043f-be33-e74c7d3fc86d",
+            }
+        },
+        "from": "15550104171",
+        "id": "wamid.HBgLMjc4MjY0MTk5NzcVAgARGBI2NThCNjVCOEUxMzZBMjhDMDMA",
+        "preview_url": False,
+        "recipient_type": "individual",
+        "text": {"body": "Guten Tag!"},
+        "timestamp": "1710234998",
+        "to": "0723456789",
+        "type": "text",
+    }
+
+
+def status_message():
+    return {
+        "statuses": [
+            {
+                "id": "ABGGFlA5FpafAgo6tHcNmNjXmuSf",
+                "status": "sent",
+                "timestamp": "1518694700",
+                "message": {"recipient_id": "16315555555"},
+            }
+        ]
+    }
+
+
 def voice_message():
     return {
         "contacts": [{"profile": {"name": "User"}, "wa_id": "27456897512"}],

--- a/apps/channels/tests/test_whatsapp_integration.py
+++ b/apps/channels/tests/test_whatsapp_integration.py
@@ -100,7 +100,7 @@ class TestTwilio:
 class TestTurnio:
     @pytest.mark.parametrize(
         ("message", "message_type"),
-        [(turnio_messages.text_message(), "text"), (turnio_messages.audio_message(), "voice")],
+        [(turnio_messages.text_message(), "text"), (turnio_messages.voice_message(), "voice")],
     )
     def test_parse_text_message(self, message, message_type):
         message = TurnWhatsappMessage.parse(message)
@@ -112,7 +112,7 @@ class TestTurnio:
             assert message.media_id == "180e1c3f-ae50-481b-a9f0-7c698233965f"
             assert message.content_type == MESSAGE_TYPES.VOICE
 
-    @pytest.mark.parametrize("incoming_message", [turnio_messages.text_message(), turnio_messages.audio_message()])
+    @pytest.mark.parametrize("incoming_message", [turnio_messages.text_message(), turnio_messages.voice_message()])
     @patch("apps.chat.channels.ChannelBase._get_voice_transcript")
     @patch("apps.service_providers.messaging_service.TurnIOService.send_whatsapp_text_message")
     @patch("apps.chat.channels.WhatsappChannel._get_llm_response")

--- a/apps/channels/views.py
+++ b/apps/channels/views.py
@@ -30,8 +30,8 @@ def new_twilio_message(request):
 @csrf_exempt
 def new_turn_message(request, experiment_id: uuid):
     message_data = json.loads(request.body.decode("utf-8"))
-    if "statuses" in message_data:
-        # Ignore status updates
+    if "messages" not in message_data:
+        # Normal inbound messages should have a "messages" key, so ignore everything else
         return HttpResponse()
 
     tasks.handle_turn_message.delay(experiment_id=experiment_id, message_data=message_data)


### PR DESCRIPTION
The issue: https://dimagi.sentry.io/share/issue/2dfca4995eca4b678ba51724c349d804/

Depending on how the user configures their webhook, Turn.io will send a copy of all outbound messages to the server as well. We now ignore all messages if they do not have a `messages` key, which all user messages should have [according to the docs](https://whatsapp.turn.io/docs/api/webhooks#inbound-message-webhooks).

I also updated the `ExperimentChannel` admin page to show the service provider of the channel if there's one