### PR TITLE
global admin dashboard

### DIFF
--- a/apps/admin/apps.py
+++ b/apps/admin/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AdminConfig(AppConfig):
+    name = "apps.admin"
+    label = "admin"

--- a/apps/admin/forms.py
+++ b/apps/admin/forms.py
@@ -1,0 +1,6 @@
+from django import forms
+
+
+class DateRangeForm(forms.Form):
+    start = forms.DateField(widget=forms.DateInput(attrs={"type": "date"}))
+    end = forms.DateField(widget=forms.DateInput(attrs={"type": "date"}))

--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -1,7 +1,9 @@
+import csv
+import io
 from datetime import datetime
 
-from django.db.models import Count
-from django.db.models.functions import TruncDate
+from django.db.models import Count, Sum, Value
+from django.db.models.functions import Coalesce, Length, TruncDate
 
 from apps.chat.models import ChatMessage
 from apps.experiments.models import Participant
@@ -27,3 +29,32 @@ def get_participant_stats(start: datetime, end: datetime):
         .order_by("date")
     )
     return data
+
+
+def usage_to_csv(start: datetime, end: datetime):
+    csv_in_memory = io.StringIO()
+    writer = csv.writer(csv_in_memory, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
+    writer.writerow(["Team", "Message Count", "Total Characters"])
+    for data in get_usage_data(start, end):
+        writer.writerow(data)
+
+    return csv_in_memory.getvalue()
+
+
+def get_usage_data(start: datetime, end: datetime):
+    """Usage approximation based on character counts."""
+    usage_data = (
+        ChatMessage.objects.filter(created_at__gte=start, created_at__lt=end)
+        .values("chat__team__name")
+        .annotate(
+            msg_count=Count("id"),
+            total_chars=Sum(
+                Length("content")
+                + Length("chat__experiment_session__experiment__prompt_text")
+                + Length(Coalesce("chat__experiment_session__experiment__source_material__material", Value("")))
+            ),
+        )
+        .order_by("-msg_count")
+    )
+    for data in usage_data:
+        yield data["chat__team__name"], data["msg_count"], data["total_chars"]

--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+
+from django.db.models import Count
+from django.db.models.functions import TruncDate
+
+from apps.chat.models import ChatMessage
+
+
+def get_message_stats(start: datetime, end: datetime):
+    data = (
+        ChatMessage.objects.filter(created_at__gte=start, created_at__lt=end)
+        .annotate(date=TruncDate("created_at"))
+        .values("date")
+        .annotate(count=Count("id"))
+        .order_by("date")
+    )
+    return data

--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -4,11 +4,23 @@ from django.db.models import Count
 from django.db.models.functions import TruncDate
 
 from apps.chat.models import ChatMessage
+from apps.experiments.models import Participant
 
 
 def get_message_stats(start: datetime, end: datetime):
     data = (
         ChatMessage.objects.filter(created_at__gte=start, created_at__lt=end)
+        .annotate(date=TruncDate("created_at"))
+        .values("date")
+        .annotate(count=Count("id"))
+        .order_by("date")
+    )
+    return data
+
+
+def get_participant_stats(start: datetime, end: datetime):
+    data = (
+        Participant.objects.filter(created_at__gte=start, created_at__lt=end)
         .annotate(date=TruncDate("created_at"))
         .values("date")
         .annotate(count=Count("id"))

--- a/apps/admin/serializers.py
+++ b/apps/admin/serializers.py
@@ -1,0 +1,6 @@
+from rest_framework import serializers
+
+
+class StatsSerializer(serializers.Serializer):
+    date = serializers.DateField()
+    count = serializers.IntegerField()

--- a/apps/admin/urls.py
+++ b/apps/admin/urls.py
@@ -6,4 +6,5 @@ app_name = "ocs_admin"
 
 urlpatterns = [
     path("", views.admin_home, name="home"),
+    path("usage/", views.usage_chart, name="usage_chart"),
 ]

--- a/apps/admin/urls.py
+++ b/apps/admin/urls.py
@@ -7,4 +7,6 @@ app_name = "ocs_admin"
 urlpatterns = [
     path("", views.admin_home, name="home"),
     path("usage/", views.usage_chart, name="usage_chart"),
+    path("export/usage/", views.export_usage, name="export_usage"),
+    path("export/whatsapp/", views.export_whatsapp, name="export_whatsapp"),
 ]

--- a/apps/admin/urls.py
+++ b/apps/admin/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from . import views
+
+app_name = "ocs_admin"
+
+urlpatterns = [
+    path("", views.admin_home, name="home"),
+]

--- a/apps/admin/views.py
+++ b/apps/admin/views.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from apps.admin.forms import DateRangeForm
-from apps.admin.queries import get_message_stats, get_participant_stats, usage_to_csv
+from apps.admin.queries import get_message_stats, get_participant_stats, get_whatsapp_numbers, usage_to_csv
 from apps.admin.serializers import StatsSerializer
 from apps.experiments.models import Participant
 
@@ -66,7 +66,9 @@ def export_usage(request):
 
 @user_passes_test(lambda u: u.is_staff, login_url="/404")
 def export_whatsapp(request):
-    pass
+    response = HttpResponse(get_whatsapp_numbers(), content_type="text/csv")
+    response["Content-Disposition"] = 'attachment; filename="whatsapp_numbers.csv"'
+    return response
 
 
 def _get_date_param(request, param_name, default):

--- a/apps/admin/views.py
+++ b/apps/admin/views.py
@@ -1,7 +1,45 @@
+from datetime import datetime, timedelta
+
 from django.contrib.auth.decorators import user_passes_test
-from django.shortcuts import render
+from django.template.response import TemplateResponse
+from django.utils import timezone
+
+from apps.admin.forms import DateRangeForm
+from apps.admin.queries import get_message_stats
+from apps.admin.serializers import StatsSerializer
+from apps.users.models import CustomUser
 
 
-@user_passes_test(lambda u: u.is_superuser)
+@user_passes_test(lambda u: u.is_staff, login_url="/404")
 def admin_home(request):
-    return render(request, "admin/home.html", context={})
+    end = _get_date_param(request, "end", timezone.now().date())
+    start = _get_date_param(request, "start", end - timedelta(days=90))
+
+    serializer = StatsSerializer(get_message_stats(start, end), many=True)
+
+    form = DateRangeForm(initial={"start": start, "end": end})
+    start_value = CustomUser.objects.filter(date_joined__lt=start).count()
+    return TemplateResponse(
+        request,
+        "admin/home.html",
+        context={
+            "active_tab": "admin",
+            "usage_data": serializer.data,
+            "form": form,
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+            "start_value": start_value,
+        },
+    )
+
+
+def _get_date_param(request, param_name, default):
+    value = request.GET.get(param_name)
+    if value:
+        return _string_to_date(value)
+    return default
+
+
+def _string_to_date(date_str: str) -> datetime.date:
+    date_format = "%Y-%m-%d"
+    return datetime.strptime(date_str, date_format).date()

--- a/apps/admin/views.py
+++ b/apps/admin/views.py
@@ -1,0 +1,7 @@
+from django.contrib.auth.decorators import user_passes_test
+from django.shortcuts import render
+
+
+@user_passes_test(lambda u: u.is_superuser)
+def admin_home(request):
+    return render(request, "admin/home.html", context={})

--- a/assets/javascript/admin-dashboard.js
+++ b/assets/javascript/admin-dashboard.js
@@ -1,0 +1,120 @@
+'use strict'
+import Chart from 'chart.js/auto'
+
+function listToDict (list) {
+  // gpt
+  return list.reduce((acc, item) => {
+    acc[item.date] = item.count
+    return acc
+  }, {})
+}
+
+function toDateString (dateObj) {
+  return dateObj.toISOString().split('T')[0]
+}
+
+function getTimeSeriesData (start, end, data) {
+  const dataDict = listToDict(data)
+  const chartData = []
+  const current = new Date(start)
+  while (current <= end) { // eslint-disable-line no-unmodified-loop-condition
+    const curString = toDateString(current)
+    chartData.push({
+      x: curString,
+      y: dataDict[curString] || 0
+    })
+    current.setDate(current.getDate() + 1)
+  }
+  return chartData
+}
+
+export const barChartWithDates = (ctx, start, end, data, label) => {
+  const chartData = getTimeSeriesData(start, end, data)
+  return new Chart(ctx, {
+    type: 'bar',
+    data: {
+      datasets: [
+        {
+          label,
+          data: chartData
+        }
+      ]
+    },
+    options: {
+      aspectRatio: 3,
+      responsive: true,
+      plugins: {
+        legend: {
+          display: false
+        }
+      },
+      scales: {
+        x: {
+          title: {
+            display: true,
+            text: 'Date'
+          }
+        },
+        y: {
+          beginAtZero: true,
+          title: {
+            display: true,
+            text: label
+          }
+        }
+      }
+    }
+  })
+}
+
+export const cumulativeChartWithDates = (
+  ctx,
+  start,
+  end,
+  data,
+  label,
+  startValue
+) => {
+  const chartData = getTimeSeriesData(start, end, data)
+  let currentValue = startValue || 0
+  for (const row of chartData) {
+    currentValue += row.y
+    row.y = currentValue
+  }
+  return new Chart(ctx, {
+    type: 'line',
+    data: {
+      datasets: [
+        {
+          label,
+          fill: true,
+          data: chartData
+        }
+      ]
+    },
+    options: {
+      aspectRatio: 3,
+      responsive: true,
+      plugins: {
+        legend: {
+          display: false
+        }
+      },
+      scales: {
+        x: {
+          title: {
+            display: true,
+            text: 'Date'
+          }
+        },
+        y: {
+          beginAtZero: true,
+          title: {
+            display: true,
+            text: label
+          }
+        }
+      }
+    }
+  })
+}

--- a/assets/javascript/admin-dashboard.js
+++ b/assets/javascript/admin-dashboard.js
@@ -41,8 +41,8 @@ export const barChartWithDates = (ctx, start, end, data, label) => {
       ]
     },
     options: {
-      aspectRatio: 3,
       responsive: true,
+      maintainAspectRatio: false,
       plugins: {
         legend: {
           display: false
@@ -93,8 +93,8 @@ export const cumulativeChartWithDates = (
       ]
     },
     options: {
-      aspectRatio: 3,
       responsive: true,
+      maintainAspectRatio: false,
       plugins: {
         legend: {
           display: false

--- a/gpt_playground/urls.py
+++ b/gpt_playground/urls.py
@@ -46,9 +46,10 @@ team_urlpatterns = [
 ]
 
 urlpatterns = [
+    path("admin/", include("apps.admin.urls")),
     # redirect Django admin login to main login page
-    path("admin/login/", RedirectView.as_view(pattern_name="account_login")),
-    path("admin/", admin.site.urls),
+    path("django-admin/login/", RedirectView.as_view(pattern_name="account_login")),
+    path("django-admin/", admin.site.urls),
     path("i18n/", include("django.conf.urls.i18n")),
     path("sitemap.xml", sitemap, {"sitemaps": sitemaps}, name="django.contrib.sitemaps.views.sitemap"),
     path("a/<slug:team_slug>/", include(team_urlpatterns)),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "alertifyjs": "^1.14.0",
         "alpinejs": "^3.13.1",
         "axios": "^1.6.8",
+        "chart.js": "^4.4.3",
         "daisyui": "^4",
         "htmx.org": "^1.9.6",
         "js-cookie": "^3.0.5",
@@ -2098,6 +2099,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+    },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
@@ -3683,6 +3689,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.3.tgz",
+      "integrity": "sha512-qK1gkGSRYcJzqrrzdR6a+I0vQ4/R+SoODXyAjscQ/4mzuNzySaMCd+hyVxitSY1+L2fjPD1Gbn+ibNqRmwQeLw==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "alertifyjs": "^1.14.0",
     "alpinejs": "^3.13.1",
     "axios": "^1.6.8",
+    "chart.js": "^4.4.3",
     "daisyui": "^4",
     "htmx.org": "^1.9.6",
     "js-cookie": "^3.0.5",

--- a/templates/admin/home.html
+++ b/templates/admin/home.html
@@ -1,0 +1,8 @@
+{% extends "web/app/app_base.html" %}
+{% load i18n %}
+{% load static %}
+{% block app %}
+    <section class="app-card">
+        hi
+    </section>
+{% endblock %}

--- a/templates/admin/home.html
+++ b/templates/admin/home.html
@@ -16,7 +16,17 @@
         </div>
       </div>
     </form>
-    <div class="mt-2" id="charts"></div>
+    <div class="mt-4" id="charts"></div>
+    <div class="flex space-x-3">
+      <a class="btn" href="{% url "ocs_admin:export_usage" %}">
+        <i class="fa-solid fa-download"></i>
+        Usage Data
+      </a>
+      <a class="btn" href="{% url "ocs_admin:export_whatsapp" %}">
+        <i class="fa-solid fa-download"></i>
+        WhatsApp Numbers
+      </a>
+    </div>
   </section>
 {% endblock %}
 {% block page_js %}

--- a/templates/admin/home.html
+++ b/templates/admin/home.html
@@ -6,7 +6,7 @@
   <section class="app-card">
 
     <h1 class="pg-title">{% translate "Project Dashboard" %}</h1>
-    <form>
+    <form hx-get="{% url "ocs_admin:usage_chart" %}" hx-target="#charts" hx-trigger="load, changed, submit">
       <div class="pg-columns">
         <div class="pg-column">
           {% render_field form.start %}
@@ -19,7 +19,7 @@
         <input type="submit" class="pg-button-primary" value="Update">
       </div>
     </form>
-    <div class="mt-2">
+    <div class="mt-2" id="charts">
       <div class="pg-subtitle">{% translate "Chat Messages (Daily)" %}
         <canvas id="usage-chart" class="mt-2"></canvas>
       </div>
@@ -27,15 +27,23 @@
   </section>
 {% endblock %}
 {% block page_js %}
-  {{ usage_data|json_script:'usage_data' }}
   <script src="{% static 'js/adminDashboard-bundle.js' %}"></script>
   <script>
-    const start = new Date("{{ start }}");
-    const end = new Date("{{ end }}");
-    const startValue = {{ start_value }};
+    let chart;
+    htmx.onLoad(() => {
+      const element = document.getElementById('usage_data');
+      if (!element) {
+        return;
+      }
+      const usageData = JSON.parse(document.getElementById('usage_data').textContent);
+      const start = new Date(usageData.start);
+      const end = new Date(usageData.end);
 
-    const usageChart = document.getElementById('usage-chart').getContext('2d');
-    const usageData = JSON.parse(document.getElementById('usage_data').textContent);
-    SiteJS.adminDashboard.barChartWithDates(usageChart, start, end, usageData, "Chat Messages");
+      const usageChart = document.getElementById('usage-chart').getContext('2d');
+      if (chart) {
+        chart.destroy();
+      }
+      chart = SiteJS.adminDashboard.barChartWithDates(usageChart, start, end, usageData.data, "Chat Messages");
+    })
   </script>
 {% endblock %}

--- a/templates/admin/home.html
+++ b/templates/admin/home.html
@@ -6,7 +6,7 @@
   <section class="app-card">
 
     <h1 class="pg-title">{% translate "Project Dashboard" %}</h1>
-    <form hx-get="{% url "ocs_admin:usage_chart" %}" hx-target="#charts" hx-trigger="load, changed, submit">
+    <form hx-get="{% url "ocs_admin:usage_chart" %}" hx-target="#charts" hx-trigger="load, change, submit">
       <div class="pg-columns">
         <div class="pg-column">
           {% render_field form.start %}
@@ -15,35 +15,35 @@
           {% render_field form.end %}
         </div>
       </div>
-      <div class="pg-text-right mt-2">
-        <input type="submit" class="pg-button-primary" value="Update">
-      </div>
     </form>
-    <div class="mt-2" id="charts">
-      <div class="pg-subtitle">{% translate "Chat Messages (Daily)" %}
-        <canvas id="usage-chart" class="mt-2"></canvas>
-      </div>
-    </div>
+    <div class="mt-2" id="charts"></div>
   </section>
 {% endblock %}
 {% block page_js %}
   <script src="{% static 'js/adminDashboard-bundle.js' %}"></script>
   <script>
-    let chart;
+    let messageChart;
+    let participantChart;
     htmx.onLoad(() => {
-      const element = document.getElementById('usage_data');
+      const element = document.getElementById('chart_data');
       if (!element) {
         return;
       }
-      const usageData = JSON.parse(document.getElementById('usage_data').textContent);
-      const start = new Date(usageData.start);
-      const end = new Date(usageData.end);
+      const chartData = JSON.parse(element.textContent);
+      const start = new Date(chartData.start);
+      const end = new Date(chartData.end);
 
-      const usageChart = document.getElementById('usage-chart').getContext('2d');
-      if (chart) {
-        chart.destroy();
+      const messageChartCtx = document.getElementById('message-chart').getContext('2d');
+      const participantChartCtx = document.getElementById('participant-chart').getContext('2d');
+      if (messageChart) {
+        messageChart.destroy();
       }
-      chart = SiteJS.adminDashboard.barChartWithDates(usageChart, start, end, usageData.data, "Chat Messages");
+      if (participantChart) {
+        participantChart.destroy();
+      }
+      messageChart = SiteJS.adminDashboard.barChartWithDates(messageChartCtx, start, end, chartData.message_data, "Chat Messages");
+      let participantData = chartData.participant_data;
+      participantChart = SiteJS.adminDashboard.cumulativeChartWithDates(participantChartCtx, start, end, participantData.data, "Participants", participantData.start_value);
     })
   </script>
 {% endblock %}

--- a/templates/admin/home.html
+++ b/templates/admin/home.html
@@ -1,8 +1,41 @@
 {% extends "web/app/app_base.html" %}
+{% load form_tags %}
 {% load i18n %}
 {% load static %}
 {% block app %}
-    <section class="app-card">
-        hi
-    </section>
+  <section class="app-card">
+
+    <h1 class="pg-title">{% translate "Project Dashboard" %}</h1>
+    <form>
+      <div class="pg-columns">
+        <div class="pg-column">
+          {% render_field form.start %}
+        </div>
+        <div class="pg-column">
+          {% render_field form.end %}
+        </div>
+      </div>
+      <div class="pg-text-right mt-2">
+        <input type="submit" class="pg-button-primary" value="Update">
+      </div>
+    </form>
+    <div class="mt-2">
+      <div class="pg-subtitle">{% translate "Chat Messages (Daily)" %}
+        <canvas id="usage-chart" class="mt-2"></canvas>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+{% block page_js %}
+  {{ usage_data|json_script:'usage_data' }}
+  <script src="{% static 'js/adminDashboard-bundle.js' %}"></script>
+  <script>
+    const start = new Date("{{ start }}");
+    const end = new Date("{{ end }}");
+    const startValue = {{ start_value }};
+
+    const usageChart = document.getElementById('usage-chart').getContext('2d');
+    const usageData = JSON.parse(document.getElementById('usage_data').textContent);
+    SiteJS.adminDashboard.barChartWithDates(usageChart, start, end, usageData, "Chat Messages");
+  </script>
 {% endblock %}

--- a/templates/admin/usage_chart.html
+++ b/templates/admin/usage_chart.html
@@ -1,0 +1,8 @@
+{% load form_tags %}
+{% load i18n %}
+{% load static %}
+
+<div class="pg-subtitle">{% translate "Chat Messages (Daily)" %}
+  <canvas id="usage-chart" class="mt-2"></canvas>
+</div>
+{{ usage_data|json_script:'usage_data' }}

--- a/templates/admin/usage_chart.html
+++ b/templates/admin/usage_chart.html
@@ -2,7 +2,12 @@
 {% load i18n %}
 {% load static %}
 
-<div class="pg-subtitle">{% translate "Chat Messages (Daily)" %}
-  <canvas id="usage-chart" class="mt-2"></canvas>
+<div class="pg-subtitle">{% translate "Chat Messages" %}</div>
+<div class="w-full h-48 relative">
+  <canvas id="message-chart" class="mt-2"></canvas>
 </div>
-{{ usage_data|json_script:'usage_data' }}
+<div class="pg-subtitle">{% translate "Participant Count" %}</div>
+<div class="w-full h-48 relative">
+  <canvas id="participant-chart" class="mt-2"></canvas>
+</div>
+{{ chart_data|json_script:'chart_data' }}

--- a/templates/web/components/app_nav_menu_items.html
+++ b/templates/web/components/app_nav_menu_items.html
@@ -35,7 +35,7 @@
   <ul class="menu-list">
     <li>
       <a href="{% url 'ocs_admin:home' %}" {% if active_tab == 'admin' %}class="active"{% endif %}>
-        <i class="fa fa-user-secret h-4 w-4"></i>
+        <i class="fa fa-bar-chart-o h-4 w-4"></i>
         {% translate "Admin" %}
       </a>
     </li>

--- a/templates/web/components/app_nav_menu_items.html
+++ b/templates/web/components/app_nav_menu_items.html
@@ -28,16 +28,24 @@
     </a>
   </li>
 </ul>
-{% if user.is_superuser %}
+{% if user.is_staff or user.is_superuser %}
   <li class="menu-title">
     <span>{% translate "Admin" %}</span>
   </li>
   <ul class="menu-list">
     <li>
-      <a href="{% url 'support:hijack_user' %}" {% if active_tab == 'support' %}class="active"{% endif %}>
+      <a href="{% url 'ocs_admin:home' %}" {% if active_tab == 'admin' %}class="active"{% endif %}>
         <i class="fa fa-user-secret h-4 w-4"></i>
-        {% translate "Impersonate a User" %}
+        {% translate "Admin" %}
       </a>
     </li>
+    {% if user.is_superuser %}
+      <li>
+        <a href="{% url 'support:hijack_user' %}" {% if active_tab == 'support' %}class="active"{% endif %}>
+          <i class="fa fa-user-secret h-4 w-4"></i>
+          {% translate "Impersonate a User" %}
+        </a>
+      </li>
+    {% endif %}
   </ul>
 {% endif %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
     site: './assets/javascript/site.js',  // global site javascript
     app: './assets/javascript/app.js',  // logged-in javascript
     'pipeline': './assets/javascript/apps/pipeline.tsx',
+    adminDashboard: './assets/javascript/admin-dashboard.js',
   },
   output: {
     path: path.resolve(__dirname, './static'),


### PR DESCRIPTION
This serves as a place to put global admin tools. Currently:

* basic charts
* Options to download usage data and whatsapp number list

In future this can be expanded with more features as needed.

Access to these pages is permitted to `staff` users.

Note: this also moves the Django Admin to `/django-admin/`

![image](https://github.com/user-attachments/assets/b41d3a09-7967-4808-a827-4a57601e7a34)


FYI @bderenzi 