### PR TITLE
Fix: Trigger messages load on intersect event

### DIFF
--- a/templates/experiments/experiment_session_view.html
+++ b/templates/experiments/experiment_session_view.html
@@ -46,7 +46,7 @@
       <div role="tabpanel" class="tab-content pt-3">
         <div id="messages-container" class="min-w-full"
              hx-get="{% url 'experiments:experiment_session_messages_view' request.team.slug experiment.public_id experiment_session.external_id %}"
-             hx-trigger="revealed once"
+             hx-trigger="intersect once"
              hx-indicator="#messages-initial-loading">
           <div id="messages-initial-loading" class="flex items-center justify-center p-10">
             <span class="loading loading-spinner"></span>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Resolves #1484 

I was able to reproduce this and noticed that the `/messages` call is not being made in the cases when it seems to be stuck. It comes down to the browser not firing the `revealed` event. Why this is, I am not 100% sure. Explanations welcome.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Messages should always be loaded when the user opens up the session details view at the `messages` tab and scrolls down.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
Pending