### PR TITLE
Warn the user if the whatsapp number as not found at the provider

### DIFF
--- a/apps/channels/tests/test_forms.py
+++ b/apps/channels/tests/test_forms.py
@@ -72,7 +72,7 @@ def test_whatsapp_form_checks_number(
     provider = MessagingProviderFactory(type=provider_type, config={"account_sid": "123", "auth_token": "123"})
     messaging_provider.return_value = provider
     form = WhatsappChannelForm({"number": number, "messaging_provider": provider.id})
-
+    assert form.is_valid()
     if not number_found_at_provider:
         assert form.warning_message == (
             f"{number} was not found at the provider. Please make sure it is there before proceeding"

--- a/apps/channels/tests/test_forms.py
+++ b/apps/channels/tests/test_forms.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import pytest
 from django.forms.widgets import HiddenInput, Select
@@ -52,25 +52,28 @@ def test_whatsapp_form_validates_number_format(messaging_provider, number, is_va
         assert form.errors["number"] == ["Enter a valid phone number (e.g. +12125552368)."]
 
 
-# TODO: See the `is_valid_number` method in the TwilioService class
-# @pytest.mark.django_db()
-# @pytest.mark.parametrize(
-#     ("provider_type", "number", "is_valid"),
-#     [
-#         (MessagingProviderType.twilio, "+12125552368", True),
-#         (MessagingProviderType.twilio, "+12125552333", False),
-#         # Turnio doesn't have a way to list account numbers, so assume it's always valid
-#         (MessagingProviderType.turnio, "+12125552368", True),
-#         (MessagingProviderType.turnio, "+12125552333", True),
-#     ],
-# )
-# @patch("apps.channels.forms.ExtraFormBase.messaging_provider", new_callable=PropertyMock)
-# @patch("apps.service_providers.messaging_service.TwilioService._get_account_numbers")
-# def test_whatsapp_form_checks_number(_get_account_numbers, messaging_provider, provider_type, number, is_valid):
-#     _get_account_numbers.return_value = ["+12125552368"]
-#     provider = MessagingProviderFactory(type=provider_type, config={"account_sid": "123", "auth_token": "123"})
-#     messaging_provider.return_value = provider
-#     form = WhatsappChannelForm({"number": number, "messaging_provider": provider.id})
-#     assert form.is_valid() == is_valid
-#     if not is_valid:
-#         assert form.errors == {"number": [f"{number} was not found at the provider."]}
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("provider_type", "number", "number_found_at_provider"),
+    [
+        (MessagingProviderType.twilio, "+12125552368", True),
+        (MessagingProviderType.twilio, "+12125552333", False),
+        # Turnio doesn't have a way to list account numbers, so assume it's always valid
+        (MessagingProviderType.turnio, "+12125552368", True),
+        (MessagingProviderType.turnio, "+12125552333", True),
+    ],
+)
+@patch("apps.channels.forms.ExtraFormBase.messaging_provider", new_callable=PropertyMock)
+@patch("apps.service_providers.messaging_service.TwilioService._get_account_numbers")
+def test_whatsapp_form_checks_number(
+    _get_account_numbers, messaging_provider, provider_type, number, number_found_at_provider
+):
+    _get_account_numbers.return_value = ["+12125552368"]
+    provider = MessagingProviderFactory(type=provider_type, config={"account_sid": "123", "auth_token": "123"})
+    messaging_provider.return_value = provider
+    form = WhatsappChannelForm({"number": number, "messaging_provider": provider.id})
+
+    if not number_found_at_provider:
+        assert form.warning_message == (
+            f"{number} was not found at the provider. Please make sure it is there before proceeding"
+        )

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -580,8 +580,11 @@ def create_channel(request, team_slug: str, experiment_id: int):
             except ExperimentChannelException as e:
                 messages.error(request, "Error saving channel: " + str(e))
             else:
-                if message := extra_form.get_success_message(channel=form.instance):
-                    messages.info(request, message)
+                if extra_form.success_message:
+                    messages.info(request, extra_form.success_message)
+
+                if extra_form.warning_message:
+                    messages.warning(request, extra_form.warning_message)
     return redirect("experiments:single_experiment_home", team_slug, experiment_id)
 
 

--- a/apps/service_providers/messaging_service.py
+++ b/apps/service_providers/messaging_service.py
@@ -132,14 +132,12 @@ class TwilioService(MessagingService):
         return [num.phone_number for num in self.client.incoming_phone_numbers.list()]
 
     def is_valid_number(self, number: str) -> bool:
-        # if settings.DEBUG:
-        #     # The sandbox number doesn't belong to any account, so this check will always fail. For dev purposes
-        #     # let's just always return True
-        #     return True
+        if settings.DEBUG:
+            # The sandbox number doesn't belong to any account, so this check will always fail. For dev purposes
+            # let's just always return True
+            return True
 
-        # return number in self._get_account_numbers()
-        # TODO: Seems like the incoming_phone_numbers isn't a reliable way to verify phone numbers.
-        return True
+        return number in self._get_account_numbers()
 
 
 class TurnIOService(MessagingService):


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to to understand the change. -->
Warn the user if the whatsapp number as not found at the provider

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users will not be blocked if we cannot verify the number at the provider (in this case Twilio), but they will be warned and encouraged to double check

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![demo](https://github.com/user-attachments/assets/7210d3de-66d3-4f45-be99-decb0bf8a2c8)


### Docs
<!--Link to documentation that has been updated.-->
Will update on merge