### PR TITLE
rename `Attachment.read_string` to `Attachment.read_text`

### DIFF
--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -59,7 +59,7 @@ class Attachment(BaseModel):
             return b""
         return self._file.file.read()
 
-    def read_string(self):
+    def read_text(self):
         return self.document.get_contents_as_string()
 
 

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -738,14 +738,11 @@ class AssistantNode(PipelineNode):
             return AssistantChat(adapter=adapter, history_manager=history_manager)
 
 
-DEFAULT_FUNCTION = """# You must define a main function, which takes the node input as a string.
+CODE_NODE_DOCS = f"{settings.DOCUMENTATION_BASE_URL}{settings.DOCUMENTATION_LINKS['node_code']}"
+DEFAULT_FUNCTION = f"""# You must define a main function, which takes the node input as a string.
 # Return a string to pass to the next node.
 
-# Available functions:
-# - get_participant_data() -> dict
-# - set_participant_data(data: Any) -> None
-# - get_temp_state_key(key_name: str) -> str | None
-# - set_temp_state_key(key_name: str, data: Any) -> None
+# Learn more about Python nodes at {CODE_NODE_DOCS}
 
 def main(input: str, **kwargs) -> str:
     return input

--- a/apps/pipelines/tests/data/CodeNode.json
+++ b/apps/pipelines/tests/data/CodeNode.json
@@ -7,7 +7,7 @@
       "ui:widget": "node_name"
     },
     "code": {
-      "default": "# You must define a main function, which takes the node input as a string.\n# Return a string to pass to the next node.\n\n# Available functions:\n# - get_participant_data() -> dict\n# - set_participant_data(data: Any) -> None\n# - get_temp_state_key(key_name: str) -> str | None\n# - set_temp_state_key(key_name: str, data: Any) -> None\n\ndef main(input: str, **kwargs) -> str:\n    return input\n",
+      "default": "# You must define a main function, which takes the node input as a string.\n# Return a string to pass to the next node.\n\n# Learn more about Python nodes at https://dimagi.github.io/open-chat-studio-docs/concepts/pipelines/nodes/#python-node\n\ndef main(input: str, **kwargs) -> str:\n    return input\n",
       "description": "The code to run",
       "title": "Code",
       "type": "string",

--- a/apps/pipelines/tests/test_code_node.py
+++ b/apps/pipelines/tests/test_code_node.py
@@ -293,7 +293,7 @@ def test_read_attachments(pipeline, experiment_session):
 
     code_get = """
 def main(input, **kwargs):
-    return f'content {get_temp_state_key("attachments")[0].read_string()}'
+    return f'content {get_temp_state_key("attachments")[0].read_text()}'
 """
     nodes = [
         start_node(),


### PR DESCRIPTION
## Description
I think `read_text` is more self explanatory and easier for non-programmers to understand.

## User Impact
This will break any existing Python Nodes using the `read_string` function however there are no usages of them currently.

### Docs
Already updated in docs
