### PR TITLE
improve pipeline save and reload

### DIFF
--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -192,6 +192,7 @@ class Pipeline(BaseTeamModel, VersionsMixin):
                         id=node.flow_id,
                         type=node.type,
                         params=node.params,
+                        label=node.label,
                     ),
                 )
             )


### PR DESCRIPTION
## Description
This change makes pipelines only save when data that we care about is changed and also doesn't reset the flow after successful save.

Prior to this there were various UI artifacts that occurred due to re-rendering after the autosave. Also, almost every UI interaction would trigger a save e.g. changing which node was selected.

## User Impact
Improved user experience when editing pipelines.

### Docs and Changelog
NA
