### PR TITLE
Fix older/newer pagination for experiment sessions

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1518,9 +1518,9 @@ def experiment_session_pagination_view(request, team_slug: str, experiment_id: u
     experiment = request.experiment
     query = ExperimentSession.objects.exclude(external_id=session_id).filter(experiment=experiment)
     if request.GET.get("dir", "next") == "next":
-        next_session = query.filter(created_at__gte=session.created_at).first()
+        next_session = query.filter(created_at__gte=session.created_at).order_by("created_at").first()
     else:
-        next_session = query.filter(created_at__lte=session.created_at).last()
+        next_session = query.filter(created_at__lte=session.created_at).order_by("created_at").last()
 
     if not next_session:
         messages.warning(request, "No more sessions to paginate")


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
flagged in slack, for session pagination older and newer only when to the first and last session and skipped the middle

## User Impact
<!-- Describe the impact of this change on the end-users. -->
now the middle ones are shown

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
n/a