### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/templates/table/single_table.html
+++ b/templates/table/single_table.html
@@ -9,7 +9,12 @@
       element.addEventListener('click', function (event) {
         if (event.target.tagName === 'TR' || event.target.tagName === 'TD') {
           let editUrl = this.getAttribute('data-redirect-url');
-          window.location.href = editUrl;
+          try {
+            let url = new URL(editUrl, window.location.origin);
+            window.location.href = url.href;
+          } catch (e) {
+            console.error('Invalid URL:', editUrl);
+          }
         }
       });
     });


### PR DESCRIPTION
Fixes [https://github.com/dimagi/open-chat-studio/security/code-scanning/1](https://github.com/dimagi/open-chat-studio/security/code-scanning/1)

To fix the problem, we need to ensure that the value of `data-redirect-url` is properly validated or sanitized before it is used to set `window.location.href`. One way to achieve this is by using a URL parser to ensure the value is a valid URL and does not contain any malicious content.

We will:
1. Parse the `data-redirect-url` value using the `URL` constructor to ensure it is a valid URL.
2. Only set `window.location.href` if the parsed URL is valid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
