### PR TITLE
OpenAI compatible chat completions API

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -51,6 +51,19 @@ paths:
   /api/openai/{experiment_id}/chat/completions:
     post:
       operationId: openai_chat_completions
+      description: "\n    Use OpenAI's client to send messages to the experiment and\
+        \ get responses. This will\n    create a new session in the experiment with\
+        \ all the provided messages\n    and return the response from the experiment.\n\
+        \    \n    The last message must be a 'user' message.\n    \n    Example (Python):\n\
+        \    \n        experiment_id = \"your experiment ID\"\n        \n        client\
+        \ = OpenAI(\n            api_key=\"your API key\",\n            base_url=f\"\
+        https://chatbots.dimagi.com/api/openai/{experiment_id}\",\n        )\n   \
+        \     \n        completion = client.chat.completions.create(\n           \
+        \ model=\"anything\",\n            messages=[\n                {\"role\":\
+        \ \"assistant\", \"content\": \"How can I help you today?\"},\n          \
+        \      {\"role\": \"user\", \"content\": \"I need help with something.\"},\n\
+        \            ],\n        )\n        \n        reply = completion.choices[0].message\n\
+        \    "
       summary: Chat Completions API for Experiments
       parameters:
       - in: path

--- a/api-schema.yml
+++ b/api-schema.yml
@@ -48,6 +48,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/Experiment'
           description: ''
+  /api/openai/{experiment_id}/chat/completions:
+    post:
+      operationId: openai_chat_completions
+      summary: Chat Completions API for Experiments
+      parameters:
+      - in: path
+        name: experiment_id
+        schema:
+          type: string
+        description: Experiment ID
+        required: true
+      tags:
+      - OpenAi
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/chat.completion.request'
+        required: true
+      security:
+      - tokenAuth: []
+      - ApiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/chat.completion'
+          description: ''
   /api/participants/{participant_id}/:
     post:
       operationId: update_participant_data
@@ -257,13 +286,13 @@ components:
     Message:
       type: object
       properties:
-        type:
-          $ref: '#/components/schemas/TypeEnum'
-        message:
+        role:
+          $ref: '#/components/schemas/RoleEnum'
+        content:
           type: string
       required:
-      - message
-      - type
+      - content
+      - role
     NewAPIMessage:
       type: object
       properties:
@@ -341,6 +370,16 @@ components:
       required:
       - data
       - experiment
+    RoleEnum:
+      enum:
+      - system
+      - user
+      - assistant
+      type: string
+      description: |-
+        * `system` - system
+        * `user` - user
+        * `assistant` - assistant
     Team:
       type: object
       properties:
@@ -354,16 +393,51 @@ components:
       required:
       - name
       - slug
-    TypeEnum:
-      enum:
-      - human
-      - ai
-      type: string
-      description: |-
-        * `human` - human
-        * `ai` - ai
+    chat.choices:
+      type: object
+      properties:
+        finish_reason:
+          type: string
+        index:
+          type: integer
+        message:
+          type: string
+      required:
+      - finish_reason
+      - index
+      - message
+    chat.completion:
+      type: object
+      properties:
+        id:
+          type: string
+        choices:
+          type: array
+          items:
+            $ref: '#/components/schemas/chat.choices'
+        created:
+          type: integer
+        model:
+          type: string
+      required:
+      - choices
+      - created
+      - id
+      - model
+    chat.completion.request:
+      type: object
+      properties:
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+      required:
+      - messages
   securitySchemes:
     ApiKeyAuth:
       type: apiKey
       in: header
       name: X-Api-Key
+    tokenAuth:
+      type: http
+      scheme: bearer

--- a/apps/api/helpers.py
+++ b/apps/api/helpers.py
@@ -24,7 +24,7 @@ def get_team_from_request(request: HttpRequest) -> CustomUser | None:
 
 
 def get_team_membership_for_request(request: HttpRequest):
-    return Membership.objects.get(team=request.team, user=request.user)
+    return Membership.objects.filter(team=request.team, user=request.user).first()
 
 
 def _get_api_key_object(request, model_class):

--- a/apps/api/helpers.py
+++ b/apps/api/helpers.py
@@ -2,6 +2,7 @@ from django.http import HttpRequest
 from rest_framework_api_key.permissions import KeyParser
 
 from apps.api.models import UserAPIKey
+from apps.teams.models import Membership
 from apps.users.models import CustomUser
 
 
@@ -20,6 +21,10 @@ def get_team_from_request(request: HttpRequest) -> CustomUser | None:
         return None
     user_api_key = _get_api_key_object(request, UserAPIKey)
     return user_api_key.team
+
+
+def get_team_membership_for_request(request: HttpRequest):
+    return Membership.objects.get(team=request.team, user=request.user)
 
 
 def _get_api_key_object(request, model_class):

--- a/apps/api/openai.py
+++ b/apps/api/openai.py
@@ -1,0 +1,49 @@
+import time
+
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.response import Response
+
+from apps.api.permissions import HasUserAPIKey
+from apps.api.serializers import ExperimentSessionCreateSerializer
+from apps.channels.tasks import handle_api_message
+
+
+@api_view(["POST"])
+@permission_classes([HasUserAPIKey])
+def chat_completions(request, experiment_id: str):
+    messages = request.data.get("messages", [])
+    try:
+        last_message = messages.pop()
+    except IndexError:
+        # TODO: openai error responses
+        return Response(data={})
+
+    if last_message.get("role") != "user":
+        # TODO: openai error responses
+        return Response(data={})
+
+    converted_data = {
+        "experiment": experiment_id,
+        "messages": messages,
+    }
+    serializer = ExperimentSessionCreateSerializer(data=converted_data, context={"request": request})
+    serializer.is_valid(raise_exception=True)  # TODO: openai error responses
+    session = serializer.save()
+
+    response_message = handle_api_message(
+        request.user, session.experiment, last_message.get("content"), session.participant.identifier, session
+    )
+    completion = {
+        "id": session.external_id,
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "index": 0,
+                "message": response_message,
+            }
+        ],
+        "created": int(time.time()),
+        "model": session.experiment.llm,
+        "object": "chat.completion",
+    }
+    return Response(data=completion)

--- a/apps/api/openai.py
+++ b/apps/api/openai.py
@@ -15,6 +15,32 @@ from apps.channels.tasks import handle_api_message
 @extend_schema(
     operation_id="openai_chat_completions",
     summary="Chat Completions API for Experiments",
+    description="""
+    Use OpenAI's client to send messages to the experiment and get responses. This will
+    create a new session in the experiment with all the provided messages
+    and return the response from the experiment.
+    
+    The last message must be a 'user' message.
+    
+    Example (Python):
+    
+        experiment_id = "your experiment ID"
+        
+        client = OpenAI(
+            api_key="your API key",
+            base_url=f"https://chatbots.dimagi.com/api/openai/{experiment_id}",
+        )
+        
+        completion = client.chat.completions.create(
+            model="anything",
+            messages=[
+                {"role": "assistant", "content": "How can I help you today?"},
+                {"role": "user", "content": "I need help with something."},
+            ],
+        )
+        
+        reply = completion.choices[0].message
+    """,
     tags=["OpenAi"],
     request=inline_serializer(
         "chat.completion.request",

--- a/apps/api/openai.py
+++ b/apps/api/openai.py
@@ -1,15 +1,16 @@
 import time
 
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.response import Response
 
-from apps.api.permissions import HasUserAPIKey
+from apps.api.permissions import BearerTokenAuthentication
 from apps.api.serializers import ExperimentSessionCreateSerializer
 from apps.channels.tasks import handle_api_message
 
 
 @api_view(["POST"])
-@permission_classes([HasUserAPIKey])
+@authentication_classes([BearerTokenAuthentication])
+@permission_classes([])  # remove the default
 def chat_completions(request, experiment_id: str):
     messages = request.data.get("messages", [])
     try:

--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -1,11 +1,42 @@
 import typing
 
 from django.http import HttpRequest
+from django.utils.translation import gettext as _
+from rest_framework import exceptions
+from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import DjangoModelPermissions, IsAuthenticated
 from rest_framework_api_key.permissions import BaseHasAPIKey
 
-from .helpers import get_team_from_request, get_user_from_request
+from .helpers import get_team_from_request, get_team_membership_for_request, get_user_from_request
 from .models import UserAPIKey
+
+
+class BearerTokenAuthentication(TokenAuthentication):
+    """Used by OpenAI API"""
+
+    keyword = "Bearer"
+    model = UserAPIKey
+
+    def authenticate(self, request):
+        user_auth_tuple = super().authenticate(request)
+        if user_auth_tuple:
+            user, api_key = user_auth_tuple
+            request.user = user
+            request.team = api_key.team
+            request.team_membership = get_team_membership_for_request(request)
+        return user_auth_tuple
+
+    def authenticate_credentials(self, key):
+        model = self.get_model()
+        try:
+            token = model.objects.get_from_key(key)
+        except model.DoesNotExist:
+            raise exceptions.AuthenticationFailed(_("Invalid token."))
+
+        if not token.user.is_active:
+            raise exceptions.AuthenticationFailed(_("User inactive or deleted."))
+
+        return token.user, token
 
 
 class HasUserAPIKey(BaseHasAPIKey):
@@ -17,6 +48,7 @@ class HasUserAPIKey(BaseHasAPIKey):
             # if they have permission, also populate the request.user object for convenience
             request.user = get_user_from_request(request)
             request.team = get_team_from_request(request)
+            request.team_membership = get_team_membership_for_request(request)
         return has_perm
 
 

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -45,8 +45,28 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
 
 
 class MessageSerializer(serializers.Serializer):
-    type = serializers.ChoiceField(choices=["human", "ai"])
-    message = serializers.CharField()
+    role = serializers.ChoiceField(choices=["system", "user", "assistant"], source="type")
+    content = serializers.CharField(source="message")
+
+    def to_representation(self, instance):
+        output = super().to_representation(instance)
+        # map internal names to external names
+        output["role"] = {
+            "human": "user",
+            "ai": "assistant",
+            "system": "system",
+        }[output["role"]]
+        return output
+
+    def to_internal_value(self, data):
+        # map external names to internal names
+        data = super().to_internal_value(data)
+        data["type"] = {
+            "user": "human",
+            "assistant": "ai",
+            "system": "system",
+        }[data["type"]]
+        return data
 
 
 class ExperimentSessionCreateSerializer(serializers.ModelSerializer):

--- a/apps/api/tests/integration_tests.py
+++ b/apps/api/tests/integration_tests.py
@@ -27,13 +27,14 @@ def test_create_new_session_and_post_message(mock_response, experiment):
     data = {
         "experiment": experiment_id,
         "messages": [
-            {"type": "ai", "message": "hi"},
-            {"type": "human", "message": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "hello"},
         ],
     }
     response = client.post(reverse("api:session-list"), data=data, format="json")
-    assert response.status_code == 201
-    session_id = response.json()["id"]
+    response_json = response.json()
+    assert response.status_code == 201, response_json
+    session_id = response_json["id"]
 
     mock_response.return_value = "Fido"
     new_message_url = reverse("channels:new_api_message", kwargs={"experiment_id": experiment_id})

--- a/apps/api/tests/test_message_serializer.py
+++ b/apps/api/tests/test_message_serializer.py
@@ -1,0 +1,18 @@
+import pytest
+
+from apps.api.serializers import MessageSerializer
+
+CASES = [("system", "system"), ("human", "user"), ("ai", "assistant")]
+
+
+@pytest.mark.parametrize(("type_", "role"), CASES)
+def test_message_serializer_api_to_internal(type_, role):
+    serializer = MessageSerializer(data={"role": role, "content": "hello"})
+    assert serializer.is_valid()
+    assert serializer.validated_data == {"type": type_, "message": "hello"}
+
+
+@pytest.mark.parametrize(("type_", "role"), CASES)
+def test_message_serializer_internal_to_api(type_, role):
+    serializer = MessageSerializer(instance={"type": type_, "message": "hello"})
+    assert serializer.data == {"role": role, "content": "hello"}

--- a/apps/api/tests/test_openai_api.py
+++ b/apps/api/tests/test_openai_api.py
@@ -45,7 +45,8 @@ def api_key(team_with_users):
     # Needed to provide cascaded rollback for the testdata. I'm not certain which apps are necessary but these
     # seem to work.
     # See https://docs.djangoproject.com/en/5.0/topics/testing/advanced/#django.test.TransactionTestCase.available_apps
-    available_apps=["apps.api", "apps.experiments", "apps.teams", "apps.users"]
+    available_apps=["apps.api", "apps.experiments", "apps.teams", "apps.users"],
+    serialized_rollback=True,
 )
 @patch("apps.chat.channels.ApiChannel._get_experiment_response")
 def test_chat_completion(mock_experiment_response, experiment, api_key, live_server):

--- a/apps/api/tests/test_openai_api.py
+++ b/apps/api/tests/test_openai_api.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+
+from apps.experiments.models import ExperimentSession
+from apps.utils.factories.experiment import ExperimentFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+from apps.utils.tests.clients import ApiTestClient
+
+
+@pytest.fixture()
+def experiment(db):
+    return ExperimentFactory(team=TeamWithUsersFactory())
+
+
+@pytest.mark.django_db()
+@patch("apps.chat.channels.ApiChannel._get_experiment_response")
+def test_chat_completion(mock_experiment_response, experiment):
+    mock_experiment_response.return_value = "I am fine, thank you."
+
+    user = experiment.team.members.first()
+    client = ApiTestClient(user, experiment.team)
+
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hi, how are you?"},
+        ],
+    }
+    response = client.post(
+        reverse("api:openai-chat-completions", kwargs={"experiment_id": experiment.public_id}),
+        data=data,
+        format="json",
+    )
+    response_json = response.json()
+    assert response.status_code == 200, response_json
+    session = ExperimentSession.objects.first()
+    assert response_json == {
+        "id": session.external_id,
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "index": 0,
+                "message": "I am fine, thank you.",
+            }
+        ],
+        "created": response_json["created"],
+        "model": experiment.llm,
+        "object": "chat.completion",
+    }

--- a/apps/api/tests/test_session_api.py
+++ b/apps/api/tests/test_session_api.py
@@ -79,8 +79,8 @@ def test_create_session_with_messages(experiment):
     data = {
         "experiment": experiment.public_id,
         "messages": [
-            {"type": "ai", "message": "hi"},
-            {"type": "human", "message": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "hello"},
         ],
     }
     response = client.post(reverse("api:session-list"), data=data, format="json")

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -11,6 +11,6 @@ router.register(r"sessions", views.ExperimentSessionViewSet, basename="session")
 
 urlpatterns = [
     path("participants/<str:participant_id>/", views.update_participant_data, name="update-participant-data"),
-    path("e/<str:experiment_id>/chat/completions", openai.chat_completions, name="openai-chat-completions"),
+    path("openai/<str:experiment_id>/chat/completions", openai.chat_completions, name="openai-chat-completions"),
     path("", include(router.urls)),
 ]

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -1,7 +1,7 @@
 from django.urls import include, path
 from rest_framework import routers
 
-from . import views
+from . import openai, views
 
 app_name = "api"
 
@@ -11,5 +11,6 @@ router.register(r"sessions", views.ExperimentSessionViewSet, basename="session")
 
 urlpatterns = [
     path("participants/<str:participant_id>/", views.update_participant_data, name="update-participant-data"),
+    path("e/<str:experiment_id>/chat/completions", openai.chat_completions, name="openai-chat-completions"),
     path("", include(router.urls)),
 ]

--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -10,6 +10,7 @@ from twilio.request_validator import RequestValidator
 from apps.channels.datamodels import BaseMessage, TelegramMessage, TurnWhatsappMessage, TwilioMessage
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import ApiChannel, FacebookMessengerChannel, TelegramChannel, WhatsappChannel
+from apps.experiments.models import Experiment
 from apps.service_providers.models import MessagingProviderType
 from apps.utils.taskbadger import update_taskbadger_data
 
@@ -95,8 +96,17 @@ def handle_turn_message(self, experiment_id: uuid, message_data: dict):
     channel.new_user_message(message)
 
 
-def handle_api_message(user, experiment_channel: ExperimentChannel, message_data: dict):
+def handle_api_message(user, experiment: Experiment, message_text: str, participant_id: str, session=None):
     """Synchronously handles the message coming from the API"""
-    message = BaseMessage(participant_id=message_data["participant"], message_text=message_data["message"])
-    channel = ApiChannel(experiment_channel=experiment_channel, user=user)
+    experiment_channel, _created = ExperimentChannel.objects.get_or_create(
+        name=f"{experiment.id}-api",
+        experiment=experiment,
+        platform=ChannelPlatform.API,
+    )
+    message = BaseMessage(participant_id=participant_id, message_text=message_text)
+    channel = ApiChannel(
+        experiment_channel=experiment_channel,
+        experiment_session=session,
+        user=user,
+    )
     return channel.new_user_message(message)

--- a/apps/channels/tests/test_api_integration.py
+++ b/apps/channels/tests/test_api_integration.py
@@ -44,8 +44,9 @@ def test_new_message_creates_a_channel_and_participant(get_llm_response_mock, ex
 
 
 @pytest.mark.django_db()
+@patch("apps.chat.channels.ApiChannel._get_latest_session")
 @patch("apps.chat.channels.ApiChannel._get_experiment_response")
-def test_new_message_with_existing_session(get_llm_response_mock, experiment, client):
+def test_new_message_with_existing_session(get_llm_response_mock, _get_latest_session, experiment, client):
     get_llm_response_mock.return_value = "Hi user"
 
     user = experiment.team.members.first()
@@ -64,10 +65,11 @@ def test_new_message_with_existing_session(get_llm_response_mock, experiment, cl
 
     # check that no new sessions were created
     assert not ExperimentSession.objects.exclude(id=session.id).exists()
+    _get_latest_session.assert_not_called()
 
 
 @pytest.mark.django_db()
-def test_new_message_with_to_another_users_session(experiment, client):
+def test_new_message_to_another_users_session(experiment, client):
     users = experiment.team.members.all()
     session_user = users[1]
     participant, _ = Participant.objects.get_or_create(

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -388,14 +388,8 @@ class ChannelBase(ABC):
         If the user requested a new session (by sending the reset command), this will create a new experiment
         session.
         """
-        self.experiment_session = (
-            ExperimentSession.objects.filter(
-                experiment=self.experiment,
-                participant__identifier=str(self.participant_identifier),
-            )
-            .order_by("-created_at")
-            .first()
-        )
+        if not self.experiment_session:
+            self.experiment_session = self._get_latest_session()
 
         if not self.experiment_session:
             self._create_new_experiment_session()
@@ -414,6 +408,16 @@ class ChannelBase(ABC):
                 # to the channel sessions when removing this code
                 self.experiment_session.experiment_channel = self.experiment_channel
                 self.experiment_session.save()
+
+    def _get_latest_session(self):
+        return (
+            ExperimentSession.objects.filter(
+                experiment=self.experiment,
+                participant__identifier=str(self.participant_identifier),
+            )
+            .order_by("-created_at")
+            .first()
+        )
 
     def _reset_session(self):
         """Resets the session by ending the current `experiment_session` and creating a new one"""

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -15,6 +15,7 @@ from apps.utils.factories.experiment import (
 )
 from apps.utils.factories.service_provider_factories import VoiceProviderFactory
 from apps.utils.factories.team import TeamFactory
+from apps.utils.pytest import django_db_with_data
 
 
 @pytest.fixture()
@@ -33,13 +34,13 @@ class TestSyntheticVoice:
         voices_queryset = SyntheticVoice.get_for_team(team=None)
         assert voices_queryset.count() == SyntheticVoice.objects.count()
 
-    @pytest.mark.django_db()
+    @django_db_with_data()
     def test_get_for_team_excludes_service(self):
         voices_queryset = SyntheticVoice.get_for_team(team=None, exclude_services=[SyntheticVoice.AWS])
         services = set(voices_queryset.values_list("service", flat=True))
         assert services == {SyntheticVoice.OpenAI, SyntheticVoice.Azure}
 
-    @pytest.mark.django_db()
+    @django_db_with_data()
     def test_get_for_team_do_not_include_other_team_exclusive_voices(self):
         """Tests that `get_for_team` returns both general and team exclusive synthetic voices. Exclusive synthetic
         voices are those whose service is one of SyntheticVoice.TEAM_SCOPED_SERVICES

--- a/apps/utils/pytest.py
+++ b/apps/utils/pytest.py
@@ -1,0 +1,21 @@
+def django_db_with_data(available_apps=("apps.experiments",)):
+    """Shortcut decorator to mark a test function as requiring the database with data from migrations.
+
+    This is needed because of other tests that flush the database after each test
+    e.g. apps.api.tests.test_openai_api.test_chat_completion
+
+    Args:
+        available_apps (tuple, optional):
+            The apps that are necessary for the test. Defaults to ("apps.experiments",).
+            It is unclear which apps are necessary but these seem to work.
+    """
+    import pytest
+
+    def _inner(func):
+        return pytest.mark.django_db(
+            serialized_rollback=True,  # load the serialize DB state
+            transaction=True,  # required for serialized_rollback to work
+            available_apps=available_apps,  # required to prevent teardown from failing
+        )(func)
+
+    return _inner


### PR DESCRIPTION
FYI @bderenzi 

This adds an API endpoint that is compatible (roughly) with the [OpenAI Chat Completions](https://platform.openai.com/docs/api-reference/chat/create) API.

This can be used to create a session, populate it with messages and get a response from the experiment in one request.

This should be considered in `alpha`.

This PR also changes the JSON format for the session creation API so that the message structure matches the OpenAI message format:

```json
"messages": [
      {"role": "assistant", "content": "hi"},
      {"role": "user", "content": "hello"},
]
```

This was done for simplicity but also consistency since it's easier for users if they don't have to use different formats in different places.