### PR TITLE
allow referencing participant data internals

### DIFF
--- a/apps/service_providers/llm_service/prompt_context.py
+++ b/apps/service_providers/llm_service/prompt_context.py
@@ -122,5 +122,10 @@ class SafeAccessWrapper:
     def __str__(self):
         return str(self.data) if self.data is not None else ""
 
+    def __eq__(self, other):
+        if isinstance(other, SafeAccessWrapper):
+            return self.data == other.data
+        return self.data == other
+
 
 EMPTY = SafeAccessWrapper(None)

--- a/apps/service_providers/llm_service/prompt_context.py
+++ b/apps/service_providers/llm_service/prompt_context.py
@@ -38,8 +38,10 @@ class PromptTemplateContext:
 
     def get_participant_data(self):
         if self.is_unauthorized_participant:
-            return ""
-        return self.session.get_participant_data(use_participant_tz=True) or ""
+            data = ""
+        else:
+            data = self.session.get_participant_data(use_participant_tz=True) or ""
+        return SafeAccessWrapper(data)
 
     def get_current_datetime(self):
         return pretty_date(timezone.now(), self.session.get_participant_timezone())
@@ -54,3 +56,71 @@ class PromptTemplateContext:
         - Always True, since the external channel handles authorization
         """
         return self.session.experiment_channel.platform == ChannelPlatform.WEB and self.session.participant.user is None
+
+
+class SafeAccessWrapper:
+    """Allow access to nested data structures without raising exceptions.
+
+    This class wraps around a data structure and allows access to its elements
+    without raising exceptions. If the element does not exist, it returns an
+    empty string. This is useful when formatting strings with nested data
+    structures, where some elements may not exist.
+
+    Attributes can be accessed using dot notation, and items can be accessed
+    using dot notation or square brackets. For accessing items, the key must not be quoted
+    and can be an integer or a string. Slicing is not supported.
+
+    Examples:
+    >>> data = {"name": "John Doe", "age": 19, "tasks": [{"name": "Task 1", "status": "completed"}]}
+    >>> data = SafeAccessWrapper(data)
+    >>> print("{data.name}!".format(data=data))
+    John Doe!
+    >>> print("{data.tasks[0].name}".format(data=data))
+    Task 1
+    >>> print("{data.address}".format(data=data))
+    """
+
+    def __init__(self, data):
+        self.data = data
+
+    def __getattribute__(self, item):
+        if item and item.startswith("__"):
+            return EMPTY
+        return super().__getattribute__(item)
+
+    def __getitem__(self, key):
+        if isinstance(self.data, list | str):
+            try:
+                return SafeAccessWrapper(self.data[int(key)])
+            except (IndexError, ValueError):
+                return SafeAccessWrapper(None)
+        if isinstance(self.data, dict):
+            return SafeAccessWrapper(self.data.get(key, None))
+
+        if isinstance(self.data, int):
+            return EMPTY
+
+        try:
+            return SafeAccessWrapper(self.data[key])
+        except (IndexError, TypeError):
+            return EMPTY
+
+    def __getattr__(self, key):
+        if isinstance(self.data, dict):
+            return SafeAccessWrapper(self.data.get(key, ""))
+        elif isinstance(self.data, list | str):
+            try:
+                return SafeAccessWrapper(self.data[int(key)])
+            except (IndexError, ValueError):
+                return EMPTY
+
+        try:
+            return SafeAccessWrapper(getattr(self.data, key))
+        except AttributeError:
+            return EMPTY
+
+    def __str__(self):
+        return str(self.data) if self.data is not None else ""
+
+
+EMPTY = SafeAccessWrapper(None)

--- a/apps/service_providers/tests/test_safe_data_access.py
+++ b/apps/service_providers/tests/test_safe_data_access.py
@@ -7,7 +7,7 @@ from apps.service_providers.llm_service.prompt_context import SafeAccessWrapper
     ("prompt", "output"),
     [
         ("Hello, World!", "Hello, World!"),
-        ("{data.name}!", "John Doe!"),
+        ("{data.name} ({data.age})", "John Doe (19)"),
         ("{data.name[1]}", "o"),
         ("{data.name.1}", "o"),
         ("{data.name.name}", ""),

--- a/apps/service_providers/tests/test_safe_data_access.py
+++ b/apps/service_providers/tests/test_safe_data_access.py
@@ -1,0 +1,52 @@
+import pytest
+
+from apps.service_providers.llm_service.prompt_context import SafeAccessWrapper
+
+
+@pytest.mark.parametrize(
+    ("prompt", "output"),
+    [
+        ("Hello, World!", "Hello, World!"),
+        ("{data.name}!", "John Doe!"),
+        ("{data.name[1]}", "o"),
+        ("{data.name.1}", "o"),
+        ("{data.name.name}", ""),
+        ("{data.age}", "19"),
+        ("{data.age.0}", ""),
+        ("{data.age[1]}", ""),
+        ("{data[name]}!", "John Doe!"),
+        ("{data['name']}", ""),  # should not be quoted
+        ("{data.tasks[0].name}", "Task 1"),
+        ("{data.tasks.0.name}", "Task 1"),
+        ("{data.tasks.0[name]}", "Task 1"),
+        ("{data.email}", ""),
+        ("{data.tasks[0].due}", ""),
+        ("{data.tasks[1]}", ""),
+        ("{data.tasks.1}", ""),
+        ("{data.tasks[1].name}", ""),
+        ("{data.name[-1]}", "e"),
+        ("{data.name.-1}", "e"),
+        ("{data.tasks.-1.status}", "completed"),
+        ("{data.name[1:2]}", ""),  # slice not supported
+        ("{data.__class__}", ""),
+        ("{data.__dict__}", ""),
+        ("{data.__module__}", ""),
+        ("{data.__code__}", ""),
+        ("{data.__subclasses__()}", ""),
+        ("{data.__init__}", ""),
+        ("{data.__delattr__}", ""),
+        ("{data.__getattribute__}", ""),
+        ("{data.__setattr__}", ""),
+        ("{data.__del__}", ""),
+    ],
+)
+def test_format_participant_data(prompt, output):
+    participant_data = {
+        "name": "John Doe",
+        "age": 19,
+        "tasks": [
+            {"name": "Task 1", "status": "completed"},
+        ],
+    }
+
+    assert prompt.format(data=SafeAccessWrapper(participant_data)) == output


### PR DESCRIPTION
## Description
This change makes it possible to selectively include parts of the participant data in prompts and input formats.

For example:
```
{participant_data.name}
{participant_data.schedules.0.is_complete}
```

If any attribute or item access fails, the result will be an empty string (see test cases).

The use cases for this are probably quite niche but likely to be useful in routing. It also makes it possible to split up the participant data in the prompt (since you can reference the variable multiple times)

### Docs
TODO
