### PR TITLE
langfuse fix

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1554,6 +1554,9 @@ class ExperimentSession(BaseTeamModel):
     class Meta:
         ordering = ["-created_at"]
 
+    def __str__(self):
+        return f"ExperimentSession(id={self.external_id})"
+
     def save(self, *args, **kwargs):
         if not hasattr(self, "chat"):
             self.chat = Chat.objects.create(team=self.team, name=self.experiment.name)

--- a/apps/pipelines/admin.py
+++ b/apps/pipelines/admin.py
@@ -3,12 +3,7 @@ import json
 from django import forms
 from django.contrib import admin
 
-from .models import Node, Pipeline, PipelineChatHistory, PipelineChatMessages, PipelineRun
-
-
-class PipelineRunInline(admin.TabularInline):
-    model = PipelineRun
-    extra = 0
+from .models import Node, Pipeline, PipelineChatHistory, PipelineChatMessages
 
 
 class PipelineNodeInline(admin.TabularInline):
@@ -28,7 +23,7 @@ class PipelineAdminForm(forms.ModelForm):
 @admin.register(Pipeline)
 class PipelineAdmin(admin.ModelAdmin):
     form = PipelineAdminForm
-    inlines = [PipelineNodeInline, PipelineRunInline]
+    inlines = [PipelineNodeInline]
 
 
 class PipelineChatMessagesInline(admin.TabularInline):

--- a/apps/pipelines/management/commands/import_pipeline.py
+++ b/apps/pipelines/management/commands/import_pipeline.py
@@ -1,0 +1,43 @@
+import json
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from apps.pipelines.models import Pipeline
+from apps.teams.models import Team
+
+
+class Command(BaseCommand):
+    help = "Create a new Pipeline and related models from a JSON file for a specified team."
+
+    def add_arguments(self, parser):
+        parser.add_argument("team", type=str, help="Slug of the team.")
+        parser.add_argument("name", type=str, help="Name of the new pipeline.")
+        parser.add_argument("file_path", type=str, help="Path to the JSON file.")
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        team_slug = options["team"]
+        name = options["name"]
+        file_path = options["file_path"]
+
+        try:
+            with open(file_path) as file:
+                data = json.load(file)
+        except FileNotFoundError:
+            raise CommandError(f"File {file_path} does not exist.")
+        except json.JSONDecodeError:
+            raise CommandError("Invalid JSON file.")
+
+        try:
+            team = Team.objects.get(slug=team_slug)
+        except Team.DoesNotExist:
+            raise CommandError(f"Team with slug {team_slug} does not exist.")
+
+        new_pipeline = Pipeline.objects.create(
+            team=team,
+            data=data,
+            name=name,
+        )
+        new_pipeline.update_nodes_from_data()
+        self.stdout.write(self.style.SUCCESS(f"Pipeline '{name}' created successfully: {new_pipeline.pk}"))

--- a/apps/service_providers/tests/test_trace_serialization.py
+++ b/apps/service_providers/tests/test_trace_serialization.py
@@ -4,15 +4,16 @@ from apps.service_providers.tracing.service import serialize_input_output_dict
 
 
 def test_serialize_trace_data():
+    session = ExperimentSession()
     output = serialize_input_output_dict(
         {
-            "key1": ExperimentSession(),
+            "key1": session,
             "key2": Attachment(file_id=123, type="file_search", name="file.txt", size=100),
-            "key3": [{"session": ExperimentSession()}],
+            "key3": [{"session": session}],
         }
     )
     assert output == {
-        "key1": "ExperimentSession object (None)",
+        "key1": str(session),
         "key2": {
             "content_type": "application/octet-stream",
             "file_id": 123,
@@ -21,5 +22,5 @@ def test_serialize_trace_data():
             "type": "file_search",
             "upload_to_assistant": False,
         },
-        "key3": [{"session": "ExperimentSession object (None)"}],
+        "key3": [{"session": str(session)}],
     }

--- a/apps/service_providers/tests/test_trace_serialization.py
+++ b/apps/service_providers/tests/test_trace_serialization.py
@@ -1,0 +1,25 @@
+from apps.channels.datamodels import Attachment
+from apps.experiments.models import ExperimentSession
+from apps.service_providers.tracing.service import serialize_input_output_dict
+
+
+def test_serialize_trace_data():
+    output = serialize_input_output_dict(
+        {
+            "key1": ExperimentSession(),
+            "key2": Attachment(file_id=123, type="file_search", name="file.txt", size=100),
+            "key3": [{"session": ExperimentSession()}],
+        }
+    )
+    assert output == {
+        "key1": "ExperimentSession object (None)",
+        "key2": {
+            "content_type": "application/octet-stream",
+            "file_id": 123,
+            "name": "file.txt",
+            "size": 100,
+            "type": "file_search",
+            "upload_to_assistant": False,
+        },
+        "key3": [{"session": "ExperimentSession object (None)"}],
+    }


### PR DESCRIPTION
## Description
This is a quick fix for the langfuse tracing issue. I have not yet determined why this started happening and I also have not been able to consistently reproduce the issue however I'm alsmost certain that the error described on https://github.com/dimagi/open-chat-studio/pull/1301 is the culprit. The upgrade did not fix that error, I think it just masked it.

With the changes in this PR the celery process memory does not grow continuously. 

I think the issue is that a span / trace gets into the langfuse queue to be sent but then fails during serialization which triggers an infinite retry. The serialization fails when trying to serialize Django model objects.

The fix in this PR is to pre-serialize the data to ensure that Django model's are converted to strings using `str(model)`. This is safe for all models because the base Model class implements `__str__`.

### Longer term fix
In the long term I think we should move the 'session' out of the `PipelineState` object and try to keep that object to simple types.

## User Impact
User's can use langfuse again.

### Demo
NA

### Docs and Changelog
TODO
