### PR TITLE
ConnectId: Support consent from the create channel API

### DIFF
--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -54,10 +54,14 @@ def setup_connect_channels_for_bots(self, connect_id: UUID, experiment_data_map:
         try:
             experiment = participant_datum.experiment
             channel = channels[experiment.id]
-            commcare_connect_channel_id = connect_client.create_channel(
+            response = connect_client.create_channel(
                 connect_id=connect_id, channel_source=channel.extra_data["commcare_connect_bot_name"]
             )
-            participant_datum.system_metadata["commcare_connect_channel_id"] = commcare_connect_channel_id
+
+            participant_datum.system_metadata = {
+                "commcare_connect_channel_id": response["channel_id"],
+                "consent": response["consent"],
+            }
             participant_datum.save(update_fields=["system_metadata"])
         except Exception as e:
             logger.exception(f"Failed to create channel for participant data {participant_datum.id}: {e}")

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -299,7 +299,7 @@ def test_update_participant_data_and_setup_connect_channels(httpx_mock):
     httpx_mock.add_response(
         method="POST",
         url=f"{settings.COMMCARE_CONNECT_SERVER_URL}/messaging/create_channel/",
-        json={"channel_id": created_connect_channel_id},
+        json={"channel_id": created_connect_channel_id, "consent": True},
     )
 
     team = TeamWithUsersFactory()
@@ -373,7 +373,7 @@ def test_update_participant_data_and_setup_connect_channels(httpx_mock):
     assert request_data["channel_source"] == "bot1"
     assert Participant.objects.filter(identifier="CONNECTID_2").exists()
     data = ParticipantData.objects.get(participant__identifier="CONNECTID_2", experiment_id=experiment1.id)
-    assert data.system_metadata["commcare_connect_channel_id"] == created_connect_channel_id
+    assert data.system_metadata == {"commcare_connect_channel_id": created_connect_channel_id, "consent": True}
 
 
 @pytest.mark.django_db()

--- a/apps/channels/clients/connect_client.py
+++ b/apps/channels/clients/connect_client.py
@@ -46,7 +46,7 @@ class CommCareConnectClient:
         url = f"{self._base_url}/messaging/create_channel/"
         response = self.client.post(url, json={"connectid": str(connect_id), "channel_source": channel_source})
         response.raise_for_status()
-        return response.json()["channel_id"]
+        return response.json()
 
     def decrypt_messages(self, key: bytes, messages: list[Message]) -> list[str]:
         """


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
The create channel API's response payload now looks like this:
```json
{"channel_id": "<channel id>", "consent": "true / false"}
```

This PR adds support for this payload.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Connect users with auto consent will now be able to chat to bots again.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
N/A