### PR TITLE
Smh/filter session start

### DIFF
--- a/apps/experiments/filters.py
+++ b/apps/experiments/filters.py
@@ -71,7 +71,9 @@ def build_filter_condition(column, operator, value):
     if column == "participant":
         return build_participant_filter(operator, value)
     elif column == "last_message":
-        return build_timestamp_filter(operator, value)
+        return build_timestamp_filter(operator, value, "last_message_created_at")
+    elif column == "first_message":
+        return build_timestamp_filter(operator, value, "first_message_created_at")
     elif column == "tags":
         return build_tags_filter(operator, value)
     elif column == "versions":
@@ -94,16 +96,16 @@ def build_participant_filter(operator, value):
     return None
 
 
-def build_timestamp_filter(operator, value):
+def build_timestamp_filter(operator, value, field=None):
     """Build filter condition for timestamp"""
     try:
         date_value = datetime.strptime(value, "%Y-%m-%d").date()
         if operator == Operators.ON:
-            return Q(last_message_created_at__date=date_value)
+            return Q(**{f"{field}__date": date_value})
         elif operator == Operators.BEFORE:
-            return Q(last_message_created_at__date__lt=date_value)
+            return Q(**{f"{field}__date__lt": date_value})
         elif operator == Operators.AFTER:
-            return Q(last_message_created_at__date__gt=date_value)
+            return Q(**{f"{field}__date__gt": date_value})
     except (ValueError, TypeError):
         pass
     return None

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -126,6 +126,7 @@ class ExperimentSessionsTableView(LoginAndTeamRequiredMixin, SingleTableView, Pe
     def get_queryset(self):
         query_set = (
             ExperimentSession.objects.with_last_message_created_at()
+            .with_first_message_created_at()
             .filter(team=self.request.team, experiment__id=self.kwargs["experiment_id"])
             .select_related("participant__user")
         )

--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -124,6 +124,7 @@
         loading: false,
         columns: {
           'participant': {type: 'string', operators: fieldTypeFilters.string, label: 'Participant'},
+          'first_message': {type: 'timestamp', operators: fieldTypeFilters.timestamp, label: 'First Message'},
           'last_message': {type: 'timestamp', operators: fieldTypeFilters.timestamp, label: 'Last Message'},
           'tags': {type: 'choice', operators: fieldTypeFilters.choice, options: tags, label: 'Tags' },
           'versions': {type: 'choice', operators: fieldTypeFilters.choice, options: versionsList, label: 'Versions'}


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
resolves [#1503](https://github.com/dimagi/open-chat-studio/issues/1503)

Note: I chose to add "First Message"out of alphabetical order of the drop down to keep it next to the "Last Message"

## User Impact
<!-- Describe the impact of this change on the end-users. -->
users can now filter by the start of the experiment session

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
[loom](https://www.loom.com/share/74e6415ae8324951a3f63424a277cb5e?sid=1bda78bf-8de7-4f99-a05c-4437d4ebd528)

### Docs and Changelog
<!--Link to documentation that has been updated.-->
no docs, yes changelog
