### PR TITLE
render full event form

### DIFF
--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -45,6 +45,7 @@ def _create_event_view(trigger_form_class, request, team_slug: str, experiment_i
     context = {
         "action_form": action_form,
         "trigger_form": trigger_form,
+        "event_type": trigger_form_class._meta.model._meta.model_name,
     }
     return render(request, "events/manage_event.html", context)
 

--- a/templates/events/manage_event.html
+++ b/templates/events/manage_event.html
@@ -20,8 +20,10 @@
                 {% csrf_token %}
                 {% block form %}
                     <h1 class="pg-title">Event Details</h1>
-                    {% if trigger_form.type %}
+                    {% if event_type == 'statictrigger' %}
                         {% render_field trigger_form.type xmodel="triggerType" %}
+                    {% else %}
+                        {% render_form_fields trigger_form %}
                     {% endif %}
                     {% render_form_fields action_form.primary %}
                     {% for key, form in action_form.secondary.items %}


### PR DESCRIPTION
Resolves https://github.com/dimagi/open-chat-studio/issues/1362

## Description
Render the full 'timeout event' form to allow users to create timeout events.

## User Impact
User's can create timeout events again.

### Docs and Changelog
https://github.com/dimagi/open-chat-studio-docs/pull/76