### PR TITLE
Check imported assistant instructions for illegal variables

### DIFF
--- a/apps/assistants/forms.py
+++ b/apps/assistants/forms.py
@@ -74,7 +74,7 @@ class OpenAiAssistantForm(forms.ModelForm):
         validate_prompt_variables(
             form_data=cleaned_data,
             prompt_key="instructions",
-            known_vars={"participant_data", "current_datetime"},
+            known_vars=OpenAiAssistant.ALLOWED_INSTRUCTIONS_VARIABLES,
         )
         return cleaned_data
 

--- a/apps/assistants/models.py
+++ b/apps/assistants/models.py
@@ -31,6 +31,8 @@ class OpenAiAssistantManager(VersionsObjectManagerMixin, AuditingManager):
     audit_special_queryset_writes=True,
 )
 class OpenAiAssistant(BaseTeamModel, VersionsMixin):
+    ALLOWED_INSTRUCTIONS_VARIABLES = {"participant_data", "current_datetime"}
+
     assistant_id = models.CharField(max_length=255)
     name = models.CharField(max_length=255)
     instructions = models.TextField()

--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -177,7 +177,7 @@ def import_openai_assistant(assistant_id: str, llm_provider: LlmProvider, team: 
     return assistant
 
 
-def validate_instructions(instructions: str) -> bool:
+def validate_instructions(instructions: str):
     validate_prompt_variables(
         form_data={"instructions": instructions},
         prompt_key="instructions",

--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -62,6 +62,7 @@ from io import BytesIO
 
 import openai
 from django.db.models import Count, Subquery
+from django.forms import ValidationError
 from langchain_core.utils.function_calling import convert_to_openai_tool as lc_convert_to_openai_tool
 from openai import OpenAI
 from openai.types.beta import Assistant
@@ -72,6 +73,7 @@ from apps.assistants.utils import chunk_list, get_assistant_tool_options
 from apps.files.models import File
 from apps.service_providers.models import LlmProvider, LlmProviderModel, LlmProviderTypes
 from apps.teams.models import Team
+from apps.utils.prompt import validate_prompt_variables
 
 logger = logging.getLogger("openai_sync")
 
@@ -94,6 +96,8 @@ def wrap_openai_errors(fn):
                     pass
 
             raise OpenAiSyncError(message) from e
+        except ValidationError as e:
+            raise OpenAiSyncError(str(e)) from e
 
     return _inner
 
@@ -167,9 +171,18 @@ def import_openai_assistant(assistant_id: str, llm_provider: LlmProvider, team: 
     client = llm_provider.get_llm_service().get_raw_client()
     openai_assistant = client.beta.assistants.retrieve(assistant_id)
     kwargs = _openai_assistant_to_ocs_kwargs(openai_assistant, team=team, llm_provider=llm_provider)
+    validate_instructions(kwargs["instructions"])
     assistant = OpenAiAssistant.objects.create(**kwargs)
     _sync_tool_resources_from_openai(openai_assistant, assistant)
     return assistant
+
+
+def validate_instructions(instructions: str) -> bool:
+    validate_prompt_variables(
+        form_data={"instructions": instructions},
+        prompt_key="instructions",
+        known_vars=OpenAiAssistant.ALLOWED_INSTRUCTIONS_VARIABLES,
+    )
 
 
 @wrap_openai_errors


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
We now also check the assistant instructions for illegal variables for imported assistants

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users will not be able to use non-supported variables in the prompts. This is good, since their assistant will not break when they try to chat to it anymore.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
Example: this will show when you try and import an invalid one:

![Screenshot from 2024-12-17 13-39-34](https://github.com/user-attachments/assets/4252e827-8c1d-4553-b56b-ca8e627342a8)

### Docs
<!--Link to documentation that has been updated.-->
