### PR TITLE
Agent tool to delete reminders

### DIFF
--- a/apps/assistants/tests/test_sync.py
+++ b/apps/assistants/tests/test_sync.py
@@ -92,7 +92,6 @@ def test_push_assistant_to_openai_update(mock_update, vs_retrieve, vs_files_list
 
     # Make sure that all tools in TOOL_CLASS_MAP was speceified
     tool_specs = mock_update.call_args_list[0].kwargs.get("tools")
-    assert len(tool_specs) == 3
     tool_names = set([tool_spec["function"]["name"] for tool_spec in tool_specs])
     expected_tools = set(tools.TOOL_CLASS_MAP.keys())
     assert expected_tools - tool_names == set()

--- a/apps/chat/agent/schemas.py
+++ b/apps/chat/agent/schemas.py
@@ -30,6 +30,10 @@ class OneOffReminderSchema(BaseModel):
     message: str = Field(description="The reminder message")
 
 
+class DeleteReminderSchema(BaseModel):
+    message_id: str = Field(description="the id of the scheduled message")
+
+
 class ScheduledMessageSchema(BaseModel):
     name: str = Field(description="the name of the scheduled message")
     weekday: WeekdaysEnum = Field(description="The day of the week")

--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -120,6 +120,25 @@ class UpdateScheduledMessageTool(CustomBaseTool):
         return f"The new datetime is {pretty_date(message.next_trigger_date)}"
 
 
+class DeleteReminderTool(CustomBaseTool):
+    name = AgentTools.DELETE_REMINDER
+    description = "useful to delete reminders"
+    requires_session = True
+    args_schema: type[schemas.DeleteReminderSchema] = schemas.DeleteReminderSchema
+
+    def action(self, message_id: str):
+        try:
+            scheduled_message = self.experiment_session.participant.schduled_messages.get(external_id=message_id)
+            if scheduled_message.action_id:
+                # Participants should not be able to delete a scheduled message that was created through an action
+                return "Cannot delete this reminder"
+        except ScheduledMessage.DoesNotExist:
+            return "Could not find this reminder"
+
+        scheduled_message.delete()
+        return "Success"
+
+
 def _move_datetime_to_new_weekday_and_time(date: datetime, new_weekday: int, new_hour: int, new_minute: int):
     current_weekday = date.weekday()
     day_diff = new_weekday - current_weekday
@@ -171,6 +190,7 @@ TOOL_CLASS_MAP = {
     AgentTools.SCHEDULE_UPDATE: UpdateScheduledMessageTool,
     AgentTools.ONE_OFF_REMINDER: OneOffReminderTool,
     AgentTools.RECURRING_REMINDER: RecurringReminderTool,
+    AgentTools.DELETE_REMINDER: DeleteReminderTool,
 }
 
 

--- a/apps/chat/tests/test_tools.py
+++ b/apps/chat/tests/test_tools.py
@@ -163,15 +163,15 @@ class TestDeleteReminderTool:
     def session(self, db):
         return ExperimentSessionFactory()
 
-    @pytest.fixture()
-    def schedule_params(self):
+    @staticmethod
+    def schedule_params():
         return {"time_period": "days", "frequency": 1, "repetitions": 2, "prompt_text": "", "name": "Testy"}
 
-    def test_user_cannot_delete_system_scheduled_message(self, session, schedule_params):
+    def test_user_cannot_delete_system_scheduled_message(self, session):
         scheduled_message = ScheduledMessage.objects.create(
             participant=session.participant,
             team=session.team,
-            action=EventActionFactory(params=schedule_params),
+            action=EventActionFactory(params=self.schedule_params()),
             experiment=session.experiment,
         )
 
@@ -182,12 +182,12 @@ class TestDeleteReminderTool:
         except ScheduledMessage.DoesNotExist:
             pytest.fail(reason="Expected ScheduledMessage.DoesNotExist to not be raised")
 
-    def test_user_can_delete_their_scheduled_message(self, session, schedule_params):
+    def test_user_can_delete_their_scheduled_message(self, session):
         scheduled_message = ScheduledMessage.objects.create(
             participant=session.participant,
             team=session.team,
             experiment=session.experiment,
-            custom_schedule_params=schedule_params,
+            custom_schedule_params=self.schedule_params(),
         )
         response = self._invoke_tool(session, message_id=scheduled_message.external_id)
         assert response == "Success"

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -344,14 +344,15 @@ class ScheduledMessage(BaseTeamModel):
         return self.params["repetitions"]
 
     def as_string(self, as_timezone: str | None = None):
+        schedule_name_part = f"{self.name} (ID={self.external_id})"
         if self.repetitions == 0:
-            schedule = f"{self.external_id}: One-off reminder"
+            schedule = f"{schedule_name_part}: One-off reminder"
         else:
-            schedule = f"{self.external_id}: Every {self.frequency} {self.time_period}, {self.repetitions} times"
+            schedule = f"{schedule_name_part}: Every {self.frequency} {self.time_period}, {self.repetitions} times"
             if self.time_period not in ["hour", "day"]:
                 weekday = self.next_trigger_date.strftime("%A")
                 schedule = (
-                    f"{self.external_id}: Every {self.frequency} {self.time_period} on {weekday} for "
+                    f"{schedule_name_part}: Every {self.frequency} {self.time_period} on {weekday} for "
                     f"{self.repetitions} times"
                 )
 

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -344,14 +344,20 @@ class ScheduledMessage(BaseTeamModel):
         return self.params["repetitions"]
 
     def as_string(self, as_timezone: str | None = None):
-        schedule = f"{self.name}: Every {self.frequency} {self.time_period}, {self.repetitions} times"
-        if self.time_period not in ["hour", "day"]:
-            weekday = self.next_trigger_date.strftime("%A")
-            schedule = (
-                f"{self.name}: Every {self.frequency} {self.time_period} on {weekday} for {self.repetitions} times"
-            )
+        if self.repetitions == 0:
+            schedule = f"{self.external_id}: One-off reminder"
+        else:
+            schedule = f"{self.external_id}: Every {self.frequency} {self.time_period}, {self.repetitions} times"
+            if self.time_period not in ["hour", "day"]:
+                weekday = self.next_trigger_date.strftime("%A")
+                schedule = (
+                    f"{self.external_id}: Every {self.frequency} {self.time_period} on {weekday} for "
+                    f"{self.repetitions} times"
+                )
+
         next_trigger = pretty_date(self.next_trigger_date, as_timezone=as_timezone)
-        return f"{schedule} (next trigger is {next_trigger})"
+        from_system = self.action is not None
+        return f"{schedule} with next trigger at {next_trigger}. (automatic reminder: {from_system})"
 
     def __str__(self):
         return self.as_string()

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -356,8 +356,10 @@ class ScheduledMessage(BaseTeamModel):
                 )
 
         next_trigger = pretty_date(self.next_trigger_date, as_timezone=as_timezone)
-        from_system = self.action is not None
-        return f"{schedule} with next trigger at {next_trigger}. (automatic reminder: {from_system})"
+        schedule_details = f"{schedule} with next trigger at {next_trigger}"
+        if self.action is not None:
+            schedule_details = f"{schedule_details} (System)"
+        return schedule_details
 
     def __str__(self):
         return self.as_string()

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -272,6 +272,7 @@ class VoiceResponseBehaviours(models.TextChoices):
 class AgentTools(models.TextChoices):
     RECURRING_REMINDER = "recurring-reminder", gettext("Recurring Reminder")
     ONE_OFF_REMINDER = "one-off-reminder", gettext("One-off Reminder")
+    DELETE_REMINDER = "delete-reminder", gettext("Delete Reminder")
     SCHEDULE_UPDATE = "schedule-update", gettext("Schedule Update")
 
 

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -789,6 +789,7 @@ class ExperimentSession(BaseTeamModel):
                 scheduled_messages.append(
                     {
                         "name": message.name,
+                        "external_id": message.external_id,
                         "frequency": message.frequency,
                         "time_period": message.time_period,
                         "repetitions": message.repetitions,

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -120,12 +120,12 @@ class TestExperimentSession:
         )
         assert len(session.get_participant_scheduled_messages()) == 2
         str_version1 = (
-            f"{message1.external_id}: Every 1 days on Tuesday for 1 times with next trigger at Tuesday, 02"
-            " January 2024 00:00:00 UTC (System)"
+            f"{message1.name} (ID={message1.external_id}): Every 1 days on Tuesday for 1 times with next trigger "
+            "at Tuesday, 02 January 2024 00:00:00 UTC (System)"
         )
         str_version2 = (
-            f"{message2.external_id}: Every 1 days on Tuesday for 1 times with next trigger at Tuesday, 02"
-            " January 2024 00:00:00 UTC"
+            f"{message2.name} (ID={message2.external_id}): Every 1 days on Tuesday for 1 times with next trigger "
+            "at Tuesday, 02 January 2024 00:00:00 UTC"
         )
 
         scheduled_messages_str = session.get_participant_scheduled_messages()
@@ -135,6 +135,7 @@ class TestExperimentSession:
         expected_dict_version = [
             {
                 "name": "Test",
+                "external_id": message1.external_id,
                 "frequency": 1,
                 "time_period": "days",
                 "repetitions": 1,
@@ -142,6 +143,7 @@ class TestExperimentSession:
             },
             {
                 "name": "Test",
+                "external_id": message2.external_id,
                 "frequency": 1,
                 "time_period": "days",
                 "repetitions": 1,
@@ -218,8 +220,8 @@ class TestExperimentSession:
             "timezone": "Africa/Johannesburg",
             "scheduled_messages": [
                 (
-                    f"{message.external_id}: Every 1 days on Sunday for 1 times with next trigger at Sunday, 02 "
-                    f"January 2022 {timezone_time} (System)"
+                    f"{message.name} (ID={message.external_id}): Every 1 days on Sunday for 1 times with next "
+                    f"trigger at Sunday, 02 January 2022 {timezone_time} (System)"
                 )
             ],
         }

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -102,21 +102,36 @@ class TestExperimentSession:
     @freeze_time("2024-01-01")
     def test_get_participant_scheduled_messages(self):
         session = ExperimentSessionFactory()
-        event_action = event_action, params = self._construct_event_action(
+        event_action, params = self._construct_event_action(
             time_period=TimePeriod.DAYS, experiment_id=session.experiment.id
         )
-        ScheduledMessageFactory.create_batch(
-            size=2,
+        message1 = ScheduledMessageFactory(
             experiment=session.experiment,
             team=session.team,
             participant=session.participant,
             action=event_action,
         )
+        message2 = ScheduledMessageFactory(
+            experiment=session.experiment,
+            team=session.team,
+            participant=session.participant,
+            custom_schedule_params=params,
+            action=None,
+        )
         assert len(session.get_participant_scheduled_messages()) == 2
-        expected_str_version = [
-            "Test: Every 1 days on Tuesday for 1 times (next trigger is Tuesday, 02 January 2024 00:00:00 UTC)",
-            "Test: Every 1 days on Tuesday for 1 times (next trigger is Tuesday, 02 January 2024 00:00:00 UTC)",
-        ]
+        str_version1 = (
+            f"{message1.external_id}: Every 1 days on Tuesday for 1 times with next trigger at Tuesday, 02"
+            " January 2024 00:00:00 UTC (System)"
+        )
+        str_version2 = (
+            f"{message2.external_id}: Every 1 days on Tuesday for 1 times with next trigger at Tuesday, 02"
+            " January 2024 00:00:00 UTC"
+        )
+
+        scheduled_messages_str = session.get_participant_scheduled_messages()
+        assert str_version1 in scheduled_messages_str
+        assert str_version2 in scheduled_messages_str
+
         expected_dict_version = [
             {
                 "name": "Test",
@@ -133,7 +148,6 @@ class TestExperimentSession:
                 "next_trigger_date": "2024-01-02T00:00:00+00:00",
             },
         ]
-        assert session.get_participant_scheduled_messages() == expected_str_version
         assert session.get_participant_scheduled_messages(as_dict=True) == expected_dict_version
 
     @pytest.mark.django_db()
@@ -186,7 +200,7 @@ class TestExperimentSession:
         event_action = event_action, params = self._construct_event_action(
             time_period=TimePeriod.DAYS, experiment_id=session.experiment.id
         )
-        ScheduledMessageFactory(
+        message = ScheduledMessageFactory(
             experiment=session.experiment,
             team=session.team,
             participant=session.participant,
@@ -203,7 +217,10 @@ class TestExperimentSession:
             "name": "Tester",
             "timezone": "Africa/Johannesburg",
             "scheduled_messages": [
-                f"Test: Every 1 days on Sunday for 1 times (next trigger is Sunday, 02 January 2022 {timezone_time})"
+                (
+                    f"{message.external_id}: Every 1 days on Sunday for 1 times with next trigger at Sunday, 02 "
+                    f"January 2022 {timezone_time} (System)"
+                )
             ],
         }
         assert session.get_participant_data(use_participant_tz=use_participant_tz) == expected_data


### PR DESCRIPTION
This PR builds on top of https://github.com/dimagi/open-chat-studio/pull/595

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to to understand the change. -->
Agent tool to delete reminders

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Agents now have the ability to delete a participant created reminder. When enabled, participants will be able to delete one of their reminders

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![demo](https://github.com/user-attachments/assets/59442c6f-62b5-4200-8baf-3b5aaf77ad3e)

### Docs
<!--Link to documentation that has been updated.-->
Will update here when I merge