### PR TITLE
Check assistant exists before making requests

### DIFF
--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -158,6 +158,9 @@ def delete_file_from_openai(client: OpenAI, file: File):
 @wrap_openai_errors
 def sync_from_openai(assistant: OpenAiAssistant):
     """Syncs the local assistant instance with the remote OpenAI assistant."""
+    if not assistant.assistant_id:
+        return
+
     client = assistant.llm_provider.get_llm_service().get_raw_client()
     openai_assistant = client.beta.assistants.retrieve(assistant.assistant_id)
     for key, value in _openai_assistant_to_ocs_kwargs(openai_assistant, team=assistant.team).items():
@@ -190,6 +193,9 @@ def delete_openai_assistant(assistant: OpenAiAssistant):
     """Deletes the assistant from OpenAI and removes all associated files.
 
     This function should be idempotent and safe to call multiple times."""
+    if not assistant.assistant_id:
+        return
+
     client = assistant.llm_provider.get_llm_service().get_raw_client()
     try:
         client.beta.assistants.delete(assistant.assistant_id)

--- a/apps/assistants/tests/test_sync.py
+++ b/apps/assistants/tests/test_sync.py
@@ -238,7 +238,7 @@ def test_import_openai_assistant_raises_for_invalid_instructions(mock_retrieve):
 @patch("openai.resources.Files.delete")
 def test_delete_openai_assistant(mock_file_delete, mock_vector_store_delete, mock_delete):
     files = FileFactory.create_batch(3, external_id="test_id", external_source="openai")
-    local_assistant = OpenAiAssistantFactory()
+    local_assistant = OpenAiAssistantFactory(assistant_id="123")
 
     code_resource = ToolResources.objects.create(tool_type="code_interpreter", assistant=local_assistant)
     code_resource.files.set(files[:2])

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -619,6 +619,9 @@ class CreateExperimentVersion(LoginAndTeamRequiredMixin, CreateView):
         if not experiment.assistant:
             return False
 
+        if not experiment.assistant.assistant_id:
+            return True
+
         if len(get_diff_with_openai_assistant(experiment.assistant)) > 0:
             return True
 

--- a/templates/assistants/sync_status.html
+++ b/templates/assistants/sync_status.html
@@ -3,52 +3,53 @@
     <div id="sync-notification" role="alert" class="alert">
       <p><strong>Warning:</strong> This assistant has not yet been created on OpenAI.</p>
     </div>
-  {% endif %}
-  {% if files_missing_local or files_missing_remote or diffs %}
-    <div id="sync-notification" role="alert" class="alert">
-      <div class="flex flex-col gap-2">
-        {% if diffs %}
+  {% else %}
+    {% if files_missing_local or files_missing_remote or diffs %}
+      <div id="sync-notification" role="alert" class="alert">
+        <div class="flex flex-col gap-2">
+          {% if diffs %}
+            <div>
+              <p><strong>Warning:</strong> The assistant has modifications on OpenAI which are not reflected here.</p>
+              <p><strong>Fields that differ:</strong> {{ diffs|join:", " }}</p>
+            </div>
+          {% endif %}
+          {% if files_missing_local %}
+            <div>
+              <p><strong>Warning:</strong> Your assistant has files that are uploaded to OpenAI but not present in Open
+                Chat
+                Studio. This may lead to unexpected behavior in the assistant. To resolve this issue, update the assistant
+                from OpenAI and then re-upload the files marked with <i class="fa-solid fa-triangle-exclamation text-warning"></i>.</p>
+              <p><strong>Missing files:</strong></p>
+              {% for tool_type, files in files_missing_local.items %}
+                <p class="pl-2"><strong>{{ tool_type }}:</strong> {{ files|join:", " }}</p>
+              {% endfor %}
+            </div>
+          {% endif %}
+          {% if files_missing_remote %}
+            <div>
+              <p><strong>Warning:</strong> Some files have been removed from OpenAI but are still present here.
+                If you save this assistant the files will be re-uploaded to OpenAI. If you want to remove the files
+                from this assistant click the 'update' button below.</p>
+              <p><strong>Files:</strong></p>
+              {% for tool_type, files in files_missing_remote.items %}
+                <p class="pl-2"><strong>{{ tool_type }}:</strong> {{ files|join:", " }}</p>
+              {% endfor %}
+            </div>
+          {% endif %}
           <div>
-            <p><strong>Warning:</strong> The assistant has modifications on OpenAI which are not reflected here.</p>
-            <p><strong>Fields that differ:</strong> {{ diffs|join:", " }}</p>
-          </div>
-        {% endif %}
-        {% if files_missing_local %}
-          <div>
-            <p><strong>Warning:</strong> Your assistant has files that are uploaded to OpenAI but not present in Open
-              Chat
-              Studio. This may lead to unexpected behavior in the assistant. To resolve this issue, update the assistant
-              from OpenAI and then re-upload the files marked with <i class="fa-solid fa-triangle-exclamation text-warning"></i>.</p>
-            <p><strong>Missing files:</strong></p>
-            {% for tool_type, files in files_missing_local.items %}
-              <p class="pl-2"><strong>{{ tool_type }}:</strong> {{ files|join:", " }}</p>
-            {% endfor %}
-          </div>
-        {% endif %}
-        {% if files_missing_remote %}
-          <div>
-            <p><strong>Warning:</strong> Some files have been removed from OpenAI but are still present here.
-              If you save this assistant the files will be re-uploaded to OpenAI. If you want to remove the files
-              from this assistant click the 'update' button below.</p>
-            <p><strong>Files:</strong></p>
-            {% for tool_type, files in files_missing_remote.items %}
-              <p class="pl-2"><strong>{{ tool_type }}:</strong> {{ files|join:", " }}</p>
-            {% endfor %}
-          </div>
-        {% endif %}
-        <div>
-          <div class="mt-2 tooltip" data-tip="Overwrite this configuration with the data from OpenAI">
-            <button hx-post="{% url 'assistants:sync_while_editing' request.team.slug object.pk %}"
-                    hx-target="#sync-wrapper" class="btn btn-sm btn-primary">Update from OpenAI
-            </button>
+            <div class="mt-2 tooltip" data-tip="Overwrite this configuration with the data from OpenAI">
+              <button hx-post="{% url 'assistants:sync_while_editing' request.team.slug object.pk %}"
+                      hx-target="#sync-wrapper" class="btn btn-sm btn-primary">Update from OpenAI
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  {% else %}
-    <div id="sync-indicator" class="badge badge-success tooltip" data-tip="This Assistant is in sync with OpenAI">
-      <i class="fas fa-check mr-1"></i>In Sync
-    </div>
+    {% else %}
+      <div id="sync-indicator" class="badge badge-success tooltip" data-tip="This Assistant is in sync with OpenAI">
+        <i class="fas fa-check mr-1"></i>In Sync
+      </div>
+    {% endif %}
   {% endif %}
 </div>
 </div>


### PR DESCRIPTION
resolves [DIMAGI-BOTS-M7](https://dimagi.sentry.io/issues/6220897112/)

## Description
In some cases the assistant is saved in OCS but the push to OpenAI failed. This leaves it with a blank `assistant_id`.

This PR checks that the `assistant_id` is set before making requests.