### PR TITLE
Catch index and key errors when there are no providers

### DIFF
--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -97,9 +97,18 @@ def _pipeline_node_parameter_values(team, llm_providers):
 
 def _pipeline_node_default_values(llm_providers):
     """Returns the default values for each input type"""
+    try:
+        provider_id = llm_providers[0]["id"]
+    except (IndexError, KeyError):
+        provider_id = None
+
+    try:
+        llm_model = llm_providers[0]["llm_models"][0]
+    except (IndexError, KeyError):
+        llm_model = None
     return {
-        "LlmProviderId": llm_providers[0]["id"],
-        "LlmModel": llm_providers[0]["llm_models"][0],
+        "LlmProviderId": provider_id,
+        "LlmModel": llm_model,
         "LlmTemperature": 0.7,
     }
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
When a team has no providers, accessing the pipelines page would cause an index error.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users will not get an index error when accessing the pipelines page without an LLM provider

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->

Fixes https://github.com/dimagi/open-chat-studio/issues/720