### PR TITLE
add wheel to docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ RUN apt-get update \
   # dependencies for building Python packages
   && apt-get install -y build-essential libpq-dev
 COPY ./requirements /requirements
-RUN pip wheel --no-cache-dir --no-deps --wheel-dir /wheels \
+RUN pip install --upgrade pip setuptools wheel \
+    && pip wheel --no-cache-dir --no-deps --wheel-dir /wheels \
     -r /requirements/requirements.txt \
     -r /requirements/prod-requirements.txt
 


### PR DESCRIPTION
Fix docker build by adding `wheel` to the python env when building the wheels. This most likely broke due to an upstream change in the base docker image (since it isn't pinned)