### PR TITLE
Make pipeline tab active when looking at pipelines

### DIFF
--- a/templates/web/components/team_nav.html
+++ b/templates/web/components/team_nav.html
@@ -83,7 +83,7 @@
   {% flag "pipelines-v2" %}
     <li>
       {% if perms.pipelines.view_pipeline %}
-        <a href="{% url 'pipelines:home' request.team.slug %}" {% if active_tab == 'analysis' %}class="active"{% endif %}>
+        <a href="{% url 'pipelines:home' request.team.slug %}" {% if active_tab == 'pipelines' %}class="active"{% endif %}>
           <i class="fa-solid fa-puzzle-piece"></i>
           {% translate "Pipelines" %}<span class="badge badge-sm">new!</span>
         </a>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Another small thing I found - when the pipeline tab is active, it wasn't showing as such in the sidebar. 
