### PR TITLE
Bump z-index for team switcher

### DIFF
--- a/templates/web/components/app_nav.html
+++ b/templates/web/components/app_nav.html
@@ -10,7 +10,7 @@
         {{ request.user.get_display_name }}
       {% endif %}
     </div>
-    <ul tabindex="0" class="dropdown-content z-1 menu p-2 shadow-sm bg-base-200 rounded-box w-64">
+    <ul tabindex="0" class="dropdown-content z-50 menu p-2 shadow-sm bg-base-200 rounded-box w-64">
       {% include "web/components/team_nav_items.html" %}
     </ul>
   </div>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

I was having trouble switching teams, as the dropdown was rendering under the menu below

## User Impact
<!-- Describe the impact of this change on the end-users. -->

User's can switch teams.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

#### Before
![image](https://github.com/user-attachments/assets/cf30dcf1-fd82-444a-9f94-3928b3c4c74c)


#### After
![image](https://github.com/user-attachments/assets/ac1d9ee1-2693-49a6-8dee-4d7101c37ee6)


### Docs and Changelog
<!--Link to documentation that has been updated.-->
