### PR TITLE
Append index to the output only when there are multiple outputs

### DIFF
--- a/assets/javascript/apps/pipeline/nodes/NodeOutputs.tsx
+++ b/assets/javascript/apps/pipeline/nodes/NodeOutputs.tsx
@@ -7,12 +7,15 @@ import WrappedHandle from "./WrappedHandle";
 export default function NodeOutputs({nodeId, data}: {nodeId: string, data: NodeData}) {
   const outputNames = getOutputNames(data.type, data.params);
   const multipleOutputs = outputNames.length > 1;
+  const generateOutputHandle = (outputIndex: number) => {
+    return multipleOutputs ? `output_${outputIndex}` : "output";
+  };
   return (
     <>
       {multipleOutputs && <div className="divider">Outputs</div>}
       <div className={multipleOutputs ? "": "py-2 mt-2 border-t border-neutral"}>
         {outputNames.map((outputName, index) => (
-          <NodeOutput key={outputName} handleKey={`output_${index}`} nodeId={nodeId} label={outputName} />
+          <NodeOutput key={outputName} handleKey={generateOutputHandle(index)} nodeId={nodeId} label={outputName} />
         ))}
       </div>
     </>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
The generated output was `output_0` for non conditional nodes, resulting in [this check](https://github.com/dimagi/open-chat-studio/blob/fe0c67af10e1202cb62be3e0efc7e7a602bd487e/apps/pipelines/graph.py#L37-L38) failing and consequently [this code](https://github.com/dimagi/open-chat-studio/blob/fe0c67af10e1202cb62be3e0efc7e7a602bd487e/apps/pipelines/graph.py#L113-L120) is being executed for nodes that doesn't have the `process_conditional` methods

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->
