### PR TITLE
Convert assistant ID to str when creating pipeline versions

### DIFF
--- a/apps/pipelines/admin.py
+++ b/apps/pipelines/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Pipeline, PipelineChatHistory, PipelineChatMessages, PipelineRun
+from .models import Node, Pipeline, PipelineChatHistory, PipelineChatMessages, PipelineRun
 
 
 class PipelineRunInline(admin.TabularInline):
@@ -8,9 +8,14 @@ class PipelineRunInline(admin.TabularInline):
     extra = 0
 
 
+class PipelineNodeInline(admin.TabularInline):
+    model = Node
+    extra = 0
+
+
 @admin.register(Pipeline)
 class PipelineAdmin(admin.ModelAdmin):
-    inlines = [PipelineRunInline]
+    inlines = [PipelineNodeInline, PipelineRunInline]
 
 
 class PipelineChatMessagesInline(admin.TabularInline):

--- a/apps/pipelines/migrations/0011_migrate_assistant_id.py
+++ b/apps/pipelines/migrations/0011_migrate_assistant_id.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+
+def _update_assistant_id_type(apps, schema_editor):
+    Node = apps.get_model("pipelines", "Node")
+
+    for node in Node.objects.filter(type="AssistantNode").all():
+        if assistant_id := node.params.get("assistant_id"):
+            if isinstance(assistant_id, str):
+                continue
+
+            node.params["assistant_id"] = str(assistant_id)
+            node.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pipelines', '0010_auto_20241127_2042'),
+    ]
+
+    operations = [
+        migrations.RunPython(_update_assistant_id_type, reverse_code=migrations.RunPython.noop)
+    ]

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -338,7 +338,8 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
             assistant = OpenAiAssistant.objects.get(id=new_version.params.get("assistant_id"))
             if not assistant.is_a_version:
                 assistant_version = assistant.create_new_version()
-                new_version.params["assistant_id"] = assistant_version.id
+                # convert to string to be consistent with values from the UI
+                new_version.params["assistant_id"] = str(assistant_version.id)
 
         new_version.save()
         self._copy_custom_action_operations_to_new_version(new_node=new_version)

--- a/apps/pipelines/tests/test_models.py
+++ b/apps/pipelines/tests/test_models.py
@@ -44,7 +44,7 @@ class TestNode:
             assistant = assistant.create_new_version()
 
         pipeline = PipelineFactory()
-        NodeFactory(type="AssistantNode", pipeline=pipeline, params={"assistant_id": assistant.id})
+        NodeFactory(type="AssistantNode", pipeline=pipeline, params={"assistant_id": str(assistant.id)})
         assert pipeline.node_set.filter(type="AssistantNode").exists()
 
         pipeline.create_new_version()
@@ -57,11 +57,11 @@ class TestNode:
         node_version_assistant_id = node_version.params["assistant_id"]
 
         if versioned_assistant_linked:
-            assert original_node_assistant_id == node_version_assistant_id == assistant.id
+            assert original_node_assistant_id == node_version_assistant_id == str(assistant.id)
         else:
             assert original_node_assistant_id != node_version_assistant_id
-            assert original_node_assistant_id == assistant.id
-            assert node_version_assistant_id == assistant_version.id
+            assert original_node_assistant_id == str(assistant.id)
+            assert node_version_assistant_id == str(assistant_version.id)
 
 
 class TestPipeline:


### PR DESCRIPTION
## Description
The assistant ID is stored as a string in the pipeline node params (since the UI doesn't manage the conversion). But when we create new versions we store it as an int which breaks filtering for references to assistants (see #1011).

This PR updates all existing data to use strings and fixes the code for creating new versions.

## Note
Ideally we should convert values from the UI but that seemed like a much larger change without significant value.