### PR TITLE
Create missing flag when calling is_active_for_team

### DIFF
--- a/apps/channels/tests/test_models.py
+++ b/apps/channels/tests/test_models.py
@@ -6,6 +6,7 @@ from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
 from apps.experiments.exceptions import ChannelAlreadyUtilizedException
 from apps.service_providers.models import MessagingProviderType
+from apps.teams.models import Flag
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.service_provider_factories import MessagingProviderFactory
@@ -132,3 +133,19 @@ def _build_provider(provider_type: MessagingProviderType, team):
         case MessagingProviderType.slack:
             config = {"slack_team_id": "", "slack_installation_id": 123}
     MessagingProviderFactory(type=provider_type, team=team, config=config)
+
+
+@override_settings(WAFFLE_CREATE_MISSING_FLAGS=True)
+def test_is_active_for_team_creates_missing_flag(experiment):
+    flag = Flag.get("missing_flag_1")
+    is_active = flag.is_active_for_team(experiment.team)
+    assert is_active is False
+    assert flag.id is not None
+
+
+@override_settings(WAFFLE_CREATE_MISSING_FLAGS=False)
+def test_is_active_for_team_does_not_create_missing_flag(experiment):
+    flag = Flag.get("missing_flag_2")
+    is_active = flag.is_active_for_team(experiment.team)
+    assert is_active is False
+    assert flag.id is None

--- a/apps/teams/models.py
+++ b/apps/teams/models.py
@@ -190,7 +190,7 @@ class Flag(AbstractUserFlag):
                 cache = get_cache()
                 cache.set(self._cache_key(self.name), self)
 
-            return get_setting('FLAG_DEFAULT')
+            return get_setting("FLAG_DEFAULT")
 
         team_ids = self._get_team_ids()
         return team.pk in team_ids

--- a/apps/teams/models.py
+++ b/apps/teams/models.py
@@ -180,17 +180,17 @@ class Flag(AbstractUserFlag):
         if not team:
             return False
 
-        if not self.pk and get_setting("CREATE_MISSING_FLAGS"):
-            flag, _created = Flag.objects.get_or_create(
-                name=self.name, defaults={"everyone": get_setting("FLAG_DEFAULT")}
-            )
-            self.id = flag.id
-            self.refresh_from_db()
-            cache = get_cache()
-            cache.set(self._cache_key(self.name), self)
-        else:
-            # flag not created
-            return False
+        if not self.pk:
+            if get_setting("CREATE_MISSING_FLAGS"):
+                flag, _created = Flag.objects.get_or_create(
+                    name=self.name, defaults={"everyone": get_setting("FLAG_DEFAULT")}
+                )
+                self.id = flag.id
+                self.refresh_from_db()
+                cache = get_cache()
+                cache.set(self._cache_key(self.name), self)
+
+            return get_setting('FLAG_DEFAULT')
 
         team_ids = self._get_team_ids()
         return team.pk in team_ids

--- a/apps/teams/models.py
+++ b/apps/teams/models.py
@@ -180,7 +180,15 @@ class Flag(AbstractUserFlag):
         if not team:
             return False
 
-        if not self.pk:
+        if not self.pk and get_setting("CREATE_MISSING_FLAGS"):
+            flag, _created = Flag.objects.get_or_create(
+                name=self.name, defaults={"everyone": get_setting("FLAG_DEFAULT")}
+            )
+            self.id = flag.id
+            self.refresh_from_db()
+            cache = get_cache()
+            cache.set(self._cache_key(self.name), self)
+        else:
             # flag not created
             return False
 


### PR DESCRIPTION
resolves #1047 

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Auto creates missing flags when `WAFFLE_CREATE_MISSING_FLAGS` is `True`

## User Impact
<!-- Describe the impact of this change on the end-users. -->
N/A

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs
<!--Link to documentation that has been updated.-->
N/A