### PR TITLE
archive assistants (and delete from openai) + other version UI improvements

### DIFF
--- a/apps/assistants/admin.py
+++ b/apps/assistants/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 
 from apps.assistants.models import OpenAiAssistant, ToolResources
+from apps.experiments.admin import VersionedModelAdminMixin
 
 
 class ToolResourcesAdmin(admin.TabularInline):
@@ -8,6 +9,15 @@ class ToolResourcesAdmin(admin.TabularInline):
 
 
 @admin.register(OpenAiAssistant)
-class OpenAiAssistantAdmin(admin.ModelAdmin):
-    list_display = ("name", "team", "llm_provider", "llm_provider_model", "include_file_info")
+class OpenAiAssistantAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "name",
+        "team",
+        "llm_provider",
+        "llm_provider_model",
+        "include_file_info",
+        "version_family",
+        "version_number",
+        "is_archived",
+    )
     inlines = [ToolResourcesAdmin]

--- a/apps/assistants/models.py
+++ b/apps/assistants/models.py
@@ -67,6 +67,7 @@ class OpenAiAssistant(BaseTeamModel, VersionsMixin):
     allow_file_search_attachments = models.BooleanField(default=True)
     allow_code_interpreter_attachments = models.BooleanField(default=True)
     objects = OpenAiAssistantManager()
+    all_objects = AuditingManager()
 
     class Meta:
         ordering = ["name"]

--- a/apps/assistants/models.py
+++ b/apps/assistants/models.py
@@ -170,6 +170,12 @@ class OpenAiAssistant(BaseTeamModel, VersionsMixin):
         else:
             return self.custom_action_operations.select_related("custom_action")
 
+    def archive(self):
+        super().archive()
+        from apps.assistants.tasks import delete_openai_assistant_task
+
+        delete_openai_assistant_task.delay(self.id)
+
 
 @audit_fields(
     "assistant_id",

--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -61,6 +61,7 @@ from functools import wraps
 from io import BytesIO
 
 import openai
+from django.db.models import Count, Subquery
 from langchain_core.utils.function_calling import convert_to_openai_tool as lc_convert_to_openai_tool
 from openai import OpenAI
 from openai.types.beta import Assistant
@@ -178,13 +179,28 @@ def delete_openai_assistant(assistant: OpenAiAssistant):
     except openai.NotFoundError:
         pass
 
-    for resource in assistant.tool_resources.all():
+    tool_resources = list(assistant.tool_resources.all())
+    for resource in tool_resources:
         if resource.tool_type == "file_search" and "vector_store_id" in resource.extra:
             vector_store_id = resource.extra.pop("vector_store_id")
             client.beta.vector_stores.delete(vector_store_id=vector_store_id)
 
-        for file in resource.files.all():
+        files_to_delete = _get_files_to_delete(assistant.team, resource.id)
+        for file in files_to_delete:
             delete_file_from_openai(client, file)
+
+
+def _get_files_to_delete(team, tool_resource_id):
+    """Get files linked to the tool resource that are not referenced by any other tool resource."""
+    files_with_single_reference = (
+        ToolResources.files.through.objects.filter(toolresources__assistant__team=team)
+        .values("file")
+        .annotate(count=Count("toolresources"))
+        .filter(count=1)
+        .values("file_id")
+    )
+
+    return File.objects.filter(toolresources=tool_resource_id, id__in=Subquery(files_with_single_reference)).iterator()
 
 
 def is_tool_configured_remotely_but_missing_locally(assistant_data, local_tool_types, tool_name: str) -> bool:

--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -145,7 +145,7 @@ def delete_file_from_openai(client: OpenAI, file: File):
     try:
         client.files.delete(file.external_id)
     except openai.NotFoundError:
-        pass
+        logger.debug("File %s not found in OpenAI", file.external_id)
     file.external_id = ""
     file.external_source = ""
     return True
@@ -181,7 +181,7 @@ def delete_openai_assistant(assistant: OpenAiAssistant):
     try:
         client.beta.assistants.delete(assistant.assistant_id)
     except openai.NotFoundError:
-        pass
+        logger.debug("Assistant %s not found in OpenAI", assistant.assistant_id)
 
     tool_resources = list(assistant.tool_resources.all())
     for resource in tool_resources:
@@ -190,7 +190,7 @@ def delete_openai_assistant(assistant: OpenAiAssistant):
             try:
                 client.beta.vector_stores.delete(vector_store_id=vector_store_id)
             except openai.NotFoundError:
-                pass
+                logger.debug("Vector store %s not found in OpenAI", vector_store_id)
             resource.save(update_fields=["extra"])
 
         delete_openai_files_for_resource(client, assistant.team, resource)

--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -174,6 +174,9 @@ def import_openai_assistant(assistant_id: str, llm_provider: LlmProvider, team: 
 
 @wrap_openai_errors
 def delete_openai_assistant(assistant: OpenAiAssistant):
+    """Deletes the assistant from OpenAI and removes all associated files.
+
+    This function should be idempotent and safe to call multiple times."""
     client = assistant.llm_provider.get_llm_service().get_raw_client()
     try:
         client.beta.assistants.delete(assistant.assistant_id)
@@ -188,6 +191,7 @@ def delete_openai_assistant(assistant: OpenAiAssistant):
                 client.beta.vector_stores.delete(vector_store_id=vector_store_id)
             except openai.NotFoundError:
                 pass
+            resource.save(update_fields=["extra"])
 
         delete_openai_files_for_resource(client, assistant.team, resource)
 

--- a/apps/assistants/tasks.py
+++ b/apps/assistants/tasks.py
@@ -1,7 +1,11 @@
+import logging
+
 import openai
 from celery import shared_task
 
 from apps.assistants.sync import OpenAiSyncError, delete_openai_assistant
+
+logger = logging.getLogger("openai_sync")
 
 
 @shared_task(
@@ -21,8 +25,9 @@ def delete_openai_assistant_task(assistant_id: int):
     from apps.assistants.models import OpenAiAssistant
 
     try:
-        assistant = OpenAiAssistant.objects.get(id=assistant_id, is_archived=True)
+        assistant = OpenAiAssistant.all_objects.get(id=assistant_id, is_archived=True)
     except OpenAiAssistant.DoesNotExist:
+        logger.warning("Assistant with id %s not found or not archived, skipping deletion", assistant_id)
         return
 
     try:

--- a/apps/assistants/tasks.py
+++ b/apps/assistants/tasks.py
@@ -1,0 +1,32 @@
+import openai
+from celery import shared_task
+
+from apps.assistants.sync import OpenAiSyncError, delete_openai_assistant
+
+
+@shared_task(
+    autoretry_for=(openai.APIError,),
+    dont_autoretry_for=(
+        openai.APIResponseValidationError,
+        openai.BadRequestError,
+        openai.NotFoundError,
+        openai.PermissionDeniedError,
+        openai.UnprocessableEntityError,
+    ),
+    max_retries=5,
+    retry_backoff=True,
+    acks_late=True,
+)
+def delete_openai_assistant_task(assistant_id: int):
+    from apps.assistants.models import OpenAiAssistant
+
+    try:
+        assistant = OpenAiAssistant.objects.get(id=assistant_id, is_archived=True)
+    except OpenAiAssistant.DoesNotExist:
+        return
+
+    try:
+        delete_openai_assistant(assistant)
+    except OpenAiSyncError as e:
+        # re-raise the original error for retry purposes
+        raise e.__context__ from None

--- a/apps/assistants/tests/test_delete.py
+++ b/apps/assistants/tests/test_delete.py
@@ -1,0 +1,42 @@
+import pytest
+
+from apps.assistants.models import ToolResources
+from apps.assistants.sync import _get_files_to_delete
+from apps.utils.factories.assistants import OpenAiAssistantFactory
+from apps.utils.factories.files import FileFactory
+
+
+@pytest.fixture()
+def assistant():
+    return OpenAiAssistantFactory(assistant_id="test_id", builtin_tools=["code_interpreter", "file_search"])
+
+
+@pytest.fixture()
+def code_resource(assistant):
+    files = FileFactory.create_batch(2, team=assistant.team)
+
+    tool_resource = ToolResources.objects.create(tool_type="code_interpreter", assistant=assistant)
+    tool_resource.files.set(files)
+    return tool_resource
+
+
+@pytest.mark.django_db()
+def test_files_to_delete_when_only_referenced_by_one_resource(code_resource):
+    files_to_delete = list(_get_files_to_delete(code_resource.assistant.team, code_resource.id))
+    assert len(files_to_delete) == 2
+    assert {f.id for f in files_to_delete} == {f.id for f in code_resource.files.all()}
+
+
+@pytest.mark.django_db()
+def test_files_not_to_delete_when_referenced_by_multiple_resources(code_resource):
+    all_files = list(code_resource.files.all())
+    tool_resource = ToolResources.objects.create(tool_type="file_search", assistant=code_resource.assistant)
+    tool_resource.files.set([all_files[0]])
+
+    # only the second file should be deleted
+    files_to_delete = list(_get_files_to_delete(code_resource.assistant.team, code_resource.id))
+    assert len(files_to_delete) == 1
+    assert files_to_delete[0].id == all_files[1].id
+
+    files_to_delete = list(_get_files_to_delete(tool_resource.assistant.team, tool_resource.id))
+    assert len(files_to_delete) == 0

--- a/apps/assistants/tests/test_delete.py
+++ b/apps/assistants/tests/test_delete.py
@@ -1,7 +1,10 @@
+import uuid
+from unittest.mock import Mock
+
 import pytest
 
 from apps.assistants.models import ToolResources
-from apps.assistants.sync import _get_files_to_delete
+from apps.assistants.sync import _get_files_to_delete, delete_openai_files_for_resource
 from apps.utils.factories.assistants import OpenAiAssistantFactory
 from apps.utils.factories.files import FileFactory
 
@@ -14,6 +17,10 @@ def assistant():
 @pytest.fixture()
 def code_resource(assistant):
     files = FileFactory.create_batch(2, team=assistant.team)
+    for f in files:
+        f.external_id = str(uuid.uuid4())
+        f.external_source = "openai"
+        f.save()
 
     tool_resource = ToolResources.objects.create(tool_type="code_interpreter", assistant=assistant)
     tool_resource.files.set(files)
@@ -40,3 +47,17 @@ def test_files_not_to_delete_when_referenced_by_multiple_resources(code_resource
 
     files_to_delete = list(_get_files_to_delete(tool_resource.assistant.team, tool_resource.id))
     assert len(files_to_delete) == 0
+
+
+@pytest.mark.django_db()
+def test_delete_openai_files_for_resource(code_resource):
+    all_files = list(code_resource.files.all())
+    assert all(f.external_id for f in all_files)
+    assert all(f.external_source for f in all_files)
+    client = Mock()
+    delete_openai_files_for_resource(client, code_resource.assistant.team, code_resource)
+
+    assert client.files.delete.call_count == 2
+    all_files = list(code_resource.files.all())
+    assert not any(f.external_id for f in all_files)
+    assert not any(f.external_source for f in all_files)

--- a/apps/assistants/tests/test_sync.py
+++ b/apps/assistants/tests/test_sync.py
@@ -238,6 +238,8 @@ def test_delete_openai_assistant(mock_file_delete, mock_vector_store_delete, moc
     mock_delete.assert_called_with(local_assistant.assistant_id)
     assert mock_file_delete.call_count == 3
     assert mock_vector_store_delete.call_count == 1
+    search_resource.refresh_from_db()
+    assert search_resource.extra == {}
 
 
 @pytest.mark.django_db()

--- a/apps/assistants/views.py
+++ b/apps/assistants/views.py
@@ -277,5 +277,6 @@ class DeleteFileFromAssistant(BaseDeleteFileView):
         )
 
         client = resource.assistant.llm_provider.get_llm_service().get_raw_client()
-        delete_file_from_openai(client, file)
+        if delete_file_from_openai(client, file):
+            file.save()
         return HttpResponse()

--- a/apps/events/admin.py
+++ b/apps/events/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 from django.contrib.contenttypes.admin import GenericTabularInline
+from django.db.models import QuerySet
+from django.http import HttpRequest
 
 from apps.experiments.admin import VersionedModelAdminMixin
 
@@ -13,17 +15,56 @@ class EventLogInline(GenericTabularInline):
 
 @admin.register(TimeoutTrigger)
 class TimeoutTriggerAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "action_type",
+        "experiment",
+        "delay",
+        "total_num_triggers",
+        "version_family",
+        "is_archived",
+    )
     inlines = [EventLogInline]
+
+    @admin.display(description="Action")
+    def action_type(self, obj):
+        if obj.action:
+            return obj.action.action_type
+        return ""
+
+    def _get_working_version_label(self, working_version):
+        return working_version.id
+
+    def get_queryset(self, request: HttpRequest) -> QuerySet:
+        return super().get_queryset(request).select_related("action", "experiment")
 
 
 @admin.register(StaticTrigger)
 class StaticTriggerAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "type",
+        "experiment",
+        "action_type",
+        "version_family",
+        "is_archived",
+    )
     inlines = [EventLogInline]
+
+    @admin.display(description="Action")
+    def action_type(self, obj):
+        if obj.action:
+            return obj.action.action_type
+        return ""
+
+    def _get_working_version_label(self, working_version):
+        return working_version.id
+
+    def get_queryset(self, request: HttpRequest) -> QuerySet:
+        return super().get_queryset(request).select_related("action", "experiment")
 
 
 @admin.register(EventAction)
 class EventActionAdmin(admin.ModelAdmin):
-    pass
+    list_display = ["action_type"]
 
 
 @admin.register(ScheduledMessage)

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -169,7 +169,7 @@ class VersionsMixin:
 
     def archive(self):
         self.is_archived = True
-        self.save()
+        self.save(update_fields=["is_archived"])
 
     def is_editable(self) -> bool:
         return not self.is_archived
@@ -774,6 +774,9 @@ class Experiment(BaseTeamModel, VersionsMixin):
             self.delete_experiment_channels()
             self.versions.update(is_archived=True, audit_action=AuditAction.AUDIT)
             self.scheduled_messages.all().delete()
+
+        if self.assistant:
+            self.assistant.archive()
 
     def delete_experiment_channels(self):
         from apps.channels.models import ExperimentChannel

--- a/apps/experiments/tables.py
+++ b/apps/experiments/tables.py
@@ -160,7 +160,7 @@ class ExperimentSessionsTable(tables.Table):
 
 
 class ExperimentVersionsTable(tables.Table):
-    version_number = columns.Column(verbose_name="Version Number", accessor="version_number")
+    version_number = columns.Column(verbose_name="Version Number")
     created_at = columns.Column(verbose_name="Created On", accessor="created_at")
     version_description = columns.Column(verbose_name="Description", default="")
     is_default_version = columns.BooleanColumn(yesno="✓,", verbose_name="Published")
@@ -180,6 +180,11 @@ class ExperimentVersionsTable(tables.Table):
 
     def render_created_at(self, record):
         return record.created_at if record.working_version_id else ""
+
+    def render_version_number(self, record):
+        if record.is_working_version:
+            return f"{record.version_number} (unreleased)"
+        return record.version_number
 
 
 def _get_route_url(url_name, request, record, value):

--- a/apps/experiments/tables.py
+++ b/apps/experiments/tables.py
@@ -21,7 +21,7 @@ class ExperimentTable(tables.Table):
     )
     description = columns.Column(verbose_name="Description")
     owner = columns.Column(accessor="owner__username", verbose_name="Created By")
-    topic = columns.Column(accessor="source_material__topic", verbose_name="Topic", orderable=True)
+    type = columns.Column(orderable=False, empty_values=())
     is_public = columns.Column(verbose_name="Publically accessible", orderable=False)
     is_archived = columns.Column(verbose_name="Archived")
     actions = columns.TemplateColumn(
@@ -39,6 +39,14 @@ class ExperimentTable(tables.Table):
         }
         orderable = False
         empty_text = "No experiments found."
+
+    def render_type(self, record):
+        print(record)
+        if record.assistant_id:
+            return "Assistant"
+        if record.pipeline_id:
+            return "Pipeline"
+        return "Base LLM"
 
 
 class SafetyLayerTable(tables.Table):

--- a/apps/experiments/tables.py
+++ b/apps/experiments/tables.py
@@ -41,7 +41,6 @@ class ExperimentTable(tables.Table):
         empty_text = "No experiments found."
 
     def render_type(self, record):
-        print(record)
         if record.assistant_id:
             return "Assistant"
         if record.pipeline_id:

--- a/apps/experiments/tables.py
+++ b/apps/experiments/tables.py
@@ -163,12 +163,8 @@ class ExperimentVersionsTable(tables.Table):
     version_number = columns.Column(verbose_name="Version Number", accessor="version_number")
     created_at = columns.Column(verbose_name="Created On", accessor="created_at")
     version_description = columns.Column(verbose_name="Description", default="")
-    is_default = columns.TemplateColumn(
-        template_code="""{% if record.is_default_version %}
-        <span aria-label="true">✓</span>
-        {% endif %}""",
-        verbose_name="Published",
-    )
+    is_default_version = columns.BooleanColumn(yesno="✓,", verbose_name="Published")
+    is_archived = columns.BooleanColumn(yesno="✓,", verbose_name="Archived")
     actions = columns.TemplateColumn(
         template_name="experiments/components/experiment_version_actions.html",
         verbose_name="",

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -15,7 +15,7 @@ from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.postgres.search import TrigramSimilarity
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import transaction
-from django.db.models import Case, Count, F, IntegerField, Q, When
+from django.db.models import Case, Count, IntegerField, Q, When
 from django.http import FileResponse, Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.response import TemplateResponse
@@ -179,11 +179,7 @@ class ExperimentVersionsTableView(SingleTableView, PermissionRequiredMixin):
 
     def get_queryset(self):
         experiment_row = Experiment.objects.get_all().filter(id=self.kwargs["experiment_id"])
-        other_versions = (
-            Experiment.objects.get_all()
-            .filter(working_version=self.kwargs["experiment_id"], is_archived=F("working_version__is_archived"))
-            .all()
-        )
+        other_versions = Experiment.objects.get_all().filter(working_version=self.kwargs["experiment_id"]).all()
         return (experiment_row | other_versions).order_by("-version_number")
 
 
@@ -1514,9 +1510,12 @@ def update_version_description(request, team_slug: str, experiment_id: int, vers
 
 @login_and_team_required
 def experiment_version_details(request, team_slug: str, experiment_id: int, version_number: int):
-    experiment_version = get_object_or_404(
-        Experiment, working_version_id=experiment_id, version_number=version_number, team=request.team
-    )
+    try:
+        experiment_version = Experiment.objects.get_all().get(
+            team=request.team, working_version_id=experiment_id, version_number=version_number
+        )
+    except Experiment.DoesNotExist:
+        raise Http404
 
     context = {"version_details": experiment_version.version, "experiment": experiment_version}
     return render(request, "experiments/components/experiment_version_details_content.html", context)

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -650,6 +650,7 @@ def version_create_status(request, team_slug: str, experiment_id: int):
         {
             "active_tab": "experiments",
             "experiment": experiment,
+            "trigger_refresh": experiment.create_version_task_id is not None,
         },
     )
 

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -458,6 +458,7 @@ if TASKBADGER_ORG and TASKBADGER_PROJECT and TASKBADGER_API_KEY:
         ],
     )
 
+LOG_LEVEL = env("OCS_LOG_LEVEL", default="DEBUG" if DEBUG else "INFO")
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -478,14 +479,14 @@ LOGGING = {
         },
         "ocs": {
             "handlers": ["console"],
-            "level": env("GPT_PLAYGROUND_LOG_LEVEL", default="DEBUG" if DEBUG else "INFO"),
+            "level": LOG_LEVEL,
         },
         "httpx": {"handlers": ["console"], "level": "WARN"},
         "slack_bolt": {"handlers": ["console"], "level": "DEBUG"},
-        "audit": {"handlers": ["console"], "level": "INFO", "propagate": False},
-        "openai_sync": {"handlers": ["console"], "level": "INFO", "propagate": False},
-        "tools": {"handlers": ["console"], "level": "INFO", "propagate": False},
-        "runnables": {"handlers": ["console"], "level": "INFO", "propagate": False},
+        "audit": {"handlers": ["console"], "level": LOG_LEVEL, "propagate": False},
+        "openai_sync": {"handlers": ["console"], "level": LOG_LEVEL, "propagate": False},
+        "tools": {"handlers": ["console"], "level": LOG_LEVEL, "propagate": False},
+        "runnables": {"handlers": ["console"], "level": LOG_LEVEL, "propagate": False},
     },
 }
 

--- a/templates/experiments/components/experiment_version_actions.html
+++ b/templates/experiments/components/experiment_version_actions.html
@@ -22,5 +22,9 @@
             onclick="document.querySelector('#versionDetailsModal').showModal();">
       View Details
     </button>
+  {% else %}
+    {% if record.is_editable %}
+      {% include 'experiments/create_version_button.html' with experiment=record %}
+    {% endif %}
   {% endif %}
 </div>

--- a/templates/experiments/components/experiment_version_actions.html
+++ b/templates/experiments/components/experiment_version_actions.html
@@ -1,14 +1,20 @@
 <div class="flex flex-row gap-1">
   {% if record.working_version_id %}
-    <form method="post" action="{% url 'experiments:start_authed_web_session' team_slug=team.slug experiment_id=record.working_version_id version_number=record.version_number %}" class="inline">
-      {% csrf_token %}
-      <div class="tooltip" data-tip="Start web chat with v{{ record.version_number }}">
+    {% if record.is_archived %}
+      <button class="btn btn-sm btn-outline btn-primary" disabled>
+        <i class="fas fa-comment"></i>
+      </button>
+    {% else %}
+      <form method="post" action="{% url 'experiments:start_authed_web_session' team_slug=team.slug experiment_id=record.working_version_id version_number=record.version_number %}" class="inline">
+        {% csrf_token %}
+        <div class="tooltip" data-tip="Start web chat with v{{ record.version_number }}">
 
-        <button type="submit" class="btn btn-sm btn-outline btn-primary">
-          <i class="fas fa-comment"></i>
-        </button>
-      </div>
-    </form>
+          <button type="submit" class="btn btn-sm btn-outline btn-primary">
+            <i class="fas fa-comment"></i>
+          </button>
+        </div>
+      </form>
+    {% endif %}
     <button class="btn btn-sm btn-outline btn-primary"
             hx-get="{% url 'experiments:experiment-version-details' team_slug=team.slug experiment_id=record.working_version_id version_number=record.version_number %}"
             hx-target="#modal-content"

--- a/templates/experiments/components/experiment_version_details_content.html
+++ b/templates/experiments/components/experiment_version_details_content.html
@@ -1,6 +1,11 @@
 <div class="modal-header">
     <div class="modal-title mb-5" id="detailsModalLabel">
-        <h3 class="text-base text-xl font-bold mb-2">Details for {{ experiment }}</h3>
+        <h3 class="text-base text-xl font-bold mb-2">
+            Details for {{ experiment }}
+            {% if experiment.is_archived %}
+                <span class="badge badge-error">Archived</span>
+            {% endif %}
+        </h3>
     </div>
     <form class="my-2" x-data="{
                                editActive: false,
@@ -45,8 +50,8 @@
     {% include 'experiments/components/versions/compare.html' %}
 </div>
 
-
-<div class="divider">
+{% if not experiment.is_archived %}
+    <div class="divider"></div>
     <div class="modal-action">
         {% url 'experiments:archive-experiment' team_slug=team.slug experiment_id=experiment.working_version_id version_number=experiment.version_number as archive_url%}
         <form method="post" action="{{ archive_url }}" onsubmit="return confirm('Are you sure you want to archive this experiment?');">
@@ -63,4 +68,4 @@
             </button>
         </form>
     </div>
-</div>
+{% endif %}

--- a/templates/experiments/create_version_button.html
+++ b/templates/experiments/create_version_button.html
@@ -1,15 +1,20 @@
 {% if experiment.create_version_task_id %}
-  <div class="tooltip" data-tip="A new version is being created"
-       hx-get="{% url 'experiments:check_version_creation_status' experiment.team.slug experiment.id %}"
-       hx-trigger="every 2s"
-       hx-swap="outerHTML"
-  >
-    <button class="btn btn-sm btn-outline btn-primary mb-2 no-animation" disabled>
-      <span class="loading loading-bars loading-xs"></span> Creating Version
-    </button>
+  <div id="version_check">
+    <div class="tooltip" data-tip="A new version is being created"
+         hx-get="{% url 'experiments:check_version_creation_status' experiment.team.slug experiment.id %}"
+         hx-trigger="every 2s"
+         hx-swap="outerHTML"
+         hx-target="#version_check"
+    >
+      <button class="btn btn-sm btn-outline btn-primary no-animation" disabled>
+        <span class="loading loading-bars loading-xs"></span> Creating Version
+      </button>
+    </div>
   </div>
 {% else %}
-  <a x-init='htmx.trigger("#versions-table", "refetch-versions")' class="btn btn-sm btn-outline btn-primary mb-2" href="{% url 'experiments:create_version' experiment.team.slug experiment.id %}">
+  <a class="btn btn-sm btn-outline btn-success" href="{% url 'experiments:create_version' experiment.team.slug experiment.id %}"
+     {% if trigger_refresh %}x-init='htmx.trigger("#versions-table", "refetch-versions")'{% endif %}
+  >
     <i class="fa-regular fa-plus"></i> Create Version
   </a>
 {% endif %}

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -292,9 +292,6 @@
       <input type="radio" name="tab_group" role="tab" class="tab" aria-label="Versions" id="tab-versions" />
       <div role="tabpanel" class="tab-content" id="content-versions">
         <div class="app-card">
-          {% if experiment.is_editable %}
-            {% include 'experiments/create_version_button.html' %}
-          {% endif %}
           <div id="versions-table"
                hx-trigger="load,refetch-versions"
                hx-target="this"


### PR DESCRIPTION
## Description
* When archiving an experiment or experiment version which has an assistant also delete the assistant from OpenAI
* Various UI updates as shown in the demo

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<div>
    <a href="https://www.loom.com/share/cc3ac2859ac84fcb84d33c126ad8d0ca">
      <p>Dimagi Chatbots | Version UI updates - 13 December 2024 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/cc3ac2859ac84fcb84d33c126ad8d0ca">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/cc3ac2859ac84fcb84d33c126ad8d0ca-acf2267eae20b501-full-play.gif">
    </a>
  </div>