### PR TITLE
deploy after tests complete + create deployment in github

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  deployments: write
 
 jobs:
   deploy:
@@ -65,6 +66,15 @@ jobs:
         echo "ECS_SERVICE_DJANGO=$APP_NAME-${{ env.DEPLOY_ENV }}-Django" >> "$GITHUB_ENV"
         echo "ECS_SERVICE_CELERY=$APP_NAME-${{ env.DEPLOY_ENV }}-Celery" >> "$GITHUB_ENV"
         echo "ECS_SERVICE_CELERY_BEAT=$APP_NAME-${{ env.DEPLOY_ENV }}-CeleryBeat" >> "$GITHUB_ENV"
+
+    - name: Create GitHub deployment
+      uses: chrnorm/deployment-action@v2
+      id: deployment
+      with:
+        token: '${{ github.token }}'
+        environment: "aws-${{ env.DEPLOY_ENV }}"
+        production-environment: ${{ env.DEPLOY_ENV == 'prod' }}
+
 
     - name: configure aws credentials
       uses: aws-actions/configure-aws-credentials@v4.0.2
@@ -159,3 +169,12 @@ jobs:
     - name: Wait for service stability
       run: |
           aws ecs wait services-stable --cluster $ECS_CLUSTER --services $ECS_SERVICE_DJANGO $ECS_SERVICE_CELERY $ECS_SERVICE_CELERY_BEAT
+
+    - name: Update deployment status
+      if: success()
+      uses: chrnorm/deployment-status@v2
+      with:
+        token: '${{ github.token }}'
+        environment-url: ${{ steps.deployment.outputs.environment_url }}
+        deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+        state: "${{ success() && 'success' || 'failure' }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -170,11 +170,20 @@ jobs:
       run: |
           aws ecs wait services-stable --cluster $ECS_CLUSTER --services $ECS_SERVICE_DJANGO $ECS_SERVICE_CELERY $ECS_SERVICE_CELERY_BEAT
 
-    - name: Update deployment status
+    - name: Update deployment status (success)
       if: success()
       uses: chrnorm/deployment-status@v2
       with:
         token: '${{ github.token }}'
         environment-url: ${{ steps.deployment.outputs.environment_url }}
         deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-        state: "${{ success() && 'success' || 'failure' }}"
+        state: 'success'
+
+    - name: Update deployment status (failure)
+      if: failure()
+      uses: chrnorm/deployment-status@v2
+      with:
+        token: '${{ github.token }}'
+        environment-url: ${{ steps.deployment.outputs.environment_url }}
+        deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+        state: 'failure'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,10 @@ on:
         options:
           - dev
           - prod
-  push:
-    branches: [ "main" ]
+  workflow_run:
+    workflows: [ Run Django Tests, Build Front End ]
+    types:
+      - completed
 
 permissions:
   id-token: write


### PR DESCRIPTION
This pull request updates the deployment workflow in the `.github/workflows/deploy.yml` file to improve automation and status tracking. The most important changes include switching the trigger from `push` to `workflow_run`, adding a step to create a GitHub deployment, and updating the deployment status upon completion.

Changes to workflow triggers and permissions:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L26-R34): Changed the trigger from `push` to `workflow_run` to run after specific workflows complete. Updated permissions to include `deployments: write`.

Enhancements to deployment process:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R70-R78): Added a step to create a GitHub deployment using `chrnorm/deployment-action@v2`.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R172-R180): Added a step to update the deployment status using `chrnorm/deployment-status@v2`. This step runs only if the previous steps succeed.