### PR TITLE
Chatbots Default Homepage

### DIFF
--- a/apps/web/views.py
+++ b/apps/web/views.py
@@ -11,6 +11,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.debug import sensitive_post_parameters
 from health_check.views import MainView
+from waffle import flag_is_active
 
 from apps.teams.decorators import check_superuser_team_access, login_and_team_required
 from apps.teams.models import Membership, Team
@@ -26,6 +27,8 @@ def home(request):
     if request.user.is_authenticated:
         team = request.team
         if team:
+            if flag_is_active(request, "flag_chatbots"):
+                return HttpResponseRedirect(reverse("chatbots:chatbots_home", args=[team.slug]))
             return HttpResponseRedirect(reverse("experiments:experiments_home", args=[team.slug]))
         else:
             messages.info(


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
resolves [#1696](https://github.com/dimagi/open-chat-studio/issues/1696)
if chatbots flag is active, redirect to chatbots home as homepage

## User Impact
<!-- Describe the impact of this change on the end-users. -->
only for teams where the flag is enabled

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
n/a
### Docs and Changelog
<!--Link to documentation that has been updated.-->
[yes to changelog](https://github.com/dimagi/open-chat-studio-docs/pull/109)
