### PR TITLE
Save image files

### DIFF
--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -468,7 +468,7 @@ def test_assistant_response_with_image_file_content_block(
     result = assistant.invoke("test", attachments=[])
     assert result.output == "Ola"
     assert db_session.chat.attachments.filter(tool_type="image_file").exists() is True
-    db_session.chat.attachments.get(tool_type="image_file")
+    assert db_session.chat.attachments.get(tool_type="image_file").files.count() == 1
 
 
 @pytest.mark.parametrize(

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -53,3 +53,4 @@ twilio
 whitenoise[brotli]
 phonenumberslite
 emoji
+python-magic

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -18,7 +18,7 @@ annotated-types==0.6.0
     # via pydantic
 anthropic==0.25.2
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   langchain-anthropic
 anyio==4.4.0
     # via
@@ -28,6 +28,8 @@ anyio==4.4.0
     #   openai
 asgiref==3.8.1
     # via django
+async-timeout==4.0.3
+    # via redis
 attrs==23.1.0
     # via
     #   aiohttp
@@ -35,14 +37,14 @@ attrs==23.1.0
     #   referencing
     #   taskbadger
 azure-cognitiveservices-speech==1.32.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 backoff==2.2.1
     # via langfuse
 billiard==4.2.0
     # via celery
 boto3==1.28.85
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   django-storages
 botocore==1.31.85
     # via
@@ -52,10 +54,10 @@ brotli==1.1.0
     # via whitenoise
 celery[redis]==5.3.5
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   django-celery-beat
 celery-progress==0.3
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 certifi==2024.7.4
     # via
     #   httpcore
@@ -102,7 +104,7 @@ distro==1.8.0
     #   openai
 django==5.1
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   django-allauth
     #   django-allauth-2fa
     #   django-anymail
@@ -123,56 +125,56 @@ django==5.1
     #   drf-spectacular
 django-allauth==0.58.2
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   django-allauth-2fa
 django-allauth-2fa==0.11.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-anymail==10.2
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-appconf==1.0.5
     # via django-cryptography-django5
 django-celery-beat==2.7.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-cryptography-django5==2.2
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-environ==0.11.2
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-field-audit==1.2.8
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-health-check==3.18.3
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-hijack==3.4.2
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-otp==1.3.0
     # via django-allauth-2fa
 django-redis==5.4.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-storages[s3]==1.14.2
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-tables2==2.6.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-taggit==5.0.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-timezone-field==7.0
     # via django-celery-beat
 django-tz-detect==0.5.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 django-waffle==4.0.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 djangorestframework==3.15.2
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   drf-spectacular
 djangorestframework-api-key==3.0.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 drf-spectacular==0.26.5
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 emoji==2.12.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 fbmessenger==6.0.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 ffmpeg==1.4
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 filelock==3.13.1
     # via
     #   huggingface-hub
@@ -191,7 +193,7 @@ httpcore==0.17.3
     # via httpx
 httpx==0.24.1
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   anthropic
     #   langfuse
     #   openai
@@ -210,7 +212,7 @@ idna==3.7
 inflection==0.5.1
     # via drf-spectacular
 jinja2==3.1.4
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 jmespath==1.0.1
     # via
     #   boto3
@@ -228,9 +230,9 @@ jsonschema-specifications==2023.7.1
 kombu==5.3.3
     # via celery
 langchain==0.1.16
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 langchain-anthropic==0.1.8
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 langchain-community==0.0.32
     # via langchain
 langchain-core==0.1.42
@@ -242,22 +244,22 @@ langchain-core==0.1.42
     #   langchain-text-splitters
     #   langgraph
 langchain-openai==0.1.3
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 langchain-text-splitters==0.0.1
     # via langchain
 langfuse==2.43.3
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 langgraph==0.0.38
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 langsmith==0.1.47
     # via
     #   langchain
     #   langchain-community
     #   langchain-core
 loguru==0.7.2
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 markdown==3.5.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
@@ -282,7 +284,7 @@ oauthlib==3.2.2
     # via requests-oauthlib
 openai==1.23.6
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   langchain-openai
 orjson==3.10.0
     # via langsmith
@@ -295,20 +297,20 @@ packaging==23.2
     #   marshmallow
     #   transformers
 pandas==2.1.3
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 phonenumberslite==8.13.40
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 prompt-toolkit==3.0.41
     # via click-repl
 psycopg[binary]==3.2.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 psycopg-binary==3.2.1
     # via psycopg
 pycparser==2.21
     # via cffi
 pydantic==2.5.0
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   anthropic
     #   langchain
     #   langchain-core
@@ -318,7 +320,7 @@ pydantic==2.5.0
 pydantic-core==2.14.1
     # via pydantic
 pydub==0.25.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 pygments==2.16.1
     # via rich
 pyjwt[crypto]==2.8.0
@@ -328,7 +330,7 @@ pyjwt[crypto]==2.8.0
 pypng==0.20220715.0
     # via qrcode
 pytelegrambotapi==4.12.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 python-crontab==3.0.0
     # via django-celery-beat
 python-dateutil==2.8.2
@@ -338,6 +340,8 @@ python-dateutil==2.8.2
     #   pandas
     #   python-crontab
     #   taskbadger
+python-magic==0.4.27
+    # via -r requirements/requirements.in
 python3-openid==3.2.0
     # via django-allauth
 pytz==2023.3.post1
@@ -393,13 +397,13 @@ s3transfer==0.7.0
 safetensors==0.4.3
     # via transformers
 sentry-sdk==2.8.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 shellingham==1.5.4
     # via typer
 six==1.16.0
     # via python-dateutil
 slack-bolt==1.18.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 slack-sdk==3.27.2
     # via slack-bolt
 sniffio==1.3.0
@@ -416,16 +420,16 @@ sqlalchemy==2.0.23
 sqlparse==0.5.0
     # via django
 taskbadger==1.3.3
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 tenacity==8.2.3
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   langchain
     #   langchain-community
     #   langchain-core
 tiktoken==0.7.0
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   langchain-openai
 tokenizers==0.15.0
     # via
@@ -439,11 +443,11 @@ tqdm==4.66.3
     #   openai
     #   transformers
 transformers==4.39.3
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 turn-python==0.2.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 twilio==8.10.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 typer[all]==0.9.0
     # via taskbadger
 typing-extensions==4.8.0
@@ -482,7 +486,7 @@ vine==5.1.0
 wcwidth==0.2.10
     # via prompt-toolkit
 whitenoise[brotli]==6.6.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 wrapt==1.16.0
     # via langfuse
 yarl==1.9.2

--- a/templates/experiments/chat/ai_message.html
+++ b/templates/experiments/chat/ai_message.html
@@ -17,5 +17,22 @@
         <p>{{ message.content|render_markdown }}</p>
       </div>
     </div>
+    <div class="flex flex-col">
+      {% for file in message.get_attached_files %}
+        <div class="inline">
+          {% if request.user.is_authenticated %}
+            <a class="text-sm p-1 hover:bg-gray-300 hover:rounded-lg"
+               href="{% url 'experiments:download_file' team_slug=experiment.team.slug session_id=session.id pk=file.id %}"
+               download="{{ file.name }}">
+              <i class="fa-solid fa-download fa-sm"></i> {{ file.name }}
+            </a>
+          {% else %}
+            <div class="inline text-sm p-1">
+              <i class="fa-solid fa-file fa-sm"></i> {{ file.name }}
+            </div>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Currently we
1. don't show file attachments for AI messages. This changes in this PR
2. Ignore image files coming from OpenAI's assistant. We now save those as well.

Q: Why save image files as well?
A: Sometimes when the AI message doesn't reference a generated file, we miss it since it's not included as a message attachment. It is however available in the message contents array. What I've done is to save all images inside the message contents array as well.

Q: What happens when the image is in the message contents array and inside the text attachments? Will this not save duplicate images?
A: Yes it will. Turns out that the `file_id` for the near identical images are **not the same**. I use the term "near identical" since they differ in resolution, but the contents are the same. Even the file names are different. I could not find a robust way to check for duplicates yet. This is sub-optimal I know, but let's rather make the files available and possibly duplicate it than not having it and let the user wonder where the generated files are.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
1. A list of file attachments will be visible in the 

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
You can see in the image that the generated file is not being referenced in the text, but we make it available for download.

![image](https://github.com/user-attachments/assets/e0f19ef7-45c0-4c31-bb48-bf2afc05d9b1)


### Docs
<!--Link to documentation that has been updated.-->
No docs needed I think. This is more of a fix