### PR TITLE
Assistant citation rendering improvements

### DIFF
--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -375,7 +375,7 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
                             )
 
                             # Original citation text example:【6:0†source】
-                            message_content_value = message_content_value.replace(file_ref_text, f"[{idx}]")
+                            message_content_value = message_content_value.replace(file_ref_text, f" [{idx}]")
                             if file_link:
                                 message_content_value += f"\n[{idx}]: {file_link}"
                             else:

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -412,6 +412,10 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
             resource, _created = chat.attachments.get_or_create(tool_type="image_file")
             resource.files.add(*image_file_attachments)
 
+        # replace all instance of `[some filename.pdf](https://example.com/download/file-abc)` with
+        # just the link text
+        output_message = re.sub(r"\[(?!\d+\])([^]]+)\]\([^)]+example\.com[^)]+\)", r"*\1*", output_message)
+
         return output_message.strip(), list(file_ids)
 
     def _create_image_file_from_image_message(self, client, image_file_message) -> File | None:

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -451,7 +451,12 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
         except File.DoesNotExist:
             client = self.state.raw_client
             openai_file = client.files.retrieve(file_id=file_id)
-            file_name = openai_file.filename
+            try:
+                openai_file = client.files.retrieve(file_id=file_id)
+                file_name = openai_file.filename
+            except Exception as e:
+                logger.error(f"Failed to retrieve file {file_id} from OpenAI: {e}")
+                file_name = "Unknown File"
 
         if file_id in forbidden_file_ids:
             # Don't allow downloading assistant level files

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -392,7 +392,10 @@ def test_assistant_response_with_annotations(
     ]
     ai_message = (
         "Hi there human. The generated file can be [downloaded here](sandbox:/mnt/data/file.txt)."
+        " A made up link to [file1.pdf](https://example.com/download/file-1) "
+        "[file2.pdf](https://example.com/download/file-2)"
         " Also, leaves are tree stuff【6:0†source】."
+        " Another link to nothing [file3.pdf](https://example.com/download/file-3)"
     )
 
     assistant = create_experiment_runnable(session.experiment, session)
@@ -410,14 +413,17 @@ def test_assistant_response_with_annotations(
         # The cited file link is empty, since it's missing from the DB
         expected_output_message = (
             "![test.png](file:dimagi-test:1:10)\n"
-            "Hi there human. The generated file can be [downloaded here](file:dimagi-test:1:10). Also, leaves are"
-            " tree stuff [1].\n\[1\]: existing.txt"
+            "Hi there human. The generated file can be [downloaded here](file:dimagi-test:1:10)."
+            " A made up link to *file1.pdf* *file2.pdf*"
+            " Also, leaves are tree stuff [1]. Another link to nothing *file3.pdf*\n\\[1\\]: existing.txt"
         )
     else:
         expected_output_message = (
             "![test.png](file:dimagi-test:1:10)\n"
-            "Hi there human. The generated file can be [downloaded here](file:dimagi-test:1:10). Also, leaves are"
-            " tree stuff [1].\n[1]: file:dimagi-test:1:9"
+            "Hi there human. The generated file can be [downloaded here](file:dimagi-test:1:10)."
+            " A made up link to *file1.pdf* *file2.pdf*"
+            " Also, leaves are tree stuff [1]. Another link to nothing *file3.pdf*"
+            "\n[1]: file:dimagi-test:1:9"
         )
     assert result.output == expected_output_message
 

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -411,13 +411,13 @@ def test_assistant_response_with_annotations(
         expected_output_message = (
             "![test.png](file:dimagi-test:1:10)\n"
             "Hi there human. The generated file can be [downloaded here](file:dimagi-test:1:10). Also, leaves are"
-            " tree stuff [existing.txt]()."
+            " tree stuff [1].\n\[1\]: existing.txt"
         )
     else:
         expected_output_message = (
             "![test.png](file:dimagi-test:1:10)\n"
             "Hi there human. The generated file can be [downloaded here](file:dimagi-test:1:10). Also, leaves are"
-            " tree stuff [existing.txt](file:dimagi-test:1:9)."
+            " tree stuff [1].\n[1]: file:dimagi-test:1:9"
         )
     assert result.output == expected_output_message
 


### PR DESCRIPTION
## Description
Some updates to the annotations processing for Assistant messages. This change will make citation references render in a more usable way.

This also replaces `example.com` links produced by Assistants with just the link text in italics.

### Detailed notes
In cases where the assistant references files from the vector store we get messages like this:

```json
{
  "type": "text",
  "text": {
    "value": "pre text [some filename.pdf](https://example.com/download/file-abc). A citation【6:0†source】"
    "annotations": [
      {
        "type": "file_citation",
        "text": "【6:0†source】",
        "start_index": 950,
        "end_index": 962,
        "file_citation": {
          "file_id": "file-abc"
        }
      }
    ]
  }
}
```

**If the file is known to be an 'assistant' file in OCS**:
```diff
- pre text [some filename.pdf](https://example.com/download/file-abc). A citation []()
+ pre text [some filename.pdf](https://example.com/download/file-abc). A citation [1]
+ \[1\]: file name
```

The escaping is to render the reference as text instead of a link.

**If the file is not an assistant file in OCS**:
(this happens if the file was uploaded to OpenAI directly or it was created by the Assistant)

```diff
- pre text [some filename.pdf](https://example.com/download/file-abc). A citation [file name]()
+ pre text [some filename.pdf](https://example.com/download/file-abc). A citation [1]
+ [1]: https://link/to/file.pdf
```

This renders the `1` as in the text as a link.

## User Impact
Improved citation link rendering.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->
