### PR TITLE
Fix: Use correct versioned bot for scheduled messages

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1101,7 +1101,7 @@ class ExperimentRoute(BaseTeamModel, VersionsMixin):
         else:
             eligible_experiments = Experiment.objects.filter(team=team).exclude(id__in=parent_ids)
 
-        return eligible_experiments
+        return eligible_experiments.filter(working_version_id=None)
 
     @transaction.atomic()
     def create_new_version(self, new_parent: Experiment) -> "ExperimentRoute":

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -591,7 +591,7 @@ class TestExperimentRoute:
         assert len(queryset) == 2
 
         queryset = ExperimentRoute.eligible_children(team=parent.team)
-        assert len(queryset) == 4
+        assert len(queryset) == 3
 
     def test_compare_with_model_testcase_1(self):
         """


### PR DESCRIPTION
Resolves #987 

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Scheduled messages always point to a working experiment. When one triggers, we need to use the deployed version to generate the response. In a router setup, it can become a bit more complicated. If no experiment is specified to generate the response (see [this form](https://github.com/dimagi/open-chat-studio/blob/e00b60ba0171bb5dd1a830d95a36081a2a7b2ee9/apps/events/forms.py#L79-L81)), then we simply use the router itself. If a child bot is specified, it is the working version of said child bot.

Suppose the router bot is versioned and some version is deployed, then we can't simply use the working version of the child to generate the response, we have to use the correct version of the child bot for that router version. That's why we now filter the versioned router's child bots to find the one whose `working_version_id` is the `experiment_id` in the action params.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
The correct bot will be used to generate responses

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
The test should be enough

### Docs
<!--Link to documentation that has been updated.-->
N/A