### PR TITLE
Show user details in session detail view

### DIFF
--- a/apps/experiments/admin.py
+++ b/apps/experiments/admin.py
@@ -41,6 +41,7 @@ class ParticipantAdmin(admin.ModelAdmin):
     list_display = ("identifier", "team", "public_id")
     readonly_fields = ("public_id",)
     list_filter = ("team",)
+    search_fields = ("external_chat_id",)
 
 
 @admin.register(models.ParticipantData)

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 
 import markdown
@@ -619,3 +620,6 @@ class ExperimentSession(BaseTeamModel):
 
     def get_participant_data(self):
         return self.experiment.get_participant_data(self.participant)
+
+    def get_participant_data_json(self):
+        return json.dumps(self.experiment.get_participant_data(self.participant), indent=2)

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -616,3 +616,6 @@ class ExperimentSession(BaseTeamModel):
             from apps.events.tasks import enqueue_static_triggers
 
             enqueue_static_triggers.delay(self.id, StaticTriggerType.CONVERSATION_END)
+
+    def get_participant_data(self):
+        return self.experiment.get_participant_data(self.participant)

--- a/templates/experiments/experiment_session_view.html
+++ b/templates/experiments/experiment_session_view.html
@@ -41,15 +41,13 @@
       {% include "experiments/components/experiment_details.html" %}
     </div>
     {% if experiment_session.get_participant_data %}
-      <div x-data="{showParticipantData: false}">
-        <h3 class="text-base font-semibold leading-7 mt-8 pl-4">
-          <div class="hover:cursor-pointer" @click="showParticipantData = !showParticipantData;">
-            <i x-show="!showParticipantData" class="fa fa-arrow-right" aria-hidden="true"></i>
-            <i x-cloak x-show="showParticipantData" class="fa fa-arrow-down" aria-hidden="true"></i>
-            Participant Data
-          </div>
-        </h3>
-        <div x-cloak x-show="showParticipantData" class="max-w-5xl mt-4 rounded-2xl">
+
+      <div class="app-card collapse collapse-arrow max-w-5xl">
+        <input type="checkbox" />
+        <div class="collapse-title text-xl font-medium">
+          Participant data
+        </div>
+        <div class="collapse-content">
           <div role="tablist" class="tabs tabs-bordered">
             <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="Formatted" checked/>
             <div role="tabpanel" class="tab-content p-10">
@@ -64,13 +62,15 @@
             </div>
             <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="Raw" />
             <div role="tabpanel" class="tab-content p-10">
-              <pre class="overflow-x-auto">
-                {{ experiment_session.get_participant_data_json }}
-              </pre>
+            <pre class="overflow-x-auto">
+              {{ experiment_session.get_participant_data_json }}
+            </pre>
             </div>
           </div>
         </div>
       </div>
+
+
     {% endif %}
     <h3 class="text-base font-semibold leading-7 mt-8 pl-4">Experiment chat</h3>
     <div class="max-w-5xl mt-4 border rounded-2xl">

--- a/templates/experiments/experiment_session_view.html
+++ b/templates/experiments/experiment_session_view.html
@@ -40,6 +40,20 @@
     <div class="max-w-5xl mt-4 border rounded-2xl">
       {% include "experiments/components/experiment_details.html" %}
     </div>
+    {% if experiment_session.get_participant_data %}
+      <div x-data="{showParticipantData: false}">
+        <h3 class="text-base font-semibold leading-7 mt-8 pl-4">
+          <div class="hover:cursor-pointer" @click="showParticipantData = !showParticipantData;">
+            <i x-show="!showParticipantData" class="fa fa-arrow-right" aria-hidden="true"></i>
+            <i x-cloak x-show="showParticipantData" class="fa fa-arrow-down" aria-hidden="true"></i>
+            Participant Data
+          </div>
+        </h3>
+        <div x-cloak x-show="showParticipantData" class="max-w-5xl mt-4 rounded-2xl">
+          {{ experiment_session.get_participant_data }}
+        </div>
+      </div>
+    {% endif %}
     <h3 class="text-base font-semibold leading-7 mt-8 pl-4">Experiment chat</h3>
     <div class="max-w-5xl mt-4 border rounded-2xl">
       {% include "experiments/components/experiment_chat.html" %}

--- a/templates/experiments/experiment_session_view.html
+++ b/templates/experiments/experiment_session_view.html
@@ -50,7 +50,25 @@
           </div>
         </h3>
         <div x-cloak x-show="showParticipantData" class="max-w-5xl mt-4 rounded-2xl">
-          {{ experiment_session.get_participant_data }}
+          <div role="tablist" class="tabs tabs-bordered">
+            <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="Formatted" checked/>
+            <div role="tabpanel" class="tab-content p-10">
+              <div class="grid grid-cols-3">
+                {% for k, v in experiment_session.get_participant_data.items %}
+                  <div class="p-4 col-span-1">
+                    <div class="font-semibold text-sm">{{ k }}</div>
+                    <div class="mt-2">{{ v }}</div>
+                  </div>
+                {% endfor %}
+              </div>
+            </div>
+            <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="Raw" />
+            <div role="tabpanel" class="tab-content p-10">
+              <div class="overflow-x-auto">
+                {{ experiment_session.get_participant_data }}
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     {% endif %}

--- a/templates/experiments/experiment_session_view.html
+++ b/templates/experiments/experiment_session_view.html
@@ -64,9 +64,9 @@
             </div>
             <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="Raw" />
             <div role="tabpanel" class="tab-content p-10">
-              <div class="overflow-x-auto">
-                {{ experiment_session.get_participant_data }}
-              </div>
+              <pre class="overflow-x-auto">
+                {{ experiment_session.get_participant_data_json }}
+              </pre>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Data collapsed
![image](https://github.com/dimagi/open-chat-studio/assets/64970009/e7ae618c-8bb5-4c85-b540-95228b9d0ec0)

### Data shown
![Screenshot from 2024-04-11 14-51-57](https://github.com/dimagi/open-chat-studio/assets/64970009/d1babdb1-026f-4738-973d-9259ad0fe766)

### Future improvements
it will be nice if we don't just dump the data, but format it a bit to look a bit nicer