### PR TITLE
custom classes for token counting

### DIFF
--- a/apps/chat/tests/test_routing.py
+++ b/apps/chat/tests/test_routing.py
@@ -8,7 +8,7 @@ from apps.chat.models import ChatMessageType
 from apps.experiments.models import ExperimentRoute
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.team import TeamFactory
-from apps.utils.langchain import FakeLlm, FakeLlmService
+from apps.utils.langchain import build_fake_llm_service
 
 
 @pytest.mark.django_db()
@@ -25,13 +25,12 @@ from apps.utils.langchain import FakeLlm, FakeLlmService
 def test_experiment_routing(with_default, routing_response, expected_tag):
     experiment = _make_experiment_with_routing(with_default)
     session = ExperimentSessionFactory(experiment=experiment)
-    fake_llm = FakeLlm(responses=[routing_response, "How can I help today?"], token_counts=[0])
-    fake_service = FakeLlmService(llm=fake_llm)
+    fake_service = build_fake_llm_service(responses=[routing_response, "How can I help today?"], token_counts=[0])
     with patch("apps.experiments.models.Experiment.get_llm_service", new=lambda x: fake_service):
         bot = TopicBot(session)
         response = bot.process_input("Hi")
     assert response == "How can I help today?"
-    assert fake_llm.get_call_messages() == [
+    assert fake_service.llm.get_call_messages() == [
         [SystemMessage(content="You are a helpful assistant"), HumanMessage(content="Hi")],
         [SystemMessage(content="You are a helpful assistant"), HumanMessage(content="Hi")],
     ]

--- a/apps/service_providers/llm_service/callbacks.py
+++ b/apps/service_providers/llm_service/callbacks.py
@@ -3,8 +3,9 @@ from typing import Any
 from uuid import UUID
 
 from langchain_core.callbacks import BaseCallbackHandler
-from langchain_core.language_models import BaseLanguageModel
 from langchain_core.outputs import LLMResult
+
+from apps.service_providers.llm_service.token_counters import TokenCounter
 
 
 class TokenCountingCallbackHandler(BaseCallbackHandler):
@@ -13,27 +14,35 @@ class TokenCountingCallbackHandler(BaseCallbackHandler):
     prompt_tokens: int = 0
     completion_tokens: int = 0
 
-    def __init__(self, model: BaseLanguageModel):
+    def __init__(self, token_counter: TokenCounter):
         super().__init__()
         self._lock = threading.Lock()
-        self.model = model
+        self.token_counter = token_counter
+        self.prompts_by_run = {}
 
     def __repr__(self) -> str:
         return f"Prompt Tokens: {self.prompt_tokens}\n" f"Completion Tokens: {self.completion_tokens}\n"
 
-    def on_llm_start(self, serialized: dict[str, Any], prompts: list[str], **kwargs) -> Any:
-        with self._lock:
-            self.prompt_tokens += sum([self.model.get_num_tokens(prompt) for prompt in prompts])
+    def on_llm_start(self, serialized: dict[str, Any], prompts: list[str], *, run_id: UUID, **kwargs) -> Any:
+        self.prompts_by_run[run_id] = " ".join(prompts)
 
-    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
-        """Collect token usage."""
-        messages = []
-        for i, generations in enumerate(response.generations):
-            for j, generation in enumerate(generations):
-                messages.append(generation.message)
+    def on_llm_end(self, response: LLMResult, *, run_id: UUID, **kwargs) -> None:
+        prompt = self.prompts_by_run.pop(run_id, None)
+        if tokens := self.token_counter.get_tokens_from_response(response):
+            input_tokens, output_tokens = tokens
+        else:
+            input_tokens = self.token_counter.get_tokens_from_text(prompt)
+
+            messages = []
+            for i, generations in enumerate(response.generations):
+                for j, generation in enumerate(generations):
+                    messages.append(generation.message)
+
+            output_tokens = self.token_counter.get_tokens_from_messages(messages)
 
         with self._lock:
-            self.completion_tokens += self.model.get_num_tokens_from_messages(messages)
+            self.prompt_tokens += input_tokens
+            self.completion_tokens += output_tokens
 
     def on_llm_error(
         self,
@@ -47,4 +56,4 @@ class TokenCountingCallbackHandler(BaseCallbackHandler):
         response = kwargs.get("response", None)
         if not response:
             return
-        self.on_llm_end(response)
+        self.on_llm_end(response, run_id=run_id)

--- a/apps/service_providers/llm_service/state.py
+++ b/apps/service_providers/llm_service/state.py
@@ -62,7 +62,7 @@ class ExperimentState(RunnableState):
 
     @property
     def callback_handler(self):
-        return self.get_llm_service().get_callback_handler(self.get_chat_model())
+        return self.get_llm_service().get_callback_handler(self.experiment.llm)
 
     def format_input(self, input_key: str, runnable_input: dict):
         if self.experiment.input_formatter:

--- a/apps/service_providers/llm_service/token_counters.py
+++ b/apps/service_providers/llm_service/token_counters.py
@@ -1,0 +1,69 @@
+import dataclasses
+
+import tiktoken
+from anthropic._tokenizers import sync_get_tokenizer
+from langchain_core.messages import get_buffer_string
+from langchain_core.outputs import LLMResult
+
+
+class TokenCounter:
+    def get_tokens_from_response(self, response: LLMResult) -> None | tuple[int, int]:
+        return None
+
+    def get_tokens_from_text(self, text) -> int:
+        raise NotImplementedError()
+
+    def get_tokens_from_messages(self, messages) -> int:
+        return sum([self.get_tokens_from_text(get_buffer_string([m])) for m in messages])
+
+
+@dataclasses.dataclass
+class OpenAITokenCounter(TokenCounter):
+    model: str
+
+    def get_tokens_from_response(self, response: LLMResult) -> None | tuple[int, int]:
+        if response.llm_output is None:
+            return None
+
+        if "token_usage" not in response.llm_output:
+            return None
+
+        token_usage = response.llm_output["token_usage"]
+        completion_tokens = token_usage.get("completion_tokens", 0)
+        prompt_tokens = token_usage.get("prompt_tokens", 0)
+
+        return prompt_tokens, completion_tokens
+
+    def get_tokens_from_text(self, text) -> int:
+        if not text:
+            return 0
+        encoding_model = self._get_encoding_model()
+        return len(encoding_model.encode(text))
+
+    def _get_encoding_model(self) -> tiktoken.Encoding:
+        try:
+            return tiktoken.encoding_for_model(self.model)
+        except KeyError:
+            # fallback to gpt-4 if the model is not available for encoding
+            model = "gpt-4"
+            return tiktoken.get_encoding(model)
+
+
+class AnthropicTokenCounter(TokenCounter):
+    def get_tokens_from_response(self, response: LLMResult) -> None | tuple[int, int]:
+        if response.llm_output is None:
+            return None
+
+        if "usage" not in response.llm_output:
+            return None
+
+        token_usage = response.llm_output["usage"]
+        output_tokens = token_usage.get("output_tokens", 0)
+        input_tokens = token_usage.get("input_tokens", 0)
+
+        return input_tokens, output_tokens
+
+    def get_tokens_from_text(self, text) -> int:
+        tokenizer = sync_get_tokenizer()
+        encoded_text = tokenizer.encode(text)
+        return len(encoded_text.ids)

--- a/apps/service_providers/tests/test_runnables.py
+++ b/apps/service_providers/tests/test_runnables.py
@@ -17,18 +17,18 @@ from apps.service_providers.llm_service.runnables import (
 from apps.service_providers.llm_service.state import ChatExperimentState
 from apps.utils.factories.channels import ChannelPlatform, ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentSessionFactory
-from apps.utils.langchain import FakeLlm, FakeLlmService
+from apps.utils.langchain import build_fake_llm_service
 
 
 @pytest.fixture()
-def fake_llm():
-    return FakeLlm(responses=["this is a test message"], token_counts=[30, 20, 10])
+def fake_llm_service():
+    return build_fake_llm_service(responses=["this is a test message"], token_counts=[30, 20, 10])
 
 
 @pytest.fixture()
-def session(fake_llm):
+def session(fake_llm_service):
     session = ExperimentSessionFactory()
-    session.experiment.get_llm_service = lambda: FakeLlmService(llm=fake_llm)
+    session.experiment.get_llm_service = lambda: fake_llm_service
     session.experiment.tools = [AgentTools.SCHEDULE_UPDATE]
     session.get_participant_data = lambda *args, **kwargs: {"name": "Tester"}
     return session
@@ -63,56 +63,56 @@ def runnable(request, session):
 
 @pytest.mark.django_db()
 @freezegun.freeze_time("2024-02-08 13:00:08.877096+00:00")
-def test_runnable(runnable, session, fake_llm):
+def test_runnable(runnable, session, fake_llm_service):
     chain = runnable.build(state=ChatExperimentState(session.experiment, session))
     result = chain.invoke("hi")
     assert result == ChainOutput(output="this is a test message", prompt_tokens=30, completion_tokens=20)
-    assert len(fake_llm.get_calls()) == 1
-    assert _messages_to_dict(fake_llm.get_call_messages()[0]) == [
+    assert len(fake_llm_service.llm.get_calls()) == 1
+    assert _messages_to_dict(fake_llm_service.llm.get_call_messages()[0]) == [
         {"system": "You are a helpful assistant"},
         {"human": "hi"},
     ]
     if runnable.expect_tools:
-        assert "tools" in fake_llm.get_calls()[0].kwargs
+        assert "tools" in fake_llm_service.llm.get_calls()[0].kwargs
     else:
-        assert "tools" not in fake_llm.get_calls()[0].kwargs
+        assert "tools" not in fake_llm_service.llm.get_calls()[0].kwargs
 
 
 @pytest.mark.django_db()
 @freezegun.freeze_time("2024-02-08 13:00:08.877096+00:00")
-def test_runnable_with_source_material(runnable, session, fake_llm):
+def test_runnable_with_source_material(runnable, session, fake_llm_service):
     session.experiment.source_material = SourceMaterial(material="this is the source material")
     session.experiment.prompt_text = "System prompt with {source_material}"
     chain = runnable.build(state=ChatExperimentState(session.experiment, session))
     result = chain.invoke("hi")
     assert result == ChainOutput(output="this is a test message", prompt_tokens=30, completion_tokens=20)
     expected_system__prompt = "System prompt with this is the source material"
-    assert fake_llm.get_call_messages()[0][0] == SystemMessage(content=expected_system__prompt)
+    assert fake_llm_service.llm.get_call_messages()[0][0] == SystemMessage(content=expected_system__prompt)
 
 
 @pytest.mark.django_db()
 @freezegun.freeze_time("2024-02-08 13:00:08.877096+00:00")
-def test_runnable_with_source_material_missing(runnable, session, fake_llm):
+def test_runnable_with_source_material_missing(runnable, session, fake_llm_service):
     session.experiment.prompt_text = "System prompt with {source_material}"
     chain = runnable.build(state=ChatExperimentState(session.experiment, session))
     result = chain.invoke("hi")
     assert result == ChainOutput(output="this is a test message", prompt_tokens=30, completion_tokens=20)
     expected_system__prompt = "System prompt with "
-    assert fake_llm.get_call_messages()[0][0] == SystemMessage(content=expected_system__prompt)
+    assert fake_llm_service.llm.get_call_messages()[0][0] == SystemMessage(content=expected_system__prompt)
 
 
 @pytest.mark.django_db()
-def test_runnable_runnable_format_input(runnable, session, fake_llm):
+def test_runnable_runnable_format_input(runnable, session, fake_llm_service):
     chain = runnable.build(state=ChatExperimentState(session.experiment, session))
     session.experiment.input_formatter = "foo {input} bar"
     result = chain.invoke("hi")
     assert result == ChainOutput(output="this is a test message", prompt_tokens=30, completion_tokens=20)
-    assert len(fake_llm.get_calls()) == 1
-    assert _messages_to_dict(fake_llm.get_call_messages()[0])[1] == {"human": "foo hi bar"}
+    assert len(fake_llm_service.llm.get_calls()) == 1
+    assert _messages_to_dict(fake_llm_service.llm.get_call_messages()[0])[1] == {"human": "foo hi bar"}
 
 
 @pytest.mark.django_db()
-def test_runnable_save_input_to_history(runnable, session, chat, fake_llm):
+def test_runnable_save_input_to_history(runnable, session, chat, fake_llm_service):
     chain = runnable.build(state=ChatExperimentState(session.experiment, session))
     session.chat = chat
     assert chat.messages.count() == 1
@@ -120,13 +120,13 @@ def test_runnable_save_input_to_history(runnable, session, chat, fake_llm):
     result = chain.invoke("hi", config={"configurable": {"save_input_to_history": False}})
 
     assert result.output == "this is a test message"
-    assert len(fake_llm.get_calls()) == 1
+    assert len(fake_llm_service.llm.get_calls()) == 1
     assert chat.messages.count() == 2
 
 
 @pytest.mark.django_db()
 @freezegun.freeze_time("2024-02-08 13:00:08.877096+00:00")
-def test_runnable_with_history(runnable, session, chat, fake_llm):
+def test_runnable_with_history(runnable, session, chat, fake_llm_service):
     experiment = session.experiment
     experiment.max_token_limit = 0  # disable compression
     session.chat = chat
@@ -134,8 +134,8 @@ def test_runnable_with_history(runnable, session, chat, fake_llm):
     chain = runnable.build(state=ChatExperimentState(session.experiment, session))
     result = chain.invoke("hi")
     assert result == ChainOutput(output="this is a test message", prompt_tokens=30, completion_tokens=20)
-    assert len(fake_llm.get_calls()) == 1
-    assert _messages_to_dict(fake_llm.get_call_messages()[0]) == [
+    assert len(fake_llm_service.llm.get_calls()) == 1
+    assert _messages_to_dict(fake_llm_service.llm.get_call_messages()[0]) == [
         {"system": experiment.prompt_text},
         {"human": "Hello"},
         {"human": "hi"},
@@ -151,7 +151,13 @@ def test_runnable_with_history(runnable, session, chat, fake_llm):
 )
 @patch("apps.channels.forms.TelegramChannelForm._set_telegram_webhook")
 def test_runnable_with_participant_data(
-    _set_telegram_webhook, participant_with_user, is_web_session, considered_authorized, runnable, session, fake_llm
+    _set_telegram_webhook,
+    participant_with_user,
+    is_web_session,
+    considered_authorized,
+    runnable,
+    session,
+    fake_llm_service,
 ):
     """Participant data should be included in the prompt only for authorized users"""
     session.experiment_channel = ExperimentChannelFactory(
@@ -175,19 +181,19 @@ def test_runnable_with_participant_data(
         expected_prompt = "System prompt. Participant data: {'name': 'Tester'}"
     else:
         expected_prompt = "System prompt. Participant data: "
-    assert fake_llm.get_call_messages()[0][0] == SystemMessage(content=expected_prompt)
+    assert fake_llm_service.llm.get_call_messages()[0][0] == SystemMessage(content=expected_prompt)
 
 
 @pytest.mark.django_db()
 @freezegun.freeze_time("2024-02-08 13:00:08.877096+00:00")
-def test_runnable_with_current_datetime(runnable, session, fake_llm):
+def test_runnable_with_current_datetime(runnable, session, fake_llm_service):
     session.experiment.source_material = SourceMaterial(material="this is the source material")
     session.experiment.prompt_text = "System prompt with current datetime: {current_datetime}"
     chain = runnable.build(state=ChatExperimentState(session.experiment, session))
     result = chain.invoke("hi")
     assert result == ChainOutput(output="this is a test message", prompt_tokens=30, completion_tokens=20)
     expected_system__prompt = "System prompt with current datetime: Thursday, 08 February 2024 13:00:08 UTC"
-    assert fake_llm.get_call_messages()[0][0] == SystemMessage(content=expected_system__prompt)
+    assert fake_llm_service.llm.get_call_messages()[0][0] == SystemMessage(content=expected_system__prompt)
 
 
 def _messages_to_dict(messages: Sequence[BaseMessage]) -> list[dict]:

--- a/apps/utils/langchain.py
+++ b/apps/utils/langchain.py
@@ -1,3 +1,4 @@
+import dataclasses
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
@@ -6,20 +7,20 @@ from unittest.mock import patch
 
 from langchain.agents.openai_assistant.base import OpenAIAssistantFinish, OutputType
 from langchain_community.chat_models import FakeListChatModel
-from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.callbacks import BaseCallbackHandler, CallbackManagerForLLMRun
 from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.runnables import RunnableConfig, RunnableLambda, RunnableSerializable
 from langchain_core.utils.function_calling import convert_to_openai_tool
 
 from apps.service_providers.llm_service import LlmService
+from apps.service_providers.llm_service.callbacks import TokenCountingCallbackHandler
+from apps.service_providers.llm_service.token_counters import TokenCounter
 
 
 class FakeLlm(FakeListChatModel):
     """Extension of the FakeListChatModel that allows mocking of the token counts."""
 
-    token_counts: list = []
-    token_i: int = 0
     calls: list = []
 
     def _generate(
@@ -50,16 +51,8 @@ class FakeLlm(FakeListChatModel):
             for c in response:
                 yield ChatGenerationChunk(message=AIMessageChunk(content=c))
 
-    def get_num_tokens_from_messages(self, messages: list) -> int:
-        token_counts = self.token_counts[self.token_i]
-        if self.token_i < len(self.token_counts) - 1:
-            self.token_i += 1
-        else:
-            self.token_i = 0
-        return token_counts
-
     def get_num_tokens(self, text: str) -> int:
-        return self.get_num_tokens_from_messages([])
+        raise NotImplementedError
 
     def get_calls(self):
         return self.calls
@@ -80,14 +73,35 @@ class FakeLlm(FakeListChatModel):
         return RunnableLambda(lambda *args: self.responses[-1])
 
 
+@dataclasses.dataclass
+class FakeTokenCounter(TokenCounter):
+    token_counts: list[int] = dataclasses.field(default_factory=lambda: [1])
+    token_i: int = 0
+
+    def get_tokens_from_text(self, text) -> int:
+        token_counts = self.token_counts[self.token_i]
+        if self.token_i < len(self.token_counts) - 1:
+            self.token_i += 1
+        else:
+            self.token_i = 0
+        return token_counts
+
+
 class FakeLlmService(LlmService):
     llm: Any
+    token_counter: TokenCounter
+
+    class Config:
+        arbitrary_types_allowed = True
 
     def get_chat_model(self, llm_model: str, temperature: float):
         return self.llm
 
     def get_assistant(self, assistant_id: str, as_agent=False):
         return self.llm
+
+    def get_callback_handler(self, model: str) -> BaseCallbackHandler:
+        return TokenCountingCallbackHandler(self.token_counter)
 
 
 class FakeAssistant(RunnableSerializable[dict, OutputType]):
@@ -111,7 +125,7 @@ class FakeAssistant(RunnableSerializable[dict, OutputType]):
 
 @contextmanager
 def mock_experiment_llm(experiment, responses: list[Any], token_counts: list[int] = None):
-    service = FakeLlmService(llm=FakeLlm(responses=responses, token_counts=token_counts or [0]))
+    service = build_fake_llm_service(responses=responses, token_counts=token_counts)
 
     def fake_llm_service(self):
         return service
@@ -126,3 +140,7 @@ def mock_experiment_llm(experiment, responses: list[Any], token_counts: list[int
         patch("apps.assistants.models.OpenAiAssistant.get_assistant", new=fake_get_assistant),
     ):
         yield
+
+
+def build_fake_llm_service(responses, token_counts):
+    return FakeLlmService(llm=FakeLlm(responses=responses), token_counter=FakeTokenCounter(token_counts=token_counts))


### PR DESCRIPTION
Prior to this PR we used langchains classes for token counting. This moves away from that to our own implementation (still does the same thing at the end of the day). Having the counters under our control gives us more flexibility e.g. using Anthropic values returned from the API instead of doing the counting manually.

This will also be used in future for usage tracking within OCS

Pulled from https://github.com/dimagi/open-chat-studio/pull/511