### PR TITLE
UI tweak: add subtext "(upload files)"

### DIFF
--- a/templates/files/partials/file_formset.html
+++ b/templates/files/partials/file_formset.html
@@ -1,6 +1,6 @@
 <div x-data="{ count: 0, get zeroCount() { return this.count-1 } }">
   <div class="flex flex-row justify-between mb-4">
-    <h3 class="text-lg font-medium">{{ form_title|default:"FILES" }}</h3>
+    <h3 class="text-lg font-medium">{{ form_title|default:"FILES" }} <span class="text-xs text-gray-500">(upload files)</span></h3>
     <button type="button" class="btn btn-sm"
             @click="count++; $nextTick(() => { document.getElementById('id_files-' + zeroCount + '-file').click() })">
       <i class="fa-solid fa-paperclip"></i> Add


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Requested in slack after noting that sometimes easy to forget to add files for both code interpreter and file search
<img width="1010" alt="Screenshot 2025-03-04 at 8 12 48 AM" src="https://github.com/user-attachments/assets/23d3e1e0-af47-422f-91c4-6c2b02bb3c2e" />

## User Impact
<!-- Describe the impact of this change on the end-users. -->
adds a bit more clarity

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/a

### Docs and Changelog
<!--Link to documentation that has been updated.-->
n/a
