### PR TITLE
enable database connection pooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 SECRET_KEY='LTwzPMJVLeRNOjoLxqHidKWhfoOtjzYawyaGCezb'
 
 ## Database
-
 DATABASE_URL='postgres://postgres:postgres@localhost:5432/gpt_playground'
 
 ### Alternate database settings
@@ -10,6 +9,11 @@ DATABASE_URL='postgres://postgres:postgres@localhost:5432/gpt_playground'
 # DJANGO_DATABASE_PASSWORD=
 # DJANGO_DATABASE_HOST=
 # DJANGO_DATABASE_PORT=
+
+# Database pool settings
+# DJANGO_DATABASE_POOL_MIN_SIZE=
+# DJANGO_DATABASE_POOL_MAX_SIZE=
+# DJANGO_DATABASE_POOL_TIMEOUT=
 
 ## Cache & Celery queues
 

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -201,6 +201,7 @@ else:
     }
 
 db_options = DATABASES["default"].setdefault("OPTIONS", {})
+db_options.pop("CONN_MAX_AGE", None)  # remove connection age since it's not compatible with connection pooling
 db_options["pool"] = {
     "min_size": env.int("DJANGO_DATABASE_POOL_MIN_SIZE", default=2),
     "max_size": env.int("DJANGO_DATABASE_POOL_MAX_SIZE", default=10),

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -200,7 +200,8 @@ else:
         }
     }
 
-DATABASES["default"]["OPTIONS"]["pool"] = {
+db_options = DATABASES["default"].setdefault("OPTIONS", {})
+db_options["pool"] = {
     "min_size": env.int("DJANGO_DATABASE_POOL_MIN_SIZE", default=2),
     "max_size": env.int("DJANGO_DATABASE_POOL_MAX_SIZE", default=10),
     "timeout": env.int("DJANGO_DATABASE_POOL_TIMEOUT", default=10),

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -200,6 +200,12 @@ else:
         }
     }
 
+DATABASES["default"]["OPTIONS"]["pool"] = {
+    "min_size": env.int("DJANGO_DATABASE_POOL_MIN_SIZE", default=2),
+    "max_size": env.int("DJANGO_DATABASE_POOL_MAX_SIZE", default=10),
+    "timeout": env.int("DJANGO_DATABASE_POOL_TIMEOUT", default=10),
+}
+
 # Auth / login stuff
 
 # Django recommends overriding the user model even if you don't think you need to because it makes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "djangorestframework-api-key",
     "drf-spectacular",
     "fbmessenger",
-    "ffmpeg",  # Audio transcription
+    "ffmpeg", # Audio transcription
     "httpx",
     "jinja2",
     "langchain>=0.3,<0.4",
@@ -51,9 +51,10 @@ dependencies = [
     "openapi_pydantic",
     "pandas",
     "psycopg[binary]",
+    "psycopg-pool>=3.2.6",
     "pyTelegramBotAPI==4.12.0",
     "pydantic",
-    "pydub",  # Audio transcription
+    "pydub", # Audio transcription
     "pypdf",
     "RestrictedPython",
     "sentry-sdk",
@@ -61,7 +62,7 @@ dependencies = [
     "taskbadger",
     "tenacity",
     "tiktoken",
-    "transformers>=4.48.0",  # this is required by the tokenizer that langchain uses
+    "transformers>=4.48.0", # this is required by the tokenizer that langchain uses
     "turn-python>=0.2.0",
     "twilio",
     "whitenoise[brotli]",

--- a/uv.lock
+++ b/uv.lock
@@ -2204,6 +2204,7 @@ dependencies = [
     { name = "pgvector" },
     { name = "phonenumberslite" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "pycryptodome" },
     { name = "pydantic" },
     { name = "pydub" },
@@ -2300,6 +2301,7 @@ requires-dist = [
     { name = "pgvector" },
     { name = "phonenumberslite" },
     { name = "psycopg", extras = ["binary"] },
+    { name = "psycopg-pool", specifier = ">=3.2.6" },
     { name = "pycryptodome" },
     { name = "pydantic" },
     { name = "pydub" },
@@ -2720,6 +2722,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/dd/0ae42c64bf524d1fcf9bf861ab09d331e693ae00e527ba08131b2d3729a3/psycopg_binary-3.2.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4c84fcac8a3a3479ac14673095cc4e1fdba2935499f72c436785ac679bec0d1a", size = 3184097, upload-time = "2024-07-01T03:33:31.268Z" },
     { url = "https://files.pythonhosted.org/packages/dd/f0/09329ebb0cd03e2ee5786fc9914ac904f4965b78627f15826f8258fde734/psycopg_binary-3.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:950fd666ec9e9fe6a8eeb2b5a8f17301790e518953730ad44d715b59ffdbc67f", size = 3228517, upload-time = "2024-07-01T03:33:37.824Z" },
     { url = "https://files.pythonhosted.org/packages/60/2f/979228189adbeb59afce626f1e7c3bf73cc7ff94217099a2ddfd6fd132ff/psycopg_binary-3.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:334046a937bb086c36e2c6889fe327f9f29bfc085d678f70fac0b0618949f674", size = 2911959, upload-time = "2024-07-01T03:33:43.357Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.2.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/13/1e7850bb2c69a63267c3dbf37387d3f71a00fd0e2fa55c5db14d64ba1af4/psycopg_pool-3.2.6.tar.gz", hash = "sha256:0f92a7817719517212fbfe2fd58b8c35c1850cdd2a80d36b581ba2085d9148e5", size = 29770, upload-time = "2025-02-26T12:03:47.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/fd/4feb52a55c1a4bd748f2acaed1903ab54a723c47f6d0242780f4d97104d4/psycopg_pool-3.2.6-py3-none-any.whl", hash = "sha256:5887318a9f6af906d041a0b1dc1c60f8f0dda8340c2572b74e10907b51ed5da7", size = 38252, upload-time = "2025-02-26T12:03:45.073Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Django added support for connection pooling in v5.1: https://docs.djangoproject.com/en/5.1/releases/5.1/#postgresql-connection-pools

`django-environ` doesn't yet support this (https://github.com/joke2k/django-environ/issues/530) so I'm configuring it manually.

I'm hoping this will solve the PG connection errors: [OPEN-CHAT-STUDIO-104](https://dimagi.sentry.io/issues/6658709975/events/9ad27e4189144acdaa9217461760e88f/)