### PR TITLE
handle empty output in history manager

### DIFF
--- a/apps/service_providers/llm_service/history_managers.py
+++ b/apps/service_providers/llm_service/history_managers.py
@@ -201,7 +201,7 @@ class PipelineHistoryManager(BaseHistoryManager):
 
         try:
             history: PipelineChatHistory = self.session.pipeline_chat_history.get(
-                type=self.history_type, name=self._get_history_name(self.node_id)
+                type=self.history_type, name=self._get_history_name()
             )
         except PipelineChatHistory.DoesNotExist:
             return []
@@ -212,10 +212,10 @@ class PipelineHistoryManager(BaseHistoryManager):
             input_messages=input_messages,
         )
 
-    def _get_history_name(self, node_id):
+    def _get_history_name(self):
         if self.history_type == PipelineChatHistoryTypes.NAMED:
             return self.history_name
-        return node_id
+        return self.node_id
 
     def add_messages_to_history(
         self, input: str, input_message_metadata: dict, output: str, output_message_metadata: dict, *args, **kwargs
@@ -231,9 +231,9 @@ class PipelineHistoryManager(BaseHistoryManager):
             return
 
         history, _ = self.session.pipeline_chat_history.get_or_create(
-            type=self.history_type, name=self._get_history_name(self.node_id)
+            type=self.history_type, name=self._get_history_name()
         )
 
+        output = output or ""  # generation likely errored resulting in a None output
         message = history.messages.create(human_message=input, ai_message=output, node_id=self.node_id)
-        # TODO: Save normal session history here as well
         return message

--- a/apps/service_providers/tests/test_history_manager.py
+++ b/apps/service_providers/tests/test_history_manager.py
@@ -1,0 +1,51 @@
+import pytest
+
+from apps.pipelines.models import PipelineChatHistoryTypes
+from apps.service_providers.llm_service.history_managers import PipelineHistoryManager
+from apps.utils.factories.experiment import ExperimentSessionFactory
+
+
+@pytest.fixture()
+def mock_session():
+    return ExperimentSessionFactory()
+
+
+@pytest.mark.django_db()
+def test_returns_empty_list_when_history_type_is_none(mock_session):
+    manager = PipelineHistoryManager(session=mock_session, history_type=PipelineChatHistoryTypes.NONE)
+    assert manager.get_chat_history([]) == []
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("history_type", [PipelineChatHistoryTypes.GLOBAL, PipelineChatHistoryTypes.NAMED])
+def test_returns_empty_list_when_session_is_none(mock_session, history_type):
+    manager = PipelineHistoryManager(session=mock_session, history_type=history_type, max_token_limit=100)
+    assert manager.get_chat_history([]) == []
+
+
+@pytest.mark.django_db()
+def test_adds_messages_to_history(mock_session):
+    manager = PipelineHistoryManager(
+        session=mock_session, history_type=PipelineChatHistoryTypes.NAMED, node_id="test_node", history_name="test_name"
+    )
+    manager.add_messages_to_history("input", {}, "output", {})
+    history = mock_session.pipeline_chat_history.get(type=PipelineChatHistoryTypes.NAMED, name="test_name")
+    assert history.messages.count() == 1
+
+
+@pytest.mark.django_db()
+def test_adds_messages_to_history_with_no_ai_message(mock_session):
+    manager = PipelineHistoryManager(
+        session=mock_session, history_type=PipelineChatHistoryTypes.NAMED, node_id="test_node", history_name="test_name"
+    )
+    manager.add_messages_to_history("input", {}, None, {})
+    history = mock_session.pipeline_chat_history.get(type=PipelineChatHistoryTypes.NAMED, name="test_name")
+    assert history.messages.count() == 1
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("history_type", [PipelineChatHistoryTypes.NONE, PipelineChatHistoryTypes.GLOBAL])
+def test_does_not_add_messages(mock_session, history_type):
+    manager = PipelineHistoryManager(session=mock_session, history_type=history_type)
+    manager.add_messages_to_history("input", {}, "output", {})
+    assert not mock_session.pipeline_chat_history.exists()


### PR DESCRIPTION
[DIMAGI-BOTS-MC](https://dimagi.sentry.io/issues/6223126083/)

## Description
Don't error when saving chat history if the AI message is None. This occurs if there was an error during generation.