### PR TITLE
Use the same yesno indicators accross all boolean columns

### DIFF
--- a/apps/annotations/tables.py
+++ b/apps/annotations/tables.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.http import HttpRequest
 from django.template import Context
-from django_tables2 import tables
+from django_tables2 import columns, tables
 
 from apps.generics import actions
 
@@ -23,6 +23,7 @@ class TagTable(tables.Table):
             ),
         ]
     )
+    is_system_tag = columns.BooleanColumn(yesno="✓,", verbose_name="Is System Tag")
 
     class Meta:
         model = Tag

--- a/apps/experiments/tables.py
+++ b/apps/experiments/tables.py
@@ -22,8 +22,8 @@ class ExperimentTable(tables.Table):
     description = columns.Column(verbose_name="Description")
     owner = columns.Column(accessor="owner__username", verbose_name="Created By")
     type = columns.Column(orderable=False, empty_values=())
-    is_public = columns.Column(verbose_name="Publically accessible", orderable=False)
-    is_archived = columns.Column(verbose_name="Archived")
+    is_public = columns.BooleanColumn(verbose_name="Publically accessible", orderable=False, yesno="✓,")
+    is_archived = columns.BooleanColumn(verbose_name="Archived", yesno="✓,")
     actions = columns.TemplateColumn(
         template_name="experiments/components/experiment_actions_column.html",
     )
@@ -118,6 +118,8 @@ class ConsentFormTable(tables.Table):
             ),
         ]
     )
+    capture_identifier = columns.BooleanColumn(yesno="✓,", verbose_name="Capture Identfier")
+    is_default = columns.BooleanColumn(yesno="✓,", verbose_name="Is default")
 
     class Meta:
         model = ConsentForm


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Just a small update to use the same yesno indicators accross all tables. Some used a big check mark, others a small one and others used `True` and `False`.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Nothing really

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs
<!--Link to documentation that has been updated.-->
N/A