### PR TITLE
Fix: Loop when vector store has many files

### DIFF
--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -190,24 +190,47 @@ def are_files_in_sync_with_openai(assistant: OpenAiAssistant) -> bool:
 
     # ensure files match
     for resource in tool_resources:
-        openai_file_ids = []
-        if resource.tool_type == "code_interpreter":
-            code_interpreter = getattr(assistant_data.tool_resources, "code_interpreter", None)
-            if code_interpreter is not None and code_interpreter.file_ids:
-                openai_file_ids = code_interpreter.file_ids
-            else:
-                openai_file_ids = []
-        elif resource.tool_type == "file_search":
-            openai_vector_store_id = resource.extra.get("vector_store_id")
-            if openai_vector_store_id:
-                vector_store_data = client.beta.vector_stores.files.list(vector_store_id=openai_vector_store_id)
-                openai_file_ids = [file.id for file in getattr(vector_store_data, "data", [])]
-            else:
-                openai_file_ids = []
+        openai_file_ids = _get_tool_file_ids_from_openai(client, assistant_data, resource)
         ocs_file_ids = [file.external_id for file in resource.files.all() if file.external_id]
         if set(ocs_file_ids) != set(openai_file_ids):
             return False
     return True
+
+
+def _get_tool_file_ids_from_openai(client, assistant_data, resource: ToolResources) -> list[str]:
+    """
+    Retrieve file IDs from OpenAI based on the specified tool resource type.
+
+    Args:
+        client: The OpenAI client instance used to interact with the OpenAI API.
+        assistant_data: The assistant data containing tool resources.
+        resource (ToolResources): The tool resource object specifying the type of tool and additional parameters.
+
+    Returns:
+        list[str]: A list of file IDs retrieved from OpenAI.
+
+    The function handles two types of tool resources:
+    - "code_interpreter": Returns file IDs directly from the code interpreter tool resource if available.
+    - "file_search": Retrieves file IDs from the OpenAI vector store using the provided vector store ID.
+    """
+    openai_file_ids = []
+    if resource.tool_type == "code_interpreter":
+        code_interpreter = getattr(assistant_data.tool_resources, "code_interpreter", None)
+        if code_interpreter is not None and code_interpreter.file_ids:
+            return code_interpreter.file_ids
+    elif resource.tool_type == "file_search":
+        openai_vector_store_id = resource.extra.get("vector_store_id")
+        if openai_vector_store_id:
+            kwargs = {}
+            while True:
+                vector_store_data = client.beta.vector_stores.files.list(
+                    vector_store_id=openai_vector_store_id, limit=100, **kwargs
+                )
+                openai_file_ids.extend([file.id for file in getattr(vector_store_data, "data", [])])
+                if not vector_store_data.has_more:
+                    break
+                kwargs["after"] = vector_store_data.last_id
+    return openai_file_ids
 
 
 @wrap_openai_errors

--- a/apps/assistants/tests/test_sync.py
+++ b/apps/assistants/tests/test_sync.py
@@ -7,6 +7,7 @@ from openai.pagination import SyncCursorPage
 
 from apps.assistants.models import ToolResources
 from apps.assistants.sync import (
+    are_files_in_sync_with_openai,
     delete_openai_assistant,
     import_openai_assistant,
     push_assistant_to_openai,
@@ -237,3 +238,71 @@ def test_delete_openai_assistant(mock_file_delete, mock_vector_store_delete, moc
     mock_delete.assert_called_with(local_assistant.assistant_id)
     assert mock_file_delete.call_count == 3
     assert mock_vector_store_delete.call_count == 1
+
+
+@pytest.mark.django_db()
+@patch("openai.resources.beta.Assistants.retrieve")
+def test_code_interpreter_are_files_in_sync_with_openai(mock_retrieve):
+    tool_type = "code_interpreter"
+    openai_files = FileObjectFactory.create_batch(2)
+
+    remote_assistant = AssistantFactory()
+    remote_assistant.tool_resources.code_interpreter.file_ids = [file.id for file in openai_files]
+    del remote_assistant.tool_resources.file_search
+    mock_retrieve.return_value = remote_assistant
+
+    # setup local assistant
+    files = FileFactory.create_batch(2)
+    files[0].external_id = openai_files[0].id
+    files[1].external_id = openai_files[1].id
+    [file.save() for file in files]
+
+    local_assistant = OpenAiAssistantFactory(assistant_id="test_id", builtin_tools=[tool_type])
+    resource = ToolResources.objects.create(tool_type=tool_type, assistant=local_assistant)
+    resource.files.set([files[0]])
+
+    assert are_files_in_sync_with_openai(local_assistant) is False
+
+    # Update local files to match remote files
+    resource.files.set(files)
+    assert are_files_in_sync_with_openai(local_assistant) is True
+
+
+@pytest.mark.django_db()
+@patch("openai.resources.beta.vector_stores.files.Files.list")
+@patch("openai.resources.beta.Assistants.retrieve")
+def test_file_search_are_files_in_sync_with_openai(mock_retrieve, file_list):
+    tool_type = "file_search"
+    openai_files = FileObjectFactory.create_batch(2)
+    file_list.side_effect = [
+        SyncCursorPage(data=[FileObjectFactory(id=openai_files[0].id)], has_more=True, last_id=openai_files[0].id),
+        SyncCursorPage(data=[FileObjectFactory(id=openai_files[1].id)], has_more=False),
+    ]
+
+    remote_assistant = AssistantFactory()
+    vector_store_id = "vs_123"
+    remote_assistant.tool_resources.file_search.vector_store_ids = [vector_store_id]
+    del remote_assistant.tool_resources.code_interpreter
+    mock_retrieve.return_value = remote_assistant
+
+    # setup local assistant
+    files = FileFactory.create_batch(2)
+    files[0].external_id = openai_files[0].id
+    files[1].external_id = openai_files[1].id
+    [file.save() for file in files]
+
+    local_assistant = OpenAiAssistantFactory(assistant_id="test_id", builtin_tools=[tool_type])
+    resource = ToolResources.objects.create(
+        tool_type="file_search", assistant=local_assistant, extra={"vector_store_id": vector_store_id}
+    )
+    resource.files.set([files[0]])
+
+    assert are_files_in_sync_with_openai(local_assistant) is False
+
+    # Update local files to match remote files
+    file_list.side_effect = [
+        SyncCursorPage(data=[FileObjectFactory(id=openai_files[0].id)], has_more=True, last_id=openai_files[0].id),
+        SyncCursorPage(data=[FileObjectFactory(id=openai_files[1].id)], has_more=False),
+    ]
+    resource.files.set(files)
+    assert are_files_in_sync_with_openai(local_assistant) is True


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
- We did not consider the `has_more=True` case in the vector store result when checking if the assistants are in sync
- The default pagination result size is 20. The maximum we can set is 100
- We now set it to 100 and loop when there are even more.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
The message saying that there are files at OpenAI but not in OCS should now show correctly.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs
<!--Link to documentation that has been updated.-->
N/A
