### PR TITLE
Add get_ai_message_id to PipelineBot

### DIFF
--- a/apps/channels/tests/test_web_channel.py
+++ b/apps/channels/tests/test_web_channel.py
@@ -6,6 +6,13 @@ from mock.mock import Mock, patch
 from apps.channels.models import ChannelPlatform
 from apps.chat.channels import WebChannel
 from apps.chat.models import Chat
+from apps.pipelines.models import Pipeline
+from apps.utils.factories.pipelines import PipelineFactory
+
+
+@pytest.fixture()
+def pipeline():
+    return PipelineFactory()
 
 
 @pytest.mark.django_db()
@@ -16,6 +23,44 @@ from apps.chat.models import Chat
 @patch("apps.chat.channels.WebChannel.new_user_message")
 def test_start_new_session(new_user_message, get_ai_message_id, with_seed_message, experiment):
     """A simple test to make sure we create a session and send a session message"""
+    get_ai_message_id.return_value = 1
+
+    if with_seed_message:
+        experiment.seed_message = "Tell a joke"
+        experiment.save()
+
+    session = WebChannel.start_new_session(
+        experiment,
+        "jack@titanic.com",
+    )
+
+    assert session is not None
+    assert session.participant.identifier == "jack@titanic.com"
+    assert session.experiment_channel is not None
+    assert session.experiment_channel.platform == ChannelPlatform.WEB
+
+    if with_seed_message:
+        assert session.seed_task_id is not None
+        new_user_message.assert_called()
+        message = new_user_message.call_args[0][0]
+        assert message.participant_id == "jack@titanic.com"
+        assert message.message_text == "Tell a joke"
+        # A seed message cannot have an attachment
+        assert message.attachments == []
+
+
+@pytest.mark.django_db()
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+@pytest.mark.parametrize("with_seed_message", [True, False])
+@patch("apps.events.tasks.enqueue_static_triggers", Mock())
+@patch("apps.chat.bots.PipelineBot.get_ai_message_id")
+@patch("apps.chat.channels.WebChannel.new_user_message")
+def test_start_new_session_pipeline(
+    new_user_message, get_ai_message_id, with_seed_message, experiment, pipeline: Pipeline
+):
+    """A simple test to make sure we create a session and send a session message for a Pipeline Bot"""
+    experiment.pipeline_id = pipeline.id
+    experiment.save()
     get_ai_message_id.return_value = 1
 
     if with_seed_message:

--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 from apps.annotations.models import TagCategories
 from apps.chat.conversation import BasicConversation, Conversation
 from apps.chat.exceptions import ChatException
-from apps.chat.models import ChatMessageType
+from apps.chat.models import ChatMessage, ChatMessageType
 from apps.events.models import StaticTriggerType
 from apps.events.tasks import enqueue_static_triggers
 from apps.experiments.models import Experiment, ExperimentRoute, ExperimentSession, SafetyLayer
@@ -287,3 +287,13 @@ class PipelineBot:
             PipelineState(messages=[user_input], experiment_session=self.session), self.session
         )
         return output["messages"][-1]
+
+    def get_ai_message_id(self) -> int | None:
+        last_ai_message = (
+            ChatMessage.objects.filter(chat=self.session.chat, message_type=ChatMessageType.AI.value)
+            .values("id")
+            .last()
+        )
+        if not last_ai_message:
+            return None
+        return last_ai_message["id"]

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -837,7 +837,10 @@ def get_message_response(request, team_slug: str, experiment_id: int, session_id
     message_details = {"message": None, "error": False, "complete": progress["complete"]}
     if progress["complete"] and progress["success"]:
         result = progress["result"]
-        message_details["message"] = ChatMessage.objects.get(id=result["message_id"])
+        if result["message_id"]:
+            message_details["message"] = ChatMessage.objects.get(id=result["message_id"])
+        else:
+            message_details["message"] = {"content": result["response"]}
     elif progress["complete"]:
         message_details["error"] = True
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

The `PipelineBot` didn't have the `get_ai_message_id` parameter, and so chatting with one was failing. This was introduced here: https://github.com/dimagi/open-chat-studio/pull/702

I added a test that failed without this change. 

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users were unable to chat with Pipeline Bots. Now they can. 
