### PR TITLE
Small channel form updates

### DIFF
--- a/apps/channels/forms.py
+++ b/apps/channels/forms.py
@@ -136,7 +136,7 @@ class WhatsappChannelForm(WebhookUrlFormBase):
         label="Number",
         max_length=20,
         help_text=(
-            "This is the number you got from your provider and should be in any of the formats: "
+            "This is the WhatsApp Business Number you got from your provider and should be in any of the formats: "
             "+27812345678, +27-81-234-5678, +27 81 234 5678"
         ),
     )

--- a/apps/channels/forms.py
+++ b/apps/channels/forms.py
@@ -26,12 +26,14 @@ class ChannelForm(forms.ModelForm):
         widgets = {"platform": forms.HiddenInput()}
 
     def __init__(self, *args, **kwargs):
-        team = kwargs.pop("team", None)
+        experiment = kwargs.pop("experiment", None)
+        initial: dict = kwargs.get("initial", {})
+        initial.setdefault("name", experiment.name)
         super().__init__(*args, **kwargs)
         if self.is_bound:
             return
         platform = self.initial["platform"]
-        self._populate_available_message_providers(team, platform)
+        self._populate_available_message_providers(experiment.team, platform)
 
     def _populate_available_message_providers(self, team: Team, platform: ChannelPlatform):
         provider_types = MessagingProviderType.platform_supported_provider_types(platform)

--- a/apps/channels/forms.py
+++ b/apps/channels/forms.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 
 class ChannelForm(forms.ModelForm):
+    name = forms.CharField(required=False, help_text="If you leave this blank, it will default to the experiment name")
+
     class Meta:
         model = ExperimentChannel
         fields = ["name", "platform", "messaging_provider"]
@@ -131,7 +133,12 @@ class TelegramChannelForm(ExtraFormBase):
 
 class WhatsappChannelForm(WebhookUrlFormBase):
     number = forms.CharField(
-        label="Number", max_length=20, help_text="e.g. +27812345678, +27-81-234-5678, +27 81 234 5678"
+        label="Number",
+        max_length=20,
+        help_text=(
+            "This is the number you got from your provider and should be in any of the formats: "
+            "+27812345678, +27-81-234-5678, +27 81 234 5678"
+        ),
     )
 
     def clean_number(self):

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -151,6 +151,11 @@ class ExperimentChannel(BaseTeamModel):
     def __str__(self):
         return f"Channel: {self.name} ({self.platform})"
 
+    def save(self, *args, **kwargs):
+        if not self.name:
+            self.name = self.experiment.name
+        return super().save(*args, **kwargs)
+
     @property
     def platform_enum(self):
         return ChannelPlatform(self.platform)

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -12,7 +12,7 @@ from field_audit.models import AuditingManager
 from apps.experiments import model_audit_fields
 from apps.experiments.exceptions import ChannelAlreadyUtilizedException
 from apps.experiments.models import Experiment
-from apps.teams.models import BaseTeamModel, Team
+from apps.teams.models import BaseTeamModel
 from apps.web.meta import absolute_url
 
 WEB = "web"
@@ -58,10 +58,10 @@ class ChannelPlatform(models.TextChoices):
 
         return platform_availability
 
-    def form(self, team: Team):
+    def form(self, experiment: Experiment):
         from apps.channels.forms import ChannelForm
 
-        return ChannelForm(initial={"platform": self}, team=team)
+        return ChannelForm(initial={"platform": self}, experiment=experiment)
 
     def extra_form(self, *args, **kwargs):
         from apps.channels import forms
@@ -163,7 +163,7 @@ class ExperimentChannel(BaseTeamModel):
     def form(self, *args, **kwargs):
         from apps.channels.forms import ChannelForm
 
-        return ChannelForm(instance=self, team=self.experiment.team, *args, **kwargs)
+        return ChannelForm(instance=self, experiment=self.experiment, *args, **kwargs)
 
     def extra_form(self, *args, **kwargs):
         return self.platform_enum.extra_form(initial=self.extra_data, channel=self, *args, **kwargs)

--- a/apps/channels/tests/test_forms.py
+++ b/apps/channels/tests/test_forms.py
@@ -16,18 +16,18 @@ from apps.utils.factories.service_provider_factories import MessagingProviderFac
         ("telegram", HiddenInput),
     ],
 )
-def test_channel_form_reveals_provider_types(team_with_users, platform, expected_widget_cls):
+def test_channel_form_reveals_provider_types(experiment, platform, expected_widget_cls):
     """Test that the message provider field is being hidden when not applicable to a certain platform"""
     # First create a messaging provider
-    message_provider = MessagingProviderFactory(type=MessagingProviderType("twilio"), team=team_with_users)
+    message_provider = MessagingProviderFactory(type=MessagingProviderType("twilio"), team=experiment.team)
     MessagingProviderFactory(type=MessagingProviderType("twilio"))
 
-    form = ChannelForm(initial={"platform": ChannelPlatform(platform)}, team=team_with_users)
+    form = ChannelForm(initial={"platform": ChannelPlatform(platform)}, experiment=experiment)
     widget = form.fields["messaging_provider"].widget
     assert isinstance(widget, expected_widget_cls)
 
     form_queryset = form.fields["messaging_provider"].queryset
-    assert form_queryset.count() == MessagingProvider.objects.filter(team=team_with_users).count()
+    assert form_queryset.count() == MessagingProvider.objects.filter(team=experiment.team).count()
     assert form_queryset.first() == message_provider
 
 

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -564,7 +564,7 @@ def single_experiment_home(request, team_slug: str, experiment_id: int):
     used_platforms = {channel.platform_enum for channel in channels}
     available_platforms = ChannelPlatform.for_dropdown(used_platforms, experiment.team)
     platform_forms = {}
-    form_kwargs = {"team": request.team}
+    form_kwargs = {"experiment": experiment}
     for platform in available_platforms:
         if platform.form(**form_kwargs):
             platform_forms[platform] = platform.form(**form_kwargs)
@@ -652,7 +652,7 @@ def _get_terminal_bots_context(experiment: Experiment, team_slug: str):
 def create_channel(request, team_slug: str, experiment_id: int):
     experiment = get_object_or_404(Experiment, id=experiment_id, team=request.team)
     existing_platforms = {channel.platform_enum for channel in experiment.experimentchannel_set.all()}
-    form = ChannelForm(data=request.POST)
+    form = ChannelForm(experiment=experiment, data=request.POST)
     if not form.is_valid():
         messages.error(request, "Form has errors: " + form.errors.as_text())
     else:


### PR DESCRIPTION
An informal request - [link](https://dimagi.slack.com/archives/C05PK63Q89H/p1730803103698439)
For now I just went with defaulting the channel name to the experiment name if the user don't want to bother with it. I want to comb through the codebase some time to see if we're actually using the channel name for anything useful. I suspect not.

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
1. Be more explicit as to what number to input when adding a whatsapp number
2. Optional channel name. Default to experiment name

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Same description as above

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![image](https://github.com/user-attachments/assets/8f068ec4-8d87-4fcc-aeb1-9ca962ac4a34)

### Docs
<!--Link to documentation that has been updated.-->
N/A