### PR TITLE
Show tags when user has view-only permissions

### DIFF
--- a/apps/experiments/tables.py
+++ b/apps/experiments/tables.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.template.loader import get_template
 from django_tables2 import columns, tables
 
 from apps.experiments.models import (
@@ -166,6 +167,10 @@ class ExperimentSessionsTable(tables.Table):
         template_name="experiments/components/experiment_sessions_list_tags.html",
     )
     actions = columns.TemplateColumn(template_name="experiments/components/experiment_session_view_button.html")
+
+    def render_tags(self, record, bound_column):
+        template = get_template(bound_column.column.template_name)
+        return template.render({"tags": record.chat.tags.all()})
 
     class Meta:
         model = ExperimentSession

--- a/templates/experiments/components/experiment_chat.html
+++ b/templates/experiments/components/experiment_chat.html
@@ -40,6 +40,10 @@
                     {% include "generic/tag_multiselect.html" with object=message %}
                   </div>
                 </td>
+              {% elif perms.annotations.view_customtaggeditem %}
+                <td scope="col" class="w-1/4 overflow-y-visible">
+                  {% include 'experiments/components/experiment_sessions_list_tags.html' with tags=message.tags.all %}
+                </td>
               {% endif %}
               {% if perms.annotations.add_usercomment %}
                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">

--- a/templates/experiments/components/experiment_details.html
+++ b/templates/experiments/components/experiment_details.html
@@ -16,6 +16,13 @@
             {% include "generic/tag_multiselect.html" with object=experiment_session.chat %}
           </dd>
         </div>
+      {% elif perms.annotations.view_customtaggeditem %}
+        <div class="py-3 grid grid-cols-3">
+          <dt class="text-sm font-medium leading-6">Tags</dt>
+          <dd class="col-span-2 mr-2">
+            {% include 'experiments/components/experiment_sessions_list_tags.html' with tags=experiment_session.chat.tags.all %}
+          </dd>
+        </div>
       {% endif %}
       {% if perms.annotations.add_usercomment %}
         <div x-data="{showComments: false}">

--- a/templates/experiments/components/experiment_sessions_list_tags.html
+++ b/templates/experiments/components/experiment_sessions_list_tags.html
@@ -1,3 +1,3 @@
-{% for tag in record.chat.tags.all %}
+{% for tag in tags %}
     <span class="h-auto badge badge-neutral mb-1">{{ tag.name }}</span>
 {% endfor %}


### PR DESCRIPTION
Updated the chat detail view to show tags if the user has view-only permissions

![Screenshot from 2024-04-05 08-27-47](https://github.com/dimagi/open-chat-studio/assets/64970009/761c6881-2724-46b2-a7c0-3f5a5599cfb3)
