### PR TITLE
Only verify email when participant data is being injected into the prompt

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1566,3 +1566,6 @@ class ExperimentSession(BaseTeamModel):
         experiment's version number
         """
         return self.chat.metadata.get(Chat.MetadataKeys.EXPERIMENT_VERSION, Experiment.DEFAULT_VERSION_NUMBER)
+
+    def requires_participant_data(self) -> bool:
+        return "{participant_data}" in self.experiment.prompt_text

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1568,4 +1568,22 @@ class ExperimentSession(BaseTeamModel):
         return self.chat.metadata.get(Chat.MetadataKeys.EXPERIMENT_VERSION, Experiment.DEFAULT_VERSION_NUMBER)
 
     def requires_participant_data(self) -> bool:
-        return "{participant_data}" in self.experiment.prompt_text
+        """Determines if participant data is required for this session"""
+        from apps.assistants.models import OpenAiAssistant
+        from apps.pipelines.nodes.nodes import AssistantNode, LLMResponseWithPrompt, RouterNode
+
+        if self.experiment.assistant:
+            return "{participant_data}" in self.experiment.assistant.instructions
+        elif self.experiment.pipeline:
+            assistant_ids = self.experiment.pipeline.get_node_param_values(AssistantNode, param_name="assistant_id")
+            results = OpenAiAssistant.objects.filter(
+                id__in=assistant_ids, instructions__contains="{participant_data}"
+            ).exists()
+            if results:
+                return True
+            llm_prompts = self.experiment.pipeline.get_node_param_values(LLMResponseWithPrompt, param_name="prompt")
+            router_prompts = self.experiment.pipeline.get_node_param_values(RouterNode, param_name="prompt")
+            prompts = llm_prompts + router_prompts
+            return bool([prompt for prompt in prompts if "{participant_data}" in prompt])
+        else:
+            return "{participant_data}" in self.experiment.prompt_text

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -999,6 +999,9 @@ def _verify_user_or_start_session(identifier, request, session):
     if request.user.is_authenticated:
         return _record_consent_and_redirect(request, team_slug, session)
 
+    if not session.requires_participant_data():
+        return _record_consent_and_redirect(request, team_slug, session)
+
     if session_data := get_chat_session_access_cookie_data(request, fail_silently=True):
         if Participant.objects.filter(
             id=session_data["participant_id"], identifier=identifier, team_id=session.team_id

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -213,6 +213,9 @@ class Pipeline(BaseTeamModel, VersionsMixin):
         super().archive()
         self.node_set.update(is_archived=True)
 
+    def get_node_param_values(self, node_cls, param_name: str) -> list:
+        return list(self.node_set.filter(type=node_cls.__name__).values_list(f"params__{param_name}", flat=True))
+
 
 class Node(BaseModel, VersionsMixin):
     flow_id = models.CharField(max_length=128, db_index=True)  # The ID assigned by react-flow


### PR DESCRIPTION
See [this thread](https://dimagi.slack.com/archives/C05PK63Q89H/p1732192937178459)

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
I think it makes sense to only verify email addresses when participant data is being injected. We're not really sharing sensitive data if it's not being injected. Email verification is seen as a slight hinderance when we want to get mass participantion

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->
