### PR TITLE
Refactor Assistant Runnable + state

### DIFF
--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -128,7 +128,7 @@ class TopicBot:
             tag, chain = None, self.chain
 
         # The processor_experiment is the experiment that generated the output
-        self.processor_experiment = chain.experiment
+        self.processor_experiment = chain.state.experiment
         result = chain.invoke(
             input_str,
             config={

--- a/apps/chat/tests/test_routing.py
+++ b/apps/chat/tests/test_routing.py
@@ -72,8 +72,8 @@ def test_experiment_routing_with_tracing():
         (False, "not a valid keyword", "keyword1"),
     ],
 )
-@patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._get_output_with_annotations")
-@patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._get_response_with_retries")
+@patch("apps.service_providers.llm_service.runnables.AssistantRunnable._get_output_with_annotations")
+@patch("apps.service_providers.llm_service.runnables.AssistantRunnable._get_response_with_retries")
 def test_experiment_routing_with_assistant(
     get_response_with_retries, save_response_annotations, with_default, routing_response, expected_tag
 ):

--- a/apps/chat/tests/test_tasks.py
+++ b/apps/chat/tests/test_tasks.py
@@ -82,7 +82,7 @@ class TasksTest(TestCase):
 
 
 @pytest.mark.django_db()
-@patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._get_output_with_annotations")
+@patch("apps.service_providers.llm_service.runnables.AssistantRunnable._get_output_with_annotations")
 def test_no_activity_ping_with_assistant_bot(save_response_annotations):
     save_response_annotations.return_value = "Hey, answer me!", {}
     session = ExperimentSessionFactory()

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -31,8 +31,8 @@ from apps.experiments.models import Experiment, ExperimentSession
 from apps.files.models import File
 from apps.service_providers.llm_service.main import OpenAIAssistantRunnable
 from apps.service_providers.llm_service.state import (
-    AssistantExperimentState,
     ChatExperimentState,
+    ExperimentAssistantState,
 )
 
 if TYPE_CHECKING:
@@ -56,7 +56,7 @@ def create_experiment_runnable(
     """Create an experiment runnable based on the experiment configuration."""
     state_kwargs = {"experiment": experiment, "session": session, "trace_service": trace_service}
     if assistant := experiment.assistant:
-        state = AssistantExperimentState(**state_kwargs)
+        state = ExperimentAssistantState(**state_kwargs)
         if assistant.tools_enabled and not disable_tools:
             return AssistantAgentRunnable(state=state)
         return AssistantRunnable(state=state)
@@ -256,7 +256,7 @@ class AgentExperimentRunnable(ExperimentRunnable):
 
 
 class AssistantRunnable(RunnableSerializable[dict, ChainOutput]):
-    state: AssistantExperimentState
+    state: ExperimentAssistantState
     input_key: str = "content"
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -59,7 +59,7 @@ def create_experiment_runnable(
         state = AssistantExperimentState(**state_kwargs)
         if assistant.tools_enabled and not disable_tools:
             return AssistantAgentRunnable(state=state)
-        return AssistantExperimentRunnable(state=state)
+        return AssistantRunnable(state=state)
 
     assert experiment.llm_provider, "Experiment must have an LLM provider"
     assert experiment.llm_provider_model.name, "Experiment must have an LLM model"
@@ -255,7 +255,7 @@ class AgentExperimentRunnable(ExperimentRunnable):
         return chain.invoke(self._get_input(input)).to_messages()
 
 
-class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
+class AssistantRunnable(RunnableSerializable[dict, ChainOutput]):
     state: AssistantExperimentState
     input_key: str = "content"
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -543,7 +543,7 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
         return {}
 
 
-class AssistantAgentRunnable(AssistantExperimentRunnable):
+class AssistantAgentRunnable(AssistantRunnable):
     def _extra_input_configs(self) -> dict:
         return {}
 

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -33,7 +33,6 @@ from apps.service_providers.llm_service.main import OpenAIAssistantRunnable
 from apps.service_providers.llm_service.state import (
     AssistantExperimentState,
     ChatExperimentState,
-    ChatRunnableState,
 )
 
 if TYPE_CHECKING:
@@ -97,7 +96,7 @@ class ChainOutput(Serializable):
 
 
 class ExperimentRunnable(RunnableSerializable[str, ChainOutput]):
-    state: ChatRunnableState
+    state: ChatExperimentState
     memory: BaseMemory = ConversationBufferMemory(return_messages=True, output_key="output", input_key="input")
     cancelled: bool = False
     last_cancel_check: float | None = None
@@ -282,9 +281,8 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
 
         current_thread_id = self._sync_messages_to_thread(self.state.get_metadata(Chat.MetadataKeys.OPENAI_THREAD_ID))
 
-        if config.get("configurable", {}).get("save_input_to_history", True):
-            file_ids = set([file_id for file_ids in human_message_resource_file_ids.values() for file_id in file_ids])
-            self.state.save_message_to_history(input, ChatMessageType.HUMAN, annotation_file_ids=list(file_ids))
+        human_message_metadata = self.state.get_input_message_metadata(human_message_resource_file_ids)
+        self.state.pre_run_hook(input, config, human_message_metadata)
 
         if current_thread_id:
             input_dict["thread_id"] = current_thread_id
@@ -295,10 +293,8 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
         if not current_thread_id:
             self.state.set_chat_metadata(Chat.MetadataKeys.OPENAI_THREAD_ID, thread_id)
 
-        experiment_tag = config.get("configurable", {}).get("experiment_tag")
-        self.state.save_message_to_history(
-            output, ChatMessageType.AI, annotation_file_ids=annotation_file_ids, experiment_tag=experiment_tag
-        )
+        ai_message_metadata = self.state.get_output_message_metadata(annotation_file_ids)
+        self.state.post_run_hook(output, config, ai_message_metadata)
         return ChainOutput(output=output, prompt_tokens=0, completion_tokens=0)
 
     def _sync_messages_to_thread(self, current_thread_id):
@@ -341,8 +337,7 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
         session_id = self.state.session.id
 
         team = self.state.session.team
-        experiment = self.state.experiment
-        assistant_file_ids = ToolResources.objects.filter(assistant=experiment.assistant).values_list("files")
+        assistant_file_ids = ToolResources.objects.filter(assistant=self.state.assistant).values_list("files")
         assistant_files_ids = File.objects.filter(
             team_id=team.id, id__in=models.Subquery(assistant_file_ids)
         ).values_list("external_id", flat=True)
@@ -358,7 +353,7 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
                         image_file_attachments.append(created_file)
                         file_ids.add(created_file.external_id)
 
-                        team_slug = self.state.session.team.slug
+                        team_slug = team.slug
                         file_link = f"file:{team_slug}:{session_id}:{created_file.id}"
                         output_message += f"![{created_file.name}]({file_link})\n"
 
@@ -377,7 +372,7 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
                             )
 
                             # Original citation text example:【6:0†source】
-                            if experiment.citations_enabled:
+                            if self.state.citations_enabled:
                                 message_content_value = message_content_value.replace(file_ref_text, f" [{idx}]")
                                 if file_link:
                                     message_content_value += f"\n[{idx}]: {file_link}"
@@ -392,7 +387,7 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
                             created_file = get_and_store_openai_file(
                                 client=client,
                                 file_id=file_id,
-                                team_id=self.state.experiment.team_id,
+                                team_id=team.id,
                             )
                             # Original citation text example: sandbox:/mnt/data/the_file.csv.
                             # This is the link part in what looks like
@@ -436,7 +431,7 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
             return get_and_store_openai_file(
                 client=client,
                 file_id=file_id,
-                team_id=self.state.experiment.team_id,
+                team_id=self.state.team.id,
             )
         except Exception as ex:
             logger.exception(ex)
@@ -485,7 +480,7 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
         if not attachments:
             return resource_file_ids
 
-        client = self.state.get_llm_service().get_raw_client()
+        client = self.state.raw_client
 
         for resource_name in ["file_search", "code_interpreter"]:
             file_ids = [att.file_id for att in attachments if att.type == resource_name]
@@ -533,10 +528,6 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
             if cancelling:
                 sleep(assistant_runnable.check_every_ms / 1000)
 
-    @property
-    def experiment(self) -> Experiment:
-        return self.state.experiment
-
     def _get_response(self, assistant_runnable: OpenAIAssistantRunnable, input: dict, config: dict) -> tuple[str, str]:
         response: OpenAIAssistantFinish = assistant_runnable.invoke(input, config)
         return response.thread_id, response.run_id
@@ -545,10 +536,8 @@ class AssistantExperimentRunnable(RunnableSerializable[dict, ChainOutput]):
         # Allow builtin tools but not custom tools when not running as an agent
         # This is to prevent using tools when using the assistant to generate responses
         # for automated messages e.g. reminders
-        custom_tools = self.state.experiment.assistant.tools_enabled
-        builtin_tools = self.state.experiment.assistant.builtin_tools
-        if custom_tools and builtin_tools:
-            return {"tools": [{"type": tool} for tool in builtin_tools]}
+        if self.state.tools_enabled and self.state.builtin_tools:
+            return {"tools": [{"type": tool} for tool in self.state.builtin_tools]}
 
         # prefer not to specify if we don't need to
         return {}

--- a/apps/service_providers/llm_service/state.py
+++ b/apps/service_providers/llm_service/state.py
@@ -281,8 +281,7 @@ class BaseAssistantState(BaseRunnableState):
         pass
 
 
-class AssistantExperimentState(ExperimentState, BaseAssistantState):
-    # TODO: rename to ExperimentAssistantState
+class ExperimentAssistantState(ExperimentState, BaseAssistantState):
     # TODO: rename save_message_to_history to _save_message_to_history
     def pre_run_hook(self, input, config, message_metadata):
         if config.get("configurable", {}).get("save_input_to_history", True):

--- a/apps/service_providers/llm_service/state.py
+++ b/apps/service_providers/llm_service/state.py
@@ -282,7 +282,6 @@ class BaseAssistantState(BaseRunnableState):
 
 
 class ExperimentAssistantState(ExperimentState, BaseAssistantState):
-    # TODO: rename save_message_to_history to _save_message_to_history
     def pre_run_hook(self, input, config, message_metadata):
         if config.get("configurable", {}).get("save_input_to_history", True):
             self.save_message_to_history(input, type_=ChatMessageType.HUMAN, message_metadata=message_metadata)

--- a/apps/service_providers/llm_service/state.py
+++ b/apps/service_providers/llm_service/state.py
@@ -5,16 +5,18 @@ from django.utils import timezone
 from langchain_core.callbacks import BaseCallbackHandler
 
 from apps.annotations.models import Tag, TagCategories
+from apps.assistants.models import OpenAiAssistant
 from apps.channels.models import ChannelPlatform
 from apps.chat.agent.tools import get_tools
 from apps.chat.conversation import compress_chat_history
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
 from apps.experiments.models import Experiment, ExperimentSession
 from apps.service_providers.llm_service.main import OpenAIAssistantRunnable
+from apps.teams.models import Team
 from apps.utils.time import pretty_date
 
 
-class RunnableState(metaclass=ABCMeta):
+class BaseRunnableState(metaclass=ABCMeta):
     ai_message: ChatMessage | None = None
 
     @abstractmethod
@@ -54,8 +56,13 @@ class RunnableState(metaclass=ABCMeta):
     def set_chat_metadata(self, key: Chat.MetadataKeys, value):
         pass
 
+    @property
+    @abstractmethod
+    def chat(self):
+        pass
 
-class ExperimentState(RunnableState):
+
+class ExperimentState(BaseRunnableState):
     def __init__(self, experiment: Experiment, session: ExperimentSession, trace_service=None):
         self.experiment = experiment
         self.session = session
@@ -126,28 +133,7 @@ class ExperimentState(RunnableState):
         self.chat.set_metadata(key, value)
 
 
-class ChatRunnableState(RunnableState):
-    @abstractmethod
-    def get_chat_history(self, input_messages: list):
-        pass
-
-    def get_source_material(self):
-        pass
-
-    @abstractmethod
-    def save_message_to_history(self, message: str, type_: ChatMessageType, experiment_tag: str = None):
-        pass
-
-    @abstractmethod
-    def check_cancellation(self):
-        pass
-
-    @abstractmethod
-    def get_tools(self):
-        pass
-
-
-class ChatExperimentState(ExperimentState, ChatRunnableState):
+class ChatExperimentState(ExperimentState):
     def get_chat_history(self, input_messages: list):
         return compress_chat_history(
             self.chat,
@@ -186,36 +172,12 @@ class ChatExperimentState(ExperimentState, ChatRunnableState):
         return self.chat.metadata.get("cancelled", False)
 
 
-class AssistantState(RunnableState):
-    @abstractmethod
-    def get_assistant_instructions(self) -> str:
-        pass
-
-    @abstractmethod
-    def get_openai_assistant(self):
-        pass
-
-    @abstractmethod
-    def get_metadata(self, key: Chat.MetadataKeys):
-        pass
-
-    @abstractmethod
-    def save_message_to_history(
-        self, message: str, type_: ChatMessageType, resource_file_ids: dict | None = None
-    ) -> ChatMessage:
-        pass
-
-    @abstractmethod
-    def raw_client(self):
-        pass
-
-
-class AssistantExperimentState(ExperimentState, AssistantState):
+class BaseAssistantState(BaseRunnableState):
     def get_assistant_instructions(self):
         # Langchain doesn't support the `additional_instructions` parameter that the API specifies, so we have to
         # override the instructions if we want to pass in dynamic data.
         # https://github.com/langchain-ai/langchain/blob/cccc8fbe2fe59bde0846875f67aa046aeb1105a3/libs/langchain/langchain/agents/openai_assistant/base.py#L491
-        instructions = self.experiment.assistant.instructions
+        instructions = self.assistant.instructions
 
         instructions = instructions.format(
             participant_data=self.get_participant_data(),
@@ -223,7 +185,7 @@ class AssistantExperimentState(ExperimentState, AssistantState):
         )
 
         code_interpreter_attachments = self.get_attachments(["code_interpreter"])
-        if self.experiment.assistant.include_file_info and code_interpreter_attachments:
+        if self.assistant.include_file_info and code_interpreter_attachments:
             file_type_info = self.get_file_type_info(code_interpreter_attachments)
             instructions += "\n\nFile type information:\n\n| File Path | Mime Type |\n"
             for file_info in file_type_info:
@@ -232,33 +194,111 @@ class AssistantExperimentState(ExperimentState, AssistantState):
 
         return instructions
 
-    def get_attachments(self, attachment_type: str):
-        return self.chat.attachments.filter(tool_type__in=attachment_type)
-
-    def get_file_type_info(self, attachments: list):
-        if not self.experiment.assistant.include_file_info:
+    def get_file_type_info(self, attachments: list) -> list:
+        if not self.assistant.include_file_info:
             return ""
         file_type_info = []
         for att in attachments:
             file_type_info.extend([{file.external_id: file.content_type} for file in att.files.all()])
         return file_type_info
 
-    def get_openai_assistant(self) -> OpenAIAssistantRunnable:
-        return self.experiment.assistant.get_assistant()
+    def get_attachments(self, attachment_type: str):
+        return self.chat.attachments.filter(tool_type__in=attachment_type)
 
     @cached_property
     def raw_client(self):
         return self.get_openai_assistant().client
 
+    def get_input_message_metadata(self, resource_file_mapping: dict[str, list[str]]):
+        metadata = {"openai_thread_checkpoint": True, **self.get_trace_metadata()}
+        file_ids = set([file_id for file_ids in resource_file_mapping.values() for file_id in file_ids])
+        metadata["openai_file_ids"] = list(file_ids)
+        return metadata
+
+    def get_output_message_metadata(self, annotation_file_ids: list):
+        metadata = {"openai_thread_checkpoint": True, **self.get_trace_metadata()}
+        metadata["openai_file_ids"] = annotation_file_ids
+        return metadata
+
+    def get_messages_to_sync_to_thread(self):
+        to_sync = []
+        for message in self.chat.message_iterator(with_summaries=False):
+            if message.get_metadata("openai_thread_checkpoint"):
+                break
+            to_sync.append(message)
+        return [
+            {
+                "content": message.content,
+                "role": message.role,
+            }
+            for message in reversed(to_sync)
+            if message.message_type != "system"
+        ]
+
     def get_metadata(self, key: Chat.MetadataKeys):
         """Chat metadata"""
         return self.chat.get_metadata(key)
+
+    def get_openai_assistant(self) -> OpenAIAssistantRunnable:
+        return self.assistant.get_assistant()
+
+    @property
+    def tools_enabled(self):
+        return self.assistant.tools_enabled
+
+    @property
+    def builtin_tools(self):
+        self.assistant.builtin_tools
+
+    @cached_property
+    def team(self) -> Team:
+        return self.assistant.team
+
+    @abstractmethod
+    def pre_run_hook(self, input, config, message_metadata):
+        pass
+
+    @abstractmethod
+    def post_run_hook(self, output, config, message_metadata):
+        pass
+
+    @abstractmethod
+    def citations_enabled(self) -> bool:
+        pass
+
+    @property
+    @abstractmethod
+    def assistant(self) -> OpenAiAssistant:
+        pass
+
+    @property
+    @abstractmethod
+    def chat(self):
+        pass
+
+    @abstractmethod
+    def get_trace_metadata(self) -> dict:
+        pass
+
+
+class AssistantExperimentState(ExperimentState, BaseAssistantState):
+    # TODO: rename to ExperimentAssistantState
+    # TODO: rename save_message_to_history to _save_message_to_history
+    def pre_run_hook(self, input, config, message_metadata):
+        if config.get("configurable", {}).get("save_input_to_history", True):
+            self.save_message_to_history(input, type_=ChatMessageType.HUMAN, message_metadata=message_metadata)
+
+    def post_run_hook(self, output, config, message_metadata):
+        experiment_tag = config.get("configurable", {}).get("experiment_tag")
+        self.save_message_to_history(
+            output, type_=ChatMessageType.AI, message_metadata=message_metadata, experiment_tag=experiment_tag
+        )
 
     def save_message_to_history(
         self,
         message: str,
         type_: ChatMessageType,
-        annotation_file_ids: list | None = None,
+        message_metadata: dict | None = None,
         experiment_tag: str | None = None,
     ):
         """
@@ -266,15 +306,12 @@ class AssistantExperimentState(ExperimentState, AssistantState):
         chat message metadata.
         Example resource_file_mapping: {"resource1": ["file1", "file2"], "resource2": ["file3", "file4"]}
         """
-        metadata = {"openai_thread_checkpoint": True, **self.get_trace_metadata()}
-        if annotation_file_ids:
-            metadata["openai_file_ids"] = annotation_file_ids
-
+        message_metadata = message_metadata or {}
         chat_message = ChatMessage.objects.create(
             chat=self.chat,
             message_type=type_.value,
             content=message,
-            metadata=metadata,
+            metadata=message_metadata,
         )
 
         if experiment_tag:
@@ -296,20 +333,9 @@ class AssistantExperimentState(ExperimentState, AssistantState):
         return chat_message
 
     @property
-    def tools_enabled(self):
-        return self.experiment.assistant.tools_enabled
+    def citations_enabled(self):
+        return self.experiment.citations_enabled
 
-    def get_messages_to_sync_to_thread(self):
-        to_sync = []
-        for message in self.chat.message_iterator(with_summaries=False):
-            if message.get_metadata("openai_thread_checkpoint"):
-                break
-            to_sync.append(message)
-        return [
-            {
-                "content": message.content,
-                "role": message.role,
-            }
-            for message in reversed(to_sync)
-            if message.message_type != "system"
-        ]
+    @property
+    def assistant(self):
+        return self.experiment.assistant

--- a/apps/service_providers/tests/llm_service/test_state.py
+++ b/apps/service_providers/tests/llm_service/test_state.py
@@ -1,7 +1,7 @@
 import pytest
 
 from apps.chat.models import ChatMessage, ChatMessageType
-from apps.service_providers.llm_service.state import AssistantExperimentState, ChatExperimentState
+from apps.service_providers.llm_service.state import ChatExperimentState, ExperimentAssistantState
 from apps.utils.factories.experiment import ExperimentSessionFactory
 
 
@@ -22,9 +22,9 @@ class TestChatExperimentState:
 
 
 @pytest.mark.django_db()
-class TestAssistantExperimentState:
+class TestExperimentAssistantState:
     def test_save_message_to_history_stores_ai_message_on_state(self, session):
-        state = AssistantExperimentState(session=session, experiment=session.experiment)
+        state = ExperimentAssistantState(session=session, experiment=session.experiment)
         state.save_message_to_history(message="hi", type_=ChatMessageType.HUMAN)
         assert state.ai_message is None
         state.save_message_to_history(message="hi human", type_=ChatMessageType.AI)

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -22,7 +22,7 @@ from apps.service_providers.llm_service.runnables import (
     GenerationError,
     create_experiment_runnable,
 )
-from apps.service_providers.llm_service.state import AssistantExperimentState
+from apps.service_providers.llm_service.state import ExperimentAssistantState
 from apps.utils.factories.assistants import OpenAiAssistantFactory
 from apps.utils.factories.experiment import ExperimentSessionFactory
 from apps.utils.factories.files import FileFactory
@@ -61,11 +61,11 @@ def db_session(request):
 
 @patch("apps.chat.agent.tools.get_custom_action_tools", Mock(return_value=[]))
 @patch(
-    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    "apps.service_providers.llm_service.state.ExperimentAssistantState.get_messages_to_sync_to_thread",
     Mock(return_value=[]),
 )
-@patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
-@patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
+@patch("apps.service_providers.llm_service.state.ExperimentAssistantState.save_message_to_history", Mock())
+@patch("apps.service_providers.llm_service.state.ExperimentAssistantState.get_attachments", Mock())
 @patch("apps.service_providers.llm_service.runnables.AssistantRunnable._get_output_with_annotations")
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
@@ -95,11 +95,11 @@ def test_assistant_conversation_new_chat(
 
 @patch("apps.chat.agent.tools.get_custom_action_tools", Mock(return_value=[]))
 @patch(
-    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    "apps.service_providers.llm_service.state.ExperimentAssistantState.get_messages_to_sync_to_thread",
     Mock(return_value=[]),
 )
-@patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
-@patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
+@patch("apps.service_providers.llm_service.state.ExperimentAssistantState.save_message_to_history", Mock())
+@patch("apps.service_providers.llm_service.state.ExperimentAssistantState.get_attachments", Mock())
 @patch("apps.service_providers.llm_service.runnables.AssistantRunnable._get_output_with_annotations")
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.messages.Messages.create")
@@ -129,11 +129,11 @@ def test_assistant_conversation_existing_chat(
 
 @patch("apps.chat.agent.tools.get_custom_action_tools", Mock(return_value=[]))
 @patch(
-    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    "apps.service_providers.llm_service.state.ExperimentAssistantState.get_messages_to_sync_to_thread",
     Mock(return_value=[]),
 )
-@patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
-@patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
+@patch("apps.service_providers.llm_service.state.ExperimentAssistantState.save_message_to_history", Mock())
+@patch("apps.service_providers.llm_service.state.ExperimentAssistantState.get_attachments", Mock())
 @patch("apps.service_providers.llm_service.runnables.AssistantRunnable._get_output_with_annotations")
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
@@ -165,10 +165,10 @@ def test_assistant_conversation_input_formatting(
 
 @pytest.mark.django_db()
 @patch(
-    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    "apps.service_providers.llm_service.state.ExperimentAssistantState.get_messages_to_sync_to_thread",
     Mock(return_value=[]),
 )
-@patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_file_type_info")
+@patch("apps.service_providers.llm_service.state.ExperimentAssistantState.get_file_type_info")
 @patch("apps.service_providers.llm_service.runnables.AssistantRunnable._get_output_with_annotations")
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
@@ -203,11 +203,11 @@ def test_assistant_includes_file_type_information(
 
 @patch("apps.chat.agent.tools.get_custom_action_tools", Mock(return_value=[]))
 @patch(
-    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    "apps.service_providers.llm_service.state.ExperimentAssistantState.get_messages_to_sync_to_thread",
     Mock(return_value=[]),
 )
-@patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
-@patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
+@patch("apps.service_providers.llm_service.state.ExperimentAssistantState.save_message_to_history", Mock())
+@patch("apps.service_providers.llm_service.state.ExperimentAssistantState.get_attachments", Mock())
 def test_assistant_runnable_raises_error(session):
     experiment = session.experiment
 
@@ -220,11 +220,11 @@ def test_assistant_runnable_raises_error(session):
 
 @patch("apps.chat.agent.tools.get_custom_action_tools", Mock(return_value=[]))
 @patch(
-    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    "apps.service_providers.llm_service.state.ExperimentAssistantState.get_messages_to_sync_to_thread",
     Mock(return_value=[]),
 )
-@patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
-@patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
+@patch("apps.service_providers.llm_service.state.ExperimentAssistantState.save_message_to_history", Mock())
+@patch("apps.service_providers.llm_service.state.ExperimentAssistantState.get_attachments", Mock())
 def test_assistant_runnable_handles_cancellation_status(session):
     experiment = session.experiment
 
@@ -271,11 +271,11 @@ def test_assistant_runnable_handles_cancellation_status(session):
 )
 @patch("apps.chat.agent.tools.get_custom_action_tools", Mock(return_value=[]))
 @patch(
-    "apps.service_providers.llm_service.state.AssistantExperimentState.get_messages_to_sync_to_thread",
+    "apps.service_providers.llm_service.state.ExperimentAssistantState.get_messages_to_sync_to_thread",
     Mock(return_value=[]),
 )
-@patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
-@patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
+@patch("apps.service_providers.llm_service.state.ExperimentAssistantState.save_message_to_history", Mock())
+@patch("apps.service_providers.llm_service.state.ExperimentAssistantState.get_attachments", Mock())
 @patch("apps.service_providers.llm_service.runnables.AssistantRunnable._get_output_with_annotations")
 def test_assistant_runnable_cancels_existing_run(save_response_annotations, responses, exception, output, session):
     save_response_annotations.return_value = ("normal response", {})
@@ -497,7 +497,7 @@ def test_assistant_response_with_image_file_content_block(
     ],
 )
 def test_sync_messages_to_thread(messages, thread_id, thread_created, messages_created):
-    state = Mock(spec=AssistantExperimentState)
+    state = Mock(spec=ExperimentAssistantState)
     state.get_messages_to_sync_to_thread.return_value = messages
     assistant_runnable = AssistantRunnable(state=state)
     assistant_runnable._sync_messages_to_thread(thread_id)
@@ -521,7 +521,7 @@ def test_get_messages_to_sync_to_thread():
             ChatMessage(chat=chat, message_type="ai", content="hello3", metadata={}),
         ]
     )
-    state = AssistantExperimentState(session.experiment, session)
+    state = ExperimentAssistantState(session.experiment, session)
     to_sync = state.get_messages_to_sync_to_thread()
     assert to_sync == [
         {"role": "user", "content": "hello2"},
@@ -530,7 +530,7 @@ def test_get_messages_to_sync_to_thread():
 
 
 def _get_assistant_mocked_history_recording(session, get_attachments_return_value=None):
-    state = AssistantExperimentState(session.experiment, session)
+    state = ExperimentAssistantState(session.experiment, session)
     assistant = AssistantRunnable(state=state)
     state.save_message_to_history = Mock()
     state.get_attachments = lambda _type: get_attachments_return_value or []

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -17,7 +17,7 @@ from apps.channels.datamodels import Attachment
 from apps.chat.agent.tools import TOOL_CLASS_MAP
 from apps.chat.models import Chat, ChatAttachment, ChatMessage
 from apps.service_providers.llm_service.runnables import (
-    AssistantExperimentRunnable,
+    AssistantRunnable,
     GenerationCancelled,
     GenerationError,
     create_experiment_runnable,
@@ -66,7 +66,7 @@ def db_session(request):
 )
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
-@patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._get_output_with_annotations")
+@patch("apps.service_providers.llm_service.runnables.AssistantRunnable._get_output_with_annotations")
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
 @patch("openai.resources.beta.Threads.create_and_run")
@@ -100,7 +100,7 @@ def test_assistant_conversation_new_chat(
 )
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
-@patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._get_output_with_annotations")
+@patch("apps.service_providers.llm_service.runnables.AssistantRunnable._get_output_with_annotations")
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.messages.Messages.create")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
@@ -134,7 +134,7 @@ def test_assistant_conversation_existing_chat(
 )
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
-@patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._get_output_with_annotations")
+@patch("apps.service_providers.llm_service.runnables.AssistantRunnable._get_output_with_annotations")
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
 @patch("openai.resources.beta.Threads.create_and_run")
@@ -169,7 +169,7 @@ def test_assistant_conversation_input_formatting(
     Mock(return_value=[]),
 )
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_file_type_info")
-@patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._get_output_with_annotations")
+@patch("apps.service_providers.llm_service.runnables.AssistantRunnable._get_output_with_annotations")
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
 @patch("openai.resources.beta.Threads.create_and_run")
@@ -276,7 +276,7 @@ def test_assistant_runnable_handles_cancellation_status(session):
 )
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.save_message_to_history", Mock())
 @patch("apps.service_providers.llm_service.state.AssistantExperimentState.get_attachments", Mock())
-@patch("apps.service_providers.llm_service.runnables.AssistantExperimentRunnable._get_output_with_annotations")
+@patch("apps.service_providers.llm_service.runnables.AssistantRunnable._get_output_with_annotations")
 def test_assistant_runnable_cancels_existing_run(save_response_annotations, responses, exception, output, session):
     save_response_annotations.return_value = ("normal response", {})
     thread_id = "thread_abc"
@@ -499,7 +499,7 @@ def test_assistant_response_with_image_file_content_block(
 def test_sync_messages_to_thread(messages, thread_id, thread_created, messages_created):
     state = Mock(spec=AssistantExperimentState)
     state.get_messages_to_sync_to_thread.return_value = messages
-    assistant_runnable = AssistantExperimentRunnable(state=state)
+    assistant_runnable = AssistantRunnable(state=state)
     assistant_runnable._sync_messages_to_thread(thread_id)
 
     assert state.get_messages_to_sync_to_thread.called
@@ -531,7 +531,7 @@ def test_get_messages_to_sync_to_thread():
 
 def _get_assistant_mocked_history_recording(session, get_attachments_return_value=None):
     state = AssistantExperimentState(session.experiment, session)
-    assistant = AssistantExperimentRunnable(state=state)
+    assistant = AssistantRunnable(state=state)
     state.save_message_to_history = Mock()
     state.get_attachments = lambda _type: get_attachments_return_value or []
     return assistant


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
This is a prefactor for the assistant node. I'm planning on calling the `AssistantRunnable` from the node, but with a new  state that reads the config from the node/assistant instead of the experiment. There's still a lot we can refactor in the state/runnables files, but I'm going to only change that which is needed atm

## User Impact
<!-- Describe the impact of this change on the end-users. -->
None

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs
<!--Link to documentation that has been updated.-->
N/A