### PR TITLE
revert revert trace details

### DIFF
--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -85,7 +85,7 @@ class TopicBot:
         self.default_tag = None
         self.terminal_chain = None
         self.processor_experiment = None
-        self.trace_service = self.experiment.get_trace_service()
+        self.trace_service = self.experiment.trace_service
 
         # The chain that generated the AI message
         self.generator_chain = None

--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -93,7 +93,9 @@ class TopicBot:
 
     def _initialize(self):
         for child_route in self.child_experiment_routes:
-            child_runnable = create_experiment_runnable(child_route.child, self.session, self.disable_tools)
+            child_runnable = create_experiment_runnable(
+                child_route.child, self.session, self.disable_tools, trace_service=self.trace_service
+            )
             self.child_chains[child_route.keyword.lower().strip()] = child_runnable
             if child_route.is_default:
                 self.default_child_chain = child_runnable
@@ -102,13 +104,17 @@ class TopicBot:
         if self.child_chains and not self.default_child_chain:
             self.default_tag, self.default_child_chain = list(self.child_chains.items())[0]
 
-        self.chain = create_experiment_runnable(self.experiment, self.session, self.disable_tools)
+        self.chain = create_experiment_runnable(
+            self.experiment, self.session, self.disable_tools, trace_service=self.trace_service
+        )
 
         terminal_route = (
             ExperimentRoute.objects.select_related("child").filter(parent=self.experiment, type="terminal").first()
         )
         if terminal_route:
-            self.terminal_chain = create_experiment_runnable(terminal_route.child, self.session)
+            self.terminal_chain = create_experiment_runnable(
+                terminal_route.child, self.session, trace_service=self.trace_service
+            )
 
         # load up the safety bots. They should not be agents. We don't want them using tools (for now)
         self.safety_bots = [

--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -85,9 +85,7 @@ class TopicBot:
         self.default_tag = None
         self.terminal_chain = None
         self.processor_experiment = None
-        self.trace_service = None
-        if self.experiment.trace_provider:
-            self.trace_service = self.experiment.trace_provider.get_service()
+        self.trace_service = self.experiment.get_trace_service()
 
         # The chain that generated the AI message
         self.generator_chain = None

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -100,6 +100,7 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
         "openai_file_ids",
         # boolean indicating that this message has been synced to the thread
         "openai_thread_checkpoint",
+        "trace_info",
     }
 
     chat = models.ForeignKey(Chat, on_delete=models.CASCADE, related_name="messages")
@@ -128,6 +129,10 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
         if self.is_summary:
             raise ValueError("Cannot save a summary message")
         super().save(*args, **kwargs)
+
+    @property
+    def trace_info(self):
+        return self.metadata.get("trace_info")
 
     def get_summary_message(self):
         if not self.summary:

--- a/apps/chat/tests/test_topic_bot.py
+++ b/apps/chat/tests/test_topic_bot.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from unittest.mock import patch
 
 import pytest
@@ -5,7 +6,7 @@ import pytest
 from apps.annotations.models import TagCategories
 from apps.chat.bots import TopicBot
 from apps.chat.models import ChatMessage, ChatMessageType
-from apps.experiments.models import ExperimentRoute, ExperimentRouteType, SafetyLayer
+from apps.experiments.models import ExperimentRoute, ExperimentRouteType, ExperimentSession, SafetyLayer
 from apps.service_providers.models import TraceProvider
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.langchain import mock_experiment_llm
@@ -87,3 +88,34 @@ def test_tracing_service():
         )
         assert mock_get_trace_info.call_count == 2
     bot.process_input("test")
+
+
+@pytest.mark.django_db()
+def test_tracing_service_reentry():
+    """This tests simulates successive messages being processed by the bot and
+    verifies that the trace service is not called reentrantly."""
+    session = ExperimentSessionFactory()
+    provider = TraceProvider(type="langfuse", config={})
+
+    def _run_bot_with_wrapped_service(session, response):
+        """This configures the bot with a wrapped trace provider so that we can
+        verify that it was called. The calls to the provider are still passed
+        through to the actual service."""
+        session.experiment.trace_provider = provider
+
+        bot = TopicBot(session)
+        assert bot.trace_service is not None
+
+        # spy on the service
+        mock_service = mock.Mock(wraps=bot.trace_service)
+        bot.trace_service = mock_service
+
+        assert bot.process_input("test") == response
+        mock_service.get_callback.assert_called_once()
+
+    with mock_experiment_llm(None, responses=["response1", "response2"]):
+        _run_bot_with_wrapped_service(session, "response1")
+
+        # reload the session from the DB
+        session = ExperimentSession.objects.get(id=session.id)
+        _run_bot_with_wrapped_service(session, "response2")

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from datetime import datetime
-from functools import cache, cached_property
+from functools import cached_property
 from uuid import uuid4
 
 import markdown
@@ -653,8 +653,8 @@ class Experiment(BaseTeamModel, VersionsMixin):
         elif self.assistant:
             return self.assistant.llm_provider.get_llm_service()
 
-    @cache
-    def get_trace_service(self):
+    @cached_property
+    def trace_service(self):
         if self.trace_provider:
             return self.trace_provider.get_service()
 

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -653,7 +653,7 @@ class Experiment(BaseTeamModel, VersionsMixin):
         elif self.assistant:
             return self.assistant.llm_provider.get_llm_service()
 
-    @cached_property
+    @property
     def trace_service(self):
         if self.trace_provider:
             return self.trace_provider.get_service()

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from datetime import datetime
-from functools import cached_property
+from functools import cache, cached_property
 from uuid import uuid4
 
 import markdown
@@ -652,6 +652,11 @@ class Experiment(BaseTeamModel, VersionsMixin):
             return self.llm_provider.get_llm_service()
         elif self.assistant:
             return self.assistant.llm_provider.get_llm_service()
+
+    @cache
+    def get_trace_service(self):
+        if self.trace_provider:
+            return self.trace_provider.get_service()
 
     def get_api_url(self):
         return absolute_url(reverse("api:openai-chat-completions", args=[self.public_id]))

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -51,9 +51,11 @@ class GenerationCancelled(Exception):
         self.output = output
 
 
-def create_experiment_runnable(experiment: Experiment, session: ExperimentSession, disable_tools: bool = False):
+def create_experiment_runnable(
+    experiment: Experiment, session: ExperimentSession, disable_tools: bool = False, trace_service: Any = None
+):
     """Create an experiment runnable based on the experiment configuration."""
-    state_kwargs = {"experiment": experiment, "session": session}
+    state_kwargs = {"experiment": experiment, "session": session, "trace_service": trace_service}
     if assistant := experiment.assistant:
         state = AssistantExperimentState(**state_kwargs)
         if assistant.tools_enabled and not disable_tools:

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -287,7 +287,7 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
         output, annotation_file_ids = self._get_output_with_annotations(thread_id, run_id)
 
         if not current_thread_id:
-            self.state.set_metadata(Chat.MetadataKeys.OPENAI_THREAD_ID, thread_id)
+            self.state.set_chat_metadata(Chat.MetadataKeys.OPENAI_THREAD_ID, thread_id)
 
         experiment_tag = config.get("configurable", {}).get("experiment_tag")
         self.state.save_message_to_history(
@@ -315,7 +315,7 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
                 thread = self.state.raw_client.beta.threads.create(messages=first)
                 current_thread_id = thread.id
                 _sync_messages_to_existing_thread(current_thread_id, rest)
-                self.state.set_metadata(Chat.MetadataKeys.OPENAI_THREAD_ID, current_thread_id)
+                self.state.set_chat_metadata(Chat.MetadataKeys.OPENAI_THREAD_ID, current_thread_id)
         return current_thread_id
 
     @transaction.atomic()

--- a/apps/service_providers/llm_service/state.py
+++ b/apps/service_providers/llm_service/state.py
@@ -109,7 +109,7 @@ class ExperimentState(RunnableState):
         return get_tools(self.session, self.experiment)
 
     def get_trace_metadata(self) -> dict:
-        if trace_service := self.experiment.get_trace_service():
+        if trace_service := self.experiment.trace_service:
             trace_info = trace_service.get_current_trace_info()
             if trace_info:
                 return {
@@ -118,7 +118,7 @@ class ExperimentState(RunnableState):
         return {}
 
     def set_chat_metadata(self, key: Chat.MetadataKeys, value):
-        if trace_service := self.experiment.get_trace_service():
+        if trace_service := self.experiment.trace_service:
             trace_service.update_trace({key: value})
         self.chat.set_metadata(key, value)
 

--- a/apps/service_providers/llm_service/state.py
+++ b/apps/service_providers/llm_service/state.py
@@ -50,11 +50,19 @@ class RunnableState(metaclass=ABCMeta):
     def get_prompt(self):
         pass
 
+    @abstractmethod
+    def set_chat_metadata(self, key: Chat.MetadataKeys, value):
+        pass
+
 
 class ExperimentState(RunnableState):
     def __init__(self, experiment: Experiment, session: ExperimentSession):
         self.experiment = experiment
         self.session = session
+
+    @property
+    def chat(self):
+        return self.session.chat
 
     @cache
     def get_llm_service(self):
@@ -100,6 +108,20 @@ class ExperimentState(RunnableState):
     def get_tools(self):
         return get_tools(self.session, self.experiment)
 
+    def get_trace_metadata(self) -> dict:
+        if trace_service := self.experiment.get_trace_service():
+            trace_info = trace_service.get_current_trace_info()
+            if trace_info:
+                return {
+                    "trace_info": {**trace_info.model_dump(), "trace_provider": self.experiment.trace_provider.type},
+                }
+        return {}
+
+    def set_chat_metadata(self, key: Chat.MetadataKeys, value):
+        if trace_service := self.experiment.get_trace_service():
+            trace_service.update_trace({key: value})
+        self.chat.set_metadata(key, value)
+
 
 class ChatRunnableState(RunnableState):
     @abstractmethod
@@ -125,7 +147,7 @@ class ChatRunnableState(RunnableState):
 class ChatExperimentState(ExperimentState, ChatRunnableState):
     def get_chat_history(self, input_messages: list):
         return compress_chat_history(
-            self.session.chat,
+            self.chat,
             llm=self.get_chat_model(),
             max_token_limit=self.experiment.max_token_limit,
             input_messages=input_messages,
@@ -136,9 +158,7 @@ class ChatExperimentState(ExperimentState, ChatRunnableState):
 
     def save_message_to_history(self, message: str, type_: ChatMessageType, experiment_tag: str = None):
         chat_message = ChatMessage.objects.create(
-            chat=self.session.chat,
-            message_type=type_.value,
-            content=message,
+            chat=self.chat, message_type=type_.value, content=message, metadata=self.get_trace_metadata()
         )
         if experiment_tag:
             tag, _ = Tag.objects.get_or_create(
@@ -157,10 +177,10 @@ class ChatExperimentState(ExperimentState, ChatRunnableState):
                 )
 
     def check_cancellation(self):
-        self.session.chat.refresh_from_db(fields=["metadata"])
+        self.chat.refresh_from_db(fields=["metadata"])
         # temporary mechanism to cancel the chat
         # TODO: change this to something specific to the current chat message
-        return self.session.chat.metadata.get("cancelled", False)
+        return self.chat.metadata.get("cancelled", False)
 
 
 class AssistantState(RunnableState):
@@ -174,10 +194,6 @@ class AssistantState(RunnableState):
 
     @abstractmethod
     def get_metadata(self, key: Chat.MetadataKeys):
-        pass
-
-    @abstractmethod
-    def set_metadata(self, key: Chat.MetadataKeys, value):
         pass
 
     @abstractmethod
@@ -214,7 +230,7 @@ class AssistantExperimentState(ExperimentState, AssistantState):
         return instructions
 
     def get_attachments(self, attachment_type: str):
-        return self.session.chat.attachments.filter(tool_type__in=attachment_type)
+        return self.chat.attachments.filter(tool_type__in=attachment_type)
 
     def get_file_type_info(self, attachments: list):
         if not self.experiment.assistant.include_file_info:
@@ -231,16 +247,9 @@ class AssistantExperimentState(ExperimentState, AssistantState):
     def raw_client(self):
         return self.get_openai_assistant().client
 
-    @property
-    def chat(self):
-        return self.session.chat
-
     def get_metadata(self, key: Chat.MetadataKeys):
         """Chat metadata"""
         return self.chat.get_metadata(key)
-
-    def set_metadata(self, key: Chat.MetadataKeys, value):
-        self.chat.set_metadata(key, value)
 
     def save_message_to_history(
         self,
@@ -254,12 +263,12 @@ class AssistantExperimentState(ExperimentState, AssistantState):
         chat message metadata.
         Example resource_file_mapping: {"resource1": ["file1", "file2"], "resource2": ["file3", "file4"]}
         """
-        metadata = {"openai_thread_checkpoint": True}
+        metadata = {"openai_thread_checkpoint": True, **self.get_trace_metadata()}
         if annotation_file_ids:
             metadata["openai_file_ids"] = annotation_file_ids
 
         chat_message = ChatMessage.objects.create(
-            chat=self.session.chat,
+            chat=self.chat,
             message_type=type_.value,
             content=message,
             metadata=metadata,

--- a/apps/service_providers/models.py
+++ b/apps/service_providers/models.py
@@ -366,9 +366,9 @@ class TraceProviderType(models.TextChoices):
     def get_service(self, config: dict) -> tracing.TraceService:
         match self:
             case TraceProviderType.langfuse:
-                return tracing.LangFuseTraceService(config)
+                return tracing.LangFuseTraceService(self, config)
             case TraceProviderType.langsmith:
-                return tracing.LangSmithTraceService(config)
+                return tracing.LangSmithTraceService(self, config)
         raise Exception(f"No tracing service configured for {self}")
 
 

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -45,7 +45,6 @@ def session(request):
     session.experiment.assistant = local_assistant
     session.get_participant_data = lambda *args, **kwargs: None
     session.get_participant_timezone = lambda *args, **kwargs: ""
-    session.experiment.get_trace_service = lambda *args, **kwargs: None
     return session
 
 

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -45,6 +45,7 @@ def session(request):
     session.experiment.assistant = local_assistant
     session.get_participant_data = lambda *args, **kwargs: None
     session.get_participant_timezone = lambda *args, **kwargs: ""
+    session.experiment.get_trace_service = lambda *args, **kwargs: None
     return session
 
 
@@ -506,7 +507,7 @@ def test_sync_messages_to_thread(messages, thread_id, thread_created, messages_c
     if messages_created:
         assert state.raw_client.beta.threads.messages.create.call_count == len(messages)
     assert state.raw_client.beta.threads.create.called == thread_created
-    assert state.set_metadata.called == thread_created
+    assert state.set_chat_metadata.called == thread_created
 
 
 @pytest.mark.django_db()

--- a/apps/service_providers/tracing/service.py
+++ b/apps/service_providers/tracing/service.py
@@ -16,6 +16,10 @@ class TraceInfo(BaseModel):
 
 
 class TraceService:
+    def __init__(self, type_, config: dict):
+        self.type = type_
+        self.config = config
+
     def get_callback(self, participant_id: str, session_id: str):
         raise NotImplementedError
 
@@ -34,8 +38,8 @@ class LangFuseTraceService(TraceService):
     different credentials per call. This is why we don't use the standard 'observe' decorator.
     """
 
-    def __init__(self, config: dict):
-        self.config = config
+    def __init__(self, type_, config: dict):
+        super().__init__(type_, config)
         self._callback = None
 
     def get_callback(self, participant_id: str, session_id: str):
@@ -68,9 +72,6 @@ class LangFuseTraceService(TraceService):
 
 
 class LangSmithTraceService(TraceService):
-    def __init__(self, config: dict):
-        self.config = config
-
     def get_callback(self, participant_id: str, session_id: str):
         from langsmith import Client
 

--- a/apps/service_providers/tracing/service.py
+++ b/apps/service_providers/tracing/service.py
@@ -1,19 +1,70 @@
 from langchain_core.tracers import LangChainTracer
+from pydantic import BaseModel
+
+
+class ServiceReentryException(Exception):
+    pass
+
+
+class ServiceNotInitializedException(Exception):
+    pass
+
+
+class TraceInfo(BaseModel):
+    trace_id: str
+    trace_url: str
 
 
 class TraceService:
     def get_callback(self, participant_id: str, session_id: str):
         raise NotImplementedError
 
+    def update_trace(self, metadata: dict):
+        pass
+
+    def get_current_trace_info(self) -> TraceInfo | None:
+        return None
+
 
 class LangFuseTraceService(TraceService):
+    """
+    Notes on langfuse:
+
+    The API is designed to be used with a single set of credentials whereas we need to provide
+    different credentials per call. This is why we don't use the standard 'observe' decorator.
+    """
+
     def __init__(self, config: dict):
         self.config = config
+        self._callback = None
 
     def get_callback(self, participant_id: str, session_id: str):
         from langfuse.callback import CallbackHandler
 
-        return CallbackHandler(user_id=participant_id, session_id=session_id, **self.config)
+        if self._callback:
+            raise ServiceReentryException("Service does not support reentrant use.")
+
+        self._callback = CallbackHandler(user_id=participant_id, session_id=session_id, **self.config)
+        return self._callback
+
+    def update_trace(self, metadata: dict):
+        if not metadata:
+            return
+
+        if not self._callback:
+            raise ServiceNotInitializedException("Service not initialized.")
+
+        self._callback.trace.update(metadata=metadata)
+
+    def get_current_trace_info(self) -> TraceInfo | None:
+        if not self._callback:
+            raise ServiceNotInitializedException("Service not initialized.")
+
+        if self._callback.trace:
+            return TraceInfo(
+                trace_id=self._callback.trace.id,
+                trace_url=self._callback.trace.get_trace_url(),
+            )
 
 
 class LangSmithTraceService(TraceService):

--- a/apps/utils/langchain.py
+++ b/apps/utils/langchain.py
@@ -169,7 +169,7 @@ def mock_experiment_llm(experiment, responses: list[Any], token_counts: list[int
         patch("apps.experiments.models.Experiment.get_llm_service", new=fake_llm_service),
         patch("apps.assistants.models.OpenAiAssistant.get_assistant", new=fake_get_assistant),
     ):
-        yield
+        yield service
 
 
 def build_fake_llm_service(responses, token_counts, fake_llm=None):

--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -8,7 +8,7 @@ export async function copyToClipboard (callee, elementId) {
   const span = callee.getElementsByTagName('span')[0]
   const element = document.getElementById(elementId)
   let text;
-  if (element.tagName == "INPUT") {
+  if (element.tagName === "INPUT") {
     text = element.value;
   } else {
     text = element.innerHTML;
@@ -16,8 +16,14 @@ export async function copyToClipboard (callee, elementId) {
   
   try {
     await navigator.clipboard.writeText(text).then(() => {
+      const prevClass = icon.className;
+      const prevHTML = span.innerHTML
       icon.className = 'fa-solid fa-check'
       span.innerHTML = 'Copied!'
+      setTimeout(() => {
+        icon.className = prevClass;
+        span.innerHTML = prevHTML;
+      }, 2000);
     })
   } catch (err) {
     console.error('Failed to copy: ', err)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ export default tseslint.config(
         "navigator": "readonly",
         "console": "readonly",
         Event: "readonly",
+        setTimeout: "readonly"
       }
     },
   },

--- a/templates/experiments/chat/ai_message.html
+++ b/templates/experiments/chat/ai_message.html
@@ -1,7 +1,14 @@
 {% load chat_tags %}
 <div class="flex flex-col gap-1">
   {% if experiment.debug_mode_enabled %}
-    <div>
+    <div class="flex gap-2 items-center">
+      {% if message.trace_info %}
+        <div class="tooltip tooltip-right" data-tip="Open Trace on {{ message.trace_info.trace_provider|title }}">
+          <a class="btn btn-xs btn-square btn-outline" href="{{ message.trace_info.trace_url }}" target="_blank">
+            <i class="fa-regular fa-chart-bar"></i>
+          </a>
+        </div>
+      {% endif %}
       {% if message.get_safety_layer_tag_name %}
         <div class="badge badge-sm badge-error">Safety Layer '{{ message.get_safety_layer_tag_name }}' Triggered</div>
       {% endif %}

--- a/templates/experiments/chat/input_bar.html
+++ b/templates/experiments/chat/input_bar.html
@@ -17,7 +17,7 @@
       {% if assistant %}enctype="multipart/form-data"{% endif %}
 >
   {% csrf_token %}
-  <div class="flex flex-col" x-data="fileUploads">
+  <div class="flex flex-col" {% if assistant %}x-data="fileUploads"{% endif %}>
     <div class="flex items-center w-full">
       {% if assistant %}
         <div class="mt-1 flex flex-row gap-2">
@@ -73,34 +73,36 @@
       <input name="message" type="text" placeholder="Type your message..." aria-label="Message" autocomplete="off" class="input input-bordered input-primary w-full" oninput="checkInput()">
       <button type="submit" id="message-submit" class="ml-2 btn btn-primary" disabled>Send</button>
     </div>
-    <div class="flex flex-col gap-2 text-slate-500">
-      <div x-cloak x-show="code_interpreter_files.length > 0">
-        <h4 class="font-bold">Code Interpreter Files</h4>
-        <div class="ml-5">
-          <template x-for="(file, index) in code_interpreter_files" :key="index">
-            <div class="flex items-center gap-2">
-              <span x-text="index+1"></span><span x-text="file.name"></span>
-              <button type="button" class="btn btn-xs" @click="removeFile(index, 'code_interpreter_files')">
-                <i class="fa-solid fa-trash htmx-hide"></i>
-              </button>
-            </div>
-          </template>
+    {% if assistant %}
+      <div class="flex flex-col gap-2 text-slate-500">
+        <div x-cloak x-show="code_interpreter_files.length > 0">
+          <h4 class="font-bold">Code Interpreter Files</h4>
+          <div class="ml-5">
+            <template x-for="(file, index) in code_interpreter_files" :key="index">
+              <div class="flex items-center gap-2">
+                <span x-text="index+1"></span><span x-text="file.name"></span>
+                <button type="button" class="btn btn-xs" @click="removeFile(index, 'code_interpreter_files')">
+                  <i class="fa-solid fa-trash htmx-hide"></i>
+                </button>
+              </div>
+            </template>
+          </div>
+        </div>
+        <div x-cloak x-show="file_search_files.length > 0">
+          <h4 class="font-bold">File Search Files</h4>
+          <div class="ml-5">
+            <template x-for="(file, index) in file_search_files" :key="index">
+              <div class="flex items-center gap-2">
+                <span x-text="index+1"></span><span x-text="file.name"></span>
+                <button type="button" class="btn btn-xs" @click="removeFile(index, 'file_search_files')">
+                  <i class="fa-solid fa-trash htmx-hide"></i>
+                </button>
+              </div>
+            </template>
+          </div>
         </div>
       </div>
-      <div x-cloak x-show="file_search_files.length > 0">
-        <h4 class="font-bold">File Search Files</h4>
-        <div class="ml-5">
-          <template x-for="(file, index) in file_search_files" :key="index">
-            <div class="flex items-center gap-2">
-              <span x-text="index+1"></span><span x-text="file.name"></span>
-              <button type="button" class="btn btn-xs" @click="removeFile(index, 'file_search_files')">
-                <i class="fa-solid fa-trash htmx-hide"></i>
-              </button>
-            </div>
-          </template>
-        </div>
-      </div>
-    </div>
+    {% endif %}
   </div>
   <div class="w-full mt-2 text-center">
     <label for="end-experiment-modal" class="btn btn-warning btn-xs" >End Experiment</label>

--- a/templates/experiments/components/experiment_chat.html
+++ b/templates/experiments/components/experiment_chat.html
@@ -47,15 +47,22 @@
                             </div>
                           {% endfor %}
                         </div>
-                        <div class="mt-2 pg-text-muted flex justify-between items-center">
+                        <div class="mt-2 pg-text-muted flex justify-between items-center gap-2">
                           <div>
                             <i class="fa-solid fa-clock mr-1"></i>
                             <time datetime="{{ message.created_at.isoformat }}" title="{{ message.created_at.isoformat }}">
                               {{ message.created_at|date:"DATETIME_FORMAT" }}
                             </time>
                           </div>
+                          {% if message.trace_info %}
+                            <div class="tooltip" data-tip="Open Trace on {{ message.trace_info.trace_provider|title }}">
+                              <a class="btn btn-xs btn-square" href="{{ message.trace_info.trace_url }}" target="_blank">
+                                <i class="fa-regular fa-chart-bar"></i>
+                              </a>
+                            </div>
+                          {% endif %}
                           {% if perms.annotations.add_usercomment %}
-                            <div class="grow ml-8">
+                            <div class="grow">
                               {% include "annotations/tag_ui.html" with object=message %}
                             </div>
                           {% endif %}

--- a/templates/experiments/components/experiment_details.html
+++ b/templates/experiments/components/experiment_details.html
@@ -11,6 +11,26 @@
           </dd>
         </div>
       {% endfor %}
+      {% if experiment.assistant %}
+        <div class="py-3 grid grid-cols-3 sm:gap-4">
+          <dt class="text-sm font-medium leading-6">OpenAI Assistant</dt>
+          <dd class="text-sm col-span-2">
+            <div class="btn btn-sm" onclick="SiteJS.app.copyToClipboard(this, 'assistant_id')" title="Copy to clipboard">
+              <span id="assistant_id">{{ experiment.assistant.assistant_id }}</span>
+              <i class="fa-regular fa-copy"></i><span></span>
+            </div>
+          </dd>
+        </div>
+        <div class="py-3 grid grid-cols-3 sm:gap-4">
+          <dt class="text-sm font-medium leading-6">OpenAI Thread</dt>
+          <dd class="text-sm col-span-2">
+            <div class="btn btn-sm" onclick="SiteJS.app.copyToClipboard(this, 'thread_id')" title="Copy to clipboard">
+              <span id="thread_id">{{ experiment_session.chat.metadata.openai_thread_id }}</span>
+              <i class="fa-regular fa-copy"></i><span></span>
+            </div>
+          </dd>
+        </div>
+      {% endif %}
       <div class="py-3 grid grid-cols-3">
         <dt class="text-sm font-medium leading-6">Tags</dt>
         <dd class="col-span-2 mr-2">

--- a/templates/experiments/experiment_session_view.html
+++ b/templates/experiments/experiment_session_view.html
@@ -77,6 +77,7 @@
 
 {% block page_js %}
   {{ block.super  }}
+  <script src="{% static 'js/app-bundle.js' %}"></script>
   <script
     id="tag-multiselect"
     src="{% static "js/tagMultiselect-bundle.js" %}"


### PR DESCRIPTION
## Description
Redo of https://github.com/dimagi/open-chat-studio/pull/835

The issue that caused [DIMAGI-BOTS-HA](https://dimagi.sentry.io/issues/6051321440/) is that `functools.cache` creates a global cache which resulted in the same 'trace service' being used in successive calls. This PR adds a new commit which changes the cached function to a cached property which is local to the class instance.

For more info on the topic see https://rednafi.com/python/lru_cache_on_methods/