### PR TITLE
Show badge when changes detected

### DIFF
--- a/apps/custom_actions/models.py
+++ b/apps/custom_actions/models.py
@@ -173,8 +173,8 @@ class CustomActionOperation(BaseModel, VersionsMixin):
     def get_fields_to_exclude(self):
         return super().get_fields_to_exclude() + ["experiment", "assistant", "_operation_schema"]
 
-    def compare_with_model(self, new: Self, exclude_fields: list[str]) -> set:
-        changes = super().compare_with_model(new, exclude_fields)
+    def compare_with_model(self, new: Self, exclude_fields: list[str], early_abort=False) -> set:
+        changes = super().compare_with_model(new, exclude_fields, early_abort=early_abort)
         if self.operation_schema != new.operation_schema:
             changes.add("operation_schema")
         return changes

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1134,7 +1134,7 @@ class ExperimentRoute(BaseTeamModel, VersionsMixin):
                 # Compare experimens using their `version` instances for a comprehensive comparison
                 child_version = self.child.version
                 latest_version = latest_child_version.version
-                child_version.compare(latest_version, early_abort=True)
+                child_version.compare(latest_version)
 
                 if not child_version.fields_changed:
                     new_child = latest_child_version

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -766,7 +766,7 @@ class Experiment(BaseTeamModel, VersionsMixin, CustomActionOperationMixin):
         """
         version = self.version
         if prev_version := self.latest_version:
-            version.compare(prev_version.version)
+            version.compare(prev_version.version, early_abort=True)
         return version.fields_changed
 
     @transaction.atomic()

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1156,7 +1156,7 @@ class ExperimentRoute(BaseTeamModel, VersionsMixin):
             description = f"{description} since {changed_fields} changed."
         return description
 
-    def compare_with_model(self, route: "ExperimentRoute", exclude_fields):
+    def compare_with_model(self, route: "ExperimentRoute", exclude_fields, early_abort=False):
         """
         When comparing two ExperimentRoute versions (with the same parents), consider the following:
 
@@ -1172,22 +1172,24 @@ class ExperimentRoute(BaseTeamModel, VersionsMixin):
         """
         is_same_family = self.get_working_version() == route.get_working_version()
         if not is_same_family:
-            return super().compare_with_model(route, exclude_fields)
+            return super().compare_with_model(route, exclude_fields, early_abort=early_abort)
 
         fields_to_exclude = exclude_fields.copy()
         fields_to_exclude.extend(["parent"])
 
         if not (self.child == route.child.get_working_version() or self.child.get_working_version() == route.child):
-            return super().compare_with_model(route, fields_to_exclude)
+            return super().compare_with_model(route, fields_to_exclude, early_abort=early_abort)
 
         fields_to_exclude.append("child")
         # Compare all other fields first
-        results = list(super().compare_with_model(route, fields_to_exclude))
+        results = list(super().compare_with_model(route, fields_to_exclude), early_abort=early_abort)
+        if early_abort and results:
+            return set(results)
 
         # Now compare the children
         version1 = self.child.version
         version2 = route.child.version
-        version1.compare(version2)
+        version1.compare(version2, early_abort=early_abort)
         child_changes = [field.name for field in version1.fields if field.changed]
 
         results.extend(list(child_changes))

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1134,7 +1134,7 @@ class ExperimentRoute(BaseTeamModel, VersionsMixin):
                 # Compare experimens using their `version` instances for a comprehensive comparison
                 child_version = self.child.version
                 latest_version = latest_child_version.version
-                child_version.compare(latest_version)
+                child_version.compare(latest_version, early_abort=True)
 
                 if not child_version.fields_changed:
                     new_child = latest_child_version

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1182,7 +1182,7 @@ class ExperimentRoute(BaseTeamModel, VersionsMixin):
 
         fields_to_exclude.append("child")
         # Compare all other fields first
-        results = list(super().compare_with_model(route, fields_to_exclude), early_abort=early_abort)
+        results = list(super().compare_with_model(route, fields_to_exclude, early_abort=early_abort))
         if early_abort and results:
             return set(results)
 

--- a/apps/experiments/tests/test_versioning.py
+++ b/apps/experiments/tests/test_versioning.py
@@ -40,6 +40,7 @@ def test_differs():
     assert differs(True, False) is True
 
 
+@pytest.mark.django_db()
 class TestVersion:
     def test_compare(self):
         instance1 = ExperimentFactory.build(temperature=0.1)
@@ -76,7 +77,6 @@ class TestVersion:
         assert changed_field.changed is True
         assert changed_field.previous_field_version.raw_value == 0.2
 
-    @pytest.mark.django_db()
     def test_compare_querysets_with_equal_results(self):
         experiment = ExperimentFactory()
         queryset = Experiment.objects.filter(id=experiment.id)
@@ -89,7 +89,6 @@ class TestVersion:
         assert queryset_result_version.raw_value == experiment
         assert queryset_result_version.previous_field_version.raw_value == experiment
 
-    @pytest.mark.django_db()
     def test_compare_querysets_with_results_of_differing_versions(self):
         experiment = ExperimentFactory()
         queryset = Experiment.objects.filter(id=experiment.id)
@@ -105,7 +104,6 @@ class TestVersion:
         assert queryset_result_version.raw_value == experiment
         assert queryset_result_version.previous_field_version.raw_value == new_version
 
-    @pytest.mark.django_db()
     def test_compare_querysets_with_different_results(self):
         """
         When comparing different querysets, we expect two result versions to be created. One for the current queryset
@@ -167,7 +165,6 @@ class TestVersion:
             if group.name == temerature_group_name:
                 assert group.has_changed_fields is True
 
-    @pytest.mark.django_db()
     def test_new_queryset_is_empty(self):
         """This tests the case where a queryset's previous results are not empty, but the current results are"""
         # Let's use experiment sessions as an example

--- a/apps/experiments/urls.py
+++ b/apps/experiments/urls.py
@@ -178,6 +178,11 @@ urlpatterns = [
         views.rate_message,
         name="rate_message",
     ),
+    path(
+        "e/<int:experiment_id>/release_status_badge",
+        views.get_release_status_badge,
+        name="get_release_status_badge",
+    ),
 ]
 
 urlpatterns.extend(make_crud_urls(views, "SafetyLayer", "safety"))

--- a/apps/experiments/versioning.py
+++ b/apps/experiments/versioning.py
@@ -135,8 +135,8 @@ class VersionField:
             else:
                 version_field.changed = self.changed = True
 
-        if early_abort and self.changed:
-            return
+            if early_abort and self.changed:
+                return
 
         for previous_record in previous_queryset.exclude(id__in=previous_record_version_ids):
             # A previous record missing from the current queryset means that something changed

--- a/apps/experiments/versioning.py
+++ b/apps/experiments/versioning.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     pass
 
 
-def differs(original: Any, new: Any, exclude_model_fields: list[str] | None = None) -> bool:
+def differs(original: Any, new: Any, exclude_model_fields: list[str] | None = None, early_abort=False) -> bool:
     """
     Compares the value (or attributes in the case of a Model) between `original` and `new`.
     Returns `True` if it differs and `False` if not.
@@ -21,7 +21,7 @@ def differs(original: Any, new: Any, exclude_model_fields: list[str] | None = No
     """
     exclude_model_fields = exclude_model_fields or []
     if isinstance(original, VersioningMixin) and isinstance(new, VersioningMixin):
-        return bool(original.compare_with_model(new, exclude_model_fields))
+        return bool(original.compare_with_model(new, exclude_model_fields, early_abort=early_abort))
     return original != new
 
 
@@ -76,10 +76,15 @@ class VersionField:
             return self.to_display(self.raw_value)
         return self.raw_value or ""
 
-    def compare(self, previous_field_version: "VersionField"):
+    def compare(self, previous_field_version: "VersionField", early_abort=False):
+        """
+        Args:
+            previous_field_version (VersionField): The previous version field to compare against.
+            early_abort (bool): If True, the comparison will stop as soon as the first difference is found.
+        """
         self.previous_field_version = previous_field_version
         if self.is_queryset:
-            self._compare_queryset(previous_field_version.queryset)
+            self._compare_queryset(previous_field_version.queryset, early_abort=early_abort)
         else:
             exclude_fields = []
             current_val = self.raw_value
@@ -92,12 +97,12 @@ class VersionField:
                 else:
                     exclude_fields = current_val.get_fields_to_exclude()
 
-            if differs(current_val, previous_val, exclude_model_fields=exclude_fields):
+            if differs(current_val, previous_val, exclude_model_fields=exclude_fields, early_abort=early_abort):
                 self.changed = True
                 if isinstance(self.raw_value, str):
                     self._compute_character_level_diff()
 
-    def _compare_queryset(self, previous_queryset):
+    def _compare_queryset(self, previous_queryset, early_abort=False):
         """
         Compares two querysets by checking the differences between their results.
 
@@ -125,14 +130,19 @@ class VersionField:
                 # TODO: When comparing static trigger versions and only the action changed, it is not being picked up.
                 previous_record_version_ids.append(previous_record.id)
                 prev_version_field = VersionField(raw_value=previous_record, to_display=self.to_display)
-                version_field.compare(prev_version_field)
+                version_field.compare(prev_version_field, early_abort=early_abort)
                 self.changed = self.changed or version_field.changed
             else:
                 version_field.changed = self.changed = True
 
+        if early_abort and self.changed:
+            return
+
         for previous_record in previous_queryset.exclude(id__in=previous_record_version_ids):
             # A previous record missing from the current queryset means that something changed
             self.changed = True
+            if early_abort:
+                return
             prev_version_field = VersionField(raw_value=previous_record, to_display=self.to_display)
             version_field = VersionField(raw_value=None, previous_field_version=prev_version_field, changed=True)
             self.queryset_result_versions.append(version_field)
@@ -184,8 +194,14 @@ class Version:
             group_info.fields.append(field)
         return list(groups.values())
 
-    def compare(self, previous_version_details: "Version"):
-        """Compares the current instance with the previous version and updates the changed status of fields."""
+    def compare(self, previous_version_details: "Version", early_abort: bool = False):
+        """
+        Compares the current instance with the previous version and updates the changed status of fields.
+
+        Args:
+            previous_version_details (Version): The previous version details to compare against.
+            early_abort (bool): If True, the comparison will stop as soon as the first difference is found.
+        """
         previous_instance = previous_version_details.instance
 
         if type(previous_instance) != type(self.instance):  # noqa: E721
@@ -198,5 +214,7 @@ class Version:
 
         for field in self.fields:
             previous_field_version = previous_version_details.get_field(field.name)
-            field.compare(previous_field_version)
+            field.compare(previous_field_version, early_abort=early_abort)
             self.fields_changed = self.fields_changed or field.changed
+            if field.changed and early_abort:
+                return

--- a/apps/experiments/views/__init__.py
+++ b/apps/experiments/views/__init__.py
@@ -36,6 +36,7 @@ from .experiment import (  # noqa: F401
     generate_chat_export,
     get_export_download_link,
     get_message_response,
+    get_release_status_badge,
     poll_messages,
     send_invitation,
     set_default_experiment,

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1528,3 +1528,10 @@ def experiment_version_details(request, team_slug: str, experiment_id: int, vers
 
     context = {"version_details": experiment_version.version, "experiment": experiment_version}
     return render(request, "experiments/components/experiment_version_details_content.html", context)
+
+
+@login_and_team_required
+def get_release_status_badge(request, team_slug: str, experiment_id: int):
+    experiment = get_object_or_404(Experiment, id=experiment_id, team=request.team)
+    context = {"has_changes": experiment.compare_with_latest, "experiment": experiment}
+    return render(request, "experiments/components/unreleased_badge.html", context)

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1533,5 +1533,5 @@ def experiment_version_details(request, team_slug: str, experiment_id: int, vers
 @login_and_team_required
 def get_release_status_badge(request, team_slug: str, experiment_id: int):
     experiment = get_object_or_404(Experiment, id=experiment_id, team=request.team)
-    context = {"has_changes": experiment.compare_with_latest, "experiment": experiment}
+    context = {"has_changes": experiment.compare_with_latest(), "experiment": experiment}
     return render(request, "experiments/components/unreleased_badge.html", context)

--- a/apps/utils/models.py
+++ b/apps/utils/models.py
@@ -4,7 +4,7 @@ from django.db import models
 
 
 class VersioningMixin:
-    def compare_with_model(self, new: Self, exclude_fields: list[str]) -> set[str]:
+    def compare_with_model(self, new: Self, exclude_fields: list[str], early_abort=False) -> set[str]:
         """
         Compares the field values of between `self` and `new`, excluding those in `exclude_fields`
         """
@@ -26,6 +26,8 @@ class VersioningMixin:
 
             if new_value != current_value:
                 changed_fields.add(field.name)
+                if early_abort:
+                    return changed_fields
         return changed_fields
 
 

--- a/templates/experiments/components/unreleased_badge.html
+++ b/templates/experiments/components/unreleased_badge.html
@@ -1,0 +1,8 @@
+{% if has_changes %}
+    <div class="tooltip" data-tip="There are unreleased changes">
+        <a class="badge badge-warning badge-sm"
+           href="{% url 'experiments:create_version' experiment.team.slug experiment.id %}">
+            Draft
+        </a>
+    </div>
+{% endif %}

--- a/templates/experiments/create_version_button.html
+++ b/templates/experiments/create_version_button.html
@@ -13,7 +13,7 @@
   </div>
 {% else %}
   <a class="btn btn-sm btn-outline btn-success" href="{% url 'experiments:create_version' experiment.team.slug experiment.id %}"
-     {% if trigger_refresh %}x-init='htmx.trigger("#versions-table", "refetch-versions")'{% endif %}
+     {% if trigger_refresh %}x-init='htmx.trigger(".watchVersionChange", "version-changed")'{% endif %}
   >
     <i class="fa-regular fa-plus"></i> Create Version
   </a>

--- a/templates/experiments/experiment_form.html
+++ b/templates/experiments/experiment_form.html
@@ -131,7 +131,7 @@
       <input type="submit" class="pg-button-primary" value="{{ button_text }}">
       {% if experiment.id %}
         {% flag "experiment_versions" %}
-          <button type="submit" class="pg-button-secondary" name="action" {% if disable_version_button %}disabled="True"{% endif %} value="save_and_version">Create Version</button>
+          <button type="submit" class="pg-button-secondary" name="action" {% if disable_version_button %}disabled="True"{% endif %} value="save_and_version">Save & Create new version</button>
         {% endflag %}
         <button type="submit" class="pg-button-danger" name="action" value="save_and_archive" onclick="return confirm('Are you sure you want to archive this experiment?');">Archive</button>
       {% endif %}

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -24,11 +24,19 @@
               Archived
             </div>
           {% elif deployed_version %}
-            <div class="tooltip" data-tip="Current published version">
-              <a class="badge badge-success badge-sm"
-                 href="#versions">
-                v{{ deployed_version }}
-              </a>
+            <div class="flex flex-row gap-2">
+              <div class="tooltip" data-tip="Current published version">
+                <a class="badge badge-success badge-sm"
+                   href="#versions">
+                  v{{ deployed_version }}
+                </a>
+              </div>
+              <div
+                class="watchVersionChange"
+                hx-get="{% url 'experiments:get_release_status_badge' experiment.team.slug experiment.id %}"
+                hx-trigger="load, version-changed"
+                hx-swap="innerHTML">
+              </div>
             </div>
           {% endif %}
         {% endflag %}
@@ -296,7 +304,8 @@
       <div role="tabpanel" class="tab-content" id="content-versions">
         <div class="app-card">
           <div id="versions-table"
-               hx-trigger="load,refetch-versions"
+               class="watchVersionChange"
+               hx-trigger="load, version-changed"
                hx-target="this"
                hx-get="{% url 'experiments:versions-list' request.team.slug experiment.id %}"
                hx-swap="innerHTML">


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Check for changes async an show a badge to the user when changes are detected. A timeit test shows no major improvement between aborting early or not. Around 3ms. That said, my local bots are very simple

## User Impact
<!-- Describe the impact of this change on the end-users. -->
User will clearly see on the experiment home screen when new changes are detected

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![demo](https://github.com/user-attachments/assets/36ea33bb-9c97-47be-b231-9f38dbf1718f)

### Docs
<!--Link to documentation that has been updated.-->
N/A since this is a UI update only

### Comment
Disabling the "+ create version" button in the versions table when there are no diff - without having to do a synchronous second version comparison - is a bit more tricky (the first comparison is done by the "draft" badge async call). I'll need to play around with components chatting to each other, maybe through triggers. Not sure yet. Anycase, this is left for a followup PR