### PR TITLE
only auto-deploy when tests pass on the 'main' branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,8 @@ on:
           - prod
   workflow_run:
     workflows: [ Lint and Test ]
-    types:
-      - completed
+    types: [completed]
+    branches: [main]
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Description
Deploy was being triggered after every 'test' build run instead of only runs on the `main` branch.