### PR TITLE
Add getter function for schedules to python node

### DIFF
--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -72,13 +72,13 @@ class ParticipantDataProxy:
         """
         from apps.events.models import ScheduledMessage
 
-        experiment = self.session.experiment
-        participant = self.session.participant
+        experiment = self.session.experiment_id
+        participant = self.session.participant_id
         team = self.session.experiment.team
         messages = (
             ScheduledMessage.objects.filter(
-                experiment=experiment,
-                participant=participant,
+                experiment_id=experiment,
+                participant_id=participant,
                 team=team,
                 is_complete=False,
                 cancelled_at=None,

--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -65,3 +65,28 @@ class ParticipantDataProxy:
         participant_data.save(update_fields=["data"])
 
         self.session.participant.update_name_from_data(data)
+
+    def get_schedules(self):
+        """
+        Returns all active scheduled messages for the participant in the current experiment session.
+        """
+        from apps.events.models import ScheduledMessage
+
+        experiment = self.session.experiment
+        participant = self.session.participant
+        team = self.session.experiment.team
+        messages = (
+            ScheduledMessage.objects.filter(
+                experiment=experiment,
+                participant=participant,
+                team=team,
+                is_complete=False,
+                cancelled_at=None,
+            )
+            .select_related("action")
+            .order_by("created_at")
+        )
+        scheduled_messages = []
+        for message in messages:
+            scheduled_messages.append(message.as_string())
+        return scheduled_messages

--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -88,5 +88,5 @@ class ParticipantDataProxy:
         )
         scheduled_messages = []
         for message in messages:
-            scheduled_messages.append(message.as_string())
+            scheduled_messages.append(message.as_dict())
         return scheduled_messages

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -874,6 +874,7 @@ class CodeNode(PipelineNode):
                 "_write_": lambda x: x,
                 "get_participant_data": participant_data_proxy.get,
                 "set_participant_data": participant_data_proxy.set,
+                "get_participant_schedules": participant_data_proxy.get_schedules,
                 "get_temp_state_key": self._get_temp_state_key(state),
                 "set_temp_state_key": self._set_temp_state_key(state),
             }


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Part 2 of [this ticket](https://github.com/dimagi/open-chat-studio/issues/1181) to add access to participant's schedules to the python nodes-- only active. 

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Can be accessed in the python node

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
yes to both
