### PR TITLE
use immer to avoid nested shallow copying

### DIFF
--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -31,9 +31,7 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
     }
 
     setNode(id, produce((next) => {
-      if (next?.data?.params) {
-        next.data.params[name] = updateValue;
-      }
+      next.data.params[name] = updateValue;
     }));
   };
 

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -8,6 +8,7 @@ import {getWidgetsForNode} from "./nodes/GetInputWidget";
 import NodeInput from "./nodes/NodeInput";
 import NodeOutputs from "./nodes/NodeOutputs";
 import {HelpContent} from "./panel/ComponentHelp";
+import { produce } from "immer";
 
 export type PipelineNode = Node<NodeData>;
 
@@ -28,17 +29,11 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
     if (event.target instanceof HTMLInputElement && event.target.type === "checkbox") {
       updateValue = event.target.checked;
     }
-    
-    
-    setNode(id, (old) => ({
-      ...old,
-      data: {
-        ...old.data,
-        params: {
-          ...old.data.params,
-          [name]: updateValue,
-        },
-      },
+
+    setNode(id, produce((next) => {
+      if (next?.data?.params) {
+        next.data.params[name] = updateValue;
+      }
     }));
   };
 

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -222,7 +222,9 @@ function MultiSelectWidget(props: WidgetParams) {
 
   function getNewNodeData(old: Node, updatedList: Array<string>) {
     return produce(old, next => {
-      next.data.params[props.name] = updatedList;
+      if (next?.data?.params) {
+        next.data.params[props.name] = updatedList;
+      }
     });
   }
 
@@ -649,7 +651,9 @@ export function KeywordsWidget(props: WidgetParams) {
 
   function getNewNodeData(old: Node, keywords: any[]) {
     return produce(old, next => {
-      next.data.params["keywords"] = keywords;
+      if (next?.data?.params) {
+        next.data.params["keywords"] = keywords;
+      }
     });
   }
 
@@ -759,8 +763,10 @@ export function LlmWidget(props: WidgetParams) {
     const [providerId, providerModelId] = value.split('|:|');
     setNode(props.nodeId, (old) =>
       produce(old, (next) => {
-        next.data.params.llm_provider_id = providerId;
-        next.data.params.llm_provider_model_id = providerModelId;
+        if (next?.data?.params) {
+          next.data.params.llm_provider_id = providerId;
+          next.data.params.llm_provider_model_id = providerModelId;
+        }
       })
     );
   };

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -10,6 +10,7 @@ import {JsonSchema, NodeParams, PropertySchema} from "../types/nodeParams";
 import {Node, useUpdateNodeInternals} from "reactflow";
 import DOMPurify from 'dompurify';
 import {apiClient} from "../api/api";
+import { produce } from "immer";
 
 export function getWidget(name: string, params: PropertySchema) {
   switch (name) {
@@ -220,16 +221,9 @@ function MultiSelectWidget(props: WidgetParams) {
   const setNode = usePipelineStore((state) => state.setNode);
 
   function getNewNodeData(old: Node, updatedList: Array<string>) {
-    return {
-      ...old,
-      data: {
-        ...old.data,
-        params: {
-          ...old.data.params,
-          [props.name]: updatedList,
-        },
-      },
-    };
+    return produce(old, next => {
+      next.data.params[props.name] = updatedList;
+    });
   }
 
   function onUpdate(event: ChangeEvent<HTMLInputElement>) {
@@ -654,16 +648,9 @@ export function KeywordsWidget(props: WidgetParams) {
   const updateNodeInternals = useUpdateNodeInternals()
 
   function getNewNodeData(old: Node, keywords: any[]) {
-    return {
-      ...old,
-      data: {
-        ...old.data,
-        params: {
-          ...old.data.params,
-          ["keywords"]: keywords,
-        },
-      },
-    };
+    return produce(old, next => {
+      next.data.params["keywords"] = keywords;
+    });
   }
 
   const addKeyword = () => {
@@ -770,19 +757,13 @@ export function LlmWidget(props: WidgetParams) {
   const updateParamValue = (event: ChangeEvent<HTMLSelectElement>) => {
     const {value} = event.target;
     const [providerId, providerModelId] = value.split('|:|');
-    setNode(props.nodeId, (old) => ({
-      ...old,
-      data: {
-        ...old.data,
-        params: {
-          ...old.data.params,
-          llm_provider_id: providerId,
-          llm_provider_model_id: providerModelId,
-        },
-      },
-    }));
+    setNode(props.nodeId, (old) =>
+      produce(old, (next) => {
+        next.data.params.llm_provider_id = providerId;
+        next.data.params.llm_provider_model_id = providerModelId;
+      })
+    );
   };
-
   const makeValue = (providerId: string, providerModelId: string) => {
     return providerId + '|:|' + providerModelId;
   };

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -222,9 +222,7 @@ function MultiSelectWidget(props: WidgetParams) {
 
   function getNewNodeData(old: Node, updatedList: Array<string>) {
     return produce(old, next => {
-      if (next?.data?.params) {
-        next.data.params[props.name] = updatedList;
-      }
+      next.data.params[props.name] = updatedList;
     });
   }
 
@@ -651,9 +649,7 @@ export function KeywordsWidget(props: WidgetParams) {
 
   function getNewNodeData(old: Node, keywords: any[]) {
     return produce(old, next => {
-      if (next?.data?.params) {
-        next.data.params["keywords"] = keywords;
-      }
+      next.data.params["keywords"] = keywords;
     });
   }
 
@@ -763,10 +759,8 @@ export function LlmWidget(props: WidgetParams) {
     const [providerId, providerModelId] = value.split('|:|');
     setNode(props.nodeId, (old) =>
       produce(old, (next) => {
-        if (next?.data?.params) {
-          next.data.params.llm_provider_id = providerId;
-          next.data.params.llm_provider_model_id = providerModelId;
-        }
+        next.data.params.llm_provider_id = providerId;
+        next.data.params.llm_provider_model_id = providerModelId;
       })
     );
   };

--- a/assets/javascript/apps/pipeline/panel/EditPanel.tsx
+++ b/assets/javascript/apps/pipeline/panel/EditPanel.tsx
@@ -30,7 +30,7 @@ export default function EditPanel({nodeId}: { nodeId: string }) {
     id!,
     produce((next) => {
       if (next?.data?.params) {
-        next.data.params[name] = updateValue;
+        next.data.params[name] = value;
       }
     })
   );

--- a/assets/javascript/apps/pipeline/panel/EditPanel.tsx
+++ b/assets/javascript/apps/pipeline/panel/EditPanel.tsx
@@ -4,6 +4,7 @@ import OverlayPanel from "../components/OverlayPanel";
 import {classNames, getCachedData} from "../utils";
 import usePipelineStore from "../stores/pipelineStore";
 import {getWidgets} from "../nodes/GetInputWidget";
+import {produce} from "immer"
 
 export default function EditPanel({nodeId}: { nodeId: string }) {
   const closeEditor = useEditorStore((state) => state.closeEditor);
@@ -25,17 +26,15 @@ export default function EditPanel({nodeId}: { nodeId: string }) {
       console.warn(`Unknown parameter: ${name}`);
       return;
     }
-    setNode(id!, (old) => ({
-      ...old,
-      data: {
-        ...old.data,
-        params: {
-          ...old.data.params,
-          [name]: value
-        },
-      },
-    }));
-  };
+    setNode(
+    id!,
+    produce((next) => {
+      if (next?.data?.params) {
+        next.data.params[name] = updateValue;
+      }
+    })
+  );
+};
 
   const toggleExpand = () => {
     setExpanded(!expanded);

--- a/assets/javascript/apps/pipeline/panel/EditPanel.tsx
+++ b/assets/javascript/apps/pipeline/panel/EditPanel.tsx
@@ -29,9 +29,7 @@ export default function EditPanel({nodeId}: { nodeId: string }) {
     setNode(
     id!,
     produce((next) => {
-      if (next?.data?.params) {
-        next.data.params[name] = value;
-      }
+      next.data.params[name] = value;
     })
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "daisyui": "^4.12.13",
         "dompurify": "^3.2.4",
         "htmx.org": "^1.9.12",
+        "immer": "^10.1.1",
         "js-cookie": "^3.0.5",
         "js-tiktoken": "^1.0.16",
         "lodash": "^4.17.21",
@@ -6553,6 +6554,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/immutable": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "daisyui": "^4.12.13",
     "dompurify": "^3.2.4",
     "htmx.org": "^1.9.12",
+    "immer": "^10.1.1",
     "js-cookie": "^3.0.5",
     "js-tiktoken": "^1.0.16",
     "lodash": "^4.17.21",


### PR DESCRIPTION
## Description
Use immer to avoid shallow copy of nested objects manually. Closes #1241 

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
