### PR TITLE
Sk/fix deletion

### DIFF
--- a/apps/teams/views/manage_team_views.py
+++ b/apps/teams/views/manage_team_views.py
@@ -13,6 +13,7 @@ from apps.teams.forms import InvitationForm, TeamChangeForm
 from apps.teams.invitations import send_invitation
 from apps.teams.models import Invitation
 from apps.teams.utils import current_team
+from apps.utils.deletion import delete_object_with_auditing_of_related_objects
 from apps.web.forms import set_form_fields_disabled
 
 
@@ -76,9 +77,8 @@ def create_team(request):
 @require_POST
 @permission_required("teams.delete_team", raise_exception=True)
 def delete_team(request, team_slug):
-    # delete_object_with_auditing_of_related_objects(request.team)
-    # messages.success(request, _('The "{team}" team was successfully deleted').format(team=request.team.name))
-    messages.error(request, _("This functionality has been temporarily disabled."))
+    delete_object_with_auditing_of_related_objects(request.team)
+    messages.success(request, _('The "{team}" team was successfully deleted').format(team=request.team.name))
     return HttpResponseRedirect(reverse("web:home"))
 
 

--- a/apps/utils/tests/test_delete_with_auditing.py
+++ b/apps/utils/tests/test_delete_with_auditing.py
@@ -2,6 +2,10 @@ import pytest
 from field_audit.models import AuditEvent
 
 from apps.utils.deletion import delete_object_with_auditing_of_related_objects
+from apps.utils.factories.assistants import OpenAiAssistantFactory
+from apps.utils.factories.experiment import ExperimentFactory
+from apps.utils.factories.service_provider_factories import LlmProviderFactory
+from apps.utils.factories.team import TeamFactory
 
 
 @pytest.mark.django_db()
@@ -39,3 +43,23 @@ def test_delete_with_auditing(obj_name, delete_events, update_events, expected_s
         for e in AuditEvent.objects.filter(is_delete=False, is_create=False, object_class_path__in=MODEL_NAMES)
     }
     assert actual_update_events == set(update_events)
+
+
+@pytest.mark.django_db()
+def test_deleting_a_team_does_not_remove_llm_providers_from_other_teams():
+    """
+    There was an issue where if you remove a team that has an LLMProvider, it would clear the LLMProvider FKs from
+    some experiments and assistants that were associated with other teams. This test ensures that this issue is fixed.
+    """
+    team = TeamFactory()
+    experiment = ExperimentFactory(llm_provider=LlmProviderFactory(team=team), team=team)
+    assistant = OpenAiAssistantFactory(llm_provider=LlmProviderFactory(team=team), team=team)
+
+    team_to_delete = TeamFactory()
+    LlmProviderFactory(team=team_to_delete)
+
+    delete_object_with_auditing_of_related_objects(team_to_delete)
+    experiment.refresh_from_db()
+    assistant.refresh_from_db()
+    assert experiment.llm_provider is not None
+    assert assistant.llm_provider is not None


### PR DESCRIPTION
## Description
Prevent objects from being updated which do not match the queryset filters.

```python
combined_updates.update = field.model.objects.update
```

This was an issue with method binding (`field.model.objects.update` is bound to a queryset with no filtering). This could have been solved by binding the `.update` method to the `combined_updates` queryset however that introduced another error because of the `super()` calls in `AuditQuerySet.update`

## User Impact
Allow safe deletion of teams.