### PR TITLE
External channels should not resue sessions that ended

### DIFF
--- a/apps/channels/tests/test_base_channel_behavior.py
+++ b/apps/channels/tests/test_base_channel_behavior.py
@@ -59,6 +59,7 @@ def test_incoming_message_adds_channel_info(telegram_channel):
 @patch("apps.chat.channels.TelegramChannel.send_text_to_user", Mock())
 @patch("apps.chat.channels.TelegramChannel._get_bot_response", Mock())
 def test_channel_added_for_experiment_session(telegram_channel):
+    """Ensure that the experiment session gets a link to the experimentt channel that this is using"""
     chat_id = 123123
     message = telegram_messages.text_message(chat_id=chat_id)
     _send_user_message_on_channel(telegram_channel, message)
@@ -98,6 +99,32 @@ def test_incoming_message_uses_existing_experiment_session(telegram_channel):
     assert experiment_sessions_count == 1
 
     telegram_channel._create_new_experiment_session.assert_not_called()
+
+
+@pytest.mark.django_db()
+@patch("apps.chat.channels.TelegramChannel.send_text_to_user", Mock())
+@patch("apps.chat.channels.TelegramChannel._get_bot_response", Mock())
+def test_non_active_sessions_are_not_resused(telegram_channel):
+    """
+    Sessions that were ended should not be reused when the user sends a new message. Rather, a new session should be
+    created
+    """
+    chat_id = 12312331
+    experiment = telegram_channel.experiment
+
+    message = telegram_messages.text_message(chat_id=chat_id)
+    _send_user_message_on_channel(telegram_channel, message)
+    # End the session. This could have been done using a timeout trigger for instance
+    telegram_channel.experiment_session.end()
+
+    # Remove the session from telegram_channel to simulate a new instance
+    telegram_channel.experiment_session = None
+
+    # When the user sends another message, a new session should be created
+    message = telegram_messages.text_message(chat_id=chat_id)
+    _send_user_message_on_channel(telegram_channel, message)
+    assert experiment.sessions.filter(participant__identifier=chat_id, status=SessionStatus.ACTIVE).count() == 1
+    assert experiment.sessions.filter(participant__identifier=chat_id, status=SessionStatus.PENDING_REVIEW).count() == 1
 
 
 @pytest.mark.django_db()

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -24,6 +24,7 @@ from apps.chat.exceptions import (
     VersionedExperimentSessionsNotAllowedException,
 )
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
+from apps.chat.tasks import STATUSES_FOR_COMPLETE_CHATS
 from apps.events.models import StaticTriggerType
 from apps.events.tasks import enqueue_static_triggers
 from apps.experiments.models import (
@@ -501,6 +502,7 @@ class ChannelBase(ABC):
                 experiment=self.experiment.get_working_version(),
                 participant__identifier=str(self.participant_identifier),
             )
+            .exclude(status__in=STATUSES_FOR_COMPLETE_CHATS)
             .order_by("-created_at")
             .first()
         )


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
I realized that when we end a session, say with a timeout trigger, then the next time that the participant sends a message, that same session would be re-used. I added logic to exclude sessions with the ended status when we try and find existing sessions.

This change will also make [Jon's request](https://dimagi.slack.com/archives/C05PK63Q89H/p1738705116418499) possible

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users would be able to use timeout triggers to end participant sessions. What this mean is that the next time the participant chats to the bot, it would be as if it was the first time.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
I'll add a page on sessions. Stay tuned for the PR link