### PR TITLE
Fix "unique_global_channel_per_team" error in temporary session

### DIFF
--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -18,8 +18,8 @@ def temporary_session(team: Team, user_id: int):
         experiment = Experiment.objects.create(
             team=team, name="Temporary Experiment", owner=user, consent_form=consent_form
         )
-        channel = ExperimentChannel.objects.create(
-            team=team, name="Temporary Channel", experiment=experiment, platform=ChannelPlatform.WEB
+        channel, created = ExperimentChannel.objects.get_or_create(
+            team=team, platform=ChannelPlatform.WEB, defaults={"name": "Temporary Channel", "experiment": experiment}
         )
         chat = Chat.objects.create(team=team, name="Temporary Chat")
         participant, _ = Participant.objects.get_or_create(user=user, team=team, platform=ChannelPlatform.WEB)

--- a/apps/pipelines/tests/test_node_helpers.py
+++ b/apps/pipelines/tests/test_node_helpers.py
@@ -1,8 +1,11 @@
 import pytest
 
+from apps.channels.models import ChannelPlatform
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.experiments.models import ExperimentSession
 from apps.pipelines.nodes.helpers import temporary_session
+from apps.utils.factories.channels import ExperimentChannelFactory
+from apps.utils.factories.experiment import ExperimentSessionFactory
 from apps.utils.factories.team import TeamFactory, UserFactory
 
 
@@ -10,7 +13,10 @@ from apps.utils.factories.team import TeamFactory, UserFactory
 def test_temporary_session_is_temporary():
     session_id = None
     user = UserFactory()
-    with temporary_session(TeamFactory(), user.id) as session:
+    team = TeamFactory()
+    channel = ExperimentChannelFactory(team=team, platform=ChannelPlatform.WEB)
+    session = ExperimentSessionFactory(team=team, experiment=channel.experiment, experiment_channel=channel)
+    with temporary_session(team, user.id) as session:
         session_id = session.id
         message = session.chat.messages.create(message_type=ChatMessageType.HUMAN, content="Hello, world!")
 


### PR DESCRIPTION
There is a constraint that there is a single `WEB` channel for every team. If you have a previously created session with a web channel, then you were not able to use `simple_invoke` as it attempted to make a new channel. 

I'm not sure how re-using a channel that already exists affects the rollback, but it "fixes" the bug. 

