### PR TITLE
display schedules in participant data view

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -825,9 +825,6 @@ class ExperimentSession(BaseTeamModel):
             if not fail_silently:
                 raise e
 
-    def get_participant_scheduled_messages(self, as_dict=False, as_timezone: str | None = None):
-        return self.participant.get_schedules_for_experiment(self.experiment, as_dict=as_dict, as_timezone=as_timezone)
-
     @cached_property
     def participant_data_from_experiment(self) -> dict:
         try:
@@ -847,7 +844,7 @@ class ExperimentSession(BaseTeamModel):
         if use_participant_tz:
             as_timezone = self.get_participant_timezone()
 
-        scheduled_messages = self.get_participant_scheduled_messages(as_timezone=as_timezone)
+        scheduled_messages = self.participant.get_schedules_for_experiment(self.experiment, as_timezone=as_timezone)
         if scheduled_messages:
             participant_data = {**participant_data, "scheduled_messages": scheduled_messages}
         return participant_data

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import uuid
 from datetime import datetime
@@ -852,10 +851,3 @@ class ExperimentSession(BaseTeamModel):
         if scheduled_messages:
             participant_data = {**participant_data, "scheduled_messages": scheduled_messages}
         return participant_data
-
-    def get_participant_data_json(self):
-        participant_data = self.participant_data_from_experiment
-        scheduled_messages = self.get_participant_scheduled_messages(as_dict=True)
-        if scheduled_messages:
-            participant_data = {**participant_data, "scheduled_messages": scheduled_messages}
-        return json.dumps(participant_data, indent=2)

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -102,23 +102,24 @@ class TestExperimentSession:
     @freeze_time("2024-01-01")
     def test_get_participant_scheduled_messages(self):
         session = ExperimentSessionFactory()
-        event_action, params = self._construct_event_action(
-            time_period=TimePeriod.DAYS, experiment_id=session.experiment.id
-        )
+        experiment = session.experiment
+        event_action, params = self._construct_event_action(time_period=TimePeriod.DAYS, experiment_id=experiment.id)
+        participant = session.participant
         message1 = ScheduledMessageFactory(
-            experiment=session.experiment,
+            experiment=experiment,
             team=session.team,
-            participant=session.participant,
+            participant=participant,
             action=event_action,
         )
         message2 = ScheduledMessageFactory(
-            experiment=session.experiment,
+            experiment=experiment,
             team=session.team,
-            participant=session.participant,
+            participant=participant,
             custom_schedule_params=params,
             action=None,
         )
-        assert len(session.get_participant_scheduled_messages()) == 2
+
+        assert len(participant.get_schedules_for_experiment(experiment)) == 2
         str_version1 = (
             f"{message1.name} (ID={message1.external_id}, message={message1.prompt_text}): Every 1 days on Tuesday, "
             "1 times. Next trigger is at Tuesday, 02 January 2024 00:00:00 UTC. (System)"
@@ -128,7 +129,7 @@ class TestExperimentSession:
             "1 times. Next trigger is at Tuesday, 02 January 2024 00:00:00 UTC. "
         )
 
-        scheduled_messages_str = session.get_participant_scheduled_messages()
+        scheduled_messages_str = participant.get_schedules_for_experiment(experiment)
         assert str_version1 in scheduled_messages_str
         assert str_version2 in scheduled_messages_str
 
@@ -150,7 +151,7 @@ class TestExperimentSession:
                 "next_trigger_date": "2024-01-02T00:00:00+00:00",
             },
         ]
-        assert session.get_participant_scheduled_messages(as_dict=True) == expected_dict_version
+        assert participant.get_schedules_for_experiment(experiment, as_dict=True) == expected_dict_version
 
     @pytest.mark.django_db()
     def test_get_participant_scheduled_messages_includes_child_experiments(self):
@@ -165,8 +166,8 @@ class TestExperimentSession:
         ScheduledMessageFactory(experiment=session2.experiment, team=team, participant=participant, action=event_action)
         ExperimentRoute.objects.create(team=team, parent=session.experiment, child=session2.experiment, keyword="test")
 
-        assert len(session2.get_participant_scheduled_messages()) == 1
-        assert len(session.get_participant_scheduled_messages()) == 2
+        assert len(participant.get_schedules_for_experiment(session2.experiment)) == 1
+        assert len(participant.get_schedules_for_experiment(session.experiment)) == 2
 
     @pytest.mark.django_db()
     @pytest.mark.parametrize("use_custom_experiment", [False, True])

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -104,5 +104,9 @@ class ExperimentData(LoginAndTeamRequiredMixin, TemplateView, PermissionRequired
         context["participant"] = participant
         context["experiment"] = experiment
         context["sessions"] = participant.experimentsession_set.filter(experiment=experiment).all()
-        context["participant_data"] = json.dumps(participant.get_data_for_experiment(experiment), indent=4)
+        data = participant.get_data_for_experiment(experiment)
+        schedules = participant.get_schedules_for_experiment(experiment)
+        if schedules:
+            data["schedules"] = schedules
+        context["participant_data"] = json.dumps(data, indent=4)
         return context

--- a/apps/utils/factories/experiment.py
+++ b/apps/utils/factories/experiment.py
@@ -88,5 +88,7 @@ class ExperimentSessionFactory(factory.django.DjangoModelFactory):
     experiment = factory.SubFactory(ExperimentFactory)
     team = factory.LazyAttribute(lambda obj: obj.experiment.team)
     chat = factory.SubFactory(ChatFactory)
-    participant = factory.SubFactory(ParticipantFactory)
-    experiment_channel = factory.SubFactory("apps.utils.factories.channels.ExperimentChannelFactory")
+    participant = factory.SubFactory(ParticipantFactory, team=factory.SelfAttribute("..team"))
+    experiment_channel = factory.SubFactory(
+        "apps.utils.factories.channels.ExperimentChannelFactory", team=factory.SelfAttribute("..team")
+    )


### PR DESCRIPTION
## Description
Add the list of schedules to the participant data view.

## User Impact
Shows the list of schedules in the participant data tab when viewing a participant.

### Demo
![image](https://github.com/user-attachments/assets/c73bbb2d-2efd-45b7-a5e4-48e45545b16a)

@SmittieC @stephherbers do you think this should be here or in a new tab. One issue is that they should not be editable so perhaps a new tab is better?

### Docs
<!--Link to documentation that has been updated.-->
