### PR TITLE
move custom actions server URL to a form field instead of part of the API schema

### DIFF
--- a/apps/custom_actions/forms.py
+++ b/apps/custom_actions/forms.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from urllib.parse import urljoin
 
 from django import forms
@@ -21,6 +22,11 @@ class CustomActionForm(forms.ModelForm):
         help_text="Use this field to provide additional instructions to the LLM",
         max_length=1000,
     )
+    server_url = forms.URLField(
+        label="Base URL",
+        help_text="The base URL of the API server. This will be used to generate the API calls for the LLM.",
+        required=True,
+    )
     api_schema = JsonOrYamlField(
         widget=forms.Textarea(attrs={"rows": "10"}),
         required=True,
@@ -40,7 +46,7 @@ class CustomActionForm(forms.ModelForm):
 
     class Meta:
         model = CustomAction
-        fields = ("name", "description", "auth_provider", "prompt", "api_schema", "allowed_operations")
+        fields = ("name", "description", "auth_provider", "prompt", "server_url", "api_schema", "allowed_operations")
 
     def __init__(self, request, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -54,6 +60,17 @@ class CustomActionForm(forms.ModelForm):
             self.fields["allowed_operations"].choices = [
                 (path, [(op.operation_id, str(op)) for op in ops]) for path, ops in grouped_ops.items()
             ]
+        self.fields["server_url"].validators = [self.url_validator]
+
+    def clean_server_url(self):
+        server_url = self.cleaned_data["server_url"]
+
+        try:
+            validate_user_input_url(server_url, strict=not settings.DEBUG)
+        except InvalidURL as e:
+            raise forms.ValidationError(f"The server URL is invalid: {str(e)}")
+
+        return server_url
 
     def clean_api_schema(self):
         api_schema = self.cleaned_data["api_schema"]
@@ -70,6 +87,7 @@ class CustomActionForm(forms.ModelForm):
         if schema is None or operations is None:
             return self.cleaned_data
 
+        server_url = self.cleaned_data["server_url"]
         spec = OpenAPISpec.from_spec_dict(schema)
         operations_by_id = {op.operation_id: op for op in get_operations_from_spec(spec)}
         invalid_operations = set(operations) - set(operations_by_id)
@@ -80,12 +98,23 @@ class CustomActionForm(forms.ModelForm):
 
         for op_id in operations:
             op = operations_by_id[op_id]
+
+            try:
+                self.url_validator(urljoin(server_url, op.path))
+            except forms.ValidationError:
+                raise forms.ValidationError(f"Invalid path: {op.path}")
+
             try:
                 openapi_spec_op_to_function_def(spec, op.path, op.method)
             except ValueError as e:
                 raise forms.ValidationError({"allowed_operations": f"The '{op}' operation is not supported ({e})"})
 
         return {**self.cleaned_data, "allowed_operations": operations}
+
+    @cached_property
+    def url_validator(self):
+        schemes = ["https", "http"] if settings.DEBUG else ["https"]
+        return URLValidator(schemes=schemes)
 
 
 def validate_api_schema(api_schema):
@@ -96,36 +125,10 @@ def validate_api_schema(api_schema):
     except ValueError:
         raise forms.ValidationError("Invalid OpenAPI schema.")
 
-    servers = api_schema.get("servers", [])
-    if not servers:
-        raise forms.ValidationError("No servers found in the schema.")
-    if len(servers) > 1:
-        raise forms.ValidationError("Multiple servers found in the schema. Only one is allowed.")
-    server_url = servers[0].get("url")
-    if not server_url:
-        raise forms.ValidationError("No server URL found in the schema.")
-
-    schemes = ["https", "http"] if settings.DEBUG else ["https"]
-    url_validator = URLValidator(schemes=schemes)
-
-    # Fist pass with Django's URL validator
-    try:
-        url_validator(server_url)
-    except forms.ValidationError:
-        raise forms.ValidationError("The server URL is invalid. Ensure that the URL is a valid HTTPS URL")
-
-    try:
-        validate_user_input_url(server_url, strict=not settings.DEBUG)
-    except InvalidURL as e:
-        raise forms.ValidationError(f"The server URL is invalid: {str(e)}")
-
     paths = api_schema.get("paths", {})
     if not paths:
         raise forms.ValidationError("No paths found in the schema.")
 
-    for path in paths:
-        try:
-            url_validator(urljoin(server_url, path))
-        except forms.ValidationError:
-            raise forms.ValidationError(f"Invalid path: {path}")
+    api_schema.pop("servers", None)
+
     return api_schema

--- a/apps/custom_actions/models.py
+++ b/apps/custom_actions/models.py
@@ -53,7 +53,6 @@ class CustomAction(BaseTeamModel):
         self._operations = [op.model_dump() for op in value]
 
     def save(self, *args, **kwargs):
-        self.server_url = self.api_schema.get("servers", [{}])[0].get("url", "")
         try:
             self.operations = get_operations_from_spec_dict(self.api_schema)
         except Exception as e:

--- a/apps/custom_actions/schema_utils.py
+++ b/apps/custom_actions/schema_utils.py
@@ -13,10 +13,10 @@ def get_standalone_schema_for_action_operation(action_operation):
     if not operation:
         raise ValidationError("Custom action operation is no longer available")
 
-    return get_standalone_spec(action.api_schema, operation.path, operation.method)
+    return get_standalone_spec(action.server_url, action.api_schema, operation.path, operation.method)
 
 
-def get_standalone_spec(openapi_spec: dict, path: str, method: str):
+def get_standalone_spec(server_url: str, openapi_spec: dict, path: str, method: str):
     """Returns a standalone OpenAPI spec for a single operation."""
     openapi_spec = trim_spec(openapi_spec)
     info = openapi_spec["info"]
@@ -24,6 +24,7 @@ def get_standalone_spec(openapi_spec: dict, path: str, method: str):
     info["description"] = f"Standalone OpenAPI spec for {method} {path}"
     paths = openapi_spec.pop("paths")
     openapi_spec["paths"] = {path: {method: paths[path][method]}}
+    openapi_spec["servers"] = [{"url": server_url}]
     return openapi_spec
 
 
@@ -32,7 +33,7 @@ def trim_spec(openapi_spec: dict) -> dict:
     If there are any refs in the schema, they will be resolved.
     """
     openapi_spec = resolve_references(openapi_spec)
-    top_level_keys = ["openapi", "info", "servers", "paths"]
+    top_level_keys = ["openapi", "info", "paths"]
     for key in list(openapi_spec.keys()):
         if key not in top_level_keys:
             del openapi_spec[key]

--- a/apps/custom_actions/tests/test_versioning.py
+++ b/apps/custom_actions/tests/test_versioning.py
@@ -90,6 +90,7 @@ def custom_action(experiment):
         prompt="Custom action prompt",
         api_schema=ACTION_SCHEMA,
         allowed_operations=["weather_get"],
+        server_url="https://api.weather.com",
     )
 
 

--- a/apps/custom_actions/views.py
+++ b/apps/custom_actions/views.py
@@ -51,12 +51,14 @@ class CreateCustomAction(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Cre
         return {**super().get_form_kwargs(), "request": self.request}
 
     def get_success_url(self):
-        messages.info(self.request, "Select the operations you want to allow for this custom action.")
-        return reverse("custom_actions:edit", args=[self.request.team.slug, self.object.id])
+        return reverse("single_team:manage_team", args=[self.request.team.slug])
 
     def form_valid(self, form):
         form.instance.team = self.request.team
-        return super().form_valid(form)
+        resp = super().form_valid(form)
+        self.object.allowed_operations = list(self.object.get_operations_by_id())
+        self.object.save(update_fields=["allowed_operations"])
+        return resp
 
 
 class EditCustomAction(LoginAndTeamRequiredMixin, PermissionRequiredMixin, UpdateView):

--- a/templates/generic/object_home_content.html
+++ b/templates/generic/object_home_content.html
@@ -3,7 +3,9 @@
   <div class="grid grid-cols-6">
     <div class="col-span-5">
       <div class="flex">
-        <h1 class="{{ title_class|default:"pg-title" }}">{{ title }}</h1>
+        <h1 id="{{ title|slugify }}" class="{{ title_class|default:"pg-title" }} hover:cursor-pointer">
+          <a href="#{{ title|slugify }}">{{ title }}</a>
+        </h1>
         {% if info_link %}
           <a class="mx-2 text-xs text-neutral-500" href="{{ info_link }}" target="_blank">Learn more <i class="text-xs fa fa-circle-question"></i></a>
         {% endif %}


### PR DESCRIPTION
Most schema's don't contain the "servers" key so rather make it a separate field. There already was a field on the model so this is just a UI / logic change.

## User impact

Simpler to add custom actions.