### PR TITLE
participant data access

### DIFF
--- a/apps/chat/conversation.py
+++ b/apps/chat/conversation.py
@@ -10,7 +10,6 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.memory import BaseMemory
 from langchain_core.messages import BaseMessage, SystemMessage, get_buffer_string
 from langchain_core.prompts import (
-    ChatPromptTemplate,
     HumanMessagePromptTemplate,
     MessagesPlaceholder,
     SystemMessagePromptTemplate,
@@ -18,6 +17,7 @@ from langchain_core.prompts import (
 
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
 from apps.pipelines.models import PipelineChatHistory, PipelineChatMessages
+from apps.utils.prompt import OcsPromptTemplate
 
 SUMMARY_TOO_LARGE_ERROR_MESSAGE = "Unable to compress chat history: existing summary too large"
 
@@ -58,7 +58,7 @@ class BasicConversation(Conversation):
         self._build_chain()
 
     def _build_chain(self):
-        prompt = ChatPromptTemplate.from_messages(
+        prompt = OcsPromptTemplate.from_messages(
             [
                 self.system_prompt,
                 MessagesPlaceholder(variable_name="history"),

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -10,7 +10,7 @@ from django.core.validators import validate_email
 from jinja2 import meta
 from jinja2.sandbox import SandboxedEnvironment
 from langchain_core.messages import BaseMessage
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder, PromptTemplate
+from langchain_core.prompts import MessagesPlaceholder, PromptTemplate
 from langchain_core.runnables import RunnableLambda, RunnablePassthrough
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from pydantic import BaseModel, Field, create_model, field_validator
@@ -39,7 +39,7 @@ from apps.service_providers.llm_service.runnables import (
     SimpleLLMChat,
 )
 from apps.service_providers.models import LlmProviderModel
-from apps.utils.prompt import PromptVars, validate_prompt_variables
+from apps.utils.prompt import OcsPromptTemplate, PromptVars, validate_prompt_variables
 
 
 class RenderTemplate(PipelineNode):
@@ -325,7 +325,7 @@ class RouterNode(Passthrough, HistoryMixin):
         return value[:num_outputs]  # Ensure the number of keywords matches the number of outputs
 
     def _process_conditional(self, state: PipelineState, node_id=None):
-        prompt = ChatPromptTemplate.from_messages(
+        prompt = OcsPromptTemplate.from_messages(
             [("system", self.prompt), MessagesPlaceholder("history", optional=True), ("human", "{input}")]
         )
 

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -15,7 +15,7 @@ from langchain_core.messages import BaseMessage
 from langchain_core.messages.tool import ToolMessage, tool_call
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompt_values import PromptValue
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.prompts import MessagesPlaceholder
 from langchain_core.runnables import (
     Runnable,
     RunnableConfig,
@@ -33,6 +33,7 @@ from apps.files.models import File
 from apps.service_providers.llm_service.adapters import AssistantAdapter, ChatAdapter
 from apps.service_providers.llm_service.history_managers import ExperimentHistoryManager, PipelineHistoryManager
 from apps.service_providers.llm_service.main import OpenAIAssistantRunnable
+from apps.utils.prompt import OcsPromptTemplate
 
 if TYPE_CHECKING:
     from apps.channels.datamodels import Attachment
@@ -201,7 +202,7 @@ class LLMChat(RunnableSerializable[str, ChainOutput]):
 
     @property
     def prompt(self):
-        return ChatPromptTemplate.from_messages(
+        return OcsPromptTemplate.from_messages(
             [
                 ("system", self.adapter.get_prompt()),
                 MessagesPlaceholder("history", optional=True),
@@ -256,7 +257,7 @@ class AgentLLMChat(LLMChat):
     @property
     def prompt(self):
         prompt = super().prompt
-        return ChatPromptTemplate.from_messages(
+        return OcsPromptTemplate.from_messages(
             prompt.messages + [MessagesPlaceholder("agent_scratchpad", optional=True)]
         )
 


### PR DESCRIPTION
## Description
This finishes off the changes that started in https://github.com/dimagi/open-chat-studio/pull/885 by modifying prompt validation to allow participant data access.

## User Impact
User's can reference specific parts of the participant data in their prompts e.g. `{participant_data.name}`

### Docs
TODO: update https://dimagi.github.io/open-chat-studio-docs/concepts/prompt_variables/
