### PR TITLE
Tiny updates

### DIFF
--- a/apps/assistants/views.py
+++ b/apps/assistants/views.py
@@ -37,7 +37,7 @@ from .sync import (
 from .tables import OpenAiAssistantTable
 from .utils import get_llm_providers_for_assistants
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("ocs.assistants")
 
 
 class OpenAiAssistantHome(LoginAndTeamRequiredMixin, TemplateView, PermissionRequiredMixin):

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -464,12 +464,12 @@ class CreateExperiment(BaseExperimentView, CreateView):
         else:
             return self.form_invalid(form, file_formset)
 
-    @transaction.atomic()
     def form_valid(self, form, file_formset):
-        self.object = form.save()
-        if file_formset:
-            files = file_formset.save(self.request)
-            self.object.files.set(files)
+        with transaction.atomic():
+            self.object = form.save()
+            if file_formset:
+                files = file_formset.save(self.request)
+                self.object.files.set(files)
 
         task_id = async_create_experiment_version.delay(
             experiment_id=self.object.id, version_description="", make_default=True


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
- Move invocation of `async_create_experiment_version` outside of the transaction. If for some reason the task gets executed by a worker before the transaction closes (which happened one or two times to me), we can't create a version.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Fixes the edge case described above

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
N/A