### PR TITLE
Show chat dates + timezone support

### DIFF
--- a/apps/experiments/tests/test_views.py
+++ b/apps/experiments/tests/test_views.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError
 from django.urls import reverse
 from waffle.testutils import override_flag
 
-from apps.experiments.models import Experiment, ExperimentSession, Participant, VoiceResponseBehaviours
+from apps.experiments.models import Experiment, ExperimentSession, Participant, ParticipantData, VoiceResponseBehaviours
 from apps.experiments.views.experiment import ExperimentForm, _start_experiment_session, _validate_prompt_variables
 from apps.teams.backends import add_user_to_team
 from apps.utils.factories.assistants import OpenAiAssistantFactory
@@ -313,3 +313,31 @@ def test_user_email_used_for_participant_identifier(_trigger_mock, client):
     )
     client.post(url, data=post_data)
     assert Participant.objects.filter(team=experiment.team, identifier=user.email).exists()
+
+
+@pytest.mark.django_db()
+@mock.patch("apps.experiments.views.experiment.enqueue_static_triggers")
+def test_timezone_saved_in_participant_data(_trigger_mock):
+    """A participant's timezone data should be saved in all ParticipantData records"""
+    experiment = ExperimentFactory(team=TeamWithUsersFactory())
+    experiment2 = ExperimentFactory()
+    channel = ExperimentChannelFactory(experiment=experiment)
+    team = experiment.team
+    identifier = "someone@example.com"
+    participant = Participant.objects.create(identifier=identifier, team=team)
+    part_data1 = ParticipantData.objects.create(team=team, participant=participant, content_object=experiment)
+    part_data2 = ParticipantData.objects.create(
+        team=experiment2.team, participant=participant, content_object=experiment2
+    )
+
+    _start_experiment_session(
+        experiment,
+        experiment_channel=channel,
+        participant_identifier=identifier,
+        timezone="Africa/Johannesburg",
+    )
+
+    part_data1.refresh_from_db()
+    part_data2.refresh_from_db()
+    assert part_data1.data["timezone"] == "Africa/Johannesburg"
+    assert part_data2.data["timezone"] == "Africa/Johannesburg"

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -52,7 +52,14 @@ from apps.experiments.forms import (
     SurveyCompletedForm,
 )
 from apps.experiments.helpers import get_real_user_or_none
-from apps.experiments.models import Experiment, ExperimentSession, Participant, SessionStatus, SyntheticVoice
+from apps.experiments.models import (
+    Experiment,
+    ExperimentSession,
+    Participant,
+    ParticipantData,
+    SessionStatus,
+    SyntheticVoice,
+)
 from apps.experiments.tables import ExperimentSessionsTable, ExperimentTable
 from apps.experiments.tasks import get_response_for_webchat_task
 from apps.experiments.views.prompt import PROMPT_DATA_SESSION_KEY
@@ -557,6 +564,7 @@ def _start_experiment_session(
     participant_identifier: str,
     participant_user: CustomUser | None = None,
     session_status: SessionStatus = SessionStatus.ACTIVE,
+    timezone: str | None = None,
 ) -> ExperimentSession:
     if not participant_identifier and not participant_user:
         raise ValueError("Either participant_identifier or participant_user must be specified!")
@@ -586,6 +594,15 @@ def _start_experiment_session(
             status=session_status,
             participant=participant,
         )
+
+        # Record the participant's timezone
+        if timezone:
+            data_records = ParticipantData.objects.filter(participant=participant)
+            for data_record in data_records:
+                data_record.data["timezone"] = timezone
+                data_record.save()
+            ParticipantData.objects.bulk_update(data_records, fields=["data"])
+
     if participant.experimentsession_set.count() == 1:
         enqueue_static_triggers.delay(session.id, StaticTriggerType.PARTICIPANT_JOINED_EXPERIMENT)
     enqueue_static_triggers.delay(session.id, StaticTriggerType.CONVERSATION_START)
@@ -613,6 +630,7 @@ def start_authed_web_session(request, team_slug: str, experiment_id: int):
         experiment_channel=experiment_channel,
         participant_user=request.user,
         participant_identifier=request.user.email,
+        timezone=request.session.get("detected_tz", None),
     )
     return HttpResponseRedirect(
         reverse("experiments:experiment_chat_session", args=[team_slug, experiment_id, session.id])
@@ -743,6 +761,7 @@ def start_session_public(request, team_slug: str, experiment_id: str):
                 experiment_channel=experiment_channel,
                 participant_user=user,
                 participant_identifier=identifier,
+                timezone=request.session.get("detected_tz", None),
             )
             return _record_consent_and_redirect(request, team_slug, session)
 
@@ -796,6 +815,7 @@ def experiment_invitations(request, team_slug: str, experiment_id: str):
                         experiment_channel=channel,
                         participant_identifier=post_form.cleaned_data["email"],
                         session_status=SessionStatus.SETUP,
+                        timezone=request.session.get("detected_tz", None),
                     )
                 if post_form.cleaned_data["invite_now"]:
                     send_experiment_invitation(session)

--- a/apps/teams/tests/test_permissions.py
+++ b/apps/teams/tests/test_permissions.py
@@ -56,6 +56,7 @@ IGNORE_APPS = {
     "humanize",
     "field_audit",
     "taggit",
+    "tz_detect",
 }
 
 IGNORE_MODELS = {"teams": {"flag"}}

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -510,4 +510,4 @@ API_KEY_CUSTOM_HEADER = "HTTP_X_API_KEY"
 FIELD_AUDIT_AUDITORS = ["apps.audit.auditors.RequestAuditor", "field_audit.auditors.SystemUserAuditor"]
 
 # tz_detect
-TZ_DETECT_COUNTRIES = ["ZA"]
+TZ_DETECT_COUNTRIES = ["US", "IN", "GB", "ZA", "KE"]

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -70,6 +70,7 @@ THIRD_PARTY_APPS = [
     "django_tables2",
     "field_audit",
     "taggit",
+    "tz_detect",
 ]
 
 PROJECT_APPS = [
@@ -111,6 +112,7 @@ MIDDLEWARE = [
     "waffle.middleware.WaffleMiddleware",
     "field_audit.middleware.FieldAuditMiddleware",
     "apps.web.htmx_middleware.HtmxMessageMiddleware",
+    "tz_detect.middleware.TimezoneMiddleware",
 ]
 
 ROOT_URLCONF = "gpt_playground.urls"

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -508,3 +508,6 @@ API_KEY_CUSTOM_HEADER = "HTTP_X_API_KEY"
 
 # Django Field Audit
 FIELD_AUDIT_AUDITORS = ["apps.audit.auditors.RequestAuditor", "field_audit.auditors.SystemUserAuditor"]
+
+# tz_detect
+TZ_DETECT_COUNTRIES = ["ZA"]

--- a/gpt_playground/urls.py
+++ b/gpt_playground/urls.py
@@ -65,4 +65,5 @@ urlpatterns = [
     path("hijack/", include("hijack.urls", namespace="hijack")),
     path("channels/", include("apps.channels.urls", namespace="channels")),
     path("api/", include("apps.api.urls", namespace="api")),
+    path("tz_detect/", include("tz_detect.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -5,16 +5,16 @@
 #    inv requirements
 #
 gevent==23.9.1
-    # via -r prod-requirements.in
+    # via -r requirements/prod-requirements.in
 greenlet==3.0.1
     # via
-    #   -c requirements.txt
+    #   -c requirements/requirements.txt
     #   gevent
 gunicorn==22.0.0
-    # via -r prod-requirements.in
+    # via -r requirements/prod-requirements.in
 packaging==23.2
     # via
-    #   -c requirements.txt
+    #   -c requirements/requirements.txt
     #   gunicorn
 zope-event==5.0
     # via gevent

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -47,3 +47,4 @@ jinja2
 django-taggit
 transformers # this is required by the tokenizer that langchain uses
 # See https://github.com/langchain-ai/langchain/blob/ad3fd44a7f83e3c5e6b25024ce1b49f1a828defe/libs/core/langchain_core/language_models/base.py#L43
+django-tz-detect

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -20,7 +20,7 @@ annotated-types==0.6.0
     # via pydantic
 anthropic==0.25.2
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   langchain-anthropic
 anyio==3.7.1
     # via
@@ -29,6 +29,8 @@ anyio==3.7.1
     #   openai
 asgiref==3.7.2
     # via django
+async-timeout==4.0.3
+    # via redis
 attrs==23.1.0
     # via
     #   aiohttp
@@ -36,12 +38,12 @@ attrs==23.1.0
     #   referencing
     #   taskbadger
 azure-cognitiveservices-speech==1.32.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 billiard==4.2.0
     # via celery
 boto3==1.28.85
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   django-storages
 botocore==1.31.85
     # via
@@ -51,10 +53,10 @@ brotli==1.1.0
     # via whitenoise
 celery[redis]==5.3.5
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   django-celery-beat
 celery-progress==0.3
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 certifi==2023.7.22
     # via
     #   httpcore
@@ -101,7 +103,7 @@ distro==1.8.0
     #   openai
 django==4.2.11
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   django-allauth
     #   django-allauth-2fa
     #   django-anymail
@@ -115,55 +117,58 @@ django==4.2.11
     #   django-tables2
     #   django-taggit
     #   django-timezone-field
+    #   django-tz-detect
     #   django-waffle
     #   djangorestframework
     #   drf-spectacular
 django-allauth==0.58.2
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   django-allauth-2fa
 django-allauth-2fa==0.11.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-anymail==10.2
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-appconf==1.0.5
     # via django-cryptography
 django-celery-beat==2.5.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-cryptography==1.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-environ==0.11.2
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-field-audit==1.2.8
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-hijack==3.4.2
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-otp==1.3.0
     # via django-allauth-2fa
 django-redis==5.4.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-storages[s3]==1.14.2
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-tables2==2.6.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-taggit==5.0.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-timezone-field==6.0.1
     # via django-celery-beat
+django-tz-detect==0.5.0
+    # via -r requirements/requirements.in
 django-waffle==4.0.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 djangorestframework==3.14.0
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   drf-spectacular
 djangorestframework-api-key==3.0.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 drf-spectacular==0.26.5
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 fbmessenger==6.0.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 ffmpeg==1.4
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 filelock==3.13.1
     # via
     #   huggingface-hub
@@ -182,7 +187,7 @@ httpcore==0.17.3
     # via httpx
 httpx==0.24.1
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   anthropic
     #   openai
     #   taskbadger
@@ -199,7 +204,7 @@ idna==3.4
 inflection==0.5.1
     # via drf-spectacular
 jinja2==3.1.4
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 jmespath==1.0.1
     # via
     #   boto3
@@ -217,9 +222,9 @@ jsonschema-specifications==2023.7.1
 kombu==5.3.3
     # via celery
 langchain==0.1.16
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 langchain-anthropic==0.1.8
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 langchain-community==0.0.32
     # via langchain
 langchain-core==0.1.42
@@ -230,7 +235,7 @@ langchain-core==0.1.42
     #   langchain-openai
     #   langchain-text-splitters
 langchain-openai==0.1.3
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 langchain-text-splitters==0.0.1
     # via langchain
 langsmith==0.1.47
@@ -239,7 +244,7 @@ langsmith==0.1.47
     #   langchain-community
     #   langchain-core
 markdown==3.5.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
@@ -264,7 +269,7 @@ oauthlib==3.2.2
     # via requests-oauthlib
 openai==1.23.6
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   langchain-openai
 orjson==3.10.0
     # via langsmith
@@ -276,16 +281,16 @@ packaging==23.2
     #   marshmallow
     #   transformers
 pandas==2.1.3
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 prompt-toolkit==3.0.41
     # via click-repl
 psycopg2-binary==2.9.9
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 pycparser==2.21
     # via cffi
 pydantic==2.5.0
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   anthropic
     #   langchain
     #   langchain-core
@@ -294,17 +299,18 @@ pydantic==2.5.0
 pydantic-core==2.14.1
     # via pydantic
 pydub==0.25.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 pygments==2.16.1
     # via rich
 pyjwt[crypto]==2.8.0
     # via
     #   django-allauth
+    #   pyjwt
     #   twilio
 pypng==0.20220715.0
     # via qrcode
 pytelegrambotapi==4.12.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 python-crontab==3.0.0
     # via django-celery-beat
 python-dateutil==2.8.2
@@ -318,6 +324,7 @@ python3-openid==3.2.0
     # via django-allauth
 pytz==2023.3.post1
     # via
+    #   django-tz-detect
     #   djangorestframework
     #   pandas
 pyyaml==6.0.1
@@ -369,7 +376,7 @@ s3transfer==0.7.0
 safetensors==0.4.3
     # via transformers
 sentry-sdk==1.35.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 shellingham==1.5.4
     # via typer
 six==1.16.0
@@ -388,16 +395,16 @@ sqlalchemy==2.0.23
 sqlparse==0.5.0
     # via django
 taskbadger==1.3.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 tenacity==8.2.3
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   langchain
     #   langchain-community
     #   langchain-core
 tiktoken==0.7.0
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   langchain-openai
 tokenizers==0.15.0
     # via
@@ -411,13 +418,15 @@ tqdm==4.66.3
     #   openai
     #   transformers
 transformers==4.39.3
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 turn-python==0.2.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 twilio==8.10.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 typer[all]==0.9.0
-    # via taskbadger
+    # via
+    #   taskbadger
+    #   typer
 typing-extensions==4.8.0
     # via
     #   anthropic
@@ -452,6 +461,6 @@ vine==5.1.0
 wcwidth==0.2.10
     # via prompt-toolkit
 whitenoise[brotli]==6.6.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 yarl==1.9.2
     # via aiohttp

--- a/templates/experiments/components/experiment_chat.html
+++ b/templates/experiments/components/experiment_chat.html
@@ -30,7 +30,9 @@
                   {% else %}
                     {% include "experiments/chat/components/user_icon.html" %}
                   {% endif %}
-                  <small>{{ message.created_at }}</small>
+                  <small><time datetime="{{ message.created_at.isoformat }}" title="{{ message.created_at.isoformat }}">
+                    {{ message.created_at|date:"DATETIME_FORMAT" }}
+                  </time></small>
                 </div>
               </td>
               <td class="px-3 py-4 text-sm text-gray-500">{{ message.content|render_markdown }}</td>

--- a/templates/experiments/components/experiment_chat.html
+++ b/templates/experiments/components/experiment_chat.html
@@ -30,7 +30,7 @@
                   {% else %}
                     {% include "experiments/chat/components/user_icon.html" %}
                   {% endif %}
-                  <small>{{ message.created_at.time }}</small>
+                  <small>{{ message.created_at }}</small>
                 </div>
               </td>
               <td class="px-3 py-4 text-sm text-gray-500">{{ message.content|render_markdown }}</td>

--- a/templates/web/base.html
+++ b/templates/web/base.html
@@ -67,5 +67,7 @@
     {% block page_js %}
     {% endblock page_js %}
     {% include 'web/components/messages-js.html' %}
+    {% load tz_detect %}
+    {% tz_detect %}
   </body>
 </html>


### PR DESCRIPTION
Resolves #421. The detected timezones will be persisted on the user's session (django will use this timezone automaticlly) and also update a participant's data when they start a new session.
Q: Why only then?
A: The library injects JS that grabs the browser's timezone and then makes a request to the server to store it in the user's current session. Note that this happens 1. once per session at the start (so when a user initially loads the page) 2. even if the user is not logged in yet. This means that we cannot reliably tell who the user was whose timezone was sent to the server unless they are logged in. Since the timezone persists on the session throughout future calls we'll be able to identify the participant + timezone once they start a new session. It is OK though, since the participant will start a session, we'll update any participant data that there might be and only in a subsequent call will their queries for the bot be handled, by which time we'll already have timezone data if it's needed for the bot.