### PR TITLE
Hide the working version number

### DIFF
--- a/apps/experiments/tables.py
+++ b/apps/experiments/tables.py
@@ -183,9 +183,7 @@ class ExperimentVersionsTable(tables.Table):
         return record.created_at if record.working_version_id else ""
 
     def render_version_number(self, record):
-        if record.is_working_version:
-            return f"{record.version_number} (unreleased)"
-        return record.version_number
+        return "(unreleased)" if record.is_working_version else record.version_number
 
 
 def _get_route_url(url_name, request, record, value):


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Removed the version number of the unreleased version. In the office hours, people were being confused by the fact that the unreleased version had a number. There were questions about making changes and to which version that will belong to.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Hopefully this will mitigate confusion over which version changes belongs to

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![image](https://github.com/user-attachments/assets/b0e9dff9-cbbd-4567-beb1-5fa2fff69ffe)

### Docs
<!--Link to documentation that has been updated.-->
N/A