### PR TITLE
Fix: Create version async when creating experiment

### DIFF
--- a/apps/experiments/tests/test_views.py
+++ b/apps/experiments/tests/test_views.py
@@ -75,6 +75,7 @@ def test_create_experiment_success(client, team_with_users):
 
 
 @override_flag("experiment_versions", active=True)
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 @pytest.mark.django_db()
 def test_create_experiment_creates_first_version(client, team_with_users):
     user = team_with_users.members.first()

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -453,7 +453,11 @@ class CreateExperiment(BaseExperimentView, CreateView):
             self.object.files.set(files)
 
         if flag_is_active(self.request, "experiment_versions"):
-            self.object.create_new_version()
+            task_id = async_create_experiment_version.delay(
+                experiment_id=self.object.id, version_description="", make_default=True
+            )
+            self.object.create_version_task_id = task_id
+            self.object.save(update_fields=["create_version_task_id"])
 
         return HttpResponseRedirect(self.get_success_url())
 


### PR DESCRIPTION
We now create versions async when creating experiments also

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Will not cause [504 for large assistants](https://dimagi.slack.com/archives/C05PK63Q89H/p1733389144397429)

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->
