### PR TITLE
fix missing mimetype files

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -35,6 +35,8 @@ RUN apt-get update && apt-get install -y \
   build-essential libssl-dev ca-certificates libasound2 wget \
   # curl for heroku log shipping
   curl \
+  # mimetype detection (creates /etc/mime.types)
+  mailcap \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Resolves https://github.com/dimagi/open-chat-studio/issues/628

## Description
The python `mimetypes` module relies on mime type mapping in the OS but some of the mapping files were missing in the docker image. This installs [mailcap](https://pkgs.alpinelinux.org/package/edge/main/armhf/mailcap) into the docker image which contains those mimetype mapping files.