### PR TITLE
add django-cleanup to cleanup files on model deletion

### DIFF
--- a/apps/teams/tests/test_permissions.py
+++ b/apps/teams/tests/test_permissions.py
@@ -36,6 +36,7 @@ IGNORE_APPS = {
     "contenttypes",
     "db",  # heath_check.db
     "django_celery_beat",
+    "django_cleanup",
     "django_otp",
     "django_tables2",
     "drf_spectacular",

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -99,7 +99,11 @@ PROJECT_APPS = [
     "apps.participants",
 ]
 
-INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + PROJECT_APPS
+SPECIAL_APPS = [
+    "django_cleanup"  # according to the docs, this should be the last app installed
+]
+
+INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + PROJECT_APPS + SPECIAL_APPS
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -101,8 +101,6 @@ pyyaml==6.0.1
     #   pre-commit
 ruff==0.7.1
     # via -r dev-requirements.in
-setuptools==75.3.0
-    # via pip-tools
 six==1.16.0
     # via
     #   -c requirements.txt
@@ -125,3 +123,6 @@ watchfiles==0.24.0
     # via -r dev-requirements.in
 wheel==0.44.0
     # via pip-tools
+
+# The following packages were excluded from the output:
+# setuptools

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -16,3 +16,6 @@ zope-event==5.0
     # via gevent
 zope-interface==6.1
     # via gevent
+
+# The following packages were excluded from the output:
+# setuptools

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -9,6 +9,7 @@ celery[redis]
 django-allauth
 django-allauth-2fa
 django-anymail
+django-cleanup
 # original django-cryptography is not compatible with Django 5 and does not seem to be maintained
 # https://github.com/georgemarshall/django-cryptography/issues/74
 django-cryptography-django5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -131,6 +131,8 @@ django-appconf==1.0.5
     # via django-cryptography-django5
 django-celery-beat==2.7.0
     # via -r requirements.in
+django-cleanup==9.0.0
+    # via -r requirements.in
 django-cryptography-django5==2.2
     # via -r requirements.in
 django-environ==0.11.2

--- a/tasks.py
+++ b/tasks.py
@@ -37,7 +37,7 @@ def requirements(c: Context, upgrade_all=False, upgrade_package=None):
     args = " -U" if upgrade_all else ""
     has_uv = c.run("uv -V", hide=True, timeout=1, warn=True)
     if has_uv.ok:
-        cmd_base = "uv pip compile --no-strip-extras"
+        cmd_base = "uv pip compile --no-strip-extras --no-emit-package setuptools"
     else:
         cmd_base = "pip-compile --resolver=backtracking"
     env = {"CUSTOM_COMPILE_COMMAND": "inv requirements", "UV_CUSTOM_COMPILE_COMMAND": "inv requirements"}


### PR DESCRIPTION
## Description
Add the [django-cleanup](https://github.com/un1t/django-cleanup) app to manage file deletion when DB models referencing them are deleted.

Noting this from their docs:
> This app is designed with the assumption that each file is referenced only once. If you are sharing a file over two or more model instances you will not have the desired functionality. Be cautious of copying model instances, as this will cause a file to be shared by more than one instance. If you want to reference a file from multiple models add a level of indirection. That is, use a separate file model that is referenced from other models through a foreign key. There are many file management apps already available in the django ecosystem that fulfill this behavior.

I don't think that's an issue for us but worth noting.