### PR TITLE
Ignore the version suffix when comparing assistant names

### DIFF
--- a/apps/assistants/models.py
+++ b/apps/assistants/models.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models, transaction
@@ -130,6 +132,15 @@ class OpenAiAssistant(BaseTeamModel, VersionsMixin):
 
         push_assistant_to_openai(assistant_version, internal_tools=get_assistant_tools(assistant_version))
         return assistant_version
+
+    def compare_with_model(self, new: Self, exclude_fields: list[str]) -> set:
+        exclude = exclude_fields.copy()
+        exclude.append("name")
+        changes = super().compare_with_model(new, exclude)
+        new_name = new.name.split(f" v{new.version_number}")[0]
+        if self.name != new_name:
+            changes.add("name")
+        return changes
 
     def _copy_custom_action_operations_to_new_version(self, new_version):
         for operation in self.get_custom_action_operations():


### PR DESCRIPTION
resolves #890 

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Since we appended the version as a suffix to the assistant version name and it will always change, we must ignore it when computing the difference between two versions. I think it makes sense to literally add the version in the name instead of doing it in the `__str__` method, since then we don't have to manually add the version each time we care about query results. A good example is in pipelines when we list the available assistants. It doesn't use the `__str__` representation, but rather the DB name

## User Impact
<!-- Describe the impact of this change on the end-users. -->
The diff view will show the assistant changed when it actually did

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->
