### PR TITLE
add security decorators and checks

### DIFF
--- a/apps/chatbots/tests/test_chatbot_views.py
+++ b/apps/chatbots/tests/test_chatbot_views.py
@@ -39,7 +39,7 @@ def test_chatbot_experiment_table_view(client, team_with_users):
         owner=user,
         team=team,
     )
-    client.login(username="testuser", password="testpass")
+    client.force_login(user)
     url = reverse("chatbots:table", args=[team.slug])
     response = client.get(url)
 

--- a/apps/experiments/decorators.py
+++ b/apps/experiments/decorators.py
@@ -24,6 +24,9 @@ def experiment_session_view(allowed_states=None):
 
         @wraps(view_func)
         def decorated_view(request, team_slug: str, experiment_id: uuid.UUID, session_id: str, **kwargs):
+            if not request.team:
+                raise Http404
+
             request.experiment = get_object_or_404(
                 Experiment.objects.get_all(), public_id=experiment_id, team=request.team
             )

--- a/apps/experiments/views/chat.py
+++ b/apps/experiments/views/chat.py
@@ -2,13 +2,15 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, render
 
 from apps.chat.models import ChatMessage, ChatMessageType
+from apps.teams.decorators import team_required
 
 
+@team_required
 def rate_message(request, team_slug: str, message_id: int, rating: str):
     if rating not in ["👍", "👎"]:
         raise Http404()
 
-    message = get_object_or_404(ChatMessage, id=message_id, message_type=ChatMessageType.AI)
+    message = get_object_or_404(ChatMessage, id=message_id, message_type=ChatMessageType.AI, chat__team=request.team)
     message.add_rating(rating)
 
     return render(

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -90,7 +90,7 @@ from apps.files.views import BaseAddFileHtmxView, BaseDeleteFileView
 from apps.generics.chips import Chip
 from apps.generics.views import generic_home
 from apps.service_providers.utils import get_llm_provider_choices
-from apps.teams.decorators import login_and_team_required
+from apps.teams.decorators import login_and_team_required, team_required
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 from apps.utils.base_experiment_table_view import BaseExperimentTableView
 
@@ -112,12 +112,12 @@ class ExperimentTableView(BaseExperimentTableView):
     permission_required = "experiments.view_experiment"
 
 
-class ExperimentSessionsTableView(SingleTableView, PermissionRequiredMixin):
+class ExperimentSessionsTableView(LoginAndTeamRequiredMixin, SingleTableView, PermissionRequiredMixin):
     model = ExperimentSession
     paginate_by = 25
     table_class = ExperimentSessionsTable
     template_name = "table/single_table.html"
-    permission_required = "annotations.view_customtaggeditem"
+    permission_required = "experiments.view_experimentsession"
 
     def get_queryset(self):
         query_set = (
@@ -131,7 +131,7 @@ class ExperimentSessionsTableView(SingleTableView, PermissionRequiredMixin):
         return query_set
 
 
-class ExperimentVersionsTableView(SingleTableView, PermissionRequiredMixin):
+class ExperimentVersionsTableView(LoginAndTeamRequiredMixin, SingleTableView, PermissionRequiredMixin):
     model = Experiment
     paginate_by = 25
     table_class = ExperimentVersionsTable
@@ -797,12 +797,13 @@ def get_message_response(request, team_slug: str, experiment_id: uuid.UUID, sess
     )
 
 
+@team_required
 def poll_messages(request, team_slug: str, experiment_id: int, session_id: int):
     user = get_real_user_or_none(request.user)
     params = request.GET.dict()
     since_param = params.get("since")
     experiment_session = get_object_or_404(
-        ExperimentSession, participant__user=user, experiment_id=experiment_id, id=session_id, team__slug=team_slug
+        ExperimentSession, participant__user=user, experiment_id=experiment_id, id=session_id, team=request.team
     )
 
     since = timezone.now()
@@ -829,6 +830,7 @@ def poll_messages(request, team_slug: str, experiment_id: int, session_id: int):
     )
 
 
+@team_required
 def start_session_public(request, team_slug: str, experiment_id: uuid.UUID):
     try:
         experiment = get_object_or_404(Experiment, public_id=experiment_id, team=request.team)
@@ -909,6 +911,7 @@ def start_session_public(request, team_slug: str, experiment_id: uuid.UUID):
 
 
 @xframe_options_exempt
+@team_required
 def start_session_public_embed(request, team_slug: str, experiment_id: uuid.UUID):
     """Special view for starting sessions from embedded widgets. This will ignore consent and pre-surveys and
     will ALWAYS create anonymous participants."""
@@ -960,6 +963,7 @@ def _verify_user_or_start_session(identifier, request, experiment, session):
     return TemplateResponse(request=request, template="account/participant_email_verify.html")
 
 
+@team_required
 def verify_public_chat_token(request, team_slug: str, experiment_id: uuid.UUID, token: str):
     try:
         claims = jwt.decode(token, settings.SECRET_KEY, algorithms="HS256")
@@ -1312,6 +1316,7 @@ def experiment_session_pagination_view(request, team_slug: str, experiment_id: u
     return redirect("experiments:experiment_session_view", team_slug, experiment_id, next_session.external_id)
 
 
+@team_required
 def download_file(request, team_slug: str, session_id: int, pk: int):
     resource = get_object_or_404(
         File, id=pk, team__slug=team_slug, chatattachment__chat__experiment_session__id=session_id

--- a/apps/experiments/views/experiment_routes.py
+++ b/apps/experiments/views/experiment_routes.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from django.contrib import messages
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
@@ -12,7 +13,8 @@ from apps.experiments.models import Experiment, ExperimentRoute, ExperimentRoute
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 
 
-class CreateExperimentRoute(CreateView):
+class CreateExperimentRoute(LoginAndTeamRequiredMixin, CreateView, PermissionRequiredMixin):
+    permission_required = "experiments.add_experimentroute"
     model = ExperimentRoute
     template_name = "generic/object_form.html"
     extra_context = {
@@ -49,7 +51,8 @@ class CreateExperimentRoute(CreateView):
         return super().form_valid(form)
 
 
-class EditExperimentRoute(UpdateView):
+class EditExperimentRoute(LoginAndTeamRequiredMixin, UpdateView, PermissionRequiredMixin):
+    permission_required = "experiments.change_experimentroute"
     model = ExperimentRoute
     template_name = "generic/object_form.html"
     extra_context = {
@@ -77,7 +80,9 @@ class EditExperimentRoute(UpdateView):
         return f"{url}#routes"
 
 
-class DeleteExperimentRoute(LoginAndTeamRequiredMixin, View):
+class DeleteExperimentRoute(LoginAndTeamRequiredMixin, View, PermissionRequiredMixin):
+    permission_required = "experiments.delete_experimentroute"
+
     def delete(self, request, team_slug: str, pk: int, experiment_id: int):
         experiment_route = get_object_or_404(ExperimentRoute, id=pk, parent_id=experiment_id, team=request.team)
         experiment_route.archive()

--- a/apps/experiments/views/prompt.py
+++ b/apps/experiments/views/prompt.py
@@ -15,7 +15,7 @@ from apps.experiments.models import Experiment, PromptBuilderHistory, SourceMate
 from apps.experiments.tasks import get_prompt_builder_response_task
 from apps.service_providers.models import LlmProviderModel
 from apps.service_providers.utils import get_llm_provider_choices
-from apps.teams.decorators import login_and_team_required
+from apps.teams.decorators import login_and_team_required, team_required
 
 PROMPT_DATA_SESSION_KEY = "prompt_data"
 
@@ -82,6 +82,7 @@ def experiments_prompt_builder_get_message(request, team_slug: str):
     return JsonResponse({"task_id": result.task_id})
 
 
+@team_required
 def get_prompt_builder_message_response(request, team_slug: str):
     task_id = request.GET.get("task_id")
     progress = Progress(AsyncResult(task_id))

--- a/apps/service_providers/utils.py
+++ b/apps/service_providers/utils.py
@@ -2,7 +2,7 @@ import dataclasses
 import functools
 from collections import defaultdict
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 from django import forms
 from django.db import models
@@ -42,6 +42,10 @@ class ServiceProviderType:
     subtype: Enum
 
     primary_fields: list[str]
+
+    def get_permission(self, action: Literal["view", "add", "change", "delete"]) -> Any:
+        assert action in ("view", "add", "change", "delete")
+        return f"{self.model._meta.app_label}.{action}_{self.model._meta.model_name}"
 
 
 class ServiceProvider(ServiceProviderType, Enum):

--- a/apps/teams/decorators.py
+++ b/apps/teams/decorators.py
@@ -30,6 +30,17 @@ def login_and_team_required(view_func):
     return _inner
 
 
+def team_required(view_func):
+    @wraps(view_func)
+    def _inner(request, *args, **kwargs):
+        if not request.team:
+            # treat not having access to a team like a 404 to avoid accidentally leaking information
+            raise Http404
+        return view_func(request, *args, **kwargs)
+
+    return _inner
+
+
 def valid_auth_and_membership(request):
     if not request.user.is_authenticated:
         return False

--- a/apps/utils/base_experiment_table_view.py
+++ b/apps/utils/base_experiment_table_view.py
@@ -3,10 +3,11 @@ from django.contrib.postgres.search import TrigramSimilarity
 from django.db.models import Q
 from django_tables2 import SingleTableView
 
+from apps.teams.mixins import LoginAndTeamRequiredMixin
 from apps.utils.search import similarity_search
 
 
-class BaseExperimentTableView(SingleTableView, PermissionRequiredMixin):
+class BaseExperimentTableView(LoginAndTeamRequiredMixin, SingleTableView, PermissionRequiredMixin):
     paginate_by = 25
     template_name = "table/single_table.html"
 


### PR DESCRIPTION
## Description
Prompted by [OPEN-CHAT-STUDIO-SF](https://dimagi.sentry.io/issues/6459913444/events/6656277c4a44419089ee611fa509c53b/) I did an audit of all views and found a number that didn't have correct security checks.

I've also added a `@team_required` decorator for views that don't require auth but do require a real team.

## Testing
I tested all these views with the exception of `verify_public_chat_token` and `download_file`

## User Impact
None

### Docs and Changelog
NA
