### PR TITLE
show api sessions + HTMX table sorting

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -124,11 +124,12 @@ class ExperimentSessionsTableView(SingleTableView, PermissionRequiredMixin):
     permission_required = "annotations.view_customtaggeditem"
 
     def get_queryset(self):
-        query_set = (
-            ExperimentSession.objects.with_last_message_created_at()
-            .filter(team=self.request.team, experiment__id=self.kwargs["experiment_id"])
-            .exclude(experiment_channel__platform=ChannelPlatform.API)
+        query_set = ExperimentSession.objects.with_last_message_created_at().filter(
+            team=self.request.team, experiment__id=self.kwargs["experiment_id"]
         )
+        if not self.request.GET.get("show-all"):
+            query_set = query_set.exclude(experiment_channel__platform=ChannelPlatform.API)
+
         tags_query = self.request.GET.get("tags")
         if tags_query:
             tags = tags_query.split("&")

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -468,7 +468,6 @@ def single_experiment_home(request, team_slug: str, experiment_id: int):
         )
         .exclude(experiment_channel__platform=ChannelPlatform.API)
     )
-    sort = request.GET.get("sort", None)
     channels = experiment.experimentchannel_set.exclude(platform__in=[ChannelPlatform.WEB, ChannelPlatform.API]).all()
     used_platforms = {channel.platform_enum for channel in channels}
     available_platforms = ChannelPlatform.for_dropdown(used_platforms, experiment.team)
@@ -489,10 +488,6 @@ def single_experiment_home(request, team_slug: str, experiment_id: int):
             "platform_forms": platform_forms,
             "channels": channels,
             "available_tags": experiment.team.tag_set.filter(is_system_tag=False),
-            "filter_tags_url": reverse(
-                "experiments:sessions-list", kwargs={"team_slug": team_slug, "experiment_id": experiment.id}
-            ),
-            "sort": sort,
             **_get_events_context(experiment, team_slug),
             **_get_routes_context(experiment, team_slug),
             **_get_terminal_bots_context(experiment, team_slug),

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -212,7 +212,7 @@
                   <div class="form-control ml-2">
                     <label class="label cursor-pointer">
                       <span class="label-text mr-2">Include API Sessions</span>
-                      <input type="checkbox" name="show-all" class="toggle" checked="0"/>
+                      <input type="checkbox" name="show-all" class="toggle" />
                     </label>
                   </div>
                 </div>

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -3,7 +3,7 @@
 {% load team_tags %}
 {% load static %}
 {% load form_tags %}
-{% load render_table from django_tables2 %}
+{% load django_tables2 %}
 {% block breadcrumbs %}
   {% load waffle_tags %}
 
@@ -180,34 +180,37 @@
       <input type="radio" name="tab_group" role="tab" class="tab" aria-label="All Sessions" id="tab-allsessions" checked/>
       <div role="tabpanel" class="tab-content" id="content-allsessions">
         <div class="app-card">
-          <div x-data="{tags: ''}" x-init="$watch('tags', value => filterSessions(value))">
+          <div x-data="{tags: ''}">
             <div class="grid grid-flow-col auto-cols-max gap-x-2">
               {% if perms.experiments.download_chats %}
-                <form method="post" action="{% url 'experiments:download_experiment_chats' team.slug experiment.id %}" class="my-2">
+                <form method="post" action="{% url 'experiments:download_experiment_chats' team.slug experiment.id %}"
+                      class="my-2">
                   {% csrf_token %}
-                  <input name="tags" class="hidden" x-bind:value="tags" />
-                  <input class="btn btn-sm btn-outline btn-primary" type="submit" value="Download All" />
+                  <input name="tags" class="hidden" x-bind:value="tags"/>
+                  <input class="btn btn-sm btn-outline btn-primary" type="submit" value="Download All"/>
                 </form>
               {% endif %}
-              {% if perms.annotations.view_customtaggeditem %}
-                <div class="w-96 my-2">
-                  <select x-model="tags" id="tag-multiselect-filter" name="state[]" multiple placeholder="Filter tags..." autocomplete="off">
-                    <option value="">Filter tags...</option>
-                    {% for tag in available_tags %}
-                      <option value="{{ tag.name }}">{{ tag.name }}</option>
-                    {% endfor %}
-                  </select>
-                </div>
-              {% endif %}
+              <form
+                hx-trigger="load, change"
+                hx-target="#sessions-table"
+                hx-get="{% url 'experiments:sessions-list' request.team.slug experiment.id %}"
+                hx-swap="innerHTML"
+              >
+                {% if perms.annotations.view_customtaggeditem %}
+                  <div class="w-96 my-2">
+                    <select x-model="tags" id="tag-multiselect-filter" name="tags" multiple placeholder="Filter tags..."
+                            autocomplete="off">
+                      <option value="">Filter tags...</option>
+                      {% for tag in available_tags %}
+                        <option value="{{ tag.name }}">{{ tag.name }}</option>
+                      {% endfor %}
+                    </select>
+                  </div>
+                {% endif %}
+              </form>
             </div>
-            <div
-              id="sessions-table"
-              hx-trigger="load, tagFilter"
-              hx-target="this"
-              hx-get="{% url 'experiments:sessions-list' request.team.slug experiment.id %}{% if sort %}?sort={{ sort }}{% endif %}"
-              hx-swap="innerHTML"
-            ></div>
           </div>
+          <div id="sessions-table"></div>
         </div>
       </div>
     {% endif %}
@@ -288,9 +291,8 @@
   </div>
   <script src="{% static 'js/app-bundle.js' %}"></script>
   <script>
-    let url = "{{ filter_tags_url|escapejs }}"
     function filterSessions(tags) {
-      htmx.ajax('GET', url, {target: "#sessions-table", swap: 'innerHTML', values: {"tags": tags.join("&")}});
+      htmx.trigger(htmx.find("#sessions-table"), "tagFilter", {});
     }
 
     let element = document.getElementById('tag-multiselect-filter');

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -228,20 +228,20 @@
     <div role="tabpanel" class="tab-content" id="content-mysessions">
       <div class="app-card">
         <div class="overflow-x-auto">
-          <table class="pg-table">
-            <thead>
+          <table class="w-full table-fixed">
+            <thead class="bg-base-200 base-content uppercase text-sm leading-normal">
               <tr>
-                <th>Started</th>
-                <th>Last Message</th>
-                <th>Actions</th>
+                <th class="px-3 py-3 text-left">Started</th>
+                <th class="px-3 py-3 text-left">Last Message</th>
+                <th class="px-3 py-3 text-left">Actions</th>
               </tr>
             </thead>
             <tbody>
               {% for session in user_sessions %}
-                <tr>
-                  <td>{{ session.created_at }}</td>
-                  <td>{{ session.last_message_created_at }}</td>
-                  <td>
+                <tr class="text-sm">
+                  <td class="overflow-hidden px-3 py-3 text-left">{{ session.created_at }}</td>
+                  <td class="overflow-hidden px-3 py-3 text-left">{{ session.last_message_created_at }}</td>
+                  <td class="overflow-hidden px-3 py-3 text-left">
                     {% if session.is_complete %}
                       <a class="btn btn-sm btn-outline btn-primary"
                          href="{% url 'experiments:experiment_session_view' team.slug experiment.public_id session.external_id %}"

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -196,17 +196,26 @@
                 hx-get="{% url 'experiments:sessions-list' request.team.slug experiment.id %}"
                 hx-swap="innerHTML"
               >
-                {% if perms.annotations.view_customtaggeditem %}
-                  <div class="w-96 my-2">
-                    <select x-model="tags" id="tag-multiselect-filter" name="tags" multiple placeholder="Filter tags..."
-                            autocomplete="off">
-                      <option value="">Filter tags...</option>
-                      {% for tag in available_tags %}
-                        <option value="{{ tag.name }}">{{ tag.name }}</option>
-                      {% endfor %}
-                    </select>
+                <div class="flex">
+                  {% if perms.annotations.view_customtaggeditem %}
+                    <div class="w-96 my-2">
+                      <select x-model="tags" id="tag-multiselect-filter" name="tags" multiple
+                              placeholder="Filter tags..."
+                              autocomplete="off">
+                        <option value="">Filter tags...</option>
+                        {% for tag in available_tags %}
+                          <option value="{{ tag.name }}">{{ tag.name }}</option>
+                        {% endfor %}
+                      </select>
+                    </div>
+                  {% endif %}
+                  <div class="form-control ml-2">
+                    <label class="label cursor-pointer">
+                      <span class="label-text mr-2">Include API Sessions</span>
+                      <input type="checkbox" name="show-all" class="toggle" checked="0"/>
+                    </label>
                   </div>
-                {% endif %}
+                </div>
               </form>
             </div>
           </div>

--- a/templates/table/tailwind_js_pagination.html
+++ b/templates/table/tailwind_js_pagination.html
@@ -1,8 +1,30 @@
 {% extends 'table/tailwind.html' %}
 {% load django_tables2 %}
 {% comment %}
-Override pagination in base template to use htmx
+Override pagination and sorting in base template to use htmx
 {% endcomment %}
+
+{% block table.thead %}
+    {% if table.show_header %}
+        <thead {{ table.attrs.thead.as_html }}>
+            <tr>
+                {% for column in table.columns %}
+                    <th {{ column.attrs.th.as_html }} scope="col"
+                        {% if column.orderable %}
+                            hx-get="{{ request.path_info }}{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}"
+                            hx-trigger="click"
+                            hx-target="div.table-container"
+                            hx-swap="outerHTML"
+                            style="cursor: pointer;"
+                        {% endif %}>
+                        {{ column.header }}
+                    </th>
+                {% endfor %}
+            </tr>
+        </thead>
+    {% endif %}
+{% endblock table.thead %}
+
 {% block prev-page-link-attr %}
     hx-get="{{ request.path_info }}{% querystring table.prefixed_page_field=table.page.previous_page_number %}"
     hx-trigger="click"


### PR DESCRIPTION
## Description
Some fixes or session table sorting and filtering as well as adding an option to show API sessions in the session table.

## User Impact
Ability to show API sessions in the session list.

### Demo

<div>
    <a href="https://www.loom.com/share/ba791f40751a4f2d94a88b97a029d9d9">
      <p>Dimagi Chatbots | Experiments with AI, GPT and LLMs - 5 September 2024 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/ba791f40751a4f2d94a88b97a029d9d9">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/ba791f40751a4f2d94a88b97a029d9d9-6e5f8b7c3e91e547-full-play.gif">
    </a>
  </div>

### Docs
<!--Link to documentation that has been updated.-->
