### PR TITLE
Archive pipeline versions when archiving experiment versions

### DIFF
--- a/apps/assistants/tables.py
+++ b/apps/assistants/tables.py
@@ -28,7 +28,7 @@ class OpenAiAssistantTable(tables.Table):
                 title="Archive",
                 icon_class="fa-solid fa-box-archive",
                 required_permissions=["assistants.delete_openaiassistant"],
-                confirm_message="This will only not delete the assistant from OpenAI.",
+                confirm_message="This will not delete the assistant from OpenAI.",
                 hx_method="delete",
             ),
             actions.AjaxAction(

--- a/apps/assistants/views.py
+++ b/apps/assistants/views.py
@@ -223,6 +223,7 @@ class LocalDeleteOpenAiAssistant(LoginAndTeamRequiredMixin, View, PermissionRequ
             response = render_to_string(
                 "assistants/partials/referenced_objects.html",
                 context={
+                    "object_name": "assistant",
                     "experiments": experiments,
                     "pipeline_nodes": pipeline_nodes,
                 },

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -1012,6 +1012,20 @@ class TestExperimentModel:
         assert second_version.is_archived is True
         assert ScheduledMessage.objects.filter(experiment=experiment).exists() is False
 
+    def test_archive_with_assistant(self, experiment):
+        """
+        Archiving an assistant experiment should only archive the assistant when it is not still being referenced by
+        another experiment or pipeline
+        """
+        pytest.fail("Not implemented")
+
+    def test_archive_with_pipeline(self, experiment):
+        """
+        Archiving a pipeline experiment should only archive the pipeline when it is not still being referenced by
+        another experiment or static trigger action
+        """
+        pytest.fail("Not implemented")
+
     def _construct_event_action(self, time_period: TimePeriod, experiment_id: int, frequency=1, repetitions=1) -> tuple:
         params = self._get_params(experiment_id, time_period, frequency, repetitions)
         return EventActionFactory(params=params, action_type=EventActionType.SCHEDULETRIGGER), params

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -1022,6 +1022,62 @@ class TestExperimentModel:
         assert second_version.is_archived is True
         assert ScheduledMessage.objects.filter(experiment=experiment).exists() is False
 
+    @patch("apps.assistants.tasks.delete_openai_assistant_task.delay")
+    @patch("apps.assistants.sync.push_assistant_to_openai", Mock())
+    def test_archive_with_assistant(self, delete_openai_assistant_task):
+        """
+        Archiving an assistant experiment should only archive the assistant when it is not still being referenced by
+        another experiment or pipeline or when referenced by the working version
+        """
+
+        assistant = OpenAiAssistantFactory()
+        experiment1 = ExperimentFactory(assistant=assistant)
+        experiment2 = ExperimentFactory(assistant=assistant)
+
+        # Version assistant should be archived and removed from OpenAI. Only the version points to it
+        new_version = experiment1.create_new_version()
+        assistant_version = new_version.assistant
+        new_version.archive()
+        delete_openai_assistant_task.assert_called_with(assistant_version.id)
+        delete_openai_assistant_task.reset_mock()
+        self._assert_archived(assistant_version, True)
+
+        experiment1.archive()
+        self._assert_archived(experiment1, True)
+        self._assert_archived(assistant, False)
+
+        experiment2.archive()
+        self._assert_archived(experiment2, True)
+        self._assert_archived(assistant, False)
+
+        delete_openai_assistant_task.assert_not_called()
+
+    @patch("apps.assistants.tasks.delete_openai_assistant_task.delay")
+    @patch("apps.assistants.sync.push_assistant_to_openai", Mock())
+    def test_archive_with_pipeline(self, delete_openai_assistant_task):
+        assistant = OpenAiAssistantFactory()
+        pipeline = PipelineFactory()
+        NodeFactory(pipeline=pipeline, type="AssistantNode", params={"assistant_id": assistant.id})
+        experiment = ExperimentFactory(pipeline=pipeline)
+
+        # For a version, the pipeline should be archived as well as the assistant that it references
+        new_version = experiment.create_new_version()
+        assert assistant.versions.count() == 1
+        assistant_version = assistant.versions.first()
+        new_version.archive()
+        self._assert_archived(new_version.pipeline, True)
+        self._assert_archived(assistant_version, True)
+        delete_openai_assistant_task.assert_called_with(assistant_version.id)
+        delete_openai_assistant_task.reset_mock()
+
+        experiment.archive()
+        self._assert_archived(experiment.pipeline, False)
+        self._assert_archived(assistant, False)
+
+    def _assert_archived(self, model_obj, archived: bool):
+        model_obj.refresh_from_db(fields=["is_archived"])
+        assert model_obj.is_archived == archived
+
 
 @pytest.mark.django_db()
 class TestExperimentObjectManager:

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -994,7 +994,17 @@ class TestExperimentModel:
     def test_archive_working_experiment(self, experiment):
         """Test that archiving an experiment archives all versions and deletes its scheduled messages"""
         session = ExperimentSessionFactory(experiment=experiment)
-        event_action, _ = self._construct_event_action(time_period=TimePeriod.DAYS, experiment_id=experiment.id)
+        event_action = EventActionFactory(
+            action_type=EventActionType.SCHEDULETRIGGER,
+            params={
+                "name": "Test",
+                "time_period": TimePeriod.DAYS,
+                "frequency": 1,
+                "repetitions": 1,
+                "prompt_text": "hi",
+                "experiment_id": experiment.id,
+            },
+        )
         ScheduledMessageFactory(
             experiment=experiment, team=experiment.team, participant=session.participant, action=event_action
         )
@@ -1011,34 +1021,6 @@ class TestExperimentModel:
         assert first_version.is_archived is True
         assert second_version.is_archived is True
         assert ScheduledMessage.objects.filter(experiment=experiment).exists() is False
-
-    def test_archive_with_assistant(self, experiment):
-        """
-        Archiving an assistant experiment should only archive the assistant when it is not still being referenced by
-        another experiment or pipeline
-        """
-        pytest.fail("Not implemented")
-
-    def test_archive_with_pipeline(self, experiment):
-        """
-        Archiving a pipeline experiment should only archive the pipeline when it is not still being referenced by
-        another experiment or static trigger action
-        """
-        pytest.fail("Not implemented")
-
-    def _construct_event_action(self, time_period: TimePeriod, experiment_id: int, frequency=1, repetitions=1) -> tuple:
-        params = self._get_params(experiment_id, time_period, frequency, repetitions)
-        return EventActionFactory(params=params, action_type=EventActionType.SCHEDULETRIGGER), params
-
-    def _get_params(self, experiment_id: int, time_period: TimePeriod = TimePeriod.DAYS, frequency=1, repetitions=1):
-        return {
-            "name": "Test",
-            "time_period": time_period,
-            "frequency": frequency,
-            "repetitions": repetitions,
-            "prompt_text": "hi",
-            "experiment_id": experiment_id,
-        }
 
 
 @pytest.mark.django_db()

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -262,12 +262,39 @@ class Pipeline(BaseTeamModel, VersionsMixin):
         return pipeline_version
 
     @transaction.atomic()
-    def archive(self):
+    def archive(self) -> bool:
+        """
+        Archive this record only when it is not still being referenced by other records. If this record is the working
+        version, all of its versions will be archived as well. The same goes for its nodes.
+        """
+        if self.get_related_experiments_queryset().exists():
+            return False
+
+        if self.get_related_actions_queryset().exists():
+            return False
+
         super().archive()
-        self.node_set.update(is_archived=True)
+        for node in self.node_set.all():
+            node.archive()
+
+        if self.is_working_version:
+            for version in self.versions.filter(is_archived=False):
+                version.archive()
+
+        return True
 
     def get_node_param_values(self, node_cls, param_name: str) -> list:
         return list(self.node_set.filter(type=node_cls.__name__).values_list(f"params__{param_name}", flat=True))
+
+    def get_related_experiments_queryset(self) -> models.QuerySet:
+        return self.experiment_set.filter(is_archived=False)
+
+    def get_related_actions_queryset(self) -> models.QuerySet:
+        from apps.events.models import EventAction, EventActionType
+
+        return EventAction.objects.filter(
+            action_type=EventActionType.PIPELINE_START, params__pipeline_id=self.id, static_trigger__is_archived=False
+        )
 
 
 class Node(BaseModel, VersionsMixin):
@@ -310,6 +337,20 @@ class Node(BaseModel, VersionsMixin):
         if save:
             new_version.save()
         return new_version
+
+    def archive(self):
+        """
+        Archiving a node will also archive the assistant if it is an assistant node. The node's versions will be
+        archived when the pipeline they belong to is archived.
+        """
+        from apps.assistants.models import OpenAiAssistant
+
+        super().archive()
+        if self.is_a_version and self.type == "AssistantNode":
+            assistant_id = self.params.get("assistant_id")
+            if assistant_id:
+                assistant = OpenAiAssistant.objects.get(id=assistant_id)
+                assistant.archive()
 
 
 class PipelineRunStatus(models.TextChoices):

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -270,7 +270,7 @@ class Pipeline(BaseTeamModel, VersionsMixin):
         if self.get_related_experiments_queryset().exists():
             return False
 
-        if self.get_static_trigger_experiments():
+        if len(self.get_static_trigger_experiment_ids()) > 0:
             return False
 
         super().archive()
@@ -289,7 +289,7 @@ class Pipeline(BaseTeamModel, VersionsMixin):
     def get_related_experiments_queryset(self) -> models.QuerySet:
         return self.experiment_set.filter(is_archived=False)
 
-    def get_static_trigger_experiments(self) -> models.QuerySet:
+    def get_static_trigger_experiment_ids(self) -> models.QuerySet:
         from apps.events.models import EventAction, EventActionType
 
         return (
@@ -298,8 +298,8 @@ class Pipeline(BaseTeamModel, VersionsMixin):
                 params__pipeline_id=self.id,
                 static_trigger__is_archived=False,
             )
-            .annotate(experiment=models.F("static_trigger__experiment"))
-            .values("experiment")
+            .annotate(trigger_experiment_id=models.F("static_trigger__experiment"))
+            .values("trigger_experiment_id")
         )
 
 

--- a/apps/pipelines/tables.py
+++ b/apps/pipelines/tables.py
@@ -16,9 +16,13 @@ class PipelineTable(tables.Table):
     actions = actions.ActionsColumn(
         actions=[
             actions.edit_action(url_name="pipelines:edit"),
-            actions.delete_action(
-                url_name="pipelines:delete",
+            actions.AjaxAction(
+                "pipelines:delete",
+                title="Archive",
+                icon_class="fa-solid fa-box-archive",
+                required_permissions=["pipelines.delete_pipeline"],
                 confirm_message="This will delete the pipeline and any associated logs. Are you sure?",
+                hx_method="delete",
             ),
         ]
     )

--- a/apps/pipelines/tests/test_models.py
+++ b/apps/pipelines/tests/test_models.py
@@ -4,9 +4,11 @@ from unittest.mock import Mock, patch
 import pytest
 
 from apps.channels.models import ExperimentChannel
+from apps.events.models import EventActionType
 from apps.experiments.models import Experiment, ExperimentSession, Participant
 from apps.pipelines.tests.utils import create_runnable, end_node, llm_response_with_prompt_node, start_node
 from apps.utils.factories.assistants import OpenAiAssistantFactory
+from apps.utils.factories.events import EventActionFactory, ExperimentFactory, StaticTriggerFactory
 from apps.utils.factories.pipelines import NodeFactory, PipelineFactory
 from apps.utils.factories.service_provider_factories import (
     LlmProviderFactory,
@@ -125,3 +127,33 @@ class TestPipeline:
         ] == expected_call_messages
 
         assert ExperimentSession.objects.count() == 0
+
+    @pytest.mark.django_db()
+    def test_archive_pipeline(self):
+        assistant = OpenAiAssistantFactory()
+        pipeline = PipelineFactory()
+        NodeFactory(pipeline=pipeline, type="AssistantNode", params={"assistant_id": assistant.id})
+        start_pipeline__action = EventActionFactory(
+            action_type=EventActionType.PIPELINE_START,
+            params={
+                "pipeline_id": pipeline.id,
+            },
+        )
+        experiment1 = ExperimentFactory()
+        experiment2 = ExperimentFactory()
+        static_trigger = StaticTriggerFactory(experiment=experiment2, action=start_pipeline__action)
+
+        # Experiment and Static trigger still uses it
+        assert pipeline.archive() is False
+
+        experiment1.archive()
+        # Static trigger from experiment2 still uses it
+        assert pipeline.archive() is False
+
+        static_trigger.archive()
+        # Nothing uses it, so archive it
+        assert pipeline.archive() is True
+
+        # Double check that the node didn't archive the assistant
+        assistant.refresh_from_db()
+        assert assistant.is_archived is False

--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -98,7 +98,7 @@ class DeletePipeline(LoginAndTeamRequiredMixin, View, PermissionRequiredMixin):
                 for experiment in pipeline.get_related_experiments_queryset()
             ]
 
-            query = pipeline.get_static_trigger_experiments()
+            query = pipeline.get_static_trigger_experiment_ids()
             static_trigger_experiments = [
                 Chip(label=experiment.name, url=experiment.get_absolute_url())
                 for experiment in Experiment.objects.filter(id__in=Subquery(query)).all()

--- a/templates/assistants/partials/referenced_objects.html
+++ b/templates/assistants/partials/referenced_objects.html
@@ -1,5 +1,5 @@
 <div>
-  <p>This assistant is still referenced by other objects. You must archive those first.</p>
+  <p>This {{ object_name }} is still referenced by other objects. You must archive those first.</p>
   {% if experiments %}
     <h2 class="font-semibold my-2">Experiments</h2>
     <ul class="list-disc list-inside">
@@ -14,6 +14,15 @@
     <ul class="list-disc list-inside">
       {% for node in pipeline_nodes %}
         <li>{% include "generic/chip.html" with chip=node %}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+
+  {% if static_trigger_experiments %}
+    <h2 class="font-semibold my-2">Static Trigger Experiments</h2>
+    <ul class="list-disc list-inside">
+      {% for experiment in static_trigger_experiments %}
+        <li>{% include "generic/chip.html" with chip=experiment %}</li>
       {% endfor %}
     </ul>
   {% endif %}


### PR DESCRIPTION
resolves #988 

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
- Archiving the pipeline working version also archives its versions
- Prevent users from archiving a pipeline when there are still objects referencing it + show these to the user

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Better UI/UX

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![demo](https://github.com/user-attachments/assets/0e937765-2448-4287-a1ca-b62a7a1ae66a)


### Docs
<!--Link to documentation that has been updated.-->
N/A