### PR TITLE
Lower the similarity score to 0.1 for experiments

### DIFF
--- a/apps/utils/base_experiment_table_view.py
+++ b/apps/utils/base_experiment_table_view.py
@@ -27,5 +27,6 @@ class BaseExperimentTableView(LoginAndTeamRequiredMixin, SingleTableView, Permis
                 search_phase=search,
                 columns=["name", "description"],
                 extra_conditions=Q(owner__username__icontains=search),
+                score=0.1,
             )
         return query_set


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Lowered the similarity score to allow for tiny fractions of named to be used as a search string and still return results

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users should be able to use search strings that are fractions of names

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
N/A