### PR TITLE
Tiny refactor

### DIFF
--- a/apps/chat/conversation.py
+++ b/apps/chat/conversation.py
@@ -298,6 +298,7 @@ def summarize_history(llm, history, max_token_limit, input_message_tokens, summa
                 summary, summary_token_limit = _reduce_summary_size(llm, summary, summary_token_limit)
         else:
             summary = ""
+            summary_tokens = 0
 
     return history, pruned_memory, summary
 

--- a/apps/chat/conversation.py
+++ b/apps/chat/conversation.py
@@ -294,7 +294,7 @@ def summarize_history(llm, history, max_token_limit, input_message_tokens, summa
 
         if summary := _get_new_summary(llm, pruned_memory, summary, model_token_limit=max_token_limit):
             summary_tokens = llm.get_num_tokens_from_messages([SystemMessage(content=summary)])
-            if summary and summary_tokens > summary_token_limit:
+            if summary_tokens > summary_token_limit:
                 summary, summary_token_limit = _reduce_summary_size(llm, summary, summary_token_limit)
         else:
             summary = ""

--- a/apps/chat/conversation.py
+++ b/apps/chat/conversation.py
@@ -292,10 +292,12 @@ def summarize_history(llm, history, max_token_limit, input_message_tokens, summa
         # Generate a new summary after pruning messages
         summary_token_limit = max_token_limit - history_tokens - input_message_tokens
 
-        summary = _get_new_summary(llm, pruned_memory, summary, model_token_limit=max_token_limit)
-        summary_tokens = llm.get_num_tokens_from_messages([SystemMessage(content=summary)])
-        if summary and summary_tokens > summary_token_limit:
-            summary, summary_token_limit = _reduce_summary_size(llm, summary, summary_token_limit)
+        if summary := _get_new_summary(llm, pruned_memory, summary, model_token_limit=max_token_limit):
+            summary_tokens = llm.get_num_tokens_from_messages([SystemMessage(content=summary)])
+            if summary and summary_tokens > summary_token_limit:
+                summary, summary_token_limit = _reduce_summary_size(llm, summary, summary_token_limit)
+        else:
+            summary = ""
 
     return history, pruned_memory, summary
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Should resolve [this issue](https://dimagi.sentry.io/issues/6644432134/?alert_rule_id=14063560&alert_type=issue&notification_uuid=10e8ac32-b6b0-4eb0-86b7-a3622fe8b973&project=4505001320316928&referrer=digest-slack). The issue here is the fact that Anthropic complains when we're trying to count tokens for an emtpy message. What I did was to not try and get summary tokens when there isn't a summary

## User Impact
<!-- Describe the impact of this change on the end-users. -->
No real impact

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
N/A