### PR TITLE
Limit the number of messages that can be sent to the LLM

### DIFF
--- a/apps/chat/conversation.py
+++ b/apps/chat/conversation.py
@@ -259,7 +259,7 @@ def _get_new_summary(llm, pruned_memory, summary, max_token_limit):
     recursively call this function with the remaining memory."""
     tokens, context = _get_summary_tokens_with_context(llm, summary, pruned_memory)
     next_batch = []
-    while pruned_memory and tokens > max_token_limit and len(pruned_memory) > MAX_UNCOMPRESSED_MESSAGES:
+    while pruned_memory and tokens > max_token_limit or len(pruned_memory) > MAX_UNCOMPRESSED_MESSAGES:
         next_batch.insert(0, pruned_memory.pop())
         tokens, context = _get_summary_tokens_with_context(llm, summary, pruned_memory)
 

--- a/apps/chat/tests/test_compress_chat_history.py
+++ b/apps/chat/tests/test_compress_chat_history.py
@@ -213,3 +213,28 @@ def test_get_new_summary_with_large_summary(caplog):
     assert new_summary == "Summary"
     assert len(llm.get_calls()) == 1
     assert caplog.record_tuples == [("ocs.bots", logging.ERROR, SUMMARY_TOO_LARGE_ERROR_MESSAGE)]
+
+
+@mock.patch("apps.chat.conversation.MAX_UNCOMPRESSED_MESSAGES", 5)
+@mock.patch("apps.chat.conversation._tokens_exceeds_limit")
+@mock.patch("apps.chat.conversation._get_new_summary")
+def test_summarization_is_forced_when_too_many_messages(_get_new_summary, _tokens_exceeds_limit, chat):
+    """Summarization should be forced when the amount of messages exceed the `MAX_UNCOMPRESSED_MESSAGES` limit, even
+    though the max token count is not reached
+    """
+    _tokens_exceeds_limit.return_value = False
+    _get_new_summary.return_value = "Summary"
+
+    for i in range(15):
+        ChatMessage.objects.create(chat=chat, content=f"Hello {i}", message_type=ChatMessageType.HUMAN)
+
+    llm = FakeLlmSimpleTokenCount(responses=[])
+    result = compress_chat_history(chat, llm, max_token_limit=250000, input_messages=[HumanMessage("Hi")])
+
+    # The result length should be equal to MAX_UNCOMPRESSED_MESSAGES
+    assert len(result) == 5
+
+    # _tokens_exceeds_limit should have been called 8 times
+    # 2 calls before pruning + 1 call until message count == MAX_UNCOMPRESSED_MESSAGES + 1 final call to exit the loop
+    # := 2 + 5 + 1 = 8
+    _tokens_exceeds_limit.call_count = 8


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
- Limit the number of messages that can be sent to the LLM. This fixes [this error](https://dimagi.sentry.io/issues/5842110431/?project=4505001320316928&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=7d&stream_index=1#exception). This happens when the total token count of all messages are smaller than the model's limit, so then the API's limit is reached. I couldn't find this limit in the docs.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users should be able to have super long conversations without this happening again

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/53