### PR TITLE
Improved user management for public bot links

### DIFF
--- a/apps/experiments/forms.py
+++ b/apps/experiments/forms.py
@@ -11,10 +11,15 @@ class ConsentForm(forms.Form):
     participant_id = forms.IntegerField(required=False, widget=forms.HiddenInput())
 
     def __init__(self, consent, *args, **kwargs):
+        redirect_url = kwargs.pop("redirect_url", None)
         super().__init__(*args, **kwargs)
         if consent.capture_identifier:
             self.fields["identifier"].required = True
             self.fields["identifier"].label = consent.identifier_label
+            if redirect_url:
+                self.fields[
+                    "identifier"
+                ].help_text = f"Have a user? Be sure to <a class='font-bold' href={redirect_url}>log in</a> first"
 
             if consent.identifier_type == "email":
                 self.fields["identifier"].widget = forms.EmailInput()

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -931,6 +931,7 @@ def start_session_public(request, team_slug: str, experiment_id: str):
     else:
         form = ConsentForm(
             consent,
+            redirect_url=f"{login_url}?next={request.path}",
             initial={
                 "experiment_id": experiment_version.id,
                 "identifier": user.email if user else None,
@@ -1068,7 +1069,8 @@ def start_session_from_invite(request, team_slug: str, experiment_id: str, sessi
             return _record_consent_and_redirect(request, team_slug, experiment_session)
 
     else:
-        form = ConsentForm(consent, initial=initial)
+        login_url = reverse(settings.LOGIN_URL)
+        form = ConsentForm(consent, redirect_url=f"{login_url}?next={request.path}", initial=initial)
 
     consent_notice = consent.get_rendered_content()
     version_specific_vars = {


### PR DESCRIPTION
resolves #732 to an extend.
Q: What extend?
A: We tell the user to log in if they have a user on OCS and if they did not, we redirect them to the login screen if the specified identifier belongs to a platform user. We don't send out OTPs or anything (yet?)

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
On public links, platform users are taken to the login screen and redirected back to the consent screen after loggin in.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
This should solve the confusing / "buggy" behaviour that some users encountered where they were platform users, but could chat to the bot when they were logged out.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![second](https://github.com/user-attachments/assets/99972675-1933-46b7-8e98-53a0b876de8a)

### Docs
<!--Link to documentation that has been updated.-->
