### PR TITLE
WIP: Some versioning refactor

### DIFF
--- a/apps/assistants/models.py
+++ b/apps/assistants/models.py
@@ -276,6 +276,10 @@ class OpenAiAssistant(BaseTeamModel, VersionsMixin, CustomActionOperationMixin):
             ],
         )
 
+    @property
+    def versioned_fields(self):
+        return [field.name for field in self.version_details.fields]
+
 
 @audit_fields(
     "assistant_id",

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -142,21 +142,28 @@ class StaticTrigger(BaseModel, VersionsMixin):
         new_instance.save()
         return new_instance
 
+    # @property
+    # def version_details(self):
+    #     action_param_versions = []
+    #     static_trigger_type = StaticTriggerType(self.type).label.lower()
+    #     event_action_type = EventActionType(self.action.action_type).label
+    #     # Static trigger group names should be user friendly
+    #     group_name = f"When {static_trigger_type} then {event_action_type}"
+
+    #     for name, value in self.action.params.items():
+    #         action_param_versions.append(VersionField(group_name=group_name, name=name, raw_value=value))
+
+    #     return VersionDetails(
+    #         instance=self,
+    #         fields=action_param_versions,
+    #     )
+
     @property
-    def version_details(self):
-        action_param_versions = []
+    def versioned_fields(self):
         static_trigger_type = StaticTriggerType(self.type).label.lower()
         event_action_type = EventActionType(self.action.action_type).label
-        # Static trigger group names should be user friendly
-        group_name = f"When {static_trigger_type} then {event_action_type}"
-
-        for name, value in self.action.params.items():
-            action_param_versions.append(VersionField(group_name=group_name, name=name, raw_value=value))
-
-        return VersionDetails(
-            instance=self,
-            fields=action_param_versions,
-        )
+        # for name, value in self.action.params.items():
+        #     action_param_versions.append(VersionField(group_name=group_name, name=name, raw_value=value))
 
 
 class TimeoutTrigger(BaseModel, VersionsMixin):

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -699,9 +699,9 @@ class TestExperimentModel:
         versioned_child = ExperimentFactory(
             team=team, version_number=1, working_version=ExperimentFactory(version_number=2)
         )
-        ExperimentRoute(team=team, parent=experiment, child=versioned_child, keyword="versioned")
+        ExperimentRoute.objects.create(team=team, parent=experiment, child=versioned_child, keyword="versioned")
         working_child = ExperimentFactory(team=team)
-        ExperimentRoute(team=team, parent=experiment, child=working_child, keyword="working")
+        ExperimentRoute.objects.create(team=team, parent=experiment, child=working_child, keyword="working")
 
         # Setup Files
         experiment.files.set(FileFactory.create_batch(3))

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -584,12 +584,7 @@ class CreateExperimentVersion(LoginAndTeamRequiredMixin, CreateView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         working_experiment = self.get_object()
-        version = working_experiment.version_details
-        if prev_version := working_experiment.latest_version:
-            # Populate diffs
-            version.compare(prev_version.version_details)
-
-        context["version_details"] = version
+        context["experiment_diff"] = working_experiment.compare_with_latest(early_abort=True)
         context["experiment"] = working_experiment
         return context
 
@@ -1542,5 +1537,6 @@ def experiment_version_details(request, team_slug: str, experiment_id: int, vers
 @login_and_team_required
 def get_release_status_badge(request, team_slug: str, experiment_id: int):
     experiment = get_object_or_404(Experiment, id=experiment_id, team=request.team)
-    context = {"has_changes": experiment.compare_with_latest(), "experiment": experiment}
+    diff = experiment.compare_with_latest(early_abort=True)
+    context = {"has_changes": diff.changes, "experiment": experiment}
     return render(request, "experiments/components/unreleased_badge.html", context)


### PR DESCRIPTION
This PR is not meant to be merged, but rather to evoke discussion.

The current versioning code is too complex. Here's some initial code to convey a different approach. Do let me know what you think.

The `InstanceDiff` would typically be the main entry point, so maybe start there if you want to build a mental model

The main things to focus on is the code in the `versioning.py` file and the new `versioning_fields`, `get_versioned_field_value` and `get_versioned_fields_for_display` methods.

Basically, we need 1. a way to know which fields to get, 2. we need to get the values for those fields. Sometimes it's not just a simle `getattr`, but a more comlex query, or in the case of triggers where we want to fetch action params, we need to do that in this step. Lastly, method 3 is for display purposes.

I think here we can do the same as we did with `VersionField` where we return a single wrapper that knows how to display the current value, but I still need to do that. Anycase, leaving this as-is for now.