### PR TITLE
Remove "all of" operator from version filter in filter widget

### DIFF
--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -128,7 +128,7 @@
           'first_message': {type: 'timestamp', operators: fieldTypeFilters.timestamp, label: 'First Message'},
           'last_message': {type: 'timestamp', operators: fieldTypeFilters.timestamp, label: 'Last Message'},
           'tags': {type: 'choice', operators: fieldTypeFilters.choice, options: tags, label: 'Tags' },
-          'versions': {type: 'choice', operators: fieldTypeFilters.choice, options: versionsList, label: 'Versions'},
+          'versions': {type: 'choice', operators: fieldTypeFilters.choice.filter(op => op === 'any of' || op === 'excludes'), options: versionsList, label: 'Versions'},
           'channels': {type: 'choice', operators: fieldTypeFilters.choice, options: channelsList, label: 'Channels'}
         }
       },


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

I went with changing in the html rather than creating a new `FIELD_TYPE_FILTERS` since to me if felt more intuitive to think of it as a choice field type tht's beinf restricted rather than creating a entirely separate type. 

<img width="647" alt="image" src="https://github.com/user-attachments/assets/e500b3f7-dcce-416f-8fb9-912c47c3f3a2" />


## User Impact
<!-- Describe the impact of this change on the end-users. -->
Restrict operator options for versions filters

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
n/a

### Docs and Changelog
<!--Link to documentation that has been updated.-->
changelog
