### PR TITLE
Remove newline characters between all html elements except p tags

### DIFF
--- a/apps/chat/templatetags/chat_tags.py
+++ b/apps/chat/templatetags/chat_tags.py
@@ -13,10 +13,8 @@ register = template.Library()
 def render_markdown(text):
     if not text:
         return ""
+
     text = markdown.markdown(text, extensions=[FencedCodeExtension(), FileExtension()])
-    text = text.replace("</li>\n<li>", "</li><li>")
-    text = text.replace("<ol>\n<li>", "<ol><li>")
-    text = text.replace("</li>\n</ol>", "</li></ol>")
-    text = text.replace("<li>\n<p>", "<li><p>")
-    text = text.replace("</p>\n</li>", "</p></li>")
+    text = text.replace(">\n<", "><")
+    text = text.replace("</p><p>", "</p>\n<p>")
     return linebreaksbr(mark_safe(text))


### PR DESCRIPTION
Sometimes, it's easier to add something than to remove everything except that thing. Hopefully this is the last time we have to look into this.

## Before

![before](https://github.com/user-attachments/assets/9f92ef8d-698d-4a26-be45-60b851c2ea45)


## After

![after](https://github.com/user-attachments/assets/29870c76-4c4f-4a7c-a535-fa965c14f493)
