### PR TITLE
Fix: Force prompt builder token indicator to be in line with its icon

### DIFF
--- a/templates/experiments/components/prompt_builder_toolbox.html
+++ b/templates/experiments/components/prompt_builder_toolbox.html
@@ -24,22 +24,18 @@
                 <!-- token display -->
                 <div class="flex flex-row">
                     <span class="flex-1 mr-2 my-auto font-semibold">Tokens</span>
-                    <ul class="flex flex-grow bg-base-100 rounded-lg mt-2 py-2 px-6 justify-between border">
-                        <li>
-                            <div>
-                                <i class="fa-solid fa-arrow-up-from-bracket" title="Output Token Count"></i>
-                                <span class="badge badge-sm" title="Output Token Count"
-                                      x-text="$store.promptBuilder.currentState.messages.reduce((acc, message) => message.author === 'Assistant' ? acc + message.output_tokens : acc, 0)"></span>
-                            </div>
-                        </li>
-                        <li>
-                            <div>
-                                <span class="badge badge-sm" title="Input Token Count"
-                                      x-text="$store.promptBuilder.currentState.messages.reduce((acc, message) => message.author === 'Assistant' ? acc + message.input_tokens : acc, 0)"></span>
-                                <i class="fa-solid fa-arrow-right-to-bracket fa-rotate-90" title="Input Token Count"></i>
-                            </div>
-                        </li>
-                    </ul>
+                    <div class="flex flex-grow bg-base-100 rounded-lg mt-2 py-2 px-6 justify-between border">
+                        <div class="flex flex-row">
+                            <i class="fa-solid fa-arrow-up-from-bracket" title="Output Token Count"></i>
+                            <span class="badge badge-sm" title="Output Token Count"
+                                  x-text="$store.promptBuilder.currentState.messages.reduce((acc, message) => message.author === 'Assistant' ? acc + message.output_tokens : acc, 0)"></span>
+                        </div>
+                        <div class="flex flex-row">
+                            <span class="badge badge-sm" title="Input Token Count"
+                                  x-text="$store.promptBuilder.currentState.messages.reduce((acc, message) => message.author === 'Assistant' ? acc + message.input_tokens : acc, 0)"></span>
+                            <i class="fa-solid fa-arrow-right-to-bracket fa-rotate-90" title="Input Token Count"></i>
+                        </div>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
See [this thread](https://dimagi.slack.com/archives/C05PK63Q89H/p1727771605499129). When the token count is more than 3 digits, the alignment gets weird. This PR forces it to be a single row.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
This is just a UI change, so it will look better

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

#### Before
![image](https://github.com/user-attachments/assets/c5409a1f-5456-4972-aae8-788c0018176b)

#### After
![image](https://github.com/user-attachments/assets/b003bfa2-cd99-4334-b29a-4c0ffcb7796c)


### Docs
<!--Link to documentation that has been updated.-->
N/A