### PR TITLE
[bugfix] select correct node input when multiple are possible

### DIFF
--- a/apps/pipelines/tests/test_runnable_builder.py
+++ b/apps/pipelines/tests/test_runnable_builder.py
@@ -927,6 +927,15 @@ def test_parallel_nodes(pipeline):
 
 @django_db_with_data(available_apps=("apps.service_providers",))
 def test_multiple_valid_inputs(pipeline):
+    """This tests the case where a node has multiple valid inputs to make sure it selects the correct one.
+
+    start --> router -+-> template --> end
+                      |                 ^
+                      +---------- ------+
+
+    In this graph, the end node can have valid input from 'router' and 'template' (if the router routes
+    to the template node). The end node should select the input from the 'template' and not the 'router'.
+    """
     start = start_node()
     router = boolean_node()
     template = render_template_node("T: {{ input }}")

--- a/apps/pipelines/tests/utils.py
+++ b/apps/pipelines/tests/utils.py
@@ -126,11 +126,11 @@ def passthrough_node():
     }
 
 
-def boolean_node():
+def boolean_node(input_equals="hello"):
     return {
         "id": str(uuid4()),
         "type": nodes.BooleanNode.__name__,
-        "params": {"name": "boolean", "input_equals": "hello"},
+        "params": {"name": "boolean", "input_equals": input_equals},
     }
 
 


### PR DESCRIPTION
## Description
In the following graph the `end` node needs to select between the `router` and `template` output when the router routes through the template:

```
start --> router -+-> template --> end
                  |                 ^
                  +-----------------+
```

The method we had for doing this before would select the first available input which is dependent on the order in which the edges are created in the graph.

This PR keeps that mechanism as a fallback but prefers to use the `langgraph_triggers` metadata to select the input.

## User Impact
Pipelines operate as expected

### Demo
See test

### Docs and Changelog
NA
