### PR TITLE
Change type annotation for _process method

### DIFF
--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -88,7 +88,7 @@ class PipelineNode(BaseModel, ABC):
             else PipelineState(outputs={node_id: output})
         )
 
-    def _process(self, input: str, state: PipelineState, node_id: str) -> PipelineState:
+    def _process(self, input: str, state: PipelineState, node_id: str) -> str:
         """The method that executes node specific functionality"""
         raise NotImplementedError
 


### PR DESCRIPTION
Something small I noticed while preparing my presentation. The output of `_process` is expected to be a string. We compile and output the `PipelineState` in `process`. 