### PR TITLE
Support api-key + bearer token auth for all APIs

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -18,7 +18,8 @@ paths:
       tags:
       - Experiments
       security:
-      - ApiKeyAuth: []
+      - apiKeyAuth: []
+      - tokenAuth: []
       responses:
         '200':
           content:
@@ -40,7 +41,8 @@ paths:
       tags:
       - Experiments
       security:
-      - ApiKeyAuth: []
+      - apiKeyAuth: []
+      - tokenAuth: []
       responses:
         '200':
           content:
@@ -81,8 +83,8 @@ paths:
               $ref: '#/components/schemas/chat.completion.request'
         required: true
       security:
+      - apiKeyAuth: []
       - tokenAuth: []
-      - ApiKeyAuth: []
       responses:
         '200':
           content:
@@ -113,7 +115,8 @@ paths:
                 $ref: '#/components/schemas/ParticipantExperimentData'
         required: true
       security:
-      - ApiKeyAuth: []
+      - apiKeyAuth: []
+      - tokenAuth: []
       responses:
         '200':
           description: No response body
@@ -137,7 +140,8 @@ paths:
       tags:
       - Experiment Sessions
       security:
-      - ApiKeyAuth: []
+      - apiKeyAuth: []
+      - tokenAuth: []
       responses:
         '200':
           content:
@@ -157,7 +161,8 @@ paths:
               $ref: '#/components/schemas/ExperimentSessionCreate'
         required: true
       security:
-      - ApiKeyAuth: []
+      - apiKeyAuth: []
+      - tokenAuth: []
       responses:
         '201':
           content:
@@ -179,7 +184,8 @@ paths:
       tags:
       - Experiment Sessions
       security:
-      - ApiKeyAuth: []
+      - apiKeyAuth: []
+      - tokenAuth: []
       responses:
         '200':
           content:
@@ -208,7 +214,8 @@ paths:
               $ref: '#/components/schemas/NewAPIMessage'
         required: true
       security:
-      - ApiKeyAuth: []
+      - apiKeyAuth: []
+      - tokenAuth: []
       responses:
         '200':
           content:
@@ -447,10 +454,10 @@ components:
       required:
       - messages
   securitySchemes:
-    ApiKeyAuth:
+    apiKeyAuth:
       type: apiKey
       in: header
-      name: X-Api-Key
+      name: X-api-key
     tokenAuth:
       type: http
       scheme: bearer

--- a/apps/api/apps.py
+++ b/apps/api/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class APIConfig(AppConfig):
     name = "apps.api"
     label = "api"
+
+    def ready(self):
+        from . import schema  # noqa

--- a/apps/api/openai.py
+++ b/apps/api/openai.py
@@ -3,11 +3,10 @@ import time
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
 from rest_framework import serializers
-from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from rest_framework.decorators import api_view
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
-from apps.api.permissions import BearerTokenAuthentication
 from apps.api.serializers import ExperimentSessionCreateSerializer, MessageSerializer
 from apps.channels.tasks import handle_api_message
 
@@ -76,8 +75,6 @@ from apps.channels.tasks import handle_api_message
     ],
 )
 @api_view(["POST"])
-@authentication_classes([BearerTokenAuthentication])
-@permission_classes([])  # remove the default
 def chat_completions(request, experiment_id: str):
     messages = request.data.get("messages", [])
     try:

--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -1,71 +1,52 @@
-import typing
-
-from django.http import HttpRequest
 from django.utils.translation import gettext as _
 from rest_framework import exceptions
-from rest_framework.authentication import TokenAuthentication
-from rest_framework.permissions import DjangoModelPermissions, IsAuthenticated
-from rest_framework_api_key.permissions import BaseHasAPIKey
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.permissions import DjangoModelPermissions
+from rest_framework_api_key.permissions import KeyParser
 
 from apps.teams.utils import set_current_team
 
-from .helpers import get_team_from_request, get_team_membership_for_request, get_user_from_request
+from .helpers import get_team_membership_for_request
 from .models import UserAPIKey
 
 
-class BearerTokenAuthentication(TokenAuthentication):
-    """Used by OpenAI API"""
+class ApiKeyAuthentication(BaseAuthentication):
+    """Default auth for APIs that supports the following methods:
+    * API Key in the X-API-KEY header (see settings.API_KEY_CUSTOM_HEADER)
+    * API Key in the Authorization header with the 'Bearer' keyword
+    """
 
     keyword = "Bearer"
-    model = UserAPIKey
 
     def authenticate(self, request):
-        user_auth_tuple = super().authenticate(request)
-        if user_auth_tuple:
-            user, api_key = user_auth_tuple
-            request.user = user
-            request.team = api_key.team
-            request.team_membership = get_team_membership_for_request(request)
-            if not request.team_membership:
-                raise exceptions.AuthenticationFailed()
+        parser = ConfigurableKeyParser(keyword=self.keyword)
+        key = parser.get(request)
+        if not key:
+            return None
 
-            # this is unset by the request_finished signal
-            set_current_team(api_key.team)
-        return user_auth_tuple
-
-    def authenticate_credentials(self, key):
-        model = self.get_model()
         try:
-            token = model.objects.get_from_key(key)
-        except model.DoesNotExist:
+            token = UserAPIKey.objects.get_from_key(key)
+        except UserAPIKey.DoesNotExist:
             raise exceptions.AuthenticationFailed(_("Invalid token."))
 
         if not token.user.is_active:
             raise exceptions.AuthenticationFailed(_("User inactive or deleted."))
 
-        return token.user, token
+        user = token.user
+        request.user = user
+        request.team = token.team
+        request.team_membership = get_team_membership_for_request(request)
+        if not request.team_membership:
+            raise exceptions.AuthenticationFailed()
+
+        # this is unset by the request_finished signal
+        set_current_team(token.team)
+        return user, token
 
 
-class HasUserAPIKey(BaseHasAPIKey):
-    model = UserAPIKey
-
-    def has_permission(self, request: HttpRequest, view: typing.Any) -> bool:
-        has_perm = super().has_permission(request, view)
-        if has_perm:
-            # if they have permission, also populate the request.user object for convenience
-            request.user = get_user_from_request(request)
-            request.team = get_team_from_request(request)
-            request.team_membership = get_team_membership_for_request(request)
-            if not request.team_membership:
-                return False
-
-            # this is unset by the request_finished signal
-            set_current_team(request.team)
-        return has_perm
-
-
-# hybrid permission class that can check for API keys or authentication
-IsAuthenticatedOrHasUserAPIKey = IsAuthenticated | HasUserAPIKey
+class ConfigurableKeyParser(KeyParser):
+    def __init__(self, keyword: str):
+        self.keyword = keyword
 
 
 class DjangoModelPermissionsWithView(DjangoModelPermissions):

--- a/apps/api/schema.py
+++ b/apps/api/schema.py
@@ -1,0 +1,27 @@
+from drf_spectacular.authentication import TokenScheme
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
+
+from gpt_playground import settings
+
+
+class ApiScheme(OpenApiAuthenticationExtension):
+    target_class = "apps.api.permissions.ApiKeyAuthentication"
+    name = "apiKeyAuth"
+    match_subclasses = True
+    priority = -1
+
+    def get_security_definition(self, auto_schema):
+        header_name = settings.API_KEY_CUSTOM_HEADER
+        if header_name.startswith("HTTP_"):
+            header_name = header_name[5:]
+        header_name = header_name.replace("_", "-").capitalize()
+
+        return {
+            "type": "apiKey",
+            "in": "header",
+            "name": header_name,
+        }
+
+
+class BearerScheme(TokenScheme):
+    target_class = "apps.api.permissions.BearerTokenAuthentication"

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -4,11 +4,11 @@ from django.shortcuts import get_object_or_404
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import filters, mixins, status
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
-from apps.api.permissions import DjangoModelPermissionsWithView, HasUserAPIKey
+from apps.api.permissions import DjangoModelPermissionsWithView
 from apps.api.serializers import (
     ExperimentSerializer,
     ExperimentSessionCreateSerializer,
@@ -39,7 +39,7 @@ from apps.experiments.models import Experiment, ExperimentSession, Participant, 
     ),
 )
 class ExperimentViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, GenericViewSet):
-    permission_classes = [HasUserAPIKey, DjangoModelPermissionsWithView]
+    permission_classes = [DjangoModelPermissionsWithView]
     serializer_class = ExperimentSerializer
     lookup_field = "public_id"
     lookup_url_kwarg = "id"
@@ -64,7 +64,6 @@ class ExperimentViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, Generi
     ],
 )
 @api_view(["POST"])
-@permission_classes([HasUserAPIKey])
 @permission_required("experiments.change_participantdata")
 def update_participant_data(request, participant_id: str):
     """
@@ -123,7 +122,7 @@ def update_participant_data(request, participant_id: str):
     ),
 )
 class ExperimentSessionViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, GenericViewSet):
-    permission_classes = [HasUserAPIKey, DjangoModelPermissionsWithView]
+    permission_classes = [DjangoModelPermissionsWithView]
     serializer_class = ExperimentSessionSerializer
     filter_backends = [filters.OrderingFilter]
     ordering_fields = ["created_at"]

--- a/apps/channels/views.py
+++ b/apps/channels/views.py
@@ -8,10 +8,9 @@ from django.views.decorators.csrf import csrf_exempt
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
 from rest_framework import serializers
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from apps.api.permissions import HasUserAPIKey
 from apps.channels import tasks
 from apps.experiments.models import Experiment, ExperimentSession
 
@@ -78,7 +77,6 @@ def new_turn_message(request, experiment_id: uuid):
     ],
 )
 @api_view(["POST"])
-@permission_classes([HasUserAPIKey])
 def new_api_message(request, experiment_id: uuid):
     """Chat with an experiment."""
     message_data = request.data.copy()

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -337,7 +337,10 @@ SITE_ID = 1
 
 # DRF config
 REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": ["apps.api.permissions.ApiKeyAuthentication"],
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "apps.api.permissions.ApiKeyAuthentication",
+        "apps.api.permissions.BearerTokenAuthentication",
+    ],
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer"],
     "DEFAULT_PARSER_CLASSES": ["rest_framework.parsers.JSONParser"],
@@ -354,12 +357,6 @@ SPECTACULAR_SETTINGS = {
     "SWAGGER_UI_SETTINGS": {
         "displayOperationId": True,
     },
-    "APPEND_COMPONENTS": {"securitySchemes": {"ApiKeyAuth": {"type": "apiKey", "in": "header", "name": "X-Api-Key"}}},
-    # "SECURITY": [
-    #     {
-    #         "ApiKeyAuth": [],
-    #     }
-    # ],
 }
 
 # Celery setup (using redis)

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -337,8 +337,8 @@ SITE_ID = 1
 
 # DRF config
 REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": [],
-    "DEFAULT_PERMISSION_CLASSES": ["apps.api.permissions.HasUserAPIKey"],
+    "DEFAULT_AUTHENTICATION_CLASSES": ["apps.api.permissions.ApiKeyAuthentication"],
+    "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer"],
     "DEFAULT_PARSER_CLASSES": ["rest_framework.parsers.JSONParser"],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
@@ -355,11 +355,11 @@ SPECTACULAR_SETTINGS = {
         "displayOperationId": True,
     },
     "APPEND_COMPONENTS": {"securitySchemes": {"ApiKeyAuth": {"type": "apiKey", "in": "header", "name": "X-Api-Key"}}},
-    "SECURITY": [
-        {
-            "ApiKeyAuth": [],
-        }
-    ],
+    # "SECURITY": [
+    #     {
+    #         "ApiKeyAuth": [],
+    #     }
+    # ],
 }
 
 # Celery setup (using redis)


### PR DESCRIPTION
This cleans up and standardized the api auth:

* Use authenticator for api key auth instead of 'permissions'
* Support both api-key and bearer auth on all APIs
  * Initially we only supported bearer auth for the openai api but there's no down side to supporting it for them all. Also, I needed to add api key auth to the openai api for Athina.
 