### PR TITLE
Add custom error message of invalid parameter errors type string

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -795,11 +795,8 @@ def get_message_response(request, team_slug: str, experiment_id: uuid.UUID, sess
             message_details["message"] = {"content": response}
         if error := result.get("error"):
             if not experiment.debug_mode_enabled:
-                if isinstance(error, dict) and "message" in error:
-                    if "Invalid parameter" in error["message"]:  # TODO: temporary
-                        message_details["error_msg"] = CUSTOM_ERROR_MESSAGE
-                    else:
-                        message_details["error_msg"] = DEFAULT_ERROR_MESSAGE
+                if "Invalid parameter" in error:  # TODO: temporary
+                    message_details["error_msg"] = CUSTOM_ERROR_MESSAGE
                 else:
                     message_details["error_msg"] = DEFAULT_ERROR_MESSAGE
             else:


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
followup to https://github.com/dimagi/open-chat-studio/pull/1481

Error is type str not dict
able to test locally

## User Impact
<!-- Describe the impact of this change on the end-users. -->
More accurate error message for this type of error

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
n/a

### Docs and Changelog
<!--Link to documentation that has been updated.-->
