### PR TITLE
Update participant data UI

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -508,9 +508,15 @@ class Participant(BaseTeamModel):
                 joined_on=Subquery(joined_on),
                 last_message=Subquery(last_message),
             )
-            .filter(sessions__participant=self)
+            .filter(Q(sessions__participant=self) | Q(participant_data__participant=self))
             .distinct()
         )
+
+    def get_data_for_experiment(self, experiment) -> dict:
+        try:
+            return self.data_set.get(bots=experiment).data
+        except ParticipantData.DoesNotExist:
+            return {}
 
     @transaction.atomic()
     def update_memory(self, data: dict, experiment: Experiment | None = None):

--- a/apps/generics/urls.py
+++ b/apps/generics/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 
-def make_crud_urls(views_module, model_name: str, prefix: str = ""):
+def make_crud_urls(views_module, model_name: str, prefix: str = "", new=True, edit=True, delete=True):
     f"""Make the CRUD URLs for a given model.
 
     Views (all are expected to be class based views):
@@ -18,16 +18,36 @@ def make_crud_urls(views_module, model_name: str, prefix: str = ""):
     """
     url_prefix = f"{prefix}/" if prefix else ""
     name_prefix = f"{prefix}_" if prefix else ""
-    return [
+    urls = [
         path(f"{url_prefix}", getattr(views_module, f"{model_name}Home").as_view(), name=f"{name_prefix}home"),
-        path(f"{url_prefix}new/", getattr(views_module, f"Create{model_name}").as_view(), name=f"{name_prefix}new"),
-        path(f"{url_prefix}<int:pk>/", getattr(views_module, f"Edit{model_name}").as_view(), name=f"{name_prefix}edit"),
         path(
-            f"{url_prefix}<int:pk>/delete/",
-            getattr(views_module, f"Delete{model_name}").as_view(),
-            name=f"{name_prefix}delete",
-        ),
-        path(
-            f"{url_prefix}table/", getattr(views_module, f"{model_name}TableView").as_view(), name=f"{name_prefix}table"
+            f"{url_prefix}table/",
+            getattr(views_module, f"{model_name}TableView").as_view(),
+            name=f"{name_prefix}table",
         ),
     ]
+
+    if new:
+        urls.append(
+            path(f"{url_prefix}new/", getattr(views_module, f"Create{model_name}").as_view(), name=f"{name_prefix}new")
+        )
+
+    if edit:
+        urls.append(
+            path(
+                f"{url_prefix}<int:pk>/",
+                getattr(views_module, f"Edit{model_name}").as_view(),
+                name=f"{name_prefix}edit",
+            )
+        )
+
+    if delete:
+        urls.append(
+            path(
+                f"{url_prefix}<int:pk>/delete/",
+                getattr(views_module, f"Delete{model_name}").as_view(),
+                name=f"{name_prefix}delete",
+            )
+        )
+
+    return urls

--- a/apps/participants/tables.py
+++ b/apps/participants/tables.py
@@ -2,20 +2,11 @@ from django.conf import settings
 from django_tables2 import columns, tables
 
 from apps.experiments.models import Participant
-from apps.generics import actions
 
 
 class ParticipantTable(tables.Table):
     platform = columns.Column(accessor="get_platform_display")
     created_at = columns.DateTimeColumn(verbose_name="Created On", format="Y-m-d H:i:s")
-    actions = columns.TemplateColumn(
-        template_name="generic/crud_actions_column.html",
-        extra_context={
-            "actions": [
-                actions.edit_action(url_name="participants:participant_edit"),
-            ]
-        },
-    )
 
     class Meta:
         model = Participant

--- a/apps/participants/urls.py
+++ b/apps/participants/urls.py
@@ -14,4 +14,4 @@ urlpatterns = [
     ),
 ]
 
-urlpatterns.extend(make_crud_urls(views, "Participant", "participant"))
+urlpatterns.extend(make_crud_urls(views, "Participant", "participant", edit=False, delete=False, new=False))

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -1,13 +1,10 @@
 import json
 
-from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db.models import Q
-from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.views import View
-from django.views.generic import CreateView, TemplateView, UpdateView
+from django.views.generic import CreateView, TemplateView
 from django_tables2 import SingleTableView
 
 from apps.experiments.models import Experiment, Participant, ParticipantData
@@ -25,7 +22,7 @@ class ParticipantHome(LoginAndTeamRequiredMixin, TemplateView, PermissionRequire
         return {
             "active_tab": "participants",
             "title": "Participants",
-            "new_object_url": reverse("participants:participant_new", args=[team_slug]),
+            "allow_new": False,
             "table_url": reverse("participants:participant_table", args=[team_slug]),
             "enable_search": True,
         }
@@ -49,32 +46,6 @@ class CreateParticipant(CreateView, PermissionRequiredMixin):
         form.instance.team = self.request.team
         form.instance.created_by = self.request.user
         return super().form_valid(form)
-
-
-class EditParticipant(UpdateView, PermissionRequiredMixin):
-    permission_required = "experiments.change_participant"
-    model = Participant
-    form_class = ParticipantForm
-    template_name = "generic/object_form.html"
-    extra_context = {
-        "title": "Update Participant",
-        "button_text": "Update",
-        "active_tab": "participants",
-    }
-
-    def get_queryset(self):
-        return Participant.objects.filter(team=self.request.team)
-
-    def get_success_url(self):
-        return reverse("participants:participant_home", args=[self.request.team.slug])
-
-
-class DeleteParticipant(LoginAndTeamRequiredMixin, View, PermissionRequiredMixin):
-    permission_required = "experiments.delete_participant"
-
-    def delete(self, request, team_slug: str, pk: int):
-        messages.error(request, "Cannot delete a Participant")
-        return HttpResponse()
 
 
 class ParticipantTableView(SingleTableView):

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -108,7 +108,7 @@ class SingleParticipantHome(LoginAndTeamRequiredMixin, TemplateView, PermissionR
             sessions = participant.experimentsession_set.filter(experiment=experiment).all()
             experiment_data[experiment] = {
                 "sessions": sessions,
-                "participant_data": json.dumps(sessions.first().participant_data_from_experiment, indent=4),
+                "participant_data": json.dumps(participant.get_data_for_experiment(experiment), indent=4),
             }
         context["experiment_data"] = experiment_data
         return context

--- a/templates/generic/object_home_content.html
+++ b/templates/generic/object_home_content.html
@@ -10,10 +10,10 @@
       </div>
       <span class="text-neutral-500">{{ subtitle }}</span>
     </div>
-    {% if allow_new|default:True or actions %}
+    {% if allow_new|default_if_none:True or actions %}
       <div class="justify-self-end">
         <div class="join">
-          {% if allow_new|default:True %}
+          {% if allow_new|default_if_none:True %}
             <a class="btn btn-sm join-item {{ button_style|default:"btn-primary" }}"
                href="{{ new_object_url }}">Add new
             </a>

--- a/templates/participants/partials/participant_data.html
+++ b/templates/participants/partials/participant_data.html
@@ -1,10 +1,15 @@
-
-<form x-data="{data: '{{ participant_data|escapejs }}', validJson: false}" x-init="validJson = isValidJSON(data)" method="post" action="{% url 'participants:edit-participant-data' experiment.team.slug participant.id experiment.id %}">
-    {% csrf_token %}
-    <div class="mb-4">
-        <textarea x-model="data" x-on:input="validJson = isValidJSON(data)" name="participant-data" id="{{ experiment }}-data" class="textarea textarea-bordered mt-1 block w-full h-96">{{ participant_data }}</textarea>
+{% if perms.experiments.change_participantdata %}
+    <form x-data="{data: '{{ participant_data|escapejs }}', validJson: false}" x-init="validJson = isValidJSON(data)" method="post" action="{% url 'participants:edit-participant-data' experiment.team.slug participant.id experiment.id %}">
+        {% csrf_token %}
+        <div class="mb-4">
+            <textarea x-model="data" x-on:input="validJson = isValidJSON(data)" name="participant-data" id="{{ experiment }}-data" class="textarea textarea-bordered mt-1 block w-full h-96">{{ participant_data }}</textarea>
+        </div>
+        <div class="flex items-center justify-between">
+            <button class="btn btn-primary" id="submit-{{ experiment }}" type="submit" :disabled="!validJson">Update</button>
+        </div>
+    </form>
+{% else %}
+    <div class="mt-3 p-3 border rounded-lg border-neutral-500">
+    <pre><code>{{ participant_data }}</code></pre>
     </div>
-    <div class="flex items-center justify-between">
-        <button class="btn btn-primary" id="submit-{{ experiment }}" type="submit" :disabled="!validJson">Update</button>
-    </div>
-</form>
+{% endif %}

--- a/templates/participants/partials/participant_experiments.html
+++ b/templates/participants/partials/participant_experiments.html
@@ -27,19 +27,18 @@
         </tr>
         <tr x-show="experimentsRow === {{ forloop.counter }}" x-cloak>
           <td colspan="100%" class="px-3 py-2">
-            {% if perms.experiments.change_participantdata %}
-              <div role="tablist" class="tabs tabs-bordered">
-                <input type="radio" name="experiment_tabs-{{ experiment.id }}" role="tab" class="tab" aria-label="Sessions" checked />
-                <div role="tabpanel" class="tab-content">
-                  {% include 'participants/partials/experiment_sessions.html' %}
-                </div>
+            <div role="tablist" class="tabs tabs-bordered">
+              <input type="radio" name="experiment_tabs-{{ experiment.id }}" role="tab" class="tab" aria-label="Sessions" checked />
+              <div role="tabpanel" class="tab-content">
+                {% include 'participants/partials/experiment_sessions.html' %}
+              </div>
+              {% if perms.experiments.view_participantdata %}
                 <input type="radio" name="experiment_tabs-{{ experiment.id }}" role="tab" class="tab" aria-label="Participant Data" />
                 <div role="tabpanel" class="tab-content">
                   {% include 'participants/partials/participant_data.html' %}
                 </div>
-            {% else %}
-              {% include 'participants/partials/experiment_sessions.html' %}
-            {% endif %}
+              {% endif %}
+            </div>
           </td>
         </tr>
       {% endwith %}

--- a/templates/participants/partials/participant_experiments.html
+++ b/templates/participants/partials/participant_experiments.html
@@ -18,8 +18,8 @@
           x-on:click="experimentsRow = (experimentsRow === {{ forloop.counter }} ? null : {{ forloop.counter }})"
         >
           <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ experiment.name }}</td>
-          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ experiment.joined_on }}</td>
-          <td class="px-3 py-4 text-sm text-gray-500">{{ experiment.last_message }}</td>
+          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ experiment.joined_on|default:"" }}</td>
+          <td class="px-3 py-4 text-sm text-gray-500">{{ experiment.last_message|default:"" }}</td>
           <td class="">
             <i class="fa-solid fa-chevron-down" x-show="experimentsRow !== {{ forloop.counter }}"></i>
             <i class="fa-solid fa-chevron-up" x-show="experimentsRow === {{ forloop.counter }}" x-cloak></i>

--- a/templates/participants/partials/participant_experiments.html
+++ b/templates/participants/partials/participant_experiments.html
@@ -9,7 +9,7 @@
       <th scope="col" class=""></th>
     </tr>
   </thead>
-  <tbody class="divide-y divide-gray-200" x-data="{experimentsRow: null}">
+  <tbody class="divide-y divide-gray-200" x-data="{experimentsRow: 1}">
     {% for experiment, info in experiment_data.items %}
       {% with sessions=info|dict_lookup:"sessions" participant_data=info|dict_lookup:"participant_data" %}
         <tr


### PR DESCRIPTION
* Show all participant data even if not linked to a session e.g. created by API
* Update permission checks and show read-only version if the user does not have write permission
* Expand the first row to make the participant data more discoverable

This PR also removes the new, edit and delete views (delete was already disabled). The edit view only allowed changing the 'user' field which shouldn't be changed and I don't think it is very useful to be able to create new participants individually. In future we could add an import feature for platforms where the identifier is known e.g. whatsapp.