### PR TITLE
Allow Experiment Session Table sorting by date

### DIFF
--- a/apps/experiments/tables.py
+++ b/apps/experiments/tables.py
@@ -137,8 +137,8 @@ class ConsentFormTable(tables.Table):
 
 class ExperimentSessionsTable(tables.Table):
     participant = columns.Column(verbose_name="Participant", accessor="participant__identifier")
-    started = columns.Column(accessor="created_at", verbose_name="Started")
-    last_message = columns.Column(accessor="last_message_created_at", verbose_name="Last Message")
+    started = columns.Column(accessor="created_at", verbose_name="Started", orderable=True)
+    last_message = columns.Column(accessor="last_message_created_at", verbose_name="Last Message", orderable=True)
     tags = columns.TemplateColumn(
         verbose_name="Tags",
         template_name="experiments/components/experiment_sessions_list_tags.html",

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -446,6 +446,7 @@ def single_experiment_home(request, team_slug: str, experiment_id: int):
         )
         .exclude(experiment_channel__platform=ChannelPlatform.API)
     )
+    sort = request.GET.get("sort", None)
     channels = experiment.experimentchannel_set.exclude(platform__in=[ChannelPlatform.WEB, ChannelPlatform.API]).all()
     used_platforms = {channel.platform_enum for channel in channels}
     available_platforms = ChannelPlatform.for_dropdown(used_platforms, experiment.team)
@@ -469,6 +470,7 @@ def single_experiment_home(request, team_slug: str, experiment_id: int):
             "filter_tags_url": reverse(
                 "experiments:sessions-list", kwargs={"team_slug": team_slug, "experiment_id": experiment.id}
             ),
+            "sort": sort,
             **_get_events_context(experiment, team_slug),
             **_get_routes_context(experiment, team_slug),
         },

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -199,7 +199,7 @@
               id="sessions-table"
               hx-trigger="load, tagFilter"
               hx-target="this"
-              hx-get="{% url 'experiments:sessions-list' request.team.slug experiment.id %}"
+              hx-get="{% url 'experiments:sessions-list' request.team.slug experiment.id %}?sort={{ sort }}"
               hx-swap="innerHTML"
             ></div>
           </div>

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -199,7 +199,7 @@
               id="sessions-table"
               hx-trigger="load, tagFilter"
               hx-target="this"
-              hx-get="{% url 'experiments:sessions-list' request.team.slug experiment.id %}?sort={{ sort }}"
+              hx-get="{% url 'experiments:sessions-list' request.team.slug experiment.id %}{% if sort %}?sort={{ sort }}{% endif %}"
               hx-swap="innerHTML"
             ></div>
           </div>


### PR DESCRIPTION
https://github.com/dimagi/open-chat-studio/issues/564

https://github.com/user-attachments/assets/7cf14d7c-ceb6-4162-a1e3-b5ba342f95ab

table can be sorted ascending & descending by "started" and "last message" columns