### PR TITLE
Do not show a channel if the provider isn't configured

### DIFF
--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -1,5 +1,4 @@
 import uuid
-from collections import OrderedDict
 
 from django.conf import settings
 from django.db import models
@@ -34,12 +33,12 @@ class ChannelPlatform(models.TextChoices):
     SLACK = "slack", "Slack"
 
     @classmethod
-    def for_dropdown(cls, used_platforms, team) -> OrderedDict:
+    def for_dropdown(cls, used_platforms, team) -> dict:
         """Returns a dictionary of available platforms for this team. Available platforms will have a `True` value"""
         from apps.service_providers.models import MessagingProvider
 
         all_platforms = cls.as_list(exclude=[cls.API, cls.WEB])
-        platform_availability = OrderedDict.fromkeys(all_platforms, value=False)
+        platform_availability = {platform: False for platform in all_platforms}
         platform_availability[cls.TELEGRAM] = True
 
         for provider in MessagingProvider.objects.filter(team=team):

--- a/apps/channels/tests/test_models.py
+++ b/apps/channels/tests/test_models.py
@@ -1,7 +1,8 @@
 import pytest
+from django.test import override_settings
 from django.urls import reverse
 
-from apps.channels.models import ExperimentChannel
+from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
 from apps.experiments.exceptions import ChannelAlreadyUtilizedException
 from apps.service_providers.models import MessagingProviderType
@@ -10,7 +11,8 @@ from apps.utils.factories.experiment import ExperimentFactory, ExperimentSession
 from apps.utils.factories.service_provider_factories import MessagingProviderFactory
 
 
-def test_new_integration_does_not_raise_exception(db):
+@pytest.mark.django_db()
+def test_new_integration_does_not_raise_exception():
     channel = ExperimentChannelFactory()
     new_experiment = ExperimentFactory()
 
@@ -19,7 +21,8 @@ def test_new_integration_does_not_raise_exception(db):
     )
 
 
-def test_duplicate_integration_raises_exception(db):
+@pytest.mark.django_db()
+def test_duplicate_integration_raises_exception():
     channel = ExperimentChannelFactory()
     new_experiment = ExperimentFactory()
 
@@ -29,7 +32,8 @@ def test_duplicate_integration_raises_exception(db):
         )
 
 
-def test_channel_webhook_url(db):
+@pytest.mark.django_db()
+def test_channel_webhook_url():
     # Setup providers
     twilio_provider = MessagingProviderFactory(type=MessagingProviderType.twilio)
     turnio_provider = MessagingProviderFactory(type=MessagingProviderType.turnio)
@@ -46,7 +50,8 @@ def test_channel_webhook_url(db):
     assert turnio_uri in turnio_channel.webhook_url
 
 
-def test_deleting_experiment_channel_only_removes_the_experiment_channel(db):
+@pytest.mark.django_db()
+def test_deleting_experiment_channel_only_removes_the_experiment_channel():
     """Test to make sure that removing an experiment channel does not remove important related records"""
     experiment = ExperimentFactory(conversational_consent_enabled=True)
     experiment_channel = ExperimentChannelFactory(experiment=experiment)
@@ -75,3 +80,47 @@ def test_deleting_experiment_channel_only_removes_the_experiment_channel(db):
     _assert_not_deleted(experiment)
     _assert_not_deleted(experiment_session)
     _assert_not_deleted(chat)
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("slack_enabled", "messaging_provider_types", "expected_channels"),
+    [
+        (False, [], [ChannelPlatform.TELEGRAM]),
+        (
+            False,
+            [MessagingProviderType.twilio],
+            [ChannelPlatform.TELEGRAM, ChannelPlatform.WHATSAPP, ChannelPlatform.FACEBOOK],
+        ),
+        (False, [MessagingProviderType.turnio], [ChannelPlatform.TELEGRAM, ChannelPlatform.WHATSAPP]),
+        (
+            False,
+            [MessagingProviderType.turnio, MessagingProviderType.twilio],
+            [ChannelPlatform.TELEGRAM, ChannelPlatform.WHATSAPP, ChannelPlatform.FACEBOOK],
+        ),
+        (False, [MessagingProviderType.sureadhere], [ChannelPlatform.TELEGRAM, ChannelPlatform.SUREADHERE]),
+        (
+            True,
+            [MessagingProviderType.sureadhere],
+            [ChannelPlatform.TELEGRAM, ChannelPlatform.SLACK, ChannelPlatform.SUREADHERE],
+        ),
+    ],
+)
+def test_available_channels(slack_enabled, messaging_provider_types, expected_channels, experiment):
+    for provider_type in messaging_provider_types:
+        _build_provider(provider_type, team=experiment.team)
+
+    with override_settings(SLACK_ENABLED=slack_enabled):
+        assert ChannelPlatform.for_dropdown(experiment.team) - set(expected_channels) == set()
+
+
+def _build_provider(provider_type: MessagingProviderType, team):
+    config = {}
+    match provider_type:
+        case MessagingProviderType.twilio:
+            config = {"auth_token": "test_key", "account_sid": "test_secret"}
+        case MessagingProviderType.turnio:
+            config = {"auth_token": "test_key"}
+        case MessagingProviderType.sureadhere:
+            config = {"client_id": "", "client_secret": "", "base_url": ""}
+    MessagingProviderFactory(type=provider_type, team=team, config=config)

--- a/apps/channels/tests/test_models.py
+++ b/apps/channels/tests/test_models.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import pytest
 from django.test import override_settings
 from django.urls import reverse
@@ -113,7 +111,7 @@ def test_available_channels(slack_enabled, messaging_provider_types, channels_en
         _build_provider(provider_type, team=experiment.team)
 
     all_platforms = ChannelPlatform.as_list(exclude=[ChannelPlatform.API, ChannelPlatform.WEB])
-    expected_status = OrderedDict.fromkeys(all_platforms, value=False)
+    expected_status = {platform: False for platform in all_platforms}
     for platform in channels_enabled:
         expected_status[platform] = True
 

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -448,7 +448,7 @@ def single_experiment_home(request, team_slug: str, experiment_id: int):
     )
     channels = experiment.experimentchannel_set.exclude(platform__in=[ChannelPlatform.WEB, ChannelPlatform.API]).all()
     used_platforms = {channel.platform_enum for channel in channels}
-    available_platforms = set(ChannelPlatform.for_dropdown()) - used_platforms
+    available_platforms = set(ChannelPlatform.for_dropdown(experiment.team)) - used_platforms
     platform_forms = {}
     form_kwargs = {"team": request.team}
     for platform in available_platforms:

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -448,10 +448,10 @@ def single_experiment_home(request, team_slug: str, experiment_id: int):
     )
     channels = experiment.experimentchannel_set.exclude(platform__in=[ChannelPlatform.WEB, ChannelPlatform.API]).all()
     used_platforms = {channel.platform_enum for channel in channels}
-    available_platforms = set(ChannelPlatform.for_dropdown(experiment.team)) - used_platforms
+    available_platforms = ChannelPlatform.for_dropdown(used_platforms, experiment.team)
     platform_forms = {}
     form_kwargs = {"team": request.team}
-    for platform in available_platforms:
+    for platform in available_platforms.keys():
         if platform.form(**form_kwargs):
             platform_forms[platform] = platform.form(**form_kwargs)
 

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -451,7 +451,7 @@ def single_experiment_home(request, team_slug: str, experiment_id: int):
     available_platforms = ChannelPlatform.for_dropdown(used_platforms, experiment.team)
     platform_forms = {}
     form_kwargs = {"team": request.team}
-    for platform in available_platforms.keys():
+    for platform in available_platforms:
         if platform.form(**form_kwargs):
             platform_forms[platform] = platform.form(**form_kwargs)
 

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -112,12 +112,25 @@
             <i class="fa-regular fa-plus"></i>
           </button>
           <ul tabindex="0" class="dropdown-content z-10 menu p-2 shadow bg-base-100 rounded-box w-52 border">
-            {% for platform in platforms %}
-              <li><a onclick="{{ platform.value }}_modal.showModal()">{{ platform.label }}</a></li>
+            {% for platform, available in platforms.items %}
+              <li>
+                <button
+                  class="disabled:text-gray-600 tooltip tooltip-right"
+                  {% if not available %}
+                    disabled
+                    data-tip="You need to configure your {{ platform|capfirst }} provider to use this channel"
+                  {% endif %}
+                  onclick="{{ platform.value }}_modal.showModal()"
+
+                >
+                  {{ platform.label }} {% if not available %}
+                  {% endif %}
+                </button>
+              </li>
             {% endfor %}
           </ul>
         </div>
-        {% for platform in platforms %}
+        {% for platform, available in platforms.items %}
           <dialog id="{{ platform.value }}_modal" class="modal">
             <div class="modal-box">
               <h3 class="font-bold text-lg">Link with {{ platform.label }}</h3>

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -131,26 +131,28 @@
           </ul>
         </div>
         {% for platform, available in platforms.items %}
-          <dialog id="{{ platform.value }}_modal" class="modal">
-            <div class="modal-box">
-              <h3 class="font-bold text-lg">Link with {{ platform.label }}</h3>
-              <form method="post" action="{% url "experiments:create_channel" request.team.slug experiment.id %}"
-                    x-data="{ buttonDisabled: false }" x-on:submit="buttonDisabled = true">
-                {% csrf_token %}
-                {% render_form_fields platform_forms|dict_lookup:platform %}
-                {% if platform.extra_form %}
-                  <div {% include "generic/attrs.html" with attrs=platform.extra_form.form_attrs %}>
-                    {% render_form_fields platform.extra_form %}
+          {% if available %}
+            <dialog id="{{ platform.value }}_modal" class="modal">
+              <div class="modal-box">
+                <h3 class="font-bold text-lg">Link with {{ platform.label }}</h3>
+                <form method="post" action="{% url "experiments:create_channel" request.team.slug experiment.id %}"
+                      x-data="{ buttonDisabled: false }" x-on:submit="buttonDisabled = true">
+                  {% csrf_token %}
+                  {% render_form_fields platform_forms|dict_lookup:platform %}
+                  {% if platform.extra_form %}
+                    <div {% include "generic/attrs.html" with attrs=platform.extra_form.form_attrs %}>
+                      {% render_form_fields platform.extra_form %}
+                    </div>
+                  {% endif %}
+                  <div class="modal-action">
+                    <span class="loading loading-spinner loading-sm p-3 ml-4" x-show="buttonDisabled" x-cloak></span>
+                    <button class="btn btn-primary" type="submit" x-bind:disabled="buttonDisabled">Create</button>
+                    <button class="btn" type="button" onclick="{{ platform.value }}_modal.close()" x-bind:disabled="buttonDisabled">Close</button>
                   </div>
-                {% endif %}
-                <div class="modal-action">
-                  <span class="loading loading-spinner loading-sm p-3 ml-4" x-show="buttonDisabled" x-cloak></span>
-                  <button class="btn btn-primary" type="submit" x-bind:disabled="buttonDisabled">Create</button>
-                  <button class="btn" type="button" onclick="{{ platform.value }}_modal.close()" x-bind:disabled="buttonDisabled">Close</button>
-                </div>
-              </form>
-            </div>
-          </dialog>
+                </form>
+              </div>
+            </dialog>
+          {% endif %}
         {% endfor %}
       {% endif %}
     </div>


### PR DESCRIPTION
Stems from [this issue](https://dimagi.sentry.io/issues/5664583590/?referrer=issue_alert-slack&notification_uuid=91e5f819-bb2c-42b8-aac9-7360616dbae6&alert_rule_id=14063560&alert_type=issue). We now only make channels available if a provider for it is configured. Doesn't really make sense to allow users to try and add them if they cannot do it in anycase. So users will not see for instance "Whatsapp" if turn.io or twilio is not configured


![image](https://github.com/user-attachments/assets/41622014-55f8-494e-952e-d34a49225381)
