### PR TITLE
Fix: Chunk with chunksize=500 for batch API

### DIFF
--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -65,7 +65,7 @@ from openai import OpenAI
 from openai.types.beta import Assistant
 
 from apps.assistants.models import OpenAiAssistant, ToolResources
-from apps.assistants.utils import get_assistant_tool_options
+from apps.assistants.utils import chunk_list, get_assistant_tool_options
 from apps.files.models import File
 from apps.service_providers.models import LlmProvider, LlmProviderModel, LlmProviderTypes
 from apps.teams.models import Team
@@ -426,8 +426,8 @@ def _update_or_create_vector_store(assistant, name, vector_store_id, file_ids) -
         return vector_store_id
 
     vector_store = client.beta.vector_stores.create(name=name, file_ids=file_ids[:100])
-    if len(file_ids) > 100:
-        client.beta.vector_stores.file_batches.create(vector_store_id=vector_store.id, file_ids=file_ids[100:])
+    for chunk in chunk_list(file_ids[100:], 500):
+        client.beta.vector_stores.file_batches.create(vector_store_id=vector_store.id, file_ids=chunk)
     return vector_store.id
 
 

--- a/apps/assistants/tests/test_sync.py
+++ b/apps/assistants/tests/test_sync.py
@@ -309,20 +309,22 @@ def test_file_search_are_files_in_sync_with_openai(mock_retrieve, file_list):
 @pytest.mark.parametrize(
     ("file_ids", "expect_batch_api_called"),
     [
-        ([f"file_{file_id}" for file_id in range(105)], True),
+        ([f"file_{file_id}" for file_id in range(780)], True),
         ([f"file_{file_id}" for file_id in range(10)], False),
     ],
 )
 @patch("openai.resources.beta.vector_stores.VectorStores.create", return_value=ObjectWithId(id="vs_123"))
 @patch("openai.resources.beta.vector_stores.file_batches.FileBatches.create")
 def test_vector_store_create_batch_files(create_file_batch, create_vector_store, file_ids, expect_batch_api_called):
+    """The `client.beta.vector_stores.create` API can only handle 100 file_ids whereas the batch API can handle 500"""
     local_assistant = OpenAiAssistantFactory(builtin_tools=["file_search"], assistant_id="")
 
     _update_or_create_vector_store(local_assistant, "test_v_store", vector_store_id=None, file_ids=file_ids)
     assert create_vector_store.call_count == 1
     create_vector_store.assert_called_with(name="test_v_store", file_ids=file_ids[:100])
     if expect_batch_api_called:
-        assert create_file_batch.call_count == 1
-        create_file_batch.assert_called_with(vector_store_id="vs_123", file_ids=file_ids[100:])
+        assert create_file_batch.call_count == 2
+        assert len(create_file_batch.call_args_list[0][1]["file_ids"]) == 500
+        assert len(create_file_batch.call_args_list[1][1]["file_ids"]) == 180
     else:
         assert create_file_batch.call_count == 0

--- a/apps/assistants/utils.py
+++ b/apps/assistants/utils.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+
 from apps.service_providers.models import LlmProviderTypes
 
 
@@ -10,3 +12,8 @@ def get_assistant_tool_options():
         ("code_interpreter", "Code Interpreter"),
         ("file_search", "File Search"),
     ]
+
+
+def chunk_list(list_: list, chunk_size: int) -> Generator[list, None, None]:
+    for i in range(0, len(list_), chunk_size):
+        yield list_[i : i + chunk_size]


### PR DESCRIPTION
A followup on [this PR](https://github.com/dimagi/open-chat-studio/pull/954). Seems like the batch API has a 500 file_id limit

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->
