### PR TITLE
Make email node passthrough

### DIFF
--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -294,7 +294,7 @@ class SendEmail(PipelineNode):
         send_email_from_pipeline.delay(
             recipient_list=self.recipient_list.split(","), subject=self.subject, message=input
         )
-        return PipelineState.from_node_output(node_name=self.name, node_id=node_id, output=None)
+        return PipelineState.from_node_output(node_name=self.name, node_id=node_id, output=input)
 
 
 class Passthrough(PipelineNode):


### PR DESCRIPTION
resolves #1095 

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
- Email node returns the input

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Bots can send emails while still answering questions

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/29