### PR TITLE
Session API to allow filtering by chat tags

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -198,6 +198,12 @@ paths:
         description: Which field to use when ordering the results.
         schema:
           type: string
+      - in: query
+        name: tags
+        schema:
+          type: string
+        description: A list of session tags (comma separated) to filter the results
+          by
       tags:
       - Experiment Sessions
       security:

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -216,6 +216,14 @@ def _create_update_schedules(team, experiment, participant, schedule_data):
         operation_id="session_list",
         summary="List Experiment Sessions",
         tags=["Experiment Sessions"],
+        parameters=[
+            OpenApiParameter(
+                name="tags",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="A list of session tags (comma separated) to filter the results by",
+            ),
+        ],
     ),
     retrieve=extend_schema(
         operation_id="session_retrieve",

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -263,7 +263,10 @@ class ExperimentSessionViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
         return serializer_class(*args, **kwargs)
 
     def get_queryset(self):
-        return ExperimentSession.objects.filter(team__slug=self.request.team.slug).all()
+        queryset = ExperimentSession.objects.filter(team__slug=self.request.team.slug).all()
+        if tags_query_param := self.request.query_params.get("tags"):
+            queryset = queryset.filter(chat__tags__name__in=tags_query_param.split(","))
+        return queryset
 
     def create(self, request, *args, **kwargs):
         # Custom create method because we use a different serializer processing the request than for


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
resolves https://github.com/dimagi/open-chat-studio/issues/636. We can filter the experiment session list results by passing in a list of tags as the `tags` query parameter. There are a few ways one could handle a list of query params, but I opted to use comma separated values. I find this more intuitive. Suggestions welcome

## User Impact
<!-- Describe the impact of this change on the end-users. -->
The results of the session list API call can be filtered using the newly supported `tags` parameter.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![Peek 2024-09-18 14-01](https://github.com/user-attachments/assets/48799503-c859-4890-9b67-924d588a5ef3)

### Docs
<!--Link to documentation that has been updated.-->
Will update the confluence docs on merge. The API docs are updated as part of this change