### PR TITLE
create participant if not exists + specify platform

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -92,27 +92,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/CreateChatCompletionResponse'
           description: ''
-  /api/participants/{participant_id}/:
+  /api/participants/:
     post:
       operationId: update_participant_data
       description: Upsert participant data for all specified experiments in the payload
       summary: Update Participant Data
-      parameters:
-      - in: path
-        name: participant_id
-        schema:
-          type: string
-        description: Channel specific participant identifier
-        required: true
       tags:
       - Participants
       requestBody:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/ParticipantExperimentData'
+              $ref: '#/components/schemas/ParticipantDataUpdateRequest'
         required: true
       security:
       - apiKeyAuth: []
@@ -449,6 +440,24 @@ components:
         identifier:
           type: string
           maxLength: 320
+    ParticipantDataUpdateRequest:
+      type: object
+      properties:
+        identifier:
+          type: string
+          title: Participant identifier
+        platform:
+          allOf:
+          - $ref: '#/components/schemas/PlatformEnum'
+          default: api
+          title: Participant Platform
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParticipantExperimentData'
+      required:
+      - data
+      - identifier
     ParticipantExperimentData:
       type: object
       properties:
@@ -463,6 +472,22 @@ components:
       required:
       - data
       - experiment
+    PlatformEnum:
+      enum:
+      - telegram
+      - web
+      - whatsapp
+      - facebook
+      - api
+      - slack
+      type: string
+      description: |-
+        * `telegram` - Telegram
+        * `web` - Web
+        * `whatsapp` - WhatsApp
+        * `facebook` - Facebook
+        * `api` - API
+        * `slack` - Slack
     Team:
       type: object
       properties:

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -114,3 +114,11 @@ class ExperimentSessionCreateSerializer(serializers.ModelSerializer):
 class ParticipantExperimentData(serializers.Serializer):
     experiment = serializers.UUIDField(label="Experiment ID")
     data = serializers.DictField(label="Participant Data")
+
+
+class ParticipantDataUpdateRequest(serializers.Serializer):
+    identifier = serializers.CharField(label="Participant identifier")
+    platform = serializers.ChoiceField(
+        choices=ChannelPlatform.choices, default=ChannelPlatform.API, label="Participant Platform"
+    )
+    data = ParticipantExperimentData(many=True)

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -75,18 +75,17 @@ def test_only_experiments_from_the_scoped_team_is_returned():
 
 
 @pytest.mark.django_db()
-def test_update_participant_data():
+def test_create_and_update_participant_data():
     identifier = "part1"
     experiment = ExperimentFactory(team=TeamWithUsersFactory())
     experiment2 = ExperimentFactory(team=experiment.team)
-    participant = Participant.objects.create(identifier=identifier, team=experiment.team, platform="api")
     user = experiment.team.members.first()
     client = ApiTestClient(user, experiment.team)
 
     # This call should create ParticipantData
     data = {
-        "identifier": participant.identifier,
-        "platform": participant.platform,
+        "identifier": identifier,
+        "platform": "api",
         "data": [
             {"experiment": str(experiment.public_id), "data": {"name": "John"}},
             {"experiment": str(experiment2.public_id), "data": {"name": "Doe"}},
@@ -96,8 +95,8 @@ def test_update_participant_data():
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
-    participant_data_exp_1 = experiment.participant_data.get(participant=participant)
-    participant_data_exp_2 = experiment2.participant_data.get(participant=participant)
+    participant_data_exp_1 = experiment.participant_data.get(participant__identifier=identifier)
+    participant_data_exp_2 = experiment2.participant_data.get(participant__identifier=identifier)
     assert participant_data_exp_1.data["name"] == "John"
     assert participant_data_exp_2.data["name"] == "Doe"
 

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -119,10 +119,14 @@ def test_update_participant_data_returns_404():
     client = ApiTestClient(user, experiment.team)
 
     # This call should create ParticipantData for team 1's experiment only
-    data = [
-        {"experiment": str(experiment.public_id), "data": {"name": "John"}},
-        {"experiment": str(experiment2.public_id), "data": {"name": "Doe"}},
-    ]
+    data = {
+        "identifier": participant.identifier,
+        "platform": participant.platform,
+        "data": [
+            {"experiment": str(experiment.public_id), "data": {"name": "John"}},
+            {"experiment": str(experiment2.public_id), "data": {"name": "Doe"}},
+        ],
+    }
     url = reverse("api:update-participant-data", kwargs={"participant_id": participant.identifier})
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 404

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -127,7 +127,7 @@ def test_update_participant_data_returns_404():
             {"experiment": str(experiment2.public_id), "data": {"name": "Doe"}},
         ],
     }
-    url = reverse("api:update-participant-data", kwargs={"participant_id": participant.identifier})
+    url = reverse("api:update-participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 404
     assert response.json() == {"errors": [{"message": f"Experiment {experiment2.public_id} not found"}]}

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -84,11 +84,15 @@ def test_update_participant_data():
     client = ApiTestClient(user, experiment.team)
 
     # This call should create ParticipantData
-    data = [
-        {"experiment": str(experiment.public_id), "data": {"name": "John"}},
-        {"experiment": str(experiment2.public_id), "data": {"name": "Doe"}},
-    ]
-    url = reverse("api:update-participant-data", kwargs={"participant_id": participant.identifier})
+    data = {
+        "identifier": participant.identifier,
+        "platform": participant.platform,
+        "data": [
+            {"experiment": str(experiment.public_id), "data": {"name": "John"}},
+            {"experiment": str(experiment2.public_id), "data": {"name": "Doe"}},
+        ],
+    }
+    url = reverse("api:update-participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
@@ -98,7 +102,7 @@ def test_update_participant_data():
     assert participant_data_exp_2.data["name"] == "Doe"
 
     # Let's update the data
-    data = [{"experiment": str(experiment.public_id), "data": {"name": "Harry"}}]
+    data["data"] = [{"experiment": str(experiment.public_id), "data": {"name": "Harry"}}]
     client.post(url, json.dumps(data), content_type="application/json")
     participant_data_exp_1.refresh_from_db()
     assert participant_data_exp_1.data["name"] == "Harry"

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -10,7 +10,7 @@ router.register(r"experiments", views.ExperimentViewSet, basename="experiment")
 router.register(r"sessions", views.ExperimentSessionViewSet, basename="session")
 
 urlpatterns = [
-    path("participants/<str:participant_id>/", views.update_participant_data, name="update-participant-data"),
+    path("participants/", views.update_participant_data, name="update-participant-data"),
     path("openai/<str:experiment_id>/chat/completions", openai.chat_completions, name="openai-chat-completions"),
     path("", include(router.urls)),
 ]


### PR DESCRIPTION
Updates to the participant data API to allow creating participants. The data structure is now as follows:

```json
{
  "identifier": "abc",
  "platform": "api",
  "data": [{"experiment": "123", "data": {"name": "joe"}}],
}
```

`platform` is now required and the URL no longer contains the identifier

I don't think anyone is using this API so I think it's safe to update. I will post on the user group though.