### PR TITLE
Limit file uploads to a total of 512mb per request

### DIFF
--- a/templates/experiments/chat/input_bar.html
+++ b/templates/experiments/chat/input_bar.html
@@ -105,11 +105,26 @@
 {% if session.experiment.assistant %}
   <script>
     document.addEventListener('alpine:init', () => {
+      const metabyte_in_bytes = 1048576;
+      const byte_limit = metabyte_in_bytes*512;
       Alpine.data('fileUploads', () => ({
         code_interpreter_files: [],
         file_search_files: [],
+        total_upload_size_bytes: 0,
         handleFileChange(event, targetArray) {
           const files = Array.from(event.target.files);
+          let new_upload_bytes = 0
+          for (let i = 0; i < files.length; i++){
+            new_upload_bytes = new_upload_bytes + files[i].size
+          }
+
+          if (this.total_upload_size_bytes + new_upload_bytes > byte_limit) {
+            let current_files_mb = this.total_upload_size_bytes/metabyte_in_bytes
+            let message = "Unable to add new file(s). The maximum upload capacity is 512MB. Current size is " + current_files_mb + "MB";
+            alert(message);
+            return;
+          }
+          this.total_upload_size_bytes = this.total_upload_size_bytes + new_upload_bytes
           this[targetArray].push(...files);
           const dataTransfer = new DataTransfer();
           this[targetArray].forEach(file => dataTransfer.items.add(file));
@@ -118,7 +133,12 @@
         removeFile(index, targetArray) {
           this[targetArray].splice(index, 1);
           const dataTransfer = new DataTransfer();
-          this[targetArray].forEach(file => dataTransfer.items.add(file));
+          this.total_upload_size_bytes = 0;
+
+          this[targetArray].forEach(file => {
+            dataTransfer.items.add(file)
+            this.total_upload_size_bytes = this.total_upload_size_bytes + file.size
+          });
           if (targetArray === 'code_interpreter_files') {
             this.$refs.codeInterpreter.files = dataTransfer.files;
           } else if (targetArray === 'file_search_files') {

--- a/templates/experiments/chat/input_bar.html
+++ b/templates/experiments/chat/input_bar.html
@@ -109,8 +109,8 @@
 {% if session.experiment.assistant %}
   <script>
     document.addEventListener('alpine:init', () => {
-      const metabyte_in_bytes = 1048576;
-      const byte_limit = metabyte_in_bytes*512;
+      const megabyte_in_bytes = 1048576;
+      const byte_limit = megabyte_in_bytes*512;
       const code_interpreter_max_files = 20
       Alpine.data('fileUploads', () => ({
         code_interpreter_files: [],
@@ -126,7 +126,7 @@
           }
 
           if (this.total_upload_size_bytes + new_upload_bytes > byte_limit) {
-            let current_files_mb = this.total_upload_size_bytes/metabyte_in_bytes
+            let current_files_mb = this.total_upload_size_bytes/megabyte_in_bytes
             let message = "Unable to add new file(s). The maximum upload capacity is 512MB. Current size is " + current_files_mb + "MB";
             alert(message);
             return;

--- a/templates/experiments/chat/input_bar.html
+++ b/templates/experiments/chat/input_bar.html
@@ -26,7 +26,11 @@
               <li>
                 <a
                   class="btn btn-sm"
-                  {% if not session.experiment.assistant.supports_code_interpreter %} disabled {% endif %}
+                  {% if not session.experiment.assistant.supports_code_interpreter %}
+                    disabled
+                  {% else %}
+                    x-bind:disabled="disableCodeInterpreterUpload"
+                  {% endif %}
                   @click="$refs.codeInterpreter.click()">
                   Code Interpreter
                 </a>
@@ -74,7 +78,7 @@
         <div class="ml-5">
           <template x-for="(file, index) in code_interpreter_files" :key="index">
             <div class="flex items-center gap-2">
-              <span x-text="file.name"></span>
+              <span x-text="index+1"></span><span x-text="file.name"></span>
               <button type="button" class="btn btn-xs" @click="removeFile(index, 'code_interpreter_files')">
                 <i class="fa-solid fa-trash htmx-hide"></i>
               </button>
@@ -87,7 +91,7 @@
         <div class="ml-5">
           <template x-for="(file, index) in file_search_files" :key="index">
             <div class="flex items-center gap-2">
-              <span x-text="file.name"></span>
+              <span x-text="index+1"></span><span x-text="file.name"></span>
               <button type="button" class="btn btn-xs" @click="removeFile(index, 'file_search_files')">
                 <i class="fa-solid fa-trash htmx-hide"></i>
               </button>
@@ -107,12 +111,15 @@
     document.addEventListener('alpine:init', () => {
       const metabyte_in_bytes = 1048576;
       const byte_limit = metabyte_in_bytes*512;
+      const code_interpreter_max_files = 20
       Alpine.data('fileUploads', () => ({
         code_interpreter_files: [],
         file_search_files: [],
         total_upload_size_bytes: 0,
+        disableCodeInterpreterUpload: false,
         handleFileChange(event, targetArray) {
           const files = Array.from(event.target.files);
+
           let new_upload_bytes = 0
           for (let i = 0; i < files.length; i++){
             new_upload_bytes = new_upload_bytes + files[i].size
@@ -124,6 +131,20 @@
             alert(message);
             return;
           }
+
+          // Evaluate code interpreter file counts
+          if (targetArray == "code_interpreter_files") {
+            let curr_file_count = this[targetArray].length;
+            let new_file_count = curr_file_count + files.length;
+
+            if (new_file_count == code_interpreter_max_files) {
+              this.disableCodeInterpreterUpload = true;
+            } else if (new_file_count > code_interpreter_max_files) {
+              alert("You cannot add more then " + code_interpreter_max_files + " files to code interpreter");
+              return;
+            }
+          }
+
           this.total_upload_size_bytes = this.total_upload_size_bytes + new_upload_bytes
           this[targetArray].push(...files);
           const dataTransfer = new DataTransfer();
@@ -141,6 +162,10 @@
           });
           if (targetArray === 'code_interpreter_files') {
             this.$refs.codeInterpreter.files = dataTransfer.files;
+            if (this.$refs.codeInterpreter.files.length < code_interpreter_max_files) {
+              this.disableCodeInterpreterUpload = false;
+            }
+
           } else if (targetArray === 'file_search_files') {
             this.$refs.fileSearch.files = dataTransfer.files;
           }


### PR DESCRIPTION
https://github.com/dimagi/open-chat-studio/issues/558.

It made more sense to limit the file uploads by total size than by number of files. For code interpreter, OpenAI says that it only [allows 20 files](https://platform.openai.com/docs/assistants/deep-dive/creating-assistants#:~:text=You%20can%20attach,increase%20this%20limit.), so we're limiting that as well