### PR TITLE
record embed source in chat metadata

### DIFF
--- a/apps/channels/tests/test_web_channel.py
+++ b/apps/channels/tests/test_web_channel.py
@@ -29,12 +29,14 @@ def test_start_new_session(new_user_message, with_seed_message, experiment):
     session = WebChannel.start_new_session(
         experiment,
         "jack@titanic.com",
+        metadata={Chat.MetadataKeys.EMBED_SOURCE: "remote host"},
     )
 
     assert session is not None
     assert session.participant.identifier == "jack@titanic.com"
     assert session.experiment_channel is not None
     assert session.experiment_channel.platform == ChannelPlatform.WEB
+    assert session.chat.metadata.get(Chat.MetadataKeys.EMBED_SOURCE) == "remote host"
 
     if with_seed_message:
         assert session.seed_task_id is not None

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -26,6 +26,10 @@ class Chat(BaseTeamModel, TaggedModelMixin, UserCommentsMixin):
     name = models.CharField(max_length=128, default="Unnamed Chat")
     metadata = models.JSONField(default=dict)
 
+    @property
+    def embed_source(self):
+        return self.metadata.get(Chat.MetadataKeys.EMBED_SOURCE)
+
     def get_metadata(self, key: MetadataKeys):
         return self.metadata.get(key, None)
 

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -20,6 +20,7 @@ class Chat(BaseTeamModel, TaggedModelMixin, UserCommentsMixin):
     class MetadataKeys(StrEnum):
         OPENAI_THREAD_ID = "openai_thread_id"
         EXPERIMENT_VERSION = "experiment_version"
+        EMBED_SOURCE = "embed_source"
 
     # must match or be greater than experiment name field
     name = models.CharField(max_length=128, default="Unnamed Chat")

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -36,7 +36,7 @@ from apps.channels.exceptions import ExperimentChannelException
 from apps.channels.forms import ChannelForm
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import WebChannel
-from apps.chat.models import ChatAttachment, ChatMessage, ChatMessageType
+from apps.chat.models import Chat, ChatAttachment, ChatMessage, ChatMessageType
 from apps.events.models import (
     EventLogStatusChoices,
     StaticTrigger,
@@ -966,6 +966,7 @@ def start_session_public_embed(request, team_slug: str, experiment_id: uuid.UUID
         working_experiment=experiment,
         participant_identifier=participant.identifier,
         timezone=request.session.get("detected_tz", None),
+        metadata={Chat.MetadataKeys.EMBED_SOURCE: request.headers.get("referer", None)},
     )
     redirect_url = (
         "chatbots:chatbot_chat_embed" if request.origin == "chatbots" else "experiments:experiment_chat_embed"

--- a/apps/generics/views.py
+++ b/apps/generics/views.py
@@ -133,7 +133,6 @@ def render_session_details(
                 (gettext("Started"), session.consent_date or session.created_at),
                 (gettext("Ended"), session.ended_at or "-"),
                 (gettext(session_type), experiment.name),
-                (gettext("Platform"), session.get_platform_name),
             ],
             "available_tags": [t.name for t in Tag.objects.filter(team__slug=team_slug, is_system_tag=False).all()],
             "event_triggers": [

--- a/templates/experiments/components/experiment_details.html
+++ b/templates/experiments/components/experiment_details.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% load waffle_tags %}
 
 <div>
@@ -11,6 +12,17 @@
           </dd>
         </div>
       {% endfor %}
+      <div class="py-3 grid grid-cols-3 sm:gap-4">
+        <dt class="text-sm font-medium leading-6">{% translate "Platform" %}</dt>
+        <dd class="text-sm col-span-2">
+          {{ experiment_session.get_platform_name }}
+          {% if experiment_session.chat.embed_source %}
+            (Embedded at <a class="link" href="{{ experiment_session.chat.embed_source }}" target="_blank">
+              {{ experiment_session.chat.embed_source }}
+            </a>)
+          {% endif %}
+        </dd>
+      </div>
       {% if experiment.assistant %}
         <div class="py-3 grid grid-cols-3 sm:gap-4">
           <dt class="text-sm font-medium leading-6">OpenAI Assistant</dt>

--- a/templates/experiments/experiment_session_view.html
+++ b/templates/experiments/experiment_session_view.html
@@ -36,7 +36,7 @@
         </div>
       {% endif %}
     </div>
-    <h3 class="text-base font-semibold leading-7 mt-8 pl-4">Experiment details</h3>
+    <h3 class="text-base font-semibold leading-7 mt-8 pl-4">Session details</h3>
     <div class="max-w-5xl mt-4 border rounded-2xl">
       {% include "experiments/components/experiment_details.html" %}
     </div>


### PR DESCRIPTION
## Description
Record the referer header when starting session from the embedded chatbot. This gives more information about where the bot is being embedded for auditing purposes.

Should we also capture the IP address for all web sessions? Unclear if that's useful unless we also geolocate it.

## User Impact
User's can more easily tell where web sessions are coming from.

### Demo
![image](https://github.com/user-attachments/assets/72f77a91-86b4-4c52-81de-60c4fcaccf01)


### Docs and Changelog
TODO
