### PR TITLE
Show Assistant chip in version details

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -14,6 +14,7 @@ from django.core.exceptions import FieldDoesNotExist
 from django.core.validators import MaxValueValidator, MinValueValidator, validate_email
 from django.db import models, transaction
 from django.db.models import BooleanField, Case, Count, F, OuterRef, Q, Subquery, UniqueConstraint, When
+from django.template.loader import get_template
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext
@@ -907,7 +908,14 @@ class Experiment(BaseTeamModel, VersionsMixin):
         def _format_assistant(assistant) -> str:
             if not assistant:
                 return ""
-            return assistant.name.split(f" v{assistant.version_number}")[0]
+            name = assistant.name.split(f" v{assistant.version_number}")[0]
+            template = get_template("generic/chip.html")
+            url = (
+                assistant.get_absolute_url()
+                if assistant.is_working_version
+                else assistant.working_version.get_absolute_url()
+            )
+            return template.render({"chip": Chip(label=name, url=url)})
 
         return Version(
             instance=self,


### PR DESCRIPTION
Resolves [this issue](https://github.com/dimagi/open-chat-studio-docs/issues/13)

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
- Added assistant chip to version details view and diff view that links to the **working version**
- Ideally in the future we'd have a dropdown showing what's inside each version.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
User will be able to navigate to the assistant and assistant version
- Easy way to navigate to the assistant

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![demo](https://github.com/user-attachments/assets/01fe9fef-72ef-434f-9f31-82cb42199baf)


### Docs
<!--Link to documentation that has been updated.-->
