### PR TITLE
Use a custom type to coerce empty strings to `None`

### DIFF
--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -4,7 +4,7 @@ import json
 import logging
 import random
 import time
-from typing import Literal
+from typing import Annotated, Literal
 
 import tiktoken
 from django.conf import settings
@@ -16,7 +16,7 @@ from langchain_core.messages import BaseMessage
 from langchain_core.prompts import MessagesPlaceholder, PromptTemplate
 from langchain_core.runnables import RunnableLambda, RunnablePassthrough
 from langchain_text_splitters import RecursiveCharacterTextSplitter
-from pydantic import BaseModel, Field, create_model, field_validator, model_validator
+from pydantic import BaseModel, BeforeValidator, Field, create_model, field_validator, model_validator
 from pydantic.config import ConfigDict
 from pydantic_core import PydanticCustomError
 from pydantic_core.core_schema import FieldValidationInfo
@@ -50,6 +50,8 @@ from apps.service_providers.llm_service.runnables import (
 )
 from apps.service_providers.models import LlmProviderModel
 from apps.utils.prompt import OcsPromptTemplate, PromptVars, validate_prompt_variables
+
+OptionalInt = Annotated[int | None, BeforeValidator(lambda x: None if x == "" else x)]
 
 
 class RenderTemplate(PipelineNode):
@@ -240,14 +242,14 @@ class LLMResponseWithPrompt(LLMResponse, HistoryMixin):
         json_schema_extra=NodeSchema(label="LLM", documentation_link=settings.DOCUMENTATION_LINKS["node_llm"])
     )
 
-    source_material_id: int | None = Field(
+    source_material_id: OptionalInt = Field(
         None, json_schema_extra=UiSchema(widget=Widgets.select, options_source=OptionsSource.source_material)
     )
     prompt: str = Field(
         default="You are a helpful assistant. Answer the user's query as best you can",
         json_schema_extra=UiSchema(widget=Widgets.expandable_text),
     )
-    collection_id: int | None = Field(
+    collection_id: OptionalInt = Field(
         None,
         title="Media",
         json_schema_extra=UiSchema(

--- a/apps/pipelines/tests/test_nodes.py
+++ b/apps/pipelines/tests/test_nodes.py
@@ -1,8 +1,8 @@
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 from pydantic_core import ValidationError
 
-from apps.pipelines.nodes.nodes import SendEmail, StructuredDataSchemaValidatorMixin
+from apps.pipelines.nodes.nodes import OptionalInt, SendEmail, StructuredDataSchemaValidatorMixin
 
 
 class TestStructuredDataSchemaValidatorMixin:
@@ -45,3 +45,16 @@ class TestSendEmailInputValidation:
     def test_invalid_recipient_list(self, recipient_list):
         with pytest.raises(ValidationError, match="Invalid list of emails addresses"):
             SendEmail(name="email", recipient_list=recipient_list, subject="Test Subject")
+
+
+def test_optional_int_type():
+    ta = TypeAdapter(OptionalInt)
+    assert ta.validate_python(1) == 1
+    assert ta.validate_python(None) is None
+    assert ta.validate_python("") is None
+
+    with pytest.raises(ValidationError):
+        ta.validate_python(1.2)
+
+    with pytest.raises(ValidationError):
+        ta.validate_python("test")


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Added a custom type `OptionalInt` that is the equivalent of `int | None`, but also coerces empty strings to `None`. This comes in handy when users deselect something from a select input, like source material. The value from the UI comes back as an emtpy string.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Deselecting source material for instance

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
