### PR TITLE
remove duplicate CSS imports

### DIFF
--- a/assets/site-tailwind.js
+++ b/assets/site-tailwind.js
@@ -1,6 +1,1 @@
 require('./styles/site-tailwind.css');
-require('./styles/app/chat.css');
-require('./styles/app/table.css');
-require('./styles/app/alertify.css');
-require('./styles/app/pg-components.css');
-require('./styles/app/prompt-builder.css');

--- a/assets/styles/app/alertify.css
+++ b/assets/styles/app/alertify.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 @layer components {
     .alertify .ajs-dialog {
         @apply bg-white shadow-md rounded-lg;

--- a/assets/styles/app/chat.css
+++ b/assets/styles/app/chat.css
@@ -1,5 +1,3 @@
-@tailwind components;
-
 @layer components {
   .chat-pane {
     @apply overflow-y-auto flex flex-col flex-grow p-4 space-y-4 bg-gray-50;

--- a/assets/styles/app/pg-components.css
+++ b/assets/styles/app/pg-components.css
@@ -1,5 +1,3 @@
-@tailwind components;
-
 @layer components {
   /* typography helpers */
 

--- a/assets/styles/site-tailwind.css
+++ b/assets/styles/site-tailwind.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@import './app/chat.css';
+@import './app/table.css';
+@import './app/alertify.css';
+@import './app/pg-components.css';
+@import './app/prompt-builder.css';
+
 @layer components {
 
   .section {


### PR DESCRIPTION
## Description
Removed duplicate imports where things like `@tailwind components;` were being imported in `site-tailwind.css`, then again in`chat.css` and other files. This reduced the final CSS file size by almost 75%. 

## User Impact
Less to download I guess

### Demo
Unless there's a mistake it should look identical.

### Docs
N/A