### PR TITLE
Read-only view for archived versions

### DIFF
--- a/apps/experiments/decorators.py
+++ b/apps/experiments/decorators.py
@@ -23,7 +23,9 @@ def experiment_session_view(allowed_states=None):
 
         @wraps(view_func)
         def decorated_view(request, team_slug: str, experiment_id: str, session_id: str, **kwargs):
-            request.experiment = get_object_or_404(Experiment, public_id=experiment_id, team=request.team)
+            request.experiment = get_object_or_404(
+                Experiment.objects.get_all(), public_id=experiment_id, team=request.team
+            )
             request.experiment_session = get_object_or_404(
                 ExperimentSession,
                 experiment=request.experiment,

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -171,6 +171,9 @@ class VersionsMixin:
         self.is_archived = True
         self.save()
 
+    def is_not_archived(self) -> bool:
+        return not self.is_archived
+
 
 @audit_fields(*model_audit_fields.SOURCE_MATERIAL_FIELDS, audit_special_queryset_writes=True)
 class SourceMaterial(BaseTeamModel, VersionsMixin):

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -885,6 +885,7 @@ class Experiment(BaseTeamModel, VersionsMixin):
         return Version(
             instance=self,
             fields=[
+                VersionField(group_name="General", name="name", raw_value=self.name),
                 VersionField(group_name="General", name="description", raw_value=self.description),
                 VersionField(
                     group_name="General",

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -171,7 +171,7 @@ class VersionsMixin:
         self.is_archived = True
         self.save()
 
-    def is_not_archived(self) -> bool:
+    def is_editable(self) -> bool:
         return not self.is_archived
 
 

--- a/apps/experiments/tables.py
+++ b/apps/experiments/tables.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.template.loader import get_template
 from django.urls import reverse
-from django.utils.html import format_html
 from django_tables2 import columns, tables
 
 from apps.experiments.models import (
@@ -35,17 +34,11 @@ class ExperimentTable(tables.Table):
         row_attrs = {
             **settings.DJANGO_TABLES2_ROW_ATTRS,
             "data-redirect-url": lambda record: (
-                record.get_absolute_url() if hasattr(record, "get_absolute_url") and not record.is_archived else ""
+                record.get_absolute_url() if hasattr(record, "get_absolute_url") else ""
             ),
         }
         orderable = False
         empty_text = "No experiments found."
-
-    def render_name(self, record):
-        """Conditionally linkify the name field based on is_archived."""
-        if not record.is_archived:
-            return format_html('<a href="{}" class="link">{}</a>', record.get_absolute_url(), record.name)
-        return record.name
 
 
 class SafetyLayerTable(tables.Table):

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -593,6 +593,10 @@ class CreateExperimentVersion(LoginAndTeamRequiredMixin, CreateView):
         description = form.cleaned_data["version_description"]
         is_default = form.cleaned_data["is_default_version"]
         working_version = Experiment.objects.get(id=self.kwargs["experiment_id"])
+
+        if working_version.is_archived:
+            raise PermissionDenied("Unable to version an archived experiment.")
+
         if working_version.create_version_task_id:
             messages.error(self.request, "Version creation is already in progress.")
         else:
@@ -863,6 +867,9 @@ def experiment_chat_session(request, team_slug: str, experiment_id: int, session
 def experiment_session_message(request, team_slug: str, experiment_id: int, session_id: int, version_number: int):
     working_experiment = request.experiment
     session = request.experiment_session
+
+    if working_experiment.is_archived:
+        raise PermissionDenied("Cannot chat with an archived experiment.")
 
     try:
         experiment_version = working_experiment.get_version(version_number)

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -118,7 +118,11 @@ class ExperimentTableView(SingleTableView, PermissionRequiredMixin):
     permission_required = "experiments.view_experiment"
 
     def get_queryset(self):
-        query_set = Experiment.objects.get_all().filter(team=self.request.team, working_version__isnull=True)
+        query_set = (
+            Experiment.objects.get_all()
+            .filter(team=self.request.team, working_version__isnull=True)
+            .order_by("is_archived")
+        )
         show_archived = self.request.GET.get("show_archived") == "on"
         if not show_archived:
             query_set = query_set.filter(is_archived=False)

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -16,7 +16,7 @@ from django.contrib.postgres.search import TrigramSimilarity
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import transaction
 from django.db.models import Case, Count, IntegerField, Q, When
-from django.http import FileResponse, Http404, HttpResponse, HttpResponseRedirect
+from django.http import FileResponse, Http404, HttpResponse, HttpResponseNotAllowed, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -489,8 +489,13 @@ class EditExperiment(BaseExperimentView, UpdateView):
     def get_object(self, queryset=None):
         obj = super().get_object(queryset)
         if obj.working_version:
-            raise Http404("Cannot edit experiment versions.")
+            raise Http404("Experiment not found.")
         return obj
+
+    def post(self, request, *args, **kwargs):
+        if self.get_object().is_archived:
+            raise HttpResponseNotAllowed("Cannot edit archived experiments.")
+        return super().post(request, *args, **kwargs)
 
 
 def _get_voice_provider_alpine_context(request):

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -389,7 +389,7 @@ class BaseExperimentView(LoginAndTeamRequiredMixin, PermissionRequiredMixin):
         return reverse("experiments:single_experiment_home", args=[self.request.team.slug, self.object.pk])
 
     def get_queryset(self):
-        return Experiment.objects.filter(team=self.request.team)
+        return Experiment.objects.get_all().filter(team=self.request.team)
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -622,7 +622,7 @@ def version_create_status(request, team_slug: str, experiment_id: int):
 @login_and_team_required
 @permission_required("experiments.view_experiment", raise_exception=True)
 def single_experiment_home(request, team_slug: str, experiment_id: int):
-    experiment = get_object_or_404(Experiment, id=experiment_id, team=request.team)
+    experiment = get_object_or_404(Experiment.objects.get_all(), id=experiment_id, team=request.team)
     user_sessions = (
         ExperimentSession.objects.with_last_message_created_at()
         .filter(

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -416,7 +416,7 @@ class BaseExperimentView(LoginAndTeamRequiredMixin, PermissionRequiredMixin):
 
         if self.request.POST.get("action") == "save_and_archive":
             experiment = get_object_or_404(Experiment, id=experiment.id, team=self.request.team)
-            experiment.archive_working_experiment()
+            experiment.archive()
             return redirect("experiments:experiments_home", self.request.team.slug)
         return response
 

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -16,7 +16,7 @@ from django.contrib.postgres.search import TrigramSimilarity
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import transaction
 from django.db.models import Case, Count, F, IntegerField, Q, When
-from django.http import FileResponse, Http404, HttpResponse, HttpResponseNotAllowed, HttpResponseRedirect
+from django.http import FileResponse, Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -496,7 +496,7 @@ class EditExperiment(BaseExperimentView, UpdateView):
 
     def post(self, request, *args, **kwargs):
         if self.get_object().is_archived:
-            raise HttpResponseNotAllowed("Cannot edit archived experiments.")
+            raise PermissionDenied("Cannot edit archived experiments.")
         return super().post(request, *args, **kwargs)
 
 

--- a/templates/experiments/components/experiment_actions_column.html
+++ b/templates/experiments/components/experiment_actions_column.html
@@ -11,7 +11,7 @@
   </a>
 {% else %}
   <a class="btn btn-sm"
-     href="{% url 'experiments:edit' record.team.slug record.id %}" title="Edit">
+     href="{% url 'experiments:edit' record.team.slug record.id %}" title="View">
     <i class="fa-solid fa-eye"></i>
   </a>
 {% endif %}

--- a/templates/experiments/components/experiment_actions_column.html
+++ b/templates/experiments/components/experiment_actions_column.html
@@ -1,4 +1,4 @@
-{% if record.is_not_archived %}
+{% if record.is_editable %}
   <form method="post" action="{% url 'experiments:start_authed_web_session' record.team.slug record.id record.get_working_version.version_number %}" class="inline">
     {% csrf_token %}
     <button type="submit" class="btn btn-sm" title="New Session">

--- a/templates/experiments/components/experiment_actions_column.html
+++ b/templates/experiments/components/experiment_actions_column.html
@@ -9,4 +9,9 @@
      href="{% url 'experiments:edit' record.team.slug record.id %}" title="Edit">
     <i class="fa-solid fa-pencil"></i>
   </a>
+{% else %}
+  <a class="btn btn-sm"
+     href="{% url 'experiments:edit' record.team.slug record.id %}" title="Edit">
+    <i class="fa-solid fa-eye"></i>
+  </a>
 {% endif %}

--- a/templates/experiments/components/experiment_actions_column.html
+++ b/templates/experiments/components/experiment_actions_column.html
@@ -1,4 +1,4 @@
-{% if not record.is_archived %}
+{% if record.is_not_archived %}
   <form method="post" action="{% url 'experiments:start_authed_web_session' record.team.slug record.id record.get_working_version.version_number %}" class="inline">
     {% csrf_token %}
     <button type="submit" class="btn btn-sm" title="New Session">

--- a/templates/experiments/components/experiment_chat.html
+++ b/templates/experiments/components/experiment_chat.html
@@ -65,7 +65,7 @@
                           {% endif %}
                           {% if perms.annotations.add_usercomment %}
                             <div class="grow">
-                              {% include "annotations/tag_ui.html" with object=message allow_edit=experiment.is_not_archived %}
+                              {% include "annotations/tag_ui.html" with object=message allow_edit=experiment.is_editable %}
                             </div>
                           {% endif %}
                         </div>
@@ -89,7 +89,7 @@
                             <i class="fa-solid fa-close"></i>
                           </button>
                         </div>
-                        {% include "experiments/components/user_comments.html" with object=message allow_edit=experiment.is_not_archived %}
+                        {% include "experiments/components/user_comments.html" with object=message allow_edit=experiment.is_editable %}
                       </div>
                     {% endif %}
                   </td>

--- a/templates/experiments/components/experiment_chat.html
+++ b/templates/experiments/components/experiment_chat.html
@@ -65,7 +65,7 @@
                           {% endif %}
                           {% if perms.annotations.add_usercomment %}
                             <div class="grow">
-                              {% include "annotations/tag_ui.html" with object=message %}
+                              {% include "annotations/tag_ui.html" with object=message allow_edit=experiment.is_not_archived %}
                             </div>
                           {% endif %}
                         </div>
@@ -89,7 +89,7 @@
                             <i class="fa-solid fa-close"></i>
                           </button>
                         </div>
-                        {% include "experiments/components/user_comments.html" with object=message %}
+                        {% include "experiments/components/user_comments.html" with object=message allow_edit=experiment.is_not_archived %}
                       </div>
                     {% endif %}
                   </td>

--- a/templates/experiments/components/experiment_details.html
+++ b/templates/experiments/components/experiment_details.html
@@ -34,7 +34,7 @@
       <div class="py-3 grid grid-cols-3">
         <dt class="text-sm font-medium leading-6">Tags</dt>
         <dd class="col-span-2 mr-2">
-          {% include "annotations/tag_ui.html" with object=experiment_session.chat allow_edit=experiment.is_not_archived %}
+          {% include "annotations/tag_ui.html" with object=experiment_session.chat allow_edit=experiment.is_editable %}
         </dd>
       </div>
       {% if perms.annotations.add_usercomment %}
@@ -51,7 +51,7 @@
             </dd>
           </div>
           <div class="col-span-3 mr-2" x-cloak x-show="showComments">
-            {% include "experiments/components/user_comments.html" with object=experiment_session.chat allow_edit=experiment.is_not_archived %}
+            {% include "experiments/components/user_comments.html" with object=experiment_session.chat allow_edit=experiment.is_editable %}
           </div>
         </div>
       {% endif %}

--- a/templates/experiments/components/experiment_details.html
+++ b/templates/experiments/components/experiment_details.html
@@ -34,7 +34,7 @@
       <div class="py-3 grid grid-cols-3">
         <dt class="text-sm font-medium leading-6">Tags</dt>
         <dd class="col-span-2 mr-2">
-          {% include "annotations/tag_ui.html" with object=experiment_session.chat %}
+          {% include "annotations/tag_ui.html" with object=experiment_session.chat allow_edit=experiment.is_not_archived %}
         </dd>
       </div>
       {% if perms.annotations.add_usercomment %}
@@ -51,7 +51,7 @@
             </dd>
           </div>
           <div class="col-span-3 mr-2" x-cloak x-show="showComments">
-            {% include "experiments/components/user_comments.html" with object=experiment_session.chat %}
+            {% include "experiments/components/user_comments.html" with object=experiment_session.chat allow_edit=experiment.is_not_archived %}
           </div>
         </div>
       {% endif %}

--- a/templates/experiments/components/user_comments.html
+++ b/templates/experiments/components/user_comments.html
@@ -16,7 +16,7 @@
                             </div>
                         </td>
                         <td class="w-1/6">
-                            {% if request.user == user_comment.user %}
+                            {% if request.user == user_comment.user and allow_edit|default_if_none:True %}
                                 <form
                                     class="p-2"
                                     hx-post="{% url 'annotations:remove_comment' request.team.slug %}"
@@ -41,34 +41,36 @@
             </tbody>
         </table>
 
-        <div class="py-2">
-            <form
-                class="w-full p-2"
-                hx-post="{% url 'annotations:add_comment' request.team.slug %}"
-                hx-swap="outerHTML"
-                hx-indicator="#add-comment-submit"
-                hx-target="#comments-{{ object.id }}">
-                {% csrf_token %}
-                <div class="flex items-center w-full h-1/4" x-data="{commentInput: ''}">
-                    <textarea
-                        class="w-full textarea textarea-bordered rounded-md"
-                        name="comment"
-                        type="text"
-                        placeholder="Add new comment..."
-                        aria-label="comment"
-                        x-model="commentInput"></textarea>
+        {% if allow_edit|default_if_none:True %}
+            <div class="py-2">
+                <form
+                    class="w-full p-2"
+                    hx-post="{% url 'annotations:add_comment' request.team.slug %}"
+                    hx-swap="outerHTML"
+                    hx-indicator="#add-comment-submit"
+                    hx-target="#comments-{{ object.id }}">
+                    {% csrf_token %}
+                    <div class="flex items-center w-full h-1/4" x-data="{commentInput: ''}">
+                        <textarea
+                            class="w-full textarea textarea-bordered rounded-md"
+                            name="comment"
+                            type="text"
+                            placeholder="Add new comment..."
+                            aria-label="comment"
+                            x-model="commentInput"></textarea>
 
-                    <input type="hidden" name="object_info" value="{{ object.object_info }}">
-                    <button
-                        type="submit"
-                        id="add-comment-submit"
-                        class="ml-2 btn btn-sm"
-                        x-bind:disabled="commentInput.length === 0"
-                    >
-                        Add comment
-                    </button>
-                </div>
-            </form>
-        </div>
+                        <input type="hidden" name="object_info" value="{{ object.object_info }}">
+                        <button
+                            type="submit"
+                            id="add-comment-submit"
+                            class="ml-2 btn btn-sm"
+                            x-bind:disabled="commentInput.length === 0"
+                        >
+                            Add comment
+                        </button>
+                    </div>
+                </form>
+            </div>
+        {% endif %}
     </div>
 </div>

--- a/templates/experiments/experiment_form.html
+++ b/templates/experiments/experiment_form.html
@@ -123,7 +123,7 @@
     </div>
 {% endblock form %}
 {% block form_actions %}
-  {% if not experiment.is_archived %}
+  {% if experiment.is_not_archived %}
     <div class="mt-2">
       <input type="submit" class="pg-button-primary" value="{{ button_text }}">
       {% if experiment.id %}

--- a/templates/experiments/experiment_form.html
+++ b/templates/experiments/experiment_form.html
@@ -123,7 +123,7 @@
     </div>
 {% endblock form %}
 {% block form_actions %}
-  {% if experiment.is_editable %}
+  {% if not experiment or experiment.is_editable %}
     <div class="mt-2">
       <input type="submit" class="pg-button-primary" value="{{ button_text }}">
       {% if experiment.id %}

--- a/templates/experiments/experiment_form.html
+++ b/templates/experiments/experiment_form.html
@@ -123,15 +123,17 @@
     </div>
 {% endblock form %}
 {% block form_actions %}
-  <div class="mt-2">
-    <input type="submit" class="pg-button-primary" value="{{ button_text }}">
-    {% if experiment.id %}
-      {% flag "experiment_versions" %}
-        <button type="submit" class="pg-button-secondary" name="action" {% if disable_version_button %}disabled="True"{% endif %} value="save_and_version">Create Version</button>
-      {% endflag %}
-      <button type="submit" class="pg-button-danger" name="action" value="save_and_archive" onclick="return confirm('Are you sure you want to archive this experiment?');">Archive</button>
-    {% endif %}
-  </div>
+  {% if not experiment.is_archived %}
+    <div class="mt-2">
+      <input type="submit" class="pg-button-primary" value="{{ button_text }}">
+      {% if experiment.id %}
+        {% flag "experiment_versions" %}
+          <button type="submit" class="pg-button-secondary" name="action" {% if disable_version_button %}disabled="True"{% endif %} value="save_and_version">Create Version</button>
+        {% endflag %}
+        <button type="submit" class="pg-button-danger" name="action" value="save_and_archive" onclick="return confirm('Are you sure you want to archive this experiment?');">Archive</button>
+      {% endif %}
+    </div>
+  {% endif %}
 {% endblock %}
 {% block page_js %}
   {{ voice_providers_types|json_script:"voiceProviderTypes" }}

--- a/templates/experiments/experiment_form.html
+++ b/templates/experiments/experiment_form.html
@@ -123,7 +123,7 @@
     </div>
 {% endblock form %}
 {% block form_actions %}
-  {% if experiment.is_not_archived %}
+  {% if experiment.is_editable %}
     <div class="mt-2">
       <input type="submit" class="pg-button-primary" value="{{ button_text }}">
       {% if experiment.id %}

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -35,7 +35,7 @@
       </div>
       <div class="justify-self-end">
         <div class="join">
-          {% if experiment.is_not_archived %}
+          {% if experiment.is_editable %}
             <div class="tooltip" data-tip="Chat to the bot">
               <div class="dropdown dropdown-hover">
                 <div tabindex="0" role="button" class="btn btn-primary join-item btn-sm !rounded-l-full">
@@ -79,7 +79,7 @@
       </div>
     </div>
     <h2 class="flex-1 pg-subtitle">{{ experiment.description }}</h2>
-    {% if experiment.is_not_archived %}
+    {% if experiment.is_editable %}
       <div class="my-4">
         <h3 class="font-bold text-lg inline mr-4">Channels:</h3>
         <input id="api-url-link" type="hidden" value="{{ experiment.get_api_url }}" />
@@ -292,7 +292,7 @@
       <input type="radio" name="tab_group" role="tab" class="tab" aria-label="Versions" id="tab-versions" />
       <div role="tabpanel" class="tab-content" id="content-versions">
         <div class="app-card">
-          {% if experiment.is_not_archived %}
+          {% if experiment.is_editable %}
             {% include 'experiments/create_version_button.html' %}
           {% endif %}
           <div id="versions-table"
@@ -324,7 +324,7 @@
         {% if experiment.assistant %}
           Assistants cannot be router bots. Please use a normal bot
         {% elif can_make_child_routes %}
-          {% if experiment.is_not_archived %}
+          {% if experiment.is_editable %}
             <a class="btn btn-sm btn-outline btn-primary mb-2" href="{% url 'experiments:experiment_route_new' team.slug experiment.id 'processor' %}"><i class="fa-regular fa-plus"></i> Create child route</a>
           {% endif %}
           {% render_table child_routes_table %}
@@ -337,7 +337,7 @@
     <input type="radio" name="tab_group" role="tab" class="tab" aria-label="Terminal Bot" id="tab-terminal_bots"/>
     <div role="tabpanel" class="tab-content" id="content-terminal_bots">
       <div class="app-card">
-        {% if terminal_bots_table.data|length == 0 and experiment.is_not_archived%}
+        {% if terminal_bots_table.data|length == 0 and experiment.is_editable%}
           <a class="btn btn-sm btn-outline btn-primary mb-2" href="{% url 'experiments:experiment_route_new' team.slug experiment.id 'terminal' %}"><i class="fa-regular fa-plus"></i> Add terminal bot</a>
         {% endif %}
         {% render_table terminal_bots_table %}

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -35,7 +35,7 @@
       </div>
       <div class="justify-self-end">
         <div class="join">
-          {% if not experiment.is_archived %}
+          {% if experiment.is_not_archived %}
             <div class="tooltip" data-tip="Chat to the bot">
               <div class="dropdown dropdown-hover">
                 <div tabindex="0" role="button" class="btn btn-primary join-item btn-sm !rounded-l-full">
@@ -79,7 +79,7 @@
       </div>
     </div>
     <h2 class="flex-1 pg-subtitle">{{ experiment.description }}</h2>
-    {% if not experiment.is_archived %}
+    {% if experiment.is_not_archived %}
       <div class="my-4">
         <h3 class="font-bold text-lg inline mr-4">Channels:</h3>
         <input id="api-url-link" type="hidden" value="{{ experiment.get_api_url }}" />
@@ -292,7 +292,7 @@
       <input type="radio" name="tab_group" role="tab" class="tab" aria-label="Versions" id="tab-versions" />
       <div role="tabpanel" class="tab-content" id="content-versions">
         <div class="app-card">
-          {% if not experiment.is_archived %}
+          {% if experiment.is_not_archived %}
             {% include 'experiments/create_version_button.html' %}
           {% endif %}
           <div id="versions-table"
@@ -324,7 +324,7 @@
         {% if experiment.assistant %}
           Assistants cannot be router bots. Please use a normal bot
         {% elif can_make_child_routes %}
-          {% if not experiment.is_archived %}
+          {% if experiment.is_not_archived %}
             <a class="btn btn-sm btn-outline btn-primary mb-2" href="{% url 'experiments:experiment_route_new' team.slug experiment.id 'processor' %}"><i class="fa-regular fa-plus"></i> Create child route</a>
           {% endif %}
           {% render_table child_routes_table %}
@@ -337,7 +337,7 @@
     <input type="radio" name="tab_group" role="tab" class="tab" aria-label="Terminal Bot" id="tab-terminal_bots"/>
     <div role="tabpanel" class="tab-content" id="content-terminal_bots">
       <div class="app-card">
-        {% if terminal_bots_table.data|length == 0 and not experiment.is_archived%}
+        {% if terminal_bots_table.data|length == 0 and experiment.is_not_archived%}
           <a class="btn btn-sm btn-outline btn-primary mb-2" href="{% url 'experiments:experiment_route_new' team.slug experiment.id 'terminal' %}"><i class="fa-regular fa-plus"></i> Add terminal bot</a>
         {% endif %}
         {% render_table terminal_bots_table %}

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -35,147 +35,158 @@
       </div>
       <div class="justify-self-end">
         <div class="join">
-          <div class="tooltip" data-tip="Chat to the bot">
-            <div class="dropdown dropdown-hover">
-              <div tabindex="0" role="button" class="btn btn-primary join-item btn-sm !rounded-l-full">
-                <i class="fas fa-comment"></i><i class="fa-solid fa-caret-down fa-sm"></i>
+          {% if not experiment.is_archived %}
+            <div class="tooltip" data-tip="Chat to the bot">
+              <div class="dropdown dropdown-hover">
+                <div tabindex="0" role="button" class="btn btn-primary join-item btn-sm !rounded-l-full">
+                  <i class="fas fa-comment"></i><i class="fa-solid fa-caret-down fa-sm"></i>
+                </div>
+                <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
+                  <li>
+                    <form method="post"
+                          action="{% url 'experiments:start_authed_web_session' team.slug experiment.id experiment.version_number %}"
+                          class="inline">
+                      {% csrf_token %}
+                      <button type="submit">Unreleased version</button>
+                    </form>
+                  </li>
+                  <li>
+                    <form method="post"
+                          action="{% url 'experiments:start_authed_web_session' team.slug experiment.id 0 %}"
+                          class="inline">
+                      {% csrf_token %}
+                      <button type="submit">Published version</button>
+                    </form>
+                  </li>
+                </ul>
               </div>
-              <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
-                <li>
-                  <form method="post"
-                        action="{% url 'experiments:start_authed_web_session' team.slug experiment.id experiment.version_number %}"
-                        class="inline">
-                    {% csrf_token %}
-                    <button type="submit">Unreleased version</button>
-                  </form>
-                </li>
-                <li>
-                  <form method="post"
-                        action="{% url 'experiments:start_authed_web_session' team.slug experiment.id 0 %}"
-                        class="inline">
-                    {% csrf_token %}
-                    <button type="submit">Published version</button>
-                  </form>
-                </li>
-              </ul>
             </div>
-          </div>
-          <div class="tooltip" data-tip="Edit">
-            <a class="btn btn-primary join-item btn-sm rounded-r-full"
-               href="{% url 'experiments:edit' team.slug experiment.id %}">
-              <i class="fa-solid fa-pencil"></i>
-            </a>
-          </div>
+            <div class="tooltip" data-tip="Edit">
+              <a class="btn btn-primary join-item btn-sm rounded-r-full"
+                 href="{% url 'experiments:edit' team.slug experiment.id %}">
+                <i class="fa-solid fa-pencil"></i>
+              </a>
+            </div>
+          {% else %}
+            <div class="tooltip" data-tip="View">
+              <a class="btn btn-primary join-item btn-sm rounded-l-full rounded-r-full"
+                 href="{% url 'experiments:edit' team.slug experiment.id %}">
+                <i class="fa-solid fa-eye"></i>
+              </a>
+            </div>
+          {% endif %}
         </div>
       </div>
     </div>
     <h2 class="flex-1 pg-subtitle">{{ experiment.description }}</h2>
-    <div class="my-4">
-      <h3 class="font-bold text-lg inline mr-4">Channels:</h3>
-      <input id="api-url-link" type="hidden" value="{{ experiment.get_api_url }}" />
-      <button class="btn btn-ghost btn-sm no-animation !normal-case" onclick="SiteJS.app.copyToClipboard(this, 'api-url-link')" title="Copy to clipboard">
-        <i class="fa-solid fa-link"></i> API <i class="fa-regular fa-copy fa-sm pg-text-muted"></i>
-      </button>
-      <div class="dropdown dropdown-hover">
-        <div tabindex="0" role="button" class="btn btn-ghost btn-sm !normal-case">
-          <i class="fa-regular fa-window-maximize"></i> Web <i class="fa-solid fa-caret-down fa-sm pg-text-muted"></i>
-        </div>
-        <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow border">
-          {% if experiment.is_public %}
-            <li>
-              <a href="{% url 'experiments:start_session_public' team.slug experiment.public_id %}" target="_blank">
-                <i class="fa-solid fa-link"></i> Public Link
-              </a>
-            </li>
-          {% endif %}
-          {% if perms.experiments.invite_participants %}
-            <li>
-              <a href="{% url 'experiments:experiment_invitations' team.slug experiment.id %}">
-                <i class="fa-regular fa-envelope"></i> Invitations
-              </a>
-            </li>
-          {% endif %}
-        </ul>
-      </div>
-    {#  Commented elements included for Tailwind processing #}
-    {#  <i class="fa-brands fa-telegram"></i> #}
-    {#  <i class="fa-brands fa-whatsapp"></i> #}
-      {% for channel in channels %}
-        <div class="btn btn-ghost btn-sm !normal-case" onclick="channel_{{ channel.id }}_modal.showModal()">
-          <span class="tooltip" data-tip="{{ channel.name }}"><i class="fa-brands fa-{{ channel.platform_enum.value }}"></i> {{ channel.platform_enum.label }}</span>
-        </div>
-        <dialog id="channel_{{ channel.id }}_modal" class="modal">
-          <div class="modal-box">
-            <h3 class="font-bold text-lg">Edit {{ platform.label }} Channel</h3>
-            <form method="post" action="{% url "experiments:update_channel" request.team.slug experiment.id channel.id %}"
-                  {# debounce the submit event handler so that disabling the button only happens after submit and the 'action' param is submitted #}
-                  x-data="{ buttonDisabled: false }" x-on:submit.debounce="buttonDisabled = true">
-              {% csrf_token %}
-              {% render_form_fields channel.form %}
-              {% if channel.extra_form %}
-                <div {% include "generic/attrs.html" with attrs=channel.extra_form.form_attrs %}>
-                  {% render_form_fields channel.extra_form %}
-                </div>
-              {% endif %}
-              <div class="modal-action">
-                <button class="btn btn-primary" type="submit" name="action" value="update" x-bind:disabled="buttonDisabled">Update</button>
-                <button class="btn btn-error" type="submit" name="action" value="delete" x-bind:disabled="buttonDisabled">Delete</button>
-                <button class="btn" type="button" onclick="channel_{{ channel.id }}_modal.close()" x-bind:disabled="buttonDisabled">Close</button>
-              </div>
-            </form>
+    {% if not experiment.is_archived %}
+      <div class="my-4">
+        <h3 class="font-bold text-lg inline mr-4">Channels:</h3>
+        <input id="api-url-link" type="hidden" value="{{ experiment.get_api_url }}" />
+        <button class="btn btn-ghost btn-sm no-animation !normal-case" onclick="SiteJS.app.copyToClipboard(this, 'api-url-link')" title="Copy to clipboard">
+          <i class="fa-solid fa-link"></i> API <i class="fa-regular fa-copy fa-sm pg-text-muted"></i>
+        </button>
+        <div class="dropdown dropdown-hover">
+          <div tabindex="0" role="button" class="btn btn-ghost btn-sm !normal-case">
+            <i class="fa-regular fa-window-maximize"></i> Web <i class="fa-solid fa-caret-down fa-sm pg-text-muted"></i>
           </div>
-        </dialog>
-      {% endfor %}
-      {% if platforms %}
-        <div class="dropdown">
-          <button tabindex="0" class="btn btn-ghost btn-sm">
-            <i class="fa-regular fa-plus"></i>
-          </button>
-          <ul tabindex="0" class="dropdown-content z-10 menu p-2 shadow bg-base-100 rounded-box w-52 border">
-            {% for platform, available in platforms.items %}
+          <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow border">
+            {% if experiment.is_public %}
               <li>
-                <button
-                  class="disabled:text-gray-600 tooltip tooltip-right"
-                  {% if not available %}
-                    disabled
-                    data-tip="You need to configure your {{ platform|capfirst }} provider to use this channel"
-                  {% endif %}
-                  onclick="{{ platform.value }}_modal.showModal()"
-
-                >
-                  {{ platform.label }} {% if not available %}
-                  {% endif %}
-                </button>
+                <a href="{% url 'experiments:start_session_public' team.slug experiment.public_id %}" target="_blank">
+                  <i class="fa-solid fa-link"></i> Public Link
+                </a>
               </li>
-            {% endfor %}
+            {% endif %}
+            {% if perms.experiments.invite_participants %}
+              <li>
+                <a href="{% url 'experiments:experiment_invitations' team.slug experiment.id %}">
+                  <i class="fa-regular fa-envelope"></i> Invitations
+                </a>
+              </li>
+            {% endif %}
           </ul>
         </div>
-        {% for platform, available in platforms.items %}
-          {% if available %}
-            <dialog id="{{ platform.value }}_modal" class="modal">
-              <div class="modal-box">
-                <h3 class="font-bold text-lg">Link with {{ platform.label }}</h3>
-                <form method="post" action="{% url "experiments:create_channel" request.team.slug experiment.id %}"
-                      x-data="{ buttonDisabled: false }" x-on:submit="buttonDisabled = true">
-                  {% csrf_token %}
-                  {% render_form_fields platform_forms|dict_lookup:platform %}
-                  {% if platform.extra_form %}
-                    <div {% include "generic/attrs.html" with attrs=platform.extra_form.form_attrs %}>
-                      {% render_form_fields platform.extra_form %}
-                    </div>
-                  {% endif %}
-                  <div class="modal-action">
-                    <span class="loading loading-spinner loading-sm p-3 ml-4" x-show="buttonDisabled" x-cloak></span>
-                    <button class="btn btn-primary" type="submit" x-bind:disabled="buttonDisabled">Create</button>
-                    <button class="btn" type="button" onclick="{{ platform.value }}_modal.close()" x-bind:disabled="buttonDisabled">Close</button>
+      {#  Commented elements included for Tailwind processing #}
+      {#  <i class="fa-brands fa-telegram"></i> #}
+      {#  <i class="fa-brands fa-whatsapp"></i> #}
+        {% for channel in channels %}
+          <div class="btn btn-ghost btn-sm !normal-case" onclick="channel_{{ channel.id }}_modal.showModal()">
+            <span class="tooltip" data-tip="{{ channel.name }}"><i class="fa-brands fa-{{ channel.platform_enum.value }}"></i> {{ channel.platform_enum.label }}</span>
+          </div>
+          <dialog id="channel_{{ channel.id }}_modal" class="modal">
+            <div class="modal-box">
+              <h3 class="font-bold text-lg">Edit {{ platform.label }} Channel</h3>
+              <form method="post" action="{% url "experiments:update_channel" request.team.slug experiment.id channel.id %}"
+                    {# debounce the submit event handler so that disabling the button only happens after submit and the 'action' param is submitted #}
+                    x-data="{ buttonDisabled: false }" x-on:submit.debounce="buttonDisabled = true">
+                {% csrf_token %}
+                {% render_form_fields channel.form %}
+                {% if channel.extra_form %}
+                  <div {% include "generic/attrs.html" with attrs=channel.extra_form.form_attrs %}>
+                    {% render_form_fields channel.extra_form %}
                   </div>
-                </form>
-              </div>
-            </dialog>
-          {% endif %}
+                {% endif %}
+                <div class="modal-action">
+                  <button class="btn btn-primary" type="submit" name="action" value="update" x-bind:disabled="buttonDisabled">Update</button>
+                  <button class="btn btn-error" type="submit" name="action" value="delete" x-bind:disabled="buttonDisabled">Delete</button>
+                  <button class="btn" type="button" onclick="channel_{{ channel.id }}_modal.close()" x-bind:disabled="buttonDisabled">Close</button>
+                </div>
+              </form>
+            </div>
+          </dialog>
         {% endfor %}
-      {% endif %}
-    </div>
+        {% if platforms %}
+          <div class="dropdown">
+            <button tabindex="0" class="btn btn-ghost btn-sm">
+              <i class="fa-regular fa-plus"></i>
+            </button>
+            <ul tabindex="0" class="dropdown-content z-10 menu p-2 shadow bg-base-100 rounded-box w-52 border">
+              {% for platform, available in platforms.items %}
+                <li>
+                  <button
+                    class="disabled:text-gray-600 tooltip tooltip-right"
+                    {% if not available %}
+                      disabled
+                      data-tip="You need to configure your {{ platform|capfirst }} provider to use this channel"
+                    {% endif %}
+                    onclick="{{ platform.value }}_modal.showModal()"
+
+                  >
+                    {{ platform.label }} {% if not available %}
+                    {% endif %}
+                  </button>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+          {% for platform, available in platforms.items %}
+            {% if available %}
+              <dialog id="{{ platform.value }}_modal" class="modal">
+                <div class="modal-box">
+                  <h3 class="font-bold text-lg">Link with {{ platform.label }}</h3>
+                  <form method="post" action="{% url "experiments:create_channel" request.team.slug experiment.id %}"
+                        x-data="{ buttonDisabled: false }" x-on:submit="buttonDisabled = true">
+                    {% csrf_token %}
+                    {% render_form_fields platform_forms|dict_lookup:platform %}
+                    {% if platform.extra_form %}
+                      <div {% include "generic/attrs.html" with attrs=platform.extra_form.form_attrs %}>
+                        {% render_form_fields platform.extra_form %}
+                      </div>
+                    {% endif %}
+                    <div class="modal-action">
+                      <span class="loading loading-spinner loading-sm p-3 ml-4" x-show="buttonDisabled" x-cloak></span>
+                      <button class="btn btn-primary" type="submit" x-bind:disabled="buttonDisabled">Create</button>
+                      <button class="btn" type="button" onclick="{{ platform.value }}_modal.close()" x-bind:disabled="buttonDisabled">Close</button>
+                    </div>
+                  </form>
+                </div>
+              </dialog>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      </div>
+    {% endif %}
 
     {% if not can_make_child_routes %}
       <div class="my-4">
@@ -281,7 +292,9 @@
       <input type="radio" name="tab_group" role="tab" class="tab" aria-label="Versions" id="tab-versions" />
       <div role="tabpanel" class="tab-content" id="content-versions">
         <div class="app-card">
-          {% include 'experiments/create_version_button.html' %}
+          {% if not experiment.is_archived %}
+            {% include 'experiments/create_version_button.html' %}
+          {% endif %}
           <div id="versions-table"
                hx-trigger="load,refetch-versions"
                hx-target="this"
@@ -311,7 +324,9 @@
         {% if experiment.assistant %}
           Assistants cannot be router bots. Please use a normal bot
         {% elif can_make_child_routes %}
-          <a class="btn btn-sm btn-outline btn-primary mb-2" href="{% url 'experiments:experiment_route_new' team.slug experiment.id 'processor' %}"><i class="fa-regular fa-plus"></i> Create child route</a>
+          {% if not experiment.is_archived %}
+            <a class="btn btn-sm btn-outline btn-primary mb-2" href="{% url 'experiments:experiment_route_new' team.slug experiment.id 'processor' %}"><i class="fa-regular fa-plus"></i> Create child route</a>
+          {% endif %}
           {% render_table child_routes_table %}
         {% else %}
           Child experiments cannot have their own routes.
@@ -322,7 +337,7 @@
     <input type="radio" name="tab_group" role="tab" class="tab" aria-label="Terminal Bot" id="tab-terminal_bots"/>
     <div role="tabpanel" class="tab-content" id="content-terminal_bots">
       <div class="app-card">
-        {% if terminal_bots_table.data|length == 0 %}
+        {% if terminal_bots_table.data|length == 0 and not experiment.is_archived%}
           <a class="btn btn-sm btn-outline btn-primary mb-2" href="{% url 'experiments:experiment_route_new' team.slug experiment.id 'terminal' %}"><i class="fa-regular fa-plus"></i> Add terminal bot</a>
         {% endif %}
         {% render_table terminal_bots_table %}

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -19,7 +19,11 @@
       <div class="flex-1 flex flex-row gap-2">
         <h1 class="pg-title">{{ experiment.name }}</h1>
         {% flag "experiment_versions" %}
-          {% if deployed_version %}
+          {% if experiment.is_archived %}
+            <div class="badge badge-warning badge-sm">
+              Archived
+            </div>
+          {% elif deployed_version %}
             <div class="tooltip" data-tip="Current published version">
               <a class="badge badge-success badge-sm"
                  href="#versions">

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -268,7 +268,7 @@
                   <td class="overflow-hidden px-3 py-3 text-left">{{ session.last_message_created_at }}</td>
                   <td class="overflow-hidden px-3 py-3 text-left">{{session.experiment_version_for_display }}</td>
                   <td class="overflow-hidden px-3 py-3 text-left">
-                    {% if session.is_complete %}
+                    {% if session.is_complete or not experiment.is_editable %}
                       <a class="btn btn-sm btn-outline btn-primary"
                          href="{% url 'experiments:experiment_session_view' team.slug experiment.public_id session.external_id %}"
                          class="link">Review Chat</a>


### PR DESCRIPTION
Resolves #951 

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
- Removed a bunch of edit + chat buttons on the experiment home page as well as the edit page.
-  You can't chat to an archived version, only view it
- To allow some views to "see" archived versions when we want to navigate there, I had to use the `objects.get_all()` queryset in some places instead of the default one that filters out archived versions.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users will be able to see their archived experiments

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
https://www.loom.com/share/bd24d967870649f48f5b1b24b7835c6d?sid=ac5f920d-2eb7-43c5-988a-c071ca33bfd7

### Docs
<!--Link to documentation that has been updated.-->
