### PR TITLE
Checks related models before deleting service provider

### DIFF
--- a/templates/assistants/partials/referenced_objects.html
+++ b/templates/assistants/partials/referenced_objects.html
@@ -26,4 +26,12 @@
       {% endfor %}
     </ul>
   {% endif %}
+  {% if assistants %}
+    <h2 class="font-semibold my-2">Assistants</h2>
+    <ul class="list-disc list-inside">
+      {% for assistant in assistants %}
+        <li>{% include "generic/chip.html" with chip=assistant %}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
 </div>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
tests in progress

right now only unreleased and published experiments and assistants will be displayed to the user


## User Impact
<!-- Describe the impact of this change on the end-users. -->
This prevents users from accidentally sabotaging other experiments when deleting a service provider with warning on which models will be affected

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
to-do

<img width="1003" alt="Screenshot 2025-01-30 at 4 23 08 PM" src="https://github.com/user-attachments/assets/0317fbbe-ff4d-4fda-ae8d-bda7ae11a64b" />

### Docs
<!--Link to documentation that has been updated.-->
to do 