### PR TITLE
Remove extra newlines in LLMs response

### DIFF
--- a/apps/chat/templatetags/chat_tags.py
+++ b/apps/chat/templatetags/chat_tags.py
@@ -11,4 +11,10 @@ register = template.Library()
 def render_markdown(text):
     if not text:
         return ""
-    return linebreaksbr(mark_safe(markdown.markdown(text, extensions=[FencedCodeExtension()])))
+    text = markdown.markdown(text, extensions=[FencedCodeExtension()])
+    text = text.replace("</li>\n<li>", "</li><li>")
+    text = text.replace("<ol>\n<li>", "<ol><li>")
+    text = text.replace("</li>\n</ol>", "</li></ol>")
+    text = text.replace("<li>\n<p>", "<li><p>")
+    text = text.replace("</p>\n</li>", "</p></li>")
+    return linebreaksbr(mark_safe(text))


### PR DESCRIPTION
A very naive way of fixing the weird spacing we get when the LLM returns a list. There are typically two newline characters between the items, where the first one gets converted into a \<li\> or \<p\> tag and the second into a \<br\> tag when we call `linebreaksbr`. If we simply remove the `linebreaksbr` call, then the paragraphs gets squashed which doesn't look very good. Any recommendations welcome.

## Before
![b_1](https://github.com/dimagi/open-chat-studio/assets/64970009/8dca5115-c540-49da-81d3-e1b12b1cf48a)
![b_2](https://github.com/dimagi/open-chat-studio/assets/64970009/22d294b7-ae6d-4a35-92bc-5c1e227054c2)

## After
![a_1](https://github.com/dimagi/open-chat-studio/assets/64970009/228f3eb1-6d01-4762-a702-5ee4ac1e3457)
![a_2](https://github.com/dimagi/open-chat-studio/assets/64970009/b6176b11-9cb2-40eb-9f92-22c442811afc)

