### PR TITLE
ensure emojis get included in uniqueness constait and fail gracefully

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1,4 +1,5 @@
 import logging
+import unicodedata
 import uuid
 from datetime import datetime
 from typing import cast
@@ -249,6 +250,7 @@ class CreateExperiment(BaseExperimentView, CreateView):
 
     def form_valid(self, form, file_formset):
         with transaction.atomic():
+            form.instance.name = unicodedata.normalize("NFC", form.instance.name)
             self.object = form.save()
             if file_formset:
                 files = file_formset.save(self.request)


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
resolves #1475
1) bug: duplicate emojis tags will not be added
2) nice add in: all duplicate tags will fail more gracefully in the UI

Tested on string & emoji tags for both duplicates and non-duplicates

## User Impact
<!-- Describe the impact of this change on the end-users. -->
A user will not be notified when tag is a duplicate rather than being shown an "oh shucks" page

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

<img width="834" alt="Screenshot 2025-04-17 at 1 59 42 PM" src="https://github.com/user-attachments/assets/9309eea9-7248-4909-9baf-5641451c2891" />

### Docs and Changelog
<!--Link to documentation that has been updated.-->
yes to changelog
