### PR TITLE
Map `minutes` to `mins` for compatibility with MakeInterval

### DIFF
--- a/apps/events/actions.py
+++ b/apps/events/actions.py
@@ -74,9 +74,14 @@ class ScheduleTriggerAction(EventActionHandlerBase):
             - If the scheduled message's last_triggered_at field is not None (it has fired before), that field is
             then used as the baseline for adding the new delta
         """
+        params = action.params.copy()
+        # We need to map `minutes` to `mins` for compatibility with MakeInterval
+        if params["time_period"] == "minutes":
+            params["time_period"] = "mins"
+
         (
             action.scheduled_messages.annotate(
-                new_delta=MakeInterval(action.params["time_period"], action.params["frequency"]),
+                new_delta=MakeInterval(params["time_period"], params["frequency"]),
             )
             .filter(is_complete=False, custom_schedule_params={})
             .update(

--- a/apps/events/tests/test_scheduled_messages.py
+++ b/apps/events/tests/test_scheduled_messages.py
@@ -267,8 +267,8 @@ def test_schedule_update():
 def test_update_schedule_to_minute_perdiod():
     """
     This test reproduces an exception that was raised when the user updates the schedule to use TimePeriod.MINUTES. The
-    exception is due to a mismatch between the value of `TimePeriod.MINUTES` and that which Postgres expects in the
-    MakeInterval function i.e. postgres expects `mins` and the value is `minutes`.
+    exception was caused because of a mismatch between the value of `TimePeriod.MINUTES` and that which Postgres expects
+    in the MakeInterval function i.e. postgres expects `mins` and the value is `minutes`.
     """
     session = ExperimentSessionFactory()
     event_action, _params = _construct_event_action(

--- a/apps/events/tests/test_scheduled_messages.py
+++ b/apps/events/tests/test_scheduled_messages.py
@@ -264,7 +264,7 @@ def test_schedule_update():
 
 
 @pytest.mark.django_db()
-def test_update_schedule_to_minute_perdiod():
+def test_update_schedule_to_minute_period():
     """
     This test reproduces an exception that was raised when the user updates the schedule to use TimePeriod.MINUTES. The
     exception was caused because of a mismatch between the value of `TimePeriod.MINUTES` and that which Postgres expects

--- a/apps/events/tests/test_scheduled_messages.py
+++ b/apps/events/tests/test_scheduled_messages.py
@@ -280,7 +280,7 @@ def test_update_schedule_to_minute_perdiod():
     )
 
     event_action.params["time_period"] = TimePeriod.MINUTES
-    # An error would was thrown previously when saving
+    # An error was previously thrown when saving
     event_action.save()
     assert scheduled_message.action.params["time_period"] == "minutes"
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
An alternative approach to [this](https://github.com/dimagi/open-chat-studio/pull/1066) that was reverted [here](https://github.com/dimagi/open-chat-studio/pull/1067).

I included a test that failed with the error we got on prod.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
users should be able to update the time period to minutes without it erroring

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![demo](https://github.com/user-attachments/assets/999faff0-3ad5-4043-acc6-e2ca25b74623)

### Docs
<!--Link to documentation that has been updated.-->
N/A