### PR TITLE
Add separate view for the old path and update api spec

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -130,10 +130,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/CreateChatCompletionResponse'
           description: ''
-  /api/participants/:
+  /api/participants:
     post:
       operationId: update_participant_data
-      description: Upsert participant data for all specified experiments in the payload
       summary: Update Participant Data
       tags:
       - Participants

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -16,7 +16,7 @@ connect_patterns = [
 ]
 
 urlpatterns = [
-    path("participants/", views.update_participant_data, name="update-participant-data"),
+    path("participants/", views.update_participant_data_old, name="update-participant-data-old"),
     # Duplicate update-participant-data without a trailing "/" for backwards compatibility
     path("participants", views.update_participant_data, name="update-participant-data"),
     path("openai/<uuid:experiment_id>/chat/completions", openai.chat_completions, name="openai-chat-completions"),

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -125,6 +125,18 @@ class ExperimentViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, Generi
 @api_view(["POST"])
 @permission_required("experiments.change_participantdata")
 def update_participant_data(request):
+    return _update_participant_data(request)
+
+
+@extend_schema(exclude=True)
+@api_view(["POST"])
+@permission_required("experiments.change_participantdata")
+def update_participant_data_old(request):
+    # This endpoint is kept for backwards compatibility of the path with a trailing "/"
+    return _update_participant_data(request)
+
+
+def _update_participant_data(request):
     """
     Upsert participant data for all specified experiments in the payload
     """


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
- Updated the API spec to only include the "new" path without the trailing "/"
- I had to add a new view that calls the same code as the old one and had to update the url to point to that one. Better approach suggestions welcome

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users will only see the "new" path, but the old one is still usable

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs
<!--Link to documentation that has been updated.-->
Doc update is in this PR