### PR TITLE
monkeypatch executor for pipeline test runs

### DIFF
--- a/apps/pipelines/executor.py
+++ b/apps/pipelines/executor.py
@@ -1,0 +1,34 @@
+from concurrent.futures import Executor, Future
+from contextlib import contextmanager
+
+
+class CurrentThreadExecutor(Executor):
+    """Fake thread pool executor that runs tasks in the current thread."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def submit(self, fn, /, *args, **kwargs):
+        future = Future()
+        try:
+            result = fn(*args, **kwargs)
+        except BaseException as exc:
+            future.set_exception(exc)
+        else:
+            future.set_result(result)
+
+        return future
+
+
+@contextmanager
+def patch_executor():
+    """Monkeypatch the langchain executor to run tasks in the current thread.
+    This is used for pipeline tests where the DB transaction is not committed."""
+    from langchain_core.runnables import config
+
+    original = config.ContextThreadPoolExecutor
+    config.ContextThreadPoolExecutor = CurrentThreadExecutor
+    try:
+        yield
+    finally:
+        config.ContextThreadPoolExecutor = original

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -15,6 +15,7 @@ from apps.chat.models import ChatMessage, ChatMessageType
 from apps.custom_actions.form_utils import set_custom_actions
 from apps.custom_actions.mixins import CustomActionOperationMixin
 from apps.experiments.models import ExperimentSession, VersionsMixin, VersionsObjectManagerMixin
+from apps.pipelines.executor import patch_executor
 from apps.pipelines.flow import Flow, FlowNode, FlowNodeData
 from apps.pipelines.logging import PipelineLoggingCallbackHandler
 from apps.pipelines.nodes.base import PipelineState
@@ -173,11 +174,11 @@ class Pipeline(BaseTeamModel, VersionsMixin):
         """Invoke the pipeline without a session or the ability to save the run to history"""
         from apps.pipelines.graph import PipelineGraph
 
-        output = ""
         with temporary_session(self.team, user_id) as session:
             runnable = PipelineGraph.build_runnable_from_pipeline(self)
             input = PipelineState(messages=[input], experiment_session=session, pipeline_version=self.version_number)
-            output = runnable.invoke(input)
+            with patch_executor():
+                output = runnable.invoke(input, config={"max_concurrency": 1})
             output = PipelineState(**output).json_safe()
         return output
 


### PR DESCRIPTION
Resolves [DIMAGI-BOTS-M3](https://dimagi.sentry.io/issues/6220745979/)
Resolves [DIMAGI-BOTS-M4](https://dimagi.sentry.io/issues/6220774167/)

## Description
When running the 'test pipeline' task we create a temporary experiment and session and use Django transactions to roll that back after the pipeline has completed. If a pipeline has concurrent nodes langgraph will use a `ThreadPoolExecutor` to run the nodes. Because the nodes execute in a separate thread they will use a different DB connection and hence won't be able to see the temporary session because the transaction is still open.

This PR patches the langchain code to use a fake executor during the pipeline test. The fake executor runs the nodes in the main thread.

## User Impact
Users will be able to test pipelines that have concurrent nodes without receiving weird DB errors.

### Demo
![image](https://github.com/user-attachments/assets/b0d06200-f3d4-4907-9989-867db4e35d74)

