### PR TITLE
Add temporary trailing slash to connect endpoint

### DIFF
--- a/apps/channels/urls.py
+++ b/apps/channels/urls.py
@@ -16,5 +16,6 @@ urlpatterns = [
     ),
     path("whatsapp/turn/<uuid:experiment_id>/incoming_message", views.new_turn_message, name="new_turn_message"),
     path("api/<uuid:experiment_id>/incoming_message", views.new_api_message, name="new_api_message"),
-    path("commcare_connect/incoming_message", views.new_connect_message, name="new_connect_message"),
+    # TODO: Remove trailing / and update endpoint at ConnectID
+    path("commcare_connect/incoming_message/", views.new_connect_message, name="new_connect_message"),
 ]


### PR DESCRIPTION
I noticed the URL that the connect server uses to forward messages has a trailing slash (my mistake, I gave it like that). In the django logs I can see a 404, which explains why we're not receiving any messages back. This "fix" is temporary in that I want to deploy it and make sure everything works, then I'll change it back and notify the connect team to update the url.