### PR TITLE
allow caller of `handle_api_message` to determine how to fetch the channel

### DIFF
--- a/apps/api/openai.py
+++ b/apps/api/openai.py
@@ -103,7 +103,11 @@ def chat_completions(request, experiment_id: str):
 
     session = serializer.save()
     response_message = handle_api_message(
-        request.user, session.experiment, last_message.get("content"), session.participant.identifier, session
+        request.user,
+        session.experiment_channel,
+        last_message.get("content"),
+        session.participant.identifier,
+        session,
     )
     completion = {
         "id": session.external_id,

--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -115,11 +115,14 @@ def handle_turn_message(self, experiment_id: uuid, message_data: dict):
 
 def handle_api_message(user, experiment: Experiment, message_text: str, participant_id: str, session=None):
     """Synchronously handles the message coming from the API"""
-    experiment_channel, _created = ExperimentChannel.objects.get_or_create(
-        name=f"{experiment.id}-api",
-        experiment=experiment,
-        platform=ChannelPlatform.API,
-    )
+    if session and session.experiment_channel_id:
+        experiment_channel = session.experiment_channel
+    else:
+        experiment_channel, _created = ExperimentChannel.objects.get_or_create(
+            name=f"{experiment.id}-api",
+            experiment=experiment,
+            platform=ChannelPlatform.API,
+        )
     message = BaseMessage(participant_id=participant_id, message_text=message_text)
     channel = ApiChannel(
         experiment_channel=experiment_channel,

--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -10,7 +10,6 @@ from twilio.request_validator import RequestValidator
 from apps.channels.datamodels import BaseMessage, TelegramMessage, TurnWhatsappMessage, TwilioMessage
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import ApiChannel, FacebookMessengerChannel, TelegramChannel, WhatsappChannel
-from apps.experiments.models import Experiment
 from apps.service_providers.models import MessagingProviderType
 from apps.teams.utils import current_team
 from apps.utils.taskbadger import update_taskbadger_data
@@ -113,16 +112,8 @@ def handle_turn_message(self, experiment_id: uuid, message_data: dict):
         channel.new_user_message(message)
 
 
-def handle_api_message(user, experiment: Experiment, message_text: str, participant_id: str, session=None):
+def handle_api_message(user, experiment_channel, message_text: str, participant_id: str, session=None):
     """Synchronously handles the message coming from the API"""
-    if session and session.experiment_channel_id:
-        experiment_channel = session.experiment_channel
-    else:
-        experiment_channel, _created = ExperimentChannel.objects.get_or_create(
-            name=f"{experiment.id}-api",
-            experiment=experiment,
-            platform=ChannelPlatform.API,
-        )
     message = BaseMessage(participant_id=participant_id, message_text=message_text)
     channel = ApiChannel(
         experiment_channel=experiment_channel,

--- a/apps/channels/views.py
+++ b/apps/channels/views.py
@@ -3,6 +3,7 @@ import uuid
 
 from django.conf import settings
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
+from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
@@ -12,7 +13,7 @@ from rest_framework.response import Response
 
 from apps.channels import tasks
 from apps.channels.models import ChannelPlatform, ExperimentChannel
-from apps.experiments.models import ExperimentSession
+from apps.experiments.models import Experiment, ExperimentSession
 
 
 @csrf_exempt
@@ -98,9 +99,10 @@ def new_api_message(request, experiment_id: uuid):
         participant_id = session.participant.identifier
         experiment_channel = session.experiment_channel
     else:
+        experiment = get_object_or_404(Experiment, public_id=experiment_id, team=request.team)
         experiment_channel, _ = ExperimentChannel.objects.get_or_create(
-            name=f"{experiment_id}-api",
-            experiment_id=experiment_id,
+            name=f"{experiment.id}-api",
+            experiment=experiment,
             platform=ChannelPlatform.API,
         )
 

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -489,8 +489,8 @@ class WebChannel(ChannelBase):
         session_status: SessionStatus = SessionStatus.ACTIVE,
         timezone: str | None = None,
     ):
-        experiment_channel = _ensure_experiment_channel_exists(
-            experiment=experiment, platform="web", name=f"{experiment.id}-web"
+        experiment_channel, _ = ExperimentChannel.objects.get_or_create(
+            experiment=experiment, platform=ChannelPlatform.WEB, name=f"{experiment.id}-web"
         )
         session = super().start_new_session(
             experiment, experiment_channel, participant_identifier, participant_user, session_status, timezone
@@ -726,8 +726,3 @@ def _start_experiment_session(
         enqueue_static_triggers.delay(session.id, StaticTriggerType.PARTICIPANT_JOINED_EXPERIMENT)
     enqueue_static_triggers.delay(session.id, StaticTriggerType.CONVERSATION_START)
     return session
-
-
-def _ensure_experiment_channel_exists(experiment: Experiment, platform: str, name: str) -> ExperimentChannel:
-    channel, _created = ExperimentChannel.objects.get_or_create(experiment=experiment, platform=platform, name=name)
-    return channel


### PR DESCRIPTION
Small refactor of api message handling to try and reduce the chance of duplicate channels (I still don't quite see where they are coming from).

* Also inline `_ensure_experiment_channel_exists` function since it's only one line

