### PR TITLE
Assistants should also save router tags

### DIFF
--- a/apps/chat/tests/test_routing.py
+++ b/apps/chat/tests/test_routing.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -6,6 +6,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from apps.chat.bots import TopicBot
 from apps.chat.models import ChatMessageType
 from apps.experiments.models import ExperimentRoute
+from apps.utils.factories.assistants import OpenAiAssistantFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.team import TeamFactory
 from apps.utils.langchain import build_fake_llm_service
@@ -38,25 +39,61 @@ def test_experiment_routing(with_default, routing_response, expected_tag):
     assert list(message.tags.values_list("name", flat=True)) == [expected_tag]
 
 
-def _make_experiment_with_routing(with_default=True):
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("with_default", "routing_response", "expected_tag"),
+    [
+        (True, "keyword1", "keyword1"),
+        (True, "keyword3", "keyword3"),
+        (True, "not a valid keyword", "keyword2"),
+        (False, "keyword2", "keyword2"),
+        (False, "not a valid keyword", "keyword1"),
+    ],
+)
+@patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._save_response_annotations")
+@patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._get_response_with_retries")
+def test_experiment_routing_with_assistant(
+    get_response_with_retries, save_response_annotations, with_default, routing_response, expected_tag
+):
+    response = Mock()
+    response.thread_id = "thread_id"
+    get_response_with_retries.return_value = response
+    save_response_annotations.return_value = ("How can I help today?", [])
+
+    experiment = _make_experiment_with_routing(with_default=with_default, assistant_children=True)
+    session = ExperimentSessionFactory(experiment=experiment)
+    fake_service = build_fake_llm_service(responses=[routing_response], token_counts=[0])
+
+    with patch("apps.experiments.models.Experiment.get_llm_service", new=lambda x: fake_service):
+        bot = TopicBot(session)
+        response = bot.process_input("Hi")
+    assert response == "How can I help today?"
+
+    message = session.chat.messages.filter(message_type=ChatMessageType.AI).first()
+    assert list(message.tags.values_list("name", flat=True)) == [expected_tag]
+
+
+def _make_experiment_with_routing(with_default=True, assistant_children=False):
     team = TeamFactory()
     experiments = ExperimentFactory.create_batch(4, team=team)
+    router = experiments[0]
+    if assistant_children:
+        for exp in experiments[1:]:
+            exp.assistant = OpenAiAssistantFactory(team=team)
+            exp.save()
+
     ExperimentRoute.objects.bulk_create(
         [
-            ExperimentRoute(
-                team=team, parent=experiments[0], child=experiments[1], keyword="keyword1", is_default=False
-            ),
+            ExperimentRoute(team=team, parent=router, child=experiments[1], keyword="keyword1", is_default=False),
             ExperimentRoute(
                 # make the middle one the default to avoid first / last false positives
                 team=team,
-                parent=experiments[0],
+                parent=router,
                 child=experiments[2],
                 keyword="keyword2",
                 is_default=with_default,
             ),
-            ExperimentRoute(
-                team=team, parent=experiments[0], child=experiments[3], keyword="keyword3", is_default=False
-            ),
+            ExperimentRoute(team=team, parent=router, child=experiments[3], keyword="keyword3", is_default=False),
         ]
     )
-    return experiments[0]
+    return router

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -289,7 +289,10 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
         if not thread_id:
             self.state.set_metadata(Chat.MetadataKeys.OPENAI_THREAD_ID, response.thread_id)
 
-        self.state.save_message_to_history(output, ChatMessageType.AI, annotation_file_ids=annotation_file_ids)
+        experiment_tag = config.get("configurable", {}).get("experiment_tag")
+        self.state.save_message_to_history(
+            output, ChatMessageType.AI, annotation_file_ids=annotation_file_ids, experiment_tag=experiment_tag
+        )
         return ChainOutput(output=output, prompt_tokens=0, completion_tokens=0)
 
     @transaction.atomic()

--- a/apps/service_providers/llm_service/state.py
+++ b/apps/service_providers/llm_service/state.py
@@ -206,15 +206,31 @@ class AssistantExperimentState(ExperimentState, AssistantState):
     def set_metadata(self, key: Chat.MetadataKeys, value):
         self.chat.set_metadata(key, value)
 
-    def save_message_to_history(self, message: str, type_: ChatMessageType, annotation_file_ids: list | None = None):
+    def save_message_to_history(
+        self,
+        message: str,
+        type_: ChatMessageType,
+        annotation_file_ids: list | None = None,
+        experiment_tag: str | None = None,
+    ):
         """
         Create a chat message and appends the file ids from each resource to the `openai_file_ids` array in the
         chat message metadata.
         Example resource_file_mapping: {"resource1": ["file1", "file2"], "resource2": ["file3", "file4"]}
         """
-        return ChatMessage.objects.create(
+        chat_message = ChatMessage.objects.create(
             chat=self.session.chat,
             message_type=type_.value,
             content=message,
             metadata={"openai_file_ids": annotation_file_ids} if annotation_file_ids else {},
         )
+
+        if experiment_tag:
+            tag, _ = Tag.objects.get_or_create(
+                name=experiment_tag,
+                team=self.session.team,
+                is_system_tag=True,
+                category=TagCategories.BOT_RESPONSE,
+            )
+            chat_message.add_tag(tag, team=self.session.team, added_by=None)
+        return chat_message

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -260,9 +260,7 @@
     <input type="radio" name="tab_group" role="tab" class="tab" aria-label="Routes" id="tab-routes"/>
     <div role="tabpanel" class="tab-content" id="content-routes">
       <div class="app-card">
-        {% if experiment.assistant %}
-          Assistants cannot be used as a router bot
-        {% elif can_make_child_routes %}
+        {% if can_make_child_routes %}
           <a class="btn btn-sm btn-outline btn-primary mb-2" href="{% url 'experiments:experiment_route_new' team.slug experiment.id 'processor' %}"><i class="fa-regular fa-plus"></i> Create child route</a>
           {% render_table child_routes_table %}
         {% else %}

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -260,7 +260,9 @@
     <input type="radio" name="tab_group" role="tab" class="tab" aria-label="Routes" id="tab-routes"/>
     <div role="tabpanel" class="tab-content" id="content-routes">
       <div class="app-card">
-        {% if can_make_child_routes %}
+        {% if experiment.assistant %}
+          Assistants cannot be used as a router bot
+        {% elif can_make_child_routes %}
           <a class="btn btn-sm btn-outline btn-primary mb-2" href="{% url 'experiments:experiment_route_new' team.slug experiment.id 'processor' %}"><i class="fa-regular fa-plus"></i> Create child route</a>
           {% render_table child_routes_table %}
         {% else %}


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to to understand the change. -->
1. Assistants didn't save router tags. That's fixed now.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
1. Users will be able to see which assistant child bot generated an answer

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
No demo needed, but here's a screenshot

![image](https://github.com/user-attachments/assets/a99e98c3-3141-45b1-9596-798f10b5bf64)


### Docs
<!--Link to documentation that has been updated.-->
Release docs will be updated on release