### PR TITLE
Add tab view for Experiments

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,3 @@
+.tab:is(input[type="radio"]) {
+    width: max-content;
+}

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -119,85 +119,97 @@
       {% endfor %}
     {% endif %}
   </div>
-  <div class="app-card">
 
-    <h2 class="pg-subtitle">My Previous Chat Sessions</h2>
-    <div class="overflow-x-auto">
-      <table class="pg-table">
-        <thead>
-          <tr>
-            <th>Started</th>
-            <th>Last Message</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for session in user_sessions %}
-            <tr>
-              <td>{{ session.created_at }}</td>
-              <td>{{ session.last_message_created_at }}</td>
-              <td>
-                {% if session.is_complete %}
-                  <a class="btn btn-sm btn-outline btn-primary"
-                     href="{% url 'experiments:experiment_session_view' team.slug experiment.public_id session.public_id %}"
-                     class="link">Review Chat</a>
-                {% else %}
-                  <a class="btn btn-sm btn-outline btn-primary"
-                     href="{% url 'experiments:experiment_chat_session' team.slug experiment.id session.id %}" class="link">
-                    Continue Chat
-                  </a>
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  </div>
-  {% if perms.chat.view_chat %}
-    <div class="app-card">
-      <h2 class="pg-subtitle">All Chat Sessions</h2>
-      <div x-data="{tags: ''}" x-init="$watch('tags', value => filterSessions(value))">
-        <div class="grid grid-flow-col auto-cols-max gap-x-2">
-          {% if perms.experiments.download_chats %}
-            <form method="post" action="{% url 'experiments:download_experiment_chats' team.slug experiment.id %}" class="my-2">
-              {% csrf_token %}
-              <input name="tags" class="hidden" x-bind:value="tags" />
-              <input class="btn btn-sm btn-outline btn-primary" type="submit" value="Download All" />
-            </form>
-          {% endif %}
-          {% if perms.annotations.view_customtaggeditem %}
-            <div class="w-96 my-2">
-              <select x-model="tags" id="tag-multiselect-filter" name="state[]" multiple placeholder="Filter tags..." autocomplete="off">
-                <option value="">Filter tags...</option>
-                {% for tag in available_tags %}
-                  <option value="{{ tag.name }}">{{ tag.name }}</option>
-                {% endfor %}
-              </select>
-            </div>
-          {% endif %}
+  <div role="tablist" class="tabs tabs-bordered">
+    <input type="radio" name="tab_group" role="tab" class="tab" aria-label="My Sessions" checked />
+    <div role="tabpanel" class="tab-content">
+      <div class="app-card">
+        <h2 class="pg-subtitle">My Previous Chat Sessions</h2>
+        <div class="overflow-x-auto">
+          <table class="pg-table">
+            <thead>
+              <tr>
+                <th>Started</th>
+                <th>Last Message</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for session in user_sessions %}
+                <tr>
+                  <td>{{ session.created_at }}</td>
+                  <td>{{ session.last_message_created_at }}</td>
+                  <td>
+                    {% if session.is_complete %}
+                      <a class="btn btn-sm btn-outline btn-primary"
+                         href="{% url 'experiments:experiment_session_view' team.slug experiment.public_id session.public_id %}"
+                         class="link">Review Chat</a>
+                    {% else %}
+                      <a class="btn btn-sm btn-outline btn-primary"
+                         href="{% url 'experiments:experiment_chat_session' team.slug experiment.id session.id %}" class="link">
+                        Continue Chat
+                      </a>
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
-        <div
-          id="sessions-table"
-          hx-trigger="load, tagFilter"
-          hx-target="this"
-          hx-get="{% url 'experiments:sessions-list' request.team.slug experiment.id %}"
-          hx-swap="innerHTML"
-        ></div>
       </div>
     </div>
-  {% endif %}
-  {% flag "events" %}
-    <div class="app-card">
-      <h2 class="pg-subtitle">Events</h2>
-      <a class="btn btn-sm btn-outline btn-primary" href="{% url 'experiments:events:static_event_new' team.slug experiment.id %}"><i class="fa-regular fa-plus"></i> Create Static Event</a>
-      <a class="btn btn-sm btn-outline btn-primary" href="{% url 'experiments:events:timeout_event_new' team.slug experiment.id %}"><i class="fa-regular fa-plus"></i> Create Timeout Event</a>
-      {% if show_events %}
-        {% render_table events_table %}
-      {% endif %}
-    </div>
-  {% endflag %}
 
+    {% if perms.chat.view_chat %}
+      <input type="radio" name="tab_group" role="tab" class="tab" aria-label="All Sessions"/>
+      <div role="tabpanel" class="tab-content">
+        <div class="app-card">
+          <h2 class="pg-subtitle">All Chat Sessions</h2>
+          <div x-data="{tags: ''}" x-init="$watch('tags', value => filterSessions(value))">
+            <div class="grid grid-flow-col auto-cols-max gap-x-2">
+              {% if perms.experiments.download_chats %}
+                <form method="post" action="{% url 'experiments:download_experiment_chats' team.slug experiment.id %}" class="my-2">
+                  {% csrf_token %}
+                  <input name="tags" class="hidden" x-bind:value="tags" />
+                  <input class="btn btn-sm btn-outline btn-primary" type="submit" value="Download All" />
+                </form>
+              {% endif %}
+              {% if perms.annotations.view_customtaggeditem %}
+                <div class="w-96 my-2">
+                  <select x-model="tags" id="tag-multiselect-filter" name="state[]" multiple placeholder="Filter tags..." autocomplete="off">
+                    <option value="">Filter tags...</option>
+                    {% for tag in available_tags %}
+                      <option value="{{ tag.name }}">{{ tag.name }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+              {% endif %}
+            </div>
+            <div
+              id="sessions-table"
+              hx-trigger="load, tagFilter"
+              hx-target="this"
+              hx-get="{% url 'experiments:sessions-list' request.team.slug experiment.id %}"
+              hx-swap="innerHTML"
+            ></div>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
+    {% flag "events" %}
+      <input type="radio" name="tab_group" role="tab" class="tab" aria-label="Events"/>
+      <div role="tabpanel" class="tab-content">
+        <div class="app-card">
+          <h2 class="pg-subtitle">Events</h2>
+          <a class="btn btn-sm btn-outline btn-primary" href="{% url 'experiments:events:static_event_new' team.slug experiment.id %}"><i class="fa-regular fa-plus"></i> Create Static Event</a>
+          <a class="btn btn-sm btn-outline btn-primary" href="{% url 'experiments:events:timeout_event_new' team.slug experiment.id %}"><i class="fa-regular fa-plus"></i> Create Timeout Event</a>
+          {% if show_events %}
+            {% render_table events_table %}
+          {% endif %}
+        </div>
+      </div>
+    {% endflag %}
+  </div>
   <script>
     let url = "{{ filter_tags_url|escapejs }}"
     function filterSessions(tags) {

--- a/templates/web/base.html
+++ b/templates/web/base.html
@@ -37,6 +37,7 @@
     {% include 'web/components/favicon.html' %}
     <link rel="stylesheet" href="{% static 'css/site-base.css' %}">
     <link rel="stylesheet" href="{% static 'css/site-tailwind.css' %}">
+    <link rel="stylesheet" href="{% static 'css/custom.css' %}">
     <!-- Font Awesome Icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" integrity="sha512-xh6O/CkQoPOWDdYTDqeRdPCVd1SpvCA9XXcUnZS2FmJNp1coAFzvtCN9BmamE+4aHK8yyUHUSCcJHgXloTyT2A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/v4-shims.min.css" integrity="sha512-ARfx5eajdcCAuWvuJrgUuJ6D25ON3KZRTCghNXXKeJldCQJ5bXS+6CvG2EhcFWITF95uwZydzpufSKvhmSpTxA==" crossorigin="anonymous" referrerpolicy="no-referrer" />


### PR DESCRIPTION
https://github.com/dimagi/open-chat-studio/issues/352 

![Untitled design (1)](https://github.com/dimagi/open-chat-studio/assets/36681924/d68e5d81-30ee-4437-9e4d-d3cd2c7841c7)

Adds tabs to page rather than having all the content on one page.

Also added custom CSS to override the tailwind defaults so that "All Sessions" is on on line when selected rather than changing to have the line going through the text. I opted for adding a new css file rather than directly modifying the default (but open to feedback)

All of the original content within the cards remains the same. 
