### PR TITLE
updates to attachment handling in pipelines

### DIFF
--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -17,7 +17,7 @@ class Attachment(BaseModel):
     file_id: int
     type: AttachmentType
     name: str
-    size: int
+    size: int = Field(..., ge=0)
     content_type: str = "application/octet-stream"
 
     upload_to_assistant: bool = False

--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -6,10 +6,25 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from apps.channels.models import ChannelPlatform
 from apps.chat.channels import MESSAGE_TYPES
 
+AttachmentType = Literal["code_interpreter", "file_search"]
+
 
 class Attachment(BaseModel):
     file_id: int
-    type: Literal["code_interpreter", "file_search"]
+    type: AttachmentType
+    name: str
+    size: int
+    content_type: str = Field(default="application/octet-stream")
+
+    @classmethod
+    def from_file(cls, file, type: AttachmentType):
+        return cls(
+            file_id=file.id,
+            type=type,
+            name=file.name,
+            size=file.content_size,
+            content_type=file.content_type,
+        )
 
 
 class BaseMessage(BaseModel):
@@ -18,7 +33,7 @@ class BaseMessage(BaseModel):
     participant_id: str
     message_text: str
     content_type: MESSAGE_TYPES | None = Field(default=MESSAGE_TYPES.TEXT)
-    attachments: list[Attachment] = Field(default={})
+    attachments: list[Attachment] = Field(default=[])
 
 
 class TelegramMessage(BaseMessage):

--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -55,6 +55,7 @@ class Attachment(BaseModel):
 
     def read_string(self):
         # TODO: error handling for read errors or decode errors
+        # TODO: large file handling (maybe limit file size?)
         content = self.read_bytes()
         return content.decode("utf-8")
 

--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -26,6 +26,10 @@ class Attachment(BaseModel):
             content_type=file.content_type,
         )
 
+    @property
+    def id(self):
+        return self.file_id
+
 
 class BaseMessage(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import Literal
 
 import phonenumbers
@@ -33,6 +34,23 @@ class Attachment(BaseModel):
     @property
     def id(self):
         return self.file_id
+
+    @cached_property
+    def _file(self):
+        from apps.files.models import File
+
+        try:
+            return File.objects.get(id=self.file_id)
+        except File.DoesNotExist:
+            return None
+
+    def read_bytes(self):
+        if not self._file:
+            return b""
+        return self._file.file.read()
+
+    def read_string(self):
+        return self.read_bytes().decode("utf-8")
 
 
 class BaseMessage(BaseModel):

--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -14,7 +14,11 @@ class Attachment(BaseModel):
     type: AttachmentType
     name: str
     size: int
-    content_type: str = Field(default="application/octet-stream")
+    content_type: str = "application/octet-stream"
+
+    upload_to_assistant: bool = False
+    """Setting this to True will cause the Assistant Node to send the attachment
+    as a file attachment with the message."""
 
     @classmethod
     def from_file(cls, file, type: AttachmentType):

--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import phonenumbers
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -7,7 +9,7 @@ from apps.chat.channels import MESSAGE_TYPES
 
 class Attachment(BaseModel):
     file_id: int
-    type: str
+    type: Literal["code_interpreter", "file_search"]
 
 
 class BaseMessage(BaseModel):

--- a/apps/events/tests/test_actions.py
+++ b/apps/events/tests/test_actions.py
@@ -65,7 +65,11 @@ def test_end_conversation_runs_pipeline(session, pipeline):
                 "end": {"message": f"human: {input}"},
             },
             "experiment_session": session.id,
-            "shared_state": {"user_input": output_message, "outputs": {"start": output_message, "end": output_message}},
+            "shared_state": {
+                "user_input": output_message,
+                "attachments": [],
+                "outputs": {"start": output_message, "end": output_message},
+            },
         }
     )
     assert pipeline.runs.count() == 1

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -67,8 +67,7 @@ def get_response_for_webchat_task(
         )
         message_attachments = []
         for file_entry in attachments:
-            type, file_id = file_entry.values()
-            message_attachments.append(Attachment(file_id=file_id, type=type))
+            message_attachments.append(Attachment.model_validate(file_entry))
 
         message = BaseMessage(
             participant_id=experiment_session.participant.identifier,

--- a/apps/experiments/tests/test_get_response_for_webchat_task.py
+++ b/apps/experiments/tests/test_get_response_for_webchat_task.py
@@ -1,0 +1,28 @@
+import pytest
+
+from apps.experiments.tasks import get_response_for_webchat_task
+from apps.utils.factories.experiment import ExperimentSessionFactory
+from apps.utils.langchain import mock_experiment_llm
+
+
+@pytest.fixture()
+def session():
+    return ExperimentSessionFactory()
+
+
+@pytest.mark.django_db()
+def test_get_response_for_webchat_task(session):
+    """Basic test for the code in the task. Not intended to test the functions called in the task."""
+    with mock_experiment_llm(None, responses=["how can I help?"]):
+        response = get_response_for_webchat_task(
+            session.id,
+            session.experiment.id,
+            "Hi",
+            [
+                {"file_id": 1, "type": "code_interpreter"},
+                {"file_id": 2, "type": "file_search"},
+            ],
+        )
+    assert response["response"] == "how can I help?"
+    assert response["message_id"] is not None
+    assert response["error"] is None

--- a/apps/experiments/tests/test_get_response_for_webchat_task.py
+++ b/apps/experiments/tests/test_get_response_for_webchat_task.py
@@ -1,5 +1,6 @@
 import pytest
 
+from apps.channels.datamodels import Attachment
 from apps.experiments.tasks import get_response_for_webchat_task
 from apps.utils.factories.experiment import ExperimentSessionFactory
 from apps.utils.langchain import mock_experiment_llm
@@ -13,15 +14,14 @@ def session():
 @pytest.mark.django_db()
 def test_get_response_for_webchat_task(session):
     """Basic test for the code in the task. Not intended to test the functions called in the task."""
+
+    attachments = [
+        Attachment(file_id=1, type="code_interpreter", name="code.py", size=100),
+        Attachment(file_id=2, type="file_search", name="file_search.json", size=100),
+    ]
     with mock_experiment_llm(None, responses=["how can I help?"]):
         response = get_response_for_webchat_task(
-            session.id,
-            session.experiment.id,
-            "Hi",
-            [
-                {"file_id": 1, "type": "code_interpreter"},
-                {"file_id": 2, "type": "file_search"},
-            ],
+            session.id, session.experiment.id, "Hi", [att.model_dump() for att in attachments]
         )
     assert response["response"] == "how can I help?"
     assert response["message_id"] is not None

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -2,6 +2,7 @@ import json
 import logging
 import uuid
 from datetime import datetime
+from typing import cast
 from urllib.parse import quote
 
 import jwt
@@ -32,6 +33,7 @@ from waffle import flag_is_active
 
 from apps.annotations.models import Tag
 from apps.assistants.sync import get_diff_with_openai_assistant, get_out_of_sync_files
+from apps.channels.datamodels import Attachment, AttachmentType
 from apps.channels.exceptions import ExperimentChannelException
 from apps.channels.forms import ChannelForm
 from apps.channels.models import ChannelPlatform, ExperimentChannel
@@ -917,7 +919,7 @@ def experiment_session_message(request, team_slug: str, experiment_id: uuid.UUID
         )
         for uploaded_file in uploaded_files.getlist(resource_type):
             new_file = File.objects.create(name=uploaded_file.name, file=uploaded_file, team=request.team)
-            attachments.append({"type": resource_type, "file_id": new_file.id})
+            attachments.append(Attachment.from_file(new_file, cast(AttachmentType, resource_type)))
             created_files.append(new_file)
 
         tool_resource.files.add(*created_files)
@@ -929,7 +931,7 @@ def experiment_session_message(request, team_slug: str, experiment_id: uuid.UUID
         experiment_session_id=session.id,
         experiment_id=experiment_version.id,
         message_text=message_text,
-        attachments=attachments,
+        attachments=[att.model_dump() for att in attachments],
     )
     version_specific_vars = {
         "assistant": experiment_version.get_assistant(),

--- a/apps/pipelines/logging.py
+++ b/apps/pipelines/logging.py
@@ -4,19 +4,14 @@ from langchain_core.callbacks import BaseCallbackHandler
 from loguru import logger
 
 
-class PipelineLoggingCallbackHandler(BaseCallbackHandler):
-    """Handles logging within the pipeline
-
-    Since Langchain / Langgraph runs in separate threads, we append to a list
-    in a thread-safe manner, then periodically write to the DB later.
-
-    """
-
-    def __init__(self, pipeline_run, verbose=False) -> None:
-        self.pipeline_run = pipeline_run
-        self.logger = get_logger(uuid.uuid4().hex, self.pipeline_run)
+class LoggingCallbackHandler(BaseCallbackHandler):
+    def __init__(self, verbose=False) -> None:
         self.verbose = verbose
         self._run_id_names = {}
+        self._init_get_logger()
+
+    def _init_get_logger(self):
+        self.logger, self.log_entries = noop_logger()
 
     def _should_log(self, kwargs):
         """We only log steps that are defined nodes inside of the pipeline.
@@ -65,13 +60,32 @@ class PipelineLoggingCallbackHandler(BaseCallbackHandler):
             )
 
     def on_chain_error(self, error, *args, **kwargs):
-        from apps.pipelines.models import PipelineRunStatus
-
-        self.pipeline_run.status = PipelineRunStatus.ERROR
         self.logger.error(error)
 
 
-def get_logger(name, pipeline_run):
+class PipelineLoggingCallbackHandler(LoggingCallbackHandler):
+    """Handles logging within the pipeline
+
+    Since Langchain / Langgraph runs in separate threads, we append to a list
+    in a thread-safe manner, then periodically write to the DB later.
+
+    """
+
+    def __init__(self, pipeline_run, verbose=False) -> None:
+        self.pipeline_run = pipeline_run
+        super().__init__(verbose)
+
+    def _init_get_logger(self):
+        self.logger = get_logger(uuid.uuid4().hex, self.pipeline_run)
+
+    def on_chain_error(self, error, *args, **kwargs):
+        from apps.pipelines.models import PipelineRunStatus
+
+        self.pipeline_run.status = PipelineRunStatus.ERROR
+        super().on_chain_error(error, *args, **kwargs)
+
+
+def get_logger(name, pipeline_run) -> logger:
     log = logger.bind(name=name)
     log.level("DEBUG")
     log.remove()
@@ -79,15 +93,18 @@ def get_logger(name, pipeline_run):
     return log
 
 
-def noop_logger():
+def noop_logger() -> tuple[logger, list]:
     log = logger.bind(name=uuid.uuid4().hex)
+    log.level("DEBUG")
     log.remove()
-    return log
+    handler = MemLogHandler()
+    log.add(handler)
+    return log, handler.entries
 
 
-class LogHandler:
-    def __init__(self, pipeline_run):
-        self.pipeline_run = pipeline_run
+class MemLogHandler:
+    def __init__(self):
+        self.entries = []
 
     def __call__(self, message):
         from apps.pipelines.models import LogEntry
@@ -105,6 +122,18 @@ class LogHandler:
                 "input": str(input) if input else None,
             }
         )
+        self._save(log_entry)
+
+    def _save(self, entry):
+        self.entries.append(entry)
+
+
+class LogHandler(MemLogHandler):
+    def __init__(self, pipeline_run):
+        super().__init__()
+        self.pipeline_run = pipeline_run
+
+    def _save(self, entry):
         # Appending to a list is thread safe in python
-        self.pipeline_run.log["entries"].append(log_entry.model_dump())
+        self.pipeline_run.log["entries"].append(entry.model_dump())
         self.pipeline_run.save()

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -3,7 +3,7 @@ from abc import ABC
 from collections.abc import Sequence
 from enum import StrEnum
 from functools import cached_property
-from typing import Annotated, Any, Literal, Self
+from typing import Annotated, Any, Literal, Self, TypedDict
 
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -40,12 +40,18 @@ def add_shared_state_messages(left: dict, right: dict):
     return output
 
 
+class SharedState(TypedDict):
+    user_input: str
+    outputs: dict
+    attachments: list
+
+
 class PipelineState(dict):
     messages: Annotated[Sequence[Any], operator.add]
     outputs: Annotated[dict, add_messages]
     experiment_session: ExperimentSession
     pipeline_version: int
-    shared_state: Annotated[dict, add_shared_state_messages]
+    shared_state: Annotated[SharedState, add_shared_state_messages]
     ai_message_id: int | None = None
     message_metadata: dict | None = None
     attachments: list = Field(default=[])

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -108,7 +108,10 @@ class PipelineNode(BaseModel, ABC):
                 break
         else:  # This is the first node in the graph
             input = state["messages"][-1]
+
+            # init shared state here to avoid having to do it in each place the pipeline is invoked
             state["shared_state"]["user_input"] = input
+            state["shared_state"]["attachments"] = [{"id": att["file_id"]} for att in state.get("attachments", [])]
         return self._process(input=input, state=state, node_id=node_id)
 
     def process_conditional(self, state: PipelineState, node_id: str | None = None) -> str:

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -3,11 +3,12 @@ from abc import ABC
 from collections.abc import Sequence
 from enum import StrEnum
 from functools import cached_property
-from typing import Annotated, Any, Literal, Self, TypedDict
+from typing import Annotated, Any, Literal, Self
 
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.config import JsonDict
+from typing_extensions import TypedDict
 
 from apps.experiments.models import ExperimentSession
 from apps.pipelines.logging import LoggingCallbackHandler, noop_logger

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.config import JsonDict
 
 from apps.experiments.models import ExperimentSession
-from apps.pipelines.logging import PipelineLoggingCallbackHandler, noop_logger
+from apps.pipelines.logging import LoggingCallbackHandler, noop_logger
 
 
 def add_messages(left: dict, right: dict):
@@ -136,9 +136,9 @@ class PipelineNode(BaseModel, ABC):
     @cached_property
     def logger(self):
         for handler in self._config["callbacks"].handlers:
-            if isinstance(handler, PipelineLoggingCallbackHandler):
+            if isinstance(handler, LoggingCallbackHandler):
                 return handler.logger
-        return noop_logger()
+        return noop_logger()[0]
 
 
 class Widgets(StrEnum):

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -773,9 +773,10 @@ class CodeNode(PipelineNode):
 
         custom_locals = {}
         custom_globals = self._get_custom_globals(state)
+        kwargs = {"logger": self.logger}
         try:
             exec(byte_code, custom_globals, custom_locals)
-            result = str(custom_locals[function_name](input))
+            result = str(custom_locals[function_name](input, **kwargs))
         except Exception as exc:
             raise PipelineNodeRunError(exc) from exc
         return PipelineState.from_node_output(node_name=self.name, node_id=node_id, output=result)

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -21,7 +21,6 @@ from pydantic_core.core_schema import FieldValidationInfo
 from RestrictedPython import compile_restricted, safe_builtins, safe_globals
 
 from apps.assistants.models import OpenAiAssistant
-from apps.channels.datamodels import Attachment
 from apps.chat.agent.tools import get_node_tools
 from apps.chat.conversation import compress_chat_history, compress_pipeline_chat_history
 from apps.chat.models import ChatMessageType
@@ -682,9 +681,7 @@ class AssistantNode(PipelineNode):
 
         session: ExperimentSession | None = state.get("experiment_session")
         runnable = self._get_assistant_runnable(assistant, session=session, node_id=node_id)
-        attachments = [Attachment.model_validate(params) for params in state.get("attachments", [])]
-        if for_upload := state.get("shared_state", {}).get("attachments_to_upload", []):
-            attachments = [att for att in attachments if att["file_id"] in for_upload]
+        attachments = self._get_attachments(state)
         chain_output: ChainOutput = runnable.invoke(input, config={}, attachments=attachments)
         output = chain_output.output
 
@@ -697,6 +694,9 @@ class AssistantNode(PipelineNode):
                 "output": runnable.adapter.get_message_metadata(ChatMessageType.AI),
             },
         )
+
+    def _get_attachments(self, state) -> list:
+        return [att for att in state.get("shared_state", {}).get("attachments", []) if att.upload_to_assistant]
 
     def _get_assistant_runnable(self, assistant: OpenAiAssistant, session: ExperimentSession, node_id: str):
         history_manager = PipelineHistoryManager.for_assistant()

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -683,6 +683,8 @@ class AssistantNode(PipelineNode):
         session: ExperimentSession | None = state.get("experiment_session")
         runnable = self._get_assistant_runnable(assistant, session=session, node_id=node_id)
         attachments = [Attachment.model_validate(params) for params in state.get("attachments", [])]
+        if for_upload := state.get("shared_state", {}).get("attachments_to_upload", []):
+            attachments = [att for att in attachments if att["file_id"] in for_upload]
         chain_output: ChainOutput = runnable.invoke(input, config={}, attachments=attachments)
         output = chain_output.output
 

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -815,7 +815,7 @@ class CodeNode(PipelineNode):
 
     def _set_state_key(self, state: PipelineState):
         def set_state_key(key_name: str, value):
-            if key_name in {"user_input", "outputs"}:
+            if key_name in {"user_input", "outputs", "attachments"}:
                 raise PipelineNodeRunError(f"Cannot set the '{key_name}' key of the shared state")
             state["shared_state"][key_name] = value
 

--- a/apps/pipelines/tests/test_pipeline_runs.py
+++ b/apps/pipelines/tests/test_pipeline_runs.py
@@ -44,7 +44,7 @@ def test_running_pipeline_creates_run(pipeline: Pipeline, session: ExperimentSes
             pipeline.node_ids[0]: {"message": "foo"},
             pipeline.node_ids[1]: {"message": "foo"},
         },
-        shared_state={"outputs": {"end": "foo", "start": "foo"}, "user_input": "foo"},
+        shared_state={"outputs": {"end": "foo", "start": "foo"}, "user_input": "foo", "attachments": []},
     )
 
     assert len(run.log["entries"]) == 8

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -300,6 +300,10 @@ def test_assistant_runnable_cancels_existing_run(save_response_annotations, resp
 @patch("openai.resources.beta.threads.messages.Messages.list")
 @patch("openai.resources.beta.threads.runs.Runs.retrieve")
 @patch("openai.resources.beta.Threads.create_and_run")
+@patch(
+    "apps.service_providers.llm_service.runnables.AssistantChat._get_output_with_annotations",
+    new=Mock(return_value=("ai response", {})),
+)
 def test_assistant_uploads_new_file(create_and_run, retrieve_run, list_messages, create_files_remote, db_session):
     """Test that attachments are uploaded to OpenAI and that its remote file ids are stored on the chat message"""
     session = db_session
@@ -318,8 +322,8 @@ def test_assistant_uploads_new_file(create_and_run, retrieve_run, list_messages,
 
     assistant = create_experiment_runnable(session.experiment, session)
     attachments = [
-        Attachment(type="code_interpreter", file_id=files[0].id),
-        Attachment(type="file_search", file_id=files[1].id),
+        Attachment.from_file(files[0], "code_interpreter"),
+        Attachment.from_file(files[1], "file_search"),
     ]
 
     result = assistant.invoke("test", attachments=attachments)


### PR DESCRIPTION
Resolves https://github.com/dimagi/open-chat-studio/issues/1039

## Description
From the ticket:

* Attachments are exposed via the `attachments` key in `shared_state`:

```python
get_state_key("attachments")
```

This will return a list of [attachment objects](https://github.com/dimagi/open-chat-studio/blob/ebf965e34e48ac0d846390c69f6be3eca7877ff4/apps/channels/datamodels.py#L12)
 
* Assistant node won't attach media to threads by default
* Users will need to use a code node to specify which attachments to upload

```python
for att in get_state_key("attachments"):
    att.upload_to_assistant = True
```

In addition, the attachment content should be accessible in the Python Node:

```python
def main(input, **kwargs):
    attachment = get_state_key("attachments")[0]
    file_content = attachment.read_string()
    return f'Here is the file content {file_content}'
```

## User Impact
Bot authors have full control over how attachments are handled and can access attachment data via the python node.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->
