### PR TITLE
add 'minutes' to the scheduling time period options

### DIFF
--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -299,6 +299,7 @@ class TimeoutTrigger(BaseModel, VersionsMixin):
 
 
 class TimePeriod(models.TextChoices):
+    MINUTES = ("minutes", "Minutes")
     HOURS = ("hours", "Hours")
     DAYS = ("days", "Days")
     WEEKS = ("weeks", "Weeks")


### PR DESCRIPTION
## Description
Allow users to schedule events in the 'minutes' range.

This was a request from the SUDCare project (mostly for demo purposes).