### PR TITLE
Update Langchain core

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -33,7 +33,7 @@ ffmpeg # Audio transcription
 httpx
 jinja2
 langchain>=0.3,<0.4
-langchain-core>=0.3,<0.4
+langchain-core>=0.3.23,<0.4
 langchain-anthropic
 langchain-openai
 langchain-community>=0.3,<0.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -28,6 +28,8 @@ anyio==4.4.0
     #   openai
 asgiref==3.8.1
     # via django
+async-timeout==5.0.1
+    # via redis
 attrs==23.1.0
     # via
     #   aiohttp
@@ -241,7 +243,7 @@ langchain-anthropic==0.2.3
     # via -r requirements.in
 langchain-community==0.3.3
     # via -r requirements.in
-langchain-core==0.3.21
+langchain-core==0.3.25
     # via
     #   -r requirements.in
     #   langchain


### PR DESCRIPTION
As part of trying to fix the following issue, I'm updating langchain. Might as well

```shell
>>> self._get_response(assistant_runnable, input_dict, config)
[18/Dec/2024 09:33:37] INFO "runnables" Invoking tool execute_sql_query_execute_sql_query_post
[18/Dec/2024 09:33:37] INFO "tools" [execute_sql_query_execute_sql_query_post] POST https://espen-sql-api-6862a814f96e.herokuapp.com/execute_sql_query
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/code/apps/service_providers/llm_service/runnables.py", line 591, in _get_response
    tool_outputs, tool_outputs_with_artifacts = self._invoke_tools(response)
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/apps/service_providers/llm_service/runnables.py", line 620, in _invoke_tools
    tool_output = tool.invoke(tool_call(name=action.tool, args=action.tool_input, id=action.tool_call_id))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain_core/tools/base.py", line 484, in invoke
    return self.run(tool_input, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain_core/tools/base.py", line 689, in run
    raise error_to_raise
  File "/usr/local/lib/python3.11/site-packages/langchain_core/tools/base.py", line 666, in run
    raise ValueError(msg)
ValueError: Since response_format='content_and_artifact' a two-tuple of the message content and raw tool output is expected. Instead generated response of type: <class 'dict'>.

```