### PR TITLE
Add LLM provider to required fields for OpenAIAssistant

### DIFF
--- a/apps/assistants/forms.py
+++ b/apps/assistants/forms.py
@@ -51,7 +51,9 @@ class OpenAiAssistantForm(forms.ModelForm):
         self.fields["llm_provider"].widget.attrs = {
             "x-model.number.fill": "llmProvider",
         }
+        self.fields["llm_provider"].required = True
         self.fields["llm_provider_model"].widget.template_name = "django/forms/widgets/select_dynamic.html"
+        self.fields["llm_provider_model"].required = True
         self.fields["include_file_info"].help_text = """If checked, extra information about uploaded files will
             be appended to the instructions. This will give the assistant knowledge about the file types."""
         self.fields["builtin_tools"].required = False


### PR DESCRIPTION
flagged from an ops channels error

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Before this, an assistant form could be entered without an LLM provider or model, but then would fail immediately on `push_assistant_to_openai` causing a "shucks" page

## User Impact
<!-- Describe the impact of this change on the end-users. -->
now it will fail gracefully

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
<img width="1003" alt="Screenshot 2025-01-30 at 11 43 44 AM" src="https://github.com/user-attachments/assets/0122f156-6c69-4720-8e4a-3fabd1b3b1ae" />

### Docs
<!--Link to documentation that has been updated.-->
n/a