### PR TITLE
Fix: Populate the node assistant's trace service with the existing callback

### DIFF
--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -101,7 +101,9 @@ class PipelineNode(BaseModel, ABC):
     _config: RunnableConfig | None = None
     name: str = Field(title="Node Name", json_schema_extra={"ui:widget": "node_name"})
 
-    def process(self, node_id: str, incoming_edges: list, state: PipelineState, config) -> PipelineState:
+    def process(
+        self, node_id: str, incoming_edges: list, state: PipelineState, config: RunnableConfig
+    ) -> PipelineState:
         from apps.channels.datamodels import Attachment
 
         self._config = config

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -700,7 +700,7 @@ class AssistantNode(PipelineNode):
 
     def _get_assistant_runnable(self, assistant: OpenAiAssistant, session: ExperimentSession, node_id: str):
         trace_service = session.experiment.trace_service
-        trace_service.from_callback_manager(self._config.get("callbacks"))
+        trace_service.initialize_from_callback_manager(self._config.get("callbacks"))
 
         history_manager = PipelineHistoryManager.for_assistant()
         adapter = AssistantAdapter.for_pipeline(session=session, node=self, trace_service=trace_service)

--- a/apps/service_providers/llm_service/adapters.py
+++ b/apps/service_providers/llm_service/adapters.py
@@ -180,15 +180,14 @@ class AssistantAdapter(BaseAdapter):
         )
 
     @staticmethod
-    def for_pipeline(session: ExperimentSession, node: "AssistantNode") -> Self:
+    def for_pipeline(session: ExperimentSession, node: "AssistantNode", trace_service=None) -> Self:
         assistant = OpenAiAssistant.objects.get(id=node.assistant_id)
-        experiment = session.experiment
         return AssistantAdapter(
             session=session,
             assistant=assistant,
             citations_enabled=node.citations_enabled,
             input_formatter=node.input_formatter,
-            trace_service=experiment.trace_service,
+            trace_service=trace_service,
             save_message_metadata_only=True,
         )
 

--- a/apps/service_providers/tracing/service.py
+++ b/apps/service_providers/tracing/service.py
@@ -30,7 +30,7 @@ class TraceService:
     def get_current_trace_info(self) -> TraceInfo | None:
         return None
 
-    def from_callback_manager(self, callback_manager: CallbackManager):
+    def initialize_from_callback_manager(self, callback_manager: CallbackManager):
         pass
 
 
@@ -55,7 +55,7 @@ class LangFuseTraceService(TraceService):
         self._callback = CallbackHandler(user_id=participant_id, session_id=session_id, **self.config)
         return self._callback
 
-    def from_callback_manager(self, callback_manager: CallbackManager):
+    def initialize_from_callback_manager(self, callback_manager: CallbackManager):
         """
         Populates the callback from the callback handler already configured in `callback_manager`. This allows the trace
         service to reuse existing callbacks.

--- a/apps/service_providers/tracing/service.py
+++ b/apps/service_providers/tracing/service.py
@@ -1,3 +1,4 @@
+from langchain_core.callbacks.manager import CallbackManager
 from langchain_core.tracers import LangChainTracer
 from pydantic import BaseModel
 
@@ -29,6 +30,9 @@ class TraceService:
     def get_current_trace_info(self) -> TraceInfo | None:
         return None
 
+    def from_callback_manager(self, callback_manager: CallbackManager):
+        pass
+
 
 class LangFuseTraceService(TraceService):
     """
@@ -50,6 +54,17 @@ class LangFuseTraceService(TraceService):
 
         self._callback = CallbackHandler(user_id=participant_id, session_id=session_id, **self.config)
         return self._callback
+
+    def from_callback_manager(self, callback_manager: CallbackManager):
+        """
+        Populates the callback from the callback handler already configured in `callback_manager`. This allows the trace
+        service to reuse existing callbacks.
+        """
+        from langfuse.callback import CallbackHandler
+
+        for handler in callback_manager.handlers:
+            if isinstance(handler, CallbackHandler):
+                self._callback = handler
 
     def update_trace(self, metadata: dict):
         if not metadata:


### PR DESCRIPTION
resolves #1088 

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
The issue was that the `trace_service` gets initialized [here](https://github.com/dimagi/open-chat-studio/blob/17924881036c4e579a8d45f98540f987e62c062d/apps/pipelines/models.py#L220), but only callback is being passed in as config to the runnable. When we initialize the `AssistantAdapter` for the pipeline (see [here](https://github.com/dimagi/open-chat-studio/blob/5f589856a6e01a502af3ab5e7ef6ed943243787a/apps/service_providers/llm_service/adapters.py#L191)), we fetch a fresh instance of the tracing service, but uninitialized.

The idea behind the PR is to essentially initialize the tracing service with the existing callback that already has a trace that we can piggyback on.

We don't have to do this for the `LLMResponseWithPrompt` node, because it's not trying to update the trace with extra metadata as the assistant node is doing.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users would be able to use langfuse tracing services with pipeline assistants.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs
<!--Link to documentation that has been updated.-->
N/A