### PR TITLE
add category in router node tags

### DIFF
--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -24,6 +24,7 @@ from pydantic_core import PydanticCustomError
 from pydantic_core.core_schema import FieldValidationInfo
 from RestrictedPython import compile_restricted, safe_builtins, safe_globals
 
+from apps.annotations.models import TagCategories
 from apps.assistants.models import OpenAiAssistant
 from apps.chat.agent.tools import get_node_tools
 from apps.chat.conversation import compress_chat_history, compress_pipeline_chat_history
@@ -514,9 +515,9 @@ class RouterMixin(BaseModel):
         """
         return {f"output_{output_num}": keyword for output_num, keyword in enumerate(self.keywords)}
 
-    def get_output_tags(self, selected_route) -> list[str]:
+    def get_output_tags(self, selected_route) -> list[tuple[str, str]]:
         if self.tag_output_message:
-            return [f"{self.name}:{selected_route}"]
+            return [(f"{self.name}:{selected_route}", TagCategories.BOT_RESPONSE)]
         return []
 
 

--- a/apps/pipelines/tests/test_runnable_builder.py
+++ b/apps/pipelines/tests/test_runnable_builder.py
@@ -7,6 +7,7 @@ from django.core import mail
 from django.test import override_settings
 from langchain_core.messages import AIMessage, ToolCall
 
+from apps.annotations.models import TagCategories
 from apps.channels.datamodels import Attachment
 from apps.experiments.models import ParticipantData
 from apps.pipelines.exceptions import PipelineBuildError, PipelineNodeBuildError
@@ -459,7 +460,7 @@ def test_router_sets_tags_correctly(pipeline, experiment_session):
                 messages=["Test message"], experiment_session=experiment_session, temp_state={"route_to": route_to}
             )
         )
-        assert output["output_message_tags"] == [f"static router:{expected_tag}"]
+        assert output["output_message_tags"] == [(f"static router:{expected_tag}", TagCategories.BOT_RESPONSE)]
 
     _check_routing_and_tags("first", "first")
     _check_routing_and_tags("second", "second")


### PR DESCRIPTION
## Description
Fixes [this exception](https://dimagi.sentry.io/issues/6624535451/?referrer=issue_alert-slack&notification_uuid=0c9f33d1-8687-4afc-b760-2bf2d016607f&alert_rule_id=14063560&alert_type=issue)
Tag category was missing from output_messge_tags in router node.

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
