### PR TITLE
don't show chat attachment dropdown if only one kind of file input is allowed

### DIFF
--- a/apps/teams/tests/test_permissions.py
+++ b/apps/teams/tests/test_permissions.py
@@ -62,6 +62,7 @@ IGNORE_APPS = {
     "socialaccount",
     "staticfiles",
     "taggit",
+    "template_partials",
     "tz_detect",
     "users",
     "waffle",

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -76,6 +76,7 @@ THIRD_PARTY_APPS = [
     "health_check.cache",
     "health_check.contrib.celery",
     "health_check.contrib.redis",
+    "template_partials",
 ]
 
 PROJECT_APPS = [
@@ -161,6 +162,7 @@ TEMPLATES = [
             "loaders": _DEFAULT_LOADERS if DEBUG else _CACHED_LOADERS,
             "builtins": [
                 "apps.web.templatetags.default_tags",
+                "template_partials.templatetags.partials",
             ],
         },
     },

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -12,10 +12,6 @@ packaging==23.2
     # via
     #   -c requirements.txt
     #   gunicorn
-setuptools==75.3.0
-    # via
-    #   zope-event
-    #   zope-interface
 zope-event==5.0
     # via gevent
 zope-interface==6.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -21,6 +21,7 @@ django-redis
 django-storages[s3]
 django-tables2
 django-taggit
+django-template-partials
 django-tz-detect
 django-waffle
 django_celery_beat

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -114,6 +114,7 @@ django==5.1.2
     #   django-storages
     #   django-tables2
     #   django-taggit
+    #   django-template-partials
     #   django-timezone-field
     #   django-tz-detect
     #   django-waffle
@@ -152,6 +153,8 @@ django-storages[s3]==1.14.2
 django-tables2==2.6.0
     # via -r requirements.in
 django-taggit==5.0.1
+    # via -r requirements.in
+django-template-partials==24.4
     # via -r requirements.in
 django-timezone-field==7.0
     # via django-celery-beat

--- a/templates/experiments/chat/input_bar.html
+++ b/templates/experiments/chat/input_bar.html
@@ -20,55 +20,59 @@
   <div class="flex flex-col" {% if assistant %}x-data="fileUploads"{% endif %}>
     <div class="flex items-center w-full">
       {% if assistant %}
-        <div class="flex flex-row gap-2">
-          <div class="dropdown dropdown-top">
-            <div tabindex="0" role="button" class="btn m-1"><i class="fa-solid fa-paperclip"></i></div>
-            <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
-              <li>
-                <a
-                  class="btn btn-sm"
-                  {% if not assistant.supports_code_interpreter %}
-                    disabled
-                  {% else %}
-                    x-bind:disabled="disableCodeInterpreterUpload"
-                  {% endif %}
-                  @click="$refs.codeInterpreter.click()">
-                  Code Interpreter
-                </a>
-              </li>
-              <li>
-                <a
-                  class="btn btn-sm"
-                  {% if not assistant.supports_file_search %} disabled {% endif %}
-                  @click="$refs.fileSearch.click()">
-                  File Search
-                </a>
-              </li>
-            </ul>
-          </div>
+        {% if assistant.supports_code_interpreter and assistant.supports_file_search %}
+          <div class="flex flex-row gap-2">
+            <div class="dropdown dropdown-top">
+              <div tabindex="0" role="button" class="btn m-1"><i class="fa-solid fa-paperclip"></i></div>
+              <ul tabindex="0"
+                  class="dropdown-content menu bg-base-100 rounded-box z-[1] w-40 p-2 shadow content-start">
+                <li>
+                  <a x-bind:disabled="disableCodeInterpreterUpload" @click="$refs.codeInterpreter.click()">Code
+                    Interpreter</a>
+                </li>
+                <li>
+                  <a @click="$refs.fileSearch.click()">File Search</a>
+                </li>
+              </ul>
+            </div>
+            {% partialdef code-interpreter-input inline=True %}
           <!-- Supported file types for code interpreter: https://platform.openai.com/docs/assistants/tools/code-interpreter/supported-files -->
-          <input
-            x-ref="codeInterpreter"
-            hidden
-            name="code_interpreter"
-            type="file"
-            @change="handleFileChange($event, 'code_interpreter_files')"
-            multiple
-            accept=".c,.cs,.cpp,.doc,.docx,.html,.java,.json,.md,.pdf,.php,.pptx,.py,.py,.rb,.tex,.txt,.css,.js,.sh,.ts,.csv,.jpeg,.jpg,.gif,.png,.tar,.xlsx,.xml,.zip"
-            class="file-input file-input-bordered file-input-sm w-full max-w-xs"
-          />
+              <input
+                x-ref="codeInterpreter"
+                hidden
+                name="code_interpreter"
+                type="file"
+                @change="handleFileChange($event, 'code_interpreter_files')"
+                multiple
+                accept=".c,.cs,.cpp,.doc,.docx,.html,.java,.json,.md,.pdf,.php,.pptx,.py,.py,.rb,.tex,.txt,.css,.js,.sh,.ts,.csv,.jpeg,.jpg,.gif,.png,.tar,.xlsx,.xml,.zip"
+                class="file-input file-input-bordered file-input-sm w-full max-w-xs"
+              />
+            {% endpartialdef %}
+            {% partialdef file-search-input inline=True %}
           <!-- Supported file types for file search: https://platform.openai.com/docs/assistants/tools/file-search/supported-files -->
-          <input
-            x-ref="fileSearch"
-            hidden
-            name="file_search"
-            type="file"
-            @change="handleFileChange($event, 'file_search_files')"
-            multiple
-            accept=".c,.cs,.cpp,.doc,.docx,.html,.java,.json,.md,.pdf,.php,.pptx,.py,.py,.rb,.tex,.txt,.css,.js,.sh,.ts"
-            class="file-input file-input-bordered file-input-sm w-full max-w-xs"
-          />
-        </div>
+              <input
+                x-ref="fileSearch"
+                hidden
+                name="file_search"
+                type="file"
+                @change="handleFileChange($event, 'file_search_files')"
+                multiple
+                accept=".c,.cs,.cpp,.doc,.docx,.html,.java,.json,.md,.pdf,.php,.pptx,.py,.py,.rb,.tex,.txt,.css,.js,.sh,.ts"
+                class="file-input file-input-bordered file-input-sm w-full max-w-xs"
+              />
+            {% endpartialdef %}
+          </div>
+        {% elif assistant.supports_code_interpreter %}
+          <div role="button" class="btn m-1" x-bind:disabled="disableCodeInterpreterUpload"
+               @click="$refs.codeInterpreter.click()">
+            <i class="fa-solid fa-paperclip"></i>
+          </div>
+          {% partial code-interpreter-input %}
+        {% elif assistant.supports_file_search %}
+          <div role="button" class="btn m-1" @click="$refs.fileSearch.click()"><i class="fa-solid fa-paperclip"></i>
+          </div>
+          {% partial file-search-input %}
+        {% endif %}
       {% endif %}
       <input name="message" type="text" placeholder="Type your message..." aria-label="Message" autocomplete="off" class="input input-bordered input-primary w-full" oninput="checkInput()">
       <button type="submit" id="message-submit" class="ml-2 btn btn-primary" disabled>Send</button>
@@ -105,7 +109,7 @@
     {% endif %}
   </div>
   <div class="w-full mt-2 text-center">
-    <label for="end-experiment-modal" class="btn btn-warning btn-xs" >End Experiment</label>
+    <label for="end-experiment-modal" class="btn btn-warning btn-xs">End Experiment</label>
   </div>
 </form>
 
@@ -113,7 +117,7 @@
   <script>
     document.addEventListener('alpine:init', () => {
       const megabyte_in_bytes = 1048576;
-      const byte_limit = megabyte_in_bytes*512;
+      const byte_limit = megabyte_in_bytes * 512;
       const code_interpreter_max_files = 20
       Alpine.data('fileUploads', () => ({
         code_interpreter_files: [],
@@ -124,12 +128,12 @@
           const files = Array.from(event.target.files);
 
           let new_upload_bytes = 0
-          for (let i = 0; i < files.length; i++){
+          for (let i = 0; i < files.length; i++) {
             new_upload_bytes = new_upload_bytes + files[i].size
           }
 
           if (this.total_upload_size_bytes + new_upload_bytes > byte_limit) {
-            let current_files_mb = this.total_upload_size_bytes/megabyte_in_bytes
+            let current_files_mb = this.total_upload_size_bytes / megabyte_in_bytes
             let message = "Unable to add new file(s). The maximum upload capacity is 512MB. Current size is " + current_files_mb + "MB";
             alert(message);
             return;

--- a/templates/experiments/chat/input_bar.html
+++ b/templates/experiments/chat/input_bar.html
@@ -20,7 +20,7 @@
   <div class="flex flex-col" {% if assistant %}x-data="fileUploads"{% endif %}>
     <div class="flex items-center w-full">
       {% if assistant %}
-        <div class="mt-1 flex flex-row gap-2">
+        <div class="flex flex-row gap-2">
           <div class="dropdown dropdown-top">
             <div tabindex="0" role="button" class="btn m-1"><i class="fa-solid fa-paperclip"></i></div>
             <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">


### PR DESCRIPTION
## Description
Resolves https://github.com/dimagi/open-chat-studio/issues/903

#### Tech note:
This adds [django-template-partials](https://github.com/carltongibson/django-template-partials?tab=readme-ov-file#basic-usage) library which can be used instead of 'include' in certain places.

## User Impact
Users don't have to click twice to upload files when only one kind of file is allowed.

### Demo
<div>
    <a href="https://www.loom.com/share/9cc7157966834047a252aafa4946efc7">
      <p>Dimagi Chatbots | Chat attachment dropdown changes - 22 November 2024 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/9cc7157966834047a252aafa4946efc7">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/9cc7157966834047a252aafa4946efc7-0a5dcf160630712e-full-play.gif">
    </a>
  </div>
