### PR TITLE
Check Twilio number against the provider's numbers

### DIFF
--- a/apps/channels/forms.py
+++ b/apps/channels/forms.py
@@ -138,7 +138,11 @@ class WhatsappChannelForm(WebhookUrlFormBase):
     def clean_number(self):
         try:
             number_obj = phonenumbers.parse(self.cleaned_data["number"])
-            return phonenumbers.format_number(number_obj, phonenumbers.PhoneNumberFormat.E164)
+            number = phonenumbers.format_number(number_obj, phonenumbers.PhoneNumberFormat.E164)
+            service = self.messaging_provider.get_messaging_service()
+            if not service.is_valid_number(number):
+                raise forms.ValidationError(f"{number} was not found at the provider.")
+            return number
         except phonenumbers.NumberParseException:
             raise forms.ValidationError("Enter a valid phone number (e.g. +12125552368).")
 

--- a/apps/service_providers/messaging_service.py
+++ b/apps/service_providers/messaging_service.py
@@ -45,6 +45,12 @@ class MessagingService(pydantic.BaseModel):
         """Should return a BytesIO object in .wav format"""
         raise NotImplementedError
 
+    def is_valid_number(self, number: str) -> bool:
+        """Returns False if `number` does not belong to this account. Returns `True` by default so that this
+        doesn't prevent users from adding numbers if we cannot check the account.
+        """
+        return True
+
 
 class TwilioService(MessagingService):
     _type: ClassVar[str] = "twilio"
@@ -120,6 +126,18 @@ class TwilioService(MessagingService):
         # Example header: {'Content-Type': 'audio/ogg'}
         content_type = response.headers["Content-Type"].split("/")[1]
         return audio.convert_audio(BytesIO(response.content), target_format="wav", source_format=content_type)
+
+    def _get_account_numbers(self) -> list[str]:
+        """Returns all numbers associated with this client account"""
+        return [num.phone_number for num in self.client.incoming_phone_numbers.list()]
+
+    def is_valid_number(self, number: str) -> bool:
+        if settings.DEBUG:
+            # The sandbox number doesn't belong to any account, so this check will always fail. For dev purposes
+            # let's just always return True
+            return True
+
+        return number in self._get_account_numbers()
 
 
 class TurnIOService(MessagingService):


### PR DESCRIPTION
Check Twilio number against the provider's numbers before allowing the user to link it to an experiment. For Turn.io there doesn't seem to be a way to do this, so we always assume the number is valid