### PR TITLE
feat: Add "Create from assistant" feature for RAG collections

### DIFF
--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -410,10 +410,10 @@ def remove_files_from_tool(ocs_resource: ToolResources, files: list[int]):
     """
     client = ocs_resource.assistant.llm_provider.get_llm_service().get_raw_client()
 
-    for file in files:
-        # Remove the link to the tool resource
-        ocs_resource.files.through.objects.get(file=file).delete()
+    # Remove the link to the tool resource
+    ocs_resource.files.through.objects.filter(file__in=files).delete()
 
+    for file in files:
         if ocs_resource.tool_type == "file_search" and file.is_used():
             if ocs_resource.extra["vector_store_id"] and file.external_id:
                 index_manager = OpenAIVectorStoreManager(client)

--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -414,8 +414,8 @@ def remove_files_from_tool(ocs_resource: ToolResources, files: list[int]):
     ocs_resource.files.through.objects.filter(file__in=files).delete()
 
     for file in files:
-        if ocs_resource.tool_type == "file_search" and file.is_used():
-            if ocs_resource.extra["vector_store_id"] and file.external_id:
+        if file.is_used():
+            if ocs_resource.extra.get("vector_store_id") and file.external_id:
                 index_manager = OpenAIVectorStoreManager(client)
                 index_manager.delete_file(
                     vector_store_id=ocs_resource.extra["vector_store_id"], file_id=file.external_id

--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -232,6 +232,7 @@ def _get_files_to_delete(team, tool_resource_id):
     """Get files linked to the tool resource that are not referenced by any other tool resource or collection."""
     files_with_single_reference = (
         ToolResources.files.through.objects.filter(toolresources__assistant__team=team)
+        .values("file")
         .annotate(count=Count("toolresources"))
         .filter(count=1)
         .values("file_id")

--- a/apps/assistants/tests/test_delete.py
+++ b/apps/assistants/tests/test_delete.py
@@ -39,7 +39,7 @@ class TestAssistantDeletion:
     def test_files_not_to_delete_when_referenced_by_multiple_resources(self, code_resource):
         all_files = list(code_resource.files.all())
         tool_resource = ToolResources.objects.create(tool_type="file_search", assistant=code_resource.assistant)
-        tool_resource.files.set([all_files[0]])
+        tool_resource.files.add(all_files[0])
 
         # only the second file should be deleted
         files_to_delete = list(_get_files_to_delete(code_resource.assistant.team, code_resource.id))

--- a/apps/assistants/tests/test_sync.py
+++ b/apps/assistants/tests/test_sync.py
@@ -384,13 +384,11 @@ def test_get_files_to_delete():
     collection.files.add(file)
     resource.files.add(file)
 
-    files = [file for file in _get_files_to_delete(team, resource.id)]
-    assert len(files) == 0
+    assert len(list(_get_files_to_delete(team, resource.id))) == 0
 
     collection.files.through.objects.all().delete()  # Clear the collection files
 
-    files = [file for file in _get_files_to_delete(team, resource.id)]
-    assert len(files) == 1
+    assert len(list(_get_files_to_delete(team, resource.id))) == 1
 
 
 class TestVectorStoreManager:

--- a/apps/assistants/views.py
+++ b/apps/assistants/views.py
@@ -15,11 +15,9 @@ from django_tables2 import SingleTableView
 from apps.chat.agent.tools import get_assistant_tools
 from apps.files.views import BaseAddMultipleFilesHtmxView
 from apps.generics import actions
-from apps.service_providers.llm_service.index_managers import OpenAIVectorStoreManager
 from apps.service_providers.models import LlmProvider
 from apps.service_providers.utils import get_llm_provider_choices
 from apps.teams.mixins import LoginAndTeamRequiredMixin
-from apps.utils.deletion import get_related_m2m_objects
 from apps.utils.tables import render_table_row
 
 from ..files.models import File
@@ -29,11 +27,11 @@ from .forms import ImportAssistantForm, OpenAiAssistantForm, ToolResourceFileFor
 from .models import OpenAiAssistant, ToolResources
 from .sync import (
     OpenAiSyncError,
-    delete_file_from_openai,
     get_diff_with_openai_assistant,
     get_out_of_sync_files,
     import_openai_assistant,
     push_assistant_to_openai,
+    remove_files_from_tool,
     sync_from_openai,
 )
 from .tables import OpenAiAssistantTable
@@ -334,17 +332,7 @@ class DeleteFileFromAssistant(LoginAndTeamRequiredMixin, View, PermissionRequire
             assistant_id=self.kwargs["pk"],
             id=self.kwargs["resource_id"],
         )
-
-        resource.files.through.objects.filter(file_id=file.id).delete()
-
-        client = resource.assistant.llm_provider.get_llm_service().get_raw_client()
-        if file not in get_related_m2m_objects([file]):
-            # The file doesn't have related objects, so it's safe to remove it
-            delete_file_from_openai(client, file)
-            file.delete()
-        else:
-            index_manager = OpenAIVectorStoreManager(client)
-            index_manager.delete_file(vector_store_id=resource.extra["vector_store_id"], file_id=file.external_id)
+        remove_files_from_tool(resource, files=[file])
 
         messages.success(self.request, "File Deleted")
         return HttpResponse()

--- a/apps/documents/models.py
+++ b/apps/documents/models.py
@@ -205,17 +205,18 @@ class Collection(BaseTeamModel, VersionsMixin):
             return False
 
         super().archive()
-        if self.is_index and self.openai_vector_store_id:
-            self._remove_index()
 
         files = list(self.files.all())
-
         # Remove the references to the files in the collection
         CollectionFile.objects.filter(collection=self).delete()
 
         # Cleanup conditionally
         files_with_references = get_related_m2m_objects(files)
-        unused_file_ids = [file.id for file in files if file not in files_with_references]
+        unused_files = [file for file in files if file not in files_with_references]
+        unused_file_ids = [file.id for file in unused_files]
+
+        if self.is_index and self.openai_vector_store_id:
+            self._remove_index(unused_files)
 
         File.objects.filter(id__in=unused_file_ids).update(is_archived=True)
         return True
@@ -238,11 +239,11 @@ class Collection(BaseTeamModel, VersionsMixin):
             status__in=[FileStatus.PENDING, FileStatus.IN_PROGRESS],
         ).exists()
 
-    def _remove_index(self):
+    def _remove_index(self, remote_files_to_remove: list[File]):
         """Remove the index backend"""
         manager = self.llm_provider.get_index_manager()
         manager.delete_vector_store(self.openai_vector_store_id, fail_silently=True)
-        manager.delete_files(self.files.all())
+        manager.delete_files(remote_files_to_remove)
 
         self.openai_vector_store_id = ""
         self.save(update_fields=["openai_vector_store_id"])

--- a/apps/documents/tasks.py
+++ b/apps/documents/tasks.py
@@ -196,7 +196,6 @@ def create_collection_from_assistant_task(collection_id: int, assistant_id: int)
 
         # Link files to the new vector store at OpenAI (only if there are files with external IDs)
         if file_with_remote_ids:
-            # TODO: Figure out the chunking strategy for these files
             manager.link_files_to_vector_store(
                 vector_store_id=collection.openai_vector_store_id,
                 file_ids=[file.external_id for file in file_with_remote_ids],

--- a/apps/documents/tasks.py
+++ b/apps/documents/tasks.py
@@ -7,9 +7,10 @@ from celery.app import shared_task
 from django.db.models import QuerySet
 from taskbadger.celery import Task as TaskbadgerTask
 
+from apps.assistants.models import OpenAiAssistant
 from apps.assistants.sync import create_files_remote
 from apps.documents.exceptions import FileUploadError
-from apps.documents.models import ChunkingStrategy, Collection, CollectionFile, FileStatus
+from apps.documents.models import ChunkingStrategy, Collection, CollectionFile, CollectionFileMetadata, FileStatus
 from apps.service_providers.models import LlmProvider
 
 logger = logging.getLogger("ocs.documents.tasks.link_files_to_index")
@@ -152,3 +153,70 @@ def _ensure_remote_file_exists(client, collection_file: CollectionFile, re_uploa
             },
         )
         raise FileUploadError() from None
+
+
+@shared_task(base=TaskbadgerTask, ignore_result=True)
+def create_collection_from_assistant_task(collection_id: int, assistant_id: int):
+    """Create a collection from an assistant's file search resources"""
+    # Get file search resources from the assistant
+    collection = Collection.objects.get(id=collection_id)
+    assistant = OpenAiAssistant.objects.get(id=assistant_id)
+    file_search_resource = assistant.tool_resources.filter(tool_type="file_search").first()
+
+    if not file_search_resource:
+        # This will never happen, but just in case
+        return
+
+    # Add files to the collection
+    # Create CollectionFile entries
+    collection_files = []
+    file_with_remote_ids = []
+    file_without_remote_ids = []
+    for file in file_search_resource.files.all():
+        if file.external_id:
+            file_with_remote_ids.append(file)
+        else:
+            file_without_remote_ids.append(file)
+
+        collection_files.append(
+            CollectionFile(
+                collection=collection,
+                file=file,
+                status=FileStatus.PENDING,
+                metadata=CollectionFileMetadata(chunking_strategy=ChunkingStrategy(chunk_size=800, chunk_overlap=400)),
+            )
+        )
+    CollectionFile.objects.bulk_create(collection_files)
+
+    try:
+        # Create vector store for the collection
+        manager = collection.llm_provider.get_index_manager()
+        collection.openai_vector_store_id = manager.create_vector_store(name=collection.index_name)
+        collection.save(update_fields=["openai_vector_store_id"])
+
+        # Link files to the new vector store at OpenAI (only if there are files with external IDs)
+        if file_with_remote_ids:
+            # TODO: Figure out the chunking strategy for these files
+            manager.link_files_to_vector_store(
+                vector_store_id=collection.openai_vector_store_id,
+                file_ids=[file.external_id for file in file_with_remote_ids],
+            )
+            # Update status to completed for successfully linked files
+            CollectionFile.objects.filter(collection=collection, file__in=file_with_remote_ids).update(
+                status=FileStatus.COMPLETED
+            )
+
+    except Exception as e:
+        logger.error(f"Failed to link files to vector store: {e}")
+        # Mark files as failed
+        if file_with_remote_ids:
+            CollectionFile.objects.filter(collection=collection, file__in=file_with_remote_ids).update(
+                status=FileStatus.FAILED
+            )
+
+    # Index files that don't have external IDs
+    if file_without_remote_ids:
+        file_ids_to_index = list(
+            CollectionFile.objects.filter(file__in=file_without_remote_ids).values_list("id", flat=True)
+        )
+        index_collection_files_task(collection_file_ids=file_ids_to_index)

--- a/apps/documents/tests/test_models.py
+++ b/apps/documents/tests/test_models.py
@@ -133,7 +133,7 @@ class TestCollection:
         collection.files.add(file)
 
         # Invoke the remove_index method
-        collection._remove_index()
+        collection._remove_index([file])
 
         # Check that the vector store ID is cleared and the index is removed
         assert collection.openai_vector_store_id == ""

--- a/apps/documents/tests/test_views.py
+++ b/apps/documents/tests/test_views.py
@@ -4,6 +4,7 @@ import pytest
 from django.urls import reverse
 
 from apps.documents.models import Collection, CollectionFile, FileStatus
+from apps.files.models import File
 from apps.utils.factories.documents import CollectionFactory
 from apps.utils.factories.files import FileFactory
 from apps.utils.factories.pipelines import NodeFactory, PipelineFactory
@@ -129,3 +130,94 @@ class TestDeleteCollection:
         assert response.status_code == 200
         collection.refresh_from_db()
         assert collection.is_archived
+
+
+@pytest.mark.django_db()
+class TestDeleteCollectionFile:
+    @pytest.fixture()
+    def team_with_user(self):
+        return TeamWithUsersFactory()
+
+    def test_delete_file_from_non_indexed_collection(self, team_with_user, client):
+        """Test deleting a file from a non-indexed collection when file is not used elsewhere."""
+        collection = CollectionFactory(team=team_with_user, is_index=False)
+        file = FileFactory(team=team_with_user, external_id="file-123", external_source="openai")
+        CollectionFile.objects.create(collection=collection, file=file)
+
+        client.force_login(team_with_user.members.first())
+
+        # Mock the file deletion since it's not used elsewhere
+        with mock.patch.object(File, "delete_or_archive") as mock_delete_archive:
+            url = reverse("documents:delete_collection_file", args=[team_with_user.slug, collection.id, file.id])
+            client.post(url)
+
+            # Verify collection file relationship is deleted
+            assert not CollectionFile.objects.filter(collection=collection, file=file).exists()
+
+            # Verify file is deleted/archived since it's not used elsewhere
+            mock_delete_archive.assert_called_once()
+
+    @mock.patch("apps.documents.views.delete_file_from_openai")
+    def test_delete_file_from_indexed_collection_not_used_by_assistant(
+        self, mock_delete_openai, team_with_user, client, index_manager_mock
+    ):
+        """Test deleting a file from an indexed collection when file is not used by an assistant."""
+        llm_provider = LlmProviderFactory(team=team_with_user)
+        collection = CollectionFactory(
+            team=team_with_user, is_index=True, llm_provider=llm_provider, openai_vector_store_id="vs-123"
+        )
+        file = FileFactory(team=team_with_user, external_id="file-123", external_source="openai")
+        CollectionFile.objects.create(collection=collection, file=file)
+
+        client.force_login(team_with_user.members.first())
+
+        # Mock the file as not being used elsewhere
+        with mock.patch.object(File, "delete_or_archive") as mock_delete_archive:
+            url = reverse("documents:delete_collection_file", args=[team_with_user.slug, collection.id, file.id])
+            client.post(url)
+
+            # Verify collection file relationship is deleted
+            assert CollectionFile.objects.filter(collection=collection, file=file).exists() is False
+
+            # Verify OpenAI file deletion was called for indexed collection
+            mock_delete_openai.assert_called_once()
+
+            # Verify file is deleted/archived since it's not used elsewhere
+            mock_delete_archive.assert_called_once()
+
+    @mock.patch("apps.documents.views.delete_file_from_openai")
+    def test_delete_file_from_indexed_collection_used_by_assistant(
+        self, mock_delete_openai, team_with_user, client, index_manager_mock
+    ):
+        """Test deleting a file from an indexed collection when file is also used by another object."""
+        # Setup: Create indexed collection with file
+        llm_provider = LlmProviderFactory(team=team_with_user)
+        collection = CollectionFactory(
+            team=team_with_user, is_index=True, llm_provider=llm_provider, openai_vector_store_id="vs-123"
+        )
+        file = FileFactory(team=team_with_user, external_id="file-123", external_source="openai")
+        CollectionFile.objects.create(collection=collection, file=file)
+
+        # Login user
+        client.force_login(team_with_user.members.first())
+
+        # Mock the file as being used elsewhere (by assistant)
+        with (
+            mock.patch.object(File, "is_used", return_value=True),
+            mock.patch.object(File, "delete_or_archive") as mock_delete_archive,
+        ):
+            url = reverse("documents:delete_collection_file", args=[team_with_user.slug, collection.id, file.id])
+            client.post(url)
+
+            # Verify collection file relationship is deleted
+            assert CollectionFile.objects.filter(collection=collection, file=file).exists() is False
+
+            # Verify file is NOT deleted/archived since it's used by assistant
+            mock_delete_archive.assert_not_called()
+
+            # Verify OpenAI file deletion was NOT called since file is still used
+            mock_delete_openai.assert_not_called()
+
+            # Verify file still exists and is still linked to assistant
+            file.refresh_from_db()
+            assert file.is_archived is False

--- a/apps/documents/urls.py
+++ b/apps/documents/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
         "collections/<int:pk>/files/<int:file_id>/delete", views.delete_collection_file, name="delete_collection_file"
     ),
     path("collections/<int:pk>/retry_failed_uploads", views.retry_failed_uploads, name="retry_failed_uploads"),
+    path("collections/create-from-assistant", views.CreateCollectionFromAssistant.as_view(), name="create_from_assistant"),
 ]
 
 urlpatterns.extend(make_crud_urls(views, "Collection", "collection"))

--- a/apps/documents/urls.py
+++ b/apps/documents/urls.py
@@ -12,7 +12,9 @@ urlpatterns = [
         "collections/<int:pk>/files/<int:file_id>/delete", views.delete_collection_file, name="delete_collection_file"
     ),
     path("collections/<int:pk>/retry_failed_uploads", views.retry_failed_uploads, name="retry_failed_uploads"),
-    path("collections/create-from-assistant", views.CreateCollectionFromAssistant.as_view(), name="create_from_assistant"),
+    path(
+        "collections/create-from-assistant", views.CreateCollectionFromAssistant.as_view(), name="create_from_assistant"
+    ),
 ]
 
 urlpatterns.extend(make_crud_urls(views, "Collection", "collection"))

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -304,16 +304,7 @@ class CreateCollectionFromAssistant(LoginAndTeamRequiredMixin, FormView, Permiss
         # Get file search resources from the assistant
         file_search_resources = assistant.tool_resources.filter(tool_type="file_search")
 
-        if not file_search_resources.exists():
-            messages.error(self.request, "The selected assistant does not have any file search resources.")
-            return self.form_invalid(form)
-
         try:
-            # Check for existing collection with same name
-            if Collection.objects.filter(team=self.request.team, name=collection_name, is_version=False).exists():
-                messages.error(self.request, f"A collection with the name '{collection_name}' already exists.")
-                return self.form_invalid(form)
-
             # Create the collection
             collection = Collection.objects.create(
                 team=self.request.team,

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -42,6 +42,7 @@ class CollectionHome(LoginAndTeamRequiredMixin, TemplateView, PermissionRequired
             "new_object_url": reverse("documents:collection_new", args=[team_slug]),
             "table_url": reverse("documents:collection_table", args=[team_slug]),
             "enable_search": True,
+            "button_style": "btn-primary",
             "actions": [
                 actions.Action(
                     "documents:create_from_assistant",

--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -13,6 +13,7 @@ from apps.experiments.versioning import VersionDetails, VersionField, VersionsMi
 from apps.generics.chips import Chip
 from apps.teams.models import BaseTeamModel
 from apps.utils.conversions import bytes_to_megabytes
+from apps.utils.deletion import get_related_m2m_objects
 from apps.web.meta import absolute_url
 
 
@@ -158,6 +159,10 @@ class File(BaseTeamModel, VersionsMixin):
             self.archive()
         else:
             self.delete()
+
+    def is_used(self) -> bool:
+        # get_related_m2m_objects returns a dictionary with the file instance as the key if there are related objects
+        return self in get_related_m2m_objects([self])
 
 
 class FileChunkEmbedding(BaseTeamModel):

--- a/apps/files/tables.py
+++ b/apps/files/tables.py
@@ -10,7 +10,6 @@ class FilesTable(tables.Table):
     actions = actions.ActionsColumn(
         actions=[
             actions.edit_action(url_name="files:file_edit"),
-            actions.delete_action(url_name="files:file_delete", confirm_message="Are you sure?"),
         ]
     )
 

--- a/templates/documents/collection_form.html
+++ b/templates/documents/collection_form.html
@@ -23,8 +23,14 @@
     <div x-cloak x-show="isIndex">
       {% render_field form.llm_provider xmodel="llmProvider" %}
       {% if form.instance.id %}
-        <div role="alert" class="mt-2 alert alert-warning alert-soft" x-cloak x-show="currentProvider !== llmProvider">
-          <span>Changing the LLM provider will create a new vector store and remove the old vector store. This might take a while. Continue with caution</span>
+        <div role="alert" class="bg-base-200 rounded-lg alert alert-warning alert-soft flex flex-col" x-cloak x-show="currentProvider !== llmProvider">
+          <h3 class="font-semibold mb-2">Continue with caution! Changing the LLM provider will</h3>
+          <ul class="w-full list-disc list-inside space-y-1 text-sm">
+            <li>Remove the current vector store</li>
+            <li>Create a new vector store at the new provider</li>
+            <li>Re-upload the files to the new vector store</li>
+            <li>If this collection was created from an assistant, this operation might break the assistant</li>
+          </ul>
         </div>
       {% endif %}
     </div>

--- a/templates/documents/create_from_assistant_form.html
+++ b/templates/documents/create_from_assistant_form.html
@@ -1,78 +1,78 @@
 {% extends 'web/app/app_base.html' %}
 {% load i18n %}
-{% load django_bootstrap5 %}
+{% load form_tags %}
 
 {% block app %}
-<div class="app-card">
-  <div class="grid grid-cols-6">
-    <div class="col-span-5">
-      <h1 class="pg-title">{{ title }}</h1>
-      <span class="text-neutral-500">Create an indexed collection from an OpenAI assistant's file search tools</span>
+  <div class="app-card">
+    <div class="grid grid-cols-6">
+      <div class="col-span-5">
+        <h1 class="pg-title">{{ title }}</h1>
+        <span class="text-neutral-500">Create an indexed collection from an OpenAI assistant's file search tools</span>
+      </div>
+    </div>
+
+    <hr class="my-4">
+
+    <form method="post" class="space-y-4">
+      {% csrf_token %}
+
+      <div class="grid grid-cols-1 gap-4">
+        <div class="form-control w-full">
+          <label class="label" for="{{ form.assistant.id_for_label }}">
+            <span class="label-text">{{ form.assistant.label }}</span>
+          </label>
+          {{ form.assistant }}
+          {% if form.assistant.help_text %}
+            <label class="label">
+              <span class="label-text-alt">{{ form.assistant.help_text }}</span>
+            </label>
+          {% endif %}
+          {% if form.assistant.errors %}
+            <label class="label">
+              <span class="label-text-alt text-error">{{ form.assistant.errors.0 }}</span>
+            </label>
+          {% endif %}
+        </div>
+
+        <div class="form-control w-full">
+          <label class="label" for="{{ form.collection_name.id_for_label }}">
+            <span class="label-text">{{ form.collection_name.label }}</span>
+          </label>
+          {{ form.collection_name }}
+          {% if form.collection_name.help_text %}
+            <label class="label">
+              <span class="label-text-alt">{{ form.collection_name.help_text }}</span>
+            </label>
+          {% endif %}
+          {% if form.collection_name.errors %}
+            <label class="label">
+              <span class="label-text-alt text-error">{{ form.collection_name.errors.0 }}</span>
+            </label>
+          {% endif %}
+        </div>
+      </div>
+
+      {% if form.non_field_errors %}
+        <div class="alert alert-error">
+          {{ form.non_field_errors }}
+        </div>
+      {% endif %}
+
+      <div class="flex justify-end space-x-2 pt-4">
+        <a href="{% url 'documents:collection_home' team.slug %}" class="btn btn-outline">Cancel</a>
+        <button type="submit" class="btn btn-primary">{{ button_text }}</button>
+      </div>
+    </form>
+
+    <div class="mt-6 p-4 bg-base-200 rounded-lg">
+      <h3 class="font-semibold mb-2">What happens when you create a collection from an assistant?</h3>
+      <ul class="list-disc list-inside space-y-1 text-sm">
+        <li>A new indexed collection will be created using the same LLM provider as the assistant</li>
+        <li>All files from the assistant's file search tools will be copied to the new collection</li>
+        <li>A new vector store will be created at OpenAI for the collection</li>
+        <li>The assistant's original vector store and files remain unchanged</li>
+        <li>The collection can be used independently for RAG and document search</li>
+      </ul>
     </div>
   </div>
-  
-  <hr class="my-4">
-
-  <form method="post" class="space-y-4">
-    {% csrf_token %}
-    
-    <div class="grid grid-cols-1 gap-4">
-      <div class="form-control w-full">
-        <label class="label" for="{{ form.assistant.id_for_label }}">
-          <span class="label-text">{{ form.assistant.label }}</span>
-        </label>
-        {{ form.assistant }}
-        {% if form.assistant.help_text %}
-          <label class="label">
-            <span class="label-text-alt">{{ form.assistant.help_text }}</span>
-          </label>
-        {% endif %}
-        {% if form.assistant.errors %}
-          <label class="label">
-            <span class="label-text-alt text-error">{{ form.assistant.errors.0 }}</span>
-          </label>
-        {% endif %}
-      </div>
-
-      <div class="form-control w-full">
-        <label class="label" for="{{ form.collection_name.id_for_label }}">
-          <span class="label-text">{{ form.collection_name.label }}</span>
-        </label>
-        {{ form.collection_name }}
-        {% if form.collection_name.help_text %}
-          <label class="label">
-            <span class="label-text-alt">{{ form.collection_name.help_text }}</span>
-          </label>
-        {% endif %}
-        {% if form.collection_name.errors %}
-          <label class="label">
-            <span class="label-text-alt text-error">{{ form.collection_name.errors.0 }}</span>
-          </label>
-        {% endif %}
-      </div>
-    </div>
-
-    {% if form.non_field_errors %}
-      <div class="alert alert-error">
-        {{ form.non_field_errors }}
-      </div>
-    {% endif %}
-
-    <div class="flex justify-end space-x-2 pt-4">
-      <a href="{% url 'documents:collection_home' team.slug %}" class="btn btn-outline">Cancel</a>
-      <button type="submit" class="btn btn-primary">{{ button_text }}</button>
-    </div>
-  </form>
-
-  <div class="mt-6 p-4 bg-base-200 rounded-lg">
-    <h3 class="font-semibold mb-2">What happens when you create a collection from an assistant?</h3>
-    <ul class="list-disc list-inside space-y-1 text-sm">
-      <li>A new indexed collection will be created using the same LLM provider as the assistant</li>
-      <li>All files from the assistant's file search tools will be copied to the new collection</li>
-      <li>A new vector store will be created at OpenAI for the collection</li>
-      <li>The assistant's original vector store and files remain unchanged</li>
-      <li>The collection can be used independently for RAG and document search</li>
-    </ul>
-  </div>
-</div>
 {% endblock %}

--- a/templates/documents/create_from_assistant_form.html
+++ b/templates/documents/create_from_assistant_form.html
@@ -1,0 +1,78 @@
+{% extends 'web/app/app_base.html' %}
+{% load i18n %}
+{% load django_bootstrap5 %}
+
+{% block app %}
+<div class="app-card">
+  <div class="grid grid-cols-6">
+    <div class="col-span-5">
+      <h1 class="pg-title">{{ title }}</h1>
+      <span class="text-neutral-500">Create an indexed collection from an OpenAI assistant's file search tools</span>
+    </div>
+  </div>
+  
+  <hr class="my-4">
+
+  <form method="post" class="space-y-4">
+    {% csrf_token %}
+    
+    <div class="grid grid-cols-1 gap-4">
+      <div class="form-control w-full">
+        <label class="label" for="{{ form.assistant.id_for_label }}">
+          <span class="label-text">{{ form.assistant.label }}</span>
+        </label>
+        {{ form.assistant }}
+        {% if form.assistant.help_text %}
+          <label class="label">
+            <span class="label-text-alt">{{ form.assistant.help_text }}</span>
+          </label>
+        {% endif %}
+        {% if form.assistant.errors %}
+          <label class="label">
+            <span class="label-text-alt text-error">{{ form.assistant.errors.0 }}</span>
+          </label>
+        {% endif %}
+      </div>
+
+      <div class="form-control w-full">
+        <label class="label" for="{{ form.collection_name.id_for_label }}">
+          <span class="label-text">{{ form.collection_name.label }}</span>
+        </label>
+        {{ form.collection_name }}
+        {% if form.collection_name.help_text %}
+          <label class="label">
+            <span class="label-text-alt">{{ form.collection_name.help_text }}</span>
+          </label>
+        {% endif %}
+        {% if form.collection_name.errors %}
+          <label class="label">
+            <span class="label-text-alt text-error">{{ form.collection_name.errors.0 }}</span>
+          </label>
+        {% endif %}
+      </div>
+    </div>
+
+    {% if form.non_field_errors %}
+      <div class="alert alert-error">
+        {{ form.non_field_errors }}
+      </div>
+    {% endif %}
+
+    <div class="flex justify-end space-x-2 pt-4">
+      <a href="{% url 'documents:collection_home' team.slug %}" class="btn btn-outline">Cancel</a>
+      <button type="submit" class="btn btn-primary">{{ button_text }}</button>
+    </div>
+  </form>
+
+  <div class="mt-6 p-4 bg-base-200 rounded-lg">
+    <h3 class="font-semibold mb-2">What happens when you create a collection from an assistant?</h3>
+    <ul class="list-disc list-inside space-y-1 text-sm">
+      <li>A new indexed collection will be created using the same LLM provider as the assistant</li>
+      <li>All files from the assistant's file search tools will be copied to the new collection</li>
+      <li>A new vector store will be created at OpenAI for the collection</li>
+      <li>The assistant's original vector store and files remain unchanged</li>
+      <li>The collection can be used independently for RAG and document search</li>
+    </ul>
+  </div>
+</div>
+{% endblock %}

--- a/templates/documents/create_from_assistant_form.html
+++ b/templates/documents/create_from_assistant_form.html
@@ -16,41 +16,7 @@
     <form method="post" class="space-y-4">
       {% csrf_token %}
 
-      <div class="grid grid-cols-1 gap-4">
-        <div class="form-control w-full">
-          <label class="label" for="{{ form.assistant.id_for_label }}">
-            <span class="label-text">{{ form.assistant.label }}</span>
-          </label>
-          {{ form.assistant }}
-          {% if form.assistant.help_text %}
-            <label class="label">
-              <span class="label-text-alt">{{ form.assistant.help_text }}</span>
-            </label>
-          {% endif %}
-          {% if form.assistant.errors %}
-            <label class="label">
-              <span class="label-text-alt text-error">{{ form.assistant.errors.0 }}</span>
-            </label>
-          {% endif %}
-        </div>
-
-        <div class="form-control w-full">
-          <label class="label" for="{{ form.collection_name.id_for_label }}">
-            <span class="label-text">{{ form.collection_name.label }}</span>
-          </label>
-          {{ form.collection_name }}
-          {% if form.collection_name.help_text %}
-            <label class="label">
-              <span class="label-text-alt">{{ form.collection_name.help_text }}</span>
-            </label>
-          {% endif %}
-          {% if form.collection_name.errors %}
-            <label class="label">
-              <span class="label-text-alt text-error">{{ form.collection_name.errors.0 }}</span>
-            </label>
-          {% endif %}
-        </div>
-      </div>
+      {% render_form_fields form "assistant" "collection_name" %}
 
       {% if form.non_field_errors %}
         <div class="alert alert-error">

--- a/templates/generic/object_home_content.html
+++ b/templates/generic/object_home_content.html
@@ -14,7 +14,7 @@
       <span class="text-neutral-500">{{ subtitle }}</span>
     </div>
     {% if allow_new|default_if_none:True or actions %}
-      <div class="justify-self-end">
+      <div class="justify-self-end join">
         {% if allow_new|default_if_none:True %}
           <a class="btn btn-sm {{ button_style|default:"btn-primary" }}"
              href="{{ new_object_url }}">Add new


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Fixes #1669
Generated with [Claude Code](https://claude.ai/code)

Implements the ability to create indexed collections from OpenAI assistants' file search tools.

#### Please note!
I took the approach of linking the same File record to the collection that the assistant is using. The has the edge case where if the user created a collection from an assistant and then change the collection's provider, it will break the assistant in that the file's external ids are updated to point to the new collection provider's remote ids. I updated the warning banner to make mention of this. Happy to discuss alternatives.

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
https://www.loom.com/share/d2c9de75e6824e9ca0a639d617717105?sid=b5721e14-1ce5-4ea6-8e97-2376bcb3ceaf

#### The updated banner
![image](https://github.com/user-attachments/assets/2e3e2a7f-3e9f-4066-963f-6ac164008c82)

### Docs and Changelog
<!--Link to documentation that has been updated.-->
Pending
