### PR TITLE
Update `new_bot_message` implementation + new test

### DIFF
--- a/apps/channels/tests/conftest.py
+++ b/apps/channels/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+from apps.service_providers.models import MessagingProviderType
+from apps.utils.factories.service_provider_factories import MessagingProviderFactory
+
+
+@pytest.fixture()
+def twilio_provider(db):
+    return MessagingProviderFactory(
+        name="twilio", type=MessagingProviderType.twilio, config={"auth_token": "123", "account_sid": "123"}
+    )
+
+
+@pytest.fixture()
+def turn_io_provider():
+    return MessagingProviderFactory(name="turnio", type=MessagingProviderType.turnio, config={"auth_token": "123"})

--- a/apps/channels/tests/test_base_channel_behavior.py
+++ b/apps/channels/tests/test_base_channel_behavior.py
@@ -373,6 +373,18 @@ def test_all_channels_can_be_instantiated_from_a_session(platform, twilio_provid
 
 
 @pytest.mark.django_db()
+def test_missing_channel_raises_error(twilio_provider):
+    experiment = ExperimentFactory()
+    experiment_channel = ExperimentChannelFactory(
+        messaging_provider=twilio_provider, experiment=experiment, platform="whatsapp"
+    )
+    session = ExperimentSessionFactory(experiment_channel=experiment_channel)
+    session.experiment_channel.platform = "snail_mail"
+    with pytest.raises(Exception, match="Unsupported platform type snail_mail"):
+        ChannelBase.from_experiment_session(session)
+
+
+@pytest.mark.django_db()
 @pytest.mark.parametrize(
     ("message_type", "response_behaviour"),
     [("text", VoiceResponseBehaviours.NEVER), ("voice", VoiceResponseBehaviours.ALWAYS)],

--- a/apps/channels/tests/test_base_channel_behavior.py
+++ b/apps/channels/tests/test_base_channel_behavior.py
@@ -370,3 +370,30 @@ def test_all_channels_can_be_instantiated_from_a_session(platform, twilio_provid
     session = ExperimentSessionFactory(experiment_channel=experiment_channel)
     channel = ChannelBase.from_experiment_session(session)
     assert type(channel) in ChannelBase.__subclasses__()
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("message_type", "response_behaviour"),
+    [("text", VoiceResponseBehaviours.NEVER), ("voice", VoiceResponseBehaviours.ALWAYS)],
+)
+@patch("apps.chat.channels.TelegramChannel._reply_voice_message")
+@patch("apps.chat.channels.TelegramChannel.send_text_to_user")
+def test_new_bot_message(send_text_to_user, _reply_voice_messagem, message_type, response_behaviour, telegram_channel):
+    """A simple test to make sure that when we call `channel_instance.new_bot_message`, the correct message format
+    will be used
+    """
+
+    experiment = telegram_channel.experiment
+    experiment.voice_response_behaviour = response_behaviour
+    experiment.save()
+    bot_message = "Hi user"
+
+    telegram_channel.new_bot_message(bot_message)
+
+    if message_type == "text":
+        send_text_to_user.assert_called()
+        assert send_text_to_user.call_args[0][0] == bot_message
+    else:
+        _reply_voice_messagem.assert_called()
+        assert _reply_voice_messagem.call_args[0][0] == bot_message

--- a/apps/channels/tests/test_facebook_integration.py
+++ b/apps/channels/tests/test_facebook_integration.py
@@ -8,10 +8,8 @@ from apps.channels.datamodels import TwilioMessage
 from apps.channels.models import ChannelPlatform
 from apps.channels.tasks import handle_twilio_message
 from apps.chat.channels import MESSAGE_TYPES
-from apps.service_providers.models import MessagingProviderType
 from apps.service_providers.speech_service import SynthesizedAudio
 from apps.utils.factories.channels import ExperimentChannelFactory
-from apps.utils.factories.service_provider_factories import MessagingProviderFactory
 
 from .message_examples import twilio_messages
 
@@ -23,13 +21,6 @@ def _twilio_whatsapp_channel(twilio_provider):
         messaging_provider=twilio_provider,
         experiment__team=twilio_provider.team,
         extra_data={"page_id": "14155238886"},
-    )
-
-
-@pytest.fixture()
-def twilio_provider(db):
-    return MessagingProviderFactory(
-        name="twilio", type=MessagingProviderType.twilio, config={"auth_token": "123", "account_sid": "123"}
     )
 
 

--- a/apps/channels/tests/test_facebook_integration.py
+++ b/apps/channels/tests/test_facebook_integration.py
@@ -3,6 +3,7 @@ from io import BytesIO
 from unittest.mock import patch
 
 import pytest
+from django.test import override_settings
 
 from apps.channels.datamodels import TwilioMessage
 from apps.channels.models import ChannelPlatform
@@ -51,7 +52,7 @@ class TestTwilio:
             (twilio_messages.Messenger.audio_message(), "audio"),
         ],
     )
-    @patch("apps.service_providers.messaging_service.settings.AWS_ACCESS_KEY_ID", "123")
+    @override_settings(AWS_ACCESS_KEY_ID="123")
     @patch("apps.service_providers.speech_service.SpeechService.synthesize_voice")
     @patch("apps.chat.channels.ChannelBase._get_voice_transcript")
     @patch("apps.service_providers.messaging_service.TwilioService.send_voice_message")

--- a/apps/channels/tests/test_whatsapp_integration.py
+++ b/apps/channels/tests/test_whatsapp_integration.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+from django.test import override_settings
 from django.urls import reverse
 
 from apps.channels.datamodels import TurnWhatsappMessage, TwilioMessage
@@ -57,7 +58,7 @@ class TestTwilio:
         ("incoming_message", "message_type"),
         [(twilio_messages.Whatsapp.text_message(), "text"), (twilio_messages.Whatsapp.audio_message(), "audio")],
     )
-    @patch("apps.service_providers.messaging_service.settings.AWS_ACCESS_KEY_ID", "123")
+    @override_settings(AWS_ACCESS_KEY_ID="123")
     @patch("apps.service_providers.speech_service.SpeechService.synthesize_voice")
     @patch("apps.chat.channels.ChannelBase._get_voice_transcript")
     @patch("apps.service_providers.messaging_service.TwilioService.send_voice_message")

--- a/apps/channels/tests/test_whatsapp_integration.py
+++ b/apps/channels/tests/test_whatsapp_integration.py
@@ -10,17 +10,10 @@ from apps.channels.datamodels import TurnWhatsappMessage, TwilioMessage
 from apps.channels.models import ChannelPlatform
 from apps.channels.tasks import handle_turn_message, handle_twilio_message
 from apps.chat.channels import MESSAGE_TYPES
-from apps.service_providers.models import MessagingProviderType
 from apps.service_providers.speech_service import SynthesizedAudio
 from apps.utils.factories.channels import ExperimentChannelFactory
-from apps.utils.factories.service_provider_factories import MessagingProviderFactory
 
 from .message_examples import turnio_messages, twilio_messages
-
-
-@pytest.fixture()
-def turn_io_provider():
-    return MessagingProviderFactory(name="turnio", type=MessagingProviderType.turnio, config={"auth_token": "123"})
 
 
 @pytest.fixture()
@@ -30,13 +23,6 @@ def turnio_whatsapp_channel(turn_io_provider):
         messaging_provider=turn_io_provider,
         experiment__team=turn_io_provider.team,
         extra_data={"number": "+14155238886"},
-    )
-
-
-@pytest.fixture()
-def twilio_provider(db):
-    return MessagingProviderFactory(
-        name="twilio", type=MessagingProviderType.twilio, config={"auth_token": "123", "account_sid": "123"}
     )
 
 

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -166,6 +166,8 @@ class ChannelBase:
             PlatformMessageHandlerClass = WebChannel
         elif platform == "whatsapp":
             PlatformMessageHandlerClass = WhatsappChannel
+        elif platform == "facebook":
+            PlatformMessageHandlerClass = FacebookMessengerChannel
         else:
             raise Exception(f"Unsupported platform type {platform}")
         return PlatformMessageHandlerClass(

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -594,13 +594,6 @@ class FacebookMessengerChannel(ChannelBase):
     def message_text(self):
         return self.message.message_text
 
-    def new_bot_message(self, bot_message: str):
-        """Handles a message coming from the bot. Call this to send bot messages to the user"""
-        from_ = self.experiment_channel.extra_data.get("page_id")
-        self.messaging_service.send_text_message(
-            bot_message, from_=from_, to=self.chat_id, platform=ChannelPlatform.FACEBOOK
-        )
-
     def get_message_audio(self) -> BytesIO:
         return self.messaging_service.get_message_audio(message=self.message)
 

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -103,6 +103,8 @@ class ChannelBase:
 
     @property
     def chat_id(self) -> int:
+        if self.experiment_session and self.experiment_session.external_chat_id:
+            return self.experiment_session.external_chat_id
         return self.get_chat_id_from_message(self.message)
 
     @abstractmethod
@@ -394,6 +396,7 @@ class ChannelBase:
             # so we don't create channel_sessions for them.
             return
 
+        # We override `self.experiment_session`, since we must always use the latest (or "active") session
         self.experiment_session = (
             ExperimentSession.objects.filter(
                 experiment=self.experiment,

--- a/apps/chat/tasks.py
+++ b/apps/chat/tasks.py
@@ -146,8 +146,8 @@ def _bot_prompt_for_user(experiment_session: ExperimentSession, prompt_instructi
 def _try_send_message(experiment_session: ExperimentSession, message: str):
     """Tries to send a message to the experiment session"""
     try:
-        handler = ChannelBase.from_experiment_session(experiment_session)
-        handler.new_bot_message(message)
+        channel = ChannelBase.from_experiment_session(experiment_session)
+        channel.new_bot_message(message)
     except Exception as e:
         logging.error(f"Could not send message to experiment session {experiment_session.id}. Reason: {e}")
 


### PR DESCRIPTION
I noticed that the `new_bot_message` mimicks what the `send_text_to_user` method does. This comes from early days when we didn't support differnet message types etc. What this method should do, is call `_send_message_to_user` which will take the bot message and, depending on some config, send either a text or voice message to the user. This is what I did. Also, each channel doesn't have to implement this method anymore, since it will call `_send_message_to_user` which will call implemented methods ultimately (see the `test_new_bot_message` test case).

Another notable change: A test that will catch new channel type implementations that is missing from the `ChannelBase.from_experiment_session` method. The `FacebookMessengerChannel` type was, so this came in handy.
