### PR TITLE
Don't error when compressing long histories

### DIFF
--- a/apps/chat/conversation.py
+++ b/apps/chat/conversation.py
@@ -189,6 +189,8 @@ def compress_chat_history_from_messages(
 
 
 def _get_new_summary(llm, pruned_memory, summary, max_token_limit):
+    """Get a new summary from the pruned memory. If the prune memory is still too long, prune it further and
+    recursively call this function with the remaining memory."""
     tokens, context = _get_summary_tokens_with_context(llm, summary, pruned_memory)
     next_batch = []
     while tokens > max_token_limit:

--- a/apps/chat/conversation.py
+++ b/apps/chat/conversation.py
@@ -173,7 +173,7 @@ def compress_chat_history_from_messages(
             pruned_memory.append(history.pop(0))
             history_tokens = llm.get_num_tokens_from_messages(history)
 
-        summary = _get_new_summary(llm, pruned_memory, summary)
+        summary = _get_new_summary(llm, pruned_memory, summary, max_token_limit)
         summary_tokens = llm.get_num_tokens_from_messages([SystemMessage(content=summary)])
 
     log.info(
@@ -188,8 +188,19 @@ def compress_chat_history_from_messages(
     return history, last_message, summary
 
 
-def _get_new_summary(llm, pruned_memory, summary):
+def _get_new_summary(llm, pruned_memory, summary, max_token_limit):
     new_lines = get_buffer_string(pruned_memory)
+    context = {"summary": summary or "", "new_lines": new_lines}
+    tokens = llm.get_num_tokens(SUMMARY_PROMPT.format(**context))
+    if tokens > max_token_limit:
+        # divide the pruned memory in half and try again
+        # do this recursively until we are below the token limit
+        half_index = len(pruned_memory) // 2
+        first_batch, second_batch = pruned_memory[:half_index], pruned_memory[half_index:]
+        summary = _get_new_summary(llm, first_batch, summary, max_token_limit)
+        summary = _get_new_summary(llm, second_batch, summary, max_token_limit)
+        return summary
+
     chain = LLMChain(llm=llm, prompt=SUMMARY_PROMPT, name="compress_chat_history")
-    summary = chain.invoke({"summary": summary, "new_lines": new_lines})["text"]
+    summary = chain.invoke(context)["text"]
     return summary

--- a/apps/chat/tests/test_compress_chat_history.py
+++ b/apps/chat/tests/test_compress_chat_history.py
@@ -25,9 +25,7 @@ def _patch_initial_tokens():
 
 @pytest.fixture()
 def chat(team_with_users):
-    chat = Chat.objects.create(team=team_with_users)
-    ChatMessage.objects.create(chat=chat, content="Hello", message_type=ChatMessageType.HUMAN)
-    return chat
+    return Chat.objects.create(team=team_with_users)
 
 
 def test_compress_history_no_need_for_compression(chat):


### PR DESCRIPTION
## Description
When sessions are populated via the API we may end up in a situation where the 'pruned history' is over the token limit and results in an error while generating the summary.

To handle this we split the history up into batches and compute a summary for each batch in turn using the summary from the previous batch.

First 3 commits are test refactors. Actual change is in the last two commits: https://github.com/dimagi/open-chat-studio/pull/656/files/fd9dc4a2e88a571b38bdc9df9ef56cc37911441c..60591be87064a015e0114c7ee03059925e201abd

## User Impact
None

### Demo
Check out the unit test.

### Docs
N/A
