### PR TITLE
Generate missing encryption keys

### DIFF
--- a/apps/channels/tests/test_connect_integration.py
+++ b/apps/channels/tests/test_connect_integration.py
@@ -160,6 +160,7 @@ class TestApiEndpoint:
 
 class TestCommCareConnectChannel:
     @pytest.mark.django_db()
+    @override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
     def test_get_encryption_key_generates_missing_key(self):
         """Missing encryption keys should be generated"""
         session = ExperimentSessionFactory(experiment_channel__platform=ChannelPlatform.COMMCARE_CONNECT)

--- a/apps/channels/tests/test_connect_integration.py
+++ b/apps/channels/tests/test_connect_integration.py
@@ -14,9 +14,10 @@ from django.urls import reverse
 from apps.channels.clients.connect_client import CommCareConnectClient, Message, NewMessagePayload
 from apps.channels.models import ChannelPlatform
 from apps.channels.tasks import handle_commcare_connect_message
+from apps.chat.channels import CommCareConnectChannel
 from apps.experiments.models import ParticipantData
 from apps.utils.factories.channels import ExperimentChannelFactory
-from apps.utils.factories.experiment import ParticipantFactory
+from apps.utils.factories.experiment import ExperimentSessionFactory, ParticipantFactory
 
 
 def _setup(experiment, message_spec: dict | None = None) -> tuple:
@@ -155,3 +156,23 @@ class TestApiEndpoint:
         )
         assert response.status_code == 404
         assert response.json() == expected_response
+
+
+class TestCommCareConnectChannel:
+    @pytest.mark.django_db()
+    def test_get_encryption_key_generates_missing_key(self):
+        """Missing encryption keys should be generated"""
+        session = ExperimentSessionFactory(experiment_channel__platform=ChannelPlatform.COMMCARE_CONNECT)
+        channel = CommCareConnectChannel.from_experiment_session(session)
+        participant_data = ParticipantData.objects.create(
+            team=session.team,
+            participant=session.participant,
+            experiment=session.experiment,
+        )
+
+        assert len(participant_data.encryption_key) == 0
+        # A call to encryption_key() should generate a new key if one is missing
+        key = channel.encryption_key
+        participant_data.refresh_from_db()
+        assert key is not None
+        assert participant_data.get_encryption_key_bytes() == key

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -887,10 +887,9 @@ class CommCareConnectChannel(ChannelBase):
 
     @cached_property
     def encryption_key(self) -> bytes:
-        key = self.participant_data.get_encryption_key_bytes()
-        if not key:
-            raise ChannelException(f"Encryption key is missing for participant {self.participant_identifier}")
-        return key
+        if not self.participant_data.encryption_key:
+            self.participant_data.generate_encryption_key()
+        return self.participant_data.get_encryption_key_bytes()
 
 
 def _start_experiment_session(


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
See [this support ticket](https://dimagi.atlassian.net/browse/SUPPORT-23565)
Missing encryption keys should be generated. The mobile app will ask OCS for an encryption key first, and only then try to decrypt the messages. This means that OCS can simply return the key that was used to encrypt the message.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
OCS will be able to send messages to users before the `generate_encryption_key` API was hit.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
N/A