### PR TITLE
Fix: Only try to send an email if the identifier type is email

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -925,7 +925,7 @@ def start_session_public(request, team_slug: str, experiment_id: str):
                 participant_identifier=identifier,
                 timezone=request.session.get("detected_tz", None),
             )
-            if verify_user:
+            if verify_user and consent.identifier_type == "email":
                 return _verify_user_or_start_session(
                     identifier=identifier,
                     request=request,


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Issue: https://dimagi.sentry.io/share/issue/164b40cb13ce485fb96a1ca409a51e31/
When the identifier type is text, any identifier is accepted, but we'll try to send an email to this identifier. We now only send emails when the identifier type is email, so we know an email is entered.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Participants using non-email identifiers (in consent forms expecting text based identifiers) cannot start a chat

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->
