### PR TITLE
misc pipeline fixes

### DIFF
--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -22,7 +22,7 @@ def temporary_session(team: Team, user_id: int):
         )
         channel = ExperimentChannel.objects.get_team_web_channel(team)
         chat = Chat.objects.create(team=team, name="Temporary Chat")
-        participant, _ = Participant.objects.get_or_create(user=user, team=team, platform=ChannelPlatform.WEB)
+        participant = Participant.create_anonymous(team=team, platform=ChannelPlatform.WEB)
         experiment_session = ExperimentSession.objects.create(
             team=team,
             experiment=experiment,

--- a/apps/pipelines/tests/test_runnable_builder.py
+++ b/apps/pipelines/tests/test_runnable_builder.py
@@ -13,7 +13,7 @@ from apps.pipelines.exceptions import PipelineBuildError, PipelineNodeBuildError
 from apps.pipelines.logging import LoggingCallbackHandler
 from apps.pipelines.nodes.base import PipelineState
 from apps.pipelines.nodes.helpers import ParticipantDataProxy
-from apps.pipelines.nodes.nodes import EndNode, StartNode, StaticRouterNode
+from apps.pipelines.nodes.nodes import EndNode, RouterNode, StartNode, StaticRouterNode
 from apps.pipelines.tests.utils import (
     assistant_node,
     boolean_node,
@@ -374,36 +374,28 @@ def test_router_node(get_llm_service, provider, provider_model, pipeline, experi
     assert output["messages"][-1] == "A z"
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
+@pytest.mark.django_db()
 @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
-@mock.patch("apps.pipelines.nodes.base.PipelineNode.logger", mock.Mock())
 def test_router_node_prompt(get_llm_service, provider, provider_model, pipeline, experiment_session):
     service = build_fake_llm_echo_service()
     get_llm_service.return_value = service
-    start = start_node()
-    router = router_node(
-        str(provider.id),
-        str(provider_model.id),
-        keywords=["A"],
-        prompt="""
-    PD: {participant_data}
-    DT: {current_datetime}
-    """,
-    )
-    end = end_node()
-    nodes = [start, router, end]
-    edges = [
-        {"id": "start -> router", "source": start["id"], "target": router["id"]},
-        {
-            "id": "RouterNode -> End",
-            "source": router["id"],
-            "target": end["id"],
-            "sourceHandle": "output_0",
-        },
-    ]
-    runnable = create_runnable(pipeline, nodes, edges)
 
-    runnable.invoke(PipelineState(messages=["a"], experiment_session=experiment_session))
+    node = RouterNode(
+        name="test router",
+        prompt="PD: {participant_data}\nDT: {current_datetime}",
+        keywords=["A"],
+        llm_provider_id=provider.id,
+        llm_provider_model_id=provider_model.id,
+    )
+    node.process_conditional(
+        PipelineState(
+            outputs={"123": {}},
+            messages=["a"],
+            experiment_session=experiment_session,
+        ),
+        node_id="123",
+    )
+
     assert len(service.llm.get_call_messages()[0]) == 2
     assert str(experiment_session.get_participant_data()) in service.llm.get_call_messages()[0][0].content
 

--- a/apps/pipelines/tests/utils.py
+++ b/apps/pipelines/tests/utils.py
@@ -132,16 +132,19 @@ def boolean_node(input_equals="hello"):
     }
 
 
-def router_node(provider_id: str, provider_model_id: str, keywords: list[str]):
+def router_node(provider_id: str, provider_model_id: str, keywords: list[str], **kwargs):
     return {
         "id": str(uuid4()),
         "type": nodes.RouterNode.__name__,
         "params": {
-            "name": "router",
-            "prompt": "You are a router",
-            "keywords": keywords,
-            "llm_provider_id": provider_id,
-            "llm_provider_model_id": provider_model_id,
+            **{
+                "name": "router",
+                "prompt": "You are a router",
+                "keywords": keywords,
+                "llm_provider_id": provider_id,
+                "llm_provider_model_id": provider_model_id,
+            },
+            **kwargs,
         },
     }
 

--- a/apps/service_providers/llm_service/prompt_context.py
+++ b/apps/service_providers/llm_service/prompt_context.py
@@ -7,7 +7,7 @@ from apps.utils.time import pretty_date
 
 
 class PromptTemplateContext:
-    def __init__(self, session, source_material_id):
+    def __init__(self, session, source_material_id: int = None):
         self.session = session
         self.source_material_id = source_material_id
         self.context_cache = {}
@@ -32,6 +32,9 @@ class PromptTemplateContext:
 
     def get_source_material(self):
         from apps.experiments.models import SourceMaterial
+
+        if self.source_material_id is None:
+            return ""
 
         try:
             return SourceMaterial.objects.get(id=self.source_material_id).material


### PR DESCRIPTION
## Description
Fixes #1331 - always use an 'anonymous' participant for pipeline tests
Fixes #1332 - support all prompt variables in router prompts