### PR TITLE
move tiktoken to its own module

### DIFF
--- a/assets/javascript/site.js
+++ b/assets/javascript/site.js
@@ -4,5 +4,4 @@ import 'htmx.org';
 import './htmx';
 import './alpine';
 import './alertify';
-import './tiktoken';
 import './tom-select';

--- a/assets/javascript/tiktoken.js
+++ b/assets/javascript/tiktoken.js
@@ -1,15 +1,11 @@
 // Import the necessary parts of the js-tiktoken library
 import {encodingForModel} from "js-tiktoken";
 
-
 // Get the encoding details for gpt-3.5-turbo and gpt-4
 const encoding = encodingForModel("gpt-3.5-turbo");
 
 // Function to count tokens
-function countTokens(stringToCount) {
+export function countGPTTokens(stringToCount) {
     const tokens = encoding.encode(stringToCount);
     return tokens.length;
 }
-
-// Save the encoding object to the window for later use
-window.countGPTTokens = countTokens;

--- a/templates/experiments/prompt_builder.html
+++ b/templates/experiments/prompt_builder.html
@@ -1,6 +1,9 @@
 {% extends "web/app/app_base.html" %}
 {% load static %}
 {% load tz %}
+{% block page_js %}
+    <script src="{% static 'js/tokenCounter-bundle.js' %}"></script>
+{% endblock %}
 {% block body_wrapper %}
     <div class="container flex flex-row" id="prompt-builder-container" x-data
          @keydown.window="checkForSendShortcutKeypress($event)">
@@ -57,7 +60,8 @@
                 init() {
                     Alpine.effect(() => {
                         if (Alpine.store('promptBuilder').currentState && Alpine.store('promptBuilder').currentState.prompt !== undefined) {
-                            Alpine.store('promptBuilder').promptTokenCount = `(~${window.countGPTTokens(Alpine.store('promptBuilder').currentState.prompt)} tokens)`;
+                            const count = SiteJS.tokenCounter.countGPTTokens(Alpine.store('promptBuilder').currentState.prompt)
+                            Alpine.store('promptBuilder').promptTokenCount = `(~${count} tokens)`;
                         } else {
                             Alpine.store('promptBuilder').promptTokenCount = '';
                         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
     'pipeline': './assets/javascript/apps/pipeline.tsx',
     adminDashboard: './assets/javascript/admin-dashboard.js',
     'tagMultiselect': './assets/javascript/tag-multiselect.js',
+    'tokenCounter': './assets/javascript/tiktoken.js',
   },
   output: {
     path: path.resolve(__dirname, './static'),


### PR DESCRIPTION
## Description
I realised that tiktoken is 5.5MB and only used in prompt builder (though included in the main site JS bundle).

This PR splits the tiktoken function into it's own module on loads it directly on the prompt builder page.

This reduces the main site bundle to 175Kb.

## User Impact
Less JS downloads.


Note: I used https://github.com/relative-ci/bundle-stats to analyse the JS bundles which was very helpful in figuring out where the issue was.
