### PR TITLE
store the node ID and django node model object on the Pipeline node instance

### DIFF
--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -284,7 +284,6 @@ class PipelineBot:
                 messages=[user_input],
                 experiment_session=self.session,
                 attachments=serializable_attachments,
-                pipeline_version=self.experiment.pipeline.version_number,
             ),
             self.session,
             self.experiment,

--- a/apps/events/actions.py
+++ b/apps/events/actions.py
@@ -134,7 +134,7 @@ class PipelineStartAction(EventActionHandlerBase):
             messages = [session.chat.messages.last().to_langchain_message()]
 
         input = "\n".join(f"{message.type}: {message.content}" for message in messages)
-        state = PipelineState(messages=[input], experiment_session=session, pipeline_version=pipeline.version_number)
+        state = PipelineState(messages=[input], experiment_session=session)
         trace_service = TracingService.create_for_experiment(session.experiment)
         with trace_service.trace(
             trace_name=f"{session.experiment.name} - event pipeline execution",

--- a/apps/events/tests/test_actions.py
+++ b/apps/events/tests/test_actions.py
@@ -65,7 +65,6 @@ def test_end_conversation_runs_pipeline(session, pipeline):
                 "end": {"message": f"human: {input}"},
             },
             "experiment_session": session.id,
-            "pipeline_version": pipeline.version_number,
             "temp_state": {
                 "user_input": output_message,
                 "attachments": [],

--- a/apps/pipelines/README.md
+++ b/apps/pipelines/README.md
@@ -33,7 +33,7 @@ class FancyNode(PipelineNode):
         widget=Widgets.select, options_source=OptionsSource.source_material
     ))
     
-    def _process(self, input, state: PipelineState, node_id: str) -> str:
+    def _process(self, input, state: PipelineState) -> str:
         self.logger.debug(f"Returning input: '{input}' without modification", input=input, output=input)
         return input
 ```

--- a/apps/pipelines/graph.py
+++ b/apps/pipelines/graph.py
@@ -196,13 +196,11 @@ class PipelineGraph(pydantic.BaseModel):
                 incoming_edges = [edge.source for edge in self.edges if edge.target == node.id]
                 if isinstance(node_instance, PipelineRouterNode):
                     edge_map = self.conditional_edge_map[node.id]
-                    router_function = node_instance.build_router_function(node.id, edge_map, incoming_edges)
+                    router_function = node_instance.build_router_function(edge_map, incoming_edges)
                     state_graph.add_node(node.id, router_function)
                 else:
                     outgoing_edges = [edge.target for edge in self.edges if edge.source == node.id]
-                    state_graph.add_node(
-                        node.id, partial(node_instance.process, node.id, incoming_edges, outgoing_edges)
-                    )
+                    state_graph.add_node(node.id, partial(node_instance.process, incoming_edges, outgoing_edges))
             except ValidationError as ex:
                 raise PipelineNodeBuildError(ex) from ex
 

--- a/apps/pipelines/graph.py
+++ b/apps/pipelines/graph.py
@@ -30,7 +30,7 @@ class Node(pydantic.BaseModel):
 
     @cached_property
     def pipeline_node_instance(self):
-        return self.pipeline_node_class(_node_id=self.id, _django_node=self.django_node, **self.params)
+        return self.pipeline_node_class(node_id=self.id, django_node=self.django_node, **self.params)
 
 
 class Edge(pydantic.BaseModel):

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -290,7 +290,7 @@ class Pipeline(BaseTeamModel, VersionsMixin):
 
         with temporary_session(self.team, user_id) as session:
             runnable = PipelineGraph.build_runnable_from_pipeline(self)
-            input = PipelineState(messages=[input], experiment_session=session, pipeline_version=self.version_number)
+            input = PipelineState(messages=[input], experiment_session=session)
             with patch_executor():
                 output = runnable.invoke(input, config={"max_concurrency": 1})
             output = PipelineState(**output).json_safe()

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -225,22 +225,22 @@ class PipelineNode(BasePipelineNode, ABC):
     """
 
     def process(
-        self, node_id: str, incoming_edges: list, outgoing_edges: list, state: PipelineState, config: RunnableConfig
+        self, incoming_edges: list, outgoing_edges: list, state: PipelineState, config: RunnableConfig
     ) -> PipelineState:
         self._config = config
-        state = self._prepare_state(node_id, incoming_edges, state)
-        output = self._process(input=state["node_input"], state=state, node_id=node_id)
-        output["path"] = [(state["node_source"], node_id, outgoing_edges)]
+        state = self._prepare_state(self.node_id, incoming_edges, state)
+        output = self._process(input=state["node_input"], state=state)
+        output["path"] = [(state["node_source"], self.node_id, outgoing_edges)]
         return output
 
-    def _process(self, input: str, state: PipelineState, node_id: str) -> PipelineState:
+    def _process(self, input: str, state: PipelineState) -> PipelineState:
         """The method that executes node specific functionality"""
         raise NotImplementedError
 
 
 class PipelineRouterNode(BasePipelineNode):
     def build_router_function(
-        self, node_id: str, edge_map: dict, incoming_edges: list
+        self, edge_map: dict, incoming_edges: list
     ) -> Callable[[PipelineState, RunnableConfig], Command]:
         output_map = self.get_output_map()
         ReturnType = Command[Literal[tuple(edge_map.values())]]  # noqa
@@ -248,15 +248,15 @@ class PipelineRouterNode(BasePipelineNode):
         def router(state: PipelineState, config: RunnableConfig) -> ReturnType:
             self._config = config
 
-            state = self._prepare_state(node_id, incoming_edges, state)
+            state = self._prepare_state(self.node_id, incoming_edges, state)
 
-            conditional_branch = self._process_conditional(state, node_id)
+            conditional_branch = self._process_conditional(state)
             output_handle = next((k for k, v in output_map.items() if v == conditional_branch), None)
             tags = self.get_output_tags(conditional_branch)
             target_node_id = edge_map[conditional_branch]
-            route_path = (state["node_source"], node_id, [target_node_id])
+            route_path = (state["node_source"], self.node_id, [target_node_id])
             output = PipelineState.from_router_output(
-                node_id, self.name, state["node_input"], output_handle, tags, route_path
+                self.node_id, self.name, state["node_input"], output_handle, tags, route_path
             )
             return Command(
                 update=output,
@@ -271,7 +271,7 @@ class PipelineRouterNode(BasePipelineNode):
     def get_output_tags(self, selected_route) -> list[str]:
         raise NotImplementedError()
 
-    def _process_conditional(self, state: PipelineState, node_id: str):
+    def _process_conditional(self, state: PipelineState):
         raise NotImplementedError()
 
 

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -122,6 +122,10 @@ class BasePipelineNode(BaseModel, ABC):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     _config: RunnableConfig | None = None
+
+    _node_id: str
+    _django_node: Any
+
     name: str = Field(title="Node Name", json_schema_extra={"ui:widget": "node_name"})
 
     def _prepare_state(self, node_id: str, incoming_edges: list, state: PipelineState):

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -75,7 +75,6 @@ class PipelineState(dict):
     messages: Annotated[Sequence[Any], operator.add]
     outputs: Annotated[dict, add_messages]
     experiment_session: ExperimentSession
-    pipeline_version: int
     temp_state: Annotated[TempState, add_temp_state_messages]
     input_message_metadata: Annotated[dict, merge_dicts]
     output_message_metadata: Annotated[dict, merge_dicts]
@@ -123,8 +122,8 @@ class BasePipelineNode(BaseModel, ABC):
 
     _config: RunnableConfig | None = None
 
-    _node_id: str
-    _django_node: Any
+    node_id: str = Field(exclude=True)
+    django_node: Any = Field(exclude=True)
 
     name: str = Field(title="Node Name", json_schema_extra={"ui:widget": "node_name"})
 

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -10,6 +10,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.types import Command
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.config import JsonDict
+from pydantic.json_schema import SkipJsonSchema
 from typing_extensions import TypedDict
 
 from apps.experiments.models import ExperimentSession
@@ -122,8 +123,8 @@ class BasePipelineNode(BaseModel, ABC):
 
     _config: RunnableConfig | None = None
 
-    node_id: str = Field(exclude=True)
-    django_node: Any = Field(exclude=True)
+    node_id: SkipJsonSchema[str] = Field(exclude=True)
+    django_node: SkipJsonSchema[Any] = Field(exclude=True)
 
     name: str = Field(title="Node Name", json_schema_extra={"ui:widget": "node_name"})
 

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -73,7 +73,7 @@ class RenderTemplate(PipelineNode):
         json_schema_extra=UiSchema(widget=Widgets.expandable_text),
     )
 
-    def _process(self, input, node_id: str, state: PipelineState, **kwargs) -> PipelineState:
+    def _process(self, input, state: PipelineState, **kwargs) -> PipelineState:
         env = SandboxedEnvironment()
         try:
             content = {
@@ -108,7 +108,7 @@ class RenderTemplate(PipelineNode):
             self.logger.error(f"Template rendering failed: {e}")
             raise PipelineNodeRunError(f"Error rendering template: {e}") from e
 
-        return PipelineState.from_node_output(node_name=self.name, node_id=node_id, output=output)
+        return PipelineState.from_node_output(node_name=self.name, node_id=self.node_id, output=output)
 
 
 class LLMResponseMixin(BaseModel):
@@ -237,10 +237,10 @@ class LLMResponse(PipelineNode, LLMResponseMixin):
 
     model_config = ConfigDict(json_schema_extra=NodeSchema(label="LLM response"))
 
-    def _process(self, input, node_id: str, **kwargs) -> PipelineState:
+    def _process(self, input, **kwargs) -> PipelineState:
         llm = self.get_chat_model()
         output = llm.invoke(input, config=self._config)
-        return PipelineState.from_node_output(node_name=self.name, node_id=node_id, output=output.content)
+        return PipelineState.from_node_output(node_name=self.name, node_id=self.node_id, output=output.content)
 
 
 class LLMResponseWithPrompt(LLMResponse, HistoryMixin):
@@ -324,14 +324,14 @@ class LLMResponseWithPrompt(LLMResponse, HistoryMixin):
             )
         return value
 
-    def _process(self, input, state: PipelineState, node_id: str) -> PipelineState:
+    def _process(self, input, state: PipelineState) -> PipelineState:
         session: ExperimentSession | None = state.get("experiment_session")
         # Get runnable
         provider_model = self.get_llm_provider_model()
         chat_model = self.get_chat_model()
         history_manager = PipelineHistoryManager.for_llm_chat(
             session=session,
-            node_id=node_id,
+            node_id=self.node_id,
             history_type=self.history_type,
             history_name=self.history_name,
             max_token_limit=provider_model.max_token_limit,
@@ -368,7 +368,7 @@ class LLMResponseWithPrompt(LLMResponse, HistoryMixin):
         result = chat.invoke(input=input)
         return PipelineState.from_node_output(
             node_name=self.name,
-            node_id=node_id,
+            node_id=self.node_id,
             output=result.output,
             output_message_metadata=history_manager.output_message_metadata,
         )
@@ -398,11 +398,11 @@ class SendEmail(PipelineNode):
                 raise PydanticCustomError("invalid_recipient_list", "Invalid list of emails addresses") from None
         return value
 
-    def _process(self, input, node_id: str, **kwargs) -> PipelineState:
+    def _process(self, input, **kwargs) -> PipelineState:
         send_email_from_pipeline.delay(
             recipient_list=self.recipient_list.split(","), subject=self.subject, message=input
         )
-        return PipelineState.from_node_output(node_name=self.name, node_id=node_id, output=input)
+        return PipelineState.from_node_output(node_name=self.name, node_id=self.node_id, output=input)
 
 
 class Passthrough(PipelineNode):
@@ -410,10 +410,10 @@ class Passthrough(PipelineNode):
 
     model_config = ConfigDict(json_schema_extra=NodeSchema(label="Do Nothing", can_add=False))
 
-    def _process(self, input, state: PipelineState, node_id: str) -> PipelineState:
+    def _process(self, input, state: PipelineState) -> PipelineState:
         if self.logger:
             self.logger.debug(f"Returning input: '{input}' without modification")
-        return PipelineState.from_node_output(node_name=self.name, node_id=node_id, output=input)
+        return PipelineState.from_node_output(node_name=self.name, node_id=self.node_id, output=input)
 
 
 class StartNode(Passthrough):
@@ -443,7 +443,7 @@ class BooleanNode(PipelineRouterNode):
         json_schema_extra=UiSchema(widget=Widgets.toggle),
     )
 
-    def _process_conditional(self, state: PipelineState, node_id: str | None = None) -> Literal["true", "false"]:
+    def _process_conditional(self, state: PipelineState) -> Literal["true", "false"]:
         if self.input_equals == state["messages"][-1]:
             return "true"
         return "false"
@@ -532,7 +532,7 @@ class RouterNode(RouterMixin, PipelineRouterNode, HistoryMixin):
                 "invalid_prompt", e.error_dict["prompt"][0].message, {"field": "prompt"}
             ) from None
 
-    def _process_conditional(self, state: PipelineState, node_id=None):
+    def _process_conditional(self, state: PipelineState):
         default_keyword = self.keywords[self.default_keyword_index] if self.keywords else None
         prompt = OcsPromptTemplate.from_messages(
             [
@@ -549,7 +549,7 @@ class RouterNode(RouterMixin, PipelineRouterNode, HistoryMixin):
 
         if self.history_type != PipelineChatHistoryTypes.NONE and session:
             input_messages = prompt.format_messages(**context)
-            context["history"] = self._get_history(session, node_id, input_messages)
+            context["history"] = self._get_history(session, self.node_id, input_messages)
 
         llm = self.get_chat_model()
         router_schema = self._create_router_schema()
@@ -563,7 +563,7 @@ class RouterNode(RouterMixin, PipelineRouterNode, HistoryMixin):
             keyword = self.keywords[self.default_keyword_index]
 
         if session:
-            self._save_history(session, node_id, node_input, keyword)
+            self._save_history(session, self.node_id, node_input, keyword)
         return keyword
 
 
@@ -591,7 +591,7 @@ class StaticRouterNode(RouterMixin, PipelineRouterNode):
     )
     route_key: str = Field(..., description="The key in the data to use for routing")
 
-    def _process_conditional(self, state: PipelineState, node_id=None):
+    def _process_conditional(self, state: PipelineState):
         from apps.service_providers.llm_service.prompt_context import SafeAccessWrapper
 
         match self.data_source:
@@ -635,7 +635,7 @@ class ExtractStructuredDataNodeMixin:
     def extraction_chain(self, tool_class, reference_data):
         return self._prompt_chain(reference_data) | super().get_chat_model().with_structured_output(tool_class)
 
-    def _process(self, input, state: PipelineState, node_id: str, **kwargs) -> PipelineState:
+    def _process(self, input, state: PipelineState, **kwargs) -> PipelineState:
         ToolClass = self.get_tool_class(json.loads(self.data_schema))
         reference_data = self.get_reference_data(state)
         prompt_token_count = self._get_prompt_token_count(reference_data, ToolClass.model_json_schema())
@@ -655,7 +655,7 @@ class ExtractStructuredDataNodeMixin:
 
         self.post_extraction_hook(new_reference_data, state)
         output = input if self.is_passthrough else json.dumps(new_reference_data)
-        return PipelineState.from_node_output(node_name=self.name, node_id=node_id, output=output)
+        return PipelineState.from_node_output(node_name=self.name, node_id=self.node_id, output=output)
 
     def post_extraction_hook(self, output, state):
         pass
@@ -879,21 +879,21 @@ class AssistantNode(PipelineNode):
             if extra_vars:
                 raise PydanticCustomError("invalid_input_formatter", "Only {input} is allowed")
 
-    def _process(self, input, state: PipelineState, node_id: str, **kwargs) -> PipelineState:
+    def _process(self, input, state: PipelineState, **kwargs) -> PipelineState:
         try:
             assistant = OpenAiAssistant.objects.get(id=self.assistant_id)
         except OpenAiAssistant.DoesNotExist:
             raise PipelineNodeBuildError(f"Assistant {self.assistant_id} does not exist") from None
 
         session: ExperimentSession | None = state.get("experiment_session")
-        runnable = self._get_assistant_runnable(assistant, session=session, node_id=node_id)
+        runnable = self._get_assistant_runnable(assistant, session=session)
         attachments = self._get_attachments(state)
         chain_output: ChainOutput = runnable.invoke(input, config=self._config, attachments=attachments)
         output = chain_output.output
 
         return PipelineState.from_node_output(
             node_name=self.name,
-            node_id=node_id,
+            node_id=self.node_id,
             output=output,
             input_message_metadata=runnable.history_manager.input_message_metadata or {},
             output_message_metadata=runnable.history_manager.output_message_metadata or {},
@@ -902,7 +902,7 @@ class AssistantNode(PipelineNode):
     def _get_attachments(self, state) -> list:
         return [att for att in state.get("temp_state", {}).get("attachments", []) if att.upload_to_assistant]
 
-    def _get_assistant_runnable(self, assistant: OpenAiAssistant, session: ExperimentSession, node_id: str):
+    def _get_assistant_runnable(self, assistant: OpenAiAssistant, session: ExperimentSession):
         history_manager = PipelineHistoryManager.for_assistant()
         adapter = AssistantAdapter.for_pipeline(session=session, node=self, disabled_tools=self.disabled_tools)
 
@@ -982,7 +982,7 @@ class CodeNode(PipelineNode):
             raise PydanticCustomError("invalid_code", "{error}", {"error": exc.msg}) from None
         return value
 
-    def _process(self, input: str, state: PipelineState, node_id: str) -> PipelineState:
+    def _process(self, input: str, state: PipelineState) -> PipelineState:
         function_name = "main"
         byte_code = compile_restricted(
             self.code,
@@ -998,7 +998,7 @@ class CodeNode(PipelineNode):
             result = str(custom_locals[function_name](input, **kwargs))
         except Exception as exc:
             raise PipelineNodeRunError(exc) from exc
-        return PipelineState.from_node_output(node_name=self.name, node_id=node_id, output=result)
+        return PipelineState.from_node_output(node_name=self.name, node_id=self.node_id, output=result)
 
     def _get_custom_globals(self, state: PipelineState):
         from RestrictedPython.Eval import (

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -338,7 +338,7 @@ class LLMResponseWithPrompt(LLMResponse, HistoryMixin):
             chat_model=chat_model,
         )
 
-        tools = get_node_tools(self._django_node, session, attachment_callback=history_manager.attach_file_id)
+        tools = get_node_tools(self.django_node, session, attachment_callback=history_manager.attach_file_id)
         if self.collection_index_id:
             collection = Collection.objects.get(id=self.collection_index_id)
             builtin_tools = {"type": "file_search", "vector_store_ids": [collection.openai_vector_store_id]}

--- a/apps/pipelines/tests/test_code_node.py
+++ b/apps/pipelines/tests/test_code_node.py
@@ -234,10 +234,11 @@ def test_temp_state_get_outputs(pipeline, experiment_session):
 def main(input, **kwargs):
     return str(get_temp_state_key("outputs"))
 """
+    template_node = render_template_node("<b>The input is: {{ input }}</b>")
     nodes = [
         start_node(),
         passthrough_node(),
-        render_template_node("<b>The input is: {{ input }}</b>"),
+        template_node,
         code_node(code_get),
         end_node(),
     ]
@@ -247,7 +248,7 @@ def main(input, **kwargs):
         {
             "start": input,
             "passthrough": input,
-            "render template": f"<b>The input is: {input}</b>",
+            template_node["params"]["name"]: f"<b>The input is: {input}</b>",
         }
     )
 

--- a/apps/pipelines/tests/test_code_node.py
+++ b/apps/pipelines/tests/test_code_node.py
@@ -405,7 +405,6 @@ def test_render_template_with_context_keys(pipeline, experiment_session):
         experiment_session=experiment_session,
         messages=["Cycling"],
         temp_state={"my_key": "example_key"},
-        pipeline_version=1,
         outputs={},
     )
     nodes = [

--- a/apps/pipelines/tests/test_nodes.py
+++ b/apps/pipelines/tests/test_nodes.py
@@ -30,7 +30,9 @@ class TestSendEmailInputValidation:
         ],
     )
     def test_valid_recipient_list(self, recipient_list):
-        model = SendEmail(name="email", recipient_list=recipient_list, subject="Test Subject")
+        model = SendEmail(
+            node_id="test", django_node=None, name="email", recipient_list=recipient_list, subject="Test Subject"
+        )
         assert model.recipient_list == recipient_list
 
     @pytest.mark.parametrize(

--- a/apps/pipelines/tests/test_nodes_with_tools.py
+++ b/apps/pipelines/tests/test_nodes_with_tools.py
@@ -104,7 +104,6 @@ def test_llm_node(simple_invoke, agent_invoke, disabled_tools, provider, provide
     state = PipelineState(
         messages=["Hi there bot"],
         experiment_session=ExperimentSessionFactory(),
-        pipeline_version=pipeline.version_number,
     )
     output_state = runnable.invoke(state, config={"configurable": {"disabled_tools": disabled_tools}})
     assert output_state["messages"][-1] == "hello"

--- a/apps/pipelines/tests/test_pipeline_history.py
+++ b/apps/pipelines/tests/test_pipeline_history.py
@@ -58,9 +58,7 @@ def test_llm_with_node_history(get_llm_service, provider, pipeline, experiment_s
     runnable = create_runnable(pipeline, nodes)
 
     user_input = "The User Input"
-    runnable.invoke(PipelineState(messages=[user_input], experiment_session=experiment_session, pipeline_version=1))[
-        "messages"
-    ]
+    runnable.invoke(PipelineState(messages=[user_input], experiment_session=experiment_session))["messages"]
     expected_call_messages = [
         [("system", "Node 1:"), ("human", user_input)],
         [("system", "Node 2:"), ("human", f"Node 1: {user_input}")],
@@ -77,9 +75,9 @@ def test_llm_with_node_history(get_llm_service, provider, pipeline, experiment_s
     assert not PipelineChatHistory.objects.filter(session=experiment_session.id, name=llm_2["id"]).exists()
 
     user_input_2 = "Saying more stuff"
-    output_2 = runnable.invoke(
-        PipelineState(messages=[user_input_2], experiment_session=experiment_session, pipeline_version=1)
-    )["messages"][-1]
+    output_2 = runnable.invoke(PipelineState(messages=[user_input_2], experiment_session=experiment_session))[
+        "messages"
+    ][-1]
 
     expected_output = f"Node 2: Node 1: {user_input_2}"
     assert output_2 == expected_output
@@ -130,9 +128,9 @@ def test_llm_with_multiple_node_histories(get_llm_service, provider, pipeline, e
     runnable = create_runnable(pipeline, nodes)
 
     user_input = "The User Input"
-    output_1 = runnable.invoke(
-        PipelineState(messages=[user_input], experiment_session=experiment_session, pipeline_version=1)
-    )["messages"][-1]
+    output_1 = runnable.invoke(PipelineState(messages=[user_input], experiment_session=experiment_session))["messages"][
+        -1
+    ]
     expected_output = f"Node 2: Node 1: {user_input}"
     assert output_1 == expected_output
 
@@ -150,9 +148,9 @@ def test_llm_with_multiple_node_histories(get_llm_service, provider, pipeline, e
     ]
 
     user_input_2 = "Saying more stuff"
-    output_2 = runnable.invoke(
-        PipelineState(messages=[user_input_2], experiment_session=experiment_session, pipeline_version=1)
-    )["messages"][-1]
+    output_2 = runnable.invoke(PipelineState(messages=[user_input_2], experiment_session=experiment_session))[
+        "messages"
+    ][-1]
     expected_output = f"Node 2: Node 1: {user_input_2}"
     assert output_2 == expected_output
 
@@ -214,14 +212,14 @@ def test_global_history(get_llm_service, provider, pipeline, experiment_session)
 
     user_input = "The User Input"
     output_1 = experiment.pipeline.invoke(
-        PipelineState(messages=[user_input], experiment_session=experiment_session, pipeline_version=1),
+        PipelineState(messages=[user_input], experiment_session=experiment_session),
         experiment_session,
         experiment,
         TracingService.empty(),
     )
     user_input_2 = "Saying more stuff"
     output_2 = experiment.pipeline.invoke(
-        PipelineState(messages=[user_input_2], experiment_session=experiment_session, pipeline_version=1),
+        PipelineState(messages=[user_input_2], experiment_session=experiment_session),
         experiment_session,
         experiment,
         TracingService.empty(),
@@ -229,7 +227,7 @@ def test_global_history(get_llm_service, provider, pipeline, experiment_session)
 
     user_input_3 = "Tell me something interesting"
     experiment.pipeline.invoke(
-        PipelineState(messages=[user_input_3], experiment_session=experiment_session, pipeline_version=1),
+        PipelineState(messages=[user_input_3], experiment_session=experiment_session),
         experiment_session,
         experiment,
         TracingService.empty(),
@@ -307,9 +305,9 @@ def test_llm_with_named_history(get_llm_service, provider, pipeline, experiment_
     runnable = create_runnable(pipeline, nodes)
 
     user_input = "The User Input"
-    runnable.invoke(PipelineState(messages=[user_input], experiment_session=experiment_session, pipeline_version=1))
+    runnable.invoke(PipelineState(messages=[user_input], experiment_session=experiment_session))
     user_input_2 = "Second User Input"
-    runnable.invoke(PipelineState(messages=[user_input_2], experiment_session=experiment_session, pipeline_version=1))
+    runnable.invoke(PipelineState(messages=[user_input_2], experiment_session=experiment_session))
 
     expected_call_messages = [
         # First call to Node 1
@@ -372,9 +370,9 @@ def test_llm_with_no_history(get_llm_service, provider, pipeline, experiment_ses
     runnable = create_runnable(pipeline, nodes)
 
     user_input = "The User Input"
-    runnable.invoke(PipelineState(messages=[user_input], experiment_session=experiment_session, pipeline_version=1))
+    runnable.invoke(PipelineState(messages=[user_input], experiment_session=experiment_session))
     user_input_2 = "Second User Input"
-    runnable.invoke(PipelineState(messages=[user_input_2], experiment_session=experiment_session, pipeline_version=1))
+    runnable.invoke(PipelineState(messages=[user_input_2], experiment_session=experiment_session))
 
     expected_call_messages = [
         # First call to Node 1

--- a/apps/pipelines/tests/test_runnable_builder.py
+++ b/apps/pipelines/tests/test_runnable_builder.py
@@ -93,7 +93,6 @@ def test_full_email_sending_pipeline(get_llm_service, provider, provider_model, 
     state = PipelineState(
         messages=["Ice is not a liquid. When it is melted it turns into water."],
         experiment_session=ExperimentSessionFactory(),
-        pipeline_version=1,
     )
     create_runnable(pipeline, nodes).invoke(state)
     assert len(mail.outbox) == 1
@@ -163,7 +162,7 @@ def test_llm_with_prompt_response(
         end_node(),
     ]
     output = create_runnable(pipeline, nodes).invoke(
-        PipelineState(messages=[user_input], experiment_session=experiment_session, pipeline_version=1)
+        PipelineState(messages=[user_input], experiment_session=experiment_session)
     )["messages"][-1]
     expected_output = (
         f"Node 2: {source_material.material} Node 1: Use this {source_material.material} to answer questions "
@@ -1050,7 +1049,6 @@ def test_multiple_valid_inputs(pipeline):
     state = PipelineState(
         messages=["not hello"],
         experiment_session=experiment_session,
-        pipeline_version=1,
     )
     output = create_runnable(pipeline, nodes, edges, lenient=False).invoke(state)
     assert output["messages"][-1] == "T: not hello"
@@ -1124,7 +1122,6 @@ def test_input_with_format_strings():
     state = PipelineState(
         messages=["Is this it {the thing}"],
         experiment_session=ExperimentSessionFactory.build(),
-        pipeline_version=1,
         temp_state={},
     )
     resp = Passthrough(name="test").process("node_id", [], [], state, {})

--- a/apps/pipelines/tests/test_runnable_builder.py
+++ b/apps/pipelines/tests/test_runnable_builder.py
@@ -307,6 +307,8 @@ def test_router_node_prompt(get_llm_service, provider, provider_model, pipeline,
     get_llm_service.return_value = service
 
     node = RouterNode(
+        node_id="test",
+        django_node=None,
         name="test router",
         prompt="PD: {participant_data}",
         keywords=["A"],
@@ -1123,7 +1125,7 @@ def test_input_with_format_strings():
         experiment_session=ExperimentSessionFactory.build(),
         temp_state={},
     )
-    resp = Passthrough(name="test").process([], [], state, {})
+    resp = Passthrough(node_id="test", django_node=None, name="test").process([], [], state, {})
 
     assert resp["messages"] == ["Is this it {the thing}"]
 

--- a/apps/pipelines/tests/test_runnable_builder.py
+++ b/apps/pipelines/tests/test_runnable_builder.py
@@ -319,7 +319,6 @@ def test_router_node_prompt(get_llm_service, provider, provider_model, pipeline,
             messages=["a"],
             experiment_session=experiment_session,
         ),
-        node_id="123",
     )
 
     assert len(service.llm.get_call_messages()[0]) == 2
@@ -1124,7 +1123,7 @@ def test_input_with_format_strings():
         experiment_session=ExperimentSessionFactory.build(),
         temp_state={},
     )
-    resp = Passthrough(name="test").process("node_id", [], [], state, {})
+    resp = Passthrough(name="test").process([], [], state, {})
 
     assert resp["messages"] == ["Is this it {the thing}"]
 

--- a/apps/pipelines/tests/test_state.py
+++ b/apps/pipelines/tests/test_state.py
@@ -13,7 +13,6 @@ def test_pipline_state_json_serializable():
         messages=["a", "b", "c"],
         outputs={"a": "a", "b": "b", "c": "c"},
         experiment_session=ExperimentSession(id=1),
-        pipeline_version=1,
         temp_state={
             "user_input": "input",
             "outputs": {"a": "a", "b": "b", "c": "c"},

--- a/apps/pipelines/tests/utils.py
+++ b/apps/pipelines/tests/utils.py
@@ -206,11 +206,12 @@ def extract_structured_data_node(provider_id: str, provider_model_id: str, data_
 def code_node(code: str | None = None):
     if code is None:
         code = "return f'Hello, {input}!'"
+    node_id = str(uuid4())
     return {
-        "id": str(uuid4()),
+        "id": node_id,
         "type": nodes.CodeNode.__name__,
         "params": {
-            "name": "code node",
+            "name": "code node" + node_id[-4:],
             "code": code,
         },
     }


### PR DESCRIPTION
## Description
Storing the node ID and django node object on the pipeline node instance makes it easier to reference them without doing a DB query or having to pass the `node_id` to all the function calls.

I would like to give 'experiment' and 'session' the same treatment but I'll leave that for a future PR.

## User Impact
None

