### PR TITLE
take summary length into account when compression chat history

### DIFF
--- a/apps/chat/tests/test_compress_chat_history.py
+++ b/apps/chat/tests/test_compress_chat_history.py
@@ -24,7 +24,6 @@ def _patch_initial_tokens():
 
 @pytest.fixture()
 def chat(team_with_users):
-    # TODO: change to using unsaved / mock instance
     chat = Chat.objects.create(team=team_with_users)
     ChatMessage.objects.create(chat=chat, content="Hello", message_type=ChatMessageType.HUMAN)
     return chat

--- a/apps/chat/tests/test_compress_chat_history.py
+++ b/apps/chat/tests/test_compress_chat_history.py
@@ -1,12 +1,22 @@
 import pytest
+from langchain_core.language_models import BaseLanguageModel
 
 from apps.chat.conversation import compress_chat_history
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
 from apps.utils.langchain import FakeLlm
 
 
+class FakeLlmSimpleTokenCount(FakeLlm):
+    def get_num_tokens(self, text: str) -> int:
+        return len(text.split())
+
+    def get_num_tokens_from_messages(self, messages: list) -> int:
+        return BaseLanguageModel.get_num_tokens_from_messages(self, messages)
+
+
 @pytest.fixture()
 def chat(team_with_users):
+    # TODO: change to using unsaved / mock instance
     chat = Chat.objects.create(team=team_with_users)
     ChatMessage.objects.create(chat=chat, content="Hello", message_type=ChatMessageType.HUMAN)
     return chat
@@ -14,7 +24,7 @@ def chat(team_with_users):
 
 @pytest.fixture()
 def llm():
-    llm = FakeLlm(responses=["Summary"], token_counts=[30, 20, 10])
+    llm = FakeLlmSimpleTokenCount(responses=["Summary"])
     return llm
 
 
@@ -27,9 +37,10 @@ def test_compress_chat_history_with_need_for_compression(chat, llm):
     for i in range(15):
         ChatMessage.objects.create(chat=chat, content=f"Hello {i}", message_type=ChatMessageType.HUMAN)
     result = compress_chat_history(chat, llm, 20)
-    assert len(result) == 11
+    # 6 messages * 3 tokens + 2 tokens for summary
+    assert len(result) == 7
     assert result[0].content == "Summary"
-    assert result[1].content == "Hello 5"
+    assert result[1].content == "Hello 9"
     assert ChatMessage.objects.get(id=result[1].additional_kwargs["id"]).summary == "Summary"
 
 
@@ -38,18 +49,44 @@ def test_compress_chat_history_with_need_for_compression_after_truncate(chat, ll
     messages are removed (1 in this case)"""
     for i in range(15):
         ChatMessage.objects.create(chat=chat, content=f"Hello {i}", message_type=ChatMessageType.HUMAN)
-    result = compress_chat_history(chat, llm, 10)
-    print(result)
-    assert len(result) == 10
+    result = compress_chat_history(chat, llm, 17)
+    # 5 messages * 3 tokens + 2 tokens for summary
+    assert len(result) == 6
     assert result[0].content == "Summary"
-    assert result[1].content == "Hello 6"
+    assert result[1].content == "Hello 10"
 
 
-def test_compress_chat_history_second_compression(chat, llm):
+def test_compress_chat_history_not_needed_with_summary(chat, llm):
     for i in range(15):
-        summary = "Summary old" if i == 7 else None
+        summary = "Summary old" if i == 10 else None
         ChatMessage.objects.create(chat=chat, content=f"Hello {i}", message_type=ChatMessageType.HUMAN, summary=summary)
     result = compress_chat_history(chat, llm, 20)
-    assert len(result) == 9
-    assert result[0].content == "Summary"
-    assert result[1].content == "Hello 7"
+    assert len(result) == 6
+    assert result[0].content == "Summary old"
+    assert result[1].content == "Hello 10"
+
+
+def test_compression_with_large_summary(chat, llm):
+    for i in range(15):
+        ChatMessage.objects.create(chat=chat, content=f"Hello {i}", message_type=ChatMessageType.HUMAN)
+
+    summary_content = "Summary " * 20
+    llm.responses = [summary_content]
+    result = compress_chat_history(chat, llm, 26)
+    # 1 message * 3 tokens + 21 tokens for summary
+    assert len(result) == 2
+    assert result[0].content == summary_content
+    assert result[1].content == "Hello 14"
+
+
+def test_compression_exhausts_history(chat, llm):
+    messages = ChatMessage.objects.bulk_create(
+        [ChatMessage(chat=chat, content=f"Hello {i}", message_type=ChatMessageType.HUMAN) for i in range(15)]
+    )
+
+    summary_content = "Summary " * 20
+    llm.responses = [summary_content]
+    result = compress_chat_history(chat, llm, 20)
+    assert len(result) == 1
+    assert result[0].content == summary_content
+    assert ChatMessage.objects.get(id=messages[-1].id).summary == summary_content

--- a/apps/chat/tests/test_compress_chat_history.py
+++ b/apps/chat/tests/test_compress_chat_history.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from langchain_core.language_models import BaseLanguageModel
 
@@ -12,6 +14,12 @@ class FakeLlmSimpleTokenCount(FakeLlm):
 
     def get_num_tokens_from_messages(self, messages: list) -> int:
         return BaseLanguageModel.get_num_tokens_from_messages(self, messages)
+
+
+@pytest.fixture(autouse=True)
+def _patch_initial_tokens():
+    with mock.patch("apps.chat.conversation.INITIAL_SUMMARY_TOKENS_ESTIMATE", 2):
+        yield
 
 
 @pytest.fixture()
@@ -31,22 +39,24 @@ def llm():
 def test_compress_history_no_need_for_compression(chat, llm):
     history = compress_chat_history(chat, llm, max_token_limit=30, keep_history_len=10)
     assert len(history) == 1
+    assert len(llm.get_calls()) == 0
 
 
-def test_compress_chat_history_with_need_for_compression(chat, llm):
+def test_compress_history(chat, llm):
     for i in range(15):
         ChatMessage.objects.create(chat=chat, content=f"Hello {i}", message_type=ChatMessageType.HUMAN)
-    result = compress_chat_history(chat, llm, 20)
-    # 6 messages * 3 tokens + 2 tokens for summary
-    assert len(result) == 7
+    result = compress_chat_history(chat, llm, 20, keep_history_len=5)
+    # 5 messages * 3 tokens + 2 tokens for summary
+    assert len(result) == 6
     assert result[0].content == "Summary"
-    assert result[1].content == "Hello 9"
+    assert result[1].content == "Hello 10"
     assert ChatMessage.objects.get(id=result[1].additional_kwargs["id"]).summary == "Summary"
+    assert len(llm.get_calls()) == 1
 
 
 def test_compress_chat_history_with_need_for_compression_after_truncate(chat, llm):
     """History is still over token limit after truncating to keep_history_len so more
-    messages are removed (1 in this case)"""
+    messages are removed"""
     for i in range(15):
         ChatMessage.objects.create(chat=chat, content=f"Hello {i}", message_type=ChatMessageType.HUMAN)
     result = compress_chat_history(chat, llm, 17)
@@ -54,9 +64,10 @@ def test_compress_chat_history_with_need_for_compression_after_truncate(chat, ll
     assert len(result) == 6
     assert result[0].content == "Summary"
     assert result[1].content == "Hello 10"
+    assert len(llm.get_calls()) == 1
 
 
-def test_compress_chat_history_not_needed_with_summary(chat, llm):
+def test_compress_chat_history_not_needed_with_existing_summary(chat, llm):
     for i in range(15):
         summary = "Summary old" if i == 10 else None
         ChatMessage.objects.create(chat=chat, content=f"Hello {i}", message_type=ChatMessageType.HUMAN, summary=summary)
@@ -64,6 +75,7 @@ def test_compress_chat_history_not_needed_with_summary(chat, llm):
     assert len(result) == 6
     assert result[0].content == "Summary old"
     assert result[1].content == "Hello 10"
+    assert len(llm.get_calls()) == 0
 
 
 def test_compression_with_large_summary(chat, llm):
@@ -77,6 +89,7 @@ def test_compression_with_large_summary(chat, llm):
     assert len(result) == 2
     assert result[0].content == summary_content
     assert result[1].content == "Hello 14"
+    assert len(llm.get_calls()) == 2
 
 
 def test_compression_exhausts_history(chat, llm):
@@ -90,3 +103,4 @@ def test_compression_exhausts_history(chat, llm):
     assert len(result) == 1
     assert result[0].content == summary_content
     assert ChatMessage.objects.get(id=messages[-1].id).summary == summary_content
+    assert len(llm.get_calls()) == 2

--- a/apps/utils/langchain.py
+++ b/apps/utils/langchain.py
@@ -16,7 +16,7 @@ from apps.service_providers.llm_service import LlmService
 class FakeLlm(FakeListChatModel):
     """Extension of the FakeListChatModel that allows mocking of the token counts."""
 
-    token_counts: list
+    token_counts: list = []
     token_i: int = 0
     calls: list = []
 


### PR DESCRIPTION
The previous implementation compressed the history to below the max length but then added the summary on top of that.

This update continues to loop until the history is exhausted or the total length (including the summary) is less than the max.

It is still possible to get a message > max if the summary alone is greater but that seems unlikely.

Resolves https://dimagi.sentry.io/share/issue/dcccf4ff11de4c94b371e996dfcdc850/