### PR TITLE
Don't append messages if the status code is not 200

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -984,7 +984,7 @@ def poll_messages(request, team_slug: str, experiment_id: int, session_id: int):
     params = request.GET.dict()
     since_param = params.get("since")
     experiment_session = get_object_or_404(
-        ExperimentSession, participant__user=user, experiment_id=experiment_id, id=session_id, team=request.team
+        ExperimentSession, participant__user=user, experiment_id=experiment_id, id=session_id, team__slug=team_slug
     )
 
     since = timezone.now()

--- a/templates/experiments/chat/chat_ui.html
+++ b/templates/experiments/chat/chat_ui.html
@@ -60,16 +60,22 @@
       return;
     }
     url = url + "?since=" + lastDateTime
-    console.log(url);
     fetch(url)
-      .then(response => response.text())
+      .then(response => {
+        if (response.status !== 200) {
+          console.error('Messages not found');
+          return;
+        }
+        return response.text();
+      })
       .then(data => {
-        if (data && data) {
+        if (data) {
           appendMessage(data);
           console.log(data);
           scrollToBottom();
         }
-      });
+      })
+      .catch(error => console.error('Error fetching messages:', error));
   }
 
   function cancelPolling() {


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
This should solve the issue where the following screen shows up when chatting to a bot:

![image](https://github.com/user-attachments/assets/d6275dcc-5dea-4fba-9dfe-ab6b9f45057e)

I suspect that [this line](https://github.com/dimagi/open-chat-studio/blob/2834da44f7bcefca5d70111967f3d14a97f6e20f/apps/experiments/views/experiment.py#L989) is the offending one. I could only replicate this issue locally by manually raising `Http404`, but am not entirely sure why this would 404 for a perfectly valid chat. Either way, handling non 200 status codes is a good practice

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Hopefully they should not see those "Shucks" screens

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs
<!--Link to documentation that has been updated.-->
N/A