### PR TITLE
add nodeID and icon to nodes

### DIFF
--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -321,6 +321,7 @@ class UiSchema(BaseModel):
 
 class NodeSchema(BaseModel):
     label: str
+    icon: str = None
     flow_node_type: Literal["pipelineNode", "startNode", "endNode"] = "pipelineNode"
     can_delete: bool = None
     can_add: bool = None
@@ -360,6 +361,8 @@ class NodeSchema(BaseModel):
             schema["ui:order"] = self.field_order
         if self.documentation_link:
             schema["ui:documentation_link"] = self.documentation_link
+        if self.icon:
+            schema["ui:icon"] = self.icon
 
 
 def deprecated_node(cls=None, *, message=None):

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -63,7 +63,9 @@ class RenderTemplate(PipelineNode):
 
     model_config = ConfigDict(
         json_schema_extra=NodeSchema(
-            label="Render a template", documentation_link=settings.DOCUMENTATION_LINKS["node_template"]
+            label="Render a template",
+            icon="fa-solid fa-robot",
+            documentation_link=settings.DOCUMENTATION_LINKS["node_template"],
         )
     )
     template_string: str = Field(
@@ -245,7 +247,11 @@ class LLMResponseWithPrompt(LLMResponse, HistoryMixin):
     """Uses and LLM to respond to the input."""
 
     model_config = ConfigDict(
-        json_schema_extra=NodeSchema(label="LLM", documentation_link=settings.DOCUMENTATION_LINKS["node_llm"])
+        json_schema_extra=NodeSchema(
+            label="LLM",
+            icon="fa-solid fa-wand-magic-sparkles",
+            documentation_link=settings.DOCUMENTATION_LINKS["node_llm"],
+        )
     )
 
     source_material_id: OptionalInt = Field(
@@ -375,7 +381,9 @@ class SendEmail(PipelineNode):
 
     model_config = ConfigDict(
         json_schema_extra=NodeSchema(
-            label="Send an email", documentation_link=settings.DOCUMENTATION_LINKS["node_email"]
+            label="Send an email",
+            icon="fa-solid fa-envelope",
+            documentation_link=settings.DOCUMENTATION_LINKS["node_email"],
         )
     )
 
@@ -493,6 +501,7 @@ class RouterNode(RouterMixin, PipelineRouterNode, HistoryMixin):
     model_config = ConfigDict(
         json_schema_extra=NodeSchema(
             label="LLM Router",
+            icon="fa-solid fa-arrows-split-up-and-left",
             documentation_link=settings.DOCUMENTATION_LINKS["node_llm_router"],
             field_order=[
                 "llm_provider_id",
@@ -571,6 +580,7 @@ class StaticRouterNode(RouterMixin, PipelineRouterNode):
     model_config = ConfigDict(
         json_schema_extra=NodeSchema(
             label="Static Router",
+            icon="fa-solid fa-arrows-split-up-and-left",
             documentation_link=settings.DOCUMENTATION_LINKS["node_static_router"],
             field_order=["data_source", "route_key", "keywords"],
         )
@@ -747,6 +757,7 @@ class ExtractStructuredData(ExtractStructuredDataNodeMixin, LLMResponse, Structu
     model_config = ConfigDict(
         json_schema_extra=NodeSchema(
             label="Extract Structured Data",
+            icon="fa-solid fa-database",
             documentation_link=settings.DOCUMENTATION_LINKS["node_extract_structured_data"],
         )
     )
@@ -768,6 +779,7 @@ class ExtractParticipantData(ExtractStructuredDataNodeMixin, LLMResponse, Struct
     model_config = ConfigDict(
         json_schema_extra=NodeSchema(
             label="Update Participant Data",
+            icon="fa-solid fa-user-pen",
             documentation_link=settings.DOCUMENTATION_LINKS["node_update_participant_data"],
         )
     )
@@ -839,7 +851,9 @@ class AssistantNode(PipelineNode):
 
     model_config = ConfigDict(
         json_schema_extra=NodeSchema(
-            label="OpenAI Assistant", documentation_link=settings.DOCUMENTATION_LINKS["node_assistant"]
+            label="OpenAI Assistant",
+            icon="fa-solid fa-user-tie",
+            documentation_link=settings.DOCUMENTATION_LINKS["node_assistant"],
         )
     )
 
@@ -923,7 +937,11 @@ class CodeNode(PipelineNode):
     """Runs python"""
 
     model_config = ConfigDict(
-        json_schema_extra=NodeSchema(label="Python Node", documentation_link=settings.DOCUMENTATION_LINKS["node_code"])
+        json_schema_extra=NodeSchema(
+            label="Python Node",
+            icon="fa-solid fa-file-code",
+            documentation_link=settings.DOCUMENTATION_LINKS["node_code"],
+        )
     )
     code: str = Field(
         default=DEFAULT_FUNCTION,

--- a/apps/pipelines/tests/node_schemas/AssistantNode.json
+++ b/apps/pipelines/tests/node_schemas/AssistantNode.json
@@ -37,5 +37,6 @@
   "ui:deprecated": false,
   "ui:documentation_link": "/concepts/pipelines/nodes/#assistant",
   "ui:flow_node_type": "pipelineNode",
+  "ui:icon": "fa-solid fa-user-tie",
   "ui:label": "OpenAI Assistant"
 }

--- a/apps/pipelines/tests/node_schemas/CodeNode.json
+++ b/apps/pipelines/tests/node_schemas/CodeNode.json
@@ -24,5 +24,6 @@
   "ui:deprecated": false,
   "ui:documentation_link": "/concepts/pipelines/nodes/#python-node",
   "ui:flow_node_type": "pipelineNode",
+  "ui:icon": "fa-solid fa-file-code",
   "ui:label": "Python Node"
 }

--- a/apps/pipelines/tests/node_schemas/ExtractParticipantData.json
+++ b/apps/pipelines/tests/node_schemas/ExtractParticipantData.json
@@ -49,5 +49,6 @@
   "ui:deprecated": false,
   "ui:documentation_link": "/concepts/pipelines/nodes/#update-participant-data",
   "ui:flow_node_type": "pipelineNode",
+  "ui:icon": "fa-solid fa-user-pen",
   "ui:label": "Update Participant Data"
 }

--- a/apps/pipelines/tests/node_schemas/ExtractStructuredData.json
+++ b/apps/pipelines/tests/node_schemas/ExtractStructuredData.json
@@ -44,5 +44,6 @@
   "ui:deprecated": false,
   "ui:documentation_link": "/concepts/pipelines/nodes/#extract-structured-data",
   "ui:flow_node_type": "pipelineNode",
+  "ui:icon": "fa-solid fa-database",
   "ui:label": "Extract Structured Data"
 }

--- a/apps/pipelines/tests/node_schemas/LLMResponseWithPrompt.json
+++ b/apps/pipelines/tests/node_schemas/LLMResponseWithPrompt.json
@@ -138,5 +138,6 @@
   "ui:deprecated": false,
   "ui:documentation_link": "/concepts/pipelines/nodes/#llm",
   "ui:flow_node_type": "pipelineNode",
+  "ui:icon": "fa-solid fa-wand-magic-sparkles",
   "ui:label": "LLM"
 }

--- a/apps/pipelines/tests/node_schemas/RenderTemplate.json
+++ b/apps/pipelines/tests/node_schemas/RenderTemplate.json
@@ -24,5 +24,6 @@
   "ui:deprecated": false,
   "ui:documentation_link": "/concepts/pipelines/nodes/#template",
   "ui:flow_node_type": "pipelineNode",
+  "ui:icon": "fa-solid fa-robot",
   "ui:label": "Render a template"
 }

--- a/apps/pipelines/tests/node_schemas/RouterNode.json
+++ b/apps/pipelines/tests/node_schemas/RouterNode.json
@@ -116,6 +116,7 @@
   "ui:deprecated": false,
   "ui:documentation_link": "/concepts/pipelines/nodes/#llm-router",
   "ui:flow_node_type": "pipelineNode",
+  "ui:icon": "fa-solid fa-arrows-split-up-and-left",
   "ui:label": "LLM Router",
   "ui:order": [
     "llm_provider_id",

--- a/apps/pipelines/tests/node_schemas/SendEmail.json
+++ b/apps/pipelines/tests/node_schemas/SendEmail.json
@@ -28,5 +28,6 @@
   "ui:deprecated": false,
   "ui:documentation_link": "/concepts/pipelines/nodes/#email",
   "ui:flow_node_type": "pipelineNode",
+  "ui:icon": "fa-solid fa-envelope",
   "ui:label": "Send an email"
 }

--- a/apps/pipelines/tests/node_schemas/StaticRouterNode.json
+++ b/apps/pipelines/tests/node_schemas/StaticRouterNode.json
@@ -59,6 +59,7 @@
   "ui:deprecated": false,
   "ui:documentation_link": "/concepts/pipelines/nodes/#static-router",
   "ui:flow_node_type": "pipelineNode",
+  "ui:icon": "fa-solid fa-arrows-split-up-and-left",
   "ui:label": "Static Router",
   "ui:order": [
     "data_source",

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -101,7 +101,10 @@ function NodeHeader({nodeId, nodeSchema, nodeName}: {nodeId: string, nodeSchema:
   const icon = nodeSchema["ui:icon"];
   return (
       <div>
-        {icon && <i className={`text-primary/70 absolute ml-2 mt-1 top-4 left-2 ${icon}`}></i>}
+        {icon &&
+          <div className="text-primary/70 absolute ml-2 mt-1 top-4 left-2 tooltip tooltip-top" data-tip={nodeSchema["ui:label"]}>
+            <i className={icon}></i>
+          </div>}
         <div className="m-1 text-lg font-bold text-center align-middle">
           <DeprecationNotice nodeSchema={nodeSchema}/>
           {header}

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -74,7 +74,7 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
         </div>
       </NodeToolbar>
       <div className={nodeBorderClass(hasErrors, selected)}>
-        <NodeHeader nodeSchema={nodeSchema} nodeName={concatenate(data.params["name"])} />
+        <NodeHeader nodeId={id} nodeSchema={nodeSchema} nodeName={concatenate(data.params["name"])} />
 
         <NodeInput />
         <div className="px-4">
@@ -94,16 +94,19 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
   );
 }
 
-function NodeHeader({nodeSchema, nodeName}: {nodeSchema: JsonSchema, nodeName: string}) {
+function NodeHeader({nodeId, nodeSchema, nodeName}: {nodeId: string, nodeSchema: JsonSchema, nodeName: string}) {
   const defaultNodeNameRegex = /^[A-Za-z]+-[a-zA-Z0-9]{5}$/;
   const hasCustomName = !defaultNodeNameRegex.test(nodeName);
   const header = hasCustomName ? nodeName : nodeSchema["ui:label"];
-  const subheader = hasCustomName ? nodeSchema["ui:label"] : "";
+  const icon = nodeSchema["ui:icon"];
   return (
-    <div className="m-1 text-lg font-bold text-center">
-      <DeprecationNotice nodeSchema={nodeSchema} />
-      {header}
-      {subheader && <div className="text-sm">{subheader}</div>}
+      <div>
+        {icon && <i className={`text-primary/70 absolute ml-2 mt-1 top-4 left-2 ${icon}`}></i>}
+        <div className="m-1 text-lg font-bold text-center align-middle">
+          <DeprecationNotice nodeSchema={nodeSchema}/>
+          {header}
+          <p className="text-xs font-light text-gray-500 dark:text-gray-700">{nodeId}</p>
+        </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description
Add node ID in muted text and node icon to pipeline nodes.

## User Impact
User's can see node IDs which is useful when looking at trace data. Node icons also give an indication of the node type that's easy to see.

### Demo
![image](https://github.com/user-attachments/assets/4c07afb8-2842-42b3-a6cb-2e2c9284d717)

### Docs and Changelog
TODO
