### PR TITLE
Sort pipelines by name in ascending order

### DIFF
--- a/apps/experiments/forms.py
+++ b/apps/experiments/forms.py
@@ -183,7 +183,7 @@ class ExperimentForm(forms.ModelForm):
         # Limit to team's data
         self.fields["llm_provider"].queryset = team.llmprovider_set
         self.fields["assistant"].queryset = team.openaiassistant_set.exclude(is_version=True)
-        self.fields["pipeline"].queryset = team.pipeline_set.exclude(is_version=True)
+        self.fields["pipeline"].queryset = team.pipeline_set.exclude(is_version=True).order_by("name")
         self.fields["voice_provider"].queryset = team.voiceprovider_set.exclude(
             syntheticvoice__service__in=exclude_services
         )

--- a/apps/experiments/forms.py
+++ b/apps/experiments/forms.py
@@ -183,7 +183,7 @@ class ExperimentForm(forms.ModelForm):
         # Limit to team's data
         self.fields["llm_provider"].queryset = team.llmprovider_set
         self.fields["assistant"].queryset = team.openaiassistant_set.exclude(is_version=True)
-        self.fields["pipeline"].queryset = team.pipeline_set.exclude(is_version=True).order_by("name")
+        self.fields["pipeline"].queryset = team.pipeline_set.exclude(is_version=True)
         self.fields["voice_provider"].queryset = team.voiceprovider_set.exclude(
             syntheticvoice__service__in=exclude_services
         )

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -62,7 +62,7 @@ class Pipeline(BaseTeamModel, VersionsMixin):
     objects = PipelineManager()
 
     class Meta:
-        ordering = ["name"]
+        ordering = ["-created_at"]
 
     def __str__(self):
         if self.working_version is None:

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -62,7 +62,7 @@ class Pipeline(BaseTeamModel, VersionsMixin):
     objects = PipelineManager()
 
     class Meta:
-        ordering = ["-created_at"]
+        ordering = ["name"]
 
     def __str__(self):
         if self.working_version is None:

--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -58,8 +58,10 @@ class PipelineTableView(SingleTableView, PermissionRequiredMixin):
     template_name = "table/single_table.html"
 
     def get_queryset(self):
-        return Pipeline.objects.filter(team=self.request.team, is_version=False, is_archived=False).annotate(
-            run_count=Count("runs")
+        return (
+            Pipeline.objects.filter(team=self.request.team, is_version=False, is_archived=False)
+            .annotate(run_count=Count("runs"))
+            .order_by("name")
         )
 
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Resolves #1184 
The pipelines were sorted by `created_at` date in descending order by default. Not sure why this didn't apply in the pipelines table. They are not equally sorted by name in ascending order.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Might be easier to find a pipeline

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
#### Pipelines table
![image](https://github.com/user-attachments/assets/32ff3b8a-001d-44b3-b5b3-a43391f656cd)

#### Experiment form
![image](https://github.com/user-attachments/assets/b02c03d2-8870-44e6-9ac5-e86c0c92dd24)


### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/45