### PR TITLE
show survey and voice tabs for pipeline bots

### DIFF
--- a/templates/experiments/experiment_form.html
+++ b/templates/experiments/experiment_form.html
@@ -56,13 +56,16 @@
       <div role="tabpanel" class="tab-content">
         {% render_form_fields form "conversational_consent_enabled" %}
       </div>
-      <input type="radio" name="main_tabs" role="tab" class="tab" aria-label="Surveys" x-show="type !== 'pipeline'">
+      <input type="radio" name="main_tabs" role="tab" class="tab" aria-label="Surveys">
       <div role="tabpanel" class="tab-content">
         {% render_form_fields form "pre_survey" "post_survey" %}
       </div>
-      <input type="radio" name="main_tabs" role="tab" class="tab" aria-label="Voice" x-show="type !== 'pipeline'">
+      <input type="radio" name="main_tabs" role="tab" class="tab" aria-label="Voice">
       <div role="tabpanel" class="tab-content">
-        {% render_form_fields form "voice_provider" "synthetic_voice" "voice_response_behaviour" "echo_transcript" "use_processor_bot_voice" %}
+        {% render_form_fields form "voice_provider" "synthetic_voice" "voice_response_behaviour" "echo_transcript" %}
+        <div x-show="type !== 'pipeline'">
+          {% render_form_fields form "use_processor_bot_voice" %}
+        </div>
       </div>
       <input type="radio" name="main_tabs" role="tab" class="tab" aria-label="Source Material" x-show="type === 'llm'" {% if experiment_type != "llm" %}x-cloak{% endif %}>
       <div role="tabpanel" class="tab-content">


### PR DESCRIPTION
## Description
Show the survey and voice fields for pipeline based experiments. These configuration options will still work with pipelines since they impact functionality in the base channel.

## User Impact
Users can configure surveys and voice behaviour for pipeline bots.


### Docs and Changelog
https://github.com/dimagi/open-chat-studio-docs/pull/94
