### PR TITLE
update handle with node changes

### DIFF
--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -1,5 +1,5 @@
 import {Node, NodeProps, NodeToolbar, Position} from "reactflow";
-import React, {ChangeEvent} from "react";
+import React, {ChangeEvent, useEffect, useRef, useState} from "react";
 import {classNames, getCachedData} from "./utils";
 import usePipelineStore from "./stores/pipelineStore";
 import usePipelineManagerStore from "./stores/pipelineManagerStore";
@@ -49,6 +49,19 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
     "border px-4 py-2 shadow-md rounded-xl border-2 bg-base-100",
   )
 
+  const nodeRef = useRef<HTMLDivElement>(null);
+  const [rect, setRect] = useState<DOMRect>();
+  useEffect(() => {
+    if (nodeRef && nodeRef.current) {
+      const resizeObserver = new ResizeObserver((entries) => {
+        if (entries[0].target === nodeRef.current) {
+          setRect(nodeRef.current.getBoundingClientRect());
+        }
+      });
+      resizeObserver.observe(nodeRef.current);
+    }
+  }, [nodeRef]);
+
   return (
     <>
       <NodeToolbar position={Position.Top}>
@@ -76,6 +89,7 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
         </div>
       </NodeToolbar>
       <div
+        ref={nodeRef}
         className={nodeBorder}
       >
         <div className="m-1 text-lg font-bold text-center">{nodeSchema["ui:label"]}</div>
@@ -105,7 +119,7 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
             </div>
           )}
         </div>
-        <NodeOutputs nodeId={id} data={data}/>
+        <NodeOutputs nodeId={id} data={data} parentBounds={rect}/>
       </div>
     </>
   );

--- a/assets/javascript/apps/pipeline/nodes/NodeOutputs.tsx
+++ b/assets/javascript/apps/pipeline/nodes/NodeOutputs.tsx
@@ -4,7 +4,11 @@ import {NodeData, NodeParams} from "../types/nodeParams";
 import {concatenate} from "../utils";
 import WrappedHandle from "./WrappedHandle";
 
-export default function NodeOutputs({nodeId, data}: {nodeId: string, data: NodeData}) {
+export default function NodeOutputs({nodeId, data, parentBounds}: {
+  nodeId: string,
+  data: NodeData,
+  parentBounds?: DOMRect
+}) {
   const outputNames = getOutputNames(data.type, data.params);
   const multipleOutputs = outputNames.length > 1;
   const generateOutputHandle = (outputIndex: number) => {
@@ -13,9 +17,13 @@ export default function NodeOutputs({nodeId, data}: {nodeId: string, data: NodeD
   return (
     <>
       {multipleOutputs && <div className="divider">Outputs</div>}
-      <div className={multipleOutputs ? "": "py-2 mt-2 border-t border-neutral"}>
+      <div className={multipleOutputs ? "" : "py-2 mt-2 border-t border-neutral"}>
         {outputNames.map((outputName, index) => (
-          <NodeOutput key={outputName} handleKey={generateOutputHandle(index)} nodeId={nodeId} label={outputName} />
+          <NodeOutput
+            key={outputName}
+            handleKey={generateOutputHandle(index)}
+            nodeId={nodeId} label={outputName}
+            parentBounds={parentBounds}/>
         ))}
       </div>
     </>
@@ -26,8 +34,10 @@ interface NodeOutputProps {
   nodeId: string;
   handleKey: string;
   label: string;
+  parentBounds?: DOMRect;
 }
-const NodeOutput = React.memo(function NodeOutput({nodeId, handleKey, label}: NodeOutputProps) {
+
+const NodeOutput = React.memo(function NodeOutput({nodeId, handleKey, label, parentBounds}: NodeOutputProps) {
   return <WrappedHandle
     nodeId={nodeId}
     id={handleKey}
@@ -35,7 +45,8 @@ const NodeOutput = React.memo(function NodeOutput({nodeId, handleKey, label}: No
     position={Position.Right}
     classes="py-2 text-right"
     key={handleKey}
-    />
+    parentBounds={parentBounds}
+  />
 });
 
 

--- a/assets/javascript/apps/pipeline/nodes/WrappedHandle.tsx
+++ b/assets/javascript/apps/pipeline/nodes/WrappedHandle.tsx
@@ -1,20 +1,24 @@
 import {Handle, Position, useUpdateNodeInternals} from "reactflow";
 import React, {useEffect, useRef, useState} from "react";
 
-export default function WrappedHandle(props: {nodeId: string, label: string, classes: string, id: string, position: Position}) {
-  const ref = useRef<any>();
+export default function WrappedHandle(props: {
+  nodeId: string,
+  label: string,
+  classes: string,
+  id: string,
+  position: Position,
+  parentBounds?: DOMRect
+}) {
   const [position, setPosition] = useState(0);
+  const ref = useRef<any>();
   const updateNodeInternals = useUpdateNodeInternals()
+
   useEffect(() => {
     if (ref.current && ref.current.offsetTop && ref.current.clientHeight) {
       setPosition(ref.current.offsetTop + ref.current.clientHeight / 2)
       updateNodeInternals(props.nodeId)
     }
-  }, [props.nodeId, ref, updateNodeInternals])
-
-  useEffect(() => {
-    updateNodeInternals(props.nodeId)
-  }, [props.nodeId, position, updateNodeInternals])
+  }, [props.nodeId, props.parentBounds, updateNodeInternals])
 
   return (
     <div ref={ref} className={props.classes}>


### PR DESCRIPTION
## Description
I noticed that as we add / remove error messages to fields in the nodes, the output handles get out of alignment with the text:

![image](https://github.com/user-attachments/assets/38174d24-0cae-45f1-9b9a-7151cb181d53)

This change re-renders the handles when the node size changes.
