### PR TITLE
API endpoint to create sessions with prepopulated history

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -4,7 +4,7 @@ The API can be used to chat to a bot. For this you'll need to create a `UserAPIK
 ```python
 import requests
 
-headers = {'Accept': 'application/json', 'X-Api-Key': <api-key>}
+headers = {'Accept': 'application/json', 'Content-Type': 'application/json', 'X-Api-Key': <api-key>}
 
 # List experiments
 response = requests.get("https://chatbots.dimagi.com/api/experiments", headers=headers)
@@ -19,5 +19,24 @@ response = requests.post(
     headers=headers
 )
 data = response.json()
-```
 
+# Set up an experiment session with prepopulated history
+
+data = {
+    "ephemeral": False,
+    "user_input": "Tell me something",
+    "history" = [
+        {"type": "human", "message": "Hi there"},
+        {"type": "ai", "message": "Hi, how can I assist you today?"}
+    ]
+}
+
+response = requests.post(
+    f"https://chatbots.dimagi.com/api/experiments/{experiment_id}/sessions/new",
+    data=data,
+    headers=headers
+)
+data = response.json()
+# Example response: {"session_id": "77e2b985-0931-4236-a46f-ccdced7159b4", "response": "Ok, here's something ..."}
+```
+If `ephemeral` is true, then the created session will be deleted and `session_id` will be None.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -20,16 +20,18 @@ response = requests.post(
 )
 data = response.json()
 
-# Set up an experiment session with prepopulated history
+# Set up an experiment session with prepopulated history, or use an existing one
 
 data = {
-    "ephemeral": False,
+    "session_id": "", # Optional: The session to use
     "user_input": "Tell me something",
-    "history" = [
+    "history" = [ # Optional: History that you want to have in your session
         {"type": "human", "message": "Hi there"},
         {"type": "ai", "message": "Hi, how can I assist you today?"}
     ]
 }
+Please note that `session_id` and `history` cannot be specified in the same request. Whenever `session_id` is not
+specified, a new session with `history` will be created.
 
 response = requests.post(
     f"https://chatbots.dimagi.com/api/experiments/{experiment_id}/sessions/new",
@@ -39,4 +41,3 @@ response = requests.post(
 data = response.json()
 # Example response: {"session_id": "77e2b985-0931-4236-a46f-ccdced7159b4", "response": "Ok, here's something ..."}
 ```
-If `ephemeral` is true, then the created session will be deleted and `session_id` will be None.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -25,7 +25,7 @@ data = response.json()
 data = {
     "session_id": "", # Optional: The session to use
     "user_input": "Tell me something",
-    "history" = [ # Optional: History that you want to have in your session
+    "history": [ # Optional: History that you want to have in your session
         {"type": "human", "message": "Hi there"},
         {"type": "ai", "message": "Hi, how can I assist you today?"}
     ]

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -1,17 +1,23 @@
 import json
+from unittest.mock import patch
 
 import pytest
 from django.urls import reverse
 
-from apps.experiments.models import Participant
+from apps.experiments.models import ExperimentSession, Participant
 from apps.utils.factories.experiment import ExperimentFactory
 from apps.utils.factories.team import TeamWithUsersFactory
+from apps.utils.langchain import FakeLlm, FakeLlmService
 from apps.utils.tests.clients import ApiTestClient
 
 
 @pytest.fixture()
 def experiment(db):
     return ExperimentFactory(team=TeamWithUsersFactory())
+
+
+def fake_llm():
+    return FakeLlm(responses=[["This", " is", " a", " test", " message"]], token_counts=[30, 20, 10])
 
 
 @pytest.mark.django_db()
@@ -96,3 +102,50 @@ def test_update_participant_data_returns_404():
     assert response.json() == {"errors": [{"message": f"Experiment {experiment2.public_id} not found"}]}
     # Assert that nothing was created
     assert experiment.participant_data.filter(participant=participant).exists() is False
+
+
+@patch("apps.experiments.models.Experiment.get_llm_service", return_value=FakeLlmService(llm=fake_llm()))
+class TestCreateCustomSession:
+    def setup(self):
+        self.experiment = ExperimentFactory(team=TeamWithUsersFactory())
+        self.user = self.experiment.team.members.first()
+        self.client = ApiTestClient(self.user, self.experiment.team)
+
+    @pytest.mark.django_db()
+    def test_create_new_session(self, get_llm_service_mock):
+        data = {
+            "ephemeral": False,
+            "user_input": "Are you alive?",
+            "history": [{"type": "human", "message": "Hi there"}, {"type": "ai", "message": "Hi there human"}],
+        }
+        url = reverse("api:new-session", kwargs={"experiment_id": self.experiment.public_id})
+
+        response = self.client.post(url, json.dumps(data), content_type="application/json")
+        assert response.status_code == 200
+        participant = Participant.objects.get(team=self.experiment.team, identifier=self.user.email)
+        session = ExperimentSession.objects.get(participant=participant, experiment=self.experiment)
+        assert response.json() == {"session_id": str(session.external_id), "response": "This is a test message"}
+        assert session.chat.messages.count() == 4
+
+    @pytest.mark.django_db()
+    def test_create_new_ephemeral_session(self, get_llm_service_mock):
+        data = {
+            "ephemeral": True,
+            "user_input": "Hi there",
+            "history": [{"type": "human", "message": "Hi there"}, {"type": "ai", "message": "Hi there human"}],
+        }
+        url = reverse("api:new-session", kwargs={"experiment_id": self.experiment.public_id})
+
+        response = self.client.post(url, json.dumps(data), content_type="application/json")
+        assert response.status_code == 200
+        participant = Participant.objects.get(team=self.experiment.team, identifier=self.user.email)
+        assert ExperimentSession.objects.filter(participant=participant, experiment=self.experiment).exists() is False
+        assert response.json() == {"session_id": None, "response": "This is a test message"}
+
+    @pytest.mark.django_db()
+    def test_create_custom_session_returns_422(self, get_llm_service_mock):
+        data = {"ephemeral": False, "user_input": "Hi", "history": [{"type": "sheep", "message": "bah"}]}
+        url = reverse("api:new-session", kwargs={"experiment_id": self.experiment.public_id})
+        response = self.client.post(url, json.dumps(data), content_type="application/json")
+        assert response.status_code == 422
+        assert response.json() == {"error": "Unknown message type 'sheep'"}

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -7,4 +7,5 @@ app_name = "api"
 urlpatterns = [
     path("experiments/", views.ExperimentsView.as_view(), name="list-experiments"),
     path("participants/<str:participant_id>", views.update_participant_data, name="update-participant-data"),
+    path("experiments/<uuid:experiment_id>/sessions/new", views.new_session, name="new-session"),
 ]

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -442,6 +442,22 @@ class Experiment(BaseTeamModel):
     def get_absolute_url(self):
         return reverse("experiments:single_experiment_home", args=[self.team.slug, self.id])
 
+    def new_api_session(self, participant: "Participant") -> "ExperimentSession":
+        from apps.channels.models import ChannelPlatform, ExperimentChannel
+
+        session = ExperimentSession.objects.create(
+            team=self.team,
+            participant=participant,
+            experiment=self,
+            llm=self.llm,
+            experiment_channel=ExperimentChannel.objects.create(
+                experiment=self,
+                platform=ChannelPlatform.API,
+                name=f"{self.id}-api",
+            ),
+        )
+        return session
+
 
 class ExperimentRoute(BaseTeamModel):
     """

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -416,9 +416,13 @@ class DeleteFileFromExperiment(BaseDeleteFileView):
 @permission_required("experiments.view_experiment", raise_exception=True)
 def single_experiment_home(request, team_slug: str, experiment_id: int):
     experiment = get_object_or_404(Experiment, id=experiment_id, team=request.team)
-    user_sessions = ExperimentSession.objects.with_last_message_created_at().filter(
-        participant__user=request.user,
-        experiment=experiment,
+    user_sessions = (
+        ExperimentSession.objects.with_last_message_created_at()
+        .filter(
+            participant__user=request.user,
+            experiment=experiment,
+        )
+        .exclude(experiment_channel__platform=ChannelPlatform.API)
     )
     channels = experiment.experimentchannel_set.exclude(platform__in=[ChannelPlatform.WEB, ChannelPlatform.API]).all()
     used_platforms = {channel.platform_enum for channel in channels}


### PR DESCRIPTION
https://github.com/dimagi/open-chat-studio/issues/475. See the "proposed endpoint" section in [this doc](https://docs.google.com/document/d/1YcwdW2873zpXqWS5AHfmnlz-afjkvc8EY-uNulMuuFs/edit#heading=h.4djifeu90s3u).

API endpoint to create sessions with prepopulated history. The idea is to expand on this call for the "stateless" api work.

A sneaky fix I included is to exclude the user's own API sessions from the sessions view