### PR TITLE
filter out versioned consent forms

### DIFF
--- a/apps/assistants/tests/test_m2m_deletion.py
+++ b/apps/assistants/tests/test_m2m_deletion.py
@@ -31,4 +31,5 @@ def test_deleting_assistant_with_files_multiple_references(caplog):
     remaining = File.objects.all()
     assert len(remaining) == 1
     assert remaining[0] == files[0]
+    # See apps.files.apps.FilesConfig.delete_orphaned_files
     assert str(files[0].id) in caplog.text

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -349,7 +349,7 @@ class ScheduledMessage(BaseTeamModel):
         try:
             self._trigger()
         except Exception as e:
-            logger.exception(f"An error occured while trying to send scheduled messsage {self.id}. Error: {e}")
+            logger.exception(f"An error occurred while trying to send scheduled message {self.id}. Error: {e}")
 
     def _trigger(self):
         experiment_session = self.participant.get_latest_session(experiment=self.experiment)

--- a/apps/events/tests/test_scheduled_messages.py
+++ b/apps/events/tests/test_scheduled_messages.py
@@ -186,7 +186,7 @@ def test_error_when_sending_sending_message_to_a_user(_set_telegram_webhook, cap
 
         poll_scheduled_messages()
         assert len(caplog.records) == 1
-        expected_msg = f"An error occured while trying to send scheduled messsage {sm.id}. Error: Oops"
+        expected_msg = f"An error occurred while trying to send scheduled message {sm.id}. Error: Oops"
         assert caplog.records[0].msg == expected_msg
 
         assert sm.last_triggered_at is None

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -60,6 +60,10 @@ class VersionsObjectManagerMixin:
             query = query.filter(is_archived=False)
         return query
 
+    def working_versions_queryset(self):
+        """Returns a queryset with only working versions"""
+        return self.get_queryset().filter(working_version=None)
+
 
 class PromptObjectManager(AuditingManager):
     pass
@@ -83,10 +87,6 @@ class ExperimentObjectManager(VersionsObjectManagerMixin, AuditingManager):
             working_version_id=working_version_id, is_default_version=True, team_id=family_member.team_id
         ).first()
         return experiment if experiment else family_member
-
-    def working_versions_queryset(self):
-        """Returns a queryset for all working experiments"""
-        return self.get_queryset().filter(working_version=None)
 
 
 class SourceMaterialObjectManager(VersionsObjectManagerMixin, AuditingManager):
@@ -351,7 +351,7 @@ class ConsentForm(BaseTeamModel, VersionsMixin):
 
     @classmethod
     def get_default(cls, team):
-        return cls.objects.get(team=team, is_default=True, working_version=None)
+        return cls.objects.working_versions_queryset().get(team=team, is_default=True)
 
     def __str__(self):
         return self.name

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -351,7 +351,7 @@ class ConsentForm(BaseTeamModel, VersionsMixin):
 
     @classmethod
     def get_default(cls, team):
-        return cls.objects.get(team=team, is_default=True)
+        return cls.objects.get(team=team, is_default=True, working_version=None)
 
     def __str__(self):
         return self.name

--- a/apps/experiments/tests/test_files_deletion.py
+++ b/apps/experiments/tests/test_files_deletion.py
@@ -30,4 +30,5 @@ def test_deleting_experiment_with_files_multiple_references(caplog):
     remaining = File.objects.all()
     assert len(remaining) == 1
     assert remaining[0] == files[0]
+    # See apps.files.apps.FilesConfig.delete_orphaned_files
     assert str(files[0].id) in caplog.text

--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -119,7 +119,7 @@ class DeletePipeline(LoginAndTeamRequiredMixin, View, PermissionRequiredMixin):
 def _pipeline_node_parameter_values(team, llm_providers, llm_provider_models):
     """Returns the possible values for each input type"""
     source_materials = SourceMaterial.objects.filter(team=team).values("id", "topic").all()
-    assistants = OpenAiAssistant.objects.filter(team=team, working_version=None).values("id", "name").all()
+    assistants = OpenAiAssistant.objects.working_versions_queryset().filter(team=team).values("id", "name").all()
 
     def _option(value, label, type_=None, edit_url: str | None = None):
         data = {"value": value, "label": label}

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
 import os
+import sys
 from pathlib import Path
 
 import environ
@@ -30,6 +31,7 @@ SECRET_KEY = env("SECRET_KEY", default="YNAazYQdzqQWddeZmFZfBfROzqlzvLEwVxoOjGgK
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
+IS_TESTING = "pytest" in sys.modules
 
 ALLOWED_HOSTS = ["*"]
 CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
@@ -478,7 +480,7 @@ LOGGING = {
             "handlers": ["console"],
             "level": env("DJANGO_LOG_LEVEL", default="INFO"),
         },
-        "ocs": {"handlers": ["console"], "level": LOG_LEVEL, "propagate": False},
+        "ocs": {"handlers": ["console"], "level": LOG_LEVEL, "propagate": IS_TESTING},
         "httpx": {"handlers": ["console"], "level": "WARN"},
         "slack_bolt": {"handlers": ["console"], "level": "DEBUG"},
     },


### PR DESCRIPTION
## Description
This fixes a bug where `ConsentForm.get_default` would error with a Multiple Results error because it wasn't filtering out form versions.

This PR also includes a small refactor to move the `working_versions_queryset` method to the `VersionsObjectManagerMixin`