### PR TITLE
Copy array to prevent changing a potentially immutable object

### DIFF
--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -216,7 +216,9 @@ function MultiSelectWidget(props: WidgetParams) {
   if (options.length == 0) {
     return <></>
   }
-  let selectedValues = Array.isArray(props.paramValue) ? props.paramValue : [];
+  // props.paramValue is made immutable when produce is used to update the node, so we have to copy props.paramValue
+  // in order to push to it
+  let selectedValues = Array.isArray(props.paramValue) ? [...props.paramValue] : [];
 
   const setNode = usePipelineStore((state) => state.setNode);
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Resolves #1495

The `selectedValues` array becomes immutable after being updated by `immer` (without reloading the page). Since the `immer` library is producing a new, immutable object on update, I think this is causes the `selectedValues` array to ultimately become immutable as well.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users can toggle tools again

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

I did manual testing

### Docs and Changelog
<!--Link to documentation that has been updated.-->
Pending...