### PR TITLE
Update documentation to use correct python version and activate venv

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -29,7 +29,8 @@ Open Chat Studio uses [UV](https://docs.astral.sh/uv/getting-started/installatio
 2. **Install dependencies**
 
     ```bash
-    uv venv
+    uv venv --python 3.11
+    source .venv/bin/activate
     uv sync
     ```
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

Was having trouble setting up an environment from scratch using `uv`, as the `venv` command defaults to a different python version on my machine. 

## User Impact
<!-- Describe the impact of this change on the end-users. -->
None, docs only

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
