### PR TITLE
UI blitz

### DIFF
--- a/apps/experiments/tables.py
+++ b/apps/experiments/tables.py
@@ -22,8 +22,6 @@ class ExperimentTable(tables.Table):
     description = columns.Column(verbose_name="Description")
     owner = columns.Column(accessor="owner__username", verbose_name="Created By")
     type = columns.Column(orderable=False, empty_values=())
-    is_public = columns.BooleanColumn(verbose_name="Publically accessible", orderable=False, yesno="✓,")
-    is_archived = columns.BooleanColumn(verbose_name="Archived", yesno="✓,")
     actions = columns.TemplateColumn(
         template_name="experiments/components/experiment_actions_column.html",
     )
@@ -39,6 +37,11 @@ class ExperimentTable(tables.Table):
         }
         orderable = False
         empty_text = "No experiments found."
+
+    def render_name(self, record):
+        if record.is_archived:
+            return f"{record.name} (archived)"
+        return record.name
 
     def render_type(self, record):
         if record.assistant_id:

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -157,9 +157,12 @@ class ExperimentSessionsTableView(SingleTableView, PermissionRequiredMixin):
     permission_required = "annotations.view_customtaggeditem"
 
     def get_queryset(self):
-        query_set = ExperimentSession.objects.with_last_message_created_at().filter(
-            team=self.request.team, experiment__id=self.kwargs["experiment_id"]
+        query_set = (
+            ExperimentSession.objects.with_last_message_created_at()
+            .filter(team=self.request.team, experiment__id=self.kwargs["experiment_id"])
+            .select_related("participant__user")
         )
+
         if not self.request.GET.get("show-all"):
             query_set = query_set.exclude(experiment_channel__platform=ChannelPlatform.API)
 

--- a/apps/users/context_processors.py
+++ b/apps/users/context_processors.py
@@ -9,8 +9,11 @@ def user_teams(request):
     if current_team:
         other_membership = other_membership.exclude(team=current_team)
     return {
-        "other_teams": {
-            membership.team.name: membership.team.dashboard_url
-            for membership in other_membership.select_related("team")
-        }
+        "other_teams": sorted(
+            [
+                (membership.team.name, membership.team.dashboard_url)
+                for membership in other_membership.select_related("team")
+            ],
+            key=lambda x: x[0],
+        ),
     }

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -517,9 +517,9 @@ TAGGIT_CASE_INSENSITIVE = True
 # Documentation links
 DOCUMENTATION_LINKS = {
     # Try to make these keys grep-able so that usages are easy to find
-    "consent": "https://dimagi.atlassian.net/wiki/spaces/OCS/pages/2144305304/Consent+Forms+on+OCS",
+    "consent": "/concepts/consent/",
     "survey": "https://dimagi.atlassian.net/wiki/spaces/OCS/pages/2144305308/Surveys",
-    "experiment": "https://dimagi.atlassian.net/wiki/spaces/OCS/pages/2144305312/Creating+a+Chatbot+Experiment",
+    "experiment": "/concepts/experiment/",
     "concepts.prompt_variables": "/concepts/prompt_variables/",
     "concepts.experiments": "/concepts/experiment/",
 }

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -213,7 +213,7 @@
 
   <div role="tablist" class="tabs tabs-bordered">
     {% if perms.chat.view_chat %}
-      <input type="radio" name="tab_group" role="tab" class="tab" aria-label="All Sessions" id="tab-allsessions" checked/>
+      <input type="radio" name="tab_group" role="tab" class="tab" aria-label="Sessions" id="tab-allsessions" checked/>
       <div role="tabpanel" class="tab-content" id="content-allsessions">
         <div class="app-card">
           <div x-data="{tags: '', participant: null}">
@@ -257,46 +257,6 @@
         </div>
       </div>
     {% endif %}
-
-    <input type="radio" name="tab_group" role="tab" class="tab" aria-label="My Sessions" id="tab-mysessions" />
-    <div role="tabpanel" class="tab-content" id="content-mysessions">
-      <div class="app-card">
-        <div class="overflow-x-auto">
-          <table class="w-full table-fixed">
-            <thead class="bg-base-200 base-content uppercase text-sm leading-normal">
-              <tr>
-                <th class="px-3 py-3 text-left">Started</th>
-                <th class="px-3 py-3 text-left">Last Message</th>
-                <th class="px-3 py-3 text-left">Version</th>
-                <th class="px-3 py-3 text-left">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for session in user_sessions %}
-                <tr class="text-sm">
-                  <td class="overflow-hidden px-3 py-3 text-left">{{ session.created_at }}</td>
-                  <td class="overflow-hidden px-3 py-3 text-left">{{ session.last_message_created_at }}</td>
-                  <td class="overflow-hidden px-3 py-3 text-left">{{session.experiment_version_for_display }}</td>
-                  <td class="overflow-hidden px-3 py-3 text-left">
-                    {% if session.is_complete or not experiment.is_editable %}
-                      <a class="btn btn-sm btn-outline btn-primary"
-                         href="{% url 'experiments:experiment_session_view' team.slug experiment.public_id session.external_id %}"
-                         class="link">Review Chat</a>
-                    {% else %}
-                      <a class="btn btn-sm btn-outline btn-primary"
-                         href="{% url 'experiments:experiment_chat_session' team.slug experiment.id session.get_experiment_version_number session.id %}" class="link"
-                      >
-                        Continue Chat
-                      </a>
-                    {% endif %}
-                  </td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
 
     <input type="radio" name="tab_group" role="tab" class="tab" aria-label="Versions" id="tab-versions" />
     <div role="tabpanel" class="tab-content" id="content-versions">

--- a/templates/generic/action.html
+++ b/templates/generic/action.html
@@ -1,5 +1,5 @@
 {% if action_url %}
-  <a href="{{ action_url }}" class="btn btn-sm join-item {{ button_style|default_if_none:"btn-ghost" }}" {% if disabled %}disabled="disabled"{% endif %}>
+  <a href="{{ action_url }}" class="btn btn-sm join-item {{ button_style|default_if_none:"btn-ghost" }}" {% if disabled %}disabled="disabled"{% endif %} {% if title %}title="{{ title }}"{% endif %}>
     {{ label }}
     <i class="{{ icon_class }}"></i>
   </a>

--- a/templates/generic/object_home_content.html
+++ b/templates/generic/object_home_content.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% load django_tables2 %}
 <div class="app-card">
   <div class="grid grid-cols-6">
@@ -7,7 +8,10 @@
           <a href="#{{ title|slugify }}">{{ title }}</a>
         </h1>
         {% if info_link %}
-          <a class="mx-2 text-xs text-neutral-500" href="{{ info_link }}" target="_blank">Learn more <i class="text-xs fa-regular fa-circle-question"></i></a>
+          {% blocktranslate asvar help_text %}
+            <p><a class="link" href="{{ info_link }}" target="_blank">Learn more</a></p>
+          {% endblocktranslate %}
+          {% include "generic/help.html" with help_content=help_text %}
         {% endif %}
       </div>
       <span class="text-neutral-500">{{ subtitle }}</span>

--- a/templates/web/components/team_nav_items.html
+++ b/templates/web/components/team_nav_items.html
@@ -14,7 +14,7 @@
       <details>
         <summary>{% translate "Switch Team" %}</summary>
         <ul>
-          {% for name, url in other_teams.items %}
+          {% for name, url in other_teams %}
             <li>
               <a href="{{ url }}"><i class="fa fa-arrow-right"></i>{{ name }}</a>
             </li>


### PR DESCRIPTION
## Description
* Sort list of teams in "Switch Team" dropdown
* Update some help links
* Use the 'help' component for 'info links'
* Remove 'Is Public' and 'Archived' columns from the experiment table
  * Prepend an 'archived' icon to the name for archived experiments as a visual indicator
* Remove 'My Sessions' tab from the experiment home page & add a 'continue chat' button to the session list for sessions owned by the current user.

## Tech note
I've added a new CSS class "text-muted" which adjusts the `color` CSS property for the elements it's applied to based on the [currentColor](https://www.digitalocean.com/community/tutorials/css-currentcolor) of the element.


### Demo
**Archived Experiments**
![image](https://github.com/user-attachments/assets/5830e41a-7077-4d18-9a34-b58de8455934)

**Updated sessions table**
![image](https://github.com/user-attachments/assets/c8e89603-acd8-450d-a6d3-6ece71d7d941)


### Docs
<!--Link to documentation that has been updated.-->
