### PR TITLE
Throw tool exception

### DIFF
--- a/apps/chat/agent/openapi_tool.py
+++ b/apps/chat/agent/openapi_tool.py
@@ -90,8 +90,8 @@ class OpenAPIOperationExecutor:
             try:
                 return self.auth_service.call_with_retries(self._make_request, client, url, method, **kwargs)
             except httpx.HTTPStatusError as e:
-                if e.response and e.response.status_code == 400:
-                    return {"error": "Bad Request", "details": e.response.text}
+                # if e.response and e.response.status_code == 400:
+                # return {"error": "Bad Request", "details": e.response.text}
                 raise ToolException(f"Error making request: {str(e)}")
             except httpx.HTTPError as e:
                 raise ToolException(f"Error making request: {str(e)}")


### PR DESCRIPTION
For [this issue](https://github.com/dimagi/open-chat-studio/issues/1008)

From what I can gather, raising `ToolException` instead will let the agent know that something happened and it can handle it accordigly