### PR TITLE
Refactor history fields to only apply to nodes that use it + add history to router

### DIFF
--- a/apps/pipelines/graph.py
+++ b/apps/pipelines/graph.py
@@ -115,7 +115,7 @@ class PipelineGraph(pydantic.BaseModel):
                 node_instance = self.nodes_by_id[edge.source].pipeline_node_instance
                 state_graph.add_conditional_edges(
                     edge.source,
-                    node_instance.process_conditional,
+                    partial(node_instance.process_conditional, node_id=edge.source),
                     self.conditional_edge_map[edge.source],
                 )
             seen_sources.add(edge.source)

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -232,8 +232,6 @@ class BooleanNode(Passthrough):
 class RouterNode(Passthrough, LLMResponseMixin):
     __human_name__ = "Router"
     __node_description__ = "Routes the input to one of the linked nodes"
-    llm_provider_id: LlmProviderId
-    llm_model: LlmModel
     prompt: ExpandableText = "You are an extremely helpful router {input}"
     num_outputs: NumOutputs = 2
     keywords: Keywords = []

--- a/apps/pipelines/tests/test_runnable_builder.py
+++ b/apps/pipelines/tests/test_runnable_builder.py
@@ -486,7 +486,7 @@ def test_conditional_node(pipeline, experiment_session):
 @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
 @mock.patch("apps.pipelines.nodes.base.PipelineNode.logger", mock.Mock())
 def test_router_node(get_llm_service, provider, pipeline, experiment_session):
-    service = build_fake_llm_echo_service()
+    service = build_fake_llm_echo_service(include_system_message=False)
     get_llm_service.return_value = service
 
     data = {
@@ -556,7 +556,7 @@ def test_router_node(get_llm_service, provider, pipeline, experiment_session):
                     "type": "RouterNode",
                     "label": "Router",
                     "params": {
-                        "prompt": "{ input }",
+                        "prompt": "You are a router",
                         "keywords": ["A", "b", "c", "d"],
                         "llm_model": "claude-3-5-sonnet-20240620",
                         "num_outputs": "4",

--- a/apps/utils/langchain.py
+++ b/apps/utils/langchain.py
@@ -136,6 +136,7 @@ class FakeLlmSimpleTokenCount(FakeLlm):
 class FakeLlmEcho(FakeLlmSimpleTokenCount):
     """Echos the input"""
 
+    include_system_message: bool = True
     responses: list = []
 
     def _call(self, messages: list[BaseMessage], *args, **kwargs) -> str | BaseMessage:
@@ -149,7 +150,7 @@ class FakeLlmEcho(FakeLlmSimpleTokenCount):
         except StopIteration:
             return user_message
 
-        return f"{system_message} {user_message}"
+        return f"{system_message} {user_message}" if self.include_system_message else user_message
 
 
 @contextmanager
@@ -176,7 +177,8 @@ def build_fake_llm_service(responses, token_counts, fake_llm=None):
     return FakeLlmService(llm=fake_llm, token_counter=FakeTokenCounter(token_counts=token_counts))
 
 
-def build_fake_llm_echo_service(token_counts=None):
+def build_fake_llm_echo_service(token_counts=None, include_system_message=True):
     if token_counts is None:
         token_counts = [0]
-    return FakeLlmService(llm=FakeLlmEcho(), token_counter=FakeTokenCounter(token_counts=token_counts))
+    llm = FakeLlmEcho(include_system_message=include_system_message)
+    return FakeLlmService(llm=llm, token_counter=FakeTokenCounter(token_counts=token_counts))


### PR DESCRIPTION
## Description
Currently you can configure 'history' on nodes that don't support recording history. This change removes those fields from nodes that don't use it.

This PR also adds support for using history to the router node.

## User Impact
Simpler node interface for nodes that don't need history support + actual working history for router nodes.
