### PR TITLE
Connect get_key endpoint to use form data

### DIFF
--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -304,7 +304,12 @@ def test_update_participant_data_and_setup_connect_channels(httpx_mock):
     team = TeamWithUsersFactory()
     experiment1 = ExperimentFactory(team=team)
     ExperimentChannelFactory(team=team, experiment=experiment1, platform=ChannelPlatform.TELEGRAM)
-    ExperimentChannelFactory(team=team, experiment=experiment1, platform=ChannelPlatform.COMMCARE_CONNECT)
+    ExperimentChannelFactory(
+        team=team,
+        experiment=experiment1,
+        platform=ChannelPlatform.COMMCARE_CONNECT,
+        extra_data={"commcare_connect_bot_name": "bot1"},
+    )
     experiment2 = ExperimentFactory(team=team)
     experiment3 = ExperimentFactory(team=team)
 
@@ -363,7 +368,7 @@ def test_update_participant_data_and_setup_connect_channels(httpx_mock):
     request = httpx_mock.get_request()
     request_data = json.loads(request.read())
     assert request_data["connectid"] == "connectid_2"
-    assert request_data["channel_source"] == f"{experiment1.team}-{experiment1.name}"
+    assert request_data["channel_source"] == "bot1"
     assert Participant.objects.filter(identifier="connectid_2").exists()
     data = ParticipantData.objects.get(participant__identifier="connectid_2", object_id=experiment1.id)
     assert data.system_metadata["commcare_connect_channel_id"] == created_connect_channel_id
@@ -374,9 +379,7 @@ class TestConnectApis:
     def _make_key_request(self, client, data):
         token = uuid.uuid4()
         url = reverse("api:commcare-connect:generate_key")
-        return client.post(
-            url, data=data, headers={"Authorization": f"Bearer {token}"}, content_type="application/json"
-        )
+        return client.post(url, data=data, headers={"Authorization": f"Bearer {token}"})
 
     def test_generate_key_success(self, client, experiment, httpx_mock):
         connect_id = uuid.uuid4().hex
@@ -416,7 +419,7 @@ class TestConnectApis:
         httpx_mock.add_response(method="GET", url=settings.COMMCARE_CONNECT_GET_CONNECT_ID_URL, status_code=401)
 
         with pytest.raises(httpx.HTTPStatusError):
-            self._make_key_request(client=client, data={})
+            self._make_key_request(client=client, data={"channel_id": "123"})
 
     @override_settings(COMMCARE_CONNECT_SERVER_SECRET="123123")
     def test_user_consented(self, client, experiment):

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -332,15 +332,14 @@ def file_content_view(request, pk: int):
 def generate_key(request: Request):
     """Generates a key for a specific channel to use for secure communication"""
     token = request.META.get("HTTP_AUTHORIZATION")
-    if not (token and request.body):
+    if not (token and "channel_id" in request.POST):
         return HttpResponse("Missing token or data", status=400)
 
+    commcare_connect_channel_id = request.POST["channel_id"]
     response = httpx.get(settings.COMMCARE_CONNECT_GET_CONNECT_ID_URL, headers={"AUTHORIZATION": token})
     response.raise_for_status()
     connect_id = response.json().get("sub")
-    logger.info(f"Response: {request.body}")
-    request_data = json.loads(request.body)
-    commcare_connect_channel_id = request_data.get("channel_id")
+
     try:
         participant_data = ParticipantData.objects.defer("data").get(
             participant__identifier=connect_id, system_metadata__commcare_connect_channel_id=commcare_connect_channel_id


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
1. The generate_key endpoint should expect form data, not JSON
2. I noticed we don't use the specified bot name from the channel. We do now

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->
