### PR TITLE
Adds a /status endpoint for health checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,3 +75,7 @@ DJANGO_ALLOWED_HOSTS=
 # Defaults to SECRET_KEY if not provided
 CRYPTOGRAPHY_KEY=
 CRYPTOGRAPHY_SALT=
+
+## Health check
+# Tokens used to secure the /status endpoint. These should be kept secret
+HEALTH_CHECK_TOKENS=

--- a/apps/teams/tests/test_permissions.py
+++ b/apps/teams/tests/test_permissions.py
@@ -30,8 +30,11 @@ IGNORE_APPS = {
     "api",
     "audit",
     "auth",
+    "cache",  # heath_check.cache
+    "celery",  # heath_check.celery
     "celery_progress",
     "contenttypes",
+    "db",  # heath_check.db
     "django_celery_beat",
     "django_otp",
     "django_tables2",
@@ -39,12 +42,14 @@ IGNORE_APPS = {
     "field_audit",
     "forms",
     "generics",
+    "health_check",
     "hijack",
     "hijack_admin",
     "humanize",
     "messages",
     "otp_static",
     "otp_totp",
+    "redis",  # heath_check.redis
     "rest_framework",
     "rest_framework_api_key",
     "runserver_nostatic",

--- a/apps/web/urls.py
+++ b/apps/web/urls.py
@@ -7,6 +7,8 @@ app_name = "web"
 urlpatterns = [
     path("", views.home, name="home"),
     path("robots.txt", TemplateView.as_view(template_name="robots.txt", content_type="text/plain"), name="robots.txt"),
+    path("status/", views.HealthCheck.as_view()),
+    path("status/<str:subset>/", views.HealthCheck.as_view()),
 ]
 
 team_urlpatterns = (

--- a/apps/web/views.py
+++ b/apps/web/views.py
@@ -1,8 +1,10 @@
+from django.conf import settings
 from django.contrib import messages
-from django.http import HttpResponseRedirect
+from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+from health_check.views import MainView
 
 from apps.teams.decorators import login_and_team_required
 
@@ -34,3 +36,11 @@ def team_home(request, team_slug):
             "page_title": _("{team} Dashboard").format(team=request.team),
         },
     )
+
+
+class HealthCheck(MainView):
+    def get(self, request, *args, **kwargs):
+        tokens = settings.HEALTH_CHECK_TOKENS
+        if tokens and request.GET.get("token") not in tokens:
+            raise Http404
+        return super().get(request, *args, **kwargs)

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -71,6 +71,11 @@ THIRD_PARTY_APPS = [
     "field_audit",
     "taggit",
     "tz_detect",
+    "health_check",
+    "health_check.db",
+    "health_check.cache",
+    "health_check.contrib.celery",
+    "health_check.contrib.redis",
 ]
 
 PROJECT_APPS = [
@@ -543,3 +548,13 @@ SLACK_SCOPES = [
 ]
 SLACK_BOT_NAME = env("SLACK_BOT_NAME", default="@ocs")
 SLACK_ENABLED = SLACK_CLIENT_ID and SLACK_CLIENT_SECRET and SLACK_SIGNING_SECRET
+
+# Health checks
+# Tokens used to secure the /status endpoint. These should be kept secret
+HEALTH_CHECK_TOKENS = env.list("HEALTH_CHECK_TOKENS", default=[])
+HEALTH_CHECK = {
+    "SUBSETS": {
+        "general": ["Cache backend: default", "DatabaseBackend", "RedisHealthCheck"],
+        "celery": ["CeleryHealthCheckCelery"],
+    },
+}

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -12,6 +12,7 @@ django-anymail
 django-cryptography
 django-environ
 django-field-audit>=1.2.7
+django-health-check
 django-hijack
 django-redis
 django-storages[s3]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -104,6 +104,7 @@ django==4.2.14
     #   django-appconf
     #   django-celery-beat
     #   django-cryptography
+    #   django-health-check
     #   django-hijack
     #   django-otp
     #   django-redis
@@ -132,6 +133,8 @@ django-cryptography==1.1
 django-environ==0.11.2
     # via -r requirements.in
 django-field-audit==1.2.8
+    # via -r requirements.in
+django-health-check==3.18.3
     # via -r requirements.in
 django-hijack==3.4.2
     # via -r requirements.in


### PR DESCRIPTION
Resolves: https://github.com/dimagi/open-chat-studio/issues/548

* All checks: /status
* Site checks: /status/general/
* Celery checks: /status/celery/

Append `?format=json` to get JSON response instead of HTML