### PR TITLE
Propagate `save_input_to_history` config for pipelines

### DIFF
--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -300,6 +300,7 @@ class PipelineBot:
                 pipeline_version=self.experiment.pipeline.version_number,
             ),
             self.session,
+            save_input_to_history=save_input_to_history,
         )
         self.ai_message_id = output["ai_message_id"]
         return output["messages"][-1]

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -215,7 +215,9 @@ class Pipeline(BaseTeamModel, VersionsMixin):
             output = PipelineState(**output).json_safe()
         return output
 
-    def invoke(self, input: PipelineState, session: ExperimentSession, save_run_to_history: bool = True) -> dict:
+    def invoke(
+        self, input: PipelineState, session: ExperimentSession, save_run_to_history=True, save_input_to_history=True
+    ) -> dict:
         from apps.pipelines.graph import PipelineGraph
 
         runnable = PipelineGraph.build_runnable_from_pipeline(self)
@@ -237,9 +239,10 @@ class Pipeline(BaseTeamModel, VersionsMixin):
             pipeline_run.output = output
             if save_run_to_history and session is not None:
                 metadata = output.get("message_metadata", {})
-                self._save_message_to_history(
-                    session, input["messages"][-1], ChatMessageType.HUMAN, metadata=metadata.get("input", {})
-                )
+                if save_input_to_history:
+                    self._save_message_to_history(
+                        session, input["messages"][-1], ChatMessageType.HUMAN, metadata=metadata.get("input", {})
+                    )
                 ai_message = self._save_message_to_history(
                     session, output["messages"][-1], ChatMessageType.AI, metadata=metadata.get("output", {})
                 )

--- a/apps/pipelines/tests/test_pipeline_runs.py
+++ b/apps/pipelines/tests/test_pipeline_runs.py
@@ -165,3 +165,13 @@ def test_running_pipeline_stores_session(pipeline: Pipeline, session: Experiment
     pipeline.invoke(PipelineState(messages=[input]), session)
     assert pipeline.runs.count() == 1
     assert pipeline.runs.first().session_id == session.id
+
+
+@django_db_transactional()
+@pytest.mark.parametrize("save_input_to_history", [True, False])
+def test_save_input_to_history(save_input_to_history, pipeline: Pipeline, session: ExperimentSession):
+    input = "Hi"
+    pipeline.invoke(PipelineState(messages=[input]), session, save_input_to_history=save_input_to_history)
+    assert (
+        session.chat.messages.filter(content="Hi", message_type=ChatMessageType.HUMAN).exists() == save_input_to_history
+    )


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
For pipelines, any scheduled message or messages originating from the [generate_response_for_user](https://github.com/dimagi/open-chat-studio/blob/76a11d6fba4004abc3074f1906116c76cb134867/apps/chat/channels.py#L577-L580) method are saved as a human message. Now, it's not, since we check the `save_input_to_history` flag.

I suspect this issue might be involved in the [bot replying to itself issue](https://github.com/dimagi/open-chat-studio/issues/1195), but I could not replicate this, so I am not 100% sure.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users will not see the prompt for the bot that is used to generate a response in the chat history any more.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/55