### PR TITLE
Upgrade httpx

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -3,7 +3,7 @@
 anyio==4.4.0
     # via
     #   -c requirements.txt
-    #   httpcore
+    #   httpx
     #   watchfiles
 build==1.2.2.post1
     # via pip-tools
@@ -34,15 +34,15 @@ filelock==3.13.1
     #   virtualenv
 freezegun==1.5.1
     # via -r dev-requirements.in
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c requirements.txt
     #   httpcore
-httpcore==0.17.3
+httpcore==1.0.9
     # via
     #   -c requirements.txt
     #   httpx
-httpx==0.24.1
+httpx==0.27.2
     # via
     #   -c requirements.txt
     #   pytest-httpx
@@ -80,7 +80,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==7.4.4
+pytest==8.3.5
     # via
     #   -r dev-requirements.in
     #   pytest-cov
@@ -91,7 +91,7 @@ pytest-cov==6.0.0
     # via -r dev-requirements.in
 pytest-django==4.10.0
     # via -r dev-requirements.in
-pytest-httpx==0.24.0
+pytest-httpx==0.34.0
     # via -r dev-requirements.in
 pytest-xdist==3.6.1
     # via -r dev-requirements.in
@@ -114,7 +114,6 @@ sniffio==1.3.0
     # via
     #   -c requirements.txt
     #   anyio
-    #   httpcore
     #   httpx
 termcolor==2.5.0
     # via -r dev-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -23,7 +23,7 @@ anthropic==0.37.1
 anyio==4.4.0
     # via
     #   anthropic
-    #   httpcore
+    #   httpx
     #   langfuse
     #   openai
 asgiref==3.8.1
@@ -221,15 +221,15 @@ grpcio==1.70.0
     #   grpcio-status
 grpcio-status==1.70.0
     # via google-api-core
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==0.17.3
+httpcore==1.0.9
     # via httpx
 httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-httpx==0.24.1
+httpx==0.27.2
     # via
     #   -r requirements.in
     #   anthropic
@@ -515,7 +515,6 @@ sniffio==1.3.0
     # via
     #   anthropic
     #   anyio
-    #   httpcore
     #   httpx
     #   openai
 sqlalchemy==2.0.23


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
See https://github.com/dimagi/open-chat-studio/security/dependabot/74. Since h11 is a dependency of httpx, we should upgrade httpx instead. We need h11>=0.16.0

## User Impact
<!-- Describe the impact of this change on the end-users. -->
N/A

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
N/A