### PR TITLE
only return the final message from assistants

### DIFF
--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -337,9 +337,15 @@ class AssistantChat(RunnableSerializable[dict, ChainOutput]):
         from apps.assistants.sync import get_and_store_openai_file
 
         client = self.adapter.assistant_client
+
+        # We only want to the last message so that don't show 'thinking' messages
+        # Don't iterate to avoid loading more pages
+        messages_list = client.beta.threads.messages.list(thread_id, run_id=run_id, order="desc", limit=1).data
+        if not messages_list:
+            return "", []
+
         chat = self.adapter.session.chat
         session_id = self.adapter.session.id
-
         team = self.adapter.session.team
         assistant_file_ids = ToolResources.objects.filter(assistant=self.adapter.assistant).values_list("files")
         assistant_files_ids = File.objects.filter(
@@ -350,62 +356,63 @@ class AssistantChat(RunnableSerializable[dict, ChainOutput]):
         image_file_attachments = []
         file_path_attachments = []
         output_message = ""
-        for message in client.beta.threads.messages.list(thread_id, run_id=run_id):
-            for message_content in message.content:
-                if message_content.type == "image_file":
-                    if created_file := self._create_image_file_from_image_message(client, message_content.image_file):
-                        image_file_attachments.append(created_file)
-                        file_ids.add(created_file.external_id)
 
-                        team_slug = team.slug
-                        file_link = f"file:{team_slug}:{session_id}:{created_file.id}"
-                        output_message += f"![{created_file.name}]({file_link})\n"
+        message = messages_list[0]
+        for message_content in message.content:
+            if message_content.type == "image_file":
+                if created_file := self._create_image_file_from_image_message(client, message_content.image_file):
+                    image_file_attachments.append(created_file)
+                    file_ids.add(created_file.external_id)
 
-                elif message_content.type == "text":
-                    message_content_value = message_content.text.value
+                    team_slug = team.slug
+                    file_link = f"file:{team_slug}:{session_id}:{created_file.id}"
+                    output_message += f"![{created_file.name}]({file_link})\n"
 
-                    annotations = message_content.text.annotations
-                    for idx, annotation in enumerate(annotations):
-                        file_id = None
-                        file_ref_text = annotation.text
-                        if annotation.type == "file_citation":
-                            file_citation = annotation.file_citation
-                            file_id = file_citation.file_id
-                            file_name, file_link = self._get_file_link_for_citation(
-                                file_id=file_id, forbidden_file_ids=assistant_files_ids
-                            )
+            elif message_content.type == "text":
+                message_content_value = message_content.text.value
 
-                            # Original citation text example:【6:0†source】
-                            if self.adapter.citations_enabled:
-                                message_content_value = message_content_value.replace(file_ref_text, f" [{idx}]")
-                                if file_link:
-                                    message_content_value += f"\n[{idx}]: {file_link}"
-                                else:
-                                    message_content_value += f"\n\\[{idx}\\]: {file_name}"
+                annotations = message_content.text.annotations
+                for idx, annotation in enumerate(annotations):
+                    file_id = None
+                    file_ref_text = annotation.text
+                    if annotation.type == "file_citation":
+                        file_citation = annotation.file_citation
+                        file_id = file_citation.file_id
+                        file_name, file_link = self._get_file_link_for_citation(
+                            file_id=file_id, forbidden_file_ids=assistant_files_ids
+                        )
+
+                        # Original citation text example:【6:0†source】
+                        if self.adapter.citations_enabled:
+                            message_content_value = message_content_value.replace(file_ref_text, f" [{idx}]")
+                            if file_link:
+                                message_content_value += f"\n[{idx}]: {file_link}"
                             else:
-                                message_content_value = message_content_value.replace(file_ref_text, "")
+                                message_content_value += f"\n\\[{idx}\\]: {file_name}"
+                        else:
+                            message_content_value = message_content_value.replace(file_ref_text, "")
 
-                        elif annotation.type == "file_path":
-                            file_path = annotation.file_path
-                            file_id = file_path.file_id
-                            created_file = get_and_store_openai_file(
-                                client=client,
-                                file_id=file_id,
-                                team_id=team.id,
-                            )
-                            # Original citation text example: sandbox:/mnt/data/the_file.csv.
-                            # This is the link part in what looks like
-                            # [Download the CSV file](sandbox:/mnt/data/the_file.csv)
-                            message_content_value = message_content_value.replace(
-                                file_ref_text, f"file:{team.slug}:{session_id}:{created_file.id}"
-                            )
-                            file_path_attachments.append(created_file)
-                        file_ids.add(file_id)
+                    elif annotation.type == "file_path":
+                        file_path = annotation.file_path
+                        file_id = file_path.file_id
+                        created_file = get_and_store_openai_file(
+                            client=client,
+                            file_id=file_id,
+                            team_id=team.id,
+                        )
+                        # Original citation text example: sandbox:/mnt/data/the_file.csv.
+                        # This is the link part in what looks like
+                        # [Download the CSV file](sandbox:/mnt/data/the_file.csv)
+                        message_content_value = message_content_value.replace(
+                            file_ref_text, f"file:{team.slug}:{session_id}:{created_file.id}"
+                        )
+                        file_path_attachments.append(created_file)
+                    file_ids.add(file_id)
 
-                    output_message += message_content_value + "\n"
-                else:
-                    # Ignore any other type for now
-                    pass
+                output_message += message_content_value + "\n"
+            else:
+                # Ignore any other type for now
+                pass
 
         # Attach the generated files to the chat object as an annotation
         if file_path_attachments:

--- a/apps/service_providers/tests/test_assistant_runnable.py
+++ b/apps/service_providers/tests/test_assistant_runnable.py
@@ -83,7 +83,7 @@ def test_assistant_conversation_new_chat(
     create_and_run.return_value = run
     retrieve_run.return_value = run
 
-    list_messages.return_value = _create_thread_messages(
+    list_messages.return_value.data = _create_thread_messages(
         ASSISTANT_ID, run.id, thread_id, [{"assistant": "ai response"}]
     )
 
@@ -118,7 +118,9 @@ def test_assistant_conversation_existing_chat(
     run = _create_run(ASSISTANT_ID, thread_id)
     create_run.return_value = run
     retrieve_run.return_value = run
-    list_messages.return_value = _create_thread_messages(ASSISTANT_ID, run.id, thread_id, [{"assistant": ai_response}])
+    list_messages.return_value.data = _create_thread_messages(
+        ASSISTANT_ID, run.id, thread_id, [{"assistant": ai_response}]
+    )
 
     assistant_runnable = create_experiment_runnable(session.experiment, session)
     result = assistant_runnable.invoke("test")
@@ -154,7 +156,7 @@ def test_assistant_conversation_input_formatting(
     run = _create_run(ASSISTANT_ID, thread_id)
     create_and_run.return_value = run
     retrieve_run.return_value = run
-    list_messages.return_value = _create_thread_messages(
+    list_messages.return_value.data = _create_thread_messages(
         ASSISTANT_ID, run.id, thread_id, [{"assistant": "ai response"}]
     )
 
@@ -185,7 +187,9 @@ def test_assistant_includes_file_type_information(
     create_and_run.return_value = run
     retrieve_run.return_value = run
     get_file_type_info.return_value = [{"file-12345": "application/fmt"}]
-    list_messages.return_value = _create_thread_messages(ASSISTANT_ID, run.id, thread_id, [{"assistant": ai_response}])
+    list_messages.return_value.data = _create_thread_messages(
+        ASSISTANT_ID, run.id, thread_id, [{"assistant": ai_response}]
+    )
     assistant = session.experiment.assistant
     assistant.instructions = "Help the user"
     assistant.include_file_info = True
@@ -312,7 +316,7 @@ def test_assistant_uploads_new_file(create_and_run, retrieve_run, list_messages,
     run = _create_run(ASSISTANT_ID, thread_id)
     create_and_run.return_value = run
     retrieve_run.return_value = run
-    list_messages.return_value = _create_thread_messages(
+    list_messages.return_value.data = _create_thread_messages(
         ASSISTANT_ID, run.id, thread_id, [{"assistant": "ai response"}]
     )
 
@@ -408,7 +412,7 @@ def test_assistant_response_with_annotations(
     )
 
     assistant = create_experiment_runnable(session.experiment, session)
-    list_messages.return_value = _create_thread_messages(
+    list_messages.return_value.data = _create_thread_messages(
         ASSISTANT_ID, run.id, thread_id, [{"assistant": ai_message}], annotations
     )
 
@@ -476,7 +480,7 @@ def test_assistant_response_with_image_file_content_block(
 
     thread_id = "test_thread_id"
     run = _create_run(ASSISTANT_ID, thread_id)
-    list_messages.return_value = _create_thread_messages(ASSISTANT_ID, run.id, thread_id, [{"assistant": "Ola"}])
+    list_messages.return_value.data = _create_thread_messages(ASSISTANT_ID, run.id, thread_id, [{"assistant": "Ola"}])
     create_and_run.return_value = run
     retrieve_run.return_value = run
     assistant = create_experiment_runnable(db_session.experiment, db_session)
@@ -622,3 +626,38 @@ def test_input_message_is_saved_on_chain_error(sync_messages_to_thread, db_sessi
     assert (
         ChatMessage.objects.filter(chat__experiment_session=db_session, message_type=ChatMessageType.HUMAN).count() == 1
     )
+
+
+@pytest.mark.django_db()
+@patch("openai.resources.beta.threads.runs.Runs.retrieve")
+@patch("openai.resources.beta.Threads.create_and_run")
+@patch("openai.resources.beta.threads.messages.Messages.list")
+def test_assistant_empty_messages_list(
+    list_messages,
+    create_and_run,
+    retrieve_run,
+    db_session,
+):
+    """
+    Test that _get_output_with_annotations handles the case where no messages are returned.
+    """
+    # Set up session
+    session = db_session
+
+    # Set up OpenAI thread and run
+    thread_id = "test_thread_id"
+    run = _create_run(ASSISTANT_ID, thread_id)
+    create_and_run.return_value = run
+    retrieve_run.return_value = run
+
+    # Mock an empty messages list
+    list_messages.return_value.data = []
+
+    # Create the assistant runnable
+    assistant = create_experiment_runnable(session.experiment, session)
+
+    # Run the assistant - it should return an empty string for output
+    result = assistant.invoke("test")
+
+    # Verify that an empty output was returned
+    assert result.output == ""

--- a/apps/service_providers/tests/test_assistant_with_tools.py
+++ b/apps/service_providers/tests/test_assistant_with_tools.py
@@ -140,7 +140,7 @@ def configure_common_mocks(session):
             _create_run(assistant_id, thread_id),  # send call waiting for cancellation
             _create_run(assistant_id, thread_id),  # 3rd call after tool message
         ]
-        list_messages.return_value = _create_thread_messages(
+        list_messages.return_value.data = _create_thread_messages(
             assistant_id, run.id, thread_id, [{"assistant": "ai response"}]
         )
         yield run


### PR DESCRIPTION
## Description
Resolves #1340

Assume that all messages prior to the final message are 'thinking' messages related to tool usage and only record the last message.

I'm not if this changed at some point (that threads now include thinking messages) or whether we just never noticed it before.

## User Impact
Users won't see 'thinking' messages from assistants.

### Docs and Changelog
https://github.com/dimagi/open-chat-studio-docs/pull/72
