### PR TITLE
update_memory method for participants

### DIFF
--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -22,7 +22,6 @@ from apps.experiments.models import (
     Experiment,
     ExperimentSession,
     Participant,
-    ParticipantData,
     SessionStatus,
     VoiceResponseBehaviours,
 )
@@ -791,6 +790,7 @@ def _start_experiment_session(
                 identifier=participant_identifier,
                 team=experiment.team,
             )
+
         session = ExperimentSession.objects.create(
             team=experiment.team,
             experiment=experiment,
@@ -803,11 +803,7 @@ def _start_experiment_session(
 
         # Record the participant's timezone
         if timezone:
-            data_records = ParticipantData.objects.filter(participant=participant)
-            for data_record in data_records:
-                data_record.data["timezone"] = timezone
-                data_record.save()
-            ParticipantData.objects.bulk_update(data_records, fields=["data"])
+            participant.update_memory(data={"timezone": timezone})
 
     if participant.experimentsession_set.count() == 1:
         enqueue_static_triggers.delay(session.id, StaticTriggerType.PARTICIPANT_JOINED_EXPERIMENT)

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -12,7 +12,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MaxValueValidator, MinValueValidator, validate_email
 from django.db import models, transaction
-from django.db.models import Count, OuterRef, Q, Subquery
+from django.db.models import Count, OuterRef, Prefetch, Q, Subquery
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext
@@ -528,13 +528,13 @@ class Participant(BaseTeamModel):
         if experiment:
             experiments = [experiment]
         else:
-            experiments = Experiment.objects.filter(team=self.team).prefetch_related("participant_data").all()
-            if experiment:
-                experiments = experiments.filter(id=experiment.id)
+            experiments = Experiment.objects.filter(team=self.team).prefetch_related(
+                Prefetch("participant_data", queryset=ParticipantData.objects.filter(participant=self))
+            )
 
         records_to_update = []
         for experiment in experiments:
-            participant_data = experiment.participant_data.filter(participant=self).first()
+            participant_data = experiment.participant_data.first()
             # We cannot update the participant data using a single query, since the `data` field is encrypted at
             # the application level
             if participant_data:

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -525,9 +525,12 @@ class Participant(BaseTeamModel):
         experiment:
             If specified, only the data for this experiment will be updated
         """
-        experiments = Experiment.objects.filter(team=self.team).prefetch_related("participant_data").all()
         if experiment:
-            experiments = experiments.filter(id=experiment.id)
+            experiments = [experiment]
+        else:
+            experiments = Experiment.objects.filter(team=self.team).prefetch_related("participant_data").all()
+            if experiment:
+                experiments = experiments.filter(id=experiment.id)
 
         records_to_update = []
         for experiment in experiments:

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -11,7 +11,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelatio
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MaxValueValidator, MinValueValidator, validate_email
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Count, OuterRef, Q, Subquery
 from django.urls import reverse
 from django.utils import timezone
@@ -511,6 +511,36 @@ class Participant(BaseTeamModel):
             .filter(sessions__participant=self)
             .distinct()
         )
+
+    @transaction.atomic()
+    def update_memory(self, data: dict, experiment: Experiment | None = None):
+        """
+        Updates this participant's data records by merging `data` with the existing data. By default, data for all
+        experiments the this participant participated in will be updated. If there are no records for a specific
+        experiment, one will be created.
+
+        Paramters
+        data:
+            A dictionary containing the new data
+        experiment:
+            If specified, only the data for this experiment will be updated
+        """
+        experiments = Experiment.objects.filter(team=self.team).prefetch_related("participant_data").all()
+        if experiment:
+            experiments = experiments.filter(id=experiment.id)
+
+        records_to_update = []
+        for experiment in experiments:
+            participant_data = experiment.participant_data.filter(participant=self).first()
+            # We cannot update the participant data using a single query, since the `data` field is encrypted at
+            # the application level
+            if participant_data:
+                participant_data.data = participant_data.data | data
+                records_to_update.append(participant_data)
+            else:
+                ParticipantData.objects.create(team=self.team, content_object=experiment, data=data, participant=self)
+
+        ParticipantData.objects.bulk_update(records_to_update, fields=["data"])
 
     class Meta:
         ordering = ["identifier"]

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -525,12 +525,11 @@ class Participant(BaseTeamModel):
         experiment:
             If specified, only the data for this experiment will be updated
         """
+        experiments = Experiment.objects.filter(team=self.team).prefetch_related(
+            Prefetch("participant_data", queryset=ParticipantData.objects.filter(participant=self))
+        )
         if experiment:
-            experiments = [experiment]
-        else:
-            experiments = Experiment.objects.filter(team=self.team).prefetch_related(
-                Prefetch("participant_data", queryset=ParticipantData.objects.filter(participant=self))
-            )
+            experiments = experiments.filter(id=experiment.id)
 
         records_to_update = []
         for experiment in experiments:

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -260,7 +260,7 @@ class TestParticipant:
     def test_update_memory_for_specific_experiment(self):
         participant = ParticipantFactory()
         team = participant.team
-        sessions = ExperimentSessionFactory.create_batch(3, participant=participant, team=team)
+        sessions = ExperimentSessionFactory.create_batch(3, participant=participant, team=team, experiment__team=team)
         experiment = sessions[0].experiment
         participant.update_memory({"first_name": "Will"}, experiment=experiment)
         assert ParticipantData.objects.count() == 1

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -231,3 +231,42 @@ class TestExperimentSession:
                 _test()
         else:
             _test()
+
+
+class TestParticipant:
+    @pytest.mark.django_db()
+    def test_update_memory_updates_all_data(self):
+        participant = ParticipantFactory()
+        team = participant.team
+        sessions = ExperimentSessionFactory.create_batch(3, participant=participant, team=team, experiment__team=team)
+        # let the participant be linked to an experiment in another team as well. That experiment should be unaffected
+        ExperimentSessionFactory(participant=participant)
+        existing_data_obj = ParticipantData.objects.create(
+            team=team,
+            content_object=sessions[0].experiment,
+            data={"first_name": "Jack", "last_name": "Turner"},
+            participant=participant,
+        )
+        participant.update_memory({"first_name": "Elizabeth"})
+        participant_data_query = ParticipantData.objects.filter(team=team, participant=participant)
+        assert participant_data_query.count() == 3
+        for p_data in participant_data_query.all():
+            if p_data == existing_data_obj:
+                assert p_data.data == {"first_name": "Elizabeth", "last_name": "Turner"}
+            else:
+                assert p_data.data == {"first_name": "Elizabeth"}
+
+    @pytest.mark.django_db()
+    def test_update_memory_for_specific_experiment(self):
+        participant = ParticipantFactory()
+        team = participant.team
+        sessions = ExperimentSessionFactory.create_batch(3, participant=participant, team=team)
+        experiment = sessions[0].experiment
+        participant.update_memory({"first_name": "Will"}, experiment=experiment)
+        assert ParticipantData.objects.count() == 1
+        assert experiment.participant_data.filter(participant=participant).first().data == {"first_name": "Will"}
+        participant.update_memory({"first_name": "Bootstrap Bill", "last_name": "Turner"}, experiment=experiment)
+        assert experiment.participant_data.filter(participant=participant).first().data == {
+            "first_name": "Bootstrap Bill",
+            "last_name": "Turner",
+        }

--- a/apps/experiments/tests/test_views.py
+++ b/apps/experiments/tests/test_views.py
@@ -330,9 +330,9 @@ def test_user_email_used_for_participant_identifier(_trigger_mock, client):
 def test_timezone_saved_in_participant_data(_trigger_mock):
     """A participant's timezone data should be saved in all ParticipantData records"""
     experiment = ExperimentFactory(team=TeamWithUsersFactory())
-    experiment2 = ExperimentFactory()
-    channel = ExperimentChannelFactory(experiment=experiment)
     team = experiment.team
+    experiment2 = ExperimentFactory(team=team)
+    channel = ExperimentChannelFactory(experiment=experiment)
     identifier = "someone@example.com"
     participant = Participant.objects.create(identifier=identifier, team=team)
     part_data1 = ParticipantData.objects.create(team=team, participant=participant, content_object=experiment)


### PR DESCRIPTION
This new method does the following:
- For each experiment in the participant's team that they have participated in, it updates the data for that participant by merging the incoming data (updating or creating keys). For any of those experiments which does not have data for this participant yet, it creates a new record with the incoming data.
- Allows you to update the `ParticipantData` record for a specific experiment. This will come in useful when we extract participant data for a specfici experiment

Note: I added a comment, but will emphasize it here as well: Since the `data` field is encrypted at the application level, we are not able to use a DB query to insert/update the new data. We have to pull all records, access the data and put it back. Any suggestions on how I can make this process faster is super welcome!