### PR TITLE
Show the system error in debug mode

### DIFF
--- a/templates/experiments/chat/chat_message_response.html
+++ b/templates/experiments/chat/chat_message_response.html
@@ -12,10 +12,9 @@
       <div>
         {% if message_details.message %}
           {% include 'experiments/chat/ai_message.html' with message=message_details.message %}
-        {% elif message_details.error %}
+        {% elif message_details.error_msg %}
           <p class="chat-message-system pg-text-danger">
-            Sorry something went wrong. This was likely an intermittent error related to load.
-            Please try again, and wait a few minutes if this keeps happening.
+            {{ message_details.error_msg }}
           </p>
         {% else %}
           <span class="loading loading-dots loading-sm"></span>


### PR DESCRIPTION
Low hanging fruit: resolves #898 

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Error messages are propegated to the UI in debug mode.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users will be able to debug their bot by enabling debug mode.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
In this demo I used a dummy API key for the LLM provider.

![demo](https://github.com/user-attachments/assets/8a9cedb9-e7c0-4501-8689-ade10de95746)


### Docs
<!--Link to documentation that has been updated.-->


@snopoke maybe this is a good time to move the debug setting to the user's session instead of the experiment?