### PR TITLE
update request auditor to record hijacked users

### DIFF
--- a/apps/audit/auditors.py
+++ b/apps/audit/auditors.py
@@ -1,0 +1,45 @@
+import logging
+
+from django.core.exceptions import ValidationError
+from field_audit.auditors import BaseAuditor
+from field_audit.models import USER_TYPE_REQUEST
+
+from apps.users.models import CustomUser
+
+log = logging.getLogger("audit")
+
+
+class RequestAuditor(BaseAuditor):
+    """Auditor class for getting users from authenticated requests."""
+
+    def change_context(self, request):
+        if request is None:
+            return None
+        if request.user.is_authenticated:
+            username = get_request_username(request)
+            context = {
+                "user_type": USER_TYPE_REQUEST,
+                "username": username,
+            }
+            if username != request.user.username:
+                context["as_username"] = request.user.username
+            return context
+        # short-circuit the audit chain for not-None requests
+        return {}
+
+
+def get_request_username(request):
+    hijack_history = request.session.get("hijack_history", [])
+    if hijack_history:
+        if username := _get_hijack_username(hijack_history):
+            return username
+
+    return request.user.username
+
+
+def _get_hijack_username(hijack_history):
+    try:
+        pk = CustomUser._meta.pk.to_python(hijack_history[-1])
+        return CustomUser.objects.get(pk=pk).username
+    except (CustomUser.DoesNotExist, ValidationError) as e:
+        log.error("Error getting user from hijack history (%s): %s", hijack_history, str(e))

--- a/apps/audit/tests.py
+++ b/apps/audit/tests.py
@@ -1,0 +1,60 @@
+from unittest import mock
+
+from field_audit.models import USER_TYPE_REQUEST
+
+from apps.audit.auditors import RequestAuditor
+
+
+def test_change_context():
+    request = AuthedRequest()
+    assert RequestAuditor().change_context(request) == {
+        "user_type": USER_TYPE_REQUEST,
+        "username": request.user.username,
+    }
+
+
+def test_change_context_returns_none_without_request():
+    assert RequestAuditor().change_context(None) is None
+
+
+def test_change_context_returns_value_for_unauthorized_req():
+    request = AuthedRequest(auth=False)
+    assert RequestAuditor().change_context(request) == {}
+
+
+@mock.patch("apps.audit.auditors._get_hijack_username", return_value="admin@example.com")
+def test_change_context_hijacked_request(_):
+    request = AuthedRequest(session={"hijack_history": [1]})
+    assert RequestAuditor().change_context(request) == {
+        "user_type": USER_TYPE_REQUEST,
+        "username": "admin@example.com",
+        "as_username": request.user.username,
+    }
+
+
+@mock.patch("apps.audit.auditors._get_hijack_username", return_value=None)
+def test_change_context_hijacked_request__no_hijacked_user(_):
+    request = AuthedRequest(session={"hijack_history": [1]})
+    assert RequestAuditor().change_context(request) == {
+        "user_type": USER_TYPE_REQUEST,
+        "username": "test@example.com",
+    }
+
+
+def test_change_context_hijacked_request__bad_hijack_history():
+    request = AuthedRequest(session={"hijack_history": ["not a number"]})
+    assert RequestAuditor().change_context(request) == {
+        "user_type": USER_TYPE_REQUEST,
+        "username": "test@example.com",
+    }
+
+
+class AuthedRequest:
+    class User:
+        username = "test@example.com"
+        is_authenticated = True
+
+    def __init__(self, auth=True, session=None):
+        self.user = self.User()
+        self.session = session or {}
+        self.user.is_authenticated = auth

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -502,3 +502,6 @@ DOCUMENTATION_LINKS = {
 
 # Django rest framework config
 API_KEY_CUSTOM_HEADER = "HTTP_X_API_KEY"
+
+# Django Field Audit
+FIELD_AUDIT_AUDITORS = ["apps.audit.auditors.RequestAuditor", "field_audit.auditors.SystemUserAuditor"]


### PR DESCRIPTION
I haven't thought through if we want to keep [hijack](https://django-hijack.readthedocs.io/) in the long term but for now let's at least preserve the correct audit trail.