### PR TITLE
allow cloning all bots except ones with child routes

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -818,7 +818,7 @@ class Experiment(BaseTeamModel, VersionsMixin, CustomActionOperationMixin):
         if not is_copy:
             self.version_number = version_number + 1
             self.save(update_fields=["version_number"])
-        elif self.child_links.exists() or self.assistant:
+        elif self.child_links.exists():
             raise ValueError("Failed to create copy of chatbot")
 
         # Fetch a new instance so the previous instance reference isn't simply being updated. I am not 100% sure

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -499,6 +499,7 @@ def base_single_experiment_view(request, team_slug, experiment_id, template_name
         "deployed_version": deployed_version,
         "field_type_filters": FIELD_TYPE_FILTERS,
         "channel_list": channel_list,
+        "allow_copy": not experiment.child_links.exists(),
         **_get_events_context(experiment, team_slug, request.origin),
     }
     if active_tab != "chatbots":

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -70,12 +70,12 @@
             </div>
             <div class="tooltip" data-tip="Edit">
               <a class="btn btn-primary join-item btn-sm
-                        {% if not experiment.pipeline %}rounded-r-full{% endif %}"
+                        {% if not allow_copy %}rounded-r-full{% endif %}"
                  href="{% url 'experiments:edit' team.slug experiment.id %}">
                 <i class="fa-solid fa-pencil"></i>
               </a>
             </div>
-            {% if experiment.pipeline %}
+            {% if allow_copy %}
               <div class="tooltip" data-tip="Copy">
                 <button class="btn btn-primary join-item btn-sm rounded-r-full copy-button"
                         onclick="chatbot_copy_modal.showModal()">


### PR DESCRIPTION
## Description
I realised that there's no reason to prevent copying legacy bots as long as they don't have child routes.

This is just a UI change to show the button.

## User Impact
Users can copy other bot types.