### PR TITLE
allow unauthenticated users to download attachments

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1356,8 +1356,6 @@ def experiment_session_pagination_view(request, team_slug: str, experiment_id: u
     return redirect("experiments:experiment_session_view", team_slug, experiment_id, next_session.external_id)
 
 
-@login_and_team_required
-@permission_required("chat.view_chatattachment")
 def download_file(request, team_slug: str, session_id: int, pk: int):
     resource = get_object_or_404(
         File, id=pk, team__slug=team_slug, chatattachment__chat__experiment_session__id=session_id

--- a/templates/experiments/chat/human_message.html
+++ b/templates/experiments/chat/human_message.html
@@ -9,17 +9,11 @@
   <div class="flex flex-col">
     {% for file in attachments %}
       <div class="inline">
-        {% if request.user.is_authenticated %}
-          <a class="text-sm p-1 hover:bg-gray-300 hover:rounded-lg"
-             href="{% url 'experiments:download_file' team_slug=experiment.team.slug session_id=session.id pk=file.id %}"
-             download="{{ file.name }}">
-            <i class="fa-solid fa-download fa-sm"></i> {{ file.name }}
-          </a>
-        {% else %}
-          <div class="inline text-sm p-1">
-            <i class="fa-solid fa-file fa-sm"></i> {{ file.name }}
-          </div>
-        {% endif %}
+        <a class="text-sm p-1 hover:bg-gray-300 hover:rounded-lg"
+           href="{% url 'experiments:download_file' team_slug=experiment.team.slug session_id=session.id pk=file.id %}"
+           download="{{ file.name }}">
+          <i class="fa-solid fa-download fa-sm"></i> {{ file.name }}
+        </a>
       </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
Resolves https://github.com/dimagi/open-chat-studio/issues/1206

## Description
Chat attachments should be downloadable by unauthenticated users.

### Security considerations
Downloading an attachment requires knowing the team slug, session ID and file ID which makes guessing non-trivial.

## User Impact
Public users can access chat attachments.

### Docs and Changelog
https://github.com/dimagi/open-chat-studio-docs/pull/47
