### PR TITLE
fix attachment serialization bug

### DIFF
--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -214,9 +214,7 @@ class Pipeline(BaseTeamModel, VersionsMixin):
             output = PipelineState(**output).json_safe()
         return output
 
-    def invoke(
-        self, input: PipelineState, session: ExperimentSession, save_run_to_history: bool = True
-    ) -> PipelineState:
+    def invoke(self, input: PipelineState, session: ExperimentSession, save_run_to_history: bool = True) -> dict:
         from apps.pipelines.graph import PipelineGraph
 
         runnable = PipelineGraph.build_runnable_from_pipeline(self)

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -66,8 +66,9 @@ class PipelineState(dict):
         copy = self.copy()
         if "experiment_session" in copy:
             copy["experiment_session"] = copy["experiment_session"].id
-        if "attachments" in copy.get("shared_state", {}):
-            copy["shared_state"]["attachments"] = [att.model_dump() for att in copy["shared_state"]["attachments"]]
+
+        if "attachments" in copy.get("temp_state", {}):
+            copy["temp_state"]["attachments"] = [att.model_dump() for att in copy["temp_state"]["attachments"]]
         return copy
 
     @classmethod

--- a/apps/pipelines/tests/test_state.py
+++ b/apps/pipelines/tests/test_state.py
@@ -14,7 +14,7 @@ def test_pipline_state_json_serializable():
         outputs={"a": "a", "b": "b", "c": "c"},
         experiment_session=ExperimentSession(id=1),
         pipeline_version=1,
-        shared_state={
+        temp_state={
             "user_input": "input",
             "outputs": {"a": "a", "b": "b", "c": "c"},
             "attachments": [Attachment(file_id=1, type="code_interpreter", name="file1", size=5)],


### PR DESCRIPTION
Resolves https://github.com/dimagi/open-chat-studio/issues/1182

## Description
Fixes an bug where attachments in pipeline state were not being serialized before saving to the PipelineRun model

## Analysis

I think this happened because these 2 PRs were merged independently and the code was not updated afterwards:

* https://github.com/dimagi/open-chat-studio/pull/1093
* https://github.com/dimagi/open-chat-studio/pull/1090
