### PR TITLE
Add button to copy API link for a specific experiment

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -412,6 +412,9 @@ class Experiment(BaseTeamModel):
         elif self.assistant:
             return self.assistant.llm_provider.get_llm_service()
 
+    def get_api_url(self):
+        return absolute_url(reverse("api:openai-chat-completions", args=[self.public_id]))
+
     def get_absolute_url(self):
         return reverse("experiments:single_experiment_home", args=[self.team.slug, self.id])
 

--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -6,7 +6,14 @@ export const Cookies = JsCookie.default;
 export async function copyToClipboard (callee, elementId) {
   const icon = callee.getElementsByTagName('i')[0]
   const span = callee.getElementsByTagName('span')[0]
-  const text = document.getElementById(elementId).innerHTML
+  const element = document.getElementById(elementId)
+  let text;
+  if (element.tagName == "INPUT") {
+    text = element.value;
+  } else {
+    text = element.innerHTML;
+  }
+  
   try {
     await navigator.clipboard.writeText(text).then(() => {
       icon.className = 'fa-solid fa-check'

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -76,6 +76,10 @@
     <h2 class="flex-1 pg-subtitle">{{ experiment.description }}</h2>
     <div class="my-4">
       <h3 class="font-bold text-lg inline mr-4">Channels:</h3>
+      <input id="api-url-link" type="hidden" value="{{ experiment.get_api_url }}" />
+      <button class="btn btn-ghost btn-sm no-animation !normal-case" onclick="SiteJS.app.copyToClipboard(this, 'api-url-link')" title="Copy to clipboard">
+        <i class="fa-solid fa-link"></i> <span>API</span>
+      </button>
       <div class="btn btn-ghost btn-sm no-animation !normal-case"><i class="fa-regular fa-window-maximize"></i> Web</div>
     {#  Commented elements included for Tailwind processing #}
     {#  <i class="fa-brands fa-telegram"></i> #}
@@ -281,6 +285,7 @@
       </div>
     </div>
   </div>
+  <script src="{% static 'js/app-bundle.js' %}"></script>
   <script>
     let url = "{{ filter_tags_url|escapejs }}"
     function filterSessions(tags) {


### PR DESCRIPTION
https://github.com/dimagi/open-chat-studio/issues/609

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to to understand the change. -->
Add button to copy API link for a specific experiment

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users will be able to click on the API channel, which will copy the link for them

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
## Before clicking
![image](https://github.com/user-attachments/assets/708e7cde-a35d-4b32-afde-97ab6a0055d4)

## After clicking
![image](https://github.com/user-attachments/assets/e27d1c2d-e391-4b38-b0ef-b6e420b86ddc)

### Docs
<!--Link to documentation that has been updated.-->
