### PR TITLE
Add seed message to assistant advanced settings

### DIFF
--- a/templates/experiments/experiment_form.html
+++ b/templates/experiments/experiment_form.html
@@ -120,7 +120,7 @@
           {% render_form_fields form "seed_message" %}
         </span>
         <span x-show="type == 'assistant'">
-          {% render_form_fields form "citations_enabled" %}
+          {% render_form_fields form "seed_message" "citations_enabled" %}
         </span>
       </div>
     </div>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
This was a side effect of [this PR](https://github.com/dimagi/open-chat-studio/pull/979) flagged in slack that removed the ability to configure a seed message with an experiment using an assistant

## User Impact
<!-- Describe the impact of this change on the end-users. -->
brings back functionality that went away ~1 month ago

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
<img width="833" alt="Screenshot 2025-01-13 at 1 25 42 PM" src="https://github.com/user-attachments/assets/ad9ffd4f-3ff6-4840-8349-131ad632f74f" />
<img width="903" alt="Screenshot 2025-01-13 at 1 25 55 PM" src="https://github.com/user-attachments/assets/575d7328-4728-4d0d-ad11-1af0de6a9cce" />
<img width="903" alt="Screenshot 2025-01-13 at 1 26 03 PM" src="https://github.com/user-attachments/assets/9ccd3f3c-fb80-4f67-acf1-667fb735163c" />



### Docs
<!--Link to documentation that has been updated.-->
There is not a how-to for experiment set up yet to break down the settings but it should spell out which setting are available for each
