### PR TITLE
RAG - Retry failed uploads

### DIFF
--- a/apps/documents/exceptions.py
+++ b/apps/documents/exceptions.py
@@ -1,0 +1,2 @@
+class FileUploadError(Exception):
+    pass

--- a/apps/documents/models.py
+++ b/apps/documents/models.py
@@ -147,7 +147,7 @@ class Collection(BaseTeamModel, VersionsMixin):
             new_version.save(update_fields=["openai_vector_store_id"])
 
             # Upload files to vector store
-            index_collection_files(new_version.id, all_files=True)
+            index_collection_files(new_version.id, re_upload_all=True)
 
         return new_version
 
@@ -186,6 +186,15 @@ class Collection(BaseTeamModel, VersionsMixin):
 
         self.files.update(is_archived=True)
         return True
+
+    def has_failed_index_uploads(self) -> bool:
+        """
+        Check if any of the files in this collection failed to upload to an index
+        """
+        return CollectionFile.objects.filter(
+            collection=self,
+            status=FileStatus.FAILED,
+        ).exists()
 
     def _remove_index(self):
         """Remove the index backend"""

--- a/apps/documents/tasks.py
+++ b/apps/documents/tasks.py
@@ -43,12 +43,11 @@ def index_collection_files(collection_id: int, re_upload_all: bool, retry_failed
         The function sets file status to IN_PROGRESS while uploading,
         COMPLETED when done, and FAILED if the upload fails.
     """
-    # TODO: Preload collection files
     collection = Collection.objects.prefetch_related("llm_provider").get(id=collection_id)
     client = collection.llm_provider.get_llm_service().get_raw_client()
     previous_remote_file_ids = []
 
-    queryset = CollectionFile.objects.filter(collection=collection)
+    queryset = CollectionFile.objects.filter(collection=collection).prefetch_related("file")
     if not re_upload_all:
         scope_status = FileStatus.FAILED if retry_failed else FileStatus.PENDING
         queryset = queryset.filter(status=scope_status)

--- a/apps/documents/tests/test_models.py
+++ b/apps/documents/tests/test_models.py
@@ -79,7 +79,7 @@ class TestCollection:
         index_manager_mock.create_vector_store.assert_called_once_with(
             name=f"{new_version.index_name} v{new_version.version_number}"
         )
-        index_collection_files.assert_called_once_with(new_version.id, all_files=True)
+        index_collection_files.assert_called_once_with(new_version.id, re_upload_all=True)
 
     @pytest.mark.parametrize("is_index", [True, False])
     @mock.patch("apps.documents.models.Collection._remove_index")

--- a/apps/documents/tests/test_tasks.py
+++ b/apps/documents/tests/test_tasks.py
@@ -175,20 +175,18 @@ class TestMigrateVectorStores:
             ANY, collection, [col_file_2], chunk_size=1000, chunk_overlap=500, re_upload_all=True
         )
 
-    def test_migration_with_multiple_chunking_strategies(self, collection, index_manager_mock):
+    @patch("apps.documents.tasks.create_files_remote")
+    def test_migration_with_multiple_chunking_strategies(self, create_files_remote, collection, index_manager_mock):
         """Test migration handles multiple files with different chunking strategies"""
         # Create files with different chunking strategies
-        file1 = File.objects.create(name="test1.txt", team=collection.team)
-        file2 = File.objects.create(name="test2.txt", team=collection.team)
-
         CollectionFile.objects.create(
-            file=file1,
+            file=File.objects.create(name="test1.txt", team=collection.team),
             collection=collection,
             status=FileStatus.PENDING,
             metadata={"chunking_strategy": {"chunk_size": 1000, "chunk_overlap": 100}},
         )
         CollectionFile.objects.create(
-            file=file2,
+            file=File.objects.create(name="test2.txt", team=collection.team),
             collection=collection,
             status=FileStatus.PENDING,
             metadata={"chunking_strategy": {"chunk_size": 2000, "chunk_overlap": 200}},

--- a/apps/documents/tests/test_views.py
+++ b/apps/documents/tests/test_views.py
@@ -51,7 +51,7 @@ class TestEditCollection:
             from_llm_provider_id=mock.ANY,
         )
 
-    @mock.patch("apps.documents.views.migrate_vector_stores.delay")
+    @mock.patch("apps.documents.views.tasks.migrate_vector_stores.delay")
     def test_update_collection_without_llm_provider_change(self, migrate_vector_stores_task, collection, client):
         client.force_login(collection.team.members.first())
         url = reverse("documents:collection_edit", args=[collection.team.slug, collection.id])

--- a/apps/documents/urls.py
+++ b/apps/documents/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path(
         "collections/<int:pk>/files/<int:file_id>/delete", views.delete_collection_file, name="delete_collection_file"
     ),
+    path("collections/<int:pk>/retry_failed_uploads", views.retry_failed_uploads, name="retry_failed_uploads"),
 ]
 
 urlpatterns.extend(make_crud_urls(views, "Collection", "collection"))

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -254,3 +254,11 @@ class DeleteCollection(LoginAndTeamRequiredMixin, View, PermissionRequiredMixin)
                 },
             )
             return HttpResponse(response, headers={"HX-Reswap": "none"}, status=400)
+
+
+@require_POST
+@login_and_team_required
+@permission_required("documents.change_collection", raise_exception=True)
+def retry_failed_uploads(request, team_slug: str, pk: int):
+    tasks.index_collection_files_task.delay(pk, retry_failed=True)
+    return redirect("documents:single_collection_home", team_slug=team_slug, pk=pk)

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -3,6 +3,7 @@ import logging
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db import transaction
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -27,8 +28,9 @@ from apps.utils.search import similarity_search
 logger = logging.getLogger("ocs.documents.views")
 
 
-class CollectionHome(LoginAndTeamRequiredMixin, TemplateView):
+class CollectionHome(LoginAndTeamRequiredMixin, TemplateView, PermissionRequiredMixin):
     template_name = "generic/object_home.html"
+    permission_required = "documents.view_collection"
 
     def get_context_data(self, team_slug: str, **kwargs):
         return {
@@ -119,11 +121,12 @@ def delete_collection_file(request, team_slug: str, pk: int, file_id: int):
     return redirect("documents:single_collection_home", team_slug=team_slug, pk=pk)
 
 
-class CollectionTableView(LoginAndTeamRequiredMixin, SingleTableView):
+class CollectionTableView(LoginAndTeamRequiredMixin, SingleTableView, PermissionRequiredMixin):
     model = Collection
     paginate_by = 25
     table_class = CollectionsTable
     template_name = "table/single_table.html"
+    permission_required = "documents.view_collection"
 
     def get_queryset(self):
         queryset = Collection.objects.filter(team=self.request.team, is_version=False).order_by("-created_at")
@@ -139,10 +142,11 @@ class CollectionFormMixin:
         return kwargs
 
 
-class CreateCollection(LoginAndTeamRequiredMixin, CollectionFormMixin, CreateView):
+class CreateCollection(LoginAndTeamRequiredMixin, CollectionFormMixin, CreateView, PermissionRequiredMixin):
     model = Collection
     form_class = CollectionForm
     template_name = "documents/collection_form.html"
+    permission_required = "documents.add_collection"
     extra_context = {
         "title": "Create Collection",
         "button_text": "Create",
@@ -165,10 +169,11 @@ class CreateCollection(LoginAndTeamRequiredMixin, CollectionFormMixin, CreateVie
         return response
 
 
-class EditCollection(LoginAndTeamRequiredMixin, CollectionFormMixin, UpdateView):
+class EditCollection(LoginAndTeamRequiredMixin, CollectionFormMixin, UpdateView, PermissionRequiredMixin):
     model = Collection
     form_class = CollectionForm
     template_name = "documents/collection_form.html"
+    permission_required = "documents.change_collection"
     extra_context = {
         "title": "Update Collection",
         "button_text": "Update",
@@ -202,7 +207,9 @@ class EditCollection(LoginAndTeamRequiredMixin, CollectionFormMixin, UpdateView)
         return response
 
 
-class DeleteCollection(LoginAndTeamRequiredMixin, View):
+class DeleteCollection(LoginAndTeamRequiredMixin, View, PermissionRequiredMixin):
+    permission_required = "documents.delete_collection"
+
     def delete(self, request, team_slug: str, pk: int):
         collection = get_object_or_404(Collection, team__slug=team_slug, id=pk)
 

--- a/templates/documents/single_collection_home.html
+++ b/templates/documents/single_collection_home.html
@@ -44,9 +44,19 @@
     <div class="flex flex-col gap-4">
       <div class="flex justify-between items-center">
         <h2 class="text-lg font-semibold">Files</h2>
-        <button class="btn btn-sm btn-primary" onclick="chooseFilesModal.showModal()">
-          <i class="fa-solid fa-plus"></i> Add Files
-        </button>
+        <div class="join">
+          {% if collection.has_failed_index_uploads %}
+            <form class="join-item" action="{% url 'documents:retry_failed_uploads' team.slug collection.id %}" method="POST">
+              {% csrf_token %}
+              <button class="btn btn-sm btn-primary">
+                <i class="fa-solid fa-repeat"></i> Retry Failed Uploads
+              </button>
+            </form>
+          {% endif %}
+          <button class="join-item btn btn-sm btn-primary" onclick="chooseFilesModal.showModal()">
+            <i class="fa-solid fa-plus"></i> Add Files
+          </button>
+        </div>
       </div>
 
       {% include 'documents/file_upload_modal.html' %}


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Resolves #1580 
User will be able to retry failed uploads.

### Open question
We could catch connection / rate limit erros and tell the user to try again later when they hover over the failed status. For any other errors, we could say something like "Failed to upload due to unexpected error" or something. Do we think this lemon is worth the squeeze?

## User Impact
<!-- Describe the impact of this change on the end-users. -->
User will be able to retry failed uploads

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![demo](https://github.com/user-attachments/assets/b9d587a6-7212-4501-a1bf-7f13ef90db62)

### Docs and Changelog
<!--Link to documentation that has been updated.-->
Pending