### PR TITLE
check user before comparison

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -829,7 +829,7 @@ def poll_messages_embed(request, team_slug: str, experiment_id: uuid.UUID, sessi
 @team_required
 def poll_messages(request, team_slug: str, experiment_id: uuid.UUID, session_id: str):
     user = get_real_user_or_none(request.user)
-    if not request.experiment_session.participant.user == user:
+    if user and request.experiment_session.participant.user != user:
         return HttpResponseForbidden()
 
     return _poll_messages(request)


### PR DESCRIPTION
## Description
Resolves https://github.com/dimagi/open-chat-studio/issues/1462

This is a band aid fix. I think more work should be done on the participant identifier validation to prevent further issues and improve security.

More details in https://github.com/dimagi/open-chat-studio/issues/1463