### PR TITLE
Show conversational consent toggle for pipelines

### DIFF
--- a/templates/experiments/experiment_form.html
+++ b/templates/experiments/experiment_form.html
@@ -52,7 +52,7 @@
       <div role="tabpanel" class="tab-content">
         {% render_form_fields form "safety_layers" "safety_violation_notification_emails" "input_formatter" %}
       </div>
-      <input type="radio" name="main_tabs" role="tab" class="tab" aria-label="Consent" x-show="type !== 'pipeline'">
+      <input type="radio" name="main_tabs" role="tab" class="tab" aria-label="Consent">
       <div role="tabpanel" class="tab-content">
         {% render_form_fields form "conversational_consent_enabled" %}
       </div>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Show conversational consent toggle for pipelines

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Allows pipeline bots to use conversational consent. This is needed asap for the sudcare project

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
Watch this space