### PR TITLE
Update langchain + langchain-openai packages

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -26,6 +26,7 @@ tenacity
 whitenoise[brotli]
 langchain
 langchain-openai
+langchain-anthropic
 Markdown
 # unstructured  # langchain loaders
 # chromadb  # langchain queries

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -18,8 +18,10 @@ amqp==5.2.0
     # via kombu
 annotated-types==0.6.0
     # via pydantic
-anthropic==0.10.0
-    # via -r requirements/requirements.in
+anthropic==0.25.2
+    # via
+    #   -r requirements/requirements.in
+    #   langchain-anthropic
 anyio==3.7.1
     # via
     #   anthropic
@@ -96,7 +98,9 @@ dataclasses-json==0.6.2
     #   langchain
     #   langchain-community
 defusedxml==0.7.1
-    # via python3-openid
+    # via
+    #   langchain-anthropic
+    #   python3-openid
 distro==1.8.0
     # via
     #   anthropic
@@ -216,11 +220,14 @@ kombu==5.3.3
     # via celery
 langchain==0.1.16
     # via -r requirements/requirements.in
+langchain-anthropic==0.1.8
+    # via -r requirements/requirements.in
 langchain-community==0.0.32
     # via langchain
 langchain-core==0.1.42
     # via
     #   langchain
+    #   langchain-anthropic
     #   langchain-community
     #   langchain-openai
     #   langchain-text-splitters

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -24,12 +24,13 @@ anyio==3.7.1
     # via
     #   anthropic
     #   httpcore
-    #   langchain-core
     #   openai
 asgiref==3.7.2
     # via django
 async-timeout==4.0.3
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   redis
 attrs==23.1.0
     # via
     #   aiohttp
@@ -213,18 +214,21 @@ jsonschema-specifications==2023.7.1
     # via jsonschema
 kombu==5.3.3
     # via celery
-langchain==0.1.4
+langchain==0.1.16
     # via -r requirements/requirements.in
-langchain-community==0.0.15
+langchain-community==0.0.32
     # via langchain
-langchain-core==0.1.17
+langchain-core==0.1.42
     # via
     #   langchain
     #   langchain-community
     #   langchain-openai
-langchain-openai==0.0.5
+    #   langchain-text-splitters
+langchain-openai==0.1.3
     # via -r requirements/requirements.in
-langsmith==0.0.83
+langchain-text-splitters==0.0.1
+    # via langchain
+langsmith==0.1.47
     # via
     #   langchain
     #   langchain-community
@@ -249,7 +253,6 @@ numpy==1.26.2
     # via
     #   langchain
     #   langchain-community
-    #   langchain-openai
     #   pandas
 oauthlib==3.2.2
     # via requests-oauthlib
@@ -257,6 +260,8 @@ openai==1.12.0
     # via
     #   -r requirements/requirements.in
     #   langchain-openai
+orjson==3.10.0
+    # via langsmith
 packaging==23.2
     # via
     #   djangorestframework-api-key
@@ -335,7 +340,6 @@ requests==2.31.0
     #   huggingface-hub
     #   langchain
     #   langchain-community
-    #   langchain-core
     #   langsmith
     #   pytelegrambotapi
     #   requests-oauthlib


### PR DESCRIPTION
For #362. For anthropic tool support, I think we'll have to install `langchain-anthropic`