### PR TITLE
attach traces to all sentry events

### DIFF
--- a/apps/audit/auditors.py
+++ b/apps/audit/auditors.py
@@ -36,7 +36,7 @@ class AuditContextProvider(SystemUserAuditor):
             #   login_and_team_required decorator and has the 'team_slug' url path parameter
             # - If the view does not modify team data, add the view name to
             #   FIELD_AUDIT_TEAM_EXEMPT_VIEWS in settings
-            log.exception(  # use `exception` here to include the stack in the event log
+            log.error(  # use `exception` here to include the stack in the event log
                 "No team found for audit context",
                 extra={"audit_context": context, "view_name": _get_view_name(request)},
             )

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -444,6 +444,7 @@ if SENTRY_DSN:
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         send_default_pii=True,  # include user details in events
+        attach_stacktrace=True,  # include stack trace in all events
         environment=env("SENTRY_ENVIRONMENT", default="development"),
         integrations=[
             DjangoIntegration(),


### PR DESCRIPTION
## Description
This will make it easier to track down the origin `log.error` events.