### PR TITLE
Disallow assistant based routers

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -55,6 +55,7 @@ from apps.experiments.helpers import get_real_user_or_none
 from apps.experiments.models import (
     AgentTools,
     Experiment,
+    ExperimentRoute,
     ExperimentRouteType,
     ExperimentSession,
     SessionStatus,
@@ -326,6 +327,12 @@ class BaseExperimentView(LoginAndTeamRequiredMixin, PermissionRequiredMixin):
 
     def form_valid(self, form):
         experiment = form.instance
+        if experiment.assistant and ExperimentRoute.objects.filter(parent=experiment):
+            messages.error(
+                request=self.request, message="Assistants cannot be routers. Please remove the routes first."
+            )
+            return render(self.request, self.template_name, self.get_context_data())
+
         if experiment.conversational_consent_enabled and not experiment.seed_message:
             messages.error(
                 request=self.request, message="A seed message is required when conversational consent is enabled!"

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -260,7 +260,9 @@
     <input type="radio" name="tab_group" role="tab" class="tab" aria-label="Routes" id="tab-routes"/>
     <div role="tabpanel" class="tab-content" id="content-routes">
       <div class="app-card">
-        {% if can_make_child_routes %}
+        {% if experiment.assistant %}
+          Assistants cannot be router bots. Please use a normal bot
+        {% elif can_make_child_routes %}
           <a class="btn btn-sm btn-outline btn-primary mb-2" href="{% url 'experiments:experiment_route_new' team.slug experiment.id 'processor' %}"><i class="fa-regular fa-plus"></i> Create child route</a>
           {% render_table child_routes_table %}
         {% else %}


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to to understand the change. -->

Look at this conversation history on OpenAI for the router assistant (with english and german child bots and the english bot being the default).

![image](https://github.com/user-attachments/assets/63466aa6-affd-49a0-b4ad-60ce3415d422)

## User Impact
<!-- Describe the impact of this change on the end-users. -->
- Users will not be allowed to use an assistant as a router (or parent) bot.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![image](https://github.com/user-attachments/assets/7e57da0b-2cff-4c5a-9bee-861e40eb3dd6)

### Docs
<!--Link to documentation that has been updated.-->
