### PR TITLE
Pass tag objects to the add method instead of raw tag names

### DIFF
--- a/apps/annotations/models.py
+++ b/apps/annotations/models.py
@@ -83,7 +83,8 @@ class TaggedModelMixin(models.Model, AnnotationMixin):
     tags = TaggableManager(through=CustomTaggedItem)
 
     def add_tags(self, tags: list[str], team: Team, added_by: CustomUser):
-        for tag in tags:
+        tag_objs = Tag.objects.filter(team=team, name__in=tags)
+        for tag in tag_objs:
             self.tags.add(tag, through_defaults={"team": team, "user": added_by})
 
     @property

--- a/apps/annotations/tests/test_tags.py
+++ b/apps/annotations/tests/test_tags.py
@@ -63,6 +63,26 @@ def test_link_tag(tag, chat, client):
 
 
 @pytest.mark.django_db()
+def test_tags_with_same_name_can_be_used_in_different_teams(client):
+    """This simply ensures that different teams can use tags with the same name"""
+    team1 = TeamWithUsersFactory()
+    team2 = TeamWithUsersFactory()
+    user1 = team1.members.first()
+    user2 = team2.members.first()
+    session1 = ExperimentSessionFactory(team=team1, chat__team=team1)
+    session2 = ExperimentSessionFactory(team=team2, chat__team=team2)
+    chat1 = session1.chat
+    chat2 = session2.chat
+    tag1 = Tag.objects.create(name="testing", created_by=user1, team=team1)
+    tag2 = Tag.objects.create(name="testing", created_by=user2, team=team2)
+
+    _link_tag_to_item(client, tag=tag1, chat=chat1)
+    _link_tag_to_item(client, tag=tag2, chat=chat2)
+    chat1.tags.get(name=tag1)
+    chat2.tags.get(name=tag1)
+
+
+@pytest.mark.django_db()
 def test_new_tag_created_when_linking(chat, client):
     team = chat.team
     tag_name = "super cool"


### PR DESCRIPTION
Fixes [this](https://dimagi.sentry.io/share/issue/0088917f17b94cfcbfbeb2b9a00806fe/)