### PR TITLE
enable search by object_pk in audit list

### DIFF
--- a/apps/audit/admin.py
+++ b/apps/audit/admin.py
@@ -23,3 +23,13 @@ class AuditEventAdmin(admin.ModelAdmin):
 
     def username(self, obj):
         return obj.change_context.get("username", "")
+
+    def get_search_results(self, request, queryset, search_term):
+        try:
+            search_term_as_int = int(search_term)
+        except ValueError:
+            pass
+        else:
+            return queryset.filter(object_pk=search_term_as_int), False
+
+        return super().get_search_results(request, queryset, search_term)


### PR DESCRIPTION
## Description
A change to the admin view for Audit Events that allows filtering by object PK. This makes it possible to see all events for a specific model (not including related models)

## User Impact
None
