### PR TITLE
unwrap lazy objects before setting in context

### DIFF
--- a/apps/conftest.py
+++ b/apps/conftest.py
@@ -50,3 +50,7 @@ def _set_env():
 def _reset_team_context():
     """Resets the team context variable after each test."""
     unset_current_team()
+    try:
+        yield
+    finally:
+        unset_current_team()

--- a/apps/teams/tests/test_utils.py
+++ b/apps/teams/tests/test_utils.py
@@ -1,3 +1,5 @@
+from django.utils.functional import SimpleLazyObject
+
 from apps.teams.models import Team
 from apps.teams.utils import current_team, get_current_team, set_current_team, unset_current_team
 
@@ -14,16 +16,87 @@ def test_using_context_manager_reverts_team():
     assert get_current_team() is None
 
 
-# def test_value_error_when_changing_teams():
-#     team1 = Team(slug="team1", name="team1")
-#     team2 = Team(slug="team2", name="team2")
-#
-#     set_current_team(team1)
-#     with pytest.raises(ValueError, match="Cannot set a different team in the current context"):
-#         set_current_team(team2)
-#
-#     with pytest.raises(ValueError, match="Cannot set a different team in the current context"):
-#         with current_team(team2):
-#             pass
-#
-#     set_current_team(team1)
+def test_value_error_when_changing_teams(caplog):
+    """This was downgraded to a log error instead of a ValueError until it has been verified in production"""
+    team1 = Team(slug="team1", name="team1")
+    team2 = Team(slug="team2", name="team2")
+
+    assert get_current_team() is None
+
+    set_current_team(team1)
+    assert "Trying to set a different team" not in caplog.text
+    set_current_team(team2)
+    assert "Trying to set a different team" in caplog.text
+    assert get_current_team() == team2  # change is still done
+
+
+def test_value_error_when_changing_teams_from_none_and_back(caplog):
+    """Test that we do not trigger the validation when either the new or existing value is None"""
+    team1 = Team(slug="team1", name="team1")
+
+    assert get_current_team() is None
+
+    set_current_team(team1)
+    assert "Trying to set a different team" not in caplog.text
+    set_current_team(None)
+    assert "Trying to set a different team" not in caplog.text
+
+
+def test_value_error_when_changing_teams_context_manager(caplog):
+    team1 = Team(slug="team1", name="team1")
+    team2 = Team(slug="team2", name="team2")
+
+    assert get_current_team() is None
+
+    set_current_team(team1)
+    assert "Trying to set a different team" not in caplog.text
+
+    with current_team(team2):
+        assert get_current_team() is team2
+    assert "Trying to set a different team" in caplog.text
+
+    # check that the team is reverted to the previous one
+    assert get_current_team() is team1
+
+
+def test_team_context_lazy_object(caplog):
+    team1 = Team(slug="team1", name="team1")
+    team2 = Team(slug="team2", name="team2")
+
+    unset_current_team()  # set to None
+    assert get_current_team() is None
+
+    # test setting with `None` lazy object
+    set_current_team(SimpleLazyObject(lambda: None))
+    assert get_current_team() is None
+    assert "Trying to set a different team" not in caplog.text
+
+    set_current_team(SimpleLazyObject(lambda: team1))
+    assert get_current_team() is team1
+    assert "Trying to set a different team" not in caplog.text
+
+    # setting it again is allowed
+    set_current_team(SimpleLazyObject(lambda: team1))
+    assert get_current_team() is team1
+    assert "Trying to set a different team" not in caplog.text
+
+    set_current_team(SimpleLazyObject(lambda: team2))
+    assert get_current_team() is team2
+    assert "Trying to set a different team" in caplog.text
+
+
+def test_team_context_lazy_object_context_manager_reentry(caplog):
+    team1 = Team(slug="team1", name="team1")
+
+    unset_current_team()  # set to None
+    assert get_current_team() is None
+
+    with current_team(SimpleLazyObject(lambda: team1)):
+        assert get_current_team() is team1
+        assert "Trying to set a different team" not in caplog.text
+
+        with current_team(SimpleLazyObject(lambda: team1)):
+            assert get_current_team() is team1
+            assert "Trying to set a different team" not in caplog.text
+
+    assert "Trying to set a different team" not in caplog.text

--- a/apps/teams/utils.py
+++ b/apps/teams/utils.py
@@ -32,9 +32,11 @@ def set_current_team(team) -> Token:
         get_current_team(team)
     ```
     """
-    if existing_team := get_current_team():
+    team = _unwrap_lazy(team)
+    existing_team = get_current_team()
+    if team is not None and existing_team is not None:
         if existing_team != team:
-            log.error("Trying to set a different team in the current context")
+            log.error("Trying to set a different team in the current context: %s != %s", team, existing_team)
 
     token = _context.set(team)
     if team:
@@ -65,3 +67,14 @@ def current_team(team):
         yield
     finally:
         unset_current_team(token)
+
+
+def _unwrap_lazy(obj):
+    """Unwraps a lazy object if it is one, otherwise returns the object itself."""
+    from django.utils.functional import LazyObject, empty
+
+    if isinstance(obj, LazyObject):
+        if obj._wrapped is empty:
+            obj._setup()
+        return obj._wrapped
+    return obj


### PR DESCRIPTION
## Description
Sentry [OPEN-CHAT-STUDIO-VA](https://dimagi.sentry.io/issues/6545279442/events/c98af42251744e0790967d377ed74728/)

1. The validation should not apply when either the existing team or the new team are None
2. Unwrap `SimpleLazyObjects` to avoid any proxy issues
