### PR TITLE
Fix saving prompts and fetching history

### DIFF
--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -49,7 +49,7 @@ def get_response_for_webchat_task(
 @shared_task
 def get_prompt_builder_response_task(team_id: int, user_id, data_dict: dict) -> dict[str, str | int]:
     llm_service = LlmProvider.objects.get(id=data_dict["provider"]).get_llm_service()
-    llm_provider_model = LlmProviderModel.objects.get(id=data_dict["model"])
+    llm_provider_model = LlmProviderModel.objects.get(id=data_dict["providerModelId"])
     messages_history = data_dict["messages"]
 
     user = CustomUser.objects.get(id=user_id)

--- a/apps/experiments/views/prompt.py
+++ b/apps/experiments/views/prompt.py
@@ -51,10 +51,13 @@ def prompt_builder_load_source_material(request, team_slug: str):
 def experiments_prompt_builder(request, team_slug: str):
     llm_providers = list(request.team.llmprovider_set.all())
     default_llm_provider = llm_providers[0] if llm_providers else None
-    default_llm_provider_model = None
+    default_llm_provider_model_id = None
     if default_llm_provider:
-        default_llm_provider_model = (
-            LlmProviderModel.objects.for_team(request.team).filter(type=default_llm_provider.type).first()
+        default_llm_provider_model_id = (
+            LlmProviderModel.objects.for_team(request.team)
+            .filter(type=default_llm_provider.type)
+            .values_list("id", flat=True)
+            .first()
         )
 
     return TemplateResponse(
@@ -64,7 +67,7 @@ def experiments_prompt_builder(request, team_slug: str):
             "llm_options": get_llm_provider_choices(request.team),
             "llm_providers": llm_providers,
             "default_llm_provider": default_llm_provider,
-            "default_llm_model": default_llm_provider_model,
+            "default_llm_provider_model_id": default_llm_provider_model_id,
             "active_tab": "prompt_builder",
         },
     )
@@ -117,7 +120,8 @@ def get_prompt_builder_history(request, team_slug: str):
             "temperature": history_data.get("temperature", 0.7),
             "prompt": history_data.get("prompt", ""),
             "inputFormatter": history_data.get("inputFormatter", ""),
-            "model": history_data.get("model", "gpt-4"),
+            "provider": history_data.get("provider"),
+            "providerModelId": history_data.get("providerModelId"),
             "messages": history_data.get("messages", []),
         }
 

--- a/templates/experiments/components/prompt_builder_toolbox.html
+++ b/templates/experiments/components/prompt_builder_toolbox.html
@@ -50,9 +50,9 @@
                         {% endfor %}
                     </select>
                     <select id="model-selector" class="w-full select select-sm select-bordered"
-                            x-model="$store.promptBuilder.currentState.model">
+                            x-model="$store.promptBuilder.currentState.providerModelId">
                         <template x-for="(option, index) in $store.promptBuilder.llm_models" :key="index">
-                            <option :value="option.value" x-text="option.text" :selected="option.value == $store.promptBuilder.currentState.model"></option>
+                            <option :value="option.value" x-text="option.text" :selected="option.value == $store.promptBuilder.currentState.providerModelId"></option>
                         </template>
                     </select>
                 </div>
@@ -118,7 +118,7 @@
                 'input_formatter': Alpine.store('promptBuilder').currentState.inputFormatter,
                 'source_material': Alpine.store('promptBuilder').currentState.sourceMaterialID,
                 'llm_provider': Alpine.store('promptBuilder').currentState.provider,
-                'llm': Alpine.store('promptBuilder').currentState.model,
+                'llm_provider_model': Alpine.store('promptBuilder').currentState.providerModelId,
                 'temperature': Alpine.store('promptBuilder').currentState.temperature,
             })
         })
@@ -193,7 +193,7 @@
             sourceMaterialID: Alpine.store('promptBuilder').currentState.sourceMaterialID,
             sourceMaterialName: Alpine.store('promptBuilder').currentState.sourceMaterialName,
             provider: Alpine.store('promptBuilder').currentState.provider,
-            model: Alpine.store('promptBuilder').currentState.model,
+            providerModelId: Alpine.store('promptBuilder').currentState.providerModelId,
             temperature: Alpine.store('promptBuilder').currentState.temperature,
             messages: messagesArray
         };

--- a/templates/experiments/prompt_builder.html
+++ b/templates/experiments/prompt_builder.html
@@ -65,7 +65,7 @@
                     Alpine.effect(() => {
                         if (this.currentState && this.currentState.provider !== undefined) {
                             this.llm_models = llmModelOptions[this.currentState.provider].models
-                            this.currentState.model = this.llm_models[0].value;
+                            this.currentState.providerModelId = this.llm_models[0].value;
                         }
                     });
                 },
@@ -112,7 +112,7 @@
                                 prompt: '',
                                 inputFormatter: '',
                                 provider: {{ default_llm_provider.id|default:'null' }},
-                                model: '{{ default_llm_model|default:'null' }}',
+                                providerModelId: {{ default_llm_provider_model_id|default:'null' }},
                                 messages: []
                             }
                         ]
@@ -136,7 +136,8 @@
                         nowState.temperature = destinationState.temperature;
                         nowState.prompt = destinationState.prompt;
                         nowState.inputFormatter = destinationState.inputFormatter;
-                        nowState.model = destinationState.model;
+                        nowState.provider = destinationState.provider;
+                        nowState.providerModelId = destinationState.providerModelId;
                         nowState.messages = destinationState.messages;
 
                     // Point us to 'now' and reset previous state tracker


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
A few other issues I found in the prompt builder: saving prompts and restoring prompts from history.
I think restoring prompts from history was broken before, as the provider was not being included.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users can save prompts and load history state again. 

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->
