### PR TITLE
Optional datetime injection

### DIFF
--- a/apps/experiments/tests/test_views.py
+++ b/apps/experiments/tests/test_views.py
@@ -25,7 +25,8 @@ from apps.utils.factories.service_provider_factories import LlmProviderFactory
 from apps.utils.factories.team import TeamWithUsersFactory, UserFactory
 
 
-def test_create_experiment_success(db, client, team_with_users):
+@pytest.mark.django_db()
+def test_create_experiment_success(client, team_with_users):
     user = team_with_users.members.first()
     source_material = SourceMaterialFactory(team=team_with_users)
     consent_form = ConsentFormFactory(team=team_with_users)
@@ -36,7 +37,7 @@ def test_create_experiment_success(db, client, team_with_users):
         "name": "some name",
         "description": "Some description",
         "type": "llm",
-        "prompt_text": "You are a helpful assistant",
+        "prompt_text": "You are a helpful assistant. The current date time is {current_datetime}",
         "source_material": source_material.id if source_material else "",
         "consent_form": consent_form.id,
         "temperature": 0.7,

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -242,11 +242,11 @@ class ExperimentForm(forms.ModelForm):
 
 def _validate_prompt_variables(form_data):
     required_variables = set(PromptTemplate.from_template(form_data.get("prompt_text")).input_variables)
-    available_variables = set(["participant_data"])
+    available_variables = set(["participant_data", "current_datetime"])
     if form_data.get("source_material"):
         available_variables.add("source_material")
     missing_vars = required_variables - available_variables
-    known_vars = {"source_material", "participant_data"}
+    known_vars = {"source_material", "participant_data", "current_datetime"}
     if missing_vars:
         errors = []
         unknown_vars = missing_vars - known_vars

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -128,11 +128,12 @@ class ExperimentSessionsTableView(SingleTableView, PermissionRequiredMixin):
 class ExperimentForm(forms.ModelForm):
     PROMPT_HELP_TEXT = """
         <div class="tooltip" data-tip="
-            Available variables: {source_material}, {participant_data} and {current_datetime}. Use
-             {source_material} to place source material, {participant_data} to place participant specific data and
-             {current_datetime} to give the LLM knowledge of the current date and time. The date and time is
-             required for bots using tools.
-            ">
+            Available variables to include in your prompt: {source_material}, {participant_data}, and
+            {current_datetime}.
+            {source_material} should be included when there is source material linked to the experiment.
+            {participant_data} is optional.
+            {current_datetime} is only required when the bot is using a tool.
+        ">
             <i class="text-xs fa fa-circle-question">
             </i>
         </div>
@@ -268,7 +269,10 @@ def _validate_prompt_variables(form_data):
             errors.append("Prompt contains unknown variables: " + ", ".join(unknown_vars))
             missing_vars -= unknown_vars
         if missing_vars:
-            errors.append(f"Prompt expects {', '.join(missing_vars)} but it is not provided.")
+            errors.append(
+                f"Prompt expects {', '.join(missing_vars)} but it is not provided. See the help text on variable "
+                "usage."
+            )
         raise forms.ValidationError({"prompt_text": errors})
 
 

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -204,7 +204,6 @@ class ExperimentRunnable(BaseExperimentRunnable):
 
     @property
     def prompt(self):
-        # The bot converts to UTC unless we tell it to preserve the given timezone
         return ChatPromptTemplate.from_messages(
             [
                 ("system", self.experiment.prompt_text),

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -31,6 +31,7 @@ def session():
     local_assistant = OpenAiAssistantFactory.build(id=1, assistant_id=ASSISTANT_ID)
     session.experiment.assistant = local_assistant
     session.get_participant_data = lambda *args, **kwargs: None
+    session.get_participant_timezone = lambda *args, **kwargs: ""
     return session
 
 


### PR DESCRIPTION
Users now have to include the {current_datetime} somewhere in the prompt to inject it. 

Thoughts on this change?

![image](https://github.com/dimagi/open-chat-studio/assets/64970009/6d0a6355-6d00-48d0-a337-8bc4acdc2bc7)

TODO:
There's a pesky issue in one of the tests I still need to fix