### PR TITLE
Add support for the session state datasource in the static router

### DIFF
--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -477,6 +477,7 @@ class StaticRouterNode(RouterMixin, Passthrough):
     class DataSource(TextChoices):
         participant_data = "participant_data", "Participant Data"
         temp_state = "temp_state", "Temporary State"
+        session_state = "session_state", "Session State"
 
     model_config = ConfigDict(
         json_schema_extra=NodeSchema(
@@ -496,10 +497,13 @@ class StaticRouterNode(RouterMixin, Passthrough):
     def _process_conditional(self, state: PipelineState, node_id=None):
         from apps.service_providers.llm_service.prompt_context import SafeAccessWrapper
 
-        if self.data_source == self.DataSource.participant_data:
-            data = self.get_participant_data_proxy(state).get()
-        else:
-            data = state["temp_state"]
+        match self.data_source:
+            case self.DataSource.participant_data:
+                data = self.get_participant_data_proxy(state).get()
+            case self.DataSource.temp_state:
+                data = state["temp_state"]
+            case self.DataSource.session_state:
+                data = state["experiment_session"].state
 
         formatted_key = f"{{data.{self.route_key}}}"
         try:

--- a/apps/pipelines/tests/data/StaticRouterNode.json
+++ b/apps/pipelines/tests/data/StaticRouterNode.json
@@ -17,7 +17,8 @@
     "data_source": {
       "enum": [
         "participant_data",
-        "temp_state"
+        "temp_state",
+        "session_state"
       ],
       "title": "DataSource",
       "type": "string",
@@ -25,7 +26,8 @@
       "description": "The source of the data to use for routing",
       "ui:enumLabels": [
         "Participant Data",
-        "Temporary State"
+        "Temporary State",
+        "Session State"
       ]
     },
     "route_key": {

--- a/apps/pipelines/tests/test_runnable_builder.py
+++ b/apps/pipelines/tests/test_runnable_builder.py
@@ -455,12 +455,25 @@ def main(input, **kwargs):
 
 
 @django_db_with_data(available_apps=("apps.service_providers",))
+@pytest.mark.parametrize(
+    "data_source", [StaticRouterNode.DataSource.participant_data, StaticRouterNode.DataSource.session_state]
+)
 @mock.patch("apps.pipelines.nodes.base.PipelineNode.logger", mock.Mock())
-def test_static_router_participant_data(pipeline, experiment_session):
+def test_static_router_participant_data(data_source, pipeline, experiment_session):
+    def _update_participant_data(session, data):
+        ParticipantDataProxy(session).set(data)
+
+    def _update_session_state(session, data):
+        session.state = data
+        session.save(update_fields=["state"])
+
+    DATA_SOURCE_UPDATERS = {
+        StaticRouterNode.DataSource.participant_data: _update_participant_data,
+        StaticRouterNode.DataSource.session_state: _update_session_state,
+    }
+
     start = start_node()
-    router = state_key_router_node(
-        "route_to", ["first", "second"], data_source=StaticRouterNode.DataSource.participant_data
-    )
+    router = state_key_router_node("route_to", ["first", "second"], data_source=data_source)
     template_a = render_template_node("A {{ input }}")
     template_b = render_template_node("B {{ input }}")
     end = end_node()
@@ -484,16 +497,16 @@ def test_static_router_participant_data(pipeline, experiment_session):
     ]
     runnable = create_runnable(pipeline, nodes, edges)
 
-    ParticipantDataProxy(experiment_session).set({"route_to": "first"})
+    DATA_SOURCE_UPDATERS[data_source](experiment_session, {"route_to": "first"})
     output = runnable.invoke(PipelineState(messages=["Hi"], experiment_session=experiment_session))
     assert output["messages"][-1] == "A Hi"
 
-    ParticipantDataProxy(experiment_session).set({"route_to": "second"})
+    DATA_SOURCE_UPDATERS[data_source](experiment_session, {"route_to": "second"})
     output = runnable.invoke(PipelineState(messages=["Hi"], experiment_session=experiment_session))
     assert output["messages"][-1] == "B Hi"
 
     # default route
-    ParticipantDataProxy(experiment_session).set({})
+    DATA_SOURCE_UPDATERS[data_source](experiment_session, {})
     output = runnable.invoke(PipelineState(messages=["Hi"], experiment_session=experiment_session))
     assert output["messages"][-1] == "A Hi"
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Resolves #1381 

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Static router can now read from the session state as well

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/80