### PR TITLE
Save the user message when it violates a safety layer

### DIFF
--- a/apps/experiments/tests/test_safety_layer.py
+++ b/apps/experiments/tests/test_safety_layer.py
@@ -7,9 +7,13 @@ from apps.utils.factories.experiment import ExperimentSessionFactory
 
 @patch("apps.chat.bots.notify_users_of_violation")
 @patch("apps.chat.bots.create_conversation")
-@patch("apps.chat.bots.SafetyBot.is_safe")
-def test_violation_triggers_email(notify_users_of_violation_mock, create_conversation_mock, is_safe_mock, db):
-    is_safe_mock.return_value = False
+@patch("apps.chat.bots.SafetyBot.is_safe", lambda *args: False)
+def test_safety_layer_violation(notify_users_of_violation_mock, create_conversation_mock, db):
+    """
+    The following is expected to happen when a safety layer is breached:
+    1. Notification emails should be sent to configured emails
+    2. The user message that breached that should still be saved
+    """
     experiment_session = ExperimentSessionFactory(experiment__safety_violation_notification_emails=["user@officer.com"])
     experiment = experiment_session.experiment
     layer = SafetyLayer.objects.create(prompt_text="Is this message safe?", team=experiment.team)
@@ -18,5 +22,7 @@ def test_violation_triggers_email(notify_users_of_violation_mock, create_convers
     bot = TopicBot(experiment_session)
     bot.conversation = Mock()
     bot._call_predict = Mock()
-    bot.process_input("It's my way or the highway!")
+    user_message = "It's my way or the highway!"
+    bot.process_input(user_message)
     notify_users_of_violation_mock.assert_called()
+    assert experiment_session.chat.messages.filter(message_type="human", content=user_message).count() == 1


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
We didn't save user messages that violated safety layers, now we do. 

## User Impact
<!-- Describe the impact of this change on the end-users. -->
We didn't save user messages that violated safety layers, now we do

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs
<!--Link to documentation that has been updated.-->
Will update the release docs once I merge this