### PR TITLE
Fix: Use the `version` instances to compare router children

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1188,11 +1188,6 @@ class ExperimentRoute(BaseTeamModel, VersionsMixin):
         results.extend(list(child_changes))
         return set(results)
 
-    @property
-    def fields_to_exclude_for_child(self):
-        fields_to_keep = ["prompt_text", "voice_provider", "synthetic_voice", "llm_provider", "llm", "assistant"]
-        return [field.name for field in Experiment._meta.get_fields() if field.name not in fields_to_keep]
-
     class Meta:
         constraints = [
             UniqueConstraint(fields=["parent", "child"], condition=Q(is_archived=False), name="unique_parent_child"),


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Comparing router setups were not very comprehensive, because we limited the number of fields to compare on child experiments. This causes us to miss changes in child bot assistants. The change I made here is basically to use the `version` method on the child experiments to compare it to each other. This is very comprehensive and if we ever change the definition of an experiment version i.e. add or remove a field, then it would automatically apply when comparing router children as well. One slight concern I have with doing this is the memory footprint for large assistants, but let's see how it goes. I do think this is the right approach.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Fixes the issue described above

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs
<!--Link to documentation that has been updated.-->
N/A