### PR TITLE
Add total failures and always return a result

### DIFF
--- a/apps/events/const.py
+++ b/apps/events/const.py
@@ -1,0 +1,1 @@
+TOTAL_FAILURES = 5

--- a/apps/events/tests/test_timeout_trigger.py
+++ b/apps/events/tests/test_timeout_trigger.py
@@ -6,6 +6,7 @@ from django.test import override_settings
 from freezegun import freeze_time
 
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
+from apps.events.const import TOTAL_FAILURES
 from apps.events.models import (
     EventAction,
     EventActionType,
@@ -159,6 +160,36 @@ def test_trigger_count_reached(session):
         )
         frozen_time.tick(delta=timedelta(minutes=9))
         assert len(timeout_trigger.timed_out_sessions()) == 0
+
+
+@pytest.mark.django_db()
+def test_failure_count_reached(session):
+    timeout_trigger = TimeoutTrigger.objects.create(
+        experiment=session.experiment,
+        action=EventAction.objects.create(action_type=EventActionType.LOG),
+        total_num_triggers=2,
+        delay=10 * 60,  # 10 minutes
+    )
+    with freeze_time("2024-04-02") as frozen_time:
+        chat = Chat.objects.create(team=session.team)
+        message = ChatMessage.objects.create(
+            chat=chat,
+            content="Hello",
+            message_type=ChatMessageType.HUMAN,
+        )
+        message.save()
+        session.chat = chat
+        session.save()
+        frozen_time.tick(delta=timedelta(minutes=11))
+        assert len(timeout_trigger.timed_out_sessions()) == 1
+
+        assert timeout_trigger._has_triggers_left(session, message) is True
+        for _ in range(TOTAL_FAILURES):
+            timeout_trigger.event_logs.create(
+                session=session, chat_message=message, status=EventLogStatusChoices.FAILURE
+            )
+
+        assert timeout_trigger._has_triggers_left(session, message) is False
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
Found these two bugs while working on the events migration:
- Timeout events weren't getting triggered properly, as the action wasn't being passed properly into the action handler
- If there was a failure it would just keep retrying forever... I set it arbitrarily to retry 5 times, but we can update that if we need to. 