### PR TITLE
Close pagination div properly if there is no pagination

### DIFF
--- a/templates/table/tailwind.html
+++ b/templates/table/tailwind.html
@@ -35,8 +35,8 @@
                             <span aria-hidden="true">&raquo;</span>
                         </a>
                     </div>
-                    </div>
                 {% endif %}
+            </div>
         {% endblock pagination %}
     </div>
 {% endblock table-wrapper %}


### PR DESCRIPTION
This was causing tables rendered with {% render_table %} to have a missing closing `</div>`.

(This was the reason I'd added this random closing div: 

https://github.com/dimagi/open-chat-studio/pull/489/commits/da7ad2626e04a793578be925929b1f8eb242ea31#diff-90cb99fc79c0c021e88ed7b5553718aa81f257c2f2d7886db316f08b3b5698f7L217 )

Fixes an issue currently where the tabs on the experiments page don't render properly. 