### PR TITLE
support 'system' theme and fix theme flicker

### DIFF
--- a/apps/web/context_processors.py
+++ b/apps/web/context_processors.py
@@ -27,6 +27,7 @@ def project_meta(request):
         "temporary_superuser_access": get_temporary_superuser_access(request),
         "docs_base_url": settings.DOCUMENTATION_BASE_URL,
         "docs_links": settings.DOCUMENTATION_LINKS,
+        "dark_mode": request.COOKIES.get("theme", "") == "dark",
     }
 
 

--- a/assets/javascript/theme-toggle.js
+++ b/assets/javascript/theme-toggle.js
@@ -1,35 +1,40 @@
-document.addEventListener("DOMContentLoaded", function () {
-// Function to set the theme
+const darkTheme = 'dark';
+const lightTheme = 'light';
+const systemTheme = 'system';
+
+function syncDarkMode() {
+  const theme = localStorage.getItem('theme') || systemTheme;
+  setTheme(theme);
+}
+
 function setTheme(theme) {
-  document.body.setAttribute("data-theme", theme); // Apply to body
-  localStorage.setItem("theme", theme);
-  const themeToggle = document.getElementById("theme-toggle");
-  if (themeToggle) {
-    themeToggle.checked = theme === "light"; // Sync checkbox state
-  }
- }
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
-// Function to toggle the theme
-function toggleTheme() {
-  const currentTheme = localStorage.getItem("theme") || "light";
-  const newTheme = currentTheme === "light" ? "dark" : "light";
-  setTheme(newTheme);
+  if (theme === darkTheme || (theme === systemTheme && prefersDark)) {
+    document.documentElement.classList.add('dark');
+    document.documentElement.setAttribute('data-theme', darkTheme);
+    // set a cookie and use it during server rendering to avoid a flicker across page loads
+    document.cookie = `theme=${darkTheme};path=/;max-age=31536000`;
+  } else {
+    document.documentElement.classList.remove('dark');
+    document.documentElement.setAttribute('data-theme', lightTheme);
+    document.cookie = `theme=${lightTheme};path=/;max-age=31536000`;
+  }
 }
 
-// Function to initialize the theme
-function initializeTheme() {
-  const savedTheme = localStorage.getItem("theme");
-  const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-  const theme = savedTheme || systemTheme;
-  setTheme(theme); // Set the theme and sync the checkbox
-}
+document.addEventListener('DOMContentLoaded', () => {
 
-document.body.addEventListener('change', function (event) {
-  if (event.target && event.target.id === 'theme-toggle') {
-    toggleTheme();
-  }
+  document.getElementsByName("theme-dropdown").forEach((element) => {
+    element.addEventListener('change', (event) => {
+      const theme = event.target.value;
+      localStorage.setItem('theme', theme);
+      setTheme(theme);
+    })
+  })
+
+  // Watch for changes in the prefers-color-scheme
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  mediaQuery.addEventListener("change", syncDarkMode);
 });
 
-// Initialize the theme when the page loads
-initializeTheme();
-});
+syncDarkMode();

--- a/templates/web/base.html
+++ b/templates/web/base.html
@@ -1,7 +1,7 @@
 {% load static %}
 {% load meta_tags %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" {% if dark_mode %}class="dark" data-theme="dark"{% endif %}>
   <head>
     <meta charset="utf-8">
     <!--IE compatibility-->

--- a/templates/web/components/app_nav_menu_items.html
+++ b/templates/web/components/app_nav_menu_items.html
@@ -27,10 +27,35 @@
       {% translate "Sign out" %}
     </a>
   </li>
-  <div class="flex justify-end items-center gap-x-2 px-4 my-2">
-    <i class="fa-solid fa-circle-half-stroke h-4 w-4"></i>
-    <span>Toggle Theme</span>
-    <input type="checkbox" id="theme-toggle" class="toggle">
+  <div class="dropdown dropdown-end dropdown-right hover:cursor-pointer" x-data="{ open: false }">
+    <div tabindex="0" class="flex justify-start items-center gap-x-2 px-4 my-2" @click="open = !open">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" class="dark:hidden" />
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" class="hidden dark:block" />
+      </svg>
+      <span>Toggle Theme</span>
+    </div>
+    <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-36 p-2 shadow" x-show="open" @click.away="open = false">
+      <li>
+        <input
+          type="radio"
+          name="theme-dropdown"
+          class="theme-controller btn btn-sm btn-block btn-ghost justify-start font-medium"
+          aria-label="Light"
+          value="light" /></li>
+      <li><input
+        type="radio"
+        name="theme-dropdown"
+        class="theme-controller btn btn-sm btn-block btn-ghost justify-start font-medium"
+        aria-label="Dark"
+        value="dark" /></li>
+      <li><input
+        type="radio"
+        name="theme-dropdown"
+        class="theme-controller btn btn-sm btn-block btn-ghost justify-start font-medium"
+        aria-label="System"
+        value="system" /></li>
+    </ul>
   </div>
 </ul>
 {% if user.is_staff or user.is_superuser %}


### PR DESCRIPTION
## Description
This updates the theme selector to allow selecting 'light', 'dark' or 'system'. It also adds a cookie which is used during server side rendering to set the HTML attributes which prevents a flicker if the set theme is different from the initial theme.

## User Impact
User's can select 'system' theme to revert theme control to their browser. 

### Demo
[Screencast from 2025-02-26 11-10-46.webm](https://github.com/user-attachments/assets/e55a4f5a-3b65-4348-b9e1-60e9b31ce226)



### Docs and Changelog
NA
