### PR TITLE
Add pytest-xdist

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           DJANGO_DATABASE_USER: postgres
           DJANGO_DATABASE_PASSWORD: postgres_password
-        run: pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
+        run: pytest -n auto --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload results to Codecov
         if: ${{ !cancelled() }}

--- a/apps/events/tests/test_timeout_trigger.py
+++ b/apps/events/tests/test_timeout_trigger.py
@@ -275,7 +275,7 @@ def test_new_human_message_resets_count(session):
 @pytest.mark.django_db()
 @pytest.mark.parametrize(
     ("status", "matches"),
-    {
+    [
         (SessionStatus.SETUP, True),
         (SessionStatus.PENDING, True),
         (SessionStatus.PENDING_PRE_SURVEY, True),
@@ -283,7 +283,7 @@ def test_new_human_message_resets_count(session):
         (SessionStatus.PENDING_REVIEW, False),
         (SessionStatus.COMPLETE, False),
         (SessionStatus.UNKNOWN, False),
-    },
+    ],
 )
 def test_not_triggered_for_complete_chats(status, matches, session):
     session.status = status

--- a/apps/teams/tests/test_permissions.py
+++ b/apps/teams/tests/test_permissions.py
@@ -65,6 +65,7 @@ IGNORE_APPS = {
     "template_partials",
     "tz_detect",
     "users",
+    "utils_tests",
     "waffle",
     "web",
 }

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -12,3 +12,4 @@ pytest-django
 factory-boy
 pytest-httpx
 pytest-cov
+pytest-xdist

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -22,6 +22,8 @@ coverage[toml]==7.6.4
     # via pytest-cov
 distlib==0.3.9
     # via virtualenv
+execnet==2.1.1
+    # via pytest-xdist
 factory-boy==3.3.1
     # via -r dev-requirements.in
 faker==30.8.1
@@ -84,11 +86,14 @@ pytest==7.4.4
     #   pytest-cov
     #   pytest-django
     #   pytest-httpx
+    #   pytest-xdist
 pytest-cov==6.0.0
     # via -r dev-requirements.in
 pytest-django==4.9.0
     # via -r dev-requirements.in
 pytest-httpx==0.24.0
+    # via -r dev-requirements.in
+pytest-xdist==3.6.1
     # via -r dev-requirements.in
 python-dateutil==2.8.2
     # via


### PR DESCRIPTION
Running the full test suite locally with `pytest -n auto` (with 16 workers) runs in 80 seconds. Wanted to see what the speedup was on GHA. 