### PR TITLE
Prevent event loops with new received bot messages

### DIFF
--- a/apps/events/forms.py
+++ b/apps/events/forms.py
@@ -107,6 +107,20 @@ class EventActionForm(forms.ModelForm):
         fields = ["action_type"]
         labels = {"action_type": "Then..."}
 
+    def clean(self):
+        cleaned_data = super().clean()
+        action_type = cleaned_data.get("action_type")
+
+        if self.data and "type" in self.data:
+            trigger_type = self.data.get("type")
+            if trigger_type == "new_bot_message" and action_type in [
+                "send_message_to_bot",
+                "pipeline_start",
+                "summarize",
+            ]:
+                raise forms.ValidationError("This action is not allowed when 'A new bot message is received'")
+        return cleaned_data
+
     def save(self, commit=True, *args, **kwargs):
         experiment_id = kwargs.pop("experiment_id")
         instance = super().save(commit=False, *args, **kwargs)

--- a/templates/events/manage_event.html
+++ b/templates/events/manage_event.html
@@ -14,12 +14,50 @@
         <div>
             {% block pre_form %}
             {% endblock pre_form %}
-            <form method="post" class="my-2" {% include "generic/attrs.html" with attrs=form_attrs %} x-data="{ type: '{{ secondary_key }}' }">
+            <form method="post" class="my-2" {% include "generic/attrs.html" with attrs=form_attrs %}
+                  x-data="eventForm('{{ secondary_key }}', '{{ trigger_form.initial.type }}')"
+                  x-init="watchTriggerType()">
                 {% csrf_token %}
                 {% block form %}
                     <h1 class="pg-title">Event Details</h1>
                     {% render_form_fields trigger_form %}
                     {% render_form_fields action_form.primary %}
+                    <script>
+                        function eventForm(secondaryKey, initialTriggerType) {
+                            return {
+                                type: secondaryKey,
+                                triggerType: initialTriggerType,
+                                isActionDisabled(action) {
+                                    return this.triggerType === 'new_bot_message' &&
+                                    ['send_message_to_bot', 'pipeline_start', 'summarize'].includes(action);
+                                },
+                                watchTriggerType() {
+                                    this.$watch('triggerType', value => {
+                                        if (value === 'new_bot_message' &&
+                                            ['send_message_to_bot', 'pipeline_start', 'summarize'].includes(this.type)) {
+                                                this.type = 'log';
+                                            }
+                                    });
+                                },
+                                init() {
+                                    const triggerSelect = document.getElementById('{{ trigger_form.type.id_for_label }}');
+                                    if (triggerSelect) {
+                                        triggerSelect.setAttribute('x-model', 'triggerType');
+                                    }
+                                    const actionSelect = document.getElementById('{{ action_form.primary.action_type.id_for_label }}');
+                                    if (actionSelect) {
+                                        actionSelect.setAttribute('x-model', 'type');
+                                        actionSelect.querySelectorAll('option').forEach(option => {
+                                            const value = option.value;
+                                            option.setAttribute('x-bind:disabled', `isActionDisabled('${value}')`);
+                                            option.setAttribute('x-show', `!isActionDisabled('${value}')`);
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    </script>
+
                     {% for key, form in action_form.secondary.items %}
                         <div id="form_{{ key }}" x-show="type === '{{ key }}'" x-cloak>
                             {% render_form_fields form %}


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
[ticket](https://github.com/dimagi/open-chat-studio/issues/1170)

A loop was caused by "when bot message received" event triggered the action was to send another bot message which overloaded our celery workers

Note:I chose these to limit because testing locally I was able to break my local set up with these options.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Limits their ability to break OCS

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
<img width="815" alt="Screenshot 2025-02-19 at 3 44 43 PM" src="https://github.com/user-attachments/assets/0ae2da2e-c501-4fea-b5c3-51dc43c7d856" />

### Docs and Changelog
<!--Link to documentation that has been updated.-->
