### PR TITLE
render generated images inline with the message

### DIFF
--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -287,7 +287,7 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
             input_dict["thread_id"] = current_thread_id
         input_dict["instructions"] = self.state.get_assistant_instructions()
         thread_id, run_id = self._get_response_with_retries(merged_config, input_dict, current_thread_id)
-        output, annotation_file_ids = self._save_response_annotations(thread_id, run_id)
+        output, annotation_file_ids = self._get_output_with_annotations(thread_id, run_id)
 
         if not current_thread_id:
             self.state.set_metadata(Chat.MetadataKeys.OPENAI_THREAD_ID, thread_id)
@@ -322,7 +322,7 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
         return current_thread_id
 
     @transaction.atomic()
-    def _save_response_annotations(self, thread_id, run_id) -> tuple[str, list[str]]:
+    def _get_output_with_annotations(self, thread_id, run_id) -> tuple[str, list[str]]:
         """
         This makes a call to OpenAI with the `run_id` and `thread_id` to get more information about the response
         message, specifically regarding annotations.

--- a/apps/utils/markdown.py
+++ b/apps/utils/markdown.py
@@ -33,9 +33,20 @@ class FileLinkInlineProcessor(LinkInlineProcessor):
         return href, title, index, handled
 
 
+class FileImageInlineProcessor(ImageInlineProcessor):
+    def getLink(self, data, index):
+        href, title, index, handled = super().getLink(data, index)
+        if href.startswith("file"):
+            _, team_slug, session_id, file_id = href.split(":")
+            relative_url = reverse("experiments:download_file", args=[team_slug, session_id, file_id])
+            href = relative_url
+        return href, title, index, handled
+
+
 class FileExtension(markdown.Extension):
     def extendMarkdown(self, md, *args, **kwargs):
         md.inlinePatterns.register(FileLinkInlineProcessor(LINK_RE, md), "link", 160)
+        md.inlinePatterns.register(FileImageInlineProcessor(IMAGE_LINK_RE, md), "image_link", 150)
 
 
 class ResourceExtension(markdown.Extension):

--- a/templates/experiments/chat/ai_message.html
+++ b/templates/experiments/chat/ai_message.html
@@ -17,22 +17,5 @@
         <p>{{ message.content|render_markdown }}</p>
       </div>
     </div>
-    <div class="flex flex-col">
-      {% for file in message.get_attached_files %}
-        <div class="inline">
-          {% if request.user.is_authenticated %}
-            <a class="text-sm p-1 hover:bg-gray-300 hover:rounded-lg"
-               href="{% url 'experiments:download_file' team_slug=experiment.team.slug session_id=session.id pk=file.id %}"
-               download="{{ file.name }}">
-              <i class="fa-solid fa-download fa-sm"></i> {{ file.name }}
-            </a>
-          {% else %}
-            <div class="inline text-sm p-1">
-              <i class="fa-solid fa-file fa-sm"></i> {{ file.name }}
-            </div>
-          {% endif %}
-        </div>
-      {% endfor %}
-    </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
This updates the message processing and rendering to insert generated images as inline image links into the output markdown.

The markdown rendered will then render them as images.

## User Impact
Images are displayed in the message. This only applies to web chat when using Assistants to generate images.

### Demo
![image](https://github.com/user-attachments/assets/9e92cf07-44ad-4950-b00b-78fe5d10bfb5)


### Docs
NA
