### PR TITLE
allow variables in input formatter

### DIFF
--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -169,18 +169,9 @@ class ExperimentRunnable(RunnableSerializable[str, ChainOutput]):
 
     def _get_input_chain_context(self, with_history=True):
         prompt = self.prompt
-        context = {}
+        context = self.state.get_template_context(prompt.input_variables)
         if with_history:
             context.update(self.memory.load_memory_variables({}))
-
-        if "source_material" in prompt.input_variables:
-            context["source_material"] = self.state.get_source_material()
-
-        if "participant_data" in prompt.input_variables:
-            context["participant_data"] = self.state.get_participant_data()
-
-        if "current_datetime" in prompt.input_variables:
-            context["current_datetime"] = self.state.get_current_datetime()
 
         return RunnableLambda(lambda inputs: context | inputs, name="add_prompt_context")
 

--- a/apps/service_providers/tests/test_runnables.py
+++ b/apps/service_providers/tests/test_runnables.py
@@ -171,6 +171,7 @@ def test_runnable_with_custom_actions(session, fake_llm_service):
         ("", ""),
         (" {participant_data}", " {'name': 'Tester'}"),
         (" {current_datetime}", " the current date and time"),
+        (" {participant_data[name]}", " Tester"),
     ],
 )
 @pytest.mark.django_db()


### PR DESCRIPTION
## Description
Allow referencing the available variables in the input formatter. This is primarily to support routing based on the participant data.
