### PR TITLE
Experiments UI: Redirect to home after experiment delete

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -504,7 +504,7 @@ def _get_voice_provider_alpine_context(request):
 def delete_experiment(request, team_slug: str, pk: int):
     safety_layer = get_object_or_404(Experiment, id=pk, team=request.team)
     safety_layer.delete()
-    return HttpResponse(headers={"HX-Redirect": reverse("experiments:experiments_home", args=[team_slug])})
+    return redirect("experiments:experiments_home", team_slug=team_slug)
 
 
 class AddFileToExperiment(BaseAddFileHtmxView):


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
bug: remaining artifact of when delete was using HTMX, but no it's not so we need to do a full page redirect

## User Impact
<!-- Describe the impact of this change on the end-users. -->
properly redirects as expected

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
[loom video](https://www.loom.com/share/6a97331ddf1140adafc13d8af28a9ccb?sid=5ee1802d-a0b5-4d03-b21b-5c43566b55cd)
(what doesn't show becuase of the screen sharing settings is the popup that asks if I'm sure I want to delete the experiment prior to deleting)
### Docs
<!--Link to documentation that has been updated.-->
n/a
