### PR TITLE
small fixes for chatbot views

### DIFF
--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -86,11 +86,12 @@ class EditChatbot(LoginAndTeamRequiredMixin, TemplateView, PermissionRequiredMix
         data = super().get_context_data(**kwargs)
         llm_providers = LlmProvider.objects.filter(team=self.request.team).values("id", "name", "type").all()
         llm_provider_models = LlmProviderModel.objects.for_team(self.request.team).all()
+        experiment = get_object_or_404(Experiment.objects.get_all(), id=kwargs["pk"], team=self.request.team)
         return {
             **data,
-            "pipeline_id": kwargs["pk"],
+            "pipeline_id": experiment.pipeline_id,
             "node_schemas": _pipeline_node_schemas(),
-            "experiment": Experiment.objects.get(pipeline_id=kwargs.get("pk")),
+            "experiment": experiment,
             "parameter_values": _pipeline_node_parameter_values(self.request.team, llm_providers, llm_provider_models),
             "default_values": _pipeline_node_default_values(llm_providers, llm_provider_models),
             "origin": "chatbots",

--- a/templates/chatbots/chatbot_session_view.html
+++ b/templates/chatbots/chatbot_session_view.html
@@ -44,7 +44,14 @@
     <div role="tablist" class="mt-4 tabs tabs-bordered max-w-5xl">
       <input type="radio" name="experiment_tabs-{{ session.id }}" role="tab" class="tab" aria-label="Messages" checked/>
       <div role="tabpanel" class="tab-content pt-3">
-        {% include "experiments/components/experiment_chat.html" %}
+        <div id="messages-container" class="min-w-full"
+             hx-get="{% url 'experiments:experiment_session_messages_view' request.team.slug experiment.public_id experiment_session.external_id %}"
+             hx-trigger="intersect once"
+             hx-indicator="#messages-initial-loading">
+          <div id="messages-initial-loading" class="flex items-center justify-center p-10">
+            <span class="loading loading-spinner"></span>
+          </div>
+        </div>
       </div>
       {% if perms.experiments.view_participantdata %}
         <input type="radio" name="experiment_tabs-{{ session.id }}" role="tab" class="tab" aria-label="Participant Data" />

--- a/templates/chatbots/single_chatbot_home.html
+++ b/templates/chatbots/single_chatbot_home.html
@@ -70,7 +70,7 @@
             </div>
             <div class="tooltip" data-tip="Edit">
               <a class="btn btn-primary join-item btn-sm rounded-r-full"
-                 href="{% url 'chatbots:edit' team.slug experiment.pipeline.id %}">
+                 href="{% url 'chatbots:edit' team.slug experiment.id %}">
                 <i class="fa-solid fa-pencil"></i>
               </a>
             </div>
@@ -297,4 +297,3 @@
       window.addEventListener('hashchange', selectTabFromHash);
     </script>
 {% endblock %}
-


### PR DESCRIPTION
## Description
* Apply session view changes from https://github.com/dimagi/open-chat-studio/pull/1350
* Load pipeline from experiment avoid `MultipleObjectsReturned` error. This also keeps the URL for chatbots consistent instead of switching between experiment ID and pipeline ID

## User Impact
Fixes for beta feature

### Demo
NA

### Docs and Changelog
NA
