### PR TITLE
add version number to end of pipeline chip for version modal

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -136,7 +136,7 @@ class VersionFieldDisplayFormatters:
     def format_pipeline(pipeline) -> str:
         if not pipeline:
             return ""
-        name = pipeline.name.split(f" v{pipeline.version_number}")[0]
+        name = str(pipeline)
         template = get_template("generic/chip.html")
         url = (
             pipeline.get_absolute_url() if pipeline.is_working_version else pipeline.working_version.get_absolute_url()


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
resolves [#1440](https://github.com/dimagi/open-chat-studio/issues/1440)

## User Impact
<!-- Describe the impact of this change on the end-users. -->
user can see version number of pipeline in version modal of chatbot

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
<img width="836" alt="image" src="https://github.com/user-attachments/assets/b7479010-3be9-425f-bb7e-9518c4634c6f" />


### Docs and Changelog
<!--Link to documentation that has been updated.-->
no
