### PR TITLE
Disallow multiple source material variables in the prompt

### DIFF
--- a/apps/experiments/tests/test_views.py
+++ b/apps/experiments/tests/test_views.py
@@ -108,6 +108,7 @@ def test_experiment_form_with_assistants(
         (None, "Answer questions from this source: {source_material}", pytest.raises(ValidationError)),
         (None, "Answer questions from this source: {bob}", pytest.raises(ValidationError)),
         ("something", "Answer questions from this source: {bob}", pytest.raises(ValidationError)),
+        ("something", "Source material: {source_material} and {source_material}", pytest.raises(ValidationError)),
     ],
 )
 def test_prompt_variable_validation(source_material, prompt_str, expectation):

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -256,8 +256,10 @@ class ExperimentForm(forms.ModelForm):
 
 
 def _validate_prompt_variables(form_data):
-    required_variables = set(PromptTemplate.from_template(form_data.get("prompt_text")).input_variables)
+    prompt_text = form_data.get("prompt_text")
+    required_variables = set(PromptTemplate.from_template(prompt_text).input_variables)
     available_variables = set(["participant_data", "current_datetime"])
+
     if form_data.get("source_material"):
         available_variables.add("source_material")
 
@@ -281,6 +283,10 @@ def _validate_prompt_variables(form_data):
                 "usage."
             )
         raise forms.ValidationError({"prompt_text": errors})
+
+    if prompt_text.count("{source_material}") > 1:
+        error_msg = "Multiple source material variables found in the prompt. You can only use it once"
+        raise forms.ValidationError({"prompt_text": error_msg})
 
 
 class BaseExperimentView(LoginAndTeamRequiredMixin, PermissionRequiredMixin):

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -284,9 +284,10 @@ def _validate_prompt_variables(form_data):
             )
         raise forms.ValidationError({"prompt_text": errors})
 
-    if prompt_text.count("{source_material}") > 1:
-        error_msg = "Multiple source material variables found in the prompt. You can only use it once"
-        raise forms.ValidationError({"prompt_text": error_msg})
+    for prompt_var in ["{source_material}", "{participant_data}"]:
+        if prompt_text.count(prompt_var) > 1:
+            error_msg = f"Multiple {prompt_var} variables found in the prompt. You can only use it once"
+            raise forms.ValidationError({"prompt_text": error_msg})
 
 
 class BaseExperimentView(LoginAndTeamRequiredMixin, PermissionRequiredMixin):

--- a/assets/styles/app/utilities.sass
+++ b/assets/styles/app/utilities.sass
@@ -14,8 +14,10 @@
 
 // this is the default class assigned to errors by django forms
 .errorlist
-  color: #000000
+  color: var(--danger)
 
+.ajs-error .errorlist
+  color: #000000
 
 img.socialicon
   padding-right: .5em


### PR DESCRIPTION
Fixes https://github.com/dimagi/open-chat-studio/issues/581. I didn't do the same for `{current_datetime}`, because I can imagine a scenario where one might want to use this multiple times