### PR TITLE
Tiny updates

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -78,7 +78,7 @@ from apps.files.views import BaseAddFileHtmxView, BaseDeleteFileView
 from apps.service_providers.utils import get_llm_provider_choices
 from apps.teams.decorators import login_and_team_required
 from apps.teams.mixins import LoginAndTeamRequiredMixin
-from apps.utils.prompt import validate_prompt_variables
+from apps.utils.prompt import PromptVars, validate_prompt_variables
 
 
 @login_and_team_required
@@ -301,7 +301,7 @@ class ExperimentForm(forms.ModelForm):
         validate_prompt_variables(
             form_data=cleaned_data,
             prompt_key="prompt_text",
-            known_vars={"source_material", "participant_data", "current_datetime"},
+            known_vars=set(PromptVars.values),
         )
         return cleaned_data
 

--- a/apps/utils/prompt.py
+++ b/apps/utils/prompt.py
@@ -36,10 +36,11 @@ def validate_prompt_variables(form_data, prompt_key: str, known_vars: set):
         raise ValidationError({prompt_key: "source_material variable expected since source material is specified"})
 
     if tools := form_data.get("tools", []):
-        tools_need = []
-        [tools_need.extend(PROMPT_VARS_REQUIRED_BY_TOOL[AgentTools(tool_name)]) for tool_name in tools]
+        required_prompt_variables = []
+        for tool_name in tools:
+            required_prompt_variables.extend(PROMPT_VARS_REQUIRED_BY_TOOL[AgentTools(tool_name)])
 
-        missing_vars = set(tools_need) - prompt_variables
+        missing_vars = set(required_prompt_variables) - prompt_variables
         if missing_vars:
             raise ValidationError(
                 {prompt_key: f"Tools require {', '.join(missing_vars)}. Please include them in your prompt."}

--- a/templates/experiments/experiment_complete.html
+++ b/templates/experiments/experiment_complete.html
@@ -1,6 +1,17 @@
 {% extends 'web/app/app_base.html' %}
+
 {% block body %}
   <div class="app-card max-w-5xl mx-auto">
+    {% block breadcrumbs %}
+      {% if user.is_authenticated %}
+        <div class="text-sm breadcrumbs" aria-label="breadcrumbs">
+          <ul>
+            <li>Experiments</li>
+            <li><a href="{% url 'experiments:single_experiment_home' request.team.slug experiment.id %}">{{ experiment.name }}</a></li>
+          </ul>
+        </div>
+      {% endif %}
+    {% endblock %}
     <h1 class="pg-title">Experiment Complete</h1>
     <div class="prose !max-w-none">
       <p>

--- a/templates/experiments/experiment_review.html
+++ b/templates/experiments/experiment_review.html
@@ -15,6 +15,16 @@
 
 {% block body %}
   <div class="app-card max-w-5xl mx-auto">
+    {% block breadcrumbs %}
+      {% if user.is_authenticated %}
+        <div class="text-sm breadcrumbs" aria-label="breadcrumbs">
+          <ul>
+            <li>Experiments</li>
+            <li><a href="{% url 'experiments:single_experiment_home' request.team.slug experiment.id %}">{{ experiment.name }}</a></li>
+          </ul>
+        </div>
+      {% endif %}
+    {% endblock %}
     <h1 class="pg-title">Experiment Review</h1>
     <div class="prose !max-w-none">
       <p>Thanks for completing the experiment!</p>


### PR DESCRIPTION
Resolves #725 
Resolves #719

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
We now have a mapping of which tools requires which prompt variables. Also, added a breadcrumb for authed users to navigate to the experiment home

## User Impact
<!-- Describe the impact of this change on the end-users. -->
1. The user wouldn't have to include unnecessary prompt variables when selecting certain tools
2. User can navigate back to the experiment after completing it

### Demo

<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![Screenshot from 2024-10-29 16-38-05](https://github.com/user-attachments/assets/6d42d68b-629d-4bce-ad79-675e022f5439)

### Docs
<!--Link to documentation that has been updated.-->
N/A