### PR TITLE
tool updates

### DIFF
--- a/apps/chat/agent/schemas.py
+++ b/apps/chat/agent/schemas.py
@@ -5,6 +5,10 @@ from pydantic import BaseModel, Field
 
 from apps.events.models import TimePeriod
 
+REMINDER_MESSAGE_HELP_TEXT = (
+    "What the reminder is about. This will be used to generate the reminder message for the user."
+)
+
 
 class WeekdaysEnum(int, Enum):
     MONDAY = 1
@@ -12,31 +16,31 @@ class WeekdaysEnum(int, Enum):
     WEDNESDAY = 3
     THURSDAY = 4
     FRIDAY = 5
-    SATERDAY = 6
+    SATURDAY = 6
     SUNDAY = 7
 
 
 class RecurringReminderSchema(BaseModel):
-    datetime_due: datetime = Field(description="the first (or only) reminder start date in ISO 8601 format")
-    every: int = Field(description="Number of periods to wait between reminders")
-    period: TimePeriod = Field(description="The time period between reminders")
-    datetime_end: datetime | None = Field(description="the date of the last reminder in ISO 8601 format", default=None)
-    message: str = Field(description="The reminder message")
+    datetime_due: datetime = Field(description="The first (or only) reminder start date in ISO 8601 format")
+    every: int = Field(description="Number of 'periods' to wait between reminders")
+    period: TimePeriod = Field(description="The time period used in conjunction with 'every'")
+    datetime_end: datetime | None = Field(description="The date of the last reminder in ISO 8601 format", default=None)
+    message: str = Field(description=REMINDER_MESSAGE_HELP_TEXT)
     repetitions: str | None = Field(description="The number of repetitions", default=None)
 
 
 class OneOffReminderSchema(BaseModel):
-    datetime_due: datetime = Field(description="the datetime that the reminder is due in ISO 8601 format")
-    message: str = Field(description="The reminder message")
+    datetime_due: datetime = Field(description="The datetime that the reminder is due in ISO 8601 format")
+    message: str = Field(description=REMINDER_MESSAGE_HELP_TEXT)
 
 
 class DeleteReminderSchema(BaseModel):
-    message_id: str = Field(description="the id of the scheduled message")
+    message_id: str = Field(description="The ID of the scheduled message to delete")
 
 
 class ScheduledMessageSchema(BaseModel):
-    message_id: str = Field(description="the id of the scheduled message")
-    weekday: WeekdaysEnum = Field(description="The day of the week")
-    hour: int = Field(description="The hour of the day, in UTC")
-    minute: int = Field(description="The minute of the hour")
-    specified_date: datetime | None = Field(description="True if the user specifies a date", default=None)
+    message_id: str = Field(description="The UD of the scheduled message to update")
+    weekday: WeekdaysEnum = Field(description="The new day of the week")
+    hour: int = Field(description="The new hour of the day, in UTC")
+    minute: int = Field(description="The new minute of the hour")
+    specified_date: datetime | None = Field(description="True if the user requested a specific date", default=None)

--- a/apps/chat/agent/schemas.py
+++ b/apps/chat/agent/schemas.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -44,3 +45,8 @@ class ScheduledMessageSchema(BaseModel):
     hour: int = Field(description="The new hour of the day, in UTC")
     minute: int = Field(description="The new minute of the hour")
     specified_date: datetime | None = Field(description="True if the user requested a specific date", default=None)
+
+
+class UpdateUserDataSchema(BaseModel):
+    key: str = Field(description="The key in the user data to update")
+    value: Any = Field(description="The new value of the user data")

--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -38,7 +38,7 @@ class CustomBaseTool(BaseTool):
 
 class RecurringReminderTool(CustomBaseTool):
     name = AgentTools.RECURRING_REMINDER
-    description = "useful to schedule recurring reminders"
+    description = "Schedule recurring reminders"
     requires_session = True
     args_schema: type[schemas.RecurringReminderSchema] = schemas.RecurringReminderSchema
 
@@ -65,7 +65,7 @@ class RecurringReminderTool(CustomBaseTool):
 
 class OneOffReminderTool(CustomBaseTool):
     name = AgentTools.ONE_OFF_REMINDER
-    description = "useful to schedule one-off reminders"
+    description = "Schedule one-off reminders"
     requires_session = True
     args_schema: type[schemas.OneOffReminderSchema] = schemas.OneOffReminderSchema
 
@@ -81,7 +81,7 @@ class OneOffReminderTool(CustomBaseTool):
 
 class MoveScheduledMessageDateTool(CustomBaseTool):
     name = AgentTools.MOVE_SCHEDULED_MESSAGE_DATE
-    description = "useful to move the day and time that the scheduled message should trigger"
+    description = "Move the day and time that the scheduled message should trigger"
     requires_session = True
     args_schema: type[schemas.ScheduledMessageSchema] = schemas.ScheduledMessageSchema
 
@@ -118,7 +118,7 @@ class MoveScheduledMessageDateTool(CustomBaseTool):
 
 class DeleteReminderTool(CustomBaseTool):
     name = AgentTools.DELETE_REMINDER
-    description = "useful to delete reminders"
+    description = "Delete scheduled reminders"
     requires_session = True
     args_schema: type[schemas.DeleteReminderSchema] = schemas.DeleteReminderSchema
 
@@ -184,7 +184,7 @@ def create_schedule_message(
             return "Success: scheduled message created"
         except Experiment.DoesNotExist:
             return "Experiment does not exist! Could not create scheduled message"
-    logging.exception(f"Could not create one-off reminder. Form erros: {form.errors}")
+    logging.exception(f"Could not create one-off reminder. Form errors: {form.errors}")
     return "Could not create scheduled message"
 
 

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -273,6 +273,7 @@ class AgentTools(models.TextChoices):
     ONE_OFF_REMINDER = "one-off-reminder", gettext("One-off Reminder")
     DELETE_REMINDER = "delete-reminder", gettext("Delete Reminder")
     MOVE_SCHEDULED_MESSAGE_DATE = "move-scheduled-message-date", gettext("Move Reminder Date")
+    UPDATE_PARTICIPANT_DATA = "update-user-data", gettext("Update Participant Data")
 
 
 @audit_fields(*model_audit_fields.EXPERIMENT_FIELDS, audit_special_queryset_writes=True)

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -585,6 +585,7 @@ class Participant(BaseTeamModel):
                 scheduled_messages.append(
                     {
                         "name": message.name,
+                        "prompt": message.prompt_text,
                         "external_id": message.external_id,
                         "frequency": message.frequency,
                         "time_period": message.time_period,

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -94,7 +94,7 @@ class TestExperimentSession:
             "time_period": time_period,
             "frequency": frequency,
             "repetitions": repetitions,
-            "prompt_text": "",
+            "prompt_text": "hi",
             "experiment_id": experiment_id,
         }
         return EventActionFactory(params=params, action_type=EventActionType.SCHEDULETRIGGER), params
@@ -146,6 +146,7 @@ class TestExperimentSession:
                 "last_triggered_at": None,
                 "total_triggers": 0,
                 "triggers_remaining": 1,
+                "prompt": "hi",
             },
             {
                 "name": "Test",
@@ -158,6 +159,7 @@ class TestExperimentSession:
                 "last_triggered_at": None,
                 "total_triggers": 0,
                 "triggers_remaining": 1,
+                "prompt": "hi",
             },
         ]
         assert participant.get_schedules_for_experiment(experiment, as_dict=True) == expected_dict_version

--- a/apps/experiments/tests/test_views.py
+++ b/apps/experiments/tests/test_views.py
@@ -100,24 +100,25 @@ def test_experiment_form_with_assistants(
 
 
 @pytest.mark.parametrize(
-    ("source_material", "prompt_str", "expectation"),
+    ("tools", "source_material", "prompt_str", "expectation"),
     [
-        (None, "You're an assistant", does_not_raise()),
-        ("something", "You're an assistant", does_not_raise()),
-        ("something", "Answer questions from this source: {source_material}", does_not_raise()),
-        (None, "Answer questions from this source: {source_material}", pytest.raises(ValidationError)),
-        (None, "Answer questions from this source: {bob}", pytest.raises(ValidationError)),
-        ("something", "Answer questions from this source: {bob}", pytest.raises(ValidationError)),
-        ("something", "Source material: {source_material} and {source_material}", pytest.raises(ValidationError)),
+        (None, None, "You're an assistant", does_not_raise()),
+        (None, "something", "You're an assistant", does_not_raise()),
+        (None, "something", "Answer questions from this source: {source_material}", does_not_raise()),
+        (None, None, "Answer questions from this source: {source_material}", pytest.raises(ValidationError)),
+        (None, None, "Answer questions from this source: {bob}", pytest.raises(ValidationError)),
+        (None, "something", "Answer questions from this source: {bob}", pytest.raises(ValidationError)),
+        (None, "something", "Source material: {source_material} and {source_material}", pytest.raises(ValidationError)),
+        ("ToolA", None, "", pytest.raises(ValidationError)),
+        ("ToolA", None, "{current_datetime}", pytest.raises(ValidationError)),
+        ("ToolA", None, "{participant_data}", pytest.raises(ValidationError)),
+        ("ToolA", None, "{current_datetime} {participant_data}", does_not_raise()),
     ],
 )
-def test_prompt_variable_validation(source_material, prompt_str, expectation):
+def test_prompt_variable_validation(tools, source_material, prompt_str, expectation):
     with expectation:
         validate_prompt_variables(
-            {
-                "source_material": source_material,
-                "prompt_text": prompt_str,
-            },
+            {"source_material": source_material, "prompt_text": prompt_str, "tools": tools},
             prompt_key="prompt_text",
             known_vars={"source_material", "participant_data", "current_datetime"},
         )

--- a/apps/experiments/tests/test_views.py
+++ b/apps/experiments/tests/test_views.py
@@ -43,7 +43,7 @@ def test_create_experiment_success(client, team_with_users):
         "name": "some name",
         "description": "Some description",
         "type": "llm",
-        "prompt_text": "You are a helpful assistant. The current date time is {current_datetime}",
+        "prompt_text": "You are a helpful assistant. The current date time is {current_datetime}. {participant_data}",
         "source_material": source_material.id if source_material else "",
         "consent_form": consent_form.id,
         "temperature": 0.7,
@@ -55,7 +55,7 @@ def test_create_experiment_success(client, team_with_users):
     }
 
     response = client.post(reverse("experiments:new", args=[team_with_users.slug]), data=post_data)
-    assert response.status_code == 302, response.context.form.errors
+    assert response.status_code == 302, response.context["form"].errors
     experiment = Experiment.objects.filter(owner=user).first()
     assert experiment is not None
     experiment.tools == [AgentTools.ONE_OFF_REMINDER]

--- a/templates/participants/partials/experiment_data.html
+++ b/templates/participants/partials/experiment_data.html
@@ -13,65 +13,70 @@
       </div>
       <input type="radio" name="experiment_tabs-{{ experiment.id }}" role="tab" class="tab" aria-label="Schedules"/>
       <div role="tabpanel" class="tab-content">
-        <div class="mt-3 p-3 border rounded-lg border-neutral-500">
+        <div class="mt-3 border rounded-lg border-neutral-500 divide-y divide-neutral-500">
           {% for schedule in participant_schedules %}
             <div class="mb-3">
-              <h3 class="text-lg font-semibold">{{ schedule.name }}</h3>
-              {% if schedule.repetitions %}
-                <p class="text-sm text-neutral-600">
-                  Every {{ schedule.frequency }} {{ schedule.time_period }}, {{ schedule.repetitions }} times
-                  {% if schedule.is_complete %}
-                    (Completed).
-                  {% else %}
-                    ({{ schedule.triggers_remaining }} left).
-                  {% endif %}
-                </p>
-                {% if not schedule.is_complete %}
-                  <p class="text-sm text-neutral-600">
-                    <span class="font-medium">Next due:</span>
-                    <time datetime="{{ schedule.next_trigger_date.isoformat }}"
-                          title="{{ schedule.next_trigger_date.isoformat }}">
-                      {{ schedule.next_trigger_date|date:"DATETIME_FORMAT" }}
-                    </time>
-                  </p>
-                {% endif %}
-                <p class="text-sm text-neutral-600">
-                  <span class="font-medium">Last triggered:</span>
-                  {% if schedule.last_triggered_at %}
-                    <time datetime="{{ schedule.last_triggered_at.isoformat }}"
-                          title="{{ schedule.last_triggered_at.isoformat }}">
-                      {{ schedule.last_triggered_at|date:"DATETIME_FORMAT" }}
-                    </time>
-                  {% else %}
-                    Not yet triggered.
-                  {% endif %}
-                </p>
-              {% else %}
-                <p class="text-sm text-neutral-600">
-                  Once off {% if schedule.is_complete %}(Completed){% endif %}.
-                </p>
-                {% if schedule.is_complete %}
-                  <p class="text-sm text-neutral-600">
-                    <span class="font-medium">Triggered on:</span>
-                    {% if schedule.last_triggered_at %}
-                      <time datetime="{{ schedule.last_triggered_at.isoformat }}"
-                            title="{{ schedule.last_triggered_at.isoformat }}">
-                        {{ schedule.last_triggered_at|date:"DATETIME_FORMAT" }}
-                      </time>
-                    {% else %}
-                      Not yet triggered.
+              <h3 class="text-lg font-semibold px-3 mt-2">{{ schedule.name }}</h3>
+              <div class="grid grid-cols-2 p-3">
+                <div><p>{{ schedule.prompt }}</p></div>
+                <div>
+                  {% if schedule.repetitions %}
+                    <p class="text-sm">
+                      Every {{ schedule.frequency }} {{ schedule.time_period }}, {{ schedule.repetitions }} times
+                      {% if schedule.is_complete %}
+                        (Completed).
+                      {% else %}
+                        ({{ schedule.triggers_remaining }} left).
+                      {% endif %}
+                    </p>
+                    {% if not schedule.is_complete %}
+                      <p class="text-sm">
+                        <span class="font-medium">Next due:</span>
+                        <time datetime="{{ schedule.next_trigger_date.isoformat }}"
+                              title="{{ schedule.next_trigger_date.isoformat }}">
+                          {{ schedule.next_trigger_date|date:"DATETIME_FORMAT" }}
+                        </time>
+                      </p>
                     {% endif %}
-                  </p>
-                {% else %}
-                  <p class="text-sm text-neutral-600">
-                    <span class="font-medium">Due:</span>
-                    <time datetime="{{ schedule.next_trigger_date.isoformat }}"
-                          title="{{ schedule.next_trigger_date.isoformat }}">
-                      {{ schedule.next_trigger_date|date:"DATETIME_FORMAT" }}
-                    </time>
-                  </p>
-                {% endif %}
-              {% endif %}
+                    <p class="text-sm">
+                      <span class="font-medium">Last triggered:</span>
+                      {% if schedule.last_triggered_at %}
+                        <time datetime="{{ schedule.last_triggered_at.isoformat }}"
+                              title="{{ schedule.last_triggered_at.isoformat }}">
+                          {{ schedule.last_triggered_at|date:"DATETIME_FORMAT" }}
+                        </time>
+                      {% else %}
+                        Not yet triggered.
+                      {% endif %}
+                    </p>
+                  {% else %}
+                    <p class="text-sm">
+                      Once off {% if schedule.is_complete %}(Completed){% endif %}.
+                    </p>
+                    {% if schedule.is_complete %}
+                      <p class="text-sm">
+                        <span class="font-medium">Triggered on:</span>
+                        {% if schedule.last_triggered_at %}
+                          <time datetime="{{ schedule.last_triggered_at.isoformat }}"
+                                title="{{ schedule.last_triggered_at.isoformat }}">
+                            {{ schedule.last_triggered_at|date:"DATETIME_FORMAT" }}
+                          </time>
+                        {% else %}
+                          Not yet triggered.
+                        {% endif %}
+                      </p>
+                    {% else %}
+                      <p class="text-sm">
+                        <span class="font-medium">Due:</span>
+                        <time datetime="{{ schedule.next_trigger_date.isoformat }}"
+                              title="{{ schedule.next_trigger_date.isoformat }}">
+                          {{ schedule.next_trigger_date|date:"DATETIME_FORMAT" }}
+                        </time>
+                      </p>
+                    {% endif %}
+                  {% endif %}
+                </div>
+              </div>
             </div>
           {% endfor %}
         </div>


### PR DESCRIPTION
Resolves https://github.com/dimagi/open-chat-studio/issues/657

## Description
Some tool updates:

* Update schedule tool schema wording for some parameters to add clarity
* A new tool allowing bots to update participant data inline.
* Update the participant data schedule view to change the layout and include the prompt text.

## User Impact
Bots can now update participant data during the chat.

## Demo

### Schedule view update
![image](https://github.com/user-attachments/assets/fc855eb3-e602-4c25-a079-106ab2022fd6)

### New tool schema

```json
{
  "type": "function",
  "function": {
    "name": "update-user-data",
    "description": "Update user data",
    "parameters": {
      "properties": {
        "key": {
          "description": "The key in the user data to update",
          "type": "string"
        },
        "value": {
          "description": "The new value of the user data"
        }
      },
      "required": [
        "key",
        "value"
      ],
      "type": "object"
    }
  }
}
```

### Docs
Updated docs here to include the new tool: https://dimagi.atlassian.net/wiki/spaces/OCS/pages/2429550658/Tool+Usage
