### PR TITLE
set team context for channel tasks and api views

### DIFF
--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -26,6 +26,9 @@ class BearerTokenAuthentication(TokenAuthentication):
             request.user = user
             request.team = api_key.team
             request.team_membership = get_team_membership_for_request(request)
+            if not request.team_membership:
+                raise exceptions.AuthenticationFailed()
+
             # this is unset by the request_finished signal
             set_current_team(api_key.team)
         return user_auth_tuple
@@ -53,6 +56,9 @@ class HasUserAPIKey(BaseHasAPIKey):
             request.user = get_user_from_request(request)
             request.team = get_team_from_request(request)
             request.team_membership = get_team_membership_for_request(request)
+            if not request.team_membership:
+                return False
+
             # this is unset by the request_finished signal
             set_current_team(request.team)
         return has_perm

--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -7,6 +7,8 @@ from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import DjangoModelPermissions, IsAuthenticated
 from rest_framework_api_key.permissions import BaseHasAPIKey
 
+from apps.teams.utils import set_current_team
+
 from .helpers import get_team_from_request, get_team_membership_for_request, get_user_from_request
 from .models import UserAPIKey
 
@@ -24,6 +26,8 @@ class BearerTokenAuthentication(TokenAuthentication):
             request.user = user
             request.team = api_key.team
             request.team_membership = get_team_membership_for_request(request)
+            # this is unset by the request_finished signal
+            set_current_team(api_key.team)
         return user_auth_tuple
 
     def authenticate_credentials(self, key):
@@ -49,6 +53,8 @@ class HasUserAPIKey(BaseHasAPIKey):
             request.user = get_user_from_request(request)
             request.team = get_team_from_request(request)
             request.team_membership = get_team_membership_for_request(request)
+            # this is unset by the request_finished signal
+            set_current_team(request.team)
         return has_perm
 
 

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -4,6 +4,7 @@ import pytest
 from django.urls import reverse
 
 from apps.experiments.models import Participant
+from apps.teams.backends import EXPERIMENT_ADMIN_GROUP, add_user_to_team
 from apps.utils.factories.experiment import ExperimentFactory
 from apps.utils.factories.team import TeamWithUsersFactory
 from apps.utils.tests.clients import ApiTestClient
@@ -53,7 +54,10 @@ def test_only_experiments_from_the_scoped_team_is_returned():
     experiment_team_2 = ExperimentFactory(team=TeamWithUsersFactory())
     team1 = experiment_team_1.team
     team2 = experiment_team_2.team
+
     user = team1.members.first()
+    add_user_to_team(team2, user, [EXPERIMENT_ADMIN_GROUP])
+
     client_team_1 = ApiTestClient(user, team1)
     client_team_2 = ApiTestClient(user, team2)
 

--- a/apps/audit/auditors.py
+++ b/apps/audit/auditors.py
@@ -38,7 +38,7 @@ class AuditContextProvider(SystemUserAuditor):
             #   login_and_team_required decorator and has the 'team_slug' url path parameter
             # - If the view does not modify team data, add the view name to
             #   FIELD_AUDIT_TEAM_EXEMPT_VIEWS in settings
-            log.error(
+            log.exception(  # use `exception` here to include the stack in the event log
                 "No team found for audit context",
                 extra={"audit_context": context, "view_name": _get_view_name(request)},
             )

--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -12,6 +12,7 @@ from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import ApiChannel, FacebookMessengerChannel, TelegramChannel, WhatsappChannel
 from apps.experiments.models import Experiment
 from apps.service_providers.models import MessagingProviderType
+from apps.teams.utils import current_team
 from apps.utils.taskbadger import update_taskbadger_data
 
 log = logging.getLogger(__name__)
@@ -20,7 +21,9 @@ log = logging.getLogger(__name__)
 @shared_task(bind=True, base=TaskbadgerTask)
 def handle_telegram_message(self, message_data: str, channel_external_id: uuid):
     experiment_channel = (
-        ExperimentChannel.objects.filter(external_id=channel_external_id).select_related("experiment").first()
+        ExperimentChannel.objects.filter(external_id=channel_external_id)
+        .select_related("experiment", "experiment__team")
+        .first()
     )
     if not experiment_channel:
         return
@@ -34,7 +37,9 @@ def handle_telegram_message(self, message_data: str, channel_external_id: uuid):
     message = TelegramMessage.parse(update)
     message_handler = TelegramChannel(experiment_channel=experiment_channel)
     update_taskbadger_data(self, message_handler, message)
-    message_handler.new_user_message(message)
+
+    with current_team(experiment_channel.experiment.team):
+        message_handler.new_user_message(message)
 
 
 @shared_task(bind=True, base=TaskbadgerTask)
@@ -52,9 +57,13 @@ def handle_twilio_message(self, message_data: str, request_uri: str, signature: 
             channel_id_key = "page_id"
             ChannelClass = FacebookMessengerChannel
 
-    experiment_channel = ExperimentChannel.objects.filter(
-        extra_data__contains={channel_id_key: message.to}, messaging_provider__type=MessagingProviderType.twilio
-    ).first()
+    experiment_channel = (
+        ExperimentChannel.objects.filter(
+            extra_data__contains={channel_id_key: message.to}, messaging_provider__type=MessagingProviderType.twilio
+        )
+        .select_related("experiment", "experiment__team")
+        .first()
+    )
     if not experiment_channel:
         return
 
@@ -62,7 +71,9 @@ def handle_twilio_message(self, message_data: str, request_uri: str, signature: 
 
     message_handler = ChannelClass(experiment_channel=experiment_channel)
     update_taskbadger_data(self, message_handler, message)
-    message_handler.new_user_message(message)
+
+    with current_team(experiment_channel.experiment.team):
+        message_handler.new_user_message(message)
 
 
 def validate_twillio_request(experiment_channel, raw_data, request_uri, signature):
@@ -84,16 +95,22 @@ def validate_twillio_request(experiment_channel, raw_data, request_uri, signatur
 @shared_task(bind=True, base=TaskbadgerTask)
 def handle_turn_message(self, experiment_id: uuid, message_data: dict):
     message = TurnWhatsappMessage.parse(message_data)
-    experiment_channel = ExperimentChannel.objects.filter(
-        experiment__public_id=experiment_id,
-        platform=ChannelPlatform.WHATSAPP,
-        messaging_provider__type=MessagingProviderType.turnio,
-    ).first()
+    experiment_channel = (
+        ExperimentChannel.objects.filter(
+            experiment__public_id=experiment_id,
+            platform=ChannelPlatform.WHATSAPP,
+            messaging_provider__type=MessagingProviderType.turnio,
+        )
+        .select_related("experiment", "experiment__team")
+        .first()
+    )
     if not experiment_channel:
         return
     channel = WhatsappChannel(experiment_channel=experiment_channel)
     update_taskbadger_data(self, channel, message)
-    channel.new_user_message(message)
+
+    with current_team(experiment_channel.experiment.team):
+        channel.new_user_message(message)
 
 
 def handle_api_message(user, experiment: Experiment, message_text: str, participant_id: str, session=None):

--- a/apps/teams/backends.py
+++ b/apps/teams/backends.py
@@ -222,13 +222,13 @@ def make_user_team_owner(team, user) -> Membership:
 def add_user_to_team(team, user, groups=None) -> Membership:
     membership = Membership.objects.create(team=team, user=user)
     if groups:
-        membership.groups.set(groups)
+        membership.groups.set(get_groups(groups))
     return membership
 
 
 def get_team_owner_groups():
-    return [Group.objects.get(name=SUPER_ADMIN_GROUP)]
+    return get_groups([SUPER_ADMIN_GROUP])
 
 
-def get_groups():
-    return {group.name: group for group in Group.objects.all()}
+def get_groups(names):
+    return list(Group.objects.filter(name__in=names))

--- a/apps/teams/middleware.py
+++ b/apps/teams/middleware.py
@@ -32,4 +32,5 @@ class TeamsMiddleware(MiddlewareMixin):
         request.team = SimpleLazyObject(lambda: _get_team(request, view_kwargs))
         request.team_membership = SimpleLazyObject(lambda: _get_team_membership(request))
 
+        # this is unset by the request_finished signal
         set_current_team(request.team)

--- a/apps/teams/tests/test_member_management.py
+++ b/apps/teams/tests/test_member_management.py
@@ -1,4 +1,5 @@
 import pytest
+from django.contrib.auth.models import Group
 from django.test import Client, TestCase
 from django.urls import reverse
 
@@ -7,7 +8,6 @@ from apps.teams.backends import (
     EXPERIMENT_ADMIN_GROUP,
     SUPER_ADMIN_GROUP,
     add_user_to_team,
-    get_groups,
     make_user_team_owner,
 )
 from apps.teams.exceptions import TeamPermissionError
@@ -34,7 +34,7 @@ class TeamMemberManagementViewTest(TestCase):
         self.normal_membership = add_user_to_team(self.team, self.member)
         self.normal_membership2 = add_user_to_team(self.team, self.member2)
 
-        self.groups = get_groups()
+        self.groups = {group.name: group for group in Group.objects.all()}
         self.admin_groups = [self.groups[SUPER_ADMIN_GROUP]]
         self.admin_group_ids = {g.id for g in self.admin_groups}
         self.member_groups = [self.groups[EXPERIMENT_ADMIN_GROUP], self.groups[CHAT_VIEWER_GROUP]]


### PR DESCRIPTION
This also includes a fix for permission checks in API permission classes where the team membership was not being checked. In reality this is likely to only be an issue in tests since you can't create an API Key for a team you don't belong to but best to check anyway (except for this: https://github.com/dimagi/open-chat-studio/pull/513)