### PR TITLE
remove deprecated .Client call

### DIFF
--- a/apps/service_providers/llm_service/token_counters.py
+++ b/apps/service_providers/llm_service/token_counters.py
@@ -80,7 +80,8 @@ class GeminiTokenCounter(TokenCounter):
         if not self.google_api_key:
             raise ValueError("KEY not found!")
 
-        self.client = genai.Client(api_key=self.google_api_key)
+        genai.configure(api_key=self.google_api_key)
+        self.client = genai
         self.model = GenerativeModel(self.model)
 
     def get_tokens_from_response(self, response: LLMResult) -> None | tuple[int, int]:


### PR DESCRIPTION
## Description
Gemini didn't work for me even after downgrading python version to 3.11. genai.Client() is deprecated and needs to be updated for google-generativeAI ersion > 0.8.4

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
