### PR TITLE
Use tripe quotes rather than multiline string for row classes

### DIFF
--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -475,10 +475,10 @@ DJANGO_TABLES2_TABLE_ATTRS = {
 }
 # text-neutral text-error (pipeline run table styles here for tailwind build)
 DJANGO_TABLES2_ROW_ATTRS = {
-    "class": (
-        "border-b border-gray-200 hover:bg-gray-100"
-        "data-[redirect-url]:[&:not([data-redirect-url=''])]:hover:cursor-pointer"
-    ),
+    "class": """
+        border-b border-gray-200 hover:bg-gray-100
+        data-[redirect-url]:[&:not([data-redirect-url=''])]:hover:cursor-pointer
+    """,
     "id": lambda record: f"record-{record.id}",
     "data-redirect-url": lambda record: record.get_absolute_url() if hasattr(record, "get_absolute_url") else "",
 }


### PR DESCRIPTION
The multiline string didn't work properly when running `npm run build`. Triple quotes seem to be doing just fine though