### PR TITLE
Pass empty attachments to seed message

### DIFF
--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -505,7 +505,7 @@ class WebChannel(ChannelBase):
 
         if session.experiment.seed_message:
             session.seed_task_id = get_response_for_webchat_task.delay(
-                session.id, message_text=session.experiment.seed_message
+                session.id, message_text=session.experiment.seed_message, attachments=[]
             ).task_id
             session.save()
         return session

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -16,7 +16,9 @@ from apps.utils.taskbadger import update_taskbadger_data
 
 
 @shared_task(bind=True, base=TaskbadgerTask)
-def get_response_for_webchat_task(self, experiment_session_id: int, message_text: str, attachments: list) -> str:
+def get_response_for_webchat_task(
+    self, experiment_session_id: int, message_text: str, attachments: list | None = None
+) -> str:
     experiment_session = ExperimentSession.objects.select_related("experiment", "experiment__team").get(
         id=experiment_session_id
     )


### PR DESCRIPTION
Fixes https://dimagi.sentry.io/share/issue/a52a1c83dc4642e19af10721d30563b4/