### PR TITLE
remove old task

### DIFF
--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -12,8 +12,6 @@ from apps.events.models import ScheduledMessage, TimePeriod
 from apps.experiments.models import AgentTools, Experiment, ExperimentSession, ParticipantData
 from apps.utils.time import pretty_date
 
-BOT_MESSAGE_FOR_USER_TASK = "apps.chat.tasks.send_bot_message_to_users"
-
 
 class CustomBaseTool(BaseTool):
     experiment_session: ExperimentSession | None = None


### PR DESCRIPTION
This was used by the previous reminder tool.

I noticed in Task Badger that this was still being called. Upon further investigation, the periodic tasks are expired however they are still scheduled by the scheduler and then immediately revoked. This resulted in stale tasks in TB. I have removed all the expired periodic tasks so this should not get called anymore.