### PR TITLE
Set session access cookie's samesite to Lax

### DIFF
--- a/apps/experiments/decorators.py
+++ b/apps/experiments/decorators.py
@@ -58,7 +58,7 @@ def set_session_access_cookie(response, experiment, experiment_session):
         max_age=MAX_AGE,
         secure=True,
         httponly=True,
-        samesite="Strict",
+        samesite="Lax",
     )
     return response
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
See [this document](https://docs.google.com/document/d/1riAikgH5JcbVSH-YD0rnMCescMPp0_knw-5vR63zErA/edit?tab=t.0)

Users should be able to click on links in emails to navigate to the chat

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users will be able to click on the email link to the chat when going to email verification.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
Pending