### PR TITLE
Ensure all files are taken into account

### DIFF
--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -176,7 +176,7 @@ def _sync_vector_store_files_to_openai(client, vector_store_id, files_ids: list[
 
     while True:
         vector_store_files = client.beta.vector_stores.files.list(
-            order='asc',
+            order="asc",
             vector_store_id=vector_store_id,
             **kwargs,
         )
@@ -188,7 +188,7 @@ def _sync_vector_store_files_to_openai(client, vector_store_id, files_ids: list[
 
         if not vector_store_files.has_more:
             break
-        kwargs['after'] = vector_store_files.last_id
+        kwargs["after"] = vector_store_files.last_id
 
     for file_id in to_delete_remote:
         client.beta.vector_stores.files.delete(vector_store_id=vector_store_id, file_id=file_id)

--- a/apps/assistants/tests/test_sync.py
+++ b/apps/assistants/tests/test_sync.py
@@ -3,6 +3,7 @@ from io import BytesIO
 from unittest.mock import call, patch
 
 import pytest
+from openai.pagination import SyncCursorPage
 
 from apps.assistants.models import ToolResources
 from apps.assistants.sync import (
@@ -71,7 +72,13 @@ def test_push_assistant_to_openai_update(mock_update, vs_retrieve, vs_files_list
     )
     search_resource.files.set(files[2:])
 
-    vs_files_list.return_value = []
+    vs_files_list.return_value = SyncCursorPage(
+        data=[],
+        object="list",
+        first_id=None,
+        last_id=None,
+        has_more=False,
+    )
 
     openai_files = FileObjectFactory.create_batch(2)
     with patch("openai.resources.Files.create", side_effect=openai_files) as mock_file_create:


### PR DESCRIPTION
The vector store list protocol seems to "page" responses; by default returning only 20 items (see [here](https://github.com/openai/openai-python/blob/f3e6e634a86d5789ab1274ae27f43adc842f4ba8/src/openai/resources/beta/vector_stores/files.py#L162-L163)). This PR updates the sync code to take this paging into account, going through all files in a store rather than the default number.