### PR TITLE
Update PR template to include changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,5 @@ Include technical details required to understand the change. -->
 <!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
 **Include step-by-step instructions to enable functionality of the change-->
 
-### Docs
+### Docs and Changelog
 <!--Link to documentation that has been updated.-->


### PR DESCRIPTION
This update will hopefully remind us to try and keep the [changelog section in the docs](https://dimagi.github.io/open-chat-studio-docs/changelog/) up-to-date