### PR TITLE
Send bot message when schedule is triggered

### DIFF
--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -415,11 +415,7 @@ class ScheduledMessage(BaseTeamModel):
             return
 
         with current_team(experiment_session.team):
-            experiment_session.ad_hoc_bot_message(
-                self.params["prompt_text"],
-                fail_silently=False,
-                use_experiment=self._get_experiment_to_generate_response(),
-            )
+            experiment_session.try_send_message(self.params["prompt_text"], fail_silently=False)
 
         utc_now = timezone.now()
         self.last_triggered_at = utc_now

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -321,16 +321,20 @@ class TestExperimentSession:
         trigger_action = ScheduleTriggerAction()
         trigger_action.invoke(session, action=event_action)
 
-        session.ad_hoc_bot_message = Mock()
+        session.try_send_message = Mock()
         message = ScheduledMessage.objects.get(action=event_action)
         message.participant.get_latest_session = lambda *args, **kwargs: session
         message.safe_trigger()
 
-        experiment_used = session.ad_hoc_bot_message.call_args_list[0].kwargs["use_experiment"]
-        if use_custom_experiment:
-            assert experiment_used == custom_experiment
-        else:
-            assert experiment_used == session.experiment
+        session.try_send_message.assert_called_once()
+        assert session.try_send_message.call_args.args[0] == "hi"
+
+        if hasattr(message, "_get_experiment_to_generate_response"):
+            experiment_used = message._get_experiment_to_generate_response()
+            if use_custom_experiment:
+                assert experiment_used == custom_experiment
+            else:
+                assert experiment_used == session.experiment
 
     @pytest.mark.parametrize(
         ("repetitions", "total_triggers", "end_date", "expected"),


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Flagged in slack

Theory: In ScheduledMessage._trigger(), it was using experiment_session.ad_hoc_bot_message() to send the reminder, but that, takes the message as an instruction_prompt and passes it to _bot_prompt_for_user(). So the bot is treating the reminder text (e.g., "Take your medication") as an instruction to generate a reminder-related response, which results in sending a confirmation message about scheduling a reminder.

Fix: directly call try_send_message() which sends the message straight to the user


## User Impact
<!-- Describe the impact of this change on the end-users. -->
fixes schedules

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
yes to change log
