### PR TITLE
Small UI updates

### DIFF
--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -319,8 +319,10 @@ class LLMResponseWithPrompt(LLMResponse, HistoryMixin):
 
         collection = Collection.objects.get(id=value)
         if collection.llm_provider_id != info.data.get("llm_provider_id"):
+            info.data.get("llm_provider_id")
             raise PydanticCustomError(
-                "invalid_collection_index", "The collection index must use the same LLM provider as the node"
+                "invalid_collection_index",
+                f"The collection index and node must use the same LLM provider ({collection.llm_provider.name})",
             )
         return value
 

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -319,7 +319,6 @@ class LLMResponseWithPrompt(LLMResponse, HistoryMixin):
 
         collection = Collection.objects.get(id=value)
         if collection.llm_provider_id != info.data.get("llm_provider_id"):
-            info.data.get("llm_provider_id")
             raise PydanticCustomError(
                 "invalid_collection_index",
                 f"The collection index and node must use the same LLM provider ({collection.llm_provider.name})",

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -824,14 +824,16 @@ export function LlmWidget(props: WidgetParams) {
         <option value="" disabled>
           Select a model
         </option>
-        {parameterValues.LlmProviderId.map((provider) => (
-          providerModelsByType[provider.type] &&
-          providerModelsByType[provider.type].map((providerModel) => (
-            <option key={provider.value + providerModel.value} value={makeValue(provider.value, providerModel.value)}>
-              {providerModel.label} ({provider.label})
-            </option>
-          ))
-        ))}
+        {parameterValues.LlmProviderId.map((provider) => {
+          const providersWithSameType = parameterValues.LlmProviderId.filter(p => p.type === provider.type).length;
+          
+          return providerModelsByType[provider.type] &&
+            providerModelsByType[provider.type].map((providerModel) => (
+              <option key={provider.value + providerModel.value} value={makeValue(provider.value, providerModel.value)}>
+                {providerModel.label}{providersWithSameType > 1 ? ` (${provider.label})` : ''}
+              </option>
+            ))
+        })}
       </select>
     </InputField>
   );

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -802,7 +802,7 @@ export function LlmWidget(props: WidgetParams) {
   };
 
   type ProviderModelsByType = { [type: string]: TypedOption[] };
-  const providerModelsByType = parameterValues.LlmProviderModelId.reduce((acc, provModel) => {
+    const providerModelsByType = parameterValues.LlmProviderModelId.reduce((acc, provModel) => {
     if (!acc[provModel.type]) {
       acc[provModel.type] = [];
     }
@@ -828,7 +828,7 @@ export function LlmWidget(props: WidgetParams) {
           providerModelsByType[provider.type] &&
           providerModelsByType[provider.type].map((providerModel) => (
             <option key={provider.value + providerModel.value} value={makeValue(provider.value, providerModel.value)}>
-              {providerModel.label}
+              {providerModel.label} ({provider.label})
             </option>
           ))
         ))}


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
- Updated the LLM provider dropdown in the LLM node to show the name of the provider when there are multiple providers of the same type.
- The error message that is shown when different providers are used for a collection index and LLM node is updated to show which provider is expected to be used on the node. In the future we can change it to either 1. auto select the node provider based on the collection index and lock it in, or 2. change the set of available options in the collection index dropdown, based on the selected node provider.

### User impact
Users will know exactly 1. from which provider instance they selected a model from and 2. which provider they should be selecting a model from if there is a mismatch between the provider that the collection index is using and the one currently selected.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
#### 1
Here you can see what it looks like when I have 1 Anthorpic provider and 2 OpenAI providers. Only the OpenAI ones have their provider names appended.

![image](https://github.com/user-attachments/assets/018fe1cd-a434-44ee-9873-e5dc9d4f60d3)

#### 2
This is what the error message looks like when there's a mismatch between the node and collection providers

![image](https://github.com/user-attachments/assets/563b57b1-d1a5-427f-bcfb-bb0eb7a51c82)


### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/101