### PR TITLE
Nested diffs | last phase 

### DIFF
--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -315,7 +315,6 @@ class TimeoutTrigger(BaseModel, VersionsMixin):
     @property
     def version_details(self) -> VersionDetails:
         event_action_type = EventActionType(self.action.action_type).label
-        event_action_type = EventActionType(self.action.action_type).label
         group_name = event_action_type
 
         action_param_versions = [VersionField(group_name=group_name, name="action", raw_value=event_action_type)]

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -312,6 +312,25 @@ class TimeoutTrigger(BaseModel, VersionsMixin):
     def get_fields_to_exclude(self):
         return super().get_fields_to_exclude() + ["action", "experiment", "event_logs"]
 
+    @property
+    def version_details(self) -> VersionDetails:
+        event_action_type = EventActionType(self.action.action_type).label
+        event_action_type = EventActionType(self.action.action_type).label
+        group_name = event_action_type
+
+        action_param_versions = [VersionField(group_name=group_name, name="action", raw_value=event_action_type)]
+        for name, value in self.action.params.items():
+            action_param_versions.append(VersionField(group_name=group_name, name=name, raw_value=value))
+
+        return VersionDetails(
+            instance=self,
+            fields=[
+                VersionField(group_name=group_name, name="delay", raw_value=self.delay),
+                VersionField(group_name=group_name, name="total_num_triggers", raw_value=self.total_num_triggers),
+                *action_param_versions,
+            ],
+        )
+
 
 class TimePeriod(models.TextChoices):
     MINUTES = ("minutes", "Minutes")

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1238,8 +1238,8 @@ class ExperimentRoute(BaseTeamModel, VersionsMixin):
         return VersionDetails(
             instance=self,
             fields=[
-                VersionField(group_name="General", name="keyword", raw_value=self.keyword),
-                VersionField(group_name="General", name="child", raw_value=self.child),
+                VersionField(group_name=self.keyword, name="keyword", raw_value=self.keyword),
+                VersionField(group_name=self.keyword, name="child", raw_value=self.child),
             ],
         )
 

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1196,43 +1196,35 @@ class ExperimentRoute(BaseTeamModel, VersionsMixin):
     @transaction.atomic()
     def create_new_version(self, new_parent: Experiment) -> "ExperimentRoute":
         """
-        Strategy for handling child versions:
-
-        1. If the child is already a version:
-        - Do not create a new child version.
-
-        2. If the child is a working version, verify whether the latest version of the child:
-        - Is identical to the current one, and
-        - Belongs to the same version family.
-
-        - If both conditions are met, reuse the latest version of the child.
-        - Otherwise, proceed to create a new version.
+        Strategy:
+        - If the current child doesn't have any versions, create a new child version for the new route version
+        - If the current child have versions and there are changes between the current child and its latest version,
+            a new child version should be created for the new route version
+        - Alternatively, if there are were changes made since the last child version were made, use the latest version
+            for the new route version
         """
 
-        new_instance = super().create_new_version(save=False)
-        new_instance.parent = new_parent
-        if not new_instance.child.is_a_version:
-            # TODO: The user must be notified and give consent to us doing this. Ignore for now
-            latest_child_version: ExperimentRoute | None = new_instance.child.latest_version
+        new_route = super().create_new_version(save=False)
+        new_route.parent = new_parent
+        new_route.child = None
+        working_child = self.child
 
-            if latest_child_version:
-                # Compare experimens using their `version` instances for a comprehensive comparison
-                child_version = self.child.version_details
-                latest_version = latest_child_version.version_details
-                child_version.compare(latest_version)
+        if latest_child_version := working_child.latest_version:
+            # Compare experimens using their `version` instances for a comprehensive comparison
+            current_version_details: VersionDetails = working_child.version_details
+            current_version_details.compare(latest_child_version.version_details)
 
-                if not child_version.fields_changed:
-                    new_child = latest_child_version
-                else:
-                    fields_changed = [f.name for f in child_version.fields if f.changed]
-                    description = self._generate_version_description(fields_changed)
-                    new_child = new_instance.child.create_new_version(version_description=description)
+            if current_version_details.fields_changed:
+                fields_changed = [f.name for f in current_version_details.fields if f.changed]
+                description = self._generate_version_description(fields_changed)
+                new_route.child = working_child.create_new_version(version_description=description)
             else:
-                new_child = new_instance.child.create_new_version(self._generate_version_description())
+                new_route.child = latest_child_version
+        else:
+            new_route.child = working_child.create_new_version()
 
-            new_instance.child = new_child
-        new_instance.save()
-        return new_instance
+        new_route.save()
+        return new_route
 
     def _generate_version_description(self, changed_fields: set | None = None) -> str:
         description = "Auto created when the parent experiment was versioned"
@@ -1241,44 +1233,15 @@ class ExperimentRoute(BaseTeamModel, VersionsMixin):
             description = f"{description} since {changed_fields} changed."
         return description
 
-    def compare_with_model(self, route: "ExperimentRoute", exclude_fields, early_abort=False):
-        """
-        When comparing two ExperimentRoute versions (with the same parents), consider the following:
-
-        1. The child of one version may belong to a different family than the child of the other version.
-
-        2. If both children belong to the same family:
-        - 2.1. If the version numbers are the same, the child has not changed.
-        - 2.2. If the version numbers differ:
-            - 2.2.1. If both are versions, then they are considered different.
-            - 2.2.2. If one of them is a working version, verify if any changes have occurred in the working version
-                    since the version was created. Some fields are not applicable to the child and can be ignored
-                    when calculating changes.
-        """
-        is_same_family = self.get_working_version() == route.get_working_version()
-        if not is_same_family:
-            return super().compare_with_model(route, exclude_fields, early_abort=early_abort)
-
-        fields_to_exclude = exclude_fields.copy()
-        fields_to_exclude.extend(["parent"])
-
-        if not (self.child == route.child.get_working_version() or self.child.get_working_version() == route.child):
-            return super().compare_with_model(route, fields_to_exclude, early_abort=early_abort)
-
-        fields_to_exclude.append("child")
-        # Compare all other fields first
-        results = list(super().compare_with_model(route, fields_to_exclude, early_abort=early_abort))
-        if early_abort and results:
-            return set(results)
-
-        # Now compare the children
-        version1 = self.child.version_details
-        version2 = route.child.version_details
-        version1.compare(version2, early_abort=early_abort)
-        child_changes = [field.name for field in version1.fields if field.changed]
-
-        results.extend(list(child_changes))
-        return set(results)
+    @property
+    def version_details(self) -> VersionDetails:
+        return VersionDetails(
+            instance=self,
+            fields=[
+                VersionField(group_name="General", name="keyword", raw_value=self.keyword),
+                VersionField(group_name="General", name="child", raw_value=self.child),
+            ],
+        )
 
     class Meta:
         constraints = [

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -98,6 +98,17 @@ class VersionFieldDisplayFormatters:
         return template.render({"chip": Chip(label=name, url=url)})
 
     @staticmethod
+    def format_pipeline(pipeline) -> str:
+        if not pipeline:
+            return ""
+        name = pipeline.name.split(f" v{pipeline.version_number}")[0]
+        template = get_template("generic/chip.html")
+        url = (
+            pipeline.get_absolute_url() if pipeline.is_working_version else pipeline.working_version.get_absolute_url()
+        )
+        return template.render({"chip": Chip(label=name, url=url)})
+
+    @staticmethod
     def format_builtin_tools(tools: set) -> str:
         """code_interpreter, file_search -> Code Interpreter, File Search"""
         return ", ".join([tool.replace("_", " ").capitalize() for tool in tools])
@@ -1068,7 +1079,12 @@ class Experiment(BaseTeamModel, VersionsMixin, CustomActionOperationMixin):
                     raw_value=self.assistant,
                     to_display=VersionFieldDisplayFormatters.format_assistant,
                 ),
-                VersionField(group_name="Pipeline", name="pipeline", raw_value=self.pipeline),
+                VersionField(
+                    group_name="Pipeline",
+                    name="pipeline",
+                    raw_value=self.pipeline,
+                    to_display=VersionFieldDisplayFormatters.format_pipeline,
+                ),
                 VersionField(group_name="Tracing", name="tracing_provider", raw_value=self.trace_provider),
                 # Triggers
                 VersionField(

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -37,8 +37,6 @@ from apps.utils.factories.experiment import (
 from apps.utils.factories.files import FileFactory
 from apps.utils.factories.pipelines import NodeFactory, PipelineFactory
 from apps.utils.factories.service_provider_factories import (
-    LlmProviderFactory,
-    LlmProviderModelFactory,
     VoiceProviderFactory,
 )
 from apps.utils.factories.team import TeamFactory
@@ -531,48 +529,48 @@ class TestSourceMaterialVersioning:
 
 @pytest.mark.django_db()
 class TestExperimentRouteVersioning:
-    @pytest.mark.parametrize("child_has_versions", [True, False])
-    def test_child_is_working_with_changes_creates_new_version(self, child_has_versions):
+    def _setup_route(self):
         parent_exp = ExperimentFactory()
         team = parent_exp.team
-        working_child = ExperimentFactory(team=team, prompt_text="some prompt")
-        working_route = ExperimentRoute.objects.create(
-            team=team, parent=parent_exp, child=working_child, keyword="testing"
-        )
+        child_exp = ExperimentFactory(team=team)
+        exp_route = ExperimentRoute.objects.create(team=team, parent=parent_exp, child=child_exp, keyword="testing")
+        return child_exp, exp_route
 
-        if child_has_versions:
-            working_child.create_new_version()
-            # Update the working version so there are changes
-            working_child.prompt_text = "a new prompt"
-            working_child.save()
+    def test_child_without_versions(self):
+        """
+        When the child doesn't have a version then we expect a new version to be created for the new route version.
+        """
+        child_exp, exp_route = self._setup_route()
+        route_version = exp_route.create_new_version(new_parent=ExperimentFactory(team=exp_route.team))
 
-        versioned_route = working_route.create_new_version(new_parent=ExperimentFactory(team=team))
-        expected_difference = set(["id", "parent_id", "child_id"])
-        _compare_models(working_route, versioned_route, expected_changed_fields=expected_difference)
-        assert versioned_route.child != working_child
-        assert versioned_route.child.working_version == working_child
+        assert route_version.child == child_exp.latest_version
 
-    def test_versioned_child_is_reused(self):
-        working_route, versioned_route = self._setup_versioned_experiment_route(child_bot="child")
-        expected_difference = set(["id", "parent_id"])
-        _compare_models(working_route, versioned_route, expected_changed_fields=expected_difference)
-        assert versioned_route.child == working_route.child
+    def test_child_with_changes_since_latest_version(self):
+        """
+        When the child have a version, but also changed since the latest version, then we expect a new version to be
+        created for the new route version.
+        """
+        child_exp, exp_route = self._setup_route()
 
-    def test_working_child_without_changes_uses_latest_version(self):
-        working_route, versioned_route = self._setup_versioned_experiment_route(child_bot="working")
-        expected_difference = set(["id", "parent_id", "child_id"])
-        _compare_models(working_route, versioned_route, expected_changed_fields=expected_difference)
-        assert versioned_route.child == working_route.child.latest_version
+        # Create a version of the child
+        first_child_version = child_exp.create_new_version()
+        # Changes since the last version
+        child_exp.prompt_text = "New prompt"
 
-    def _setup_versioned_experiment_route(self, child_bot: str):
-        parent_exp = ExperimentFactory()
-        team = parent_exp.team
-        working_child = ExperimentFactory(team=team)
-        child_version = working_child.create_new_version()
-        child_bot = working_child if child_bot == "working" else child_version
-        working_route = ExperimentRoute.objects.create(team=team, parent=parent_exp, child=child_bot, keyword="testing")
-        version = working_route.create_new_version(new_parent=ExperimentFactory(team=team))
-        return working_route, version
+        # This should create a new version of the child as well
+        route_version = exp_route.create_new_version(new_parent=ExperimentFactory(team=exp_route.team))
+        assert child_exp.latest_version != first_child_version
+        assert route_version.child == child_exp.latest_version
+
+    def test_child_with_no_changes_since_latest_version(self):
+        """When the child has a version and there are no changes between that version and the working version, then the
+        latest version should be used for the new route version.
+        """
+        child_exp, exp_route = self._setup_route()
+        # First create a version of the child
+        child_version = child_exp.create_new_version()
+        route_version = exp_route.create_new_version(new_parent=ExperimentFactory(team=exp_route.team))
+        assert route_version.child == child_version
 
 
 @pytest.mark.django_db()
@@ -593,60 +591,6 @@ class TestExperimentRoute:
         queryset = ExperimentRoute.eligible_children(team=parent.team)
         assert len(queryset) == 3
 
-    def test_compare_with_model_testcase_1(self):
-        """
-        One child is a working version and the other is a version of that working version
-        """
-        # 1. The children of both route versions are family with one being the working version
-        # 1.1. No changes between the working and versioned child
-        parent = ExperimentFactory()
-        versioned_parent = parent.create_new_version()
-        child = ExperimentFactory(team=parent.team)
-        versioned_child = child.create_new_version()
-        route = ExperimentRoute.objects.create(parent=parent, child=child, keyword="test", team=parent.team)
-        route2 = ExperimentRoute.objects.create(
-            parent=versioned_parent, child=versioned_child, keyword="test", team=parent.team, working_version=route
-        )
-        changes = route.compare_with_model(route2, exclude_fields=route2.get_fields_to_exclude())
-        assert changes == set([])
-
-        # 1.2. A change between the working and versioned child
-        child.prompt_text = "This is a change"
-        child.save()
-        changes = route.compare_with_model(route2, exclude_fields=route2.get_fields_to_exclude())
-        assert changes == set(["prompt_text"])
-
-    def test_compare_with_model_testcase_2(self):
-        """
-        Both children are versions of the same experiment
-        """
-        parent = ExperimentFactory()
-        versioned_parent = parent.create_new_version()
-        child = ExperimentFactory(team=parent.team)
-        versioned_child = child.create_new_version()
-        route = ExperimentRoute.objects.create(parent=parent, child=versioned_child, keyword="test", team=parent.team)
-        route2 = ExperimentRoute.objects.create(
-            parent=versioned_parent, child=versioned_child, keyword="test", team=parent.team, working_version=route
-        )
-        changes = route.compare_with_model(route2, exclude_fields=route2.get_fields_to_exclude())
-        assert changes == set()
-
-    def test_compare_with_model_testcase_3(self):
-        """
-        They are different versions, so we expect the compare method to pick this up
-        """
-        parent = ExperimentFactory()
-        versioned_parent = parent.create_new_version()
-        child = ExperimentFactory(team=parent.team)
-        versioned_child1 = child.create_new_version()
-        versioned_child2 = child.create_new_version()
-        route = ExperimentRoute.objects.create(parent=parent, child=versioned_child1, keyword="test", team=parent.team)
-        route2 = ExperimentRoute.objects.create(
-            parent=versioned_parent, child=versioned_child2, keyword="test", team=parent.team, working_version=route
-        )
-        changes = route.compare_with_model(route2, exclude_fields=route2.get_fields_to_exclude())
-        assert changes == set(["child"])
-
     def test_compare_with_model_testcase_4(self):
         """
         The children are experiments of different families.
@@ -654,20 +598,15 @@ class TestExperimentRoute:
         parent = ExperimentFactory()
         versioned_parent = parent.create_new_version()
         child1 = ExperimentFactory(team=parent.team)
-        child2 = ExperimentFactory(
-            team=parent.team,
-            synthetic_voice=SyntheticVoiceFactory(),
-            voice_provider=VoiceProviderFactory(),
-            llm_provider=LlmProviderFactory(),
-            llm_provider_model=LlmProviderModelFactory(name="yoda"),
-            prompt_text="this is a change",
-        )
+        child2 = ExperimentFactory(team=parent.team)
         route = ExperimentRoute.objects.create(parent=parent, child=child1, keyword="test", team=parent.team)
         route2 = ExperimentRoute.objects.create(
             parent=versioned_parent, child=child2, keyword="test", team=parent.team, working_version=route
         )
-        changes = route.compare_with_model(route2, exclude_fields=route2.get_fields_to_exclude())
-        assert changes == set(["child"])
+        route1_version = route.version_details
+        route1_version.compare(route2.version_details)
+        changed_fields = [field.name for field in route1_version.fields if field.changed]
+        assert changed_fields == ["child"]
 
     def _setup_route(self, keyword: str):
         parent = ExperimentFactory()

--- a/apps/experiments/tests/test_versioning.py
+++ b/apps/experiments/tests/test_versioning.py
@@ -248,4 +248,4 @@ class TestVersion:
         # We expect the missing field(s) from the previous version details to be added to the current version details
         assert "pipeline_id" in [f.name for f in curr_version_details.fields]
         # Since the field is missing, the value should be None
-        assert curr_version_details.get_field("pipeline_id") is None
+        assert curr_version_details.get_field("pipeline_id").raw_value is None

--- a/apps/experiments/versioning.py
+++ b/apps/experiments/versioning.py
@@ -47,7 +47,7 @@ class VersionField:
 
     name: str = ""
     raw_value: Any | None = None
-    to_display: callable = data_field(default=lambda x: x)
+    to_display: callable = None
     group_name: str = data_field(default="General")
     previous_field_version: "VersionField" = data_field(default=None)
     changed: bool = False
@@ -79,10 +79,14 @@ class VersionField:
                 self.queryset_results.append(VersionField(raw_value=record, to_display=self.to_display))
 
     def display_value(self) -> Any:
+        def default_to_display(value):
+            return value
+
+        to_display = self.to_display or default_to_display
         if self.queryset:
-            return self.to_display(self.queryset_results)
+            return to_display(self.queryset_results)
         if self.current_value:
-            return self.to_display(self.current_value)
+            return to_display(self.current_value)
         return ""
 
     def _get_fields_to_exclude(self) -> list[str]:

--- a/apps/experiments/versioning.py
+++ b/apps/experiments/versioning.py
@@ -293,4 +293,5 @@ class VersionDetails:
                     group_name=previous_field.group_name,
                 )
                 self.fields.append(missing_field)
+                self._fields_dict[missing_field.name] = missing_field
                 missing_field.compare(previous_field, early_abort=early_abort)

--- a/apps/experiments/versioning.py
+++ b/apps/experiments/versioning.py
@@ -166,7 +166,6 @@ class VersionField:
 
             if previous_record:
                 # A version of the current record exists in the previous queryset
-                # TODO: When comparing static trigger versions and only the action changed, it is not being picked up.
                 previous_records.remove(previous_record.id)
                 prev_version_field = VersionField(raw_value=previous_record, to_display=self.to_display)
                 version_field.compare(prev_version_field, early_abort=early_abort)

--- a/apps/experiments/versioning.py
+++ b/apps/experiments/versioning.py
@@ -25,6 +25,11 @@ def differs(original: Any, new: Any, exclude_model_fields: list[str] | None = No
     return original != new
 
 
+def default_to_display(value):
+    """The default function to use to display the value of a field or queryset"""
+    return value
+
+
 @dataclass
 class FieldGroup:
     name: str
@@ -79,9 +84,6 @@ class VersionField:
                 self.queryset_results.append(VersionField(raw_value=record, to_display=self.to_display))
 
     def display_value(self) -> Any:
-        def default_to_display(value):
-            return value
-
         to_display = self.to_display or default_to_display
         if self.queryset:
             return to_display(self.queryset_results)

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -429,6 +429,7 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
 
     @property
     def version_details(self) -> VersionDetails:
+        from apps.assistants.models import OpenAiAssistant
         from apps.experiments.models import VersionFieldDisplayFormatters
 
         node_name = self.params.get("name", self.type)
@@ -446,9 +447,8 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
                 case "name":
                     value = node_name
                 case "assistant_id":
-                    from apps.assistants.models import OpenAiAssistant
-
                     name = "assistant"
+                    # Load the assistant, since it is being versioned
                     value = OpenAiAssistant.objects.get(id=value)
 
             param_versions.append(

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -437,15 +437,20 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
 
         param_versions = []
         for name, value in self.params.items():
-            if name == "name":
-                value = node_name
-
             display_formatter = None
             match name:
                 case "tools":
                     display_formatter = VersionFieldDisplayFormatters.format_tools
                 case "custom_actions":
                     display_formatter = VersionFieldDisplayFormatters.format_custom_action_operation
+                case "name":
+                    value = node_name
+                case "assistant_id":
+                    from apps.assistants.models import OpenAiAssistant
+
+                    name = "assistant"
+                    value = OpenAiAssistant.objects.get(id=value)
+
             param_versions.append(
                 VersionField(group_name=node_name, name=name, raw_value=value, to_display=display_formatter)
             )

--- a/templates/experiments/components/versions/compare.html
+++ b/templates/experiments/components/versions/compare.html
@@ -2,7 +2,7 @@
     {% for group in version_details.fields_grouped %}
         {% if group.has_fields_with_values %}
             <div class="collapse collapse-arrow {% if level|default_if_none:'0'|divisibleby:'2' %}bg-base-200{% else %}bg-base-100{% endif %} mb-2">
-                <input type="checkbox" {% if group.has_changed_fields or not version_details.fields_changed %}checked{% endif %}/>
+                <input type="checkbox" {% if group.has_changed_fields %}checked{% endif %}/>
                 <div class="collapse-title text-xl font-medium">{{ group.name }}</div>
                 <div class="collapse-content">
                     {% for field in group.fields %}


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
- Removed a bunch of unnecessary code in the experiment route class where we check if an experiment version was used with a working experiement route. Since we can't use versions as children, this code will never execute
- Users will be able to see what changed when a child bot (route) changed
- Users will be able to see what changed when a trigger changed
- Fix: When there weren't changes made to a pipeline node, it didn't show the node's details when you expand it. This is fixed.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
- Users will be able to see what changed when a child bot (route) changed
- Users will be able to see what changed when a trigger changed

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
https://www.loom.com/share/74ba04a806dd44f5ad42d87d9d35410b?sid=e24c332b-9aea-4f3e-a0a9-0f963e7bb2f2

### Docs
<!--Link to documentation that has been updated.-->
N/A