### PR TITLE
Override single boolean values with the new value when merging dicts

### DIFF
--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -55,6 +55,8 @@ def merge_dicts(left: dict, right: dict):
         if key in output:
             if isinstance(output[key], list):
                 output[key] = list(set(output[key]) | set(value))
+            elif isinstance(output[key], bool):
+                output[key] = value
             else:
                 output[key] = [output[key], value]
         else:

--- a/apps/pipelines/tests/test_runnable_builder.py
+++ b/apps/pipelines/tests/test_runnable_builder.py
@@ -1074,6 +1074,7 @@ def test_pipeline_history_manager_metadata_storage(get_llm_service, pipeline):
         ({"key": [1]}, {"key": [2]}, {"key": [1, 2]}),
         ({"key": [1]}, {"key": [1]}, {"key": [1]}),
         ({"keyA": [1]}, {"keyB": [2]}, {"keyA": [1], "keyB": [2]}),
+        ({"keyA": True}, {"keyA": False}, {"keyA": False}),
     ],
 )
 def test_merge_dicts(left, right, expected):


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Fixes https://dimagi.sentry.io/issues/6488947241/?alert_rule_id=14063560&alert_type=issue&notification_uuid=d7fcbe45-f392-44ff-ae56-2e1f1cb579a4&project=4505001320316928&referrer=issue_alert-slack

For single boolean metadata values, the new value overrides the previous one. The only single value metadata I see we use is the `openai_thread_checkpoint` one, which is always a `True` value, so overriding does nothing really. Should we have appended each node's metadata key to a list and AND or OR the list at the end? This is not clear to me yet. In this specific case, it doesn't matter, but I think future cases might make the answer more obvious.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Fixes an issue with the pipeline

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
N/A