### PR TITLE
Some fixes

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1333,7 +1333,8 @@ class Participant(BaseTeamModel):
         last_message = exp_scoped_human_message.order_by("-created_at")[:1].values("created_at")
         joined_on = self.experimentsession_set.order_by("created_at")[:1].values("created_at")
         return (
-            Experiment.objects.annotate(
+            Experiment.objects.get_all()
+            .annotate(
                 joined_on=Subquery(joined_on),
                 last_message=Subquery(last_message),
             )

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1285,6 +1285,8 @@ class Participant(BaseTeamModel):
     def __str__(self):
         if self.name:
             return f"{self.name} ({self.identifier})"
+        elif self.user and self.user.get_full_name():
+            return f"{self.user.get_full_name()} ({self.identifier})"
         return self.identifier
 
     def get_platform_display(self):

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -811,7 +811,10 @@ class Experiment(BaseTeamModel, VersionsMixin, CustomActionOperationMixin):
         return Experiment.objects.get_default_or_working(self)
 
     def as_chip(self) -> Chip:
-        return Chip(label=self.name, url=self.get_absolute_url())
+        label = self.name
+        if self.is_archived:
+            label = f"{label} (archived)"
+        return Chip(label=label, url=self.get_absolute_url())
 
     def get_chat_model(self):
         service = self.get_llm_service()

--- a/apps/experiments/tables.py
+++ b/apps/experiments/tables.py
@@ -180,7 +180,7 @@ class ExperimentSessionsTable(tables.Table):
         template = get_template("generic/chip.html")
         participant = record.participant
         chip = chips.Chip(
-            label=participant.identifier, url=participant.get_link_to_experiment_data(experiment=record.experiment)
+            label=str(participant), url=participant.get_link_to_experiment_data(experiment=record.experiment)
         )
         return template.render({"chip": chip})
 

--- a/templates/experiments/components/versions/version_field.html
+++ b/templates/experiments/components/versions/version_field.html
@@ -1,4 +1,4 @@
-<div class="grid grid-cols-2 gap-1">
+<div class="grid {% if field.previous_field_version %}grid-cols-2{% else %}grid-cols-1{% endif %} gap-1">
     {% if field.is_a_version %}
         <div class="col-span-2">
             {% include 'experiments/components/versions/compare.html' with version_details=field.raw_value_version level=level|add:"1" %}

--- a/templates/experiments/experiment_version_table.html
+++ b/templates/experiments/experiment_version_table.html
@@ -2,7 +2,7 @@
 
 {% block modal %}
     <dialog id="versionDetailsModal" class="modal">
-        <div class="modal-box">
+        <div class="modal-box max-w-none w-1/2">
             <form method="dialog">
                 <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" aria-label="Close">✕</button>
             </form>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
resolves #1117 
resolves #1115 
Fixes the likes of [this issue](https://dimagi.sentry.io/issues/6261231252/?referrer=slack&alert_rule_id=14063560&alert_type=issue)

The issue was that we used the [default queryset](https://github.com/dimagi/open-chat-studio/blob/a237b328e8ed0836be27e19a5431b621c8df6ab2/apps/experiments/models.py#L1324-L1340) in the participant data list, which couldn't find archived experiments. If we only have data on a participant with archived experiments, an error is thrown. Since users can actually see archived experiments, I think it's fair to query them here as well.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
- All participants will show up in the participant data screen. The user will be able to see which experiments are archived when viewing a particular participant's data
- Better view when opening version details

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
##### Wider version details modal
![image](https://github.com/user-attachments/assets/c38b71ae-deb3-4127-8c68-02354591f456)

##### We show when an experiment is archived
![image](https://github.com/user-attachments/assets/50a3ba98-c96e-45d9-b1b9-fdcf7455f568)


### Docs
<!--Link to documentation that has been updated.-->
