### PR TITLE
sync messages to OpenAI threads

### DIFF
--- a/apps/service_providers/llm_service/state.py
+++ b/apps/service_providers/llm_service/state.py
@@ -1,6 +1,5 @@
 from abc import ABCMeta, abstractmethod
 from functools import cache, cached_property
-from typing import Any
 
 from django.utils import timezone
 from langchain_core.callbacks import BaseCallbackHandler
@@ -244,9 +243,10 @@ class AssistantExperimentState(ExperimentState, AssistantState):
         chat message metadata.
         Example resource_file_mapping: {"resource1": ["file1", "file2"], "resource2": ["file3", "file4"]}
         """
-        metadata: dict[str, Any] = {"openai_file_ids": annotation_file_ids} if annotation_file_ids else {}
-        if type_ == ChatMessageType.HUMAN:
-            metadata["openai_thread_checkpoint"] = True
+        metadata = {"openai_thread_checkpoint": True}
+        if annotation_file_ids:
+            metadata["openai_file_ids"] = annotation_file_ids
+
         chat_message = ChatMessage.objects.create(
             chat=self.session.chat,
             message_type=type_.value,

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -31,7 +31,7 @@ from apps.utils.langchain import mock_experiment_llm
 ASSISTANT_ID = "test_assistant_id"
 
 
-@pytest.fixture(params=[True, False])
+@pytest.fixture(params=[True, False], ids=["with_tools", "without_tools"])
 def session(request):
     chat = Chat()
     chat.save = lambda: None
@@ -46,7 +46,7 @@ def session(request):
     return session
 
 
-@pytest.fixture(params=[True, False])
+@pytest.fixture(params=[True, False], ids=["with_tools", "without_tools"])
 def db_session(request):
     local_assistant = OpenAiAssistantFactory(
         id=1, assistant_id=ASSISTANT_ID, tools=list(TOOL_CLASS_MAP.keys()) if request.param else []

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -57,6 +57,10 @@ def db_session(request):
     return session
 
 
+@patch(
+    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    Mock(return_value=[]),
+)
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
 @patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._save_response_annotations")
@@ -86,6 +90,10 @@ def test_assistant_conversation_new_chat(
     assert chat.get_metadata(chat.MetadataKeys.OPENAI_THREAD_ID) == thread_id
 
 
+@patch(
+    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    Mock(return_value=[]),
+)
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
 @patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._save_response_annotations")
@@ -115,6 +123,10 @@ def test_assistant_conversation_existing_chat(
     assert result.output == "ai response"
 
 
+@patch(
+    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    Mock(return_value=[]),
+)
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
 @patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._save_response_annotations")
@@ -147,6 +159,10 @@ def test_assistant_conversation_input_formatting(
 
 
 @pytest.mark.django_db()
+@patch(
+    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    Mock(return_value=[]),
+)
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_file_type_info")
 @patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._save_response_annotations")
 @patch("openai.resources.beta.threads.messages.Messages.list")
@@ -180,6 +196,10 @@ def test_assistant_includes_file_type_information(
     assert create_and_run.call_args.kwargs["instructions"] == expected_instructions
 
 
+@patch(
+    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    Mock(return_value=[]),
+)
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
 def test_assistant_runnable_raises_error(session):
@@ -192,6 +212,10 @@ def test_assistant_runnable_raises_error(session):
             assistant_runnable.invoke("test")
 
 
+@patch(
+    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    Mock(return_value=[]),
+)
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
 def test_assistant_runnable_handles_cancellation_status(session):
@@ -237,6 +261,10 @@ def test_assistant_runnable_handles_cancellation_status(session):
             None,
         ),
     ],
+)
+@patch(
+    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    Mock(return_value=[]),
 )
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())


### PR DESCRIPTION
Resolves #658

## Description
Make sure that the OpenAI thread has the same messages on OCS. This is important in a multi-bot setup where some but not all the bots are Assistants. When control passes to a non-assistant bot the OpenAI thread will not get updated so we need to add missing messages when control passes back to the assistant bot.

## User Impact
Improved performance when using Assistants in multi-bot configurations.

### Docs
NA
