### PR TITLE
Ensure pipelines in a bad state can be migrated

### DIFF
--- a/apps/pipelines/migrations/utils/migrate_start_end_nodes.py
+++ b/apps/pipelines/migrations/utils/migrate_start_end_nodes.py
@@ -1,9 +1,13 @@
 from uuid import uuid4
 
+import logging
 from apps.pipelines.flow import FlowEdge, FlowNode, FlowNodeData
 from apps.pipelines.graph import PipelineGraph
 
 from apps.pipelines.nodes.nodes import EndNode, StartNode
+
+logger = logging.getLogger(__name__)
+
 
 def remove_all_start_end_nodes(Node):
     for start_node in Node.objects.filter(type=StartNode.__name__).all():
@@ -57,6 +61,7 @@ def add_missing_start_end_nodes(pipeline, Node):
         current_end_node = next(node for node in data["nodes"] if node["id"] == current_end_id)
     except (IndexError, StopIteration):
         new_nodes, new_edges = _get_default_nodes()  # Just add start and end nodes as the pipeline is in a bad state anyway...
+        logger.exception("A pipeline is in a bad state, either it is recursive or pipeline.data['nodes'] doesn't match pipeline.node_set. Pipeline id: %s, team: %s", pipeline.id, pipeline.team)
     else:
         if not has_start:
             start_id = str(uuid4())

--- a/apps/pipelines/migrations/utils/migrate_start_end_nodes.py
+++ b/apps/pipelines/migrations/utils/migrate_start_end_nodes.py
@@ -1,4 +1,3 @@
-from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from apps.pipelines.flow import FlowEdge, FlowNode, FlowNodeData
@@ -48,49 +47,52 @@ def add_missing_start_end_nodes(pipeline, Node):
     node_ids = {n.id for n in graph.nodes}
     incoming = {e.source for e in graph.edges}
     outgoing = {e.target for e in graph.edges}
-    current_start_id = list(node_ids - outgoing)[0]
-    current_end_id = list(node_ids - incoming)[0]
-    current_start_node = next(node for node in data["nodes"] if node["id"] == current_start_id)
-    current_end_node = next(node for node in data["nodes"] if node["id"] == current_end_id)
-
     new_nodes = []
     new_edges = []
 
-    if not has_start:
-        start_id = str(uuid4())
-        new_start_node = FlowNode(
-            id=start_id,
-            type="startNode",
-            position=_get_new_position(current_start_node, -200),
-            data=FlowNodeData(id=start_id, type=StartNode.__name__),
-        )
-        new_start_edge = FlowEdge(
-            id=str(uuid4()),
-            source=new_start_node.id,
-            target=current_start_id,
-            sourceHandle="output",
-            targetHandle="input",
-        )
-        new_nodes.append(new_start_node.model_dump())
-        new_edges.append(new_start_edge.model_dump())
+    try:
+        current_start_id = list(node_ids - outgoing)[0]
+        current_end_id = list(node_ids - incoming)[0]
+        current_start_node = next(node for node in data["nodes"] if node["id"] == current_start_id)
+        current_end_node = next(node for node in data["nodes"] if node["id"] == current_end_id)
+    except (IndexError, StopIteration):
+        new_nodes, new_edges = _get_default_nodes()  # Just add start and end nodes as the pipeline is in a bad state anyway...
+    else:
+        if not has_start:
+            start_id = str(uuid4())
+            new_start_node = FlowNode(
+                id=start_id,
+                type="startNode",
+                position=_get_new_position(current_start_node, -200),
+                data=FlowNodeData(id=start_id, type=StartNode.__name__),
+            )
+            new_start_edge = FlowEdge(
+                id=str(uuid4()),
+                source=new_start_node.id,
+                target=current_start_id,
+                sourceHandle="output",
+                targetHandle="input",
+            )
+            new_nodes.append(new_start_node.model_dump())
+            new_edges.append(new_start_edge.model_dump())
 
-    if not has_end:
-        end_id = str(uuid4())
-        new_end_node = FlowNode(
-            id=end_id,
-            type="endNode",
-            position=_get_new_position(current_end_node, 350),
-            data=FlowNodeData(id=end_id, type=EndNode.__name__),
-        )
-        new_end_edge = FlowEdge(
-            id=str(uuid4()),
-            source=current_end_id,
-            target=new_end_node.id,
-            sourceHandle="output",
-            targetHandle="input",
-        )
-        new_nodes.append(new_end_node.model_dump())
-        new_edges.append(new_end_edge.model_dump())
+        if not has_end:
+            end_id = str(uuid4())
+            new_end_node = FlowNode(
+                id=end_id,
+                type="endNode",
+                position=_get_new_position(current_end_node, 350),
+                data=FlowNodeData(id=end_id, type=EndNode.__name__),
+            )
+            new_end_edge = FlowEdge(
+                id=str(uuid4()),
+                source=current_end_id,
+                target=new_end_node.id,
+                sourceHandle="output",
+                targetHandle="input",
+            )
+            new_nodes.append(new_end_node.model_dump())
+            new_edges.append(new_end_edge.model_dump())
 
     if data.get("nodes"):
         data["nodes"].extend(new_nodes)
@@ -140,7 +142,7 @@ def _get_new_position(node: dict, x_offset: int):
     return {"x": x, "y": y}
 
 
-def _create_default_nodes(pipeline, Node):
+def _get_default_nodes():
     start_id= str(uuid4())
     start_node = FlowNode(
         id=start_id,
@@ -165,6 +167,11 @@ def _create_default_nodes(pipeline, Node):
         sourceHandle="output",
         targetHandle="input",
     )
-    pipeline.data = {"nodes": [start_node.model_dump(), end_node.model_dump()], "edges": [new_edge.model_dump()]}
+    return [start_node.model_dump(), end_node.model_dump()], [new_edge.model_dump()]
+
+
+def _create_default_nodes(pipeline, Node):
+    default_nodes, default_edges = _get_default_nodes()
+    pipeline.data = {"nodes": default_nodes, "edges": default_edges}
     _set_new_nodes(pipeline, Node)
     pipeline.save()

--- a/apps/pipelines/tests/test_add_start_end_nodes.py
+++ b/apps/pipelines/tests/test_add_start_end_nodes.py
@@ -83,6 +83,77 @@ def test_dangling_edge_has_start_end_nodes(team):
 
 
 @django_db_transactional()
+def test_sentry_6107296412(team):
+    pipeline = Pipeline.objects.create(
+        team=team,
+        data={
+            "edges": [
+                {
+                    "id": "reactflow__edge-LLMResponseWithPrompt-efcB5output-BooleanNode-j4zkainput",
+                    "source": "LLMResponseWithPrompt-efcB5",
+                    "target": "BooleanNode-j4zka",
+                    "sourceHandle": "output",
+                    "targetHandle": "input",
+                }
+            ],
+            "nodes": [
+                {
+                    "id": "BooleanNode-j4zka",
+                    "data": {
+                        "id": "BooleanNode-j4zka",
+                        "type": "BooleanNode",
+                        "label": "Boolean Node",
+                        "params": {},
+                        "inputParams": [{"name": "input_equals", "type": "<class 'str'>", "default": None}],
+                    },
+                    "type": "pipelineNode",
+                    "position": {"x": 613.296875, "y": 202},
+                },
+                {
+                    "id": "LLMResponseWithPrompt-efcB5",
+                    "data": {
+                        "id": "LLMResponseWithPrompt-efcB5",
+                        "type": "LLMResponseWithPrompt",
+                        "label": "LLM response with prompt",
+                        "params": {},
+                        "inputParams": [
+                            {"name": "llm_provider_id", "type": "LlmProviderId", "default": None},
+                            {"name": "llm_model", "type": "LlmModel", "default": None},
+                            {"name": "llm_temperature", "type": "LlmTemperature", "default": 1},
+                            {"name": "history_type", "type": "HistoryType", "default": "none"},
+                            {"name": "history_name", "type": "HistoryName", "default": None},
+                            {"name": "max_token_limit", "type": "MaxTokenLimit", "default": 8192},
+                            {"name": "source_material_id", "type": "SourceMaterialId", "default": None},
+                            {
+                                "name": "prompt",
+                                "type": "Prompt",
+                                "default": "You are a helpful assistant.",
+                            },
+                        ],
+                    },
+                    "type": "pipelineNode",
+                    "position": {"x": 62.936439804895485, "y": 78.34190341898599},
+                },
+            ],
+            "viewport": {"x": 3.2980612579958346, "y": 17.332422642001603, "zoom": 0.8467453123625279},
+        },
+    )
+
+    Node.objects.create(
+        pipeline=pipeline,
+        flow_id="LLMResponseWithPrompt-efcB5",
+        label="LLM response with prompt",
+        type="LLMResponseWithPrompt",
+        params={},
+    )
+
+    add_missing_start_end_nodes(pipeline, Node)
+    assert pipeline.node_set.all().count() == 4  # The missing Node is recreated
+    assert pipeline.node_set.filter(type=StartNode.__name__).exists()
+    assert pipeline.node_set.filter(type=EndNode.__name__).exists()
+
+
+@django_db_transactional()
 def test_compliant_pipeline_not_modified(team):
     start = start_node()
     end = end_node()


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

https://dimagi.sentry.io/issues/6107296412/

There is a pipeline where the edges and the nodes don't match. These pipelines wouldn't have built anyway, so in this case we just add the required start / end nodes without new edges and rebuild the pipeline from what is in `pipeline.data`. 
