### PR TITLE
session api messages

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -50,6 +50,29 @@ paths:
               schema:
                 $ref: '#/components/schemas/Experiment'
           description: ''
+  /api/files/{id}/content:
+    get:
+      operationId: file_content
+      summary: Download File Content
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Files
+      security:
+      - apiKeyAuth: []
+      - tokenAuth: []
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
   /api/openai/{experiment_id}/chat/completions:
     post:
       operationId: openai_chat_completions
@@ -428,6 +451,24 @@ components:
       - team
       - updated_at
       - url
+    File:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        content_type:
+          type: string
+        size:
+          type: integer
+        content_url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - content_url
+      - name
+      - size
     Message:
       type: object
       properties:
@@ -435,9 +476,26 @@ components:
           $ref: '#/components/schemas/MessageRoleEnum'
         content:
           type: string
+        metadata:
+          type: object
+          additionalProperties: {}
+          readOnly: true
+        tags:
+          type: array
+          items:
+            type: string
+          readOnly: true
+        attachments:
+          type: array
+          items:
+            $ref: '#/components/schemas/File'
+          readOnly: true
       required:
+      - attachments
       - content
+      - metadata
       - role
+      - tags
     MessageRoleEnum:
       enum:
       - system

--- a/api-schema.yml
+++ b/api-schema.yml
@@ -214,7 +214,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ExperimentSession'
+                $ref: '#/components/schemas/ExperimentSessionWithMessages'
           description: ''
   /channels/api/{experiment_id}/incoming_message:
     post:
@@ -383,6 +383,50 @@ components:
             $ref: '#/components/schemas/Message'
       required:
       - experiment
+      - url
+    ExperimentSessionWithMessages:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          readOnly: true
+        id:
+          type: string
+          readOnly: true
+        team:
+          allOf:
+          - $ref: '#/components/schemas/Team'
+          readOnly: true
+        experiment:
+          allOf:
+          - $ref: '#/components/schemas/Experiment'
+          readOnly: true
+        participant:
+          allOf:
+          - $ref: '#/components/schemas/Participant'
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+          readOnly: true
+      required:
+      - created_at
+      - experiment
+      - id
+      - messages
+      - participant
+      - team
+      - updated_at
       - url
     Message:
       type: object

--- a/api-schema.yml
+++ b/api-schema.yml
@@ -76,19 +76,34 @@ paths:
   /api/openai/{experiment_id}/chat/completions:
     post:
       operationId: openai_chat_completions
-      description: "\n    Use OpenAI's client to send messages to the experiment and\
-        \ get responses. This will\n    create a new session in the experiment with\
-        \ all the provided messages\n    and return the response from the experiment.\n\
-        \    \n    The last message must be a 'user' message.\n    \n    Example (Python):\n\
-        \    \n        experiment_id = \"your experiment ID\"\n        \n        client\
-        \ = OpenAI(\n            api_key=\"your API key\",\n            base_url=f\"\
-        https://chatbots.dimagi.com/api/openai/{experiment_id}\",\n        )\n   \
-        \     \n        completion = client.chat.completions.create(\n           \
-        \ model=\"anything\",\n            messages=[\n                {\"role\":\
-        \ \"assistant\", \"content\": \"How can I help you today?\"},\n          \
-        \      {\"role\": \"user\", \"content\": \"I need help with something.\"},\n\
-        \            ],\n        )\n        \n        reply = completion.choices[0].message\n\
-        \    "
+      description: |2
+
+        Use OpenAI's client to send messages to the experiment and get responses. This will
+        create a new session in the experiment with all the provided messages
+        and return the response from the experiment.
+
+        The last message must be a 'user' message.
+
+        Example (Python):
+
+        ```python
+        experiment_id = "your experiment ID"
+
+        client = OpenAI(
+            api_key="your API key",
+            base_url=f"https://chatbots.dimagi.com/api/openai/{experiment_id}",
+        )
+
+        completion = client.chat.completions.create(
+            model="anything",
+            messages=[
+                {"role": "assistant", "content": "How can I help you today?"},
+                {"role": "user", "content": "I need help with something."},
+            ],
+        )
+
+        reply = completion.choices[0].message
+        ```
       summary: Chat Completions API for Experiments
       parameters:
       - in: path
@@ -219,6 +234,10 @@ paths:
   /api/sessions/{id}/:
     get:
       operationId: session_retrieve
+      description: |2
+
+        Retrieve the details of an session. This includes the messages exchanged during the session ordered
+        by the creation date.
       summary: Retrieve Experiment Session
       parameters:
       - in: path
@@ -472,6 +491,10 @@ components:
     Message:
       type: object
       properties:
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
         role:
           $ref: '#/components/schemas/MessageRoleEnum'
         content:
@@ -480,6 +503,13 @@ components:
           type: object
           additionalProperties: {}
           readOnly: true
+          description: |2
+
+            Metadata for the message. Currently documented keys:
+              * `is_summary`: boolean, whether this message is a summary of the conversation to date. When this
+                is true, the message will not be displayed in the chat interface but it will be used when
+                generating the chat history for the LLM. The history will include all messages up to the last
+                summary message (starting from the most recent message).
         tags:
           type: array
           items:
@@ -493,6 +523,7 @@ components:
       required:
       - attachments
       - content
+      - created_at
       - metadata
       - role
       - tags

--- a/apps/api/openai.py
+++ b/apps/api/openai.py
@@ -1,3 +1,4 @@
+import textwrap
 import time
 
 from drf_spectacular.types import OpenApiTypes
@@ -14,15 +15,17 @@ from apps.channels.tasks import handle_api_message
 @extend_schema(
     operation_id="openai_chat_completions",
     summary="Chat Completions API for Experiments",
-    description="""
-    Use OpenAI's client to send messages to the experiment and get responses. This will
-    create a new session in the experiment with all the provided messages
-    and return the response from the experiment.
-    
-    The last message must be a 'user' message.
-    
-    Example (Python):
-    
+    description=textwrap.dedent(
+        """
+        Use OpenAI's client to send messages to the experiment and get responses. This will
+        create a new session in the experiment with all the provided messages
+        and return the response from the experiment.
+        
+        The last message must be a 'user' message.
+        
+        Example (Python):
+        
+        ```python
         experiment_id = "your experiment ID"
         
         client = OpenAI(
@@ -39,7 +42,9 @@ from apps.channels.tasks import handle_api_message
         )
         
         reply = completion.choices[0].message
-    """,
+        ```
+        """
+    ),
     tags=["OpenAI"],
     request=inline_serializer(
         "CreateChatCompletionRequest",

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -36,10 +36,13 @@ class TeamSerializer(serializers.ModelSerializer):
 
 class FileSerializer(serializers.ModelSerializer):
     size = serializers.IntegerField(source="content_size")
+    content_url = serializers.HyperlinkedIdentityField(
+        view_name="api:file-content", lookup_field="id", lookup_url_kwarg="pk"
+    )
 
     class Meta:
         model = File
-        fields = ("name", "content_type", "size")
+        fields = ("name", "content_type", "size", "content_url")
 
 
 class MessageSerializer(TaggitSerializer, serializers.ModelSerializer):
@@ -95,7 +98,7 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
     @extend_schema_field(MessageSerializer(many=True))
     def get_messages(self, instance):
         messages = list(instance.chat.message_iterator())
-        return MessageSerializer(reversed(messages), many=True).data
+        return MessageSerializer(reversed(messages), many=True, context=self.context).data
 
 
 class ExperimentSessionCreateSerializer(serializers.ModelSerializer):

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -76,7 +76,8 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(MessageSerializer(many=True))
     def get_messages(self, instance):
-        return MessageSerializer(instance.chat.messages.all(), many=True).data
+        messages = list(instance.chat.message_iterator())
+        return MessageSerializer(reversed(messages), many=True).data
 
 
 class ExperimentSessionCreateSerializer(serializers.ModelSerializer):

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -32,17 +32,25 @@ class TeamSerializer(serializers.ModelSerializer):
         fields = ["name", "slug"]
 
 
+MESSAGE_METADATA_KEYS_TO_HIDE = {
+    "openai_file_ids",
+}
+
+
 class MessageSerializer(serializers.ModelSerializer):
     role = serializers.ChoiceField(choices=["system", "user", "assistant"], source="message_type")
     content = serializers.CharField()
+    metadata = serializers.JSONField(required=False)
 
     class Meta:
         model = ChatMessage
-        fields = ["role", "content"]
+        fields = ["role", "content", "metadata"]
 
     def to_representation(self, instance):
         data = super().to_representation(instance)
         data["role"] = ChatMessageType(data["role"]).role
+        for key in ChatMessage.INTERNAL_METADATA_KEYS:
+            data.pop(key, None)
         return data
 
     def to_internal_value(self, data):

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -39,10 +39,26 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
     team = TeamSerializer(read_only=True)
     experiment = ExperimentSerializer(read_only=True)
     participant = ParticipantSerializer(read_only=True)
+    messages = serializers.SerializerMethodField()
 
     class Meta:
         model = ExperimentSession
-        fields = ["url", "id", "team", "experiment", "participant", "created_at", "updated_at"]
+        fields = ["url", "id", "team", "experiment", "participant", "created_at", "updated_at", "messages"]
+
+    def __init__(self, *args, **kwargs):
+        self._include_messages = kwargs.pop("include_messages", False)
+        super().__init__(*args, **kwargs)
+        if not self._include_messages:
+            self.fields.pop("messages")
+
+    def get_messages(self, instance):
+        return [
+            {
+                "role": message.message_type,
+                "content": message.content,
+            }
+            for message in instance.chat.messages.all()
+        ]
 
 
 class MessageSerializer(serializers.Serializer):

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -57,8 +57,8 @@ class MessageSerializer(TaggitSerializer, serializers.ModelSerializer):
         fields = ["role", "content", "metadata", "tags", "attachments"]
 
     def to_representation(self, instance):
-        if instance.is_summary:
-            # summary isn't saved to the DB, so you can query for tags
+        if not instance.pk:
+            # don't try and load tags if it isn't saved to the DB e.g. summary messages
             instance.tags = []
         data = super().to_representation(instance)
         data["role"] = ChatMessageType(data["role"]).role

--- a/apps/api/tests/test_message_serializer.py
+++ b/apps/api/tests/test_message_serializer.py
@@ -16,4 +16,4 @@ def test_message_serializer_api_to_internal(type_, role):
 @pytest.mark.parametrize(("type_", "role"), CASES)
 def test_message_serializer_internal_to_api(type_, role):
     serializer = MessageSerializer(instance=ChatMessage(message_type=type_, content="hello"))
-    assert serializer.data == {"role": role, "content": "hello"}
+    assert serializer.data == {"role": role, "content": "hello", "metadata": {}, "tags": [], "attachments": []}

--- a/apps/api/tests/test_message_serializer.py
+++ b/apps/api/tests/test_message_serializer.py
@@ -1,18 +1,19 @@
 import pytest
 
 from apps.api.serializers import MessageSerializer
+from apps.chat.models import ChatMessage, ChatMessageType
 
-CASES = [("system", "system"), ("human", "user"), ("ai", "assistant")]
+CASES = [(ChatMessageType.SYSTEM, "system"), (ChatMessageType.HUMAN, "user"), (ChatMessageType.AI, "assistant")]
 
 
 @pytest.mark.parametrize(("type_", "role"), CASES)
 def test_message_serializer_api_to_internal(type_, role):
     serializer = MessageSerializer(data={"role": role, "content": "hello"})
     assert serializer.is_valid()
-    assert serializer.validated_data == {"type": type_, "message": "hello"}
+    assert serializer.validated_data == {"message_type": type_, "content": "hello"}
 
 
 @pytest.mark.parametrize(("type_", "role"), CASES)
 def test_message_serializer_internal_to_api(type_, role):
-    serializer = MessageSerializer(instance={"type": type_, "message": "hello"})
+    serializer = MessageSerializer(instance=ChatMessage(message_type=type_, content="hello"))
     assert serializer.data == {"role": role, "content": "hello"}

--- a/apps/api/tests/test_message_serializer.py
+++ b/apps/api/tests/test_message_serializer.py
@@ -1,4 +1,6 @@
 import pytest
+from django.utils import timezone
+from freezegun import freeze_time
 
 from apps.api.serializers import MessageSerializer
 from apps.chat.models import ChatMessage, ChatMessageType
@@ -14,6 +16,15 @@ def test_message_serializer_api_to_internal(type_, role):
 
 
 @pytest.mark.parametrize(("type_", "role"), CASES)
+@freeze_time("2021-01-01T12:00:00Z")
 def test_message_serializer_internal_to_api(type_, role):
-    serializer = MessageSerializer(instance=ChatMessage(message_type=type_, content="hello"))
-    assert serializer.data == {"role": role, "content": "hello", "metadata": {}, "tags": [], "attachments": []}
+    now = timezone.now()
+    serializer = MessageSerializer(instance=ChatMessage(created_at=now, message_type=type_, content="hello"))
+    assert serializer.data == {
+        "created_at": "2021-01-01T12:00:00Z",
+        "role": role,
+        "content": "hello",
+        "metadata": {},
+        "tags": [],
+        "attachments": [],
+    }

--- a/apps/api/tests/test_session_api.py
+++ b/apps/api/tests/test_session_api.py
@@ -69,11 +69,11 @@ def test_retrieve_session(session):
     assert response.json() == get_session_json(
         session,
         expected_messages=[
-            {"role": "assistant", "content": "hi"},
-            {"role": "user", "content": "hello"},
-            {"role": "assistant", "content": "magic"},
-            {"role": "system", "content": "Abracadabra"},
-            {"role": "user", "content": "rabbit in a hat"},
+            {"role": "assistant", "content": "hi", "metadata": {}},
+            {"role": "user", "content": "hello", "metadata": {}},
+            {"role": "assistant", "content": "magic", "metadata": {}},
+            {"role": "system", "content": "Abracadabra", "metadata": {"is_summary": True}},
+            {"role": "user", "content": "rabbit in a hat", "metadata": {}},
         ],
     )
 

--- a/apps/api/tests/test_session_api.py
+++ b/apps/api/tests/test_session_api.py
@@ -79,11 +79,24 @@ def test_retrieve_session(session):
     client = ApiTestClient(user, session.team)
     response = client.get(reverse("api:session-detail", kwargs={"id": session.external_id}))
     assert response.status_code == 200
-    assert response.json() == get_session_json(
+    response_json = response.json()
+
+    for message in response_json.get("messages", []):
+        message["created_at"] = "fake date"
+
+    assert response_json == get_session_json(
         session,
         expected_messages=[
-            {"role": "assistant", "content": "hi", "metadata": {}, "tags": [], "attachments": []},
             {
+                "created_at": "fake date",
+                "role": "assistant",
+                "content": "hi",
+                "metadata": {},
+                "tags": [],
+                "attachments": [],
+            },
+            {
+                "created_at": "fake date",
                 "role": "user",
                 "content": "hello",
                 "metadata": {},
@@ -104,6 +117,7 @@ def test_retrieve_session(session):
                 ],
             },
             {
+                "created_at": "fake date",
                 "role": "system",
                 "content": "Abracadabra",
                 "metadata": {"is_summary": True},
@@ -111,6 +125,7 @@ def test_retrieve_session(session):
                 "attachments": [],
             },
             {
+                "created_at": "fake date",
                 "role": "user",
                 "content": "rabbit in a hat",
                 "metadata": {},

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -12,5 +12,6 @@ router.register(r"sessions", views.ExperimentSessionViewSet, basename="session")
 urlpatterns = [
     path("participants/", views.update_participant_data, name="update-participant-data"),
     path("openai/<str:experiment_id>/chat/completions", openai.chat_completions, name="openai-chat-completions"),
+    path("files/<int:pk>/content", views.file_content_view, name="file-content"),
     path("", include(router.urls)),
 ]

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -6,8 +6,9 @@ from django.shortcuts import get_object_or_404
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import filters, mixins, status
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.exceptions import NotFound
+from rest_framework.renderers import BaseRenderer
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
@@ -262,8 +263,14 @@ class ExperimentSessionViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
         return Response(output, status=status.HTTP_201_CREATED, headers=headers)
 
 
-@extend_schema(responses=bytes)
+class BinaryRenderer(BaseRenderer):
+    media_type = "application/octet-stream"
+    format = "bin"
+
+
+@extend_schema(operation_id="file_content", summary="Download File Content", tags=["Files"], responses=bytes)
 @api_view(["GET"])
+@renderer_classes([BinaryRenderer])
 @permission_required("files.view_file")
 def file_content_view(request, pk: int):
     file = get_object_or_404(File, id=pk, team=request.team)

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -1,3 +1,5 @@
+import textwrap
+
 from django.contrib.auth.decorators import permission_required
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
@@ -223,6 +225,12 @@ def _create_update_schedules(team, experiment, participant, schedule_data):
                 description="ID of the session",
             ),
         ],
+        description=textwrap.dedent(
+            """
+            Retrieve the details of an session. This includes the messages exchanged during the session ordered
+            by the creation date.
+            """
+        ),
     ),
     create=extend_schema(
         operation_id="session_create",

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -211,6 +211,7 @@ def _create_update_schedules(team, experiment, participant, schedule_data):
         operation_id="session_retrieve",
         summary="Retrieve Experiment Session",
         tags=["Experiment Sessions"],
+        responses=ExperimentSessionSerializer(include_messages=True),
         parameters=[
             OpenApiParameter(
                 name="id",
@@ -235,6 +236,15 @@ class ExperimentSessionViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
     ordering = ["-created_at"]
     lookup_field = "external_id"
     lookup_url_kwarg = "id"
+
+    def get_serializer(self, *args, **kwargs):
+        action = getattr(self, "action")
+        if action == "retrieve":
+            kwargs["include_messages"] = True
+
+        serializer_class = self.get_serializer_class()
+        kwargs.setdefault("context", self.get_serializer_context())
+        return serializer_class(*args, **kwargs)
 
     def get_queryset(self):
         return ExperimentSession.objects.filter(team__slug=self.request.team.slug).all()

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -240,6 +240,8 @@ class ExperimentSessionViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
         return ExperimentSession.objects.filter(team__slug=self.request.team.slug).all()
 
     def create(self, request, *args, **kwargs):
+        # Custom create method because we use a different serializer processing the request than for
+        # generating the response
         serializer = ExperimentSessionCreateSerializer(data=request.data, context=self.get_serializer_context())
         serializer.is_valid(raise_exception=True)
         serializer.save()

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -117,7 +117,7 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
         return ChatMessage(
             created_at=message.created_at,
             message_type=ChatMessageType.SYSTEM,
-            content=message.content,
+            content=message.summary,
             metadata={"is_summary": True},
         )
 

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -62,6 +62,14 @@ class ChatMessageType(models.TextChoices):
             if choice[0] != ChatMessageType.SYSTEM
         )
 
+    @staticmethod
+    def from_role(role: str):
+        return {
+            "user": ChatMessageType.HUMAN,
+            "assistant": ChatMessageType.AI,
+            "system": ChatMessageType.SYSTEM,
+        }[role]
+
     @property
     def role(self):
         return {
@@ -98,10 +106,6 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
     @property
     def created_at_datetime(self):
         return quote(self.created_at.isoformat())
-
-    @property
-    def role(self):
-        return ChatMessageType(self.message_type).role
 
     def to_langchain_dict(self) -> dict:
         return self._get_langchain_dict(self.content, self.message_type)

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -62,6 +62,14 @@ class ChatMessageType(models.TextChoices):
             if choice[0] != ChatMessageType.SYSTEM
         )
 
+    @property
+    def role(self):
+        return {
+            ChatMessageType.HUMAN: "user",
+            ChatMessageType.AI: "assistant",
+            ChatMessageType.SYSTEM: "system",
+        }[self]
+
 
 class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
     """
@@ -90,6 +98,10 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
     @property
     def created_at_datetime(self):
         return quote(self.created_at.isoformat())
+
+    @property
+    def role(self):
+        return ChatMessageType(self.message_type).role
 
     def to_langchain_dict(self) -> dict:
         return self._get_langchain_dict(self.content, self.message_type)

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -89,6 +89,11 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
     A message in a chat. Analogous to the BaseMessage class in langchain.
     """
 
+    # Metadata keys that should be excluded from the API response
+    INTERNAL_METADATA_KEYS = {
+        "openai_file_ids",
+    }
+
     chat = models.ForeignKey(Chat, on_delete=models.CASCADE, related_name="messages")
     message_type = models.CharField(max_length=10, choices=ChatMessageType.choices)
     content = models.TextField()
@@ -104,7 +109,7 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
     def make_summary_message(cls, content):
         """A 'summary message' is a special message only ever exists in memory. It is
         not saved to the database. It is used to represent the summary of a chat up to a certain point."""
-        return ChatMessage(message_type=ChatMessageType.SYSTEM, content=content, metadata={"summary": True})
+        return ChatMessage(message_type=ChatMessageType.SYSTEM, content=content, metadata={"is_summary": True})
 
     def save(self, *args, **kwargs):
         if self.is_summary:
@@ -126,7 +131,7 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
 
     @property
     def is_summary(self):
-        return self.metadata.get("summary", False)
+        return self.metadata.get("is_summary", False)
 
     @property
     def created_at_datetime(self):

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -111,10 +111,15 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
         ordering = ["created_at"]
 
     @classmethod
-    def make_summary_message(cls, content):
+    def make_summary_message(cls, message):
         """A 'summary message' is a special message only ever exists in memory. It is
         not saved to the database. It is used to represent the summary of a chat up to a certain point."""
-        return ChatMessage(message_type=ChatMessageType.SYSTEM, content=content, metadata={"is_summary": True})
+        return ChatMessage(
+            created_at=message.created_at,
+            message_type=ChatMessageType.SYSTEM,
+            content=message.content,
+            metadata={"is_summary": True},
+        )
 
     def save(self, *args, **kwargs):
         if self.is_summary:
@@ -124,7 +129,7 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
     def get_summary_message(self):
         if not self.summary:
             raise ValueError("Message does not have a summary")
-        return ChatMessage.make_summary_message(self.summary)
+        return ChatMessage.make_summary_message(self)
 
     @property
     def is_ai_message(self):

--- a/apps/chat/tests/test_chat.py
+++ b/apps/chat/tests/test_chat.py
@@ -48,6 +48,9 @@ def test_chat_message_to_langchain_dict():
 def test_chat_message_summary_to_langchain_dict():
     chat = Chat()
     message = ChatMessage(chat=chat, content="Hello", message_type=ChatMessageType.HUMAN, summary="Summary")
+    summary_message = message.get_summary_message()
+    assert summary_message.is_summary
+
     expected_dict = {
         "type": ChatMessageType.SYSTEM,
         "data": {
@@ -57,4 +60,4 @@ def test_chat_message_summary_to_langchain_dict():
             },
         },
     }
-    assert message.summary_to_langchain_dict() == expected_dict
+    assert summary_message.to_langchain_dict() == expected_dict


### PR DESCRIPTION
Resolves https://github.com/dimagi/open-chat-studio/issues/637

## Description
Update the `session_retrieve` API endpoint to include the session messages. The serialized message format is as follows:

```
{
  "created_at": "a date",
  "role": "assistant|user|system",
  "content": "text",
  "tags": ["tag1", "tag2"],
  "attachments": [
    {"content-type": "", "name": "", "size": 123, "url": "..."}
  ],
  "metadata": {}
}
```

### Docs
Docs included as part of the PR (API schema changes).