### PR TITLE
Catch any exception when linking fails

### DIFF
--- a/apps/documents/tasks.py
+++ b/apps/documents/tasks.py
@@ -6,7 +6,7 @@ import openai
 from celery.app import shared_task
 from taskbadger.celery import Task as TaskbadgerTask
 
-from apps.assistants.sync import OpenAiSyncError, create_files_remote
+from apps.assistants.sync import create_files_remote
 from apps.documents.models import Collection, CollectionFile, FileStatus
 from apps.service_providers.models import LlmProvider
 
@@ -106,7 +106,7 @@ def _upload_files_to_vector_store(
             chunk_overlap=chunk_overlap,
         )
 
-    except OpenAiSyncError:
+    except Exception:
         logger.exception(
             "Failed to link files to vector store",
             extra={


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Handles [this type of error](https://dimagi.sentry.io/issues/6626215373/?alert_rule_id=14063560&alert_type=issue&notification_uuid=45c1228c-462c-453f-adc4-655578e50b19&project=4505001320316928&referrer=issue_alert-slack)

## User Impact
<!-- Describe the impact of this change on the end-users. -->
This should put the file in a failed state so that users can see it failed

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
N/A