### PR TITLE
patch docx reader

### DIFF
--- a/apps/documents/patch_docx.py
+++ b/apps/documents/patch_docx.py
@@ -1,0 +1,23 @@
+from docx.opc.oxml import parse_xml
+from docx.opc.pkgreader import _SerializedRelationship, _SerializedRelationships
+
+
+def patch_docx():
+    """
+    Workaround for python-docx issue with loading relationships from XML.
+    See https://github.com/python-openxml/python-docx/issues/1351
+    """
+
+    def load_from_xml_v2(baseURI, rels_item_xml):
+        srels = _SerializedRelationships()
+        if rels_item_xml is not None:
+            rels_elm = parse_xml(rels_item_xml)
+            for rel_elm in rels_elm.Relationship_lst:
+                if (
+                    rel_elm.target_ref in ("../NULL", "NULL") or rel_elm.target_ref.startswith("#_")  # Styled headers
+                ):
+                    continue
+                srels._srels.append(_SerializedRelationship(baseURI, rel_elm))
+        return srels
+
+    _SerializedRelationships.load_from_xml = load_from_xml_v2

--- a/apps/documents/readers.py
+++ b/apps/documents/readers.py
@@ -4,9 +4,12 @@ import docx
 import pypdf
 from pydantic import BaseModel, Field
 
+from apps.documents.patch_docx import patch_docx
 from apps.files.models import File
 
 logger = logging.getLogger("ocs.documents")
+
+patch_docx()
 
 
 class FileReadException(Exception):


### PR DESCRIPTION
Resolves: https://github.com/dimagi/open-chat-studio/issues/1286

## Description
This is to workaround issue with loading relationships from XML.

See https://github.com/python-openxml/python-docx/issues/1351

I wasn't able to get a minimal doc for reproduction but I did test with the a doc that was failing for a client.

## User Impact
Docs able to load.

### Docs and Changelog
https://github.com/dimagi/open-chat-studio-docs/pull/60
