### PR TITLE
Prevent multiple files from being returned

### DIFF
--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -436,7 +436,7 @@ class AssistantRunnable(RunnableSerializable[dict, ChainOutput]):
         team = self.state.session.team
         session_id = self.state.session.id
         try:
-            file = File.objects.get(external_id=file_id, team_id=team.id)
+            file = File.objects.get(external_id=file_id, team_id=team.id).first()
             file_link = f"file:{team.slug}:{session_id}:{file.id}"
             file_name = file.name
         except File.DoesNotExist:

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -436,9 +436,12 @@ class AssistantRunnable(RunnableSerializable[dict, ChainOutput]):
         team = self.state.session.team
         session_id = self.state.session.id
         try:
-            file = File.objects.get(external_id=file_id, team_id=team.id).first()
+            file = File.objects.get(external_id=file_id, team_id=team.id)
             file_link = f"file:{team.slug}:{session_id}:{file.id}"
             file_name = file.name
+        except File.MultipleObjectsReturned:
+            logger.error("Multiple files with the same external ID", extra={"file_id": file_id, "team": team.slug})
+            file = File.objects.filter(external_id=file_id, team_id=team.id).first()
         except File.DoesNotExist:
             client = self.state.raw_client
             try:


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
[sentry](https://dimagi.sentry.io/issues/5998995252/?project=4505001320316928&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=0)

feels like a bandaid-- why are there multiple files with the same external id in the team in the first place? but that should be resolved in another PR since this check doesn't hurt to add

## User Impact
<!-- Describe the impact of this change on the end-users. -->
prevents it from erroring out

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
n/a

### Docs
<!--Link to documentation that has been updated.-->
n/a
