### PR TITLE
prompt refactor in LLM runnables

### DIFF
--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -396,7 +396,7 @@ class RouterNode(RouterMixin, Passthrough, HistoryMixin):
         session: ExperimentSession | None = state.get("experiment_session")
 
         if self.history_type != PipelineChatHistoryTypes.NONE and session:
-            input_messages = prompt.format_messages(context)
+            input_messages = prompt.format_messages(**context)
             context["history"] = self._get_history(session, node_id, input_messages)
 
         chain = prompt | self.get_chat_model()

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -396,7 +396,7 @@ class RouterNode(RouterMixin, Passthrough, HistoryMixin):
         session: ExperimentSession | None = state.get("experiment_session")
 
         if self.history_type != PipelineChatHistoryTypes.NONE and session:
-            input_messages = prompt.invoke(context).to_messages()
+            input_messages = prompt.format_messages(context)
             context["history"] = self._get_history(session, node_id, input_messages)
 
         chain = prompt | self.get_chat_model()

--- a/apps/service_providers/llm_service/adapters.py
+++ b/apps/service_providers/llm_service/adapters.py
@@ -130,7 +130,7 @@ class ChatAdapter(BaseAdapter):
     def get_chat_model(self):
         return self.get_llm_service().get_chat_model(self.provider_model_name, self.temperature)
 
-    def get_template_context(self, variables: list[str]):
+    def get_template_context(self, variables: list[str]) -> dict:
         return self.template_context.get_context(variables)
 
     def get_prompt(self):

--- a/apps/service_providers/llm_service/prompt_context.py
+++ b/apps/service_providers/llm_service/prompt_context.py
@@ -20,7 +20,7 @@ class PromptTemplateContext:
             "current_datetime": self.get_current_datetime,
         }
 
-    def get_context(self, variables: list[str]):
+    def get_context(self, variables: list[str]) -> dict:
         context = {}
         for key, factory in self.factories.items():
             # allow partial matches to support format specifiers

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -216,7 +216,7 @@ class LLMChat(RunnableSerializable[str, ChainOutput]):
         """
         context = self._get_input_chain_context(with_history=False)
         try:
-            return self.prompt.format_messages({**self._get_input(input), **context})
+            return self.prompt.format_messages(**{**self._get_input(input), **context})
         except KeyError as e:
             raise GenerationError(str(e)) from e
 

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -622,5 +622,7 @@ def test_input_message_is_saved_on_chain_error(sync_messages_to_thread, db_sessi
 
     with pytest.raises(Exception, match="Error"):
         assistant.invoke("test", attachments=[])
-    assert ChatMessage.objects.count() == 1
-    assert ChatMessage.objects.filter(message_type=ChatMessageType.HUMAN).count() == 1
+    assert ChatMessage.objects.filter(chat__experiment_session=db_session).count() == 1
+    assert (
+        ChatMessage.objects.filter(chat__experiment_session=db_session, message_type=ChatMessageType.HUMAN).count() == 1
+    )

--- a/apps/service_providers/tests/test_runnables.py
+++ b/apps/service_providers/tests/test_runnables.py
@@ -337,5 +337,5 @@ def test_input_message_is_saved_on_chain_error(populate_memory, runnable, sessio
     )
     with pytest.raises(Exception, match="Error"):
         chain.invoke("hi")
-    assert ChatMessage.objects.count() == 1
-    assert ChatMessage.objects.filter(message_type=ChatMessageType.HUMAN).count() == 1
+    assert ChatMessage.objects.filter(chat__experiment_session=session).count() == 1
+    assert ChatMessage.objects.filter(chat__experiment_session=session, message_type=ChatMessageType.HUMAN).count() == 1

--- a/apps/service_providers/tests/test_views.py
+++ b/apps/service_providers/tests/test_views.py
@@ -29,7 +29,7 @@ def factory_for_model(model):
 def test_table_view(provider, team_with_users, client):
     factory = factory_for_model(provider.model)
     factory.create_batch(5, team=team_with_users)
-    assert provider.model.objects.count() == 5
+    assert provider.model.objects.filter(team=team_with_users).count() == 5
 
     response = client.get(
         reverse("service_providers:table", kwargs={"team_slug": team_with_users.slug, "provider_type": provider.slug})
@@ -75,4 +75,4 @@ def test_delete_view(provider, team_with_users, client):
         )
     )
     assert response.status_code == 200
-    assert provider.model.objects.count() == 0
+    assert provider.model.objects.filter(team=team_with_users).count() == 0


### PR DESCRIPTION
## Description
Simplify some of the LLM runnable code by using simpler constructs for formatting the prompt and messages instead of using langchain LCEL.

This will also simplify the tracing output by removing the 'prompt formatting' spans.

#### Added bonus
This also removes the usage of the langchain memory constructs which we don't need and have been deprecated.

## User Impact
None

### Demo
NA

### Docs and Changelog
NA
