### PR TITLE
Try test fix

### DIFF
--- a/apps/audit/tests.py
+++ b/apps/audit/tests.py
@@ -8,10 +8,12 @@ from apps.teams.utils import current_team
 
 def test_change_context():
     request = AuthedRequest()
-    assert AuditContextProvider().change_context(request) == {
-        "user_type": USER_TYPE_REQUEST,
-        "username": request.user.username,
-    }
+    # Force the team to be None
+    with current_team(None):
+        assert AuditContextProvider().change_context(request) == {
+            "user_type": USER_TYPE_REQUEST,
+            "username": request.user.username,
+        }
 
 
 def test_change_context_returns_none_without_request():


### PR DESCRIPTION
I sometimes see this test failing:

![image](https://github.com/user-attachments/assets/da699121-df97-47d0-994f-a2d11a3d9ec8)

Rerunning the tests sometimes fixes it. I think it might be the `team` context var that is being set by another test that is messing with this one