### PR TITLE
Only log the start and end of each defined node

### DIFF
--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from functools import cached_property
 
 import pydantic
 from django.core.serializers.json import DjangoJSONEncoder
@@ -26,6 +27,10 @@ class Pipeline(BaseTeamModel):
     def get_absolute_url(self):
         return reverse("pipelines:details", args=[self.team.slug, self.id])
 
+    @cached_property
+    def node_ids(self):
+        return [node.get("data", {}).get("id") for node in self.data.get("nodes", [])]
+
     def invoke(self, input: PipelineState, session: ExperimentSession | None = None) -> PipelineState:
         from apps.pipelines.graph import PipelineGraph
 
@@ -36,12 +41,16 @@ class Pipeline(BaseTeamModel):
         )
 
         logging_callback = PipelineLoggingCallbackHandler(pipeline_run)
-        logging_callback.logger.info("Starting pipeline run")
+        logging_callback.logger.debug("Starting pipeline run", input=input["messages"][-1])
         try:
             output = runnable.invoke(input, config=RunnableConfig(callbacks=[logging_callback]))
             pipeline_run.output = output
         finally:
-            logging_callback.logger.info("Pipeline run finished")
+            if pipeline_run.status == PipelineRunStatus.ERROR:
+                logging_callback.logger.debug("Pipeline run failed", input=input["messages"][-1])
+            else:
+                pipeline_run.status = PipelineRunStatus.SUCCESS
+                logging_callback.logger.debug("Pipeline run finished", output=output["messages"][-1])
             pipeline_run.save()
         return output
 
@@ -68,6 +77,8 @@ class LogEntry(pydantic.BaseModel):
     time: datetime
     level: str
     message: str
+    output: str | None = None
+    input: str | None = None
 
     class Config:
         json_encoders = {datetime: lambda v: v.strftime("%Y-%m-%d %H:%M:%S.%f")}

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -96,7 +96,7 @@ class Passthrough(PipelineNode):
 
     def get_runnable(self, node: Node) -> RunnableLambda:
         def fn(input: Input, config: RunnableConfig):
-            self.logger(config).debug(f"Returning input: '{input}' without modification")
+            self.logger(config).debug(f"Returning input: '{input}' without modification", input=input, output=input)
             return input
 
         return RunnableLambda(fn, name=self.__class__.__name__)

--- a/apps/utils/factories/pipelines.py
+++ b/apps/utils/factories/pipelines.py
@@ -11,13 +11,13 @@ class PipelineFactory(factory.django.DjangoModelFactory):
     name = "Test Pipeline"
     data = {
         "edges": [
-            {"id": "1->2", "source": "1", "target": "2"},
+            {"id": "1->2", "source": "first", "target": "second"},
         ],
         "nodes": [
             {
                 "id": "1",
                 "data": {
-                    "id": "1",
+                    "id": "first",
                     "type": "Passthrough",
                     "label": "Passthrough",
                     "params": {},
@@ -26,7 +26,7 @@ class PipelineFactory(factory.django.DjangoModelFactory):
             {
                 "id": "2",
                 "data": {
-                    "id": "2",
+                    "id": "second",
                     "type": "Passthrough",
                     "label": "Passthrough",
                     "params": {},

--- a/templates/pipelines/components/pipeline_run_detail_tabs.html
+++ b/templates/pipelines/components/pipeline_run_detail_tabs.html
@@ -18,25 +18,37 @@
 
     <input type="radio" name="pipeline_run_tabs_{{ pipeline_run.id }}" role="tab" class="tab" aria-label="Logs"/>
     <div role="tabpanel" class="tab-content p-4" x-data="{ showDebug: false }">
-        <div class="font-mono">
-
-            <div class="flex items-center cursor-pointer float-right">
+        <div class="font-mono" x-data="{ openSections: {} }">
+            <div class="flex mb-4 items-center cursor-pointer">
                 <span class="label-text mr-2">Show Debug</span>
                 <input x-model="showDebug" type="checkbox" class="toggle" />
             </div>
             {% for entry in pipeline_run.log.entries %}
-                <div class="log log-{{ entry.level|lower }}" {% if entry.level == "DEBUG" %}x-show="showDebug"{% endif %}>
-                    <time datetime="{{ entry.time }}"
-                          title="{{ entry.time }}">{{ entry.time }}</time>
-                    <div class="badge
-                                {% if entry.level == "DEBUG" %}badge-neutral
-                                {% elif entry.level == "INFO" %}badge-info
-                                {% elif entry.level == "WARNING" %}badge-warning
-                                {% elif entry.level == "ERROR" %}badge-error
-                                {% endif %}
-                               ">{{ entry.level }}</div>
-                    <span>{{ entry.message|linebreaksbr }}</span>
-                    <div class="divider"></div>
+                <div class="log log-{{ entry.level|lower }} p-4 border rounded shadow mb-2" {% if entry.level == "DEBUG" %}x-show="showDebug"{% endif %} >
+                    <i :class="openSections['{{ entry.time }}'] ? 'fa fa-chevron-up' : 'fa fa-chevron-down'" class="mr-2 float-right" aria-hidden="true"></i>
+                    <div class="flex items-center cursor-pointer" @click="openSections['{{ entry.time }}'] = !openSections['{{ entry.time }}']">
+                        <time datetime="{{ entry.time }}" title="{{ entry.time }}">{{ entry.time }}</time>
+                        <div class="badge mx-4
+                                    {% if entry.level == "DEBUG" %}badge-neutral
+                                    {% elif entry.level == "INFO" %}badge-info
+                                    {% elif entry.level == "WARNING" %}badge-warning
+                                    {% elif entry.level == "ERROR" %}badge-error
+                                    {% endif %}
+                                   ">{{ entry.level }}</div>
+                        <span>{{ entry.message|linebreaksbr }}</span>
+                    </div>
+
+                    <div x-show="openSections['{{ entry.time }}']" x-cloak>
+                        <hr class="mt-4 mb-4" />
+                        {% if entry.input %}
+                            Input: <br/>
+                            {{ entry.input|linebreaksbr }}
+                        {% endif %}
+                        {% if entry.output %}
+                            Output: <br/>
+                            {{ entry.output|linebreaksbr }}
+                        {% endif %}
+                    </div>
                 </div>
             {% endfor %}
         </div>


### PR DESCRIPTION
There was an issue with the the pipeline logger that I was having trouble testing before. Now that the tests are running, I was able to make this much better. 
It now automatically logs the entry and exit of each node, and the nodes can add logs as they please.
I also updated the tests.

There are now collapsible entries with the Input and Output of each log entry:
![image](https://github.com/dimagi/open-chat-studio/assets/146896/c9483dfe-78e6-4c20-bec4-aba93a1285b6)

And debug logs work:
![image](https://github.com/dimagi/open-chat-studio/assets/146896/d9d48d50-2c06-48ff-b470-6134e591b354)
