### PR TITLE
Convert prev_value to string in _compute_character_level_diff

### DIFF
--- a/apps/experiments/versioning.py
+++ b/apps/experiments/versioning.py
@@ -197,7 +197,9 @@ class VersionField:
 
     def _compute_character_level_diff(self):
         differ = Differ()
-        difflines = list(differ.compare(self.previous_value or "", self.current_value))
+        previous_value_str = str(self.previous_value) if self.previous_value is not None else ""
+        # current_value_str = str(self.current_value) this should really be a string too to avoid mismatch type errors
+        difflines = list(differ.compare(previous_value_str, self.current_value))
 
         for line in difflines:
             operation, character = line[0], line[2:]


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
this was exposed by [this issue](https://dimagi.atlassian.net/browse/OCSBUGS-3) that then blocked users from using the site without a popup
[sentry](https://dimagi.sentry.io/issues/6297418069/?project=4505001320316928&query=user.username%3Adwarren&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=0)

This is a bandaid fix to unblock users

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
