### PR TITLE
Sk/add back schedules

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -8,7 +8,6 @@ from typing import Self
 from uuid import uuid4
 
 import markdown
-import pytz
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
@@ -1348,12 +1347,6 @@ class Participant(BaseTeamModel):
         scheduled_messages = []
         for message in messages:
             if as_dict:
-                next_trigger_date = message.next_trigger_date
-                last_triggered_at = message.last_triggered_at
-                if as_timezone:
-                    next_trigger_date = next_trigger_date.astimezone(pytz.timezone(as_timezone))
-                    if last_triggered_at:
-                        last_triggered_at = last_triggered_at.astimezone(pytz.timezone(as_timezone))
                 scheduled_messages.append(message.as_dict(as_timezone=as_timezone))
             else:
                 scheduled_messages.append(message.as_string(as_timezone=as_timezone))

--- a/apps/pipelines/tests/test_code_node.py
+++ b/apps/pipelines/tests/test_code_node.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from apps.channels.datamodels import Attachment
-from apps.experiments.models import ExperimentSession, Participant, ParticipantData
+from apps.experiments.models import Participant, ParticipantData
 from apps.files.models import File
 from apps.pipelines.exceptions import PipelineNodeBuildError, PipelineNodeRunError
 from apps.pipelines.nodes.base import PipelineState
@@ -52,16 +52,16 @@ def main(input, **kwargs):
         (IMPORTS, json.dumps({"a": "b"}), str(json.loads('{"a": "b"}'))),  # Importing json will work
     ],
 )
-def test_code_node(pipeline, code, input, output):
+def test_code_node(pipeline, experiment_session, code, input, output):
     nodes = [
         start_node(),
         code_node(code),
         end_node(),
     ]
     assert (
-        create_runnable(pipeline, nodes).invoke(
-            PipelineState(messages=[input], experiment_session=ExperimentSession())
-        )["messages"][-1]
+        create_runnable(pipeline, nodes).invoke(PipelineState(messages=[input], experiment_session=experiment_session))[
+            "messages"
+        ][-1]
         == output
     )
 
@@ -126,16 +126,16 @@ def test_code_node_build_errors(pipeline, code, input, error):
         ("def main(input, **kwargs):\n\treturn f'Hello, {blah}!'", "", "name 'blah' is not defined"),
     ],
 )
-def test_code_node_runtime_errors(pipeline, code, input, error):
+def test_code_node_runtime_errors(pipeline, experiment_session, code, input, error):
     nodes = [
         start_node(),
         code_node(code),
         end_node(),
     ]
     with pytest.raises(PipelineNodeRunError, match=error):
-        create_runnable(pipeline, nodes).invoke(
-            PipelineState(messages=[input], experiment_session=ExperimentSession())
-        )["messages"][-1]
+        create_runnable(pipeline, nodes).invoke(PipelineState(messages=[input], experiment_session=experiment_session))[
+            "messages"
+        ][-1]
 
 
 @django_db_with_data(available_apps=("apps.service_providers",))

--- a/apps/service_providers/llm_service/prompt_context.py
+++ b/apps/service_providers/llm_service/prompt_context.py
@@ -153,6 +153,7 @@ class ParticipantDataProxy:
 
     def __init__(self, experiment_session):
         self.session = experiment_session
+        self.experiment = self.session.experiment
         self._participant_data = None
         self._scheduled_messages = None
 
@@ -188,23 +189,9 @@ class ParticipantDataProxy:
         Returns all active scheduled messages for the participant in the current experiment session.
         """
         if self._scheduled_messages is None:
-            from apps.events.models import ScheduledMessage
-
-            experiment = self.session.experiment_id
-            participant = self.session.participant_id
-            team = self.session.experiment.team
-            messages = (
-                ScheduledMessage.objects.filter(
-                    experiment_id=experiment,
-                    participant_id=participant,
-                    team=team,
-                    is_complete=False,
-                    cancelled_at=None,
-                )
-                .select_related("action")
-                .order_by("created_at")
+            self._scheduled_messages = self.session.participant.get_schedules_for_experiment(
+                self.experiment, as_dict=True, as_timezone=self.get_timezone()
             )
-            self._scheduled_messages = [message.as_dict() for message in messages]
         return self._scheduled_messages
 
     def get_timezone(self):

--- a/apps/service_providers/llm_service/prompt_context.py
+++ b/apps/service_providers/llm_service/prompt_context.py
@@ -65,7 +65,9 @@ class PromptTemplateContext:
             return ""
 
     def get_participant_data(self):
-        data = self.participant_data_proxy.get() or ""
+        data = self.participant_data_proxy.get() or {}
+        if scheduled_messages := self.participant_data_proxy.get_schedules():
+            data = {**data, "scheduled_messages": scheduled_messages}
         return SafeAccessWrapper(data)
 
     def get_current_datetime(self):

--- a/apps/service_providers/llm_service/prompt_context.py
+++ b/apps/service_providers/llm_service/prompt_context.py
@@ -155,7 +155,7 @@ class ParticipantDataProxy:
 
     def __init__(self, experiment_session):
         self.session = experiment_session
-        self.experiment = self.session.experiment
+        self.experiment = self.session.experiment if self.session else None
         self._participant_data = None
         self._scheduled_messages = None
 

--- a/apps/service_providers/tests/test_participant_data_proxy.py
+++ b/apps/service_providers/tests/test_participant_data_proxy.py
@@ -1,0 +1,146 @@
+from unittest.mock import patch
+
+import pytest
+
+from apps.experiments.models import Participant, ParticipantData
+from apps.service_providers.llm_service.prompt_context import ParticipantDataProxy
+from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory, ParticipantFactory
+
+
+@pytest.mark.django_db()
+class TestParticipantDataProxy:
+    """Tests for the ParticipantDataProxy class that handles participant data access"""
+
+    def test_initialization(self):
+        """Test that ParticipantDataProxy initializes correctly"""
+        experiment = ExperimentFactory()
+        session = ExperimentSessionFactory(experiment=experiment)
+        proxy = ParticipantDataProxy(session)
+
+        assert proxy.session == session
+        assert proxy.experiment == experiment
+        assert proxy._participant_data is None
+        assert proxy._scheduled_messages is None
+
+    def test_from_state(self):
+        """Test creating a ParticipantDataProxy from pipeline state"""
+        session = ExperimentSessionFactory()
+        pipeline_state = {"experiment_session": session}
+        proxy = ParticipantDataProxy.from_state(pipeline_state)
+
+        assert proxy.session == session
+        assert proxy.experiment == session.experiment
+
+    def test_from_state_with_missing_session(self):
+        """Test handling when state doesn't have experiment_session"""
+        pipeline_state = {}
+        proxy = ParticipantDataProxy.from_state(pipeline_state)
+
+        assert proxy.session is None
+        assert proxy.experiment is None
+
+    def test_get_db_object_creates_if_not_exists(self):
+        """Test that _get_db_object creates a ParticipantData if it doesn't exist"""
+        participant = ParticipantFactory()
+        experiment = ExperimentFactory()
+        session = ExperimentSessionFactory(experiment=experiment, participant=participant)
+
+        proxy = ParticipantDataProxy(session)
+
+        # First call should create the object
+        result = proxy._get_db_object()
+        assert isinstance(result, ParticipantData)
+        assert result.participant_id == participant.id
+        assert result.experiment_id == experiment.id
+        assert result.team_id == experiment.team_id
+
+        # Second call should return the cached object
+        assert proxy._get_db_object() is result
+
+    def test_get_returns_merged_data(self):
+        """Test that get() merges participant global data with participant data"""
+        participant = ParticipantFactory(name="Test User")
+        experiment = ExperimentFactory()
+        session = ExperimentSessionFactory(experiment=experiment, participant=participant)
+
+        # Create participant data with some data
+        participant_data = ParticipantData.objects.create(
+            participant=participant, experiment=experiment, team=experiment.team, data={"favorite_color": "blue"}
+        )
+
+        proxy = ParticipantDataProxy(session)
+        proxy._participant_data = participant_data
+
+        # Participant's global_data should include the name
+        expected_data = {"name": "Test User", "favorite_color": "blue"}
+        assert proxy.get() == expected_data
+
+    def test_set_validates_data_type(self):
+        """Test that set() validates the data type"""
+        session = ExperimentSessionFactory()
+        proxy = ParticipantDataProxy(session)
+
+        with pytest.raises(ValueError, match="Data must be a dictionary"):
+            proxy.set("not a dictionary")
+
+    def test_set_updates_participant_data(self):
+        """Test that set() updates the participant data"""
+        participant = ParticipantFactory()
+        session = ExperimentSessionFactory(participant=participant)
+
+        proxy = ParticipantDataProxy(session)
+        participant_data = proxy._get_db_object()
+
+        # Set some data
+        proxy.set({"favorite_color": "blue", "name": "New Name"})
+
+        # Check that data was updated
+        participant_data.refresh_from_db()
+        assert participant_data.data == {"favorite_color": "blue", "name": "New Name"}
+
+        # Check that participant name was updated
+        participant.refresh_from_db()
+        assert participant.name == "New Name"
+
+    def test_get_schedules(self):
+        """Test that get_schedules() returns scheduled messages for the participant"""
+        participant = ParticipantFactory()
+        experiment = ExperimentFactory()
+        session = ExperimentSessionFactory(experiment=experiment, participant=participant)
+        proxy = ParticipantDataProxy(session)
+
+        # Mock the get_schedules_for_experiment method on participant
+        mock_schedules = [{"id": 1, "message": "Test reminder", "scheduled_time": "2023-01-01T10:00:00Z"}]
+        with patch.object(
+            Participant, "get_schedules_for_experiment", return_value=mock_schedules
+        ) as mock_get_schedules:
+            result = proxy.get_schedules()
+
+            # Method should be called with the experiment and timezone params
+            mock_get_schedules.assert_called_once_with(experiment, as_dict=True, as_timezone=proxy.get_timezone())
+            assert result == mock_schedules
+
+            # Subsequent calls should use cached result
+            proxy.get_schedules()
+            assert mock_get_schedules.call_count == 1
+
+    def test_get_timezone(self):
+        """Test that get_timezone returns the participant's timezone"""
+        participant = ParticipantFactory()
+        experiment = ExperimentFactory()
+        session = ExperimentSessionFactory(experiment=experiment, participant=participant)
+
+        # Create participant data with a timezone
+        participant_data = ParticipantData.objects.create(
+            participant=participant, experiment=experiment, team=experiment.team, data={"timezone": "America/New_York"}
+        )
+
+        proxy = ParticipantDataProxy(session)
+        proxy._participant_data = participant_data
+
+        assert proxy.get_timezone() == "America/New_York"
+
+        # Test with no timezone set
+        participant_data.data = {}
+        participant_data.save()
+        assert proxy.get_timezone() is None

--- a/apps/service_providers/tests/test_runnables.py
+++ b/apps/service_providers/tests/test_runnables.py
@@ -38,6 +38,7 @@ def session(fake_llm_service):
     session.experiment.tools = [AgentTools.MOVE_SCHEDULED_MESSAGE_DATE]
     proxy_mock = mock.Mock()
     proxy_mock.get.return_value = {"name": "Tester"}
+    proxy_mock.get_schedules.return_value = []
     with patch("apps.service_providers.llm_service.prompt_context.ParticipantDataProxy", return_value=proxy_mock):
         yield session
 


### PR DESCRIPTION
## Description
A change in https://github.com/dimagi/open-chat-studio/pull/1329 resulted in the scheduled message data not being included in the participant data used in the '{participant_data}' prompt variable.

This PR adds the scheduled message data back along with some tests.

## User Impact
Fixes reminders workflows where multiple reminders were being created.

### Demo
NA

### Docs and Changelog
https://github.com/dimagi/open-chat-studio-docs/pull/87
