### PR TITLE
add self to params to match parent class

### DIFF
--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -629,7 +629,7 @@ class WebChannel(ChannelBase):
             session.save()
         return session
 
-    def _inform_user_of_error():
+    def _inform_user_of_error(self):
         # Web channel's errors are optionally rendered in the UI, so no need to send a message
         pass
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
[Sentry error](https://dimagi.sentry.io/alerts/rules/open-chat-studio/14063560/details/)
_inform_user_of_error method in the WebChannel class wass defined without a self, but it's being called with self in the parent class (ChannelBase)

## User Impact
<!-- Describe the impact of this change on the end-users. -->
fixes error users see

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
n/a

### Docs and Changelog
<!--Link to documentation that has been updated.-->
n/a
