### PR TITLE
Global search endpoint + improvements to temp superuser access

### DIFF
--- a/apps/api/helpers.py
+++ b/apps/api/helpers.py
@@ -2,7 +2,6 @@ from django.http import HttpRequest
 from rest_framework_api_key.permissions import KeyParser
 
 from apps.api.models import UserAPIKey
-from apps.teams.models import Membership
 from apps.users.models import CustomUser
 
 
@@ -21,10 +20,6 @@ def get_team_from_request(request: HttpRequest) -> CustomUser | None:
         return None
     user_api_key = _get_api_key_object(request, UserAPIKey)
     return user_api_key.team
-
-
-def get_team_membership_for_request(request: HttpRequest):
-    return Membership.objects.filter(team=request.team, user=request.user).first()
 
 
 def _get_api_key_object(request, model_class):

--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -5,9 +5,9 @@ from rest_framework.authentication import BaseAuthentication
 from rest_framework.permissions import DjangoModelPermissions
 from rest_framework_api_key.permissions import KeyParser
 
+from apps.teams.helpers import get_team_membership_for_request
 from apps.teams.utils import set_current_team
 
-from .helpers import get_team_membership_for_request
 from .models import UserAPIKey
 
 

--- a/apps/experiments/admin.py
+++ b/apps/experiments/admin.py
@@ -88,6 +88,7 @@ class ExperimentAdmin(admin.ModelAdmin):
     inlines = [SafetyLayerInline]
     exclude = ["safety_layers"]
     readonly_fields = ("public_id",)
+    search_fields = ("public_id", "name")
 
     @admin.display(description="Version Family")
     def version_family(self, obj):

--- a/apps/teams/helpers.py
+++ b/apps/teams/helpers.py
@@ -5,7 +5,7 @@ from apps.users.models import CustomUser
 from apps.utils.slug import get_next_unique_slug
 
 from .backends import make_user_team_owner
-from .models import Team
+from .models import Membership, Team
 
 
 def get_default_team_name_for_user(user: CustomUser):
@@ -58,3 +58,7 @@ def create_default_team_for_user(user: CustomUser, team_name: str = None):
     team = Team.objects.create(name=team_name, slug=slug)
     make_user_team_owner(team, user)
     return team
+
+
+def get_team_membership_for_request(request: HttpRequest):
+    return Membership.objects.filter(team=request.team, user=request.user).first()

--- a/apps/teams/helpers.py
+++ b/apps/teams/helpers.py
@@ -61,4 +61,5 @@ def create_default_team_for_user(user: CustomUser, team_name: str = None):
 
 
 def get_team_membership_for_request(request: HttpRequest):
-    return Membership.objects.filter(team=request.team, user=request.user).first()
+    if request.user.is_authenticated and request.team:
+        return Membership.objects.filter(team=request.team, user=request.user).first()

--- a/apps/teams/middleware.py
+++ b/apps/teams/middleware.py
@@ -16,10 +16,7 @@ def _get_team(request, view_kwargs):
 
 def _get_team_membership(request):
     if not hasattr(request, "_cached_team_membership"):
-        team_membership = None
-        if request.user.is_authenticated and request.team:
-            team_membership = get_team_membership_for_request(request)
-        request._cached_team_membership = team_membership
+        request._cached_team_membership = get_team_membership_for_request(request)
     return request._cached_team_membership
 
 

--- a/apps/teams/middleware.py
+++ b/apps/teams/middleware.py
@@ -16,6 +16,7 @@ def _get_team(request, view_kwargs):
 
 def _get_team_membership(request):
     if not hasattr(request, "_cached_team_membership"):
+        team_membership = None
         if request.user.is_authenticated and request.team:
             team_membership = get_team_membership_for_request(request)
         request._cached_team_membership = team_membership

--- a/apps/teams/middleware.py
+++ b/apps/teams/middleware.py
@@ -1,8 +1,7 @@
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
 
-from apps.teams.helpers import get_team_for_request
-from apps.teams.models import Membership
+from apps.teams.helpers import get_team_for_request, get_team_membership_for_request
 from apps.teams.utils import set_current_team
 
 
@@ -17,12 +16,8 @@ def _get_team(request, view_kwargs):
 
 def _get_team_membership(request):
     if not hasattr(request, "_cached_team_membership"):
-        team_membership = None
         if request.user.is_authenticated and request.team:
-            try:
-                team_membership = Membership.objects.get(team=request.team, user=request.user)
-            except Membership.DoesNotExist:
-                pass
+            team_membership = get_team_membership_for_request(request)
         request._cached_team_membership = team_membership
     return request._cached_team_membership
 

--- a/apps/web/search.py
+++ b/apps/web/search.py
@@ -1,0 +1,30 @@
+import dataclasses
+
+from django.db.models import Model
+
+
+@dataclasses.dataclass
+class SearchableModel:
+    model_cls: type[Model]
+    field_name: str
+
+    def search(self, value):
+        results = self.model_cls.objects.filter(**{self.field_name: value})[:2]
+        if len(results) == 1:
+            return results[0]
+
+    @property
+    def permission(self):
+        app_label = self.model_cls._meta.app_label
+        model_name = self.model_cls._meta.model_name
+        return f"{app_label}.view_{model_name}"
+
+
+def get_searchable_models():
+    from apps.experiments.models import Experiment, ExperimentSession, Participant
+
+    return [
+        SearchableModel(Experiment, "public_id"),
+        SearchableModel(ExperimentSession, "external_id"),
+        SearchableModel(Participant, "public_id"),
+    ]

--- a/apps/web/urls.py
+++ b/apps/web/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path("status/<str:subset>/", views.HealthCheck.as_view()),
     path("sudo/<slug:slug>/", views.acquire_superuser_powers, name="sudo"),
     path("sudo/<slug:slug>/release/", views.release_superuser_powers, name="release_sudo"),
+    path("search", views.global_search, name="global_search"),
 ]
 
 team_urlpatterns = (

--- a/apps/web/views.py
+++ b/apps/web/views.py
@@ -12,7 +12,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views.decorators.debug import sensitive_post_parameters
 from health_check.views import MainView
 
-from apps.teams.decorators import TeamAccessDenied, login_and_team_required
+from apps.teams.decorators import check_superuser_team_access, login_and_team_required
 from apps.teams.models import Membership, Team
 from apps.teams.roles import is_member
 from apps.web.admin import ADMIN_SLUG
@@ -125,7 +125,7 @@ def global_search(request):
         if result := candidate.search(query):
             team = result.team
             if not is_member(request.user, team):
-                raise TeamAccessDenied
+                check_superuser_team_access(request, team.slug)
 
             if not request.user.has_perm(candidate.permission):
                 raise Http404


### PR DESCRIPTION
## Description

### Global search
This PR adds a global search endpoint that can be used to find objects by their public / external UUIDs.

    https://host/search?q=<uuid>

This will give a 404 or redirect you to the objects page if you have permission to view it.

Currently supported search models are: `Experiment`, `ExperimentSession`, `Participant`.

This PR also makes it possible to search by Experiment `public_id` in the Django Admin.

### Temp superuser updates
This PR also includes to improvements to the temporary superuser access features. Notably:

* Automatically give permission to superusers when in `DEBUG` mode
* Set a fake membership object on the request to prevent errors in places where code calls `request.team_membership`. This fake membership is only applied if the user already has temporary superuser access.

## User Impact
Easier to find objects from their public ID. The global search can also be used in a browser as an additional search engine:

* https://support.google.com/chrome/answer/95426
* https://support.mozilla.org/en-US/kb/assign-shortcuts-search-engines

## Docs
https://github.com/dimagi/open-chat-studio-docs/pull/12
