### PR TITLE
Hide pipeline experiment type when FF not enabled

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -204,7 +204,6 @@ class ExperimentForm(forms.ModelForm):
         choices=[
             ("llm", gettext("Base Language Model")),
             ("assistant", gettext("OpenAI Assistant")),
-            ("pipeline", gettext("Pipeline")),
         ],
         widget=forms.RadioSelect(attrs={"x-model": "type"}),
     )
@@ -271,6 +270,9 @@ class ExperimentForm(forms.ModelForm):
         exclude_services = [SyntheticVoice.OpenAIVoiceEngine]
         if flag_is_active(request, "open_ai_voice_engine"):
             exclude_services = []
+
+        if flag_is_active(request, "pipelines-v2"):
+            self.fields["type"].choices += [("pipeline", gettext("Pipeline"))]
 
         # Limit to team's data
         self.fields["llm_provider"].queryset = team.llmprovider_set


### PR DESCRIPTION
## Description
This PR makes sure to add the "Pipeline" option to the experiment type options only when the `pipeline-v2` feature flag is enabled when a user creates a new experiment.  

## User Impact
User's won't see the "Pipeline" experiment type option when the appropriate FF is not enabled, thus negating any confusion when the create action does nothing. 

### Demo
Without `pipeline-v2` FF enabled:
![image](https://github.com/user-attachments/assets/11d876fa-6200-49a5-84ec-406bb6b7e426)

With `pipeline-v2` FF enabled:
![image](https://github.com/user-attachments/assets/dc166bdd-8190-4c45-935e-d7a47aa9e0c7)


### Docs and Changelog
No doc updates.
