### PR TITLE
swap next & previous direction + rename for clarity

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1518,9 +1518,9 @@ def experiment_session_pagination_view(request, team_slug: str, experiment_id: u
     experiment = request.experiment
     query = ExperimentSession.objects.exclude(external_id=session_id).filter(experiment=experiment)
     if request.GET.get("dir", "next") == "next":
-        next_session = query.filter(created_at__lte=session.created_at).first()
+        next_session = query.filter(created_at__gte=session.created_at).first()
     else:
-        next_session = query.filter(created_at__gte=session.created_at).last()
+        next_session = query.filter(created_at__lte=session.created_at).last()
 
     if not next_session:
         messages.warning(request, "No more sessions to paginate")

--- a/templates/experiments/experiment_session_view.html
+++ b/templates/experiments/experiment_session_view.html
@@ -26,11 +26,11 @@
           <div class="join">
             <a class="btn join-item"
                href="{{ paginate_url }}?dir=prev">
-              <i class="fa-solid fa-backward-step"></i> Previous
+              <i class="fa-solid fa-backward-step"></i> Older
             </a>
             <a class="btn join-item rounded-r-full"
                href="{{ paginate_url }}?dir=next">
-              Next <i class="fa-solid fa-forward-step"></i>
+              Newer <i class="fa-solid fa-forward-step"></i>
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Description
Change naming of 'next' and 'previous' to 'newer' and 'older' and make them go in the right direction.

Previously 'next' went back in time and 'previous' went ahead in time. With the new wording it's clearer what will happen and more intuitive since 'newer' is to the right and 'older' is to the left.

### Demo
![image](https://github.com/user-attachments/assets/853a8086-f296-4571-b967-2379566a1a5d)
