### PR TITLE
add padding to node name to prevent overlap and allow setting node color

### DIFF
--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -105,7 +105,7 @@ function NodeHeader({nodeId, nodeSchema, nodeName}: {nodeId: string, nodeSchema:
           <div className="text-primary/70 absolute ml-2 mt-1 top-4 left-2 tooltip tooltip-top" data-tip={nodeSchema["ui:label"]}>
             <i className={icon}></i>
           </div>}
-        <div className="m-1 text-lg font-bold text-center align-middle">
+        <div className="px-10 m-1 text-lg font-bold text-center align-middle">
           <DeprecationNotice nodeSchema={nodeSchema}/>
           {header}
           <p className="text-xs font-light text-gray-500 dark:text-gray-700">{nodeId}</p>

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -16,7 +16,7 @@ export type PipelineNode = Node<NodeData>;
 const NODE_COLORS = [
   { value: "bg-base-100", label: "Default"},
   { value: "bg-red-100 dark:bg-red-950", label: "Red"},
-  { value: "bg-amber-100 dark:bg-amber-950", label: "Amber"},
+  { value: "bg-yellow-100 dark:bg-yellow-950", label: "Yellow"},
   { value: "bg-green-100 dark:bg-green-950", label: "Green"},
   { value: "bg-blue-100 dark:bg-blue-950", label: "Blue"},
   { value: "bg-purple-100 dark:bg-purple-950", label: "Purple"},
@@ -56,7 +56,6 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
   const changeNodeColor = (color: string | undefined) => {
     setNode(id, produce((next) => {
       next.data.params["color"] = color;
-      console.log(color)
     }));
   };
 

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -1,5 +1,5 @@
 import {Node, NodeProps, NodeToolbar, Position} from "reactflow";
-import React, {ChangeEvent} from "react";
+import React, {ChangeEvent, MouseEvent} from "react";
 import {concatenate, formatDocsForSchema, getCachedData, nodeBorderClass} from "./utils";
 import usePipelineStore from "./stores/pipelineStore";
 import useEditorStore from "./stores/editorStore";
@@ -11,6 +11,18 @@ import {HelpContent} from "./panel/ComponentHelp";
 import { produce } from "immer";
 
 export type PipelineNode = Node<NodeData>;
+
+// Predefined node colors with labels
+const NODE_COLORS = [
+  { value: "bg-base-100", label: "Default"},
+  { value: "bg-red-100 dark:bg-red-950", label: "Red"},
+  { value: "bg-amber-100 dark:bg-amber-950", label: "Amber"},
+  { value: "bg-green-100 dark:bg-green-950", label: "Green"},
+  { value: "bg-blue-100 dark:bg-blue-950", label: "Blue"},
+  { value: "bg-purple-100 dark:bg-purple-950", label: "Purple"},
+  { value: "bg-pink-100 dark:bg-pink-950", label: "Pink"},
+  { value: "bg-indigo-100 dark:bg-indigo-950", label: "Indigo"},
+];
 
 export function PipelineNode(nodeProps: NodeProps<NodeData>) {
   const {id, data, selected} = nodeProps;
@@ -40,6 +52,16 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
   }
 
   const nodeDocs = formatDocsForSchema(nodeSchema);
+
+  const changeNodeColor = (color: string | undefined) => {
+    setNode(id, produce((next) => {
+      next.data.params["color"] = color;
+      console.log(color)
+    }));
+  };
+
+  const currentColor = data.params["color"] || NODE_COLORS[0].value;
+  const nodeClasses = `${nodeBorderClass(hasErrors, selected)} ${currentColor}`;
 
   return (
     <>
@@ -73,8 +95,14 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
               )}
         </div>
       </NodeToolbar>
-      <div className={nodeBorderClass(hasErrors, selected)}>
-        <NodeHeader nodeId={id} nodeSchema={nodeSchema} nodeName={concatenate(data.params["name"])} />
+      <div className={nodeClasses}>
+        <NodeHeader
+          nodeId={id}
+          nodeSchema={nodeSchema}
+          nodeName={concatenate(data.params["name"])}
+          onIconClick={changeNodeColor}
+          currentColor={currentColor}
+        />
 
         <NodeInput />
         <div className="px-4">
@@ -94,21 +122,62 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
   );
 }
 
-function NodeHeader({nodeId, nodeSchema, nodeName}: {nodeId: string, nodeSchema: JsonSchema, nodeName: string}) {
+function NodeHeader({
+  nodeId,
+  nodeSchema,
+  nodeName,
+  onIconClick,
+  currentColor
+}: {
+  nodeId: string,
+  nodeSchema: JsonSchema,
+  nodeName: string,
+  onIconClick?: (color: string | undefined) => void,
+  currentColor?: string
+}) {
   const defaultNodeNameRegex = /^[A-Za-z]+-[a-zA-Z0-9]{5}$/;
   const hasCustomName = !defaultNodeNameRegex.test(nodeName);
   const header = hasCustomName ? nodeName : nodeSchema["ui:label"];
-  const icon = nodeSchema["ui:icon"];
+  const icon = nodeSchema["ui:icon"] || "fa-solid fa-code-commit";
+
+  const handleColorSelect = (e: MouseEvent, color: string | undefined) => {
+    e.stopPropagation();
+    if (onIconClick) {
+      onIconClick(color);
+    }
+  };
+
   return (
       <div>
-        {icon &&
-          <div className="text-primary/70 absolute ml-2 mt-1 top-4 left-2 tooltip tooltip-top" data-tip={nodeSchema["ui:label"]}>
+        <div className="dropdown dropdown-right absolute ml-2 mt-1 top-4 left-2">
+          <div
+            className="text-primary/70 tooltip tooltip-top cursor-pointer"
+            data-tip={nodeSchema["ui:label"] + " (Click to change node color)"}
+            tabIndex={0}
+          >
             <i className={icon}></i>
-          </div>}
+          </div>
+          <ul tabIndex={0} className="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52">
+            <li className="menu-title">Select color</li>
+            {NODE_COLORS.map((color, index) => {
+              const isCurrentColor = color.value === currentColor;
+
+              return (
+                <li key={index} onClick={(e) => handleColorSelect(e as unknown as MouseEvent, color.value)}>
+                  <a className={`flex justify-between ${isCurrentColor ? 'bg-base-200' : ''}`}>
+                    <span>{color.label}</span>
+                    <span className={`w-6 h-6 rounded-full ${color.value} border`}></span>
+                    {isCurrentColor && <i className="fa fa-check ml-2"></i>}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
         <div className="px-10 m-1 text-lg font-bold text-center align-middle">
           <DeprecationNotice nodeSchema={nodeSchema}/>
           {header}
-          <p className="text-xs font-light text-gray-500 dark:text-gray-700">{nodeId}</p>
+          <p className="text-xs font-light text-gray-500 dark:text-gray-600">{nodeId}</p>
         </div>
     </div>
   );

--- a/assets/javascript/apps/pipeline/utils.tsx
+++ b/assets/javascript/apps/pipeline/utils.tsx
@@ -23,7 +23,7 @@ export function nodeBorderClass(nodeErrors : boolean, selected : boolean ): stri
   const defaultBorder = nodeErrors ? "border-error " : ""
   const selectedBorder = nodeErrors ? "border-secondary" : "border-primary"
   const border = selected ? selectedBorder : defaultBorder
-  return classNames(border, "border py-2 shadow-md rounded-xl border-2 bg-base-100")
+  return classNames(border, "border py-2 shadow-md rounded-xl border-2")
 }
 
 const localCache = {


### PR DESCRIPTION
## Description
* Pad node name to prevent overlap with the icon
* Allow users to set node color (cause it's fun)

### Demo
**Before**
![Screenshot from 2025-05-15 20-13-19](https://github.com/user-attachments/assets/79c17e16-3b41-47de-87ea-104f6fa3cf7f)

**After**
![Screenshot from 2025-05-15 20-12-52](https://github.com/user-attachments/assets/c5494f1d-e3b7-41fd-af4e-f8f070fe6019)

**color changing**
[Screencast from 2025-05-15 20-56-37.webm](https://github.com/user-attachments/assets/092837e9-fbd8-4067-9a59-4a7add303847)

![Screenshot from 2025-05-15 22-09-59](https://github.com/user-attachments/assets/140e3c07-16c1-4107-a271-6c6e9195eba9)


![image](https://github.com/user-attachments/assets/96d91e3a-a360-4957-be18-bf16875fcf33)


