### PR TITLE
fix message polling

### DIFF
--- a/apps/experiments/urls.py
+++ b/apps/experiments/urls.py
@@ -98,9 +98,14 @@ urlpatterns = [
         name="get_message_response",
     ),
     path(
-        "e/<int:experiment_id>/session/<int:session_id>/poll_messages/",
+        "e/<uuid:experiment_id>/session/<str:session_id>/poll_messages/",
         views.poll_messages,
         name="poll_messages",
+    ),
+    path(
+        "e/<uuid:experiment_id>/session/<str:session_id>/poll_messages/embed/",
+        views.poll_messages_embed,
+        name="poll_messages_embed",
     ),
     # events
     path("e/<int:experiment_id>/events/", include("apps.events.urls")),

--- a/apps/experiments/views/__init__.py
+++ b/apps/experiments/views/__init__.py
@@ -41,6 +41,7 @@ from .experiment import (  # noqa: F401
     get_message_response,
     get_release_status_badge,
     poll_messages,
+    poll_messages_embed,
     send_invitation,
     set_default_experiment,
     single_experiment_home,

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -778,6 +778,8 @@ def get_message_response(request, team_slug: str, experiment_id: uuid.UUID, sess
     progress = Progress(AsyncResult(task_id)).get_info()
     # don't render empty messages
     skip_render = progress["complete"] and progress["success"] and not progress["result"]
+    if skip_render:
+        return HttpResponse()
 
     message_details = {"message": None, "error_msg": False, "complete": progress["complete"]}
     if progress["complete"] and progress["success"]:

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -832,16 +832,17 @@ def poll_messages(request, team_slug: str, experiment_id: int, session_id: int):
         .order_by("created_at")
         .all()
     )
-    last_message = messages[0] if messages else None
 
-    return TemplateResponse(
-        request,
-        "experiments/chat/system_message.html",
-        {
-            "messages": [message.content for message in messages],
-            "last_message_datetime": last_message and last_message.created_at,
-        },
-    )
+    if messages:
+        return TemplateResponse(
+            request,
+            "experiments/chat/system_message.html",
+            {
+                "messages": [message.content for message in messages],
+                "last_message_datetime": messages[0].created_at,
+            },
+        )
+    return HttpResponse()
 
 
 @team_required

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 from datetime import datetime
 from typing import cast
-from urllib.parse import parse_qs, quote, urlparse
+from urllib.parse import parse_qs, urlparse
 
 import jwt
 from celery.result import AsyncResult
@@ -805,7 +805,7 @@ def get_message_response(request, team_slug: str, experiment_id: uuid.UUID, sess
             "task_id": task_id,
             "message_details": message_details,
             "skip_render": skip_render,
-            "last_message_datetime": last_message and quote(last_message.created_at.isoformat()),
+            "last_message_datetime": last_message and last_message.created_at,
             "attachments": attached_files,
         },
     )
@@ -839,7 +839,7 @@ def poll_messages(request, team_slug: str, experiment_id: int, session_id: int):
         "experiments/chat/system_message.html",
         {
             "messages": [message.content for message in messages],
-            "last_message_datetime": last_message and quote(last_message.created_at.isoformat()),
+            "last_message_datetime": last_message and last_message.created_at,
         },
     )
 

--- a/templates/experiments/chat/ai_message.html
+++ b/templates/experiments/chat/ai_message.html
@@ -17,7 +17,7 @@
       {% endif %}
     </div>
   {% endif %}
-  <div class="chat-message-system flex flex-col" data-last-message-datetime="{{ created_at_datetime|safe }}">
+  <div class="chat-message-system flex flex-col" data-last-message-datetime="{{ created_at_datetime|date:"c" }}">
     <div class="flex flex-row">
       {% include "experiments/chat/components/system_icon.html" %}
       <div class="message-contents">

--- a/templates/experiments/chat/ai_message.html
+++ b/templates/experiments/chat/ai_message.html
@@ -1,5 +1,5 @@
 {% load chat_tags %}
-<div class="flex flex-col gap-1">
+<div class="flex flex-col gap-1" data-last-message-datetime="{{ created_at_datetime|date:"c" }}">
   {% if experiment.debug_mode_enabled %}
     <div class="flex gap-2 items-center">
       {% if message.trace_info %}
@@ -17,7 +17,7 @@
       {% endif %}
     </div>
   {% endif %}
-  <div class="chat-message-system flex flex-col" data-last-message-datetime="{{ created_at_datetime|date:"c" }}">
+  <div class="chat-message-system flex flex-col">
     <div class="flex flex-row">
       {% include "experiments/chat/components/system_icon.html" %}
       <div class="message-contents">

--- a/templates/experiments/chat/chat_message_response.html
+++ b/templates/experiments/chat/chat_message_response.html
@@ -1,25 +1,23 @@
 {% load chat_tags %}
-{% if not skip_render %}
-  <div class="flex"
-       {% if not message_details.complete %}
-         hx-get="{% url 'experiments:get_message_response' team.slug experiment.public_id session.external_id task_id %}"
-         hx-trigger="load delay:1s"
-         hx-swap="outerHTML"
-       {% endif %}
-       data-last-message-datetime="{{ last_message_datetime|date:"c" }}"
-  >
-    <div class="flex flex-row">
-      <div>
-        {% if message_details.message %}
-          {% include 'experiments/chat/ai_message.html' with message=message_details.message attachments=attachments %}
-        {% elif message_details.error_msg %}
-          <p class="chat-message-system pg-text-danger">
-            {{ message_details.error_msg }}
-          </p>
-        {% else %}
-          <span class="loading loading-dots loading-sm"></span>
-        {% endif %}
-      </div>
+<div class="flex"
+     {% if not message_details.complete %}
+       hx-get="{% url 'experiments:get_message_response' team.slug experiment.public_id session.external_id task_id %}"
+       hx-trigger="load delay:1s"
+       hx-swap="outerHTML"
+     {% endif %}
+     data-last-message-datetime="{{ last_message_datetime|date:"c" }}"
+>
+  <div class="flex flex-row">
+    <div>
+      {% if message_details.message %}
+        {% include 'experiments/chat/ai_message.html' with message=message_details.message attachments=attachments %}
+      {% elif message_details.error_msg %}
+        <p class="chat-message-system pg-text-danger">
+          {{ message_details.error_msg }}
+        </p>
+      {% else %}
+        <span class="loading loading-dots loading-sm"></span>
+      {% endif %}
     </div>
   </div>
-{% endif %}
+</div>

--- a/templates/experiments/chat/chat_message_response.html
+++ b/templates/experiments/chat/chat_message_response.html
@@ -6,7 +6,7 @@
          hx-trigger="load delay:1s"
          hx-swap="outerHTML"
        {% endif %}
-       data-last-message-datetime="{{ last_message_datetime|safe }}"
+       data-last-message-datetime="{{ last_message_datetime|date:"c" }}"
   >
     <div class="flex flex-row">
       <div>

--- a/templates/experiments/chat/chat_ui.html
+++ b/templates/experiments/chat/chat_ui.html
@@ -15,7 +15,7 @@
   {% endif %}
   {% for message in session.get_messages_for_display %}
     {% with message.content as message_text %}
-      {% with message.created_at_datetime as created_at_datetime %}
+      {% with message.created_at as created_at_datetime %}
         {% if message.is_ai_message %}
           {% include 'experiments/chat/ai_message.html' with attachments=message.get_attached_files %}
         {% elif message.is_human_message %}

--- a/templates/experiments/chat/chat_ui.html
+++ b/templates/experiments/chat/chat_ui.html
@@ -43,43 +43,17 @@
     refreshTimer = setTimeout(pollBackend, pollInterval);
   }
 
-  function appendMessage(messageHTML) {
-    const messageList = document.getElementById('message-list');
-    const newMessageDiv = document.createElement('div');
-    newMessageDiv.innerHTML = messageHTML;
-
-    messageList.appendChild(newMessageDiv);
-  }
-
   function pollBackend() {
-    document.body.addEventListener('htmx:afterOnLoad', function(evt) {
-      // scroll to bottom of chat after every htmx request
-      const chatUI = document.getElementById('message-list');
-      chatUI.scrollTop = chatUI.scrollHeight;
-    });
     const messageListDiv = document.getElementById('message-list');
-    var url = messageListDiv.getAttribute('data-url');
+    const url = messageListDiv.getAttribute('data-url');
     const lastMessage = messageListDiv.lastElementChild
     const lastDateTime = lastMessage.getAttribute('data-last-message-datetime')
     if (!lastDateTime) {
+      console.log("No last message datetime found, skipping poll.", lastMessage);
       return;
     }
     const params = new URLSearchParams([['since', lastDateTime]])
-    fetch(`${url}?${params}`)
-      .then(response => {
-        if (response.status !== 200) {
-          console.error('Messages not found');
-          return;
-        }
-        return response.text();
-      })
-      .then(data => {
-        if (data) {
-          appendMessage(data);
-        }
-      })
-      .catch(error => console.error('Error fetching messages:', error))
-      .finally(() => scrollToBottom());
+    htmx.ajax('GET', `${url}?${params}`, {target: '#message-list', swap: 'beforeend'})
   }
 
   function cancelPolling() {

--- a/templates/experiments/chat/chat_ui.html
+++ b/templates/experiments/chat/chat_ui.html
@@ -64,8 +64,8 @@
     if (!lastDateTime) {
       return;
     }
-    url = url + "?since=" + lastDateTime
-    fetch(url)
+    const params = new URLSearchParams([['since', lastDateTime]])
+    fetch(`${url}?${params}`)
       .then(response => {
         if (response.status !== 200) {
           console.error('Messages not found');

--- a/templates/experiments/chat/chat_ui.html
+++ b/templates/experiments/chat/chat_ui.html
@@ -1,4 +1,9 @@
-<div id="message-list" class="chat-pane" data-url="{% url 'experiments:poll_messages' team.slug experiment.id session.id %}">
+{% if embedded %}
+  {% url 'experiments:poll_messages_embed' team_slug=request.team.slug experiment_id=experiment.public_id session_id=session.external_id as poll_url%}
+{% else %}
+  {% url 'experiments:poll_messages' team_slug=request.team.slug experiment_id=experiment.public_id session_id=session.external_id as poll_url%}
+{% endif %}
+<div id="message-list" class="chat-pane" data-url="{{ poll_url }}">
   {% if not session.has_display_messages %}
     {% if session.seed_task_id %}
       {% with session.seed_task_id as task_id %}

--- a/templates/experiments/chat/chat_ui.html
+++ b/templates/experiments/chat/chat_ui.html
@@ -76,7 +76,6 @@
       .then(data => {
         if (data) {
           appendMessage(data);
-          console.log(data);
         }
       })
       .catch(error => console.error('Error fetching messages:', error))

--- a/templates/experiments/chat/chat_ui.html
+++ b/templates/experiments/chat/chat_ui.html
@@ -77,10 +77,10 @@
         if (data) {
           appendMessage(data);
           console.log(data);
-          scrollToBottom();
         }
       })
-      .catch(error => console.error('Error fetching messages:', error));
+      .catch(error => console.error('Error fetching messages:', error))
+      .finally(() => scrollToBottom());
   }
 
   function cancelPolling() {

--- a/templates/experiments/chat/chat_ui.html
+++ b/templates/experiments/chat/chat_ui.html
@@ -34,7 +34,7 @@
 {% endif %}
 <script>
   let refreshTimer = null;
-  const pollInterval = 60000;
+  const pollInterval = 30000;
 
   function scrollToBottom() {
     const chatUI = document.getElementById('message-list');

--- a/templates/experiments/chat/system_message.html
+++ b/templates/experiments/chat/system_message.html
@@ -1,5 +1,5 @@
 {% for message in messages %}
-  <div class="chat-message-system flex" data-last-message-datetime="{{ last_message_datetime|safe }}">
+  <div class="chat-message-system flex" data-last-message-datetime="{{ last_message_datetime|date:"c" }}">
     {% include "experiments/chat/components/system_icon.html" %}
     <div class="message-contents">
       <p>{{ message }}</p>


### PR DESCRIPTION
## Description
This PR fixes a bunch of issues related to polling for messages from the chat UI. It appears this code has been broken over time as changes to the chat UI have been made.

This PR fixes the polling and includes some refactors to improve it. It also makes it work for embedded chat.

## User Impact
Web chat's will now receive reminders and server generated messages without having to refresh their browser window.

### Demo
<div>
    <a href="https://www.loom.com/share/4c851a5572f94f1aa29ea23eb548594e">
      <p>OCS demo: Reminder Functionality on the web - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/4c851a5572f94f1aa29ea23eb548594e">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/4c851a5572f94f1aa29ea23eb548594e-3e75eed57358a61e-full-play.gif">
    </a>
  </div>

### Docs and Changelog
TODO
