### PR TITLE
Fix assistant migration

### DIFF
--- a/apps/assistants/migrations/0005_migrate_assistants.py
+++ b/apps/assistants/migrations/0005_migrate_assistants.py
@@ -7,9 +7,8 @@ from apps.assistants.migrations.utils import migrate_assistant_to_v2
 
 def do_migration(apps, schema_editor):
     OpenAiAssistant = apps.get_model("assistants.OpenAiAssistant")
-    ToolResources = apps.get_model("assistants.ToolResources")
     for assistant in OpenAiAssistant.objects.all():
-        migrate_assistant_to_v2(assistant, tool_resources_cls=ToolResources)
+        migrate_assistant_to_v2(assistant, apps=apps)
 
 
 class Migration(migrations.Migration):

--- a/apps/assistants/migrations/utils/__init__.py
+++ b/apps/assistants/migrations/utils/__init__.py
@@ -40,8 +40,9 @@ def _duplicate_file(file, apps=None):
         schema=file.schema,
         team=file.team,
     )
-    new_file_file = ContentFile(file.file.read())
-    new_file_file.name = file.file.name
-    new_file.file = new_file_file
+    if file.file:
+        new_file_file = ContentFile(file.file.read())
+        new_file_file.name = file.file.name
+        new_file.file = new_file_file
     new_file.save()
     return new_file

--- a/apps/assistants/migrations/utils/__init__.py
+++ b/apps/assistants/migrations/utils/__init__.py
@@ -1,8 +1,12 @@
-def migrate_assistant_to_v2(assistant, tool_resources_cls=None):
+from django.core.files.base import ContentFile
+
+
+def migrate_assistant_to_v2(assistant, apps=None):
     """This only migrates the internal DB model. It does not sync with OpenAI"""
-    if not tool_resources_cls:
+    if apps:
+        ToolResources = apps.get_model("assistants.ToolResources")
+    else:
         from apps.assistants.models import ToolResources
-        tool_resources_cls = ToolResources
 
     builtin_tools = assistant.builtin_tools
     if "retrieval" in builtin_tools:
@@ -12,10 +16,32 @@ def migrate_assistant_to_v2(assistant, tool_resources_cls=None):
     assistant.save()
 
     for tool in builtin_tools:
-        resource, created = tool_resources_cls.objects.get_or_create(tool_type=tool, assistant=assistant)
+        resource, created = ToolResources.objects.get_or_create(tool_type=tool, assistant=assistant)
         if created:
             # copy the file so that it is not shared between resources
-            files = [file.duplicate() for file in assistant.files.all()]
+            files = [_duplicate_file(file, apps) for file in assistant.files.all()]
             resource.files.set(files)
 
     assistant.files.all().delete()
+
+
+def _duplicate_file(file, apps=None):
+    if apps:
+        File = apps.get_model("files.File")
+    else:
+        from apps.files.models import File
+
+    new_file = File(
+        name=file.name,
+        external_source=file.external_source,
+        external_id=file.external_id,
+        content_size=file.content_size,
+        content_type=file.content_type,
+        schema=file.schema,
+        team=file.team,
+    )
+    new_file_file = ContentFile(file.file.read())
+    new_file_file.name = file.file.name
+    new_file.file = new_file_file
+    new_file.save()
+    return new_file

--- a/apps/assistants/tests/test_migration_v2.py
+++ b/apps/assistants/tests/test_migration_v2.py
@@ -1,6 +1,7 @@
 import pytest
 
 from apps.assistants.migrations.utils import migrate_assistant_to_v2
+from apps.assistants.models import OpenAiAssistant
 from apps.files.models import File
 from apps.utils.factories.assistants import OpenAiAssistantFactory
 from apps.utils.factories.files import FileFactory
@@ -12,8 +13,9 @@ def test_migrate_assistant():
     files = FileFactory.create_batch(2, external_id="test_id", external_source="openai")
     assistant.files.set(files)
 
-    migrate_assistant_to_v2(assistant)
+    migrate_assistant_to_v2(OpenAiAssistant.objects.get(id=assistant.id))
 
+    assistant.refresh_from_db()
     assert set(assistant.builtin_tools) == {"file_search", "code_interpreter"}
     assert assistant.files.count() == 0
     assert assistant.tool_resources.count() == 2


### PR DESCRIPTION
This fixes this sentry error: https://dimagi.sentry.io/share/issue/bfda7256a2f54b0a98a119158ba88c58/

And also another error that occurs when files (the model) have no file attachement.

I do not know why the sentry error happens but I assume it's something related to how Django loads models during migrations.

Edit: found the Django docs: https://docs.djangoproject.com/en/4.2/topics/migrations/#historical-models