### PR TITLE
Make ExtractParticipantData node passthrough

### DIFF
--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -485,7 +485,7 @@ class ExtractStructuredDataNodeMixin:
             new_reference_data = self.update_reference_data(output, reference_data)
 
         self.post_extraction_hook(new_reference_data, state)
-        output = json.dumps(new_reference_data)
+        output = input if self.is_passthrough else json.dumps(new_reference_data)
         return PipelineState.from_node_output(node_name=self.name, node_id=node_id, output=output)
 
     def post_extraction_hook(self, output, state):
@@ -598,6 +598,10 @@ class ExtractStructuredData(ExtractStructuredDataNodeMixin, LLMResponse, Structu
         json_schema_extra=UiSchema(widget=Widgets.expandable_text),
     )
 
+    @property
+    def is_passthrough(self) -> bool:
+        return False
+
 
 class ExtractParticipantData(ExtractStructuredDataNodeMixin, LLMResponse, StructuredDataSchemaValidatorMixin):
     """Extract structured data and saves it as participant data"""
@@ -615,6 +619,10 @@ class ExtractParticipantData(ExtractStructuredDataNodeMixin, LLMResponse, Struct
         json_schema_extra=UiSchema(widget=Widgets.expandable_text),
     )
     key_name: str = ""
+
+    @property
+    def is_passthrough(self) -> bool:
+        return True
 
     def get_reference_data(self, state) -> dict:
         """Returns the participant data as reference. If there is a `key_name`, the value in the participant data


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
- Update participant data node also returns the input, so this can happen in the background. 

@snopoke @bderenzi feel free to dispute this change. I know this mimics the normal update-participant-data tool, but my theory here is that you'd have more control over when exactly the bot should extract data by using a router node

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/30