### PR TITLE
Add participant global data to getter/setter for python node

### DIFF
--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -152,8 +152,7 @@ def _update_participant_data(request):
     participant, _ = Participant.objects.get_or_create(identifier=identifier, team=team, platform=platform)
 
     # Update the participant's name if provided
-    if name := serializer.data.get("name"):
-        participant.update_from_data({"name": name})
+    participant.update_name_from_data(serializer.data)
 
     experiment_data = serializer.data["data"]
     experiment_map = _get_participant_experiments(team, experiment_data)

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -153,8 +153,7 @@ def _update_participant_data(request):
 
     # Update the participant's name if provided
     if name := serializer.data.get("name"):
-        participant.name = name
-        participant.save()
+        participant.update_from_data({"name": name})
 
     experiment_data = serializer.data["data"]
     experiment_map = _get_participant_experiments(team, experiment_data)

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1298,18 +1298,13 @@ class Participant(BaseTeamModel):
             return {"name": self.name}
         return {}
 
-    def update_from_data(self, data: dict):
+    def update_name_from_data(self, data: dict):
         """
-        Updates participant fields from a data dictionary.
-        Only fields that exist in global_data will be updated.
+        Updates participant name field from a data dictionary.
         """
-        updated_fields = []
-        for key in list(self.global_data.keys()):
-            if key in data and hasattr(self, key):
-                setattr(self, key, data[key])
-                updated_fields.append(key)
-        if updated_fields:
-            self.save(update_fields=updated_fields)
+        if "name" in data:
+            self.name = data["name"]
+            self.save(update_fields=["name"])
 
     def __str__(self):
         if self.is_anonymous:

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1298,6 +1298,19 @@ class Participant(BaseTeamModel):
             return {"name": self.name}
         return {}
 
+    def update_from_data(self, data: dict):
+        """
+        Updates participant fields from a data dictionary.
+        Only fields that exist in global_data will be updated.
+        """
+        updated_fields = []
+        for key in list(self.global_data.keys()):
+            if key in data and hasattr(self, key):
+                setattr(self, key, data[key])
+                updated_fields.append(key)
+        if updated_fields:
+            self.save(update_fields=updated_fields)
+
     def __str__(self):
         if self.is_anonymous:
             suffix = str(self.public_id)[:6]

--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -55,14 +55,9 @@ class ParticipantDataProxy:
             )
         return self._participant_data
 
-    def get(self, include_global=True):
+    def get(self):
         data = self._get_db_object().data
-        if include_global and hasattr(self.session, "participant") and hasattr(self.session.participant, "global_data"):
-            # Only add global data keys that don't already exist in participant data
-            for key, value in self.session.participant.global_data.items():
-                if key not in data:
-                    data[key] = value
-        return data
+        return self.session.participant.global_data | data
 
     def set(self, data):
         participant_data = self._get_db_object()

--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -64,4 +64,4 @@ class ParticipantDataProxy:
         participant_data.data = data
         participant_data.save(update_fields=["data"])
 
-        self.session.participant.update_from_data(data)
+        self.session.participant.update_name_from_data(data)

--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -68,3 +68,13 @@ class ParticipantDataProxy:
         participant_data = self._get_db_object()
         participant_data.data = data
         participant_data.save(update_fields=["data"])
+        if hasattr(self.session, "participant") and hasattr(self.session.participant, "global_data"):
+            participant = self.session.participant
+            global_data_keys = list(participant.global_data.keys())
+            updated_fields = []
+            for key in global_data_keys:
+                if key in data and hasattr(participant, key):
+                    setattr(participant, key, data[key])
+                    updated_fields.append(key)
+            if updated_fields:
+                participant.save(update_fields=updated_fields)

--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -55,8 +55,14 @@ class ParticipantDataProxy:
             )
         return self._participant_data
 
-    def get(self):
-        return self._get_db_object().data
+    def get(self, include_global=True):
+        data = self._get_db_object().data
+        if include_global and hasattr(self.session, "participant") and hasattr(self.session.participant, "global_data"):
+            # Only add global data keys that don't already exist in participant data
+            for key, value in self.session.participant.global_data.items():
+                if key not in data:
+                    data[key] = value
+        return data
 
     def set(self, data):
         participant_data = self._get_db_object()

--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -63,13 +63,5 @@ class ParticipantDataProxy:
         participant_data = self._get_db_object()
         participant_data.data = data
         participant_data.save(update_fields=["data"])
-        if hasattr(self.session, "participant") and hasattr(self.session.participant, "global_data"):
-            participant = self.session.participant
-            global_data_keys = list(participant.global_data.keys())
-            updated_fields = []
-            for key in global_data_keys:
-                if key in data and hasattr(participant, key):
-                    setattr(participant, key, data[key])
-                    updated_fields.append(key)
-            if updated_fields:
-                participant.save(update_fields=updated_fields)
+
+        self.session.participant.update_from_data(data)


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
part one of ticket [here](https://github.com/dimagi/open-chat-studio/issues/1181)

## User Impact
<!-- Describe the impact of this change on the end-users. -->
includes global_data like the`{participant_data}` prompt variable

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
n/a

### Docs and Changelog
<!--Link to documentation that has been updated.-->
change log yes (link to be added)
