### PR TITLE
Ba/add route tags

### DIFF
--- a/apps/events/tests/test_actions.py
+++ b/apps/events/tests/test_actions.py
@@ -72,6 +72,7 @@ def test_end_conversation_runs_pipeline(session, pipeline):
             },
             "input_message_metadata": {},
             "output_message_metadata": {},
+            "output_message_tags": [],
         }
     )
     assert pipeline.runs.count() == 1

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -304,6 +304,7 @@ class Pipeline(BaseTeamModel, VersionsMixin):
     ) -> dict:
         from apps.experiments.models import AgentTools
         from apps.pipelines.graph import PipelineGraph
+
         runnable = PipelineGraph.build_runnable_from_pipeline(self)
         pipeline_run = self._create_pipeline_run(input, session)
         logging_callback = PipelineLoggingCallbackHandler(pipeline_run)

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -304,7 +304,6 @@ class Pipeline(BaseTeamModel, VersionsMixin):
     ) -> dict:
         from apps.experiments.models import AgentTools
         from apps.pipelines.graph import PipelineGraph
-
         runnable = PipelineGraph.build_runnable_from_pipeline(self)
         pipeline_run = self._create_pipeline_run(input, session)
         logging_callback = PipelineLoggingCallbackHandler(pipeline_run)

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -350,7 +350,7 @@ class Pipeline(BaseTeamModel, VersionsMixin):
                     output["messages"][-1],
                     ChatMessageType.AI,
                     metadata=output_metadata,
-                    tags=output.get("tag_output_message"),
+                    tags=output.get("output_message_tags"),
                 )
                 pipeline_output = ai_message
             else:
@@ -379,7 +379,7 @@ class Pipeline(BaseTeamModel, VersionsMixin):
         )
 
     def _save_message_to_history(
-        self, session: ExperimentSession, message: str, type_: ChatMessageType, metadata: dict, tags: dict = None
+        self, session: ExperimentSession, message: str, type_: ChatMessageType, metadata: dict, tags: list[str] = None
     ) -> ChatMessage:
         chat_message = ChatMessage.objects.create(
             chat=session.chat, message_type=type_.value, content=message, metadata=metadata
@@ -388,7 +388,7 @@ class Pipeline(BaseTeamModel, VersionsMixin):
         if type_ == ChatMessageType.AI:
             chat_message.add_version_tag(version_number=self.version_number, is_a_version=self.is_a_version)
             if tags:
-                for tag in tags.items():
+                for tag in tags:
                     chat_message.add_system_tag(tag, TagCategories.BOT_RESPONSE)
         return chat_message
 

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -79,6 +79,7 @@ class PipelineState(dict):
     input_message_metadata: Annotated[dict, merge_dicts]
     output_message_metadata: Annotated[dict, merge_dicts]
     attachments: list = Field(default=[])
+    tag_output_message: Annotated[dict, merge_dicts]
 
     def json_safe(self):
         # We need to make a copy of `self` so as to not change the actual value of `experiment_session` forever
@@ -183,7 +184,7 @@ class PipelineNode(BaseModel, ABC):
         output_handle = next((k for k, v in output_map.items() if v == conditional_branch), None)
         state["outputs"][node_id]["output_handle"] = output_handle
         if self.tag_output_message:
-            state["output_message_metadata"].setdefault("tags", []).append(conditional_branch)
+            state["tag_output_message"].setdefault("tags", []).append(f"{self.name}:{conditional_branch}")
         return conditional_branch
 
     def _process(self, input: str, state: PipelineState, node_id: str) -> PipelineState:

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -223,6 +223,7 @@ class Widgets(StrEnum):
     float = "float"
     range = "range"
     multiselect = "multiselect"
+    checkbox = "checkbox"
     none = "none"
 
     # special widgets

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -182,6 +182,9 @@ class PipelineNode(BaseModel, ABC):
         output_map = self.get_output_map()
         output_handle = next((k for k, v in output_map.items() if v == conditional_branch), None)
         state["outputs"][node_id]["output_handle"] = output_handle
+        if self.tag_output_message:
+            state["output_message_metadata"].setdefault("tags", []).append(conditional_branch)
+        breakpoint()
         return conditional_branch
 
     def _process(self, input: str, state: PipelineState, node_id: str) -> PipelineState:

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -184,7 +184,6 @@ class PipelineNode(BaseModel, ABC):
         state["outputs"][node_id]["output_handle"] = output_handle
         if self.tag_output_message:
             state["output_message_metadata"].setdefault("tags", []).append(conditional_branch)
-        breakpoint()
         return conditional_branch
 
     def _process(self, input: str, state: PipelineState, node_id: str) -> PipelineState:
@@ -226,7 +225,6 @@ class Widgets(StrEnum):
     float = "float"
     range = "range"
     multiselect = "multiselect"
-    checkbox = "checkbox"
     none = "none"
 
     # special widgets

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -79,7 +79,7 @@ class PipelineState(dict):
     input_message_metadata: Annotated[dict, merge_dicts]
     output_message_metadata: Annotated[dict, merge_dicts]
     attachments: list = Field(default=[])
-    tag_output_message: Annotated[dict, merge_dicts]
+    output_message_tags: Annotated[list[str], operator.add]
 
     def json_safe(self):
         # We need to make a copy of `self` so as to not change the actual value of `experiment_session` forever
@@ -184,7 +184,8 @@ class PipelineNode(BaseModel, ABC):
         output_handle = next((k for k, v in output_map.items() if v == conditional_branch), None)
         state["outputs"][node_id]["output_handle"] = output_handle
         if self.tag_output_message:
-            state["tag_output_message"].setdefault("tags", []).append(f"{self.name}:{conditional_branch}")
+            state.setdefault("output_message_tags", [])
+            state["output_message_tags"].append(f"{self.name}:{conditional_branch}")
         return conditional_branch
 
     def _process(self, input: str, state: PipelineState, node_id: str) -> PipelineState:

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -418,10 +418,10 @@ class BooleanNode(Passthrough):
 
 class RouterMixin(BaseModel):
     keywords: list[str] = Field(default_factory=list, json_schema_extra=UiSchema(widget=Widgets.keywords))
-    tag_message: str = Field(
-        default="False",
+    tag_message: bool = Field(
+        default=False,
         description="Tag output message with route",
-        json_schema_extra=UiSchema(widget=Widgets.toggle)
+        json_schema_extra=UiSchema(widget=Widgets.checkbox)
     )
 
     @field_validator("keywords")
@@ -522,7 +522,7 @@ class StaticRouterNode(RouterMixin, Passthrough):
     tag_message: bool = Field(
         default=False,
         description="Tag output message with route",
-        json_schema_extra=UiSchema(widget=Widgets.toggle)
+        json_schema_extra=UiSchema(widget=Widgets.checkbox)
     )
 
     def _process_conditional(self, state: PipelineState, node_id=None):

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -414,7 +414,7 @@ class BooleanNode(Passthrough):
 class RouterMixin(BaseModel):
     keywords: list[str] = Field(default_factory=list, json_schema_extra=UiSchema(widget=Widgets.keywords))
     tag_output_message: bool = Field(
-        default=False, description="Tag output message with route", json_schema_extra=UiSchema(widget=Widgets.checkbox)
+        default=False, description="Tag the output message with chosen route", json_schema_extra=UiSchema(widget=Widgets.toggle)
     )
 
     @field_validator("keywords")
@@ -488,12 +488,9 @@ class RouterNode(RouterMixin, Passthrough, HistoryMixin):
             keyword = None
         if not keyword:
             keyword = self.keywords[0]
-        if self.tag_output_message:
-            state["output_message_metadata"].setdefault("tags", []).append(keyword)
 
         if session:
             self._save_history(session, node_id, node_input, keyword)
-
         return keyword
 
 
@@ -538,11 +535,10 @@ class StaticRouterNode(RouterMixin, Passthrough):
             result = ""
 
         result_lower = result.lower()
+        breakpoint()
         for keyword in self.keywords:
             if keyword.lower() == result_lower:
                 return keyword
-        if self.tag_output_message:
-            state["output_message_metadata"].setdefault("tags", []).append(keyword)
         return self.keywords[0]
 
 

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -400,6 +400,11 @@ class BooleanNode(Passthrough):
     model_config = ConfigDict(json_schema_extra=NodeSchema(label="Conditional Node"))
 
     input_equals: str
+    tag_output_message: bool = Field(
+        default=False,
+        description="Tag the output message with the selected route",
+        json_schema_extra=UiSchema(widget=Widgets.toggle),
+    )
 
     def _process_conditional(self, state: PipelineState, node_id: str | None = None) -> Literal["true", "false"]:
         if self.input_equals == state["messages"][-1]:
@@ -415,7 +420,7 @@ class RouterMixin(BaseModel):
     keywords: list[str] = Field(default_factory=list, json_schema_extra=UiSchema(widget=Widgets.keywords))
     tag_output_message: bool = Field(
         default=False,
-        description="Tag the output message with chosen route",
+        description="Tag the output message with the selected route",
         json_schema_extra=UiSchema(widget=Widgets.toggle),
     )
 

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -414,7 +414,9 @@ class BooleanNode(Passthrough):
 class RouterMixin(BaseModel):
     keywords: list[str] = Field(default_factory=list, json_schema_extra=UiSchema(widget=Widgets.keywords))
     tag_output_message: bool = Field(
-        default=False, description="Tag the output message with chosen route", json_schema_extra=UiSchema(widget=Widgets.toggle)
+        default=False,
+        description="Tag the output message with chosen route",
+        json_schema_extra=UiSchema(widget=Widgets.toggle),
     )
 
     @field_validator("keywords")
@@ -535,7 +537,6 @@ class StaticRouterNode(RouterMixin, Passthrough):
             result = ""
 
         result_lower = result.lower()
-        breakpoint()
         for keyword in self.keywords:
             if keyword.lower() == result_lower:
                 return keyword

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -112,6 +112,11 @@ class LLMResponseMixin(BaseModel):
     llm_temperature: float = Field(
         default=0.7, ge=0.0, le=2.0, title="Temperature", json_schema_extra=UiSchema(widget=Widgets.range)
     )
+    tag_message: bool = Field(
+        default=False,
+        description="Tag output message with route",
+        json_schema_extra=UiSchema(widget=Widgets.toggle)
+    )
 
     def get_llm_service(self):
         from apps.service_providers.models import LlmProvider
@@ -413,6 +418,11 @@ class BooleanNode(Passthrough):
 
 class RouterMixin(BaseModel):
     keywords: list[str] = Field(default_factory=list, json_schema_extra=UiSchema(widget=Widgets.keywords))
+    tag_message: str = Field(
+        default="False",
+        description="Tag output message with route",
+        json_schema_extra=UiSchema(widget=Widgets.toggle)
+    )
 
     @field_validator("keywords")
     def ensure_keywords_exist(cls, value, info: FieldValidationInfo):
@@ -444,7 +454,7 @@ class RouterNode(RouterMixin, Passthrough, HistoryMixin):
         json_schema_extra=NodeSchema(
             label="LLM Router",
             documentation_link=settings.DOCUMENTATION_LINKS["node_llm_router"],
-            field_order=["llm_provider_id", "llm_temperature", "history_type", "prompt", "keywords"],
+            field_order=["llm_provider_id", "llm_temperature", "history_type", "prompt", "keywords", "tag_message"],
         )
     )
     prompt: str = Field(
@@ -476,9 +486,10 @@ class RouterNode(RouterMixin, Passthrough, HistoryMixin):
             keyword = getattr(result, "route", None)
         except ValidationError:
             keyword = None
-
         if not keyword:
             keyword = self.keywords[0]
+        if self.tag_message:
+            state["input_message_metadata"].setdefault("tags", []).append(keyword)
 
         if session:
             self._save_history(session, node_id, node_input, keyword)
@@ -508,6 +519,11 @@ class StaticRouterNode(RouterMixin, Passthrough):
         json_schema_extra=UiSchema(enum_labels=DataSource.labels),
     )
     route_key: str = Field(..., description="The key in the data to use for routing")
+    tag_message: bool = Field(
+        default=False,
+        description="Tag output message with route",
+        json_schema_extra=UiSchema(widget=Widgets.toggle)
+    )
 
     def _process_conditional(self, state: PipelineState, node_id=None):
         from apps.service_providers.llm_service.prompt_context import SafeAccessWrapper
@@ -530,6 +546,8 @@ class StaticRouterNode(RouterMixin, Passthrough):
         for keyword in self.keywords:
             if keyword.lower() == result_lower:
                 return keyword
+        if self.tag_message:
+            state["input_message_metadata"].setdefault("tags", []).append(keyword)
         return self.keywords[0]
 
 

--- a/apps/pipelines/tests/data/BooleanNode.json
+++ b/apps/pipelines/tests/data/BooleanNode.json
@@ -9,6 +9,13 @@
     "input_equals": {
       "title": "Input Equals",
       "type": "string"
+    },
+    "tag_output_message": {
+      "default": false,
+      "description": "Tag the output message with the selected route",
+      "title": "Tag Output Message",
+      "type": "boolean",
+      "ui:widget": "toggle"
     }
   },
   "required": [

--- a/apps/pipelines/tests/data/RouterNode.json
+++ b/apps/pipelines/tests/data/RouterNode.json
@@ -84,6 +84,13 @@
       "type": "array",
       "ui:widget": "keywords"
     },
+    "tag_output_message": {
+      "default": false,
+      "description": "Tag output message with route",
+      "title": "Tag Output Message",
+      "type": "boolean",
+      "ui:widget": "checkbox"
+    },
     "prompt": {
       "default": "You are an extremely helpful router",
       "minLength": 1,
@@ -110,6 +117,7 @@
     "llm_temperature",
     "history_type",
     "prompt",
-    "keywords"
+    "keywords",
+    "tag_output_message"
   ]
 }

--- a/apps/pipelines/tests/data/RouterNode.json
+++ b/apps/pipelines/tests/data/RouterNode.json
@@ -86,10 +86,10 @@
     },
     "tag_output_message": {
       "default": false,
-      "description": "Tag output message with route",
+      "description": "Tag the output message with the selected route",
       "title": "Tag Output Message",
       "type": "boolean",
-      "ui:widget": "checkbox"
+      "ui:widget": "toggle"
     },
     "prompt": {
       "default": "You are an extremely helpful router",

--- a/apps/pipelines/tests/data/StaticRouterNode.json
+++ b/apps/pipelines/tests/data/StaticRouterNode.json
@@ -14,6 +14,13 @@
       "type": "array",
       "ui:widget": "keywords"
     },
+    "tag_output_message": {
+      "default": false,
+      "description": "Tag output message with route",
+      "title": "Tag Output Message",
+      "type": "boolean",
+      "ui:widget": "checkbox"
+    },
     "data_source": {
       "enum": [
         "participant_data",

--- a/apps/pipelines/tests/data/StaticRouterNode.json
+++ b/apps/pipelines/tests/data/StaticRouterNode.json
@@ -16,10 +16,10 @@
     },
     "tag_output_message": {
       "default": false,
-      "description": "Tag output message with route",
+      "description": "Tag the output message with the selected route",
       "title": "Tag Output Message",
       "type": "boolean",
-      "ui:widget": "checkbox"
+      "ui:widget": "toggle"
     },
     "data_source": {
       "enum": [

--- a/apps/pipelines/tests/test_pipeline_runs.py
+++ b/apps/pipelines/tests/test_pipeline_runs.py
@@ -195,7 +195,6 @@ def test_save_metadata_and_tagging(pipeline: Pipeline, session: ExperimentSessio
 
     with mock.patch.object(ChatMessage, "add_system_tag") as mock_add_system_tag:
         pipeline.invoke(pipeline_state, session)
-        ai_message = session.chat.messages.filter(message_type=ChatMessageType.AI).first()
         for tag in output_message_tags:
             mock_add_system_tag.assert_any_call(tag, TagCategories.BOT_RESPONSE)
 

--- a/apps/pipelines/tests/test_runnable_builder.py
+++ b/apps/pipelines/tests/test_runnable_builder.py
@@ -427,6 +427,48 @@ def test_static_router_case_sensitive(pipeline, experiment_session):
     _check_match("THIRD", "C")
 
 
+@pytest.mark.django_db()
+def test_router_sets_tags_correctly(pipeline, experiment_session):
+    start = start_node()
+    router = state_key_router_node(
+        "route_to", ["first", "second"], data_source=StaticRouterNode.DataSource.temp_state, tag_output=True
+    )
+    template_a = render_template_node("A")
+    template_b = render_template_node("B")
+    end = end_node()
+
+    nodes = [start, router, template_a, template_b, end]
+    edges = [
+        {"id": "start -> router", "source": start["id"], "target": router["id"]},
+        {
+            "id": "router -> A",
+            "source": router["id"],
+            "target": template_a["id"],
+            "sourceHandle": "output_0",
+        },
+        {
+            "id": "router -> B",
+            "source": router["id"],
+            "target": template_b["id"],
+            "sourceHandle": "output_1",
+        },
+        {"id": "A -> end", "source": template_a["id"], "target": end["id"]},
+        {"id": "B -> end", "source": template_b["id"], "target": end["id"]},
+    ]
+    runnable = create_runnable(pipeline, nodes, edges)
+
+    def _check_routing_and_tags(route_to, expected_tag):
+        output = runnable.invoke(
+            PipelineState(
+                messages=["Test message"], experiment_session=experiment_session, temp_state={"route_to": route_to}
+            )
+        )
+        assert output["output_message_tags"] == [f"static router:{expected_tag}"]
+
+    _check_routing_and_tags("first", "first")
+    _check_routing_and_tags("second", "second")
+
+
 @django_db_with_data(available_apps=("apps.service_providers",))
 @pytest.mark.parametrize(
     "data_source", [StaticRouterNode.DataSource.participant_data, StaticRouterNode.DataSource.session_state]

--- a/apps/pipelines/tests/utils.py
+++ b/apps/pipelines/tests/utils.py
@@ -149,11 +149,17 @@ def router_node(provider_id: str, provider_model_id: str, keywords: list[str], *
     }
 
 
-def state_key_router_node(route_key: str, keywords: list[str], data_source="temp_state"):
+def state_key_router_node(route_key: str, keywords: list[str], data_source="temp_state", tag_output=False):
     return {
         "id": str(uuid4()),
         "type": nodes.StaticRouterNode.__name__,
-        "params": {"name": "static router", "data_source": data_source, "route_key": route_key, "keywords": keywords},
+        "params": {
+            "name": "static router",
+            "data_source": data_source,
+            "route_key": route_key,
+            "keywords": keywords,
+            "tag_output_message": tag_output,
+        },
     }
 
 

--- a/apps/service_providers/utils.py
+++ b/apps/service_providers/utils.py
@@ -152,8 +152,6 @@ def get_first_llm_provider_model(llm_provider, team_id):
     try:
         if llm_provider:
             model = LlmProviderModel.objects.filter(type=llm_provider.type, team_id=team_id).order_by("id").first()
-            breakpoint()
             return model
     except LlmProviderModel.DoesNotExist:
-        breakpoint()
         return None

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -176,17 +176,18 @@ function ToggleWidget(props: ToggleWidgetParams) {
 
 function CheckboxWidget(props: ToggleWidgetParams) {
   return (
-    <InputField label={props.label} help_text={props.helpText} inputError={props.inputError}>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-        <div style={{ fontWeight: 'bold' }}>{props.label}</div>
-        <input
-          type="checkbox"
-          name={props.name}
-          checked={props.paramValue}
-          onChange={props.updateParamValue}
-          style={{ width: '16px', height: '16px', cursor: 'pointer' }}
-        />
-      </div>
+    <InputField
+      label={props.label}
+      help_text={props.helpText}
+      inputError={props.inputError}
+    >
+      <input
+        type="checkbox"
+        name={props.name}
+        checked={props.paramValue}
+        onChange={props.updateParamValue}
+        className="checkbox"
+      />
     </InputField>
   );
 }

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -176,7 +176,7 @@ function ToggleWidget(props: ToggleWidgetParams) {
 
 function CheckboxWidget(props: ToggleWidgetParams) {
   return (
-    <InputField help_text={props.helpText} inputError={props.inputError}>
+    <InputField label={props.label} help_text={props.helpText} inputError={props.inputError}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
         <div style={{ fontWeight: 'bold' }}>{props.label}</div>
         <input

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -37,6 +37,8 @@ export function getWidget(name: string, params: PropertySchema) {
       return KeywordsWidget
     case "node_name":
       return NodeNameWidget
+    case "checkbox":
+        return CheckboxWidget
     default:
       if (params.enum) {
         return SelectWidget
@@ -167,6 +169,23 @@ function ToggleWidget(props: ToggleWidgetParams) {
         checked={props.paramValue}
         type="checkbox"
       ></input>
+    </InputField>
+  );
+}
+
+function CheckboxWidget(props: ToggleWidgetParams) {
+  return (
+    <InputField help_text={props.helpText} inputError={props.inputError}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        <div style={{ fontWeight: 'bold' }}>{props.label}</div>
+        <input
+          type="checkbox"
+          name={props.name}
+          checked={props.paramValue}
+          onChange={props.updateParamValue}
+          style={{ width: '16px', height: '16px', cursor: 'pointer' }}
+        />
+      </div>
     </InputField>
   );
 }

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -38,8 +38,6 @@ export function getWidget(name: string, params: PropertySchema) {
       return KeywordsWidget
     case "node_name":
       return NodeNameWidget
-    case "checkbox":
-        return CheckboxWidget
     default:
       if (params.enum) {
         return SelectWidget
@@ -170,24 +168,6 @@ function ToggleWidget(props: ToggleWidgetParams) {
         checked={props.paramValue}
         type="checkbox"
       ></input>
-    </InputField>
-  );
-}
-
-function CheckboxWidget(props: ToggleWidgetParams) {
-  return (
-    <InputField
-      label={props.label}
-      help_text={props.helpText}
-      inputError={props.inputError}
-    >
-      <input
-        type="checkbox"
-        name={props.name}
-        checked={props.paramValue}
-        onChange={props.updateParamValue}
-        className="checkbox"
-      />
     </InputField>
   );
 }

--- a/assets/javascript/apps/pipeline/panel/EditPanel.tsx
+++ b/assets/javascript/apps/pipeline/panel/EditPanel.tsx
@@ -20,7 +20,8 @@ export default function EditPanel({nodeId}: { nodeId: string }) {
   const updateParamValue = (
     event: ChangeEvent<HTMLTextAreaElement | HTMLSelectElement | HTMLInputElement>,
   ) => {
-    const {name, value} = event.target;
+    const {name, type} = event.target;
+    const value = type === 'checkbox' ? (event.target as HTMLInputElement).checked : event.target.value;
     if (!schemaProperties.includes(name)) {
       console.warn(`Unknown parameter: ${name}`);
       return;


### PR DESCRIPTION
## Description
Added a checbox widget.
Completed 2nd pt of #1143 i.e
For router nodes, both llm and static, add an additional checkbox: "Tag output message with route". The help text for this should be similar to above: "Add a tag to the generated message with the route keyword selected by this node."

**BugFix**
Fixed an issue with the Toggle widget where it couldn't be unchecked once selected.
## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
![image](https://github.com/user-attachments/assets/0c909a3d-a021-47a2-b073-9526016b25ea)


### Docs and Changelog
<!--Link to documentation that has been updated.-->
