### PR TITLE
Allow public users to download their files and generated files

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1083,8 +1083,8 @@ def experiment_session_pagination_view(request, team_slug: str, experiment_id: s
     return redirect("experiments:experiment_session_view", team_slug, experiment_id, next_session.external_id)
 
 
-@login_and_team_required
-@permission_required("chat.view_chatattachment")
+@experiment_session_view(allowed_states=[SessionStatus.ACTIVE])
+@verify_session_access_cookie
 def download_file(request, team_slug: str, session_id: int, pk: int):
     resource = get_object_or_404(
         File, id=pk, team__slug=team_slug, chatattachment__chat__experiment_session__id=session_id

--- a/templates/experiments/chat/human_message.html
+++ b/templates/experiments/chat/human_message.html
@@ -9,17 +9,11 @@
   <div class="flex flex-col">
     {% for file in attachments %}
       <div class="inline">
-        {% if request.user.is_authenticated %}
-          <a class="text-sm p-1 hover:bg-gray-300 hover:rounded-lg"
-             href="{% url 'experiments:download_file' team_slug=experiment.team.slug session_id=session.id pk=file.id %}"
-             download="{{ file.name }}">
-            <i class="fa-solid fa-download fa-sm"></i> {{ file.name }}
-          </a>
-        {% else %}
-          <div class="inline text-sm p-1">
-            <i class="fa-solid fa-file fa-sm"></i> {{ file.name }}
-          </div>
-        {% endif %}
+        <a class="text-sm p-1 hover:bg-gray-300 hover:rounded-lg"
+           href="{% url 'experiments:download_file' team_slug=experiment.team.slug session_id=session.id pk=file.id %}"
+           download="{{ file.name }}">
+          <i class="fa-solid fa-download fa-sm"></i> {{ file.name }}
+        </a>
       </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to to understand the change. -->
This update will allow public users to download the files they uploaded during a conversation as well as those generated by the assistant.

Although this change works, I am a bit uneasy about the approach I took. I think it's because I'm "breaking" tradition here by allowing session id's to be integers (i.e. db primary keys) :shrug:.

Q: Why not just use the session's external id and pass in the experiment's public key to the `download_file` endpoint?
A: Doing that will break existing links to files, since they are embedded in chat messages and use integer ids. When a user wants to continue the chat and download the file, they wouldn't be able to anymore.

If we want to keep all public facing endpoints using external ids / public ids (so revert the changes I made to the decorator), then a possible solution that will require a migration is to find all chat messages that contain links and replace the links with the new format. Finding these messages should be relatively easy, since we can just find all chats with a "file_path" attachment, then in that chat find all chat messages having a file external id in its metadata that matches any file in this attachment. From here we can simply find and replace.

Question is: Are we fine with this approach here?

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Public users will be able to download their own uploaded files as well as generated ones.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs
<!--Link to documentation that has been updated.-->
N/A

