### PR TITLE
Add afterSettle for tables that load async

### DIFF
--- a/assets/javascript/tables.js
+++ b/assets/javascript/tables.js
@@ -1,6 +1,13 @@
+const rowHandlers = new WeakMap();
+
 function initializeRowClickHandlers() {
     document.querySelectorAll('tr[data-redirect-url]:not([data-redirect-url=""])').forEach(function (element) {
-      element.addEventListener('click', function (event) {
+      if (rowHandlers.has(element)) {
+        const oldHandler = rowHandlers.get(element);
+        element.removeEventListener('click', oldHandler);
+      }
+
+      const handler = function (event) {
         if (event.target.tagName === 'TR' || event.target.tagName === 'TD') {
           let editUrl = this.getAttribute('data-redirect-url');
           try {
@@ -14,7 +21,9 @@ function initializeRowClickHandlers() {
             console.error('Invalid URL:', editUrl);
           }
         }
-      });
+      };
+      rowHandlers.set(element, handler);
+      element.addEventListener('click', handler);
     });
   }
 

--- a/assets/javascript/tables.js
+++ b/assets/javascript/tables.js
@@ -23,3 +23,7 @@ function initializeRowClickHandlers() {
   } else {
     initializeRowClickHandlers();
   }
+
+  document.addEventListener('htmx:afterSettle', function() {
+    initializeRowClickHandlers();
+  });


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
followup to https://github.com/dimagi/open-chat-studio/pull/1561

confirmed it worked locally - experiments, chatbots, participants, etc

## User Impact
<!-- Describe the impact of this change on the end-users. -->
allows users to selects links for tables that load async

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
n/a
### Docs and Changelog
<!--Link to documentation that has been updated.-->
n/a
