### PR TITLE
Save summary on the last message

### DIFF
--- a/apps/chat/conversation.py
+++ b/apps/chat/conversation.py
@@ -197,6 +197,8 @@ def compress_chat_history_from_messages(
 ):
     summary = history.pop(0).content if history[0].type == ChatMessageType.SYSTEM else None
     history, pruned_memory = history[-keep_history_len:], history[:-keep_history_len]
+    # The latest message
+    latest_message = history[-1]
 
     summary_tokens = (
         llm.get_num_tokens_from_messages([SystemMessage(content=summary)])
@@ -228,7 +230,8 @@ def compress_chat_history_from_messages(
     elif pruned_memory:
         last_message = pruned_memory[-1]
     else:
-        last_message = None
+        # When the summary was too large and the history and pruned_memory was exhausted
+        last_message = latest_message
 
     return history, last_message, summary
 


### PR DESCRIPTION
This is an attempt to fix [this issue](https://dimagi.sentry.io/issues/6121749970/?alert_rule_id=14063560&alert_type=issue&notification_uuid=d45aa2b1-8094-4ecf-acee-9b96bb665c6f&project=4505001320316928&referrer=issue_alert-slack).

I couldn't quite replicate this locally, but the test should put it in the state that I noticed.

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
What happened here is that the `history` and `pruned_memory` arrays were being cleared because of the while loops running too long. This happens because the summary + history + promtp are all very large (token wise). Previously we didn't save the summaries that were being generated on any message, but now we just save it on the latest message.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
My guess is better suited responses? It's unclear.