### PR TITLE
Use participant timezone in chats

### DIFF
--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -208,7 +208,7 @@ class ChannelBase:
         if not self.is_message_type_supported():
             return self._handle_unsupported_message()
 
-        if self.experiment_channel.platform != "web":
+        if self.experiment_channel.platform != ChannelPlatform.WEB:
             if self._is_reset_conversation_request():
                 # Webchats' statuses are updated through an "external" flow
                 return
@@ -393,13 +393,9 @@ class ChannelBase:
         If the user requested a new session (by sending the reset command), this will create a new experiment
         session.
         """
-        if self.experiment_session and not self.experiment_channel:
-            # TODO: Remove
-            # Since web channels doesn't have channel records (atm), they will only have experiment sessions
-            # so we don't create channel_sessions for them.
+        if self.experiment_session and self.experiment_channel.platform == ChannelPlatform.WEB:
             return
 
-        # We override `self.experiment_session`, since we must always use the latest (or "active") session
         self.experiment_session = (
             ExperimentSession.objects.filter(
                 experiment=self.experiment,

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -285,12 +285,15 @@ class ScheduledMessage(BaseTeamModel):
     def repetitions(self) -> str:
         return self.action.params["repetitions"]
 
-    def __str__(self):
+    def as_string(self, as_timezone: str | None = None):
         schedule = f"{self.name}: Every {self.frequency} {self.time_period}, {self.repetitions} times"
         if self.time_period not in ["hour", "day"]:
             weekday = self.next_trigger_date.strftime("%A")
             schedule = (
                 f"{self.name}: Every {self.frequency} {self.time_period} on {weekday} for {self.repetitions} times"
             )
-        next_trigger = pretty_date(self.next_trigger_date)
+        next_trigger = pretty_date(self.next_trigger_date, as_timezone=as_timezone)
         return f"{schedule} (next trigger is {next_trigger})"
+
+    def __str__(self):
+        return self.as_string()

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -3,6 +3,7 @@ import logging
 import uuid
 
 import markdown
+import pytz
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
@@ -667,13 +668,14 @@ class ExperimentSession(BaseTeamModel):
             if not fail_silently:
                 raise e
 
-    def get_participant_scheduled_messages(self, as_dict=False):
+    def get_participant_scheduled_messages(self, as_dict=False, as_timezone: str | None = None):
         """
         Returns all scheduled messages for the associated participant for this session's experiment as well as
         any child experiments in the case where the experiment is a parent
 
         Parameters:
         as_dict: If True, the data will be returned as an array of dictionaries, otherwise an an array of strings
+        timezone: The timezone to use for the dates. Defaults to the active timezone.
         """
         from apps.events.models import ScheduledMessage
 
@@ -685,7 +687,10 @@ class ExperimentSession(BaseTeamModel):
         ).select_related("action")
 
         scheduled_messages = []
+        as_timezone = as_timezone or timezone.get_current_timezone_name()
+
         for message in messages:
+            next_trigger_date = message.next_trigger_date.astimezone(pytz.timezone(as_timezone))
             if as_dict:
                 scheduled_messages.append(
                     {
@@ -693,22 +698,29 @@ class ExperimentSession(BaseTeamModel):
                         "frequency": message.frequency,
                         "time_period": message.time_period,
                         "repetitions": message.repetitions,
-                        "next_trigger_date": message.next_trigger_date.isoformat(),
+                        "next_trigger_date": next_trigger_date.isoformat(),
                     }
                 )
             else:
-                scheduled_messages.append(str(message))
+                scheduled_messages.append(message.as_string(as_timezone=as_timezone))
         return scheduled_messages
 
-    def get_participant_data(self):
+    def get_participant_data(self, use_participant_tz=False):
+        """Returns the participant's data. If `use_participant_tz` is `True`, the dates of the scheduled messages
+        will be represented in the timezone that the participant is in if that information is available"""
         participant_data = self.experiment.get_participant_data(self.participant) or {}
-        participant_data = {**participant_data, "scheduled_messages": self.get_participant_scheduled_messages()}
+        as_timezone = None
+        if use_participant_tz:
+            as_timezone = participant_data.get("timezone", as_timezone)
+
+        scheduled_messages = self.get_participant_scheduled_messages(as_timezone=as_timezone)
+        if scheduled_messages:
+            participant_data = {**participant_data, "scheduled_messages": scheduled_messages}
         return participant_data
 
     def get_participant_data_json(self):
         participant_data = self.experiment.get_participant_data(self.participant) or {}
-        participant_data = {
-            **participant_data,
-            "scheduled_messages": self.get_participant_scheduled_messages(as_dict=True),
-        }
+        scheduled_messages = self.get_participant_scheduled_messages(as_dict=True)
+        if scheduled_messages:
+            participant_data = {**participant_data, "scheduled_messages": scheduled_messages}
         return json.dumps(participant_data, indent=2)

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -17,10 +17,12 @@ from apps.utils.taskbadger import update_taskbadger_data
 @shared_task(bind=True, base=TaskbadgerTask)
 def get_response_for_webchat_task(self, experiment_session_id: int, message_text: str) -> str:
     experiment_session = ExperimentSession.objects.get(id=experiment_session_id)
-    message_handler = WebChannel(experiment_session.experiment_channel)
+    web_channel = WebChannel(
+        experiment_channel=experiment_session.experiment_channel, experiment_session=experiment_session
+    )
     message = WebMessage(chat_id=experiment_session.participant.identifier, message_text=message_text)
-    update_taskbadger_data(self, message_handler, message)
-    return message_handler.new_user_message(message)
+    update_taskbadger_data(self, web_channel, message)
+    return web_channel.new_user_message(message)
 
 
 @shared_task

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -1,7 +1,10 @@
 import pytest
+from freezegun import freeze_time
 
-from apps.experiments.models import SyntheticVoice
-from apps.utils.factories.experiment import SyntheticVoiceFactory
+from apps.events.models import EventActionType, TimePeriod
+from apps.experiments.models import ExperimentRoute, SyntheticVoice
+from apps.utils.factories.events import EventActionFactory, ScheduledMessageFactory
+from apps.utils.factories.experiment import ExperimentSessionFactory, SyntheticVoiceFactory
 from apps.utils.factories.service_provider_factories import VoiceProviderFactory
 from apps.utils.factories.team import TeamFactory
 
@@ -67,3 +70,65 @@ class TestSyntheticVoice:
         services = set(voices_queryset.values_list("service", flat=True))
         assert services == {SyntheticVoice.AWS, SyntheticVoice.OpenAI, SyntheticVoice.Azure}
         assert voice1 not in voices_queryset
+
+
+class TestExperimentSession:
+    def _construct_event_action(self, time_period: TimePeriod, frequency=1, repetitions=1) -> tuple:
+        params = {
+            "name": "Test",
+            "time_period": time_period,
+            "frequency": frequency,
+            "repetitions": repetitions,
+            "prompt_text": "",
+        }
+        return EventActionFactory(params=params, action_type=EventActionType.SCHEDULETRIGGER), params
+
+    @pytest.mark.django_db()
+    @freeze_time("2024-01-01")
+    def test_get_participant_scheduled_messages(self):
+        session = ExperimentSessionFactory()
+        event_action = event_action, params = self._construct_event_action(time_period=TimePeriod.DAYS)
+        ScheduledMessageFactory.create_batch(
+            size=2,
+            experiment=session.experiment,
+            team=session.team,
+            participant=session.participant,
+            action=event_action,
+        )
+        assert len(session.get_participant_scheduled_messages()) == 2
+        expected_str_version = [
+            "Test: Every 1 days on Tuesday for 1 times (next trigger is Tuesday, 02 January 2024 00:00:00 UTC)",
+            "Test: Every 1 days on Tuesday for 1 times (next trigger is Tuesday, 02 January 2024 00:00:00 UTC)",
+        ]
+        expected_dict_version = [
+            {
+                "name": "Test",
+                "frequency": 1,
+                "time_period": "days",
+                "repetitions": 1,
+                "next_trigger_date": "2024-01-02T00:00:00+00:00",
+            },
+            {
+                "name": "Test",
+                "frequency": 1,
+                "time_period": "days",
+                "repetitions": 1,
+                "next_trigger_date": "2024-01-02T00:00:00+00:00",
+            },
+        ]
+        assert session.get_participant_scheduled_messages() == expected_str_version
+        assert session.get_participant_scheduled_messages(as_dict=True) == expected_dict_version
+
+    @pytest.mark.django_db()
+    def test_get_participant_scheduled_messages_includes_child_experiments(self):
+        session = ExperimentSessionFactory()
+        team = session.team
+        participant = session.participant
+        session2 = ExperimentSessionFactory(experiment__team=team, participant=participant)
+        event_action = event_action, params = self._construct_event_action(time_period=TimePeriod.DAYS)
+        ScheduledMessageFactory(experiment=session.experiment, team=team, participant=participant, action=event_action)
+        ScheduledMessageFactory(experiment=session2.experiment, team=team, participant=participant, action=event_action)
+        ExperimentRoute.objects.create(team=team, parent=session.experiment, child=session2.experiment, keyword="test")
+
+        assert len(session2.get_participant_scheduled_messages()) == 1
+        assert len(session.get_participant_scheduled_messages()) == 2

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -107,7 +107,7 @@ class BaseExperimentRunnable(RunnableSerializable[dict, ChainOutput], ABC):
 
     @property
     def participant_data(self):
-        return self.experiment.get_participant_data(self.session.participant) or ""
+        return self.session.get_participant_data(use_participant_tz=True) or ""
 
 
 class ExperimentRunnable(BaseExperimentRunnable):

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -185,8 +185,10 @@ class ExperimentRunnable(BaseExperimentRunnable):
 
     @property
     def prompt(self):
-        current_datetime = pretty_date(timezone.now())
-        prompt = self.experiment.prompt_text + f"\nThe current datetime is {current_datetime}"
+        participant_tz = self.session.get_participant_timezone()
+        current_datetime = pretty_date(timezone.now(), participant_tz)
+        # The bot converts to UTC unless we tell it to preserve the given timezone
+        prompt = self.experiment.prompt_text + f"\nThe current datetime is {current_datetime} (timezone preserved)"
         system_prompt = SystemMessagePromptTemplate.from_template(prompt)
         return ChatPromptTemplate.from_messages(
             [

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -30,7 +30,8 @@ def session():
     session = ExperimentSessionFactory.build(chat=chat)
     local_assistant = OpenAiAssistantFactory.build(id=1, assistant_id=ASSISTANT_ID)
     session.experiment.assistant = local_assistant
-    session.experiment.get_participant_data = lambda *args: None
+    session.experiment.get_participant_data = lambda *args, **kwargs: None
+    session.get_participant_data = lambda *args, **kwargs: None
     return session
 
 

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -30,7 +30,6 @@ def session():
     session = ExperimentSessionFactory.build(chat=chat)
     local_assistant = OpenAiAssistantFactory.build(id=1, assistant_id=ASSISTANT_ID)
     session.experiment.assistant = local_assistant
-    session.experiment.get_participant_data = lambda *args, **kwargs: None
     session.get_participant_data = lambda *args, **kwargs: None
     return session
 

--- a/apps/service_providers/tests/test_runnables.py
+++ b/apps/service_providers/tests/test_runnables.py
@@ -66,8 +66,10 @@ def test_runnable(runnable, session, fake_llm):
     assert len(fake_llm.get_calls()) == 1
     assert _messages_to_dict(fake_llm.get_call_messages()[0]) == [
         {
-            "system": """You are a helpful assistant\nThe current datetime is Thursday, 08 February 2024 13:00:08 
-            UTC (timezone preserved)"""
+            "system": (
+                "You are a helpful assistant\nThe current datetime is Thursday, 08 February 2024 13:00:08 "
+                "UTC (timezone preserved)"
+            )
         },
         {"human": "hi"},
     ]

--- a/apps/service_providers/tests/test_runnables.py
+++ b/apps/service_providers/tests/test_runnables.py
@@ -65,7 +65,10 @@ def test_runnable(runnable, session, fake_llm):
     assert result == ChainOutput(output="this is a test message", prompt_tokens=30, completion_tokens=20)
     assert len(fake_llm.get_calls()) == 1
     assert _messages_to_dict(fake_llm.get_call_messages()[0]) == [
-        {"system": "You are a helpful assistant\nThe current datetime is Thursday, 08 February 2024 13:00:08 UTC"},
+        {
+            "system": """You are a helpful assistant\nThe current datetime is Thursday, 08 February 2024 13:00:08 
+            UTC (timezone preserved)"""
+        },
         {"human": "hi"},
     ]
     if runnable.expect_tools:
@@ -84,7 +87,7 @@ def test_runnable_with_source_material(runnable, session, fake_llm):
     assert result == ChainOutput(output="this is a test message", prompt_tokens=30, completion_tokens=20)
     expected_system__prompt = (
         "System prompt with this is the source material"
-        + "\nThe current datetime is Thursday, 08 February 2024 13:00:08 UTC"
+        + "\nThe current datetime is Thursday, 08 February 2024 13:00:08 UTC (timezone preserved)"
     )
     assert fake_llm.get_call_messages()[0][0] == SystemMessage(content=expected_system__prompt)
 
@@ -97,7 +100,7 @@ def test_runnable_with_source_material_missing(runnable, session, fake_llm):
     result = chain.invoke("hi")
     assert result == ChainOutput(output="this is a test message", prompt_tokens=30, completion_tokens=20)
     expected_system__prompt = (
-        "System prompt with " + "\nThe current datetime is Thursday, 08 February 2024 13:00:08 UTC"
+        "System prompt with " + "\nThe current datetime is Thursday, 08 February 2024 13:00:08 UTC (timezone preserved)"
     )
     assert fake_llm.get_call_messages()[0][0] == SystemMessage(content=expected_system__prompt)
 
@@ -137,7 +140,10 @@ def test_runnable_with_history(runnable, session, chat, fake_llm):
     assert result == ChainOutput(output="this is a test message", prompt_tokens=30, completion_tokens=20)
     assert len(fake_llm.get_calls()) == 1
     assert _messages_to_dict(fake_llm.get_call_messages()[0]) == [
-        {"system": experiment.prompt_text + "\nThe current datetime is Thursday, 08 February 2024 13:00:08 UTC"},
+        {
+            "system": experiment.prompt_text
+            + "\nThe current datetime is Thursday, 08 February 2024 13:00:08 UTC (timezone preserved)"
+        },
         {"human": "Hello"},
         {"human": "hi"},
     ]

--- a/apps/service_providers/tests/test_runnables_cancellation.py
+++ b/apps/service_providers/tests/test_runnables_cancellation.py
@@ -30,7 +30,7 @@ def session(fake_llm):
     session = ExperimentSessionFactory.build(chat=chat)
     session.experiment.get_llm_service = lambda: FakeLlmService(llm=fake_llm)
     session.experiment.tools = [AgentTools.SCHEDULE_UPDATE]
-    session.experiment.get_participant_data = lambda *args, **kwargs: ""
+    session.get_participant_data = lambda *args, **kwargs: ""
     return session
 
 

--- a/apps/utils/time.py
+++ b/apps/utils/time.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
 
+import pytz
 from dateutil.relativedelta import relativedelta
+from django.utils.timezone import get_current_timezone_name
 
 
 def seconds_to_human(value):
@@ -25,6 +27,9 @@ def timedelta_to_relative_delta(timedelta: timedelta):
     return relativedelta(seconds=timedelta.total_seconds())
 
 
-def pretty_date(date: datetime) -> str:
+def pretty_date(date: datetime, as_timezone: str | None = None) -> str:
+    as_timezone = as_timezone or get_current_timezone_name()
     """Returns the date like this: 'Monday, 1 January 2024 08:00:00 UTC'"""
+    if as_timezone:
+        date = date.astimezone(pytz.timezone(as_timezone))
     return date.strftime("%A, %d %B %Y %H:%M:%S %Z")

--- a/apps/utils/time.py
+++ b/apps/utils/time.py
@@ -28,8 +28,7 @@ def timedelta_to_relative_delta(timedelta: timedelta):
 
 
 def pretty_date(date: datetime, as_timezone: str | None = None) -> str:
-    as_timezone = as_timezone or get_current_timezone_name()
     """Returns the date like this: 'Monday, 1 January 2024 08:00:00 UTC'"""
-    if as_timezone:
-        date = date.astimezone(pytz.timezone(as_timezone))
+    as_timezone = as_timezone or get_current_timezone_name()
+    date = date.astimezone(pytz.timezone(as_timezone))
     return date.strftime("%A, %d %B %Y %H:%M:%S %Z")


### PR DESCRIPTION
Included in this PR
- A fix: Web chats had this issue where a participant's latest session was being used regardless which session the participant (or user) used. So if had two sessions on an experiment and used the first (the earlier) session to chat, the history and all of the second session would be used. This is just a web chat issue, and is fixed here
- If we have a participant's timezone (the `timezone` key in the participant data), this will be used when the participant data - specifically the scheduled messages - is included in the chat