### PR TITLE
Display which Assistants will be deleted with team deletion

### DIFF
--- a/apps/teams/views/manage_team_views.py
+++ b/apps/teams/views/manage_team_views.py
@@ -21,7 +21,6 @@ from apps.web.forms import set_form_fields_disabled
 
 def get_related_assistants(team):
     related_assistants = OpenAiAssistant.objects.filter(team=team)
-    print(related_assistants)
     return [Chip(label=assistant.name, url=assistant.get_absolute_url()) for assistant in related_assistants]
 
 

--- a/apps/teams/views/manage_team_views.py
+++ b/apps/teams/views/manage_team_views.py
@@ -7,6 +7,8 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
 
+from apps.assistants.models import OpenAiAssistant
+from apps.generics.chips import Chip
 from apps.teams.backends import make_user_team_owner
 from apps.teams.decorators import login_and_team_required
 from apps.teams.forms import InvitationForm, TeamChangeForm
@@ -15,6 +17,12 @@ from apps.teams.models import Invitation
 from apps.teams.utils import current_team
 from apps.utils.deletion import delete_object_with_auditing_of_related_objects
 from apps.web.forms import set_form_fields_disabled
+
+
+def get_related_assistants(team):
+    related_assistants = OpenAiAssistant.objects.filter(team=team)
+    print(related_assistants)
+    return [Chip(label=assistant.name, url=assistant.get_absolute_url()) for assistant in related_assistants]
 
 
 @login_and_team_required
@@ -47,6 +55,7 @@ def manage_team(request, team_slug):
             "team_form": team_form,
             "invitation_form": InvitationForm(team=request.team),
             "pending_invitations": Invitation.objects.filter(team=team, is_accepted=False).order_by("-created_at"),
+            "related_assistants": get_related_assistants(team),
         },
     )
 

--- a/templates/teams/components/delete_team_modal.html
+++ b/templates/teams/components/delete_team_modal.html
@@ -9,6 +9,14 @@
         <strong>This action cannot be undone.</strong>
       {% endblocktranslate %}
     </p>
+    {% if related_assistants %}
+      <h4 class="font-semibold my-2">These OpenAI Assistants will also be deleted:</h4>
+      <ul class="list-disc list-inside">
+        {% for assistant in related_assistants %}
+          <li>{% include "generic/chip.html" with chip=assistant %}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
     <footer class="modal-card-foot">
       <div class="modal-action">
         <form action="{% url 'single_team:delete_team' request.team.slug %} " method="post">

--- a/templates/teams/components/delete_team_modal.html
+++ b/templates/teams/components/delete_team_modal.html
@@ -10,7 +10,7 @@
       {% endblocktranslate %}
     </p>
     {% if related_assistants %}
-      <h4 class="font-semibold my-2">These OpenAI Assistants will also be deleted:</h4>
+      <h4 class="font-semibold my-2">These OpenAI Assistants will also be deleted from Open Chat Studio and OpenAI:</h4>
       <ul class="list-disc list-inside">
         {% for assistant in related_assistants %}
           <li>{% include "generic/chip.html" with chip=assistant %}</li>


### PR DESCRIPTION
Second part of this ticket https://github.com/dimagi/open-chat-studio/issues/1097

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
(Just a warning not blocking like for archiving) This informing the the assistants will be deleted and which ones for the user and links to them if they so desire to look at them, or they can ignore them completely and still delete the team 

## User Impact
<!-- Describe the impact of this change on the end-users. -->
users are more informed when delete teams

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
<img width="1104" alt="Screenshot 2025-02-06 at 2 22 32 PM" src="https://github.com/user-attachments/assets/6d2e9a14-68c2-4298-a678-882938327a46" />


### Docs and Changelog
<!--Link to documentation that has been updated.-->
