### PR TITLE
Assistants to support participant data

### DIFF
--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -104,6 +104,10 @@ class BaseExperimentRunnable(RunnableSerializable[dict, ChainOutput], ABC):
             input[self.input_key] = self.experiment.input_formatter.format(input=input[self.input_key])
         return input
 
+    @property
+    def participant_data(self):
+        return self.experiment.get_participant_data(self.session.participant) or ""
+
 
 class ExperimentRunnable(BaseExperimentRunnable):
     memory: BaseMemory = ConversationBufferMemory(return_messages=True, output_key="output", input_key="input")
@@ -174,10 +178,6 @@ class ExperimentRunnable(BaseExperimentRunnable):
     @property
     def source_material(self):
         return self.experiment.source_material.material if self.experiment.source_material else ""
-
-    @property
-    def participant_data(self):
-        return self.experiment.get_participant_data(self.session.participant) or ""
 
     def _build_chain(self) -> Runnable[dict[str, Any], Any]:
         raise NotImplementedError
@@ -279,6 +279,12 @@ class AssistantExperimentRunnable(BaseExperimentRunnable):
         thread_id = self.chat.get_metadata(self.chat.MetadataKeys.OPENAI_THREAD_ID)
         if thread_id:
             input_dict["thread_id"] = thread_id
+
+        # Langchain doesn't support the `additional_instructions` parameter that the API specifies, so we have to
+        # override the instructions if we want to pass in dynamic data.
+        # https://github.com/langchain-ai/langchain/blob/cccc8fbe2fe59bde0846875f67aa046aeb1105a3/libs/langchain/langchain/agents/openai_assistant/base.py#L491
+        new_instructions = self.experiment.assistant.instructions.format(participant_data=self.participant_data)
+        input_dict["instructions"] = new_instructions
 
         response = self._get_response_with_retries(config, input_dict, thread_id)
         if not thread_id:

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -33,6 +33,7 @@ def session():
     return session
 
 
+@pytest.mark.django_db()
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
 @patch("openai.resources.beta.Threads.create_and_run")
@@ -54,6 +55,7 @@ def test_assistant_conversation_new_chat(create_and_run, retrieve_run, list_mess
     assert chat.get_metadata(chat.MetadataKeys.OPENAI_THREAD_ID) == thread_id
 
 
+@pytest.mark.django_db()
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.messages.Messages.create")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
@@ -78,6 +80,7 @@ def test_assistant_conversation_existing_chat(create_run, retrieve_run, create_m
     assert result.output == "ai response"
 
 
+@pytest.mark.django_db()
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
 @patch("openai.resources.beta.Threads.create_and_run")
@@ -101,6 +104,7 @@ def test_assistant_conversation_input_formatting(create_and_run, retrieve_run, l
     assert create_and_run.call_args.kwargs["thread"]["messages"][0]["content"] == "foo test bar"
 
 
+@pytest.mark.django_db()
 def test_assistant_runnable_raises_error(session):
     experiment = session.experiment
 
@@ -111,6 +115,7 @@ def test_assistant_runnable_raises_error(session):
             assistant.invoke("test")
 
 
+@pytest.mark.django_db()
 def test_assistant_runnable_handles_cancellation_status(session):
     experiment = session.experiment
 
@@ -121,6 +126,7 @@ def test_assistant_runnable_handles_cancellation_status(session):
             assistant.invoke("test")
 
 
+@pytest.mark.django_db()
 @pytest.mark.parametrize(
     ("responses", "exception", "output"),
     [

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -30,10 +30,10 @@ def session():
     session = ExperimentSessionFactory.build(chat=chat)
     local_assistant = OpenAiAssistantFactory.build(id=1, assistant_id=ASSISTANT_ID)
     session.experiment.assistant = local_assistant
+    session.experiment.get_participant_data = lambda *args: None
     return session
 
 
-@pytest.mark.django_db()
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
 @patch("openai.resources.beta.Threads.create_and_run")
@@ -55,7 +55,6 @@ def test_assistant_conversation_new_chat(create_and_run, retrieve_run, list_mess
     assert chat.get_metadata(chat.MetadataKeys.OPENAI_THREAD_ID) == thread_id
 
 
-@pytest.mark.django_db()
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.messages.Messages.create")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
@@ -80,7 +79,6 @@ def test_assistant_conversation_existing_chat(create_run, retrieve_run, create_m
     assert result.output == "ai response"
 
 
-@pytest.mark.django_db()
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
 @patch("openai.resources.beta.Threads.create_and_run")
@@ -104,7 +102,6 @@ def test_assistant_conversation_input_formatting(create_and_run, retrieve_run, l
     assert create_and_run.call_args.kwargs["thread"]["messages"][0]["content"] == "foo test bar"
 
 
-@pytest.mark.django_db()
 def test_assistant_runnable_raises_error(session):
     experiment = session.experiment
 
@@ -115,7 +112,6 @@ def test_assistant_runnable_raises_error(session):
             assistant.invoke("test")
 
 
-@pytest.mark.django_db()
 def test_assistant_runnable_handles_cancellation_status(session):
     experiment = session.experiment
 
@@ -126,7 +122,6 @@ def test_assistant_runnable_handles_cancellation_status(session):
             assistant.invoke("test")
 
 
-@pytest.mark.django_db()
 @pytest.mark.parametrize(
     ("responses", "exception", "output"),
     [


### PR DESCRIPTION
#418 . It [doesn't look like](https://github.com/langchain-ai/langchain/blob/cccc8fbe2fe59bde0846875f67aa046aeb1105a3/libs/langchain/langchain/agents/openai_assistant/base.py#L491) LangChain supports the `additional_instructions` parameter that we could have used to pass in additional instructions. I went for overriding the instructions on each call rather.

Also I moved the `participant_data` to the base class of the class it was currently in to make that property available in the `AssistantExperimentRunnable` class