### PR TITLE
Fix: Load custom action operations when building node version details

### DIFF
--- a/apps/assistants/models.py
+++ b/apps/assistants/models.py
@@ -1,5 +1,3 @@
-from typing import Self
-
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models, transaction
@@ -106,9 +104,6 @@ class OpenAiAssistant(BaseTeamModel, VersionsMixin, CustomActionOperationMixin):
     def has_custom_actions(self):
         return self.custom_action_operations.exists()
 
-    def get_fields_to_exclude(self):
-        return super().get_fields_to_exclude() + ["assistant_id", "name"]
-
     @transaction.atomic()
     def create_new_version(self, *args, **kwargs):
         from .sync import push_assistant_to_openai
@@ -139,37 +134,6 @@ class OpenAiAssistant(BaseTeamModel, VersionsMixin, CustomActionOperationMixin):
 
         push_assistant_to_openai(assistant_version, internal_tools=get_assistant_tools(assistant_version))
         return assistant_version
-
-    def compare_with_model(self, new: Self, exclude_fields: list[str], early_abort=False) -> set:
-        changes = super().compare_with_model(new, exclude_fields, early_abort=early_abort)
-        if early_abort and changes:
-            return changes
-
-        new_name = new.name.split(f" v{new.version_number}")[0]
-        if self.name != new_name:
-            changes.add("name")
-
-        tool_resources = {r.tool_type: r for r in self.tool_resources.all()}
-        new_tool_resources = {r.tool_type: r for r in new.tool_resources.all()}
-        if set(tool_resources) != set(new_tool_resources):
-            changes.add("tool_resources")
-        else:
-            exclude_fields = self.DEFAULT_EXCLUDED_KEYS + ["extra", "assistant"]
-            for tool_type, resource in tool_resources.items():
-                new_resource = new_tool_resources[tool_type]
-                if tool_changes := resource.compare_with_model(new_resource, exclude_fields, early_abort=early_abort):
-                    changes.update([f"tool_resources.{tool_type}.{change}" for change in tool_changes])
-
-        if early_abort and changes:
-            return changes
-
-        custom_actions = VersionField("custom_actions", queryset=self.custom_action_operations.all())
-        custom_actions.compare(
-            VersionField("custom_actions", queryset=new.custom_action_operations.all()), early_abort=early_abort
-        )
-        if custom_actions.changed:
-            changes.add("custom_actions")
-        return changes
 
     def archive(self):
         from apps.assistants.tasks import delete_openai_assistant_task

--- a/apps/custom_actions/models.py
+++ b/apps/custom_actions/models.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Self
 
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
@@ -16,6 +15,7 @@ from apps.custom_actions.schema_utils import (
     get_standalone_schema_for_action_operation,
 )
 from apps.experiments.models import VersionsMixin, VersionsObjectManagerMixin
+from apps.experiments.versioning import VersionDetails, VersionField
 from apps.service_providers.auth_service import anonymous_auth_service
 from apps.teams.models import BaseTeamModel
 from apps.utils.models import BaseModel
@@ -170,11 +170,11 @@ class CustomActionOperation(BaseModel, VersionsMixin):
         new_instance.save()
         return new_instance
 
-    def get_fields_to_exclude(self):
-        return super().get_fields_to_exclude() + ["experiment", "assistant", "_operation_schema"]
-
-    def compare_with_model(self, new: Self, exclude_fields: list[str], early_abort=False) -> set:
-        changes = super().compare_with_model(new, exclude_fields, early_abort=early_abort)
-        if self.operation_schema != new.operation_schema:
-            changes.add("operation_schema")
-        return changes
+    @property
+    def version_details(self) -> VersionDetails:
+        return VersionDetails(
+            instance=self,
+            fields=[
+                VersionField(name="operation_schema", raw_value=self.operation_schema),
+            ],
+        )


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Resolves #1416 

The issue is that we never loaded the custom action operations when building node versions. The string value that is saved in the node params looks like `["1:the_custom_action_operation"]` where 1 is the custom action's id and the `the_custom_action_operation` is the operation's name. This resulted in an error when [this is called](https://github.com/dimagi/open-chat-studio/blob/3f03a276845c30490369b7d291cb76bbc632dc82/apps/experiments/models.py#L121), since `op` is a list.

I also removed some `compare_with_model` and `get_fields_to_exclude` methods that are not used for comparison anymore, since if `version_details` are implemented, the versioning code will use that instead.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users should not encounter the issue again

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/84