### PR TITLE
Do not tag human messages with bot tags

### DIFF
--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -147,9 +147,7 @@ class ExperimentRunnable(BaseExperimentRunnable):
         self._populate_memory()
 
         if config.get("configurable", {}).get("save_input_to_history", True):
-            self._save_message_to_history(
-                input, ChatMessageType.HUMAN, config.get("configurable", {}).get("add_experiment_tag", False)
-            )
+            self._save_message_to_history(input, ChatMessageType.HUMAN)
 
         output = self._get_output_check_cancellation(input, config)
         result = ChainOutput(


### PR DESCRIPTION
I think it makes sense to not tag human messags with the bot that's going to respond. After this is merged, we can deploy