### PR TITLE
SureAdhere communication channel - auth_url added toSureAdhereMessagingConfigForm

### DIFF
--- a/apps/channels/tests/conftest.py
+++ b/apps/channels/tests/conftest.py
@@ -26,7 +26,7 @@ def sureadhere_provider():
             "client_secret": "456",
             "client_scope": "https://example.onmicrosoft.com/example-app-api/.default",
             "base_url": "https://example.com",
-            "auth_url": "https://sa.b2clogin.com/sa.onmicrosoft.com/test_Patients/oauth2/v2.0/token"
+            "auth_url": "https://sa.b2clogin.com/sa.onmicrosoft.com/test_Patients/oauth2/v2.0/token",
         },
     )
 

--- a/apps/channels/tests/conftest.py
+++ b/apps/channels/tests/conftest.py
@@ -26,6 +26,7 @@ def sureadhere_provider():
             "client_secret": "456",
             "client_scope": "https://example.onmicrosoft.com/example-app-api/.default",
             "base_url": "https://example.com",
+            "auth_url": "https://sa.b2clogin.com/sa.onmicrosoft.com/test_Patients/oauth2/v2.0/token"
         },
     )
 

--- a/apps/channels/tests/test_models.py
+++ b/apps/channels/tests/test_models.py
@@ -128,7 +128,7 @@ def _build_provider(provider_type: MessagingProviderType, team):
         case MessagingProviderType.turnio:
             config = {"auth_token": "test_key"}
         case MessagingProviderType.sureadhere:
-            config = {"client_id": "", "client_secret": "", "client_scope": "", "base_url": ""}
+            config = {"client_id": "", "client_secret": "", "client_scope": "", "base_url": "", "auth_url": ""}
         case MessagingProviderType.slack:
             config = {"slack_team_id": "", "slack_installation_id": 123}
     MessagingProviderFactory(type=provider_type, team=team, config=config)

--- a/apps/service_providers/forms.py
+++ b/apps/service_providers/forms.py
@@ -182,7 +182,6 @@ class SureAdhereMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
     )
 
 
-
 class CommCareAuthConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
     obfuscate_fields = ["api_key"]
 

--- a/apps/service_providers/forms.py
+++ b/apps/service_providers/forms.py
@@ -170,11 +170,17 @@ class SureAdhereMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
     client_scope = forms.CharField(
         label=_("Client Scope"), help_text=_("Scope used for authentication with Azure AD B2C.")
     )
+    auth_url = forms.URLField(
+        label=_("Auth URL"),
+        validators=[URLValidator(schemes=["https"])],
+        help_text=_("URL used for authentication with Azure AD B2C."),
+    )
     base_url = forms.URLField(
         label=_("Base URL"),
         validators=[URLValidator(schemes=["https"])],
         help_text=_("URL of the SureAdhere backend server"),
     )
+
 
 
 class CommCareAuthConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):

--- a/apps/service_providers/messaging_service.py
+++ b/apps/service_providers/messaging_service.py
@@ -179,16 +179,16 @@ class SureAdhereService(MessagingService):
     client_secret: str
     client_scope: str
     base_url: str
+    auth_url: str
 
     def get_access_token(self):
-        auth_url = "https://sureadherelabs.b2clogin.com/sureadherelabs.onmicrosoft.com/B2C_1_Patients/oauth2/v2.0/token"
         auth_data = {
             "grant_type": "client_credentials",
             "client_id": self.client_id,
             "client_secret": self.client_secret,
             "scope": self.client_scope,
         }
-        response = requests.post(auth_url, data=auth_data)
+        response = requests.post(self.auth_url, data=auth_data)
         response.raise_for_status()
         return response.json()["access_token"]
 


### PR DESCRIPTION
## Description
SureAdhere channel -  auth_url added to SureAdhereMessagingConfigForm

## User Impact
Enables user to specify this parameter when configuring SureAdhere communication channel

