### PR TITLE
render description as markdown on consent and pre-survey pages

### DIFF
--- a/templates/experiments/experiment_invitations.html
+++ b/templates/experiments/experiment_invitations.html
@@ -1,5 +1,14 @@
 {% extends 'web/app/app_base.html' %}
 {% load form_tags %}
+{% block breadcrumbs %}
+  <div class="text-sm breadcrumbs" aria-label="breadcrumbs">
+    <ul>
+      <li><a href="{% url 'experiments:experiments_home' request.team.slug %}">Experiments</a></li>
+      <li><a href="{% url 'experiments:single_experiment_home' request.team.slug experiment.id %}">{{ experiment_name }}</a></li>
+      <li class="pg-breadcrumb-active" aria-current="page">Invitations</li>
+    </ul>
+  </div>
+{% endblock %}
 {% block app %}
   <div class="app-card">
     <h1 class="pg-title">{{ experiment_name }} Invitations</h1>

--- a/templates/experiments/pre_survey.html
+++ b/templates/experiments/pre_survey.html
@@ -1,9 +1,10 @@
 {% extends 'web/app/app_base.html' %}
+{% load chat_tags %}
 {% load form_tags %}
 {% block body %}
   <div class="app-card max-w-5xl mx-auto">
     <h1 class="pg-title">{{ experiment_name }}</h1>
-    <h2 class="pg-subtitle">{{ experiment_description }}</h2>
+    <h2 class="pg-subtitle">{{ experiment_description|render_markdown }}</h2>
     <div class="prose !max-w-none">
       <p>Before starting the experiment, we ask that you complete a short survey.</p>
       <p>

--- a/templates/experiments/pre_survey.html
+++ b/templates/experiments/pre_survey.html
@@ -4,8 +4,9 @@
 {% block body %}
   <div class="app-card max-w-5xl mx-auto">
     <h1 class="pg-title">{{ experiment_name }}</h1>
-    <h2 class="pg-subtitle">{{ experiment_description|render_markdown }}</h2>
+    <div class="mt-2 mb-4">{{ experiment_description|render_markdown }}</div>
     <div class="prose !max-w-none">
+      <h3>Survey</h3>
       <p>Before starting the experiment, we ask that you complete a short survey.</p>
       <p>
         Please click on <a href="{{ pre_survey_link }}" target="_blank">this survey link</a>, fill it out, and when you have finished,

--- a/templates/experiments/pre_survey.html
+++ b/templates/experiments/pre_survey.html
@@ -4,7 +4,7 @@
 {% block body %}
   <div class="app-card max-w-5xl mx-auto">
     <h1 class="pg-title">{{ experiment_name }}</h1>
-    <div class="mt-2 mb-4">{{ experiment_description|render_markdown }}</div>
+    <div class="mt-2 mb-4 prose">{{ experiment_description|render_markdown }}</div>
     <div class="prose !max-w-none">
       <h3>Survey</h3>
       <p>Before starting the experiment, we ask that you complete a short survey.</p>

--- a/templates/experiments/start_experiment_session.html
+++ b/templates/experiments/start_experiment_session.html
@@ -4,7 +4,7 @@
 {% block body %}
   <div class="app-card max-w-5xl mx-auto">
     <h1 class="pg-title">{{ experiment_name }}</h1>
-    <div class="mt-2 mb-4">{{ experiment_description|render_markdown }}</div>
+    <div class="mt-2 mb-4 prose">{{ experiment_description|render_markdown }}</div>
     <div class="prose !max-w-none">
       <h3>Consent</h3>
       {{ consent_notice }}

--- a/templates/experiments/start_experiment_session.html
+++ b/templates/experiments/start_experiment_session.html
@@ -4,8 +4,9 @@
 {% block body %}
   <div class="app-card max-w-5xl mx-auto">
     <h1 class="pg-title">{{ experiment_name }}</h1>
-    <h2 class="pg-subtitle">{{ experiment_description|render_markdown }}</h2>
+    <div class="mt-2 mb-4">{{ experiment_description|render_markdown }}</div>
     <div class="prose !max-w-none">
+      <h3>Consent</h3>
       {{ consent_notice }}
     </div>
     <form method="post" class="my-2 max-w-md">

--- a/templates/experiments/start_experiment_session.html
+++ b/templates/experiments/start_experiment_session.html
@@ -1,9 +1,10 @@
 {% extends 'web/app/app_base.html' %}
+{% load chat_tags %}
 {% load form_tags %}
 {% block body %}
   <div class="app-card max-w-5xl mx-auto">
     <h1 class="pg-title">{{ experiment_name }}</h1>
-    <h2 class="pg-subtitle">{{ experiment_description }}</h2>
+    <h2 class="pg-subtitle">{{ experiment_description|render_markdown }}</h2>
     <div class="prose !max-w-none">
       {{ consent_notice }}
     </div>


### PR DESCRIPTION
## Description
The experiment description is shown on the consent and pre-survey page. Without markdown rendering all formatting in the text is not shown (newlines etc). One option would be to use a 'pre' block to display the description but that also shows it with monospace font etc.

Rendering it as markdown give much more control to chatbot builders.

#### Unrelated change
I also noticed that the invitation page does not have breadcrumbs on it so I added those too.

## User Impact
Descriptions can now include markdown and will be rendered correctly.

## Demo
### Markdown rendered description
![Screenshot from 2025-02-19 12-33-38](https://github.com/user-attachments/assets/4f1f644d-e7f5-4147-b955-51fd58496a99)

#### Breadcrumbs on the invitations page
![Screenshot from 2025-02-19 12-30-01](https://github.com/user-attachments/assets/b186161f-3d0a-4b4d-b9b4-2ae66b3bb0b8)


## Docs and Changelog
https://github.com/dimagi/open-chat-studio-docs/pull/48
