### PR TITLE
Throw 404 if trying to edit experiments

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -431,6 +431,12 @@ class EditExperiment(BaseExperimentView, UpdateView):
         initial["type"] = "assistant" if self.object.assistant_id else "llm"
         return initial
 
+    def get_object(self, queryset=None):
+        obj = super().get_object(queryset)
+        if obj.working_version:
+            raise Http404("Cannot edit experiment versions.")
+        return obj
+
 
 def _get_voice_provider_alpine_context(request):
     """Add context required by the experiments/experiment_form.html template."""


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
This prevents user from manually changing the URL to edit an experiment version

## User Impact
<!-- Describe the impact of this change on the end-users. -->
There was not button to edit experiment, so although it restricts it was something they didn't have a direct link to do anyways

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
[Loom Video](https://www.loom.com/share/028278ba8ee54c53a606dd44a75d972d?sid=85573814-c252-4bc6-a2da-9d74d63ca2ae )

### Docs
<!--Link to documentation that has been updated.-->
None here!
