### PR TITLE
only create new participant data for the current experiment

### DIFF
--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -775,7 +775,7 @@ def _start_experiment_session(
 
         # Record the participant's timezone
         if timezone:
-            participant.update_memory(data={"timezone": timezone})
+            participant.update_memory(data={"timezone": timezone}, experiment=experiment)
 
     if participant.experimentsession_set.count() == 1:
         enqueue_static_triggers.delay(session.id, StaticTriggerType.PARTICIPANT_JOINED_EXPERIMENT)

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -12,7 +12,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MaxValueValidator, MinValueValidator, validate_email
 from django.db import models, transaction
-from django.db.models import Count, OuterRef, Prefetch, Q, Subquery
+from django.db.models import Count, OuterRef, Q, Subquery
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext
@@ -530,36 +530,31 @@ class Participant(BaseTeamModel):
             return {}
 
     @transaction.atomic()
-    def update_memory(self, data: dict, experiment: Experiment | None = None):
+    def update_memory(self, data: dict, experiment: Experiment):
         """
         Updates this participant's data records by merging `data` with the existing data. By default, data for all
-        experiments the this participant participated in will be updated. If there are no records for a specific
+        experiments that this participant participated in will be updated. If there are no records for a specific
         experiment, one will be created.
 
         Paramters
         data:
             A dictionary containing the new data
         experiment:
-            If specified, only the data for this experiment will be updated
+            Create a new record for this experiment if one does not exist
         """
-        experiments = Experiment.objects.filter(team=self.team).prefetch_related(
-            Prefetch("participant_data", queryset=ParticipantData.objects.filter(participant=self))
-        )
-        if experiment:
-            experiments = experiments.filter(id=experiment.id)
+        # Update all existing records
+        participant_data = ParticipantData.objects.filter(participant=self).select_for_update()
+        experiments = set()
+        with transaction.atomic():
+            experiment_content_type = ContentType.objects.get_for_model(Experiment)
+            for record in participant_data:
+                if record.content_type == experiment_content_type:
+                    experiments.add(record.object_id)
+                record.data = record.data | data
+            ParticipantData.objects.bulk_update(participant_data, fields=["data"])
 
-        records_to_update = []
-        for experiment in experiments:
-            participant_data = experiment.participant_data.first()
-            # We cannot update the participant data using a single query, since the `data` field is encrypted at
-            # the application level
-            if participant_data:
-                participant_data.data = participant_data.data | data
-                records_to_update.append(participant_data)
-            else:
-                ParticipantData.objects.create(team=self.team, content_object=experiment, data=data, participant=self)
-
-        ParticipantData.objects.bulk_update(records_to_update, fields=["data"])
+        if experiment.id not in experiments:
+            ParticipantData.objects.create(team=self.team, content_object=experiment, data=data, participant=self)
 
 
 class ParticipantDataObjectManager(models.Manager):

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -248,26 +248,13 @@ class TestParticipant:
             data={"first_name": "Jack", "last_name": "Turner"},
             participant=participant,
         )
-        participant.update_memory({"first_name": "Elizabeth"})
+        participant.update_memory({"first_name": "Elizabeth"}, experiment=sessions[1].experiment)
         participant_data_query = ParticipantData.objects.filter(team=team, participant=participant)
-        assert participant_data_query.count() == 3
+
+        # expect 2 objects, 1 that was created before and 1 that was created in `update_memory`
+        assert participant_data_query.count() == 2
         for p_data in participant_data_query.all():
             if p_data == existing_data_obj:
                 assert p_data.data == {"first_name": "Elizabeth", "last_name": "Turner"}
             else:
                 assert p_data.data == {"first_name": "Elizabeth"}
-
-    @pytest.mark.django_db()
-    def test_update_memory_for_specific_experiment(self):
-        participant = ParticipantFactory()
-        team = participant.team
-        sessions = ExperimentSessionFactory.create_batch(3, participant=participant, team=team, experiment__team=team)
-        experiment = sessions[0].experiment
-        participant.update_memory({"first_name": "Will"}, experiment=experiment)
-        assert ParticipantData.objects.count() == 1
-        assert experiment.participant_data.filter(participant=participant).first().data == {"first_name": "Will"}
-        participant.update_memory({"first_name": "Bootstrap Bill", "last_name": "Turner"}, experiment=experiment)
-        assert experiment.participant_data.filter(participant=participant).first().data == {
-            "first_name": "Bootstrap Bill",
-            "last_name": "Turner",
-        }


### PR DESCRIPTION
I noticed that we are creating participant data for every experiment in the team via the `update_memory` method which I don't think is correct. Rather we should updated existing participant data and only create new participant data for the current experiment.

This should avoid creating participant data where it's not needed.