### PR TITLE
Bump langfuse version

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -66,6 +66,8 @@ packaging==23.2
     #   -c requirements.txt
     #   build
     #   pytest
+pip==25.0.1
+    # via pip-tools
 pip-tools==7.4.1
     # via -r dev-requirements.in
 platformdirs==4.3.6
@@ -126,3 +128,6 @@ watchfiles==1.0.4
     # via -r dev-requirements.in
 wheel==0.44.0
     # via pip-tools
+
+# The following packages were excluded from the output:
+# setuptools

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -37,7 +37,7 @@ langchain-anthropic
 langchain-openai
 langchain_google_genai
 langchain-community>=0.3,<0.4
-langfuse
+langfuse>=2.59.7
 langgraph>=0.2.20,<0.3
 loguru
 openai

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -28,6 +28,8 @@ anyio==4.4.0
     #   openai
 asgiref==3.8.1
     # via django
+async-timeout==5.0.1
+    # via redis
 attrs==23.1.0
     # via
     #   aiohttp
@@ -293,7 +295,7 @@ langchain-openai==0.2.3
     # via -r requirements.in
 langchain-text-splitters==0.3.0
     # via langchain
-langfuse==2.52.1
+langfuse==2.59.7
     # via -r requirements.in
 langgraph==0.2.35
     # via -r requirements.in
@@ -471,6 +473,7 @@ requests==2.32.3
     #   huggingface-hub
     #   langchain
     #   langchain-community
+    #   langfuse
     #   langsmith
     #   pytelegrambotapi
     #   requests-oauthlib


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Fix to this issue that seemed to kill the celery worker, since it ran in what looks like an infinite loop:
![image](https://github.com/user-attachments/assets/66040488-f2ee-46bf-9e08-1fd757ef6ed5)

I also got this issue locally, but after bumping the version, it disappeared and the bot was able to respond.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users should see bots using the langfuse tracing provider responding again.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/64