### PR TITLE
Ability to message using the connect messaging channel | Phase 2

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -264,6 +264,73 @@ paths:
               schema:
                 $ref: '#/components/schemas/ExperimentSessionWithMessages'
           description: ''
+  /api/trigger_bot/:
+    post:
+      operationId: trigger_bot_message
+      description: Trigger the bot to send a message to the user
+      summary: Trigger the bot to send a message to the user
+      tags:
+      - Channels
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TriggerBotMessageRequest'
+            examples:
+              GenerateBotMessageAndSend:
+                value:
+                  identifier: part1
+                  experiment: exp1
+                  platform: connect_messaging
+                  prompt_text: Tell the user to do something
+                summary: Generates a bot message and sends it to the user
+              ParticipantNotFound:
+                value:
+                  detail: Participant not found
+                summary: Participant not found
+              ExperimentChannelNotFound:
+                value:
+                  detail: Experiment cannot send messages on the connect_messaging
+                    channel
+                summary: Experiment cannot send messages on the specified channel
+              ConsentNotGiven:
+                value:
+                  detail: User has not given consent
+                summary: User has not given consent
+        required: true
+      security:
+      - apiKeyAuth: []
+      - tokenAuth: []
+      responses:
+        '200':
+          description: No response body
+        '400':
+          content:
+            application/json:
+              schema:
+                description: Bad Request
+              examples:
+                ConsentNotGiven:
+                  value:
+                    detail: User has not given consent
+                  summary: User has not given consent
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                description: Not Found
+              examples:
+                ParticipantNotFound:
+                  value:
+                    detail: Participant not found
+                  summary: Participant not found
+                ExperimentChannelNotFound:
+                  value:
+                    detail: Experiment cannot send messages on the connect_messaging
+                      channel
+                  summary: Experiment cannot send messages on the specified channel
+          description: ''
   /channels/api/{experiment_id}/incoming_message:
     post:
       operationId: new_api_message
@@ -707,6 +774,28 @@ components:
       required:
       - name
       - slug
+    TriggerBotMessageRequest:
+      type: object
+      properties:
+        identifier:
+          type: string
+          title: Participant Identifier
+        platform:
+          allOf:
+          - $ref: '#/components/schemas/PlatformEnum'
+          title: Participant Platform
+        experiment:
+          type: string
+          format: uuid
+          title: Experiment ID
+        prompt_text:
+          type: string
+          title: Prompt to go to bot
+      required:
+      - experiment
+      - identifier
+      - platform
+      - prompt_text
   securitySchemes:
     apiKeyAuth:
       type: apiKey

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -184,3 +184,10 @@ class ParticipantDataUpdateRequest(serializers.Serializer):
         choices=ChannelPlatform.choices, default=ChannelPlatform.API, label="Participant Platform"
     )
     data = ParticipantExperimentData(many=True)
+
+
+class TriggerBotMessageRequest(serializers.Serializer):
+    identifier = serializers.CharField(label="Participant Identifier")
+    platform = serializers.ChoiceField(choices=ChannelPlatform.choices, label="Participant Platform")
+    experiment = serializers.UUIDField(label="Experiment ID")
+    prompt_text = serializers.CharField(label="Prompt to go to bot")

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -8,6 +8,7 @@ from taskbadger.celery import Task as TaskbadgerTask
 
 from apps.channels.clients.connect_client import ConnectClient
 from apps.channels.models import ChannelPlatform, ExperimentChannel
+from apps.chat.channels import ChannelBase
 from apps.experiments.models import Experiment, ParticipantData
 
 logger = logging.getLogger(__name__)
@@ -56,3 +57,26 @@ def setup_connect_channels_for_bots(self, connect_id: UUID, experiment_data_map:
             participant_datum.save(update_fields=["system_metadata"])
         except Exception as e:
             logger.exception(f"Failed to create channel for participant data {participant_datum.id}: {e}")
+
+
+@shared_task(bind=True, base=TaskbadgerTask, ignore_result=True)
+def trigger_bot_message_task(self, data):
+    """
+    Trigger a bot message for a participant on a specific platform using the prompt from the given data.
+    """
+    platform = data["platform"]
+    experiment_public_id = data["experiment"]
+    prompt_text = data["prompt_text"]
+    identifier = data["identifier"]
+
+    experiment = Experiment.objects.get(public_id=experiment_public_id)
+    experiment_channel = ExperimentChannel.objects.prefetch_related("experiment").get(
+        platform=platform, experiment=experiment
+    )
+
+    published_experiment = experiment.default_version
+    ChannelClass = ChannelBase.get_channel_class_for_platform(platform)
+    channel = ChannelClass(experiment=published_experiment, experiment_channel=experiment_channel)
+
+    channel.ensure_session_exists_for_participant(identifier)
+    channel.experiment_session.ad_hoc_bot_message(prompt_text, use_experiment=published_experiment)

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -20,5 +20,6 @@ urlpatterns = [
     path("openai/<uuid:experiment_id>/chat/completions", openai.chat_completions, name="openai-chat-completions"),
     path("files/<int:pk>/content", views.file_content_view, name="file-content"),
     path("commcare_connect/", include((connect_patterns, "commcare-connect"))),
+    path("trigger_bot/", views.trigger_bot_message, name="trigger_bot"),
     path("", include(router.urls)),
 ]

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -27,9 +27,10 @@ from apps.api.serializers import (
     ExperimentSessionCreateSerializer,
     ExperimentSessionSerializer,
     ParticipantDataUpdateRequest,
+    TriggerBotMessageRequest,
 )
-from apps.api.tasks import setup_connect_channels_for_bots
-from apps.channels.models import ChannelPlatform
+from apps.api.tasks import setup_connect_channels_for_bots, trigger_bot_message_task
+from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.events.models import ScheduledMessage, TimePeriod
 from apps.experiments.models import Experiment, ExperimentSession, Participant, ParticipantData
 from apps.files.models import File
@@ -378,3 +379,41 @@ def consent(request: Request):
     participant_data.save(update_fields=["system_metadata"])
 
     return HttpResponse()
+
+
+@api_view(["POST"])
+def trigger_bot_message(request):
+    """
+    Trigger the bot to send a message to the user
+    """
+    serializer = TriggerBotMessageRequest(data=request.data)
+    serializer.is_valid(raise_exception=True)
+
+    identifier = serializer.data["identifier"]
+    platform = serializer.data["platform"]
+    experiment_public_id = serializer.data["experiment"]
+
+    experiment = get_object_or_404(Experiment, public_id=experiment_public_id, team=request.team)
+
+    try:
+        participant_data = ParticipantData.objects.defer("data").get(
+            participant__identifier=identifier,
+            participant__platform=platform,
+            object_id=experiment.id,
+            content_type=ContentType.objects.get_for_model(Experiment),
+        )
+
+        ExperimentChannel.objects.prefetch_related("experiment").get(platform=platform, experiment=experiment)
+    except ParticipantData.DoesNotExist:
+        return Response({"detail": "Participant not found"}, status=status.HTTP_404_NOT_FOUND)
+    except ExperimentChannel.DoesNotExist:
+        return Response(
+            {"detail": f"Experiment cannot send messages on the {platform} channel"}, status=status.HTTP_404_NOT_FOUND
+        )
+
+    if not participant_data.system_metadata.get("consent", False):
+        return Response({"detail": "User has not given consent"}, status=status.HTTP_400_BAD_REQUEST)
+
+    trigger_bot_message_task.delay(serializer.data)
+
+    return Response(status=status.HTTP_200_OK)

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -381,6 +381,48 @@ def consent(request: Request):
     return HttpResponse()
 
 
+@extend_schema(
+    operation_id="trigger_bot_message",
+    summary="Trigger the bot to send a message to the user",
+    tags=["Channels"],
+    request=TriggerBotMessageRequest(),
+    responses={
+        200: {},
+        400: {"description": "Bad Request"},
+        404: {"description": "Not Found"},
+    },
+    examples=[
+        OpenApiExample(
+            name="GenerateBotMessageAndSend",
+            summary="Generates a bot message and sends it to the user",
+            value={
+                "identifier": "part1",
+                "experiment": "exp1",
+                "platform": "connect_messaging",
+                "prompt_text": "Tell the user to do something",
+            },
+            status_codes=[200],
+        ),
+        OpenApiExample(
+            name="ParticipantNotFound",
+            summary="Participant not found",
+            value={"detail": "Participant not found"},
+            status_codes=[404],
+        ),
+        OpenApiExample(
+            name="ExperimentChannelNotFound",
+            summary="Experiment cannot send messages on the specified channel",
+            value={"detail": "Experiment cannot send messages on the connect_messaging channel"},
+            status_codes=[404],
+        ),
+        OpenApiExample(
+            name="ConsentNotGiven",
+            summary="User has not given consent",
+            value={"detail": "User has not given consent"},
+            status_codes=[400],
+        ),
+    ],
+)
 @api_view(["POST"])
 def trigger_bot_message(request):
     """

--- a/apps/channels/clients/connect_client.py
+++ b/apps/channels/clients/connect_client.py
@@ -69,8 +69,8 @@ class ConnectClient:
         stop=stop_after_attempt(3),
         before_sleep=before_sleep_log(logger, logging.INFO),
     )
-    def send_message_to_user(self, channel_id: str, raw_message: str, encryption_key: bytes):
-        ciphertext_bytes, tag_bytes, nonce_bytes = self._encrypt_message(key=encryption_key, message=raw_message)
+    def send_message_to_user(self, channel_id: str, message: str, encryption_key: bytes):
+        ciphertext_bytes, tag_bytes, nonce_bytes = self._encrypt_message(key=encryption_key, message=message)
 
         payload = {
             "channel": channel_id,

--- a/apps/channels/tests/test_connect_client.py
+++ b/apps/channels/tests/test_connect_client.py
@@ -1,0 +1,70 @@
+import base64
+import json
+import os
+from uuid import uuid4
+
+import responses
+from Crypto.Cipher import AES
+from django.conf import settings
+
+from apps.channels.clients.connect_client import ConnectClient, MessagePayload
+
+
+class TestConnectClient:
+    def test_decrypt_messages(self):
+        encryption_key = os.urandom(32)
+        cipher = AES.new(encryption_key, mode=AES.MODE_GCM)
+        ciphertext, tag = cipher.encrypt_and_digest(b"this is a secret message")
+
+        connect_client = ConnectClient()
+        payload = MessagePayload(
+            timestamp="2021-10-10T10:10:10Z",
+            message_id=uuid4(),
+            ciphertext=base64.b64encode(
+                ciphertext,
+            ).decode(),
+            tag=base64.b64encode(tag).decode(),
+            nonce=base64.b64encode(cipher.nonce).decode(),
+        )
+        messages = connect_client.decrypt_messages(key=encryption_key, messages=[payload])
+        assert messages[0] == "this is a secret message"
+
+    def test_encrypt_message(self):
+        encryption_key = os.urandom(32)
+        connect_client = ConnectClient()
+        ciphertext, tag, nonce = connect_client._encrypt_message(key=encryption_key, message="this is a secret message")
+        assert isinstance(ciphertext, bytes)
+        assert isinstance(tag, bytes)
+        assert isinstance(nonce, bytes)
+
+        cipher = AES.new(encryption_key, AES.MODE_GCM, nonce=nonce)
+        assert cipher.decrypt_and_verify(ciphertext, tag).decode("utf-8") == "this is a secret message"
+
+    @responses.activate
+    def test_send_message_to_user_1(self):
+        response = responses.Response(
+            method="POST",
+            url=f"{settings.CONNECT_ID_SERVER_BASE_URL}/messaging/send_fcm/",
+            json={"message_id": "765aec754eacf3221"},
+            status=200,
+        )
+        responses.add(response)
+
+        channel_id = uuid4().hex
+        raw_message = "Hi there human"
+        encryption_key = os.urandom(32)
+
+        connect_client = ConnectClient()
+        connect_client.send_message_to_user(channel_id, raw_message=raw_message, encryption_key=encryption_key)
+        request = responses.calls[0].request
+        assert request.headers["Authorization"].split(" ")[0] == "Basic"
+        request_data = json.loads(request.body)
+        message_content = request_data["content"]
+
+        assert "content" in request_data
+        assert "channel" in request_data
+        assert "message_id" in request_data
+
+        assert "nonce" in message_content
+        assert "tag" in message_content
+        assert "ciphertext" in message_content

--- a/apps/channels/tests/test_connect_client.py
+++ b/apps/channels/tests/test_connect_client.py
@@ -7,7 +7,7 @@ import responses
 from Crypto.Cipher import AES
 from django.conf import settings
 
-from apps.channels.clients.connect_client import ConnectClient, MessagePayload
+from apps.channels.clients.connect_client import ConnectClient, NewMessagePayload
 
 
 class TestConnectClient:
@@ -17,7 +17,7 @@ class TestConnectClient:
         ciphertext, tag = cipher.encrypt_and_digest(b"this is a secret message")
 
         connect_client = ConnectClient()
-        payload = MessagePayload(
+        payload = NewMessagePayload(
             timestamp="2021-10-10T10:10:10Z",
             message_id=uuid4(),
             ciphertext=base64.b64encode(

--- a/apps/channels/tests/test_connect_integration.py
+++ b/apps/channels/tests/test_connect_integration.py
@@ -1,0 +1,105 @@
+import base64
+import os
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+import responses
+
+from apps.channels.clients.connect_client import ConnectClient, Message, NewMessagePayload
+from apps.channels.models import ChannelPlatform
+from apps.channels.tasks import handle_connect_messaging_message
+from apps.experiments.models import ParticipantData
+from apps.utils.factories.channels import ExperimentChannelFactory
+from apps.utils.factories.experiment import ParticipantFactory
+
+
+def _setup(experiment, message_spec: dict | None = None) -> tuple:
+    """
+    message_spec example: {1736835441: "hi there"}
+    """
+    if not message_spec:
+        message_spec = {1736835441: "Hi there bot"}
+
+    team = experiment.team
+    connect_id = uuid4().hex
+    channel_id = uuid4().hex
+
+    encryption_key = os.urandom(32)
+    participant = ParticipantFactory(identifier=connect_id, team=team, platform=ChannelPlatform.CONNECT_MESSAGING)
+    part_data = ParticipantData.objects.create(
+        team=team,
+        participant=participant,
+        system_metadata={"channel_id": channel_id},
+        content_object=experiment,
+        encryption_key=base64.b64encode(encryption_key).decode("utf-8"),
+    )
+    experiment_channel = ExperimentChannelFactory(
+        team=team, experiment=experiment, platform=ChannelPlatform.CONNECT_MESSAGING
+    )
+
+    connect_client = ConnectClient()
+    messages = []
+    for timestamp, message in message_spec.items():
+        ciphertext_bytes, tag_bytes, nonce_bytes = connect_client._encrypt_message(key=encryption_key, message=message)
+        messages.append(
+            Message(
+                timestamp=timestamp,
+                message_id=uuid4().hex,
+                ciphertext=base64.b64encode(ciphertext_bytes).decode(),
+                tag=base64.b64encode(tag_bytes).decode(),
+                nonce=base64.b64encode(nonce_bytes).decode(),
+            )
+        )
+
+    payload = NewMessagePayload(channel_id=channel_id, messages=messages)
+
+    return channel_id, encryption_key, experiment_channel, part_data, payload
+
+
+@pytest.mark.django_db()
+class TestHandleConnectMessageTask:
+    @patch("apps.channels.tasks.ConnectMessagingChannel")
+    def test_participant_data_is_missing(self, ConnectMessagingChannelMock, experiment, caplog):
+        channel_instance = ConnectMessagingChannelMock.return_value
+        channel_id, _, _, participant_data, payload = _setup(experiment)
+        participant_data.delete()
+
+        handle_connect_messaging_message(payload)
+        channel_instance.new_user_message.assert_not_called()
+        assert caplog.messages[0] == f"No participant data found for channel_id: {channel_id}"
+
+    @patch("apps.channels.tasks.ConnectMessagingChannel")
+    def test_experiment_channel_is_missing(self, ConnectMessagingChannelMock, experiment, caplog):
+        channel_instance = ConnectMessagingChannelMock.return_value
+        channel_id, _, experiment_channel, _, payload = _setup(experiment)
+        experiment_channel.delete()
+
+        handle_connect_messaging_message(payload)
+        channel_instance.new_user_message.assert_not_called()
+        assert caplog.messages[0] == f"No experiment channel found for participant channel_id: {channel_id}"
+
+    @patch("apps.channels.tasks.ConnectMessagingChannel")
+    def test_multiple_messages_are_sorted_and_concatenated(self, ConnectMessagingChannelMock, experiment):
+        channel_instance = ConnectMessagingChannelMock.return_value
+        _, _, _, _, payload = _setup(experiment, message_spec={2: "I need to ask something", 1: "Hi bot"})
+
+        handle_connect_messaging_message(payload)
+        base_message = channel_instance.new_user_message.call_args[0][0]
+        assert base_message.message_text == "Hi bot\n\nI need to ask something"
+
+    @responses.activate
+    @pytest.mark.django_db()
+    @patch("apps.chat.bots.TopicBot.process_input")
+    def test_bot_generate_and_sends_message(self, process_input, experiment):
+        process_input.return_value = "Hi human"
+        channel_id, encryption_key, _, _, payload = _setup(experiment)
+
+        with patch("apps.chat.channels.ConnectClient") as ConnectClientMock:
+            client_mock = ConnectClientMock.return_value
+            handle_connect_messaging_message(payload)
+            assert client_mock.send_message_to_user.call_count == 1
+            call_kwargs = client_mock.send_message_to_user.call_args[1]
+            assert call_kwargs["channel_id"] == channel_id
+            assert call_kwargs["message"] == "Hi human"
+            assert call_kwargs["encryption_key"] == encryption_key

--- a/apps/channels/urls.py
+++ b/apps/channels/urls.py
@@ -16,4 +16,5 @@ urlpatterns = [
     ),
     path("whatsapp/turn/<uuid:experiment_id>/incoming_message", views.new_turn_message, name="new_turn_message"),
     path("api/<uuid:experiment_id>/incoming_message", views.new_api_message, name="new_api_message"),
+    path("commcare_connect/new_message/", views.new_connect_message, name="new_connect_message"),
 ]

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -774,7 +774,6 @@ class SlackChannel(ChannelBase):
 
 
 class ConnectMessagingChannel(ChannelBase):
-    # TODO: Finish in followup PR
     voice_replies_supported = False
     supported_message_types = [MESSAGE_TYPES.TEXT]
 

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -788,11 +788,13 @@ class ConnectMessagingChannel(ChannelBase):
         self.client = ConnectClient()
 
     def send_text_to_user(self, text: str):
-        self.client.send_message_to_user(self.connect_channel_id, message=text, encryption_key=self.encryption_key)
+        self.client.send_message_to_user(
+            channel_id=self.connect_channel_id, message=text, encryption_key=self.encryption_key
+        )
 
     @cached_property
     def participant_data(self) -> ParticipantData:
-        return self.experiment.data_set.filter(participant__identifier=self.participant_identifier).defer("data")
+        return self.experiment.participant_data.defer("data").get(participant__identifier=self.participant_identifier)
 
     @cached_property
     def connect_channel_id(self) -> str:

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -19,7 +19,7 @@ from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.bots import get_bot
 from apps.chat.exceptions import (
     AudioSynthesizeException,
-    MessageHandlerException,
+    ChannelException,
     ParticipantNotAllowedException,
     VersionedExperimentSessionsNotAllowedException,
 )
@@ -83,7 +83,7 @@ class ChannelBase(ABC):
         experiment_session: An optional ExperimentSession object representing the experiment session associated
             with the handler.
     Raises:
-        MessageHandlerException: If both 'experiment_channel' and 'experiment_session' arguments are not provided.
+        ChannelException: If both 'experiment_channel' and 'experiment_session' arguments are not provided.
 
     Class variables:
         supported_message_types: A list of message content types that are supported by this channel
@@ -536,7 +536,7 @@ class WebChannel(ChannelBase):
 
     def _ensure_sessions_exists(self):
         if not self.experiment_session:
-            raise MessageHandlerException("WebChannel requires an existing session")
+            raise ChannelException("WebChannel requires an existing session")
 
     @classmethod
     def start_new_session(
@@ -718,7 +718,7 @@ class ApiChannel(ChannelBase):
         super().__init__(experiment, experiment_channel, experiment_session)
         self.user = user
         if not self.user and not self.experiment_session:
-            raise MessageHandlerException("ApiChannel requires either an existing session or a user")
+            raise ChannelException("ApiChannel requires either an existing session or a user")
 
     @property
     def participant_user(self):
@@ -769,7 +769,7 @@ class SlackChannel(ChannelBase):
 
     def _ensure_sessions_exists(self):
         if not self.experiment_session:
-            raise MessageHandlerException("WebChannel requires an existing session")
+            raise ChannelException("WebChannel requires an existing session")
 
 
 class ConnectMessagingChannel(ChannelBase):

--- a/apps/chat/exceptions.py
+++ b/apps/chat/exceptions.py
@@ -14,7 +14,7 @@ class AudioTranscriptionException(ChatException):
         super().__init__(message)
 
 
-class MessageHandlerException(ChatException):
+class ChannelException(ChatException):
     def __init__(self, message):
         super().__init__(message)
 

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 import uuid
 from datetime import datetime
@@ -1388,6 +1389,10 @@ class ParticipantData(BaseTeamModel):
     encryption_key = encrypt(
         models.CharField(max_length=255, blank=True, help_text="The base64 encoded encryption key")
     )
+
+    def get_encryption_key_bytes(self):
+        # TODO: What if we use a getter/setting to ensure what we have is always bytes?
+        return base64.b64decode(self.encryption_key)
 
     class Meta:
         indexes = [

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -62,3 +62,4 @@ emoji
 python-magic
 requests>=2.32.3
 urllib3>=2.3.0
+pycryptodome

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -326,6 +326,8 @@ psycopg-binary==3.2.1
     # via psycopg
 pycparser==2.21
     # via cffi
+pycryptodome==3.21.0
+    # via -r requirements.in
 pydantic==2.9.2
     # via
     #   -r requirements.in


### PR DESCRIPTION
I might break this PR up into two after code rabbit reviewed it

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
This completes all the work for the integration, except ability to link a connect messaging channel to your experiment through the UI.
- Bot is able to initiate a conversation based on the prompt given through the API
- Message encryption and decryption
- Tests

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->


## Still todo
- Ability to link a connect messaging channel to an experiment
- Manual testing