### PR TITLE
handle edge case where existing summary is too large

### DIFF
--- a/apps/chat/conversation.py
+++ b/apps/chat/conversation.py
@@ -201,7 +201,8 @@ def _get_new_summary(llm, pruned_memory, summary, max_token_limit):
 
     if not context["new_lines"]:
         log.error(SUMMARY_TOO_LARGE_ERROR_MESSAGE)
-        return summary
+        # If the summary is too large, discard it and compute a new summary from the pruned memory
+        return _get_new_summary(llm, next_batch, None, max_token_limit)
 
     chain = LLMChain(llm=llm, prompt=SUMMARY_PROMPT, name="compress_chat_history")
     summary = chain.invoke(context)["text"]

--- a/apps/chat/tests/test_compress_chat_history.py
+++ b/apps/chat/tests/test_compress_chat_history.py
@@ -181,9 +181,10 @@ def test_get_new_summary_with_large_summary(caplog):
     pruned_memory = [HumanMessage(f"Hello {i}") for i in range(2)]
 
     prompt_tokens, _ = _get_summary_tokens_with_context(llm, None, [])
-    llm.max_token_limit = prompt_tokens + 5  # set below what we expect when generating the summary
+    llm.max_token_limit = prompt_tokens + 10  # set below what we expect when generating the summary
 
     summary = "Summary " * 20
     new_summary = _get_new_summary(llm, pruned_memory, summary, llm.max_token_limit)
-    assert new_summary == summary
+    assert new_summary == "Summary"
+    assert len(llm.get_calls()) == 1
     assert caplog.record_tuples == [("ocs.bots", logging.ERROR, SUMMARY_TOO_LARGE_ERROR_MESSAGE)]


### PR DESCRIPTION
Fixes [DIMAGI-BOTS-E9](https://dimagi.sentry.io/issues/5801611231/)

## Description
If the existing summary is too large we're unable to compute a new summary. In this case ignore the existing summary and compute the new summary from the remaining history.

## User Impact
This will result in some loss of information in the chat history but it won't error.