### PR TITLE
connect channel consent tweaks

### DIFF
--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -488,18 +488,18 @@ def trigger_bot_message(request):
     if platform == ChannelPlatform.COMMCARE_CONNECT and not participant_data:
         # The commcare_connect channel requires certain data from the participant_data in order to send messages to th
         # user, which is why we need to check if the participant_data exists
-        return Response({"detail": "Participant not found"}, status=status.HTTP_404_NOT_FOUND)
+        return JsonResponse({"detail": "Participant not found"}, status=status.HTTP_404_NOT_FOUND)
     elif not Participant.objects.filter(identifier=identifier, platform=platform).exists():
-        return Response({"detail": "Participant not found"}, status=status.HTTP_404_NOT_FOUND)
+        return JsonResponse({"detail": "Participant not found"}, status=status.HTTP_404_NOT_FOUND)
 
     if not ExperimentChannel.objects.filter(platform=platform, experiment=experiment).exists():
-        return Response(
+        return JsonResponse(
             {"detail": f"Experiment cannot send messages on the {platform} channel"},
             status=status.HTTP_404_NOT_FOUND,
         )
 
     if platform == ChannelPlatform.COMMCARE_CONNECT and not participant_data.has_consented():
-        return Response({"detail": "User has not given consent"}, status=status.HTTP_400_BAD_REQUEST)
+        return JsonResponse({"detail": "User has not given consent"}, status=status.HTTP_400_BAD_REQUEST)
 
     trigger_bot_message_task.delay(data)
 

--- a/apps/channels/tests/test_base_channel_behavior.py
+++ b/apps/channels/tests/test_base_channel_behavior.py
@@ -2,6 +2,7 @@
 This test suite is designed to ensure that the base channel functionality is working as
 intended. It utilizes the Telegram channel subclass to serve as a testing framework.
 """
+
 import re
 from unittest.mock import Mock, patch
 
@@ -22,6 +23,7 @@ from apps.experiments.models import (
     ExperimentRoute,
     ExperimentSession,
     Participant,
+    ParticipantData,
     SessionStatus,
     VoiceResponseBehaviours,
 )
@@ -500,11 +502,14 @@ def test_all_channels_can_be_instantiated_from_a_session(platform, twilio_provid
     `ChannelBase.from_experiment_session`. For the sake of ease, we assume all platforms uses the Twilio
     messenging provider.
     """
-    experiment = ExperimentFactory()
-    experiment_channel = ExperimentChannelFactory(
-        messaging_provider=twilio_provider, experiment=experiment, platform=platform
+    session = ExperimentSessionFactory(experiment_channel__platform=platform)
+    ParticipantData.objects.create(
+        team=session.team,
+        experiment=session.experiment,
+        data={},
+        participant=session.participant,
+        system_metadata={"consent": True},
     )
-    session = ExperimentSessionFactory(experiment_channel=experiment_channel)
     channel = ChannelBase.from_experiment_session(session)
     assert type(channel) in ChannelBase.__subclasses__()
 

--- a/apps/channels/views.py
+++ b/apps/channels/views.py
@@ -8,7 +8,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
-from rest_framework import serializers
+from rest_framework import serializers, status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
@@ -179,6 +179,9 @@ def new_connect_message(request: HttpRequest):
         return JsonResponse({"detail": "No participant data found"}, status=404)
     except ExperimentChannel.DoesNotExist:
         return JsonResponse({"detail": "No experiment channel found"}, status=404)
+
+    if not participant_data.has_consented():
+        return JsonResponse({"detail": "User has not given consent"}, status=status.HTTP_400_BAD_REQUEST)
 
     tasks.handle_commcare_connect_message.delay(
         experiment_channel_id=channel.id, participant_data_id=participant_data.id, messages=serializer.data["messages"]

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -196,7 +196,7 @@ class ChannelBase(ABC):
         pass
 
     @staticmethod
-    def get_channel_class_for_platform(platform: ChannelPlatform) -> "ChannelBase":
+    def get_channel_class_for_platform(platform: ChannelPlatform | str) -> type["ChannelBase"]:
         if platform == "telegram":
             channel_cls = TelegramChannel
         elif platform == "web":
@@ -266,7 +266,8 @@ class ChannelBase(ABC):
         try:
             self._add_message(message)
         except ParticipantNotAllowedException:
-            return self.send_message_to_user("Sorry, you are not allowed to chat to this bot")
+            self.send_message_to_user("Sorry, you are not allowed to chat to this bot")
+            return ""
 
         try:
             if not self.is_message_type_supported():

--- a/apps/chat/exceptions.py
+++ b/apps/chat/exceptions.py
@@ -1,25 +1,22 @@
 class ChatException(Exception):
-    def __init__(self, message):
+    def __init__(self, message=""):
         self.message = message
         super().__init__(self.message)
 
 
 class AudioSynthesizeException(ChatException):
-    def __init__(self, message):
-        super().__init__(message)
+    pass
 
 
 class AudioTranscriptionException(ChatException):
-    def __init__(self, message):
-        super().__init__(message)
+    pass
 
 
 class ChannelException(ChatException):
-    def __init__(self, message):
-        super().__init__(message)
+    pass
 
 
-class ParticipantNotAllowedException(Exception):
+class ParticipantNotAllowedException(ChatException):
     pass
 
 

--- a/apps/web/superuser_utils.py
+++ b/apps/web/superuser_utils.py
@@ -58,6 +58,8 @@ def remove_expired_temporary_superuser_access(request, remove_grant=None):
     request.session["elevated_privileges"] = valid
 
 
-def get_temporary_superuser_access(request):
+def get_temporary_superuser_access(request) -> dict[str, datetime]:
+    if request.user.is_anonymous:
+        return {}
     remove_expired_temporary_superuser_access(request)
     return {grant: datetime.fromtimestamp(expire) for grant, expire in request.session.get("elevated_privileges", [])}


### PR DESCRIPTION
Sentry: OPEN-CHAT-STUDIO-NY

## Description
Some small tweaks to where consent is checked. The main goal is to check consent earlier in the process and to give feedback in the API views if consent has not been given.

## User Impact
Better API feedback. Also using less resources for participants that haven't consented.

### Demo
NA

### Docs and Changelog
NA
