### PR TITLE
Experiment page improvements

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -821,7 +821,8 @@ def experiment_chat_session(request, team_slug: str, experiment_id: int, session
     version_specific_vars = {
         "assistant": experiment_version.get_assistant(),
         "experiment_name": experiment_version.name,
-        "experiment_version_number": version_number,
+        "experiment_version": experiment_version,
+        "experiment_version_number": experiment_version.version_number,
     }
     return TemplateResponse(
         request,

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1241,8 +1241,12 @@ def experiment_pre_survey(request, team_slug: str, experiment_id: str, session_i
 @experiment_session_view(allowed_states=[SessionStatus.ACTIVE, SessionStatus.SETUP])
 @verify_session_access_cookie
 def experiment_chat(request, team_slug: str, experiment_id: str, session_id: str):
+    experiment_version = request.experiment.default_version
     version_specific_vars = {
-        "experiment_name": request.experiment.default_version.name,
+        "assistant": experiment_version.get_assistant(),
+        "experiment_name": experiment_version.name,
+        "experiment_version": experiment_version,
+        "experiment_version_number": experiment_version.version_number,
     }
     return TemplateResponse(
         request,

--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -4,8 +4,6 @@ import * as JsCookie from "js-cookie"; // generated
 export const Cookies = JsCookie.default;
 
 export async function copyToClipboard (callee, elementId) {
-  const icon = callee.getElementsByTagName('i')[0]
-  const span = callee.getElementsByTagName('span')[0]
   const element = document.getElementById(elementId)
   let text;
   if (element.tagName === "INPUT") {
@@ -16,13 +14,10 @@ export async function copyToClipboard (callee, elementId) {
   
   try {
     await navigator.clipboard.writeText(text).then(() => {
-      const prevClass = icon.className;
-      const prevHTML = span.innerHTML
-      icon.className = 'fa-solid fa-check'
-      span.innerHTML = 'Copied!'
+      const prevHTML = callee.innerHTML
+      callee.innerHTML = '<i class="fa-solid fa-check"></i>Copied!'
       setTimeout(() => {
-        icon.className = prevClass;
-        span.innerHTML = prevHTML;
+        callee.innerHTML = prevHTML;
       }, 2000);
     })
   } catch (err) {

--- a/templates/account/components/api_keys.html
+++ b/templates/account/components/api_keys.html
@@ -17,7 +17,7 @@
       <div>
         <span>API Key created. Save this somewhere safe - you will only see it once: <code id="api-key">{{ new_api_key }}</code></span>
         <button class="btn btn-ghost btn-xs" onclick="SiteJS.app.copyToClipboard(this, 'api-key')" title="Copy to clipboard">
-          <i class="fa-regular fa-copy"></i><span></span>
+          <i class="fa-regular fa-copy"></i>
         </button>
       </div>
     </div>

--- a/templates/experiments/components/experiment_details.html
+++ b/templates/experiments/components/experiment_details.html
@@ -17,7 +17,7 @@
           <dd class="text-sm col-span-2">
             <div class="btn btn-sm" onclick="SiteJS.app.copyToClipboard(this, 'assistant_id')" title="Copy to clipboard">
               <span id="assistant_id">{{ experiment.assistant.assistant_id }}</span>
-              <i class="fa-regular fa-copy"></i><span></span>
+              <i class="fa-regular fa-copy"></i>
             </div>
           </dd>
         </div>
@@ -26,7 +26,7 @@
           <dd class="text-sm col-span-2">
             <div class="btn btn-sm" onclick="SiteJS.app.copyToClipboard(this, 'thread_id')" title="Copy to clipboard">
               <span id="thread_id">{{ experiment_session.chat.metadata.openai_thread_id }}</span>
-              <i class="fa-regular fa-copy"></i><span></span>
+              <i class="fa-regular fa-copy"></i>
             </div>
           </dd>
         </div>

--- a/templates/experiments/experiment_chat.html
+++ b/templates/experiments/experiment_chat.html
@@ -9,6 +9,18 @@
       </div>
     {% endif %}
     <div class="w-full h-screen flex flex-col">
+      {% if not experiment_version.is_default_version %}
+        <div class="flex flex-row items-center justify-between bg-yellow-200 p-2 text-warning-content">
+          <div class="flex flex-row items-center">
+            <i class="fa-solid fa-triangle-exclamation"></i>
+            {% if experiment_version.is_working_version %}
+              <p class="ml-2">You are chatting with the unreleased version of this experiment (v{{ experiment_version_number }}).</p>
+            {% else %}
+              <p class="ml-2">You are chatting with a non-published version of this experiment (v{{ experiment_version_number }}).</p>
+            {% endif %}
+          </div>
+        </div>
+      {% endif %}
       {% include 'experiments/chat/chat_ui.html' %}
     </div>
   </div>

--- a/templates/experiments/experiment_form.html
+++ b/templates/experiments/experiment_form.html
@@ -107,7 +107,7 @@
               {% endfor %}
             </select>
             <button type="button" class="btn btn-ghost btn-sm no-animation !normal-case" onclick="SiteJS.app.copyToClipboard(this, 'id_participant_allowlist')" title="Copy to clipboard">
-              <i class="fa-solid fa-copy"></i> <span>Copy participant list</span>
+              <i class="fa-solid fa-copy"></i> Copy participant list
             </button>
           </div>
         </p>

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -31,13 +31,30 @@
       </div>
       <div class="justify-self-end">
         <div class="join">
-          <div class="tooltip" data-tip="Start Web Session Working Version">
-            <form method="post" action="{% url 'experiments:start_authed_web_session' team.slug experiment.id experiment.version_number %}" class="inline">
-              {% csrf_token %}
-              <button type="submit" class="btn btn-primary join-item btn-sm !rounded-l-full">
-                <i class="fas fa-comment"></i>
-              </button>
-            </form>
+          <div class="tooltip" data-tip="Chat to the bot">
+            <div class="dropdown dropdown-hover">
+              <div tabindex="0" role="button" class="btn btn-primary join-item btn-sm !rounded-l-full">
+                <i class="fas fa-comment"></i><i class="fa-solid fa-caret-down fa-sm"></i>
+              </div>
+              <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
+                <li>
+                  <form method="post"
+                        action="{% url 'experiments:start_authed_web_session' team.slug experiment.id experiment.version_number %}"
+                        class="inline">
+                    {% csrf_token %}
+                    <button type="submit">Unreleased version</button>
+                  </form>
+                </li>
+                <li>
+                  <form method="post"
+                        action="{% url 'experiments:start_authed_web_session' team.slug experiment.id 0 %}"
+                        class="inline">
+                    {% csrf_token %}
+                    <button type="submit">Published version</button>
+                  </form>
+                </li>
+              </ul>
+            </div>
           </div>
           <div class="tooltip" data-tip="Edit">
             <a class="btn btn-primary join-item btn-sm rounded-r-full"

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -31,32 +31,16 @@
       </div>
       <div class="justify-self-end">
         <div class="join">
-          {% if experiment.is_public %}
-            <div class="tooltip" data-tip="Public Link">
-              <a class="btn btn-primary join-item rounded-l-full"
-                 href="{% url 'experiments:start_session_public' team.slug experiment.public_id %}" target="_blank">
-                <i class="fa-solid fa-link"></i>
-              </a>
-            </div>
-          {% endif %}
           <div class="tooltip" data-tip="Start Web Session Working Version">
             <form method="post" action="{% url 'experiments:start_authed_web_session' team.slug experiment.id experiment.version_number %}" class="inline">
               {% csrf_token %}
-              <button type="submit" class="btn btn-primary join-item">
+              <button type="submit" class="btn btn-primary join-item btn-sm !rounded-l-full">
                 <i class="fas fa-comment"></i>
               </button>
             </form>
           </div>
-          {% if perms.experiments.invite_participants %}
-            <div class="tooltip" data-tip="Invitations">
-              <a class="btn btn-primary join-item"
-                 href="{% url 'experiments:experiment_invitations' team.slug experiment.id %}">
-                <i class="fa-regular fa-envelope"></i>
-              </a>
-            </div>
-          {% endif %}
           <div class="tooltip" data-tip="Edit">
-            <a class="btn btn-primary join-item rounded-r-full"
+            <a class="btn btn-primary join-item btn-sm rounded-r-full"
                href="{% url 'experiments:edit' team.slug experiment.id %}">
               <i class="fa-solid fa-pencil"></i>
             </a>
@@ -71,7 +55,27 @@
       <button class="btn btn-ghost btn-sm no-animation !normal-case" onclick="SiteJS.app.copyToClipboard(this, 'api-url-link')" title="Copy to clipboard">
         <i class="fa-solid fa-link"></i> <span>API</span>
       </button>
-      <div class="btn btn-ghost btn-sm no-animation !normal-case"><i class="fa-regular fa-window-maximize"></i> Web</div>
+      <div class="dropdown dropdown-hover">
+        <div tabindex="0" role="button" class="btn btn-ghost btn-sm !normal-case">
+          <i class="fa-regular fa-window-maximize"></i> Web <i class="fa-solid fa-caret-down fa-sm pg-text-muted"></i>
+        </div>
+        <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow border">
+          {% if experiment.is_public %}
+            <li>
+              <a href="{% url 'experiments:start_session_public' team.slug experiment.public_id %}" target="_blank">
+                <i class="fa-solid fa-link"></i> Public Link
+              </a>
+            </li>
+          {% endif %}
+          {% if perms.experiments.invite_participants %}
+            <li>
+              <a href="{% url 'experiments:experiment_invitations' team.slug experiment.id %}">
+                <i class="fa-regular fa-envelope"></i> Invitations
+              </a>
+            </li>
+          {% endif %}
+        </ul>
+      </div>
     {#  Commented elements included for Tailwind processing #}
     {#  <i class="fa-brands fa-telegram"></i> #}
     {#  <i class="fa-brands fa-whatsapp"></i> #}

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -53,7 +53,7 @@
       <h3 class="font-bold text-lg inline mr-4">Channels:</h3>
       <input id="api-url-link" type="hidden" value="{{ experiment.get_api_url }}" />
       <button class="btn btn-ghost btn-sm no-animation !normal-case" onclick="SiteJS.app.copyToClipboard(this, 'api-url-link')" title="Copy to clipboard">
-        <i class="fa-solid fa-link"></i> <span>API</span>
+        <i class="fa-solid fa-link"></i> API <i class="fa-regular fa-copy fa-sm pg-text-muted"></i>
       </button>
       <div class="dropdown dropdown-hover">
         <div tabindex="0" role="button" class="btn btn-ghost btn-sm !normal-case">


### PR DESCRIPTION
## Description
A few small changes to the experiment UI as discussed during one of our meetings:

* Move public link and invitations buttons from the top button bar to the 'Web' channel dropdown
* Make the 'chat' button in the top button bar a dropdown with options to chat the published version or the unreleased version
* Add a banner to the web chat UI if you are not chatting with the published version
* (bonus) add a 'copy' icon to the API channel button to indicate that you can copy something

## User Impact
Cleaner navigation and options + indicator for when you aren't chatting with the published version.

### Demo
<div>
    <a href="https://www.loom.com/share/0b9fd0cbeca3424c8341c64adc1656b2">
      <p>Dimagi Chatbots | Experiment page UI improvements - 28 November 2024 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/0b9fd0cbeca3424c8341c64adc1656b2">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/0b9fd0cbeca3424c8341c64adc1656b2-90181a8268e43370-full-play.gif">
    </a>
  </div>
