### PR TITLE
avoid additional queries in chat views

### DIFF
--- a/apps/experiments/decorators.py
+++ b/apps/experiments/decorators.py
@@ -94,7 +94,7 @@ def verify_session_access_cookie(view):
         except (signing.BadSignature, KeyError):
             raise Http404()
 
-        if not _validate_access_cookie_data(request.experiment_session, access_value):
+        if not _validate_access_cookie_data(request.experiment, request.experiment_session, access_value):
             raise Http404()
 
         return view(request, *args, **kwargs)
@@ -102,17 +102,17 @@ def verify_session_access_cookie(view):
     return _inner
 
 
-def _get_access_cookie_data(experiment_session):
+def _get_access_cookie_data(experiment, experiment_session):
     return {
-        "experiment_id": str(experiment_session.experiment.public_id),
+        "experiment_id": str(experiment.public_id),
         "session_id": str(experiment_session.external_id),
         "participant_id": experiment_session.participant_id,
         "user_id": experiment_session.participant.user_id,
     }
 
 
-def _validate_access_cookie_data(experiment_session, access_data):
-    return _get_access_cookie_data(experiment_session) == access_data
+def _validate_access_cookie_data(experiment, experiment_session, access_data):
+    return _get_access_cookie_data(experiment, experiment_session) == access_data
 
 
 def _redirect_for_state(request, team_slug):

--- a/apps/experiments/decorators.py
+++ b/apps/experiments/decorators.py
@@ -27,12 +27,14 @@ def experiment_session_view(allowed_states=None):
             request.experiment = get_object_or_404(
                 Experiment.objects.get_all(), public_id=experiment_id, team=request.team
             )
-            request.experiment_session = get_object_or_404(
-                ExperimentSession,
-                experiment=request.experiment,
-                external_id=session_id,
-                team=request.team,
-            )
+            try:
+                request.experiment_session = ExperimentSession.objects.select_related("participant", "chat").get(
+                    experiment=request.experiment,
+                    external_id=session_id,
+                    team=request.team,
+                )
+            except ExperimentSession.DoesNotExist:
+                raise Http404()
 
             if allowed_states and request.experiment_session.status not in allowed_states:
                 return _redirect_for_state(request, team_slug)

--- a/apps/experiments/decorators.py
+++ b/apps/experiments/decorators.py
@@ -45,9 +45,9 @@ def experiment_session_view(allowed_states=None):
     return decorator
 
 
-def set_session_access_cookie(response, experiment_session):
+def set_session_access_cookie(response, experiment, experiment_session):
     """Set the session access cookie on the response"""
-    value = _get_access_cookie_data(experiment_session)
+    value = _get_access_cookie_data(experiment, experiment_session)
     value = signing.get_cookie_signer(salt=CHAT_SESSION_ACCESS_SALT).sign_object(value)
     response.set_cookie(
         CHAT_SESSION_ACCESS_COOKIE,

--- a/apps/experiments/tests/test_views.py
+++ b/apps/experiments/tests/test_views.py
@@ -567,7 +567,7 @@ class TestPublicSessions:
         _verify_user_or_start_session(
             identifier=participant.identifier,
             request=request,
-            experient=experiment_session.experient,
+            experiment=experiment_session.experiment,
             session=experiment_session,
         )
 

--- a/apps/experiments/tests/test_views.py
+++ b/apps/experiments/tests/test_views.py
@@ -531,7 +531,7 @@ class TestPublicSessions:
         experiment_session = ExperimentSessionFactory()
         request.user = experiment_session.experiment.owner
 
-        _verify_user_or_start_session("something", request, experiment_session)
+        _verify_user_or_start_session("something", request, experiment_session.experiment, experiment_session)
         record_consent_and_redirect_mock.assert_called()
 
     @pytest.mark.parametrize(("participant_match"), [True, False])
@@ -564,7 +564,12 @@ class TestPublicSessions:
         get_chat_session_access_cookie_data.return_value = {
             "participant_id": participant.id if participant_match else participant.id + 1
         }
-        _verify_user_or_start_session(identifier=participant.identifier, request=request, session=experiment_session)
+        _verify_user_or_start_session(
+            identifier=participant.identifier,
+            request=request,
+            experient=experiment_session.experient,
+            session=experiment_session,
+        )
 
         if participant_match:
             record_consent_and_redirect_mock.assert_called()
@@ -595,7 +600,12 @@ class TestPublicSessions:
         request_user.is_authenticated = False
         request.user = request_user
         experiment_session = ExperimentSessionFactory(experiment__prompt_text=prompt)
-        _verify_user_or_start_session(identifier="someone@gmail.com", request=request, session=experiment_session)
+        _verify_user_or_start_session(
+            identifier="someone@gmail.com",
+            request=request,
+            experiment=experiment_session.experiment,
+            session=experiment_session,
+        )
         if participant_data_injected:
             _record_consent_and_redirect.assert_not_called()
             send_chat_link_email.assert_called()

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1169,6 +1169,9 @@ def start_session_from_invite(request, team_slug: str, experiment_id: uuid.UUID,
     if not request.experiment_session.participant:
         raise Http404()
 
+    if not consent:
+        return _record_consent_and_redirect(team_slug, request.experiment, request.experiment_session)
+
     if request.method == "POST":
         form = ConsentForm(consent, request.POST, initial=initial)
         if form.is_valid():

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -927,7 +927,7 @@ def start_session_public(request, team_slug: str, experiment_id: uuid.UUID):
             participant_identifier=identifier,
             timezone=request.session.get("detected_tz", None),
         )
-        return _record_consent_and_redirect(request, team_slug, session)
+        return _record_consent_and_redirect(team_slug, experiment, session)
 
     if request.method == "POST":
         form = ConsentForm(consent, request.POST, initial={"identifier": user.email if user else None})
@@ -953,10 +953,11 @@ def start_session_public(request, team_slug: str, experiment_id: uuid.UUID):
                 return _verify_user_or_start_session(
                     identifier=identifier,
                     request=request,
+                    experiment=experiment,
                     session=session,
                 )
             else:
-                return _record_consent_and_redirect(request, team_slug, session)
+                return _record_consent_and_redirect(team_slug, experiment, session)
     else:
         form = ConsentForm(
             consent,
@@ -1007,7 +1008,7 @@ def start_session_public_embed(request, team_slug: str, experiment_id: uuid.UUID
     return redirect("experiments:experiment_chat_embed", team_slug, experiment.public_id, session.external_id)
 
 
-def _verify_user_or_start_session(identifier, request, session):
+def _verify_user_or_start_session(identifier, request, experiment, session):
     """
     Verifies if the user is allowed to access the chat.
 
@@ -1021,16 +1022,16 @@ def _verify_user_or_start_session(identifier, request, session):
     """
     team_slug = session.team.slug
     if request.user.is_authenticated:
-        return _record_consent_and_redirect(request, team_slug, session)
+        return _record_consent_and_redirect(team_slug, experiment, session)
 
     if not session.requires_participant_data():
-        return _record_consent_and_redirect(request, team_slug, session)
+        return _record_consent_and_redirect(team_slug, experiment, session)
 
     if session_data := get_chat_session_access_cookie_data(request, fail_silently=True):
         if Participant.objects.filter(
             id=session_data["participant_id"], identifier=identifier, team_id=session.team_id
         ).exists():
-            return _record_consent_and_redirect(request, team_slug, session)
+            return _record_consent_and_redirect(team_slug, experiment, session)
 
     send_chat_link_email(session)
     return TemplateResponse(request=request, template="account/participant_email_verify.html")
@@ -1039,8 +1040,8 @@ def _verify_user_or_start_session(identifier, request, session):
 def verify_public_chat_token(request, team_slug: str, experiment_id: uuid.UUID, token: str):
     try:
         claims = jwt.decode(token, settings.SECRET_KEY, algorithms="HS256")
-        session = get_object_or_404(ExperimentSession, external_id=claims["session"])
-        return _record_consent_and_redirect(request, team_slug, session)
+        session = ExperimentSession.objects.select_related("experiment").get(external_id=claims["session"])
+        return _record_consent_and_redirect(team_slug, session.experiment, session)
     except Exception:
         messages.warning(request=request, message="This link could not be verified")
         return redirect(reverse("experiments:start_session_public", args=(team_slug, experiment_id)))
@@ -1137,7 +1138,7 @@ def send_invitation(request, team_slug: str, experiment_id: int, session_id: str
     )
 
 
-def _record_consent_and_redirect(request, team_slug: str, experiment_session: ExperimentSession):
+def _record_consent_and_redirect(team_slug: str, experiment: Experiment, experiment_session: ExperimentSession):
     # record consent, update status
     experiment_session.consent_date = timezone.now()
     if experiment_session.experiment_version.pre_survey:
@@ -1153,27 +1154,25 @@ def _record_consent_and_redirect(request, team_slug: str, experiment_session: Ex
             args=[team_slug, experiment_session.experiment.public_id, experiment_session.external_id],
         )
     )
-    return set_session_access_cookie(response, experiment_session)
+    return set_session_access_cookie(response, experiment, experiment_session)
 
 
 @experiment_session_view(allowed_states=[SessionStatus.SETUP, SessionStatus.PENDING])
 def start_session_from_invite(request, team_slug: str, experiment_id: uuid.UUID, session_id: str):
-    experiment = get_object_or_404(Experiment, public_id=experiment_id, team=request.team)
-    experiment_session = get_object_or_404(ExperimentSession, experiment=experiment, external_id=session_id)
-    default_version = experiment.default_version
+    default_version = request.experiment.default_version
     consent = default_version.consent_form
 
     initial = {
-        "participant_id": experiment_session.participant.id,
-        "identifier": experiment_session.participant.identifier,
+        "participant_id": request.experiment_session.participant.id,
+        "identifier": request.experiment_session.participant.identifier,
     }
-    if not experiment_session.participant:
+    if not request.experiment_session.participant:
         raise Http404()
 
     if request.method == "POST":
         form = ConsentForm(consent, request.POST, initial=initial)
         if form.is_valid():
-            return _record_consent_and_redirect(request, team_slug, experiment_session)
+            return _record_consent_and_redirect(team_slug, request.experiment, request.experiment_session)
 
     else:
         form = ConsentForm(consent, initial=initial)

--- a/templates/account/base.html
+++ b/templates/account/base.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load i18n %}
 {% block body %}
-  <div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+  <div class="min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
     <div class="max-w-lg w-full space-y-8">
       {% block content %}
       {% endblock content %}

--- a/templates/account/participant_email_verify.html
+++ b/templates/account/participant_email_verify.html
@@ -5,7 +5,7 @@
     <h1 class="pg-title">{% translate "Check your inbox" %}</h1>
     <h2 class="pg-subtitle">
         {% blocktranslate %}
-            We've sent you an e-mail with a link that you can follow to chat to this bot.
+            We've e-mailed you a link that you can follow to chat to this bot.
         {% endblocktranslate %}
     </h2>
 {% endblock %}


### PR DESCRIPTION
## Description
I started looking at [OPEN-CHAT-STUDIO-RR](https://dimagi.sentry.io/issues/6420077091/events/a787a9ed4e9d46ac9a8698c814543f00/) and noticed that we re-fetch the experiment in different places.

This refactors the chat views and validation code to avoid re-fetching the experiment. 

This PR also includes a fix for when consent is not set and for dark mode which I found while testing the changes.