### PR TITLE
Always show max token limit widget

### DIFF
--- a/assets/javascript/apps/pipeline/nodes/GetInputWidget.tsx
+++ b/assets/javascript/apps/pipeline/nodes/GetInputWidget.tsx
@@ -158,9 +158,6 @@ export const getInputWidget = ({id, inputParam, params, setParams, updateParamVa
       );
     }
     case "MaxTokenLimit": {
-      if (params["history_type"] !== "global") {
-        return <></>;
-      }
       return (
         <>
           <div className="m-1 font-medium text-center">


### PR DESCRIPTION
Another thing I noticed while prepping my presentation. I think this was due to a bad merge.
I'd made the change here: 

https://github.com/dimagi/open-chat-studio/pull/740/files#diff-f74e65e80b8c5d732618b424cc8655289cdf8a6e48b5e8ac08d02f5b1b6a48b9L194

But it wasn't taken into account here: 

https://github.com/dimagi/open-chat-studio/commit/d7a25d7310089f76b1270b15eaef7422aefbda74#diff-1bf3dbe6116a6ab6c3f67bb5ffe96da187018eb54613e451e6c8a7f3e5ad1b40R159-R161