### PR TITLE
Add additional pruned_memory check

### DIFF
--- a/apps/chat/conversation.py
+++ b/apps/chat/conversation.py
@@ -320,6 +320,8 @@ def _get_new_summary(llm, pruned_memory, summary, max_token_limit, first_call=Tr
             for msg in pruned_memory
             if msg.content
         ]
+        if not pruned_memory:
+            return summary
 
     tokens, context = _get_summary_tokens_with_context(llm, summary, pruned_memory)
     next_batch = []


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Sentry Issue: [OPEN-CHAT-STUDIO-TY](https://dimagi.sentry.io/issues/6535116621/?referrer=github_integration)
Theory: 

The error shows pruned_memory is `[]`
The error happens at line 334 where it raises ChatException("Unable to compress history")
This only happens when context["new_lines"] is empty and first_call is `False`

This suggests the code execution path might be:

`_get_new_summary` is called with empty pruned_memory and first_call=False
The early return check if not pruned_memory: is somehow bypassed
The code calls _get_summary_tokens_with_context which returns empty new_lines
Then it enters the condition if not context["new_lines"]: and raises the exception

idea: add extra pruned_memory check after modification during first call

*untested unsure how to test this edge case specifically

## User Impact
<!-- Describe the impact of this change on the end-users. -->
fixes case so conversation can continue

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
n/a

### Docs and Changelog
<!--Link to documentation that has been updated.-->
changelog yes