### PR TITLE
Fix save button in pipelines

### DIFF
--- a/assets/javascript/apps/pipeline/stores/pipelineManagerStore.ts
+++ b/assets/javascript/apps/pipeline/stores/pipelineManagerStore.ts
@@ -43,6 +43,7 @@ const usePipelineManagerStore = create<PipelineManagerStoreType>((set, get) => (
       apiClient.updatePipeline(get().currentPipelineId!, pipeline)
         .then((updatedFlow) => {
           if (updatedFlow) {
+            set({currentPipeline: pipeline});
             resolve();
           }
         })


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

This fixes the save button from clobbering changes you made since you loaded the page.

We fetch `currentPipeline` from the store to update the `name` parameter, then send that object to the backend to be saved. However, the reference to `currentPipeline` was not kept up to date as the data on the page was changed, so it lead to an issue where clicking the save button would actually just re-save the version of the pipeline you had when the page loaded... i.e it was an "undo" button, and did the exact opposite of what you wanted.