### PR TITLE
[Fix] Participant home fixes

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1320,10 +1320,14 @@ class Participant(BaseTeamModel):
 
     def get_absolute_url(self):
         experiment = self.get_experiments_for_display().first()
-        return self.get_link_to_experiment_data(experiment)
+        if experiment:
+            return self.get_link_to_experiment_data(experiment)
+        return reverse("participants:single-participant-home", args=[self.team.slug, self.id])
 
     def get_link_to_experiment_data(self, experiment: Experiment) -> str:
-        url = reverse("participants:single-participant-home", args=[self.team.slug, self.id, experiment.id])
+        url = reverse(
+            "participants:single-participant-home-with-experiment", args=[self.team.slug, self.id, experiment.id]
+        )
         return f"{url}#{experiment.id}"
 
     def get_experiments_for_display(self):

--- a/apps/participants/urls.py
+++ b/apps/participants/urls.py
@@ -7,9 +7,14 @@ app_name = "participants"
 
 urlpatterns = [
     path(
-        "<int:participant_id>/e/<int:experiment_id>",
+        "<int:participant_id>",
         views.SingleParticipantHome.as_view(),
         name="single-participant-home",
+    ),
+    path(
+        "<int:participant_id>/e/<int:experiment_id>",
+        views.SingleParticipantHome.as_view(),
+        name="single-participant-home-with-experiment",
     ),
     path(
         "<int:participant_id>/data/<int:experiment_id>/update",

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -116,7 +116,8 @@ class EditParticipantData(LoginAndTeamRequiredMixin, TemplateView, PermissionReq
         )
         return redirect(
             reverse(
-                "participants:single-participant-home", args=[self.request.team.slug, participant_id, experiment.id]
+                "participants:single-participant-home-with-experiment",
+                args=[self.request.team.slug, participant_id, experiment.id],
             )
             + f"#{experiment.id}"
         )

--- a/templates/participants/partials/participant_experiments.html
+++ b/templates/participants/partials/participant_experiments.html
@@ -18,7 +18,7 @@
           class="cursor-pointer"
         {% endif %}
 
-        x-on:click="window.location.href = new URL('{% url 'participants:single-participant-home' participant.team.slug participant.id experiment.id %}#{{experiment.id}}', window.location.origin)"
+        x-on:click="window.location.href = new URL('{% url 'participants:single-participant-home-with-experiment' participant.team.slug participant.id experiment.id %}#{{experiment.id}}', window.location.origin)"
       >
         <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
           <a id="{{ experiment.id }}">


### PR DESCRIPTION
Fixes https://dimagi.slack.com/archives/C07EJ7ENB1N/p1738676271725949

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Simply route to the participant home when participant they don't have any experiments

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Participant home page will not break anymore

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![demo](https://github.com/user-attachments/assets/eef63e5a-bb9b-4614-a642-17e0b3222b0a)

### Docs and Changelog
<!--Link to documentation that has been updated.-->
N/A