### PR TITLE
Sk/event bugs

### DIFF
--- a/apps/events/actions.py
+++ b/apps/events/actions.py
@@ -109,6 +109,7 @@ class SendMessageToBotAction(EventActionHandlerBase):
         last_message = session.chat.messages.last()
         if last_message:
             return last_message.content
+        return ""
 
 
 class PipelineStartAction(EventActionHandlerBase):

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -6,7 +6,6 @@ import pytz
 from dateutil.relativedelta import relativedelta
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
 from django.db.models import F, Func, OuterRef, Q, Subquery, functions
 from django.utils import timezone
@@ -497,14 +496,14 @@ class ScheduledMessage(BaseTeamModel):
             trigger = self.action.static_trigger
             trigger = StaticTrigger.objects.get_published_version(trigger)
             return trigger.action
-        except ObjectDoesNotExist:
+        except StaticTrigger.DoesNotExist:
             pass
 
         try:
             trigger = self.action.timeout_trigger
             trigger = TimeoutTrigger.objects.get_published_version(trigger)
             return trigger.action
-        except ObjectDoesNotExist:
+        except TimeoutTrigger.DoesNotExist:
             pass
 
         return self.action

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -6,6 +6,7 @@ import pytz
 from dateutil.relativedelta import relativedelta
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
 from django.db.models import F, Func, OuterRef, Q, Subquery, functions
 from django.utils import timezone
@@ -496,14 +497,14 @@ class ScheduledMessage(BaseTeamModel):
             trigger = self.action.static_trigger
             trigger = StaticTrigger.objects.get_published_version(trigger)
             return trigger.action
-        except StaticTrigger.DoesNotExist:
+        except ObjectDoesNotExist:
             pass
 
         try:
             trigger = self.action.timeout_trigger
             trigger = TimeoutTrigger.objects.get_published_version(trigger)
             return trigger.action
-        except TimeoutTrigger.DoesNotExist:
+        except ObjectDoesNotExist:
             pass
 
         return self.action

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -243,7 +243,7 @@ class TimeoutTrigger(BaseModel, VersionsMixin):
 
         sessions = (
             ExperimentSession.objects.filter(
-                experiment=self.experiment,
+                experiment=self.experiment.get_working_version(),
                 ended_at=None,
             )
             .exclude(status__in=STATUSES_FOR_COMPLETE_CHATS)

--- a/apps/events/tasks.py
+++ b/apps/events/tasks.py
@@ -34,7 +34,7 @@ def fire_static_trigger(trigger_id, session_id):
 
 @shared_task(ignore_result=True)
 def enqueue_timed_out_events():
-    active_triggers = TimeoutTrigger.objects.all()
+    active_triggers = TimeoutTrigger.objects.filter(experiment__is_default_version=True).all()
     for trigger in active_triggers:
         for session in trigger.timed_out_sessions():
             if session.is_stale():

--- a/apps/events/tasks.py
+++ b/apps/events/tasks.py
@@ -10,13 +10,17 @@ logger = logging.getLogger("ocs.events")
 
 @shared_task(ignore_result=True)
 def enqueue_static_triggers(session_id, trigger_type):
-    session = ExperimentSession.objects.get(id=session_id)
+    trigger_ids = _get_static_triggers_to_fire(session_id, trigger_type)
+    for trigger_id in trigger_ids:
+        fire_static_trigger.delay(trigger_id, session_id)
 
+
+def _get_static_triggers_to_fire(session_id, trigger_type):
+    session = ExperimentSession.objects.get(id=session_id)
     trigger_ids = StaticTrigger.objects.filter(experiment_id=session.experiment_id, type=trigger_type).values_list(
         "id", flat=True
     )
-    for trigger_id in trigger_ids:
-        fire_static_trigger.delay(trigger_id, session_id)
+    return trigger_ids
 
 
 @shared_task(ignore_result=True)

--- a/apps/events/tasks.py
+++ b/apps/events/tasks.py
@@ -17,7 +17,8 @@ def enqueue_static_triggers(session_id, trigger_type):
 
 def _get_static_triggers_to_fire(session_id, trigger_type):
     session = ExperimentSession.objects.get(id=session_id)
-    trigger_ids = StaticTrigger.objects.filter(experiment_id=session.experiment_id, type=trigger_type).values_list(
+    experiment_version = session.experiment_version
+    trigger_ids = StaticTrigger.objects.filter(experiment=experiment_version, type=trigger_type).values_list(
         "id", flat=True
     )
     return trigger_ids

--- a/apps/events/tasks.py
+++ b/apps/events/tasks.py
@@ -34,7 +34,7 @@ def fire_static_trigger(trigger_id, session_id):
 
 @shared_task(ignore_result=True)
 def enqueue_timed_out_events():
-    active_triggers = TimeoutTrigger.objects.filter(experiment__is_default_version=True).all()
+    active_triggers = TimeoutTrigger.objects.published_versions().all()
     for trigger in active_triggers:
         for session in trigger.timed_out_sessions():
             if session.is_stale():

--- a/apps/events/tests/test_enqueue_static_triggers.py
+++ b/apps/events/tests/test_enqueue_static_triggers.py
@@ -1,0 +1,113 @@
+from unittest import mock
+
+import pytest
+from django.test import override_settings
+
+from apps.events.models import EventAction, EventActionType, StaticTrigger, StaticTriggerType
+from apps.events.tasks import _get_static_triggers_to_fire, enqueue_static_triggers
+from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
+
+
+@pytest.fixture()
+def experiment_session():
+    """Create an experiment session for testing."""
+    return ExperimentSessionFactory()
+
+
+@pytest.mark.django_db()
+def test_get_static_triggers_to_fire_with_valid_data(experiment_session):
+    """Test _get_static_triggers_to_fire with valid session_id and trigger_type."""
+    # Create some static triggers for the experiment
+    trigger1 = StaticTrigger.objects.create(
+        experiment=experiment_session.experiment,
+        action=EventAction.objects.create(action_type=EventActionType.LOG),
+        type=StaticTriggerType.CONVERSATION_START,
+    )
+    trigger2 = StaticTrigger.objects.create(
+        experiment=experiment_session.experiment,
+        action=EventAction.objects.create(action_type=EventActionType.LOG),
+        type=StaticTriggerType.CONVERSATION_START,
+    )
+    # Create a trigger with a different type
+    StaticTrigger.objects.create(
+        experiment=experiment_session.experiment,
+        action=EventAction.objects.create(action_type=EventActionType.LOG),
+        type=StaticTriggerType.CONVERSATION_END,
+    )
+
+    # Get triggers for CONVERSATION_START
+    trigger_ids = _get_static_triggers_to_fire(experiment_session.id, StaticTriggerType.CONVERSATION_START)
+
+    # Should return the IDs of the two CONVERSATION_START triggers
+    assert len(trigger_ids) == 2
+    assert set(trigger_ids) == {trigger1.id, trigger2.id}
+
+
+@pytest.mark.django_db()
+def test_get_static_triggers_to_fire_with_different_experiment(experiment_session):
+    """Test _get_static_triggers_to_fire with triggers from a different experiment."""
+    # Create a trigger for the experiment
+    trigger1 = StaticTrigger.objects.create(
+        experiment=experiment_session.experiment,
+        action=EventAction.objects.create(action_type=EventActionType.LOG),
+        type=StaticTriggerType.CONVERSATION_START,
+    )
+
+    # Create another experiment and a trigger for it
+    other_experiment = ExperimentFactory(team=experiment_session.team)
+    StaticTrigger.objects.create(
+        experiment=other_experiment,
+        action=EventAction.objects.create(action_type=EventActionType.LOG),
+        type=StaticTriggerType.CONVERSATION_START,
+    )
+
+    # Get triggers for CONVERSATION_START
+    trigger_ids = _get_static_triggers_to_fire(experiment_session.id, StaticTriggerType.CONVERSATION_START)
+
+    # Should only return the trigger from the session's experiment
+    assert len(trigger_ids) == 1
+    assert trigger_ids[0] == trigger1.id
+
+
+@pytest.mark.django_db()
+def test_get_static_triggers_to_fire_with_no_matching_triggers(experiment_session):
+    """Test _get_static_triggers_to_fire when no triggers match the criteria."""
+    # Create a trigger with a different type
+    StaticTrigger.objects.create(
+        experiment=experiment_session.experiment,
+        action=EventAction.objects.create(action_type=EventActionType.LOG),
+        type=StaticTriggerType.CONVERSATION_END,
+    )
+
+    # Get triggers for CONVERSATION_START (which doesn't exist)
+    trigger_ids = _get_static_triggers_to_fire(experiment_session.id, StaticTriggerType.CONVERSATION_START)
+
+    # Should return an empty list
+    assert len(trigger_ids) == 0
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+@pytest.mark.django_db()
+def test_enqueue_static_triggers_calls_fire_for_each_trigger(experiment_session):
+    """Test that enqueue_static_triggers calls fire_static_trigger for each trigger."""
+    # Create some static triggers
+    trigger1 = StaticTrigger.objects.create(
+        experiment=experiment_session.experiment,
+        action=EventAction.objects.create(action_type=EventActionType.LOG),
+        type=StaticTriggerType.CONVERSATION_START,
+    )
+    trigger2 = StaticTrigger.objects.create(
+        experiment=experiment_session.experiment,
+        action=EventAction.objects.create(action_type=EventActionType.LOG),
+        type=StaticTriggerType.CONVERSATION_START,
+    )
+
+    # Mock the fire_static_trigger.delay method
+    with mock.patch("apps.events.tasks.fire_static_trigger.delay") as mock_fire:
+        # Call enqueue_static_triggers
+        enqueue_static_triggers(experiment_session.id, StaticTriggerType.CONVERSATION_START)
+
+        # Check that fire_static_trigger.delay was called for each trigger
+        assert mock_fire.call_count == 2
+        mock_fire.assert_any_call(trigger1.id, experiment_session.id)
+        mock_fire.assert_any_call(trigger2.id, experiment_session.id)

--- a/apps/events/tests/test_scheduled_messages.py
+++ b/apps/events/tests/test_scheduled_messages.py
@@ -7,7 +7,7 @@ from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from freezegun import freeze_time
 
-from apps.events.models import EventActionType, ScheduledMessage, TimePeriod
+from apps.events.models import EventActionType, ScheduledMessage, StaticTrigger, StaticTriggerType, TimePeriod
 from apps.events.tasks import poll_scheduled_messages
 from apps.experiments.models import ExperimentRoute
 from apps.utils.factories.events import EventActionFactory, ScheduledMessageFactory
@@ -21,7 +21,7 @@ def _construct_event_action(time_period: TimePeriod, experiment_id: int, frequen
         "time_period": time_period,
         "frequency": frequency,
         "repetitions": repetitions,
-        "prompt_text": "",
+        "prompt_text": "hi",
         "experiment_id": experiment_id,
     }
     return EventActionFactory(params=params, action_type=EventActionType.SCHEDULETRIGGER), params
@@ -355,3 +355,40 @@ def test_schedule_trigger_for_versioned_routes():
     # Clear the `params` cached property on ScheduledMessage
     del sm.params
     assert sm._get_experiment_to_generate_response() == router.default_version
+
+
+@pytest.mark.django_db()
+def test_action_params_with_versioning():
+    """Test that the message params get updated when new versions of the experiment are created."""
+    session = ExperimentSessionFactory()
+    event_action, params = _construct_event_action(
+        frequency=1, time_period=TimePeriod.DAYS, repetitions=2, experiment_id=session.experiment.id
+    )
+    trigger = StaticTrigger.objects.create(
+        experiment=session.experiment,
+        action=event_action,
+        type=StaticTriggerType.CONVERSATION_START,
+    )
+    trigger.fire(session)
+
+    messages = ScheduledMessage.objects.filter(experiment=session.experiment).all()
+    assert len(messages) == 1
+
+    # no versioning yet, so the message should reference the working version
+    assert messages[0].params["prompt_text"] == params["prompt_text"]
+
+    event_action.params["prompt_text"] = "hello"
+    event_action.save()
+
+    experiment_version = session.experiment.create_new_version(make_default=False)
+
+    # still references working version since there is no default version
+    message = ScheduledMessage.objects.get(id=messages[0].id)
+    assert message.params["prompt_text"] == params["prompt_text"]
+
+    experiment_version.is_default_version = True
+    experiment_version.save()
+
+    # now it should reference the published version
+    message = ScheduledMessage.objects.get(id=message.id)
+    assert message.params["prompt_text"] == "hello"

--- a/apps/events/tests/test_scheduled_messages.py
+++ b/apps/events/tests/test_scheduled_messages.py
@@ -347,15 +347,6 @@ def test_schedule_trigger_for_versioned_routes():
     # should be used
     assert sm._get_experiment_to_generate_response() == child_version
 
-    new_params = sm.action.params
-    new_params["experiment_id"] = None
-    sm.action.params = new_params
-    sm.action.save()
-    sm.refresh_from_db()
-    # Clear the `params` cached property on ScheduledMessage
-    del sm.params
-    assert sm._get_experiment_to_generate_response() == router.default_version
-
 
 @pytest.mark.django_db()
 def test_action_params_with_versioning():

--- a/apps/events/tests/test_timeout_trigger.py
+++ b/apps/events/tests/test_timeout_trigger.py
@@ -191,13 +191,13 @@ def test_failure_count_reached(session):
         frozen_time.tick(delta=timedelta(minutes=11))
         assert len(timeout_trigger.timed_out_sessions()) == 1
 
-        assert timeout_trigger._has_triggers_left(session, message) is True
+        assert timeout_trigger._has_triggers_left(timeout_trigger, session, message) is True
         for _ in range(TOTAL_FAILURES):
             timeout_trigger.event_logs.create(
                 session=session, chat_message=message, status=EventLogStatusChoices.FAILURE
             )
 
-        assert timeout_trigger._has_triggers_left(session, message) is False
+        assert timeout_trigger._has_triggers_left(timeout_trigger, session, message) is False
         assert len(timeout_trigger.timed_out_sessions()) == 0
 
         # The timeout passes after the next message is sent

--- a/apps/events/tests/test_timeout_trigger.py
+++ b/apps/events/tests/test_timeout_trigger.py
@@ -111,11 +111,14 @@ def test_timed_out_sessions_fired(mock_fire_trigger, session):
         session.chat = chat
         session.save()
 
+        experiment_version = session.experiment.create_new_version(make_default=True)
+        trigger_version = experiment_version.timeout_triggers.first()
+
         frozen_time.tick(delta=timedelta(minutes=15))
         timed_out_sessions = timeout_trigger.timed_out_sessions()
         assert len(timed_out_sessions) == 1
         enqueue_timed_out_events()
-        mock_fire_trigger.assert_called_with(timeout_trigger.id, session.id)
+        mock_fire_trigger.assert_called_with(trigger_version.id, session.id)
 
 
 @pytest.mark.django_db()

--- a/apps/experiments/versioning.py
+++ b/apps/experiments/versioning.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from dataclasses import field as data_field
 from difflib import Differ
-from typing import TYPE_CHECKING, Any, Self
+from typing import Any, Self
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db import transaction
@@ -18,9 +18,6 @@ from django.db.models import (
 from django.db.models.functions import Cast, Concat
 
 from apps.utils.models import VersioningMixin
-
-if TYPE_CHECKING:
-    pass
 
 
 def differs(original: Any, new: Any, exclude_model_fields: list[str] | None = None, early_abort=False) -> bool:

--- a/apps/experiments/versioning.py
+++ b/apps/experiments/versioning.py
@@ -20,7 +20,7 @@ from django.db.models.functions import Cast, Concat
 from apps.utils.models import VersioningMixin
 
 if TYPE_CHECKING:
-    from apps.experiments.models import Experiment
+    pass
 
 
 def differs(original: Any, new: Any, exclude_model_fields: list[str] | None = None, early_abort=False) -> bool:
@@ -344,7 +344,7 @@ class VersionsMixin:
     def latest_version(self):
         return self.versions.order_by("-created_at").first()
 
-    def get_working_version(self) -> "Experiment":
+    def get_working_version(self) -> Self:
         """Returns the working version of this experiment family"""
         if self.is_working_version:
             return self


### PR DESCRIPTION
## Description
Resolves [OCSBUGS-9](https://dimagi.atlassian.net/browse/OCSBUGS-9) and [OCSBUGS-11](https://dimagi.atlassian.net/browse/OCSBUGS-11)

* When firing triggers, filter static and timeout triggers to only those linked to published chatbot versions
* When firing scheduled messages, load the action params from the published version of the trigger

One issue with these changes is that it makes it impossible to test events without publishing them first. I'm not going to try and address this in the current PR.

## User Impact
* Only triggers from published chatbots will get executed
* Scheduled messages will use params from the published version instead of the version they were created from
* Events can only be tested with published chatbots

### Docs and Changelog
https://github.com/dimagi/open-chat-studio-docs/pull/100


[OCSBUGS-9]: https://dimagi.atlassian.net/browse/OCSBUGS-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCSBUGS-11]: https://dimagi.atlassian.net/browse/OCSBUGS-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ