### PR TITLE
use correct path converters in url patterns

### DIFF
--- a/apps/api/openai.py
+++ b/apps/api/openai.py
@@ -1,5 +1,6 @@
 import textwrap
 import time
+import uuid
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
@@ -86,7 +87,7 @@ from apps.channels.tasks import handle_api_message
     ],
 )
 @api_view(["POST"])
-def chat_completions(request, experiment_id: str):
+def chat_completions(request, experiment_id: uuid.UUID):
     messages = request.data.get("messages", [])
     try:
         last_message = messages.pop()

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -11,7 +11,7 @@ router.register(r"sessions", views.ExperimentSessionViewSet, basename="session")
 
 urlpatterns = [
     path("participants/", views.update_participant_data, name="update-participant-data"),
-    path("openai/<str:experiment_id>/chat/completions", openai.chat_completions, name="openai-chat-completions"),
+    path("openai/<uuid:experiment_id>/chat/completions", openai.chat_completions, name="openai-chat-completions"),
     path("files/<int:pk>/content", views.file_content_view, name="file-content"),
     path("", include(router.urls)),
 ]

--- a/apps/experiments/decorators.py
+++ b/apps/experiments/decorators.py
@@ -1,3 +1,4 @@
+import uuid
 from functools import wraps
 
 from django.contrib import messages
@@ -22,7 +23,7 @@ def experiment_session_view(allowed_states=None):
         """
 
         @wraps(view_func)
-        def decorated_view(request, team_slug: str, experiment_id: str, session_id: str, **kwargs):
+        def decorated_view(request, team_slug: str, experiment_id: uuid.UUID, session_id: str, **kwargs):
             request.experiment = get_object_or_404(
                 Experiment.objects.get_all(), public_id=experiment_id, team=request.team
             )

--- a/apps/experiments/urls.py
+++ b/apps/experiments/urls.py
@@ -83,12 +83,12 @@ urlpatterns = [
         name="experiment_chat_session",
     ),
     path(
-        "e/<str:experiment_id>/v/<int:version_number>/session/<str:session_id>/message/",
+        "e/<uuid:experiment_id>/v/<int:version_number>/session/<str:session_id>/message/",
         views.experiment_session_message,
         name="experiment_session_message",
     ),
     path(
-        "e/<str:experiment_id>/session/<str:session_id>/get_response/<slug:task_id>/",
+        "e/<uuid:experiment_id>/session/<str:session_id>/get_response/<slug:task_id>/",
         views.get_message_response,
         name="get_message_response",
     ),
@@ -100,8 +100,8 @@ urlpatterns = [
     # events
     path("e/<int:experiment_id>/events/", include("apps.events.urls")),
     # superuser tools
-    path("e/<slug:experiment_id>/invitations/", views.experiment_invitations, name="experiment_invitations"),
-    path("e/<slug:experiment_id>/invitations/send/<str:session_id>/", views.send_invitation, name="send_invitation"),
+    path("e/<int:experiment_id>/invitations/", views.experiment_invitations, name="experiment_invitations"),
+    path("e/<int:experiment_id>/invitations/send/<str:session_id>/", views.send_invitation, name="send_invitation"),
     path("e/<int:experiment_id>/exports/generate", views.generate_chat_export, name="generate_chat_export"),
     path(
         "e/<int:experiment_id>/exports/result/<slug:task_id>",
@@ -110,47 +110,47 @@ urlpatterns = [
     ),
     # public links
     path(
-        "e/<slug:experiment_id>/s/<str:session_id>/",
+        "e/<uuid:experiment_id>/s/<str:session_id>/",
         views.start_session_from_invite,
         name="start_session_from_invite",
     ),
     path(
-        "e/<slug:experiment_id>/s/<str:session_id>/pre-survey/",
+        "e/<uuid:experiment_id>/s/<str:session_id>/pre-survey/",
         views.experiment_pre_survey,
         name="experiment_pre_survey",
     ),
     path(
-        "e/<slug:experiment_id>/s/<str:session_id>/chat/",
+        "e/<uuid:experiment_id>/s/<str:session_id>/chat/",
         views.experiment_chat,
         name="experiment_chat",
     ),
     path(
-        "e/<slug:experiment_id>/s/<str:session_id>/end/",
+        "e/<uuid:experiment_id>/s/<str:session_id>/end/",
         views.end_experiment,
         name="end_experiment",
     ),
     path(
-        "e/<slug:experiment_id>/s/<str:session_id>/review/",
+        "e/<uuid:experiment_id>/s/<str:session_id>/review/",
         views.experiment_review,
         name="experiment_review",
     ),
     path(
-        "e/<slug:experiment_id>/s/<str:session_id>/complete/",
+        "e/<uuid:experiment_id>/s/<str:session_id>/complete/",
         views.experiment_complete,
         name="experiment_complete",
     ),
     path(
-        "e/<slug:experiment_id>/s/<str:session_id>/view/",
+        "e/<uuid:experiment_id>/s/<str:session_id>/view/",
         views.experiment_session_details_view,
         name="experiment_session_view",
     ),
     path(
-        "e/<slug:experiment_id>/s/<str:session_id>/paginate/",
+        "e/<uuid:experiment_id>/s/<str:session_id>/paginate/",
         views.experiment_session_pagination_view,
         name="experiment_session_pagination_view",
     ),
     # public link
-    path("e/<slug:experiment_id>/start/", views.start_session_public, name="start_session_public"),
+    path("e/<uuid:experiment_id>/start/", views.start_session_public, name="start_session_public"),
     # Experiment Routes
     path(
         "e/<int:experiment_id>/experiment_routes/<str:type>/new",
@@ -169,7 +169,7 @@ urlpatterns = [
     ),
     path("<int:session_id>/file/<int:pk>/", views.download_file, name="download_file"),
     path(
-        "e/<slug:experiment_id>/verify_token/<str:token>/",
+        "e/<uuid:experiment_id>/verify_token/<str:token>/",
         views.verify_public_chat_token,
         name="verify_public_chat_token",
     ),

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -888,7 +888,7 @@ def experiment_chat_session(request, team_slug: str, experiment_id: int, session
 @experiment_session_view()
 @verify_session_access_cookie
 @require_POST
-def experiment_session_message(request, team_slug: str, experiment_id: int, session_id: int, version_number: int):
+def experiment_session_message(request, team_slug: str, experiment_id: uuid.UUID, version_number: int, session_id: str):
     working_experiment = request.experiment
     session = request.experiment_session
 
@@ -948,7 +948,7 @@ def experiment_session_message(request, team_slug: str, experiment_id: int, sess
 
 @experiment_session_view()
 @verify_session_access_cookie
-def get_message_response(request, team_slug: str, experiment_id: str, session_id: str, task_id: str):
+def get_message_response(request, team_slug: str, experiment_id: uuid.UUID, session_id: str, task_id: str):
     experiment = request.experiment
     session = request.experiment_session
     last_message = ChatMessage.objects.filter(chat=session.chat).order_by("-created_at").first()
@@ -1014,7 +1014,7 @@ def poll_messages(request, team_slug: str, experiment_id: int, session_id: int):
     )
 
 
-def start_session_public(request, team_slug: str, experiment_id: str):
+def start_session_public(request, team_slug: str, experiment_id: uuid.UUID):
     try:
         experiment = get_object_or_404(Experiment, public_id=experiment_id, team=request.team)
     except ValidationError:
@@ -1108,7 +1108,7 @@ def _verify_user_or_start_session(identifier, request, session):
     return TemplateResponse(request=request, template="account/participant_email_verify.html")
 
 
-def verify_public_chat_token(request, team_slug: str, experiment_id: str, token: str):
+def verify_public_chat_token(request, team_slug: str, experiment_id: uuid.UUID, token: str):
     try:
         claims = jwt.decode(token, settings.SECRET_KEY, algorithms="HS256")
         session = get_object_or_404(ExperimentSession, external_id=claims["session"])
@@ -1120,7 +1120,7 @@ def verify_public_chat_token(request, team_slug: str, experiment_id: str, token:
 
 @login_and_team_required
 @permission_required("experiments.invite_participants", raise_exception=True)
-def experiment_invitations(request, team_slug: str, experiment_id: str):
+def experiment_invitations(request, team_slug: str, experiment_id: int):
     experiment = get_object_or_404(Experiment, id=experiment_id, team=request.team)
     experiment_version = experiment.default_version
     sessions = experiment.sessions.order_by("-created_at").filter(
@@ -1193,7 +1193,7 @@ def get_export_download_link(request, team_slug: str, experiment_id: str, task_i
 
 @login_and_team_required
 @permission_required("experiments.invite_participants", raise_exception=True)
-def send_invitation(request, team_slug: str, experiment_id: str, session_id: str):
+def send_invitation(request, team_slug: str, experiment_id: int, session_id: str):
     experiment = get_object_or_404(Experiment, id=experiment_id, team=request.team)
     session = ExperimentSession.objects.get(experiment=experiment, external_id=session_id)
     send_experiment_invitation(session)
@@ -1224,7 +1224,7 @@ def _record_consent_and_redirect(request, team_slug: str, experiment_session: Ex
 
 
 @experiment_session_view(allowed_states=[SessionStatus.SETUP, SessionStatus.PENDING])
-def start_session_from_invite(request, team_slug: str, experiment_id: str, session_id: str):
+def start_session_from_invite(request, team_slug: str, experiment_id: uuid.UUID, session_id: str):
     experiment = get_object_or_404(Experiment, public_id=experiment_id, team=request.team)
     experiment_session = get_object_or_404(ExperimentSession, experiment=experiment, external_id=session_id)
     default_version = experiment.default_version
@@ -1265,7 +1265,7 @@ def start_session_from_invite(request, team_slug: str, experiment_id: str, sessi
 
 @experiment_session_view(allowed_states=[SessionStatus.PENDING_PRE_SURVEY])
 @verify_session_access_cookie
-def experiment_pre_survey(request, team_slug: str, experiment_id: str, session_id: str):
+def experiment_pre_survey(request, team_slug: str, experiment_id: uuid.UUID, session_id: str):
     if request.method == "POST":
         form = SurveyCompletedForm(request.POST)
         if form.is_valid():
@@ -1302,7 +1302,7 @@ def experiment_pre_survey(request, team_slug: str, experiment_id: str, session_i
 
 @experiment_session_view(allowed_states=[SessionStatus.ACTIVE, SessionStatus.SETUP])
 @verify_session_access_cookie
-def experiment_chat(request, team_slug: str, experiment_id: str, session_id: str):
+def experiment_chat(request, team_slug: str, experiment_id: uuid.UUID, session_id: str):
     experiment_version = request.experiment.default_version
     version_specific_vars = {
         "assistant": experiment_version.get_assistant(),
@@ -1325,7 +1325,7 @@ def experiment_chat(request, team_slug: str, experiment_id: str, session_id: str
 @experiment_session_view(allowed_states=[SessionStatus.ACTIVE, SessionStatus.SETUP])
 @verify_session_access_cookie
 @require_POST
-def end_experiment(request, team_slug: str, experiment_id: str, session_id: str):
+def end_experiment(request, team_slug: str, experiment_id: uuid.UUID, session_id: str):
     experiment_session = request.experiment_session
     experiment_session.update_status(SessionStatus.PENDING_REVIEW, commit=False)
     experiment_session.end(commit=True)
@@ -1334,7 +1334,7 @@ def end_experiment(request, team_slug: str, experiment_id: str, session_id: str)
 
 @experiment_session_view(allowed_states=[SessionStatus.PENDING_REVIEW])
 @verify_session_access_cookie
-def experiment_review(request, team_slug: str, experiment_id: str, session_id: str):
+def experiment_review(request, team_slug: str, experiment_id: uuid.UUID, session_id: str):
     form = None
     survey_link = None
     survey_text = None
@@ -1374,7 +1374,7 @@ def experiment_review(request, team_slug: str, experiment_id: str, session_id: s
 
 @experiment_session_view(allowed_states=[SessionStatus.COMPLETE])
 @verify_session_access_cookie
-def experiment_complete(request, team_slug: str, experiment_id: str, session_id: str):
+def experiment_complete(request, team_slug: str, experiment_id: uuid.UUID, session_id: str):
     return TemplateResponse(
         request,
         "experiments/experiment_complete.html",
@@ -1388,7 +1388,7 @@ def experiment_complete(request, team_slug: str, experiment_id: str, session_id:
 
 @experiment_session_view()
 @verify_session_access_cookie
-def experiment_session_details_view(request, team_slug: str, experiment_id: str, session_id: str):
+def experiment_session_details_view(request, team_slug: str, experiment_id: uuid.UUID, session_id: str):
     session = request.experiment_session
     experiment = request.experiment
 
@@ -1425,7 +1425,7 @@ def experiment_session_details_view(request, team_slug: str, experiment_id: str,
 
 @experiment_session_view()
 @login_and_team_required
-def experiment_session_pagination_view(request, team_slug: str, experiment_id: str, session_id: str):
+def experiment_session_pagination_view(request, team_slug: str, experiment_id: uuid.UUID, session_id: str):
     session = request.experiment_session
     experiment = request.experiment
     query = ExperimentSession.objects.exclude(external_id=session_id).filter(experiment=experiment)

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -888,7 +888,7 @@ def experiment_chat_session(request, team_slug: str, experiment_id: int, session
 @experiment_session_view()
 @verify_session_access_cookie
 @require_POST
-def experiment_session_message(request, team_slug: str, experiment_id: uuid.UUID, version_number: int, session_id: str):
+def experiment_session_message(request, team_slug: str, experiment_id: uuid.UUID, session_id: str, version_number: int):
     working_experiment = request.experiment
     session = request.experiment_session
 

--- a/apps/teams/urls.py
+++ b/apps/teams/urls.py
@@ -7,8 +7,8 @@ app_name = "teams"
 urlpatterns = [
     path("create/", views.create_team, name="create_team"),
     # invitation acceptance views
-    path("invitation/<slug:invitation_id>/", views.accept_invitation, name="accept_invitation"),
-    path("invitation/<slug:invitation_id>/signup/", views.SignupAfterInvite.as_view(), name="signup_after_invite"),
+    path("invitation/<uuid:invitation_id>/", views.accept_invitation, name="accept_invitation"),
+    path("invitation/<uuid:invitation_id>/signup/", views.SignupAfterInvite.as_view(), name="signup_after_invite"),
 ]
 
 team_urlpatterns = (

--- a/apps/teams/views/invitation_views.py
+++ b/apps/teams/views/invitation_views.py
@@ -1,3 +1,5 @@
+import uuid
+
 from allauth.account.views import SignupView
 from django.contrib import messages
 from django.http import HttpResponseRedirect
@@ -10,7 +12,7 @@ from ..models import Invitation
 from ..roles import is_member
 
 
-def accept_invitation(request, invitation_id):
+def accept_invitation(request, invitation_id: uuid.UUID):
     invitation = get_object_or_404(Invitation, id=invitation_id)
     if not invitation.is_accepted:
         # set invitation in the session in case needed later - e.g. to redirect after login


### PR DESCRIPTION
This prevents errors when non-uuid strings are used in the url (the user sees a 404 page instead).

See [DIMAGI-BOTS-KA](https://dimagi.sentry.io/issues/6137557306/)
