### PR TITLE
Consider seed message as well for versioning

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -919,6 +919,7 @@ class Experiment(BaseTeamModel, VersionsMixin, CustomActionOperationMixin):
             fields=[
                 VersionField(group_name="General", name="name", raw_value=self.name),
                 VersionField(group_name="General", name="description", raw_value=self.description),
+                VersionField(group_name="General", name="seed_message", raw_value=self.seed_message),
                 VersionField(
                     group_name="General",
                     name="allowlist",

--- a/templates/experiments/experiment_form.html
+++ b/templates/experiments/experiment_form.html
@@ -115,12 +115,9 @@
 
       <input type="radio" name="main_tabs" role="tab" class="tab" aria-label="Advanced">
       <div role="tabpanel" class="tab-content">
-        {% render_form_fields form "debug_mode_enabled" "trace_provider" %}
-        <span x-show="type === 'llm'">
-          {% render_form_fields form "seed_message" %}
-        </span>
+        {% render_form_fields form "debug_mode_enabled" "trace_provider" "seed_message" %}
         <span x-show="type == 'assistant'">
-          {% render_form_fields form "seed_message" "citations_enabled" %}
+          {% render_form_fields form "citations_enabled" %}
         </span>
       </div>
     </div>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Seed messages was for some reason not part of versioning. Now it is. I also refactored the html piece a bit

## User Impact
<!-- Describe the impact of this change on the end-users. -->
You can now version based on the seed message

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->
N/A