### PR TITLE
allow builtin tools but not custom tools

### DIFF
--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -465,7 +465,9 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
         return response.return_values["output"], response.thread_id, response.run_id
 
     def _extra_input_configs(self) -> dict:
-        # don't allow custom tools to be used when not an agent
+        # Allow builtin tools but not custom tools when not running as an agent
+        # This is to prevent using tools when using the assistant to generate responses
+        # for automated messages e.g. reminders
         builtin_tools = self.state.experiment.assistant.builtin_tools
         return {"tools": [{"type": tool} for tool in builtin_tools]}
 

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -468,8 +468,13 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
         # Allow builtin tools but not custom tools when not running as an agent
         # This is to prevent using tools when using the assistant to generate responses
         # for automated messages e.g. reminders
+        custom_tools = self.state.experiment.assistant.tools
         builtin_tools = self.state.experiment.assistant.builtin_tools
-        return {"tools": [{"type": tool} for tool in builtin_tools]}
+        if custom_tools and builtin_tools:
+            return {"tools": [{"type": tool} for tool in builtin_tools]}
+
+        # prefer not to specify if we don't need to
+        return {}
 
 
 class AssistantAgentRunnable(AssistantExperimentRunnable):

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -465,7 +465,9 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
         return response.return_values["output"], response.thread_id, response.run_id
 
     def _extra_input_configs(self) -> dict:
-        return {"tools": []}
+        # don't allow custom tools to be used when not an agent
+        builtin_tools = self.state.experiment.assistant.builtin_tools
+        return {"tools": [{"type": tool} for tool in builtin_tools]}
 
 
 class AssistantAgentRunnable(AssistantExperimentRunnable):


### PR DESCRIPTION
## Description
Passing an empty list for tools disables all tools including builtin tools. We only want to disable custom tools in this instance since we don't want them to be called when we're generating automated responses eg. reminders.

## User Impact
Fix builtin tool calling for Assistants
