### PR TITLE
Participant UI tweaks

### DIFF
--- a/apps/participants/tables.py
+++ b/apps/participants/tables.py
@@ -5,7 +5,7 @@ from apps.experiments.models import Participant
 from apps.generics import actions
 
 
-class ParticpantTable(tables.Table):
+class ParticipantTable(tables.Table):
     created_at = columns.DateTimeColumn(verbose_name="Created On", format="Y-m-d H:i:s")
     actions = columns.TemplateColumn(
         template_name="generic/crud_actions_column.html",

--- a/apps/participants/tables.py
+++ b/apps/participants/tables.py
@@ -6,6 +6,7 @@ from apps.generics import actions
 
 
 class ParticpantTable(tables.Table):
+    created_at = columns.DateTimeColumn(verbose_name="Created On", format="Y-m-d H:i:s")
     actions = columns.TemplateColumn(
         template_name="generic/crud_actions_column.html",
         extra_context={
@@ -17,7 +18,6 @@ class ParticpantTable(tables.Table):
 
     class Meta:
         model = Participant
-        fields = ("identifier",)
+        fields = ("identifier", "created_at")
         row_attrs = settings.DJANGO_TABLES2_ROW_ATTRS
-        orderable = False
         empty_text = "No participants found."

--- a/apps/participants/tables.py
+++ b/apps/participants/tables.py
@@ -21,3 +21,4 @@ class ParticpantTable(tables.Table):
         fields = ("identifier", "created_at")
         row_attrs = settings.DJANGO_TABLES2_ROW_ATTRS
         empty_text = "No participants found."
+        order_by = ("-created_at", "identifier")

--- a/apps/participants/tests/test_views.py
+++ b/apps/participants/tests/test_views.py
@@ -31,7 +31,7 @@ def test_edit_participant_data(client, team_with_users):
 
     data["name"] = "B"
     query_data = QueryDict("", mutable=True)
-    query_data.update({"data": json.dumps(data)})
+    query_data.update({"participant-data-textarea": json.dumps(data)})
     client.post(url, query_data)
     participant_data.refresh_from_db()
     assert participant_data.data["name"] == "B"

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -26,6 +26,7 @@ class ParticipantHome(LoginAndTeamRequiredMixin, TemplateView, PermissionRequire
             "title": "Participants",
             "new_object_url": reverse("participants:participant_new", args=[team_slug]),
             "table_url": reverse("participants:participant_table", args=[team_slug]),
+            "enable_search": True,
         }
 
 
@@ -83,7 +84,11 @@ class ParticipantTableView(SingleTableView):
     permission_required = "experiments.view_participant"
 
     def get_queryset(self):
-        return Participant.objects.filter(team=self.request.team)
+        query = Participant.objects.filter(team=self.request.team)
+        search = self.request.GET.get("search")
+        if search:
+            query = query.filter(identifier__icontains=search)
+        return query
 
 
 class SingleParticipantHome(LoginAndTeamRequiredMixin, TemplateView, PermissionRequiredMixin):

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -114,7 +114,7 @@ class EditParticipantData(LoginAndTeamRequiredMixin, TemplateView, PermissionReq
     def post(self, request, team_slug, participant_id, experiment_id):
         experiment = get_object_or_404(Experiment, team__slug=team_slug, id=experiment_id)
         participant = get_object_or_404(Participant, team__slug=team_slug, id=participant_id)
-        new_data = json.loads(request.POST["data"])
+        new_data = json.loads(request.POST["participant-data-textarea"])
         ParticipantData.objects.update_or_create(
             participant=participant,
             content_type__model="experiment",

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -13,7 +13,7 @@ from apps.experiments.models import Experiment, Participant, ParticipantData
 from apps.participants.forms import ParticipantForm
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 
-from .tables import ParticpantTable
+from .tables import ParticipantTable
 
 
 class ParticipantHome(LoginAndTeamRequiredMixin, TemplateView, PermissionRequiredMixin):
@@ -79,7 +79,7 @@ class DeleteParticipant(LoginAndTeamRequiredMixin, View, PermissionRequiredMixin
 class ParticipantTableView(SingleTableView):
     model = Participant
     paginate_by = 25
-    table_class = ParticpantTable
+    table_class = ParticipantTable
     template_name = "table/single_table.html"
     permission_required = "experiments.view_participant"
 

--- a/templates/participants/partials/participant_experiments.html
+++ b/templates/participants/partials/participant_experiments.html
@@ -6,6 +6,7 @@
       <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">Experiment</th>
       <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">Joined on</th>
       <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">Last message received at</th>
+      <th scope="col" class=""></th>
     </tr>
   </thead>
   <tbody class="divide-y divide-gray-200" x-data="{experimentsRow: null}">
@@ -19,6 +20,10 @@
           <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ experiment.name }}</td>
           <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ experiment.joined_on }}</td>
           <td class="px-3 py-4 text-sm text-gray-500">{{ experiment.last_message }}</td>
+          <td class="">
+            <i class="fa-solid fa-chevron-down" x-show="experimentsRow !== {{ forloop.counter }}"></i>
+            <i class="fa-solid fa-chevron-up" x-show="experimentsRow === {{ forloop.counter }}" x-cloak></i>
+          </td>
         </tr>
         <tr x-show="experimentsRow === {{ forloop.counter }}" x-cloak>
           <td colspan="100%" class="px-3 py-2">


### PR DESCRIPTION
Some other things to think about:

* Showing the platform for each participant (we'd have to do a data migration to get this data)
* Allowing adding participant data for experiments where there aren't any sessions yet
* Export feature?

![Peek 2024-06-13 16-34](https://github.com/dimagi/open-chat-studio/assets/249606/1e4278c7-daf0-4b97-88ef-c2480aeb2ea2)
