### PR TITLE
Support for resetting sessions in the trigger bot message endpoint

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -283,6 +283,15 @@ paths:
                   platform: connect_messaging
                   prompt_text: Tell the user to do something
                 summary: Generates a bot message and sends it to the user
+              GenerateBotMessageAndSendUsingANewSession:
+                value:
+                  identifier: part1
+                  experiment: exp1
+                  platform: connect_messaging
+                  prompt_text: Tell the user to do something
+                  start_new_session: 'true'
+                summary: Generates a bot message and sends it to the user using a
+                  new session
               ParticipantNotFound:
                 value:
                   detail: Participant not found
@@ -790,6 +799,10 @@ components:
         prompt_text:
           type: string
           title: Prompt to go to bot
+        start_new_session:
+          type: boolean
+          default: false
+          title: Starts a new session
       required:
       - experiment
       - identifier

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -191,3 +191,4 @@ class TriggerBotMessageRequest(serializers.Serializer):
     platform = serializers.ChoiceField(choices=ChannelPlatform.choices, label="Participant Platform")
     experiment = serializers.UUIDField(label="Experiment ID")
     prompt_text = serializers.CharField(label="Prompt to go to bot")
+    start_new_session = serializers.BooleanField(label="Starts a new session", required=False, default=False)

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -72,6 +72,7 @@ def trigger_bot_message_task(data):
     experiment_public_id = data["experiment"]
     prompt_text = data["prompt_text"]
     identifier = data["identifier"]
+    start_new_session = data["start_new_session"]
 
     experiment = Experiment.objects.get(public_id=experiment_public_id)
     experiment_channel = ExperimentChannel.objects.get(platform=platform, experiment=experiment)
@@ -81,5 +82,5 @@ def trigger_bot_message_task(data):
     channel = ChannelClass(experiment=published_experiment, experiment_channel=experiment_channel)
 
     with current_team(experiment.team):
-        channel.ensure_session_exists_for_participant(identifier)
+        channel.ensure_session_exists_for_participant(identifier, new_session=start_new_session)
         channel.experiment_session.ad_hoc_bot_message(prompt_text, use_experiment=published_experiment)

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -417,6 +417,18 @@ def consent(request: Request):
             status_codes=[200],
         ),
         OpenApiExample(
+            name="GenerateBotMessageAndSendUsingANewSession",
+            summary="Generates a bot message and sends it to the user using a new session",
+            value={
+                "identifier": "part1",
+                "experiment": "exp1",
+                "platform": "connect_messaging",
+                "prompt_text": "Tell the user to do something",
+                "start_new_session": "true",
+            },
+            status_codes=[200],
+        ),
+        OpenApiExample(
             name="ParticipantNotFound",
             summary="Participant not found",
             value={"detail": "Participant not found"},

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -467,14 +467,14 @@ def trigger_bot_message(request):
 
     experiment = get_object_or_404(Experiment, public_id=experiment_public_id, team=request.team)
 
-    try:
-        participant_data = ParticipantData.objects.defer("data").get(
-            participant__identifier=identifier,
-            participant__platform=platform,
-            experiment=experiment.id,
-        )
-
-    except ParticipantData.DoesNotExist:
+    participant_data = ParticipantData.objects.filter(
+        participant__identifier=identifier,
+        participant__platform=platform,
+        experiment=experiment.id,
+    ).first()
+    if platform == ChannelPlatform.COMMCARE_CONNECT and not participant_data:
+        return Response({"detail": "Participant not found"}, status=status.HTTP_404_NOT_FOUND)
+    elif not Participant.objects.filter(identifier=identifier, platform=platform).exists():
         return Response({"detail": "Participant not found"}, status=status.HTTP_404_NOT_FOUND)
 
     if not ExperimentChannel.objects.filter(platform=platform, experiment=experiment).exists():

--- a/apps/channels/tests/test_api_integration.py
+++ b/apps/channels/tests/test_api_integration.py
@@ -44,9 +44,9 @@ def test_new_message_creates_a_channel_and_participant(get_llm_response_mock, ex
 
 
 @pytest.mark.django_db()
-@patch("apps.chat.channels.ApiChannel._get_latest_session")
+@patch("apps.chat.channels.ApiChannel._load_latest_session")
 @patch("apps.chat.channels.ApiChannel._get_bot_response")
-def test_new_message_with_existing_session(get_llm_response_mock, _get_latest_session, experiment, client):
+def test_new_message_with_existing_session(get_llm_response_mock, _load_latest_session, experiment, client):
     get_llm_response_mock.return_value = "Hi user"
 
     user = experiment.team.members.first()
@@ -68,7 +68,7 @@ def test_new_message_with_existing_session(get_llm_response_mock, _get_latest_se
 
     # check that no new sessions were created
     assert not ExperimentSession.objects.exclude(id=session.id).exists()
-    _get_latest_session.assert_not_called()
+    _load_latest_session.assert_not_called()
 
 
 @pytest.mark.django_db()

--- a/apps/channels/tests/test_base_channel_behavior.py
+++ b/apps/channels/tests/test_base_channel_behavior.py
@@ -860,3 +860,18 @@ class TestBaseChannelMethods:
         assert new_version.is_a_version is True
         with pytest.raises(VersionedExperimentSessionsNotAllowedException):
             ChannelBase.start_new_session(new_version, channel, participant_identifier="testy-pie")
+
+    @pytest.mark.parametrize("new_session", [True, False])
+    def test_ensure_session_exists_for_participant(self, new_session, experiment):
+        experiment_channel = ExperimentChannelFactory(experiment=experiment)
+        if new_session:
+            ExperimentSessionFactory(
+                experiment=experiment, participant__identifier="testy-pie", experiment_channel=experiment_channel
+            )
+        channel_base = TestChannel(experiment=experiment, experiment_channel=experiment_channel)
+        channel_base.ensure_session_exists_for_participant(identifier="testy-pie", new_session=new_session)
+
+        if new_session:
+            assert ExperimentSession.objects.filter(participant__identifier="testy-pie").count() == 2
+        else:
+            assert ExperimentSession.objects.filter(participant__identifier="testy-pie").count() == 1


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
resolves part 1 of #1144 

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users will be able to optionally use new sessions when hitting the trigger-bot-message API.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
The api schema is updated with an example