### PR TITLE
Catch exec error

### DIFF
--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -778,7 +778,10 @@ class CodeNode(PipelineNode):
                 mode="exec",
             )
             custom_locals = {}
-            exec(byte_code, {}, custom_locals)
+            try:
+                exec(byte_code, {}, custom_locals)
+            except Exception as exc:
+                raise PydanticCustomError("invalid_code", "{error}", {"error": exc.msg})
 
             try:
                 main = custom_locals["main"]

--- a/apps/pipelines/tests/test_code_node.py
+++ b/apps/pipelines/tests/test_code_node.py
@@ -95,6 +95,7 @@ def main(input, **kwargs):
             "",
             """"_file" is an invalid attribute name because it starts with "_".""",
         ),
+        ("import PyPDF2\ndef main(input):\n\treturn input", "", "No module named 'PyPDF2'"),
     ],
 )
 def test_code_node_build_errors(pipeline, code, input, error):


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Fixes https://dimagi.sentry.io/issues/6333464466/?alert_rule_id=14063560&alert_type=issue&notification_uuid=6b9208ed-1176-478e-b1d0-0bc6c381023e&project=4505001320316928&referrer=issue_alert-slack

## User Impact
<!-- Describe the impact of this change on the end-users. -->
The site wouldn't break when the `exec` fails

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![demo](https://github.com/user-attachments/assets/0bc2a974-224d-4976-ac2c-3b3a9d3e47b0)

### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/56