### PR TITLE
Fix: Consider message type when checking what the user said

### DIFF
--- a/apps/channels/tests/test_base_channel_behavior.py
+++ b/apps/channels/tests/test_base_channel_behavior.py
@@ -320,6 +320,7 @@ def test_reply_with_text_when_synthetic_voice_not_specified(
     send_text_to_user.assert_called()
 
 
+@pytest.mark.django_db()
 @pytest.mark.parametrize(
     ("message_func", "message_type"),
     [(telegram_messages.audio_message, "voice"), (telegram_messages.text_message, "text")],
@@ -327,7 +328,7 @@ def test_reply_with_text_when_synthetic_voice_not_specified(
 @patch("apps.chat.channels.TelegramChannel.send_text_to_user")
 @patch("apps.chat.channels.TelegramChannel._get_llm_response")
 def test_user_query_extracted_for_pre_conversation_flow(
-    _get_llm_response, send_text_to_user_mock, message_func, message_type, db
+    _get_llm_response, send_text_to_user_mock, message_func, message_type
 ):
     """The user query need to be available during the pre-conversation flow. Simply looking at `message_text` for
     this is erroneous, since it will not be available when the user sends a voice message.

--- a/apps/channels/tests/test_base_channel_behavior.py
+++ b/apps/channels/tests/test_base_channel_behavior.py
@@ -3,7 +3,7 @@ This test suite is designed to ensure that the base channel functionality is wor
 intended. It utilizes the Telegram channel subclass to serve as a testing framework.
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 
@@ -12,7 +12,7 @@ from apps.chat.channels import TelegramChannel
 from apps.chat.models import ChatMessageType
 from apps.experiments.models import ExperimentSession, SessionStatus, VoiceResponseBehaviours
 from apps.utils.factories.channels import ExperimentChannelFactory
-from apps.utils.factories.experiment import ExperimentFactory
+from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.langchain import mock_experiment_llm
 
 from .message_examples import telegram_messages
@@ -318,3 +318,38 @@ def test_reply_with_text_when_synthetic_voice_not_specified(
 
     _reply_voice_message.assert_not_called()
     send_text_to_user.assert_called()
+
+
+@pytest.mark.parametrize(
+    ("message_func", "message_type"),
+    [(telegram_messages.audio_message, "voice"), (telegram_messages.text_message, "text")],
+)
+@patch("apps.chat.channels.TelegramChannel.send_text_to_user")
+@patch("apps.chat.channels.TelegramChannel._get_llm_response")
+def test_user_query_extracted_for_pre_conversation_flow(
+    _get_llm_response, send_text_to_user_mock, message_func, message_type, db
+):
+    """The user query need to be available during the pre-conversation flow. Simply looking at `message_text` for
+    this is erroneous, since it will not be available when the user sends a voice message.
+
+    This test simply makes sure that we are able to get the user query when we need it.
+    """
+    experiment = ExperimentFactory(conversational_consent_enabled=True, seed_message="Hi human")
+    experiment_session = ExperimentSessionFactory(experiment=experiment)
+
+    channel = TelegramChannel(experiment_channel=ExperimentChannelFactory(experiment=experiment))
+    channel.experiment_session = experiment_session
+    pre_survey = experiment.pre_survey
+    telegram_chat_id = "123"
+    assert pre_survey
+
+    with patch("apps.chat.channels.TelegramChannel._get_voice_transcript") as _get_voice_transcript:
+        with patch("apps.chat.channels.TelegramChannel.message_text", new_callable=PropertyMock) as message_text_mock:
+            _get_voice_transcript.return_value = "Hi botty"
+            message_text_mock.return_value = "Hi botty"
+
+            channel.new_user_message(message_func(chat_id=telegram_chat_id))
+            if message_type == "voice":
+                _get_voice_transcript.assert_called()
+            elif message_type == "text":
+                message_text_mock.assert_called()

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -93,7 +93,7 @@ class ChannelBase:
         self.experiment_channel = experiment_channel if experiment_channel else experiment_session.experiment_channel
         self.experiment = experiment_channel.experiment if experiment_channel else experiment_session.experiment
         self.message = None
-
+        self._user_query = None
         self.initialize()
 
     @abstractmethod
@@ -172,8 +172,18 @@ class ChannelBase:
             experiment_channel=experiment_session.experiment_channel, experiment_session=experiment_session
         )
 
+    @property
+    def user_query(self):
+        """Returns the user query, extracted from whatever (supported) message type was used to convey the
+        message
+        """
+        if not self._user_query:
+            self._user_query = self._extract_user_query()
+        return self._user_query
+
     def _add_message(self, message):
         """Adds the message to the handler in order to extract session information"""
+        self._user_query = None
         self.message = message
         self._ensure_sessions_exists()
 
@@ -217,7 +227,7 @@ class ChannelBase:
         (Status==PENDING_PRE_SURVEY) user indicated that they took the survey -> sett status to ACTIVE
         """
         # We manually add the message to the history here, since this doesn't follow the normal flow
-        self._add_message_to_history(self.message_text, ChatMessageType.HUMAN)
+        self._add_message_to_history(self.user_query, ChatMessageType.HUMAN)
 
         if self.experiment_session.status == SessionStatus.SETUP:
             self._chat_initiated()
@@ -275,7 +285,7 @@ class ChannelBase:
         ]
 
     def _user_gave_consent(self) -> bool:
-        return self.message_text.strip() == USER_CONSENT_TEXT
+        return self.user_query.strip() == USER_CONSENT_TEXT
 
     def _extract_user_query(self) -> str:
         if self.message_content_type == MESSAGE_TYPES.VOICE:
@@ -299,8 +309,7 @@ class ChannelBase:
         send_message_func(bot_message)
 
     def _handle_supported_message(self):
-        user_query = self._extract_user_query()
-        response = self._get_llm_response(user_query)
+        response = self._get_llm_response(self.user_query)
         self._send_message_to_user(response)
         # Returning the response here is a bit of a hack to support chats through the web UI while trying to
         # use a coherent interface to manage / handle user messages
@@ -420,7 +429,7 @@ class ChannelBase:
         )
 
     def _is_reset_conversation_request(self):
-        return self.message_text == ExperimentChannel.RESET_COMMAND
+        return self.user_query == ExperimentChannel.RESET_COMMAND
 
     def is_message_type_supported(self) -> bool:
         return self.message_content_type is not None and self.message_content_type in self.supported_message_types


### PR DESCRIPTION
Fixes [this issue](https://dimagi.sentry.io/issues/5086818703/?project=4505001320316928&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=5). The issue is due to the code looking at `channel.message_text` during the pre-conversation flow, thereby assuming that it will always be populated, but when a voice message is sent, it is `None`. We now call a method that extracts the user's query on demand.

Note: We don't support voice interactions for the pre-conversation flow, but this is an issue for another time/PR. At least it doesn't break now