### PR TITLE
adjust file type info

### DIFF
--- a/apps/service_providers/llm_service/state.py
+++ b/apps/service_providers/llm_service/state.py
@@ -195,7 +195,10 @@ class AssistantExperimentState(ExperimentState, AssistantState):
         code_interpreter_attachments = self.get_attachments(["code_interpreter"])
         if self.experiment.assistant.include_file_info and code_interpreter_attachments:
             file_type_info = self.get_file_type_info(code_interpreter_attachments)
-            instructions += f"\n\nFile type information:\n{file_type_info}"
+            instructions += "\n\nFile type information:\n\n| File Path | Mime Type |\n"
+            for file_info in file_type_info:
+                for file_name, mime_type in file_info.items():
+                    instructions += f"| /mnt/data/{file_name} | {mime_type} |\n"
 
         return instructions
 

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -173,7 +173,10 @@ def test_assistant_includes_file_type_information(
     )
     result = assistant.invoke("test")
     assert result.output == ai_response
-    expected_instructions = "Help the user\n\nFile type information:\n[{'file-12345': 'application/fmt'}]"
+    expected_instructions = (
+        "Help the user\n\nFile type information:\n\n| File Path | Mime Type |\n"
+        "| /mnt/data/file-12345 | application/fmt |\n"
+    )
     assert create_and_run.call_args.kwargs["instructions"] == expected_instructions
 
 


### PR DESCRIPTION
## Description
When testing this, the assistant was appending the extension to the filename and then failing to read the file. Passing in the full file path seems to work (thought it will break if they ever change the path).
