### PR TITLE
Add default to participant_allowlist

### DIFF
--- a/templates/experiments/experiment_form.html
+++ b/templates/experiments/experiment_form.html
@@ -96,7 +96,7 @@
             To limit the set of particiapants that can chat with this bot, simply add their identifiers in this list.
             When the list is empty, the bot will accessible via its public link.
           {% endblocktranslate %}
-          <div class="w-96 my-2" x-data="{allowlist: {{ form.initial.participant_allowlist }}}">
+          <div class="w-96 my-2" x-data="{allowlist: {{ form.initial.participant_allowlist|default:'[]' }}}">
             <input type="hidden" name="participant_allowlist" id="id_participant_allowlist" :value="allowlist"></input>
             <select x-model="allowlist" id="allowlist-multiselect" name="state[]" multiple placeholder="Add participant identifier..." autocomplete="off">
               {% for identifier in team_participant_identifiers %}


### PR DESCRIPTION
## Description
Small thing I found - when making a new experiment I was getting errors in the javascript console as `{{ form.initial.participant_allowlist}}` resolves to nothing. 

![image](https://github.com/user-attachments/assets/e01b2763-89b0-419a-b44d-67a56f182be1)
