### PR TITLE
Fix: Batch vector store file uploads on create

### DIFF
--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -425,7 +425,9 @@ def _update_or_create_vector_store(assistant, name, vector_store_id, file_ids) -
         _sync_vector_store_files_to_openai(client, vector_store_id, file_ids)
         return vector_store_id
 
-    vector_store = client.beta.vector_stores.create(name=name, file_ids=file_ids)
+    vector_store = client.beta.vector_stores.create(name=name, file_ids=file_ids[:100])
+    if len(file_ids) > 100:
+        client.beta.vector_stores.file_batches.create(vector_store_id=vector_store.id, file_ids=file_ids[100:])
     return vector_store.id
 
 

--- a/apps/assistants/tests/test_sync.py
+++ b/apps/assistants/tests/test_sync.py
@@ -7,6 +7,7 @@ from openai.pagination import SyncCursorPage
 
 from apps.assistants.models import ToolResources
 from apps.assistants.sync import (
+    _update_or_create_vector_store,
     delete_openai_assistant,
     get_out_of_sync_files,
     import_openai_assistant,
@@ -302,3 +303,26 @@ def test_file_search_are_files_in_sync_with_openai(mock_retrieve, file_list):
     # Test in sync
     resource.files.set(files)
     assert get_out_of_sync_files(local_assistant) == ({}, {})
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("file_ids", "expect_batch_api_called"),
+    [
+        ([f"file_{file_id}" for file_id in range(105)], True),
+        ([f"file_{file_id}" for file_id in range(10)], False),
+    ],
+)
+@patch("openai.resources.beta.vector_stores.VectorStores.create", return_value=ObjectWithId(id="vs_123"))
+@patch("openai.resources.beta.vector_stores.file_batches.FileBatches.create")
+def test_vector_store_create_batch_files(create_file_batch, create_vector_store, file_ids, expect_batch_api_called):
+    local_assistant = OpenAiAssistantFactory(builtin_tools=["file_search"], assistant_id="")
+
+    _update_or_create_vector_store(local_assistant, "test_v_store", vector_store_id=None, file_ids=file_ids)
+    assert create_vector_store.call_count == 1
+    create_vector_store.assert_called_with(name="test_v_store", file_ids=file_ids[:100])
+    if expect_batch_api_called:
+        assert create_file_batch.call_count == 1
+        create_file_batch.assert_called_with(vector_store_id="vs_123", file_ids=file_ids[100:])
+    else:
+        assert create_file_batch.call_count == 0


### PR DESCRIPTION
We got this error when trying to version a large vector store (1000+ files)
```
apps.assistants.sync.OpenAiSyncError: Invalid 'file_ids': array too long. Expected an array with maximum length 100, but got an array with length 1084 instead.
```
from [task badger](https://taskbadger.net/a/dimagi/tasks/cc8d4chNZAzMwtFFSr2miHSZz8/#data). This restriction is an OpenAI API one.

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
We didn't batch upload it on vector store creation, but we do when updating the vector store

## User Impact
<!-- Describe the impact of this change on the end-users. -->
This should help with versioning fixes for super large vector stores

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->


### Docs
<!--Link to documentation that has been updated.-->
