### PR TITLE
Modal widget for text fields

### DIFF
--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -22,6 +22,7 @@ from apps.pipelines.nodes.types import (
     LlmTemperature,
     NumOutputs,
     PipelineJinjaTemplate,
+    Prompt,
     SourceMaterialId,
 )
 from apps.pipelines.tasks import send_email_from_pipeline
@@ -88,7 +89,7 @@ class LLMResponseWithPrompt(LLMResponse):
     __human_name__ = "LLM response with prompt"
 
     source_material_id: SourceMaterialId | None = None
-    prompt: str = "You are a helpful assistant. Answer the user's query as best you can: {input}"
+    prompt: Prompt = "You are a helpful assistant. Answer the user's query as best you can: {input}"
 
     def _process(self, input, state: PipelineState) -> PipelineState:
         prompt = PromptTemplate.from_template(template=self.prompt)
@@ -169,7 +170,7 @@ class RouterNode(Passthrough, LLMResponseMixin):
     __human_name__ = "Router"
     llm_provider_id: LlmProviderId
     llm_model: LlmModel
-    prompt: str = "You are an extremely helpful router {input}"
+    prompt: Prompt = "You are an extremely helpful router {input}"
     num_outputs: NumOutputs = 2
     keywords: Keywords = []
 

--- a/apps/pipelines/nodes/types.py
+++ b/apps/pipelines/nodes/types.py
@@ -1,9 +1,10 @@
 from typing_extensions import TypeAliasType
 
+Keywords = TypeAliasType("Keywords", list)
 LlmProviderId = TypeAliasType("LlmProviderId", int)
 LlmModel = TypeAliasType("LlmModel", str)
 LlmTemperature = TypeAliasType("LlmTemperature", float)
-PipelineJinjaTemplate = TypeAliasType("PipelineJinjaTemplate", str)
-SourceMaterialId = TypeAliasType("SourceMaterialId", int)
 NumOutputs = TypeAliasType("NumOutputs", int)
-Keywords = TypeAliasType("Keywords", list)
+PipelineJinjaTemplate = TypeAliasType("PipelineJinjaTemplate", str)
+Prompt = TypeAliasType("Prompt", str)
+SourceMaterialId = TypeAliasType("SourceMaterialId", int)

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -8,8 +8,8 @@ import {
   KeywordsWidget,
   LlmModelWidget,
   LlmProviderIdWidget,
-  PromptWidget,
   SourceMaterialIdWidget,
+  TextWidget,
 } from "./widgets";
 import { NodeParameterValues } from "./types/nodeParameterValues";
 
@@ -126,6 +126,7 @@ export function PipelineNode({ id, data, selected }: NodeProps<NodeData>) {
           <>
             <div className="m-1 font-medium text-center">Number of Outputs</div>
             <input
+              className="input input-bordered w-full"
               name={inputParam.name}
               onChange={updateParamValue}
               value={params[inputParam.name] || 1}
@@ -159,37 +160,26 @@ export function PipelineNode({ id, data, selected }: NodeProps<NodeData>) {
           </>
         );
       }
-      case "Prompt": {
+      default: {
+        const humanName = inputParam.human_name
+          ? inputParam.human_name
+          : inputParam.name.replace(/_/g, " ");
         return (
           <>
-            <div className="m-1 font-medium text-center">Prompt</div>
-            <PromptWidget
+            <div className="m-1 font-medium text-center capitalize">
+              {humanName}
+            </div>
+            <TextWidget
+              humanName={humanName}
               name={inputParam.name}
               onChange={updateParamValue}
               value={params[inputParam.name] || ""}
-            ></PromptWidget>
+            ></TextWidget>
           </>
         );
       }
-      default:
-        return (
-          <>
-            <div className="m-1 font-medium text-center">
-              {inputParam.human_name
-                ? inputParam.human_name
-                : inputParam.name.replace(/_/g, " ")}
-            </div>
-            <textarea
-              className="textarea textarea-bordered w-full"
-              name={inputParam.name}
-              onChange={updateParamValue}
-              value={params[inputParam.name] || ""}
-            ></textarea>
-          </>
-        );
     }
   };
-
   const getOuputHandles = () => {
     const numberOfOutputs =
       parseInt(

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -8,6 +8,7 @@ import {
   KeywordsWidget,
   LlmModelWidget,
   LlmProviderIdWidget,
+  PromptWidget,
   SourceMaterialIdWidget,
 } from "./widgets";
 import { NodeParameterValues } from "./types/nodeParameterValues";
@@ -69,6 +70,7 @@ export function PipelineNode({ id, data, selected }: NodeProps<NodeData>) {
           <>
             <div className="m-1 font-medium text-center">Temperature</div>
             <input
+              className="input input-bordered w-full"
               name={inputParam.name}
               onChange={updateParamValue}
               value={params[inputParam.name]}
@@ -154,6 +156,18 @@ export function PipelineNode({ id, data, selected }: NodeProps<NodeData>) {
                 ></KeywordsWidget>
               );
             })}
+          </>
+        );
+      }
+      case "Prompt": {
+        return (
+          <>
+            <div className="m-1 font-medium text-center">Prompt</div>
+            <PromptWidget
+              name={inputParam.name}
+              onChange={updateParamValue}
+              value={params[inputParam.name] || ""}
+            ></PromptWidget>
           </>
         );
       }

--- a/assets/javascript/apps/pipeline/widgets.tsx
+++ b/assets/javascript/apps/pipeline/widgets.tsx
@@ -3,12 +3,86 @@ import React, {
   ChangeEventHandler,
   Dispatch,
   SetStateAction,
+  useId,
 } from "react";
 import { InputParam } from "./types/nodeInputTypes";
 import { NodeParameterValues } from "./types/nodeParameterValues";
 import usePipelineStore from "./stores/pipelineStore";
 import { NodeParams } from "./types/nodeParams";
 import { NodeProps } from "reactflow";
+
+export function TextModal({
+  name,
+  value,
+  onChange,
+}: {
+  name: string;
+  value: string | string[];
+  onChange: ChangeEventHandler;
+}) {
+  const modalId = useId();
+  return (
+    <>
+      <dialog id={modalId} className="modal">
+        <div className="modal-box">
+          <form method="dialog">
+            <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+              ✕
+            </button>
+          </form>
+          <h4 className="font-bold text-lg">Edit "{name}"</h4>
+          <textarea
+            className="textarea textarea-bordered textarea-md w-full"
+            name={name}
+            onChange={onChange}
+            value={value}
+          ></textarea>
+          <form method="dialog" className="modal-backdrop">
+            <button className="pg-button-primary mt-2">Save</button>
+          </form>
+        </div>
+        <form method="dialog" className="modal-backdrop">
+          {/* Allows closing the modal by clicking outside of it */}
+          <button>close</button>
+        </form>
+      </dialog>
+      <button
+        className="btn btn-ghost"
+        onClick={() =>
+          (document.getElementById(modalId) as HTMLDialogElement)?.showModal()
+        }
+      >
+        <i className="fa-solid fa-pencil"></i>
+      </button>
+    </>
+  );
+}
+
+export function PromptWidget({
+  name,
+  onChange,
+  value,
+}: {
+  name: string;
+  value: string | string[];
+  onChange: ChangeEventHandler;
+}) {
+  return (
+    <div className="join">
+      <input
+        className="w-full input input-bordered join-item"
+        name={name}
+        onChange={onChange}
+        value={value}
+        type="text"
+        disabled
+      ></input>
+      <div className="join-item">
+        <TextModal name={name} value={value} onChange={onChange}></TextModal>
+      </div>
+    </div>
+  );
+}
 
 export function KeywordsWidget({
   index,

--- a/assets/javascript/apps/pipeline/widgets.tsx
+++ b/assets/javascript/apps/pipeline/widgets.tsx
@@ -12,10 +12,12 @@ import { NodeParams } from "./types/nodeParams";
 import { NodeProps } from "reactflow";
 
 export function TextModal({
+  humanName,
   name,
   value,
   onChange,
 }: {
+  humanName: string;
   name: string;
   value: string | string[];
   onChange: ChangeEventHandler;
@@ -23,23 +25,30 @@ export function TextModal({
   const modalId = useId();
   return (
     <>
-      <dialog id={modalId} className="modal">
-        <div className="modal-box">
+      <dialog
+        id={modalId}
+        className="modal nopan nodelete nodrag noflow nowheel"
+      >
+              <div className="modal-box  min-w-[85vw] h-[80vh] flex flex-col">
           <form method="dialog">
             <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
               ✕
             </button>
           </form>
-          <h4 className="font-bold text-lg">Edit "{name}"</h4>
-          <textarea
-            className="textarea textarea-bordered textarea-md w-full"
-            name={name}
-            onChange={onChange}
-            value={value}
-          ></textarea>
-          <form method="dialog" className="modal-backdrop">
-            <button className="pg-button-primary mt-2">Save</button>
-          </form>
+          <div className="flex-grow h-full w-full">
+            <h4 className="mb-4 font-bold text-lg bottom-2 capitalize">
+              {humanName}
+            </h4>
+            <textarea
+              className="textarea textarea-bordered textarea-lg h-[80%] w-full"
+              name={name}
+              onChange={onChange}
+              value={value}
+            ></textarea>
+            <form method="dialog" className="modal-backdrop">
+              <button className="pg-button-primary mt-2">Save</button>
+            </form>
+          </div>
         </div>
         <form method="dialog" className="modal-backdrop">
           {/* Allows closing the modal by clicking outside of it */}
@@ -58,27 +67,32 @@ export function TextModal({
   );
 }
 
-export function PromptWidget({
+export function TextWidget({
+  humanName,
   name,
   onChange,
   value,
 }: {
+  humanName: string;
   name: string;
   value: string | string[];
   onChange: ChangeEventHandler;
 }) {
   return (
     <div className="join">
-      <input
-        className="w-full input input-bordered join-item"
+      <textarea
+        className="input input-bordered join-item nopan nodelete nodrag noflow textarea nowheel w-full resize-none"
         name={name}
         onChange={onChange}
         value={value}
-        type="text"
-        disabled
-      ></input>
+      ></textarea>
       <div className="join-item">
-        <TextModal name={name} value={value} onChange={onChange}></TextModal>
+        <TextModal
+          humanName={humanName}
+          name={name}
+          value={value}
+          onChange={onChange}
+        ></TextModal>
       </div>
     </div>
   );
@@ -112,17 +126,16 @@ export function KeywordsWidget({
       return newParams;
     });
   };
+  const humanName = `Keyword ${index + 1}`;
   return (
     <>
-      <div className="m-1 font-medium text-center">
-        {`Keyword ${index + 1}`}
-      </div>
-      <textarea
-        className="textarea textarea-bordered w-full"
+      <div className="m-1 font-medium text-center">{humanName}</div>
+      <TextWidget
+        humanName={humanName}
         name="keywords"
         onChange={updateParamValue}
         value={keywords ? keywords[index] : ""}
-      ></textarea>
+      ></TextWidget>
     </>
   );
 }

--- a/assets/javascript/apps/pipeline/widgets.tsx
+++ b/assets/javascript/apps/pipeline/widgets.tsx
@@ -61,7 +61,7 @@ export function TextModal({
           (document.getElementById(modalId) as HTMLDialogElement)?.showModal()
         }
       >
-        <i className="fa-solid fa-pencil"></i>
+        <i className="fa-solid fa-expand-alt"></i>
       </button>
     </>
   );


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

Adds the ability to edit text fields inside a modal

## User Impact
<!-- Describe the impact of this change on the end-users. -->

When editing nodes with parameters with long text, it was hard to edit them in the small space available to the user. The user can now open a modal to edit longer pieces of text if necessary, but they can still edit within the node too.


### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

[Screencast from 2024-10-01 22-22-32.webm](https://github.com/user-attachments/assets/1c4b6efb-9408-4b28-b569-05a6df4f4613)


Fixes #639 
