### PR TITLE
Tag messages with bot version instead of pipeline version

### DIFF
--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -297,6 +297,7 @@ class PipelineBot:
                 pipeline_version=self.experiment.pipeline.version_number,
             ),
             self.session,
+            self.experiment,
             save_input_to_history=save_input_to_history,
             disable_reminder_tools=self.disable_reminder_tools,
         )

--- a/apps/events/actions.py
+++ b/apps/events/actions.py
@@ -133,7 +133,6 @@ class PipelineStartAction(EventActionHandlerBase):
             messages = [session.chat.messages.last().to_langchain_message()]
 
         input = "\n".join(f"{message.type}: {message.content}" for message in messages)
-        output = pipeline.invoke(
-            PipelineState(messages=[input], experiment_session=session), session, save_run_to_history=False
-        )
+        state = PipelineState(messages=[input], experiment_session=session)
+        output = pipeline.invoke(state, session, session.experiment_version, save_run_to_history=False)
         return output.content

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -18,7 +18,7 @@ from apps.annotations.models import TagCategories
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.custom_actions.form_utils import set_custom_actions
 from apps.custom_actions.mixins import CustomActionOperationMixin
-from apps.experiments.models import ExperimentSession
+from apps.experiments.models import Experiment, ExperimentSession
 from apps.experiments.versioning import VersionDetails, VersionField, VersionsMixin, VersionsObjectManagerMixin
 from apps.pipelines.exceptions import PipelineBuildError
 from apps.pipelines.executor import patch_executor
@@ -299,10 +299,11 @@ class Pipeline(BaseTeamModel, VersionsMixin):
         self,
         input: PipelineState,
         session: ExperimentSession,
+        experiment: Experiment,
         save_run_to_history=True,
         save_input_to_history=True,
         disable_reminder_tools=False,
-    ) -> dict:
+    ) -> ChatMessage:
         from apps.experiments.models import AgentTools
         from apps.pipelines.graph import PipelineGraph
 
@@ -352,6 +353,9 @@ class Pipeline(BaseTeamModel, VersionsMixin):
                     metadata=output_metadata,
                     tags=output.get("output_message_tags"),
                 )
+                ai_message.add_version_tag(
+                    version_number=experiment.version_number, is_a_version=experiment.is_a_version
+                )
                 pipeline_output = ai_message
             else:
                 pipeline_output = ChatMessage(content=output)
@@ -385,11 +389,9 @@ class Pipeline(BaseTeamModel, VersionsMixin):
             chat=session.chat, message_type=type_.value, content=message, metadata=metadata
         )
 
-        if type_ == ChatMessageType.AI:
-            chat_message.add_version_tag(version_number=self.version_number, is_a_version=self.is_a_version)
-            if tags:
-                for tag in tags:
-                    chat_message.add_system_tag(tag, TagCategories.BOT_RESPONSE)
+        if tags:
+            for tag in tags:
+                chat_message.add_system_tag(tag, TagCategories.BOT_RESPONSE)
         return chat_message
 
     @transaction.atomic()

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -357,7 +357,7 @@ class Pipeline(BaseTeamModel, VersionsMixin):
                 )
                 return ai_message
             else:
-                return ChatMessage(content=output["messages"][-1])
+                return ChatMessage(content=output)
         finally:
             if trace_service:
                 trace_service.end()

--- a/apps/pipelines/tests/test_pipeline_history.py
+++ b/apps/pipelines/tests/test_pipeline_history.py
@@ -215,17 +215,20 @@ def test_global_history(get_llm_service, provider, pipeline, experiment_session)
     output_1 = experiment.pipeline.invoke(
         PipelineState(messages=[user_input], experiment_session=experiment_session, pipeline_version=1),
         experiment_session,
+        experiment,
     )
     user_input_2 = "Saying more stuff"
     output_2 = experiment.pipeline.invoke(
         PipelineState(messages=[user_input_2], experiment_session=experiment_session, pipeline_version=1),
         experiment_session,
+        experiment,
     )
 
     user_input_3 = "Tell me something interesting"
     experiment.pipeline.invoke(
         PipelineState(messages=[user_input_3], experiment_session=experiment_session, pipeline_version=1),
         experiment_session,
+        experiment,
     )
 
     expected_call_messages = [

--- a/apps/pipelines/tests/test_pipeline_runs.py
+++ b/apps/pipelines/tests/test_pipeline_runs.py
@@ -34,7 +34,7 @@ def test_running_pipeline_creates_run(pipeline: Pipeline, session: ExperimentSes
         Attachment(file_id=123, type="code_interpreter", name="test.py", size=10),
     ]
     serialized_attachments = [att.model_dump() for att in attachments]
-    pipeline.invoke(PipelineState(messages=[input], attachments=serialized_attachments), session)
+    pipeline.invoke(PipelineState(messages=[input], attachments=serialized_attachments), session, session.experiment)
     assert pipeline.runs.count() == 1
     run = pipeline.runs.first()
     assert run.status == PipelineRunStatus.SUCCESS
@@ -136,7 +136,7 @@ def test_running_failed_pipeline_logs_error(pipeline: Pipeline, session: Experim
 
     with patch.object(nodes, StartNode.__name__, FailingNode):
         with pytest.raises(Exception, match=error_message):
-            pipeline.invoke(PipelineState(messages=[input]), session)
+            pipeline.invoke(PipelineState(messages=[input]), session, session.experiment)
 
     assert pipeline.runs.count() == 1
     run = pipeline.runs.first()
@@ -162,7 +162,7 @@ def test_running_failed_pipeline_logs_error(pipeline: Pipeline, session: Experim
 @django_db_transactional()
 def test_running_pipeline_stores_session(pipeline: Pipeline, session: ExperimentSession):
     input = "foo"
-    pipeline.invoke(PipelineState(messages=[input]), session)
+    pipeline.invoke(PipelineState(messages=[input]), session, session.experiment)
     assert pipeline.runs.count() == 1
     assert pipeline.runs.first().session_id == session.id
 
@@ -171,7 +171,9 @@ def test_running_pipeline_stores_session(pipeline: Pipeline, session: Experiment
 @pytest.mark.parametrize("save_input_to_history", [True, False])
 def test_save_input_to_history(save_input_to_history, pipeline: Pipeline, session: ExperimentSession):
     input = "Hi"
-    pipeline.invoke(PipelineState(messages=[input]), session, save_input_to_history=save_input_to_history)
+    pipeline.invoke(
+        PipelineState(messages=[input]), session, session.experiment, save_input_to_history=save_input_to_history
+    )
     assert (
         session.chat.messages.filter(content="Hi", message_type=ChatMessageType.HUMAN).exists() == save_input_to_history
     )
@@ -181,7 +183,7 @@ def test_save_input_to_history(save_input_to_history, pipeline: Pipeline, sessio
 def test_save_trace_metadata(pipeline: Pipeline, session: ExperimentSession):
     provider = TraceProvider(type="langfuse", config={})
     session.experiment.trace_provider = provider
-    pipeline.invoke(PipelineState(messages=["Hi"]), session)
+    pipeline.invoke(PipelineState(messages=["Hi"]), session, session.experiment)
     human_message = session.chat.messages.filter(message_type=ChatMessageType.HUMAN).first()
     assert "trace_info" in human_message.metadata
     ai_message = session.chat.messages.filter(message_type=ChatMessageType.AI).first()
@@ -194,7 +196,7 @@ def test_save_metadata_and_tagging(pipeline: Pipeline, session: ExperimentSessio
     pipeline_state = PipelineState(messages=["Hi"], output_message_tags=output_message_tags)
 
     with mock.patch.object(ChatMessage, "add_system_tag") as mock_add_system_tag:
-        pipeline.invoke(pipeline_state, session)
+        pipeline.invoke(pipeline_state, session, session.experiment)
         for tag in output_message_tags:
             mock_add_system_tag.assert_any_call(tag, TagCategories.BOT_RESPONSE)
 


### PR DESCRIPTION
## Description
Resolves #1454

This fixes the 'version' tag for messages which was previously using the pipeline version instead of the bot version.

## User Impact
Tag shows correct version. There may be some intermediate confusion during the switchover so comms are necessary.

### Demo
NA

### Docs and Changelog
TODO
