### PR TITLE
move source material, surveys, concent forms, and tags out of experim…

### DIFF
--- a/templates/web/components/team_nav.html
+++ b/templates/web/components/team_nav.html
@@ -9,6 +9,36 @@
         {% translate "Chatbots" %}
       </a>
     </li>
+    <li>
+      <a href="{% url 'experiments:source_material_home' request.team.slug %}"
+         {% if active_tab == 'source_material' %}class="menu-active"{% endif %}>
+        <i class="fa fa-book fa-fw"></i>
+        {% translate "Source Material" %}
+      </a>
+    </li>
+    <li>
+      <a href="{% url 'experiments:survey_home' request.team.slug %}"
+         {% if active_tab == 'survey' %}class="menu-active"{% endif %}>
+        <i class="fa-solid fa-file-circle-question fa-fw"></i>
+        {% translate "Surveys" %}
+      </a>
+    </li>
+    <li>
+      <a href="{% url 'experiments:consent_home' request.team.slug %}"
+         {% if active_tab == 'consent_forms' %}class="menu-active"{% endif %}>
+        <i class="fa-solid fa-file-contract fa-fw"></i>
+        {% translate "Consent Forms" %}
+      </a>
+    </li>
+    {% if perms.annotations.add_tag %}
+      <li>
+        <a href="{% url 'annotations:tag_home' request.team.slug %}"
+           {% if active_tab == 'tags' %}class="menu-active"{% endif %}>
+          <i class="fa fa-solid fa-tags"></i>
+          {% translate "Manage Tags" %}
+        </a>
+      </li>
+    {% endif %}
   {% endflag %}
   <li>
     <a href="{% url 'experiments:experiments_home' request.team.slug %}"{% if active_tab == 'experiments' %}class="menu-active"{% endif %}>
@@ -16,43 +46,53 @@
       {% translate "Experiments" %}
     </a>
     <ul>
-      <li>
-        <a href="{% url 'experiments:safety_home' request.team.slug %}"
-           {% if active_tab == 'safety_layers' %}class="menu-active"{% endif %}>
-          <i class="fa fa-shield fa-fw"></i>
-          {% translate "Safety Layers" %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'experiments:source_material_home' request.team.slug %}"
-           {% if active_tab == 'source_material' %}class="menu-active"{% endif %}>
-          <i class="fa fa-book fa-fw"></i>
-          {% translate "Source Material" %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'experiments:survey_home' request.team.slug %}"
-           {% if active_tab == 'survey' %}class="menu-active"{% endif %}>
-          <i class="fa-solid fa-file-circle-question fa-fw"></i>
-          {% translate "Surveys" %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'experiments:consent_home' request.team.slug %}"
-           {% if active_tab == 'consent_forms' %}class="menu-active"{% endif %}>
-          <i class="fa-solid fa-file-contract fa-fw"></i>
-          {% translate "Consent Forms" %}
-        </a>
-      </li>
-      {% if perms.annotations.add_tag %}
+      {% flag "flag_chatbots" or %}
         <li>
-          <a href="{% url 'annotations:tag_home' request.team.slug %}"
-             {% if active_tab == 'tags' %}class="menu-active"{% endif %}>
-            <i class="fa fa-solid fa-tags"></i>
-            {% translate "Manage Tags" %}
+          <a href="{% url 'experiments:safety_home' request.team.slug %}"
+             {% if active_tab == 'safety_layers' %}class="menu-active"{% endif %}>
+            <i class="fa fa-shield fa-fw"></i>
+            {% translate "Safety Layers" %}
           </a>
         </li>
-      {% endif %}
+      {% else %}
+        <li>
+          <a href="{% url 'experiments:safety_home' request.team.slug %}"
+             {% if active_tab == 'safety_layers' %}class="menu-active"{% endif %}>
+            <i class="fa fa-shield fa-fw"></i>
+            {% translate "Safety Layers" %}
+          </a>
+        </li>
+        <li>
+          <a href="{% url 'experiments:source_material_home' request.team.slug %}"
+             {% if active_tab == 'source_material' %}class="menu-active"{% endif %}>
+            <i class="fa fa-book fa-fw"></i>
+            {% translate "Source Material" %}
+          </a>
+        </li>
+        <li>
+          <a href="{% url 'experiments:survey_home' request.team.slug %}"
+             {% if active_tab == 'survey' %}class="menu-active"{% endif %}>
+            <i class="fa-solid fa-file-circle-question fa-fw"></i>
+            {% translate "Surveys" %}
+          </a>
+        </li>
+        <li>
+          <a href="{% url 'experiments:consent_home' request.team.slug %}"
+             {% if active_tab == 'consent_forms' %}class="menu-active"{% endif %}>
+            <i class="fa-solid fa-file-contract fa-fw"></i>
+            {% translate "Consent Forms" %}
+          </a>
+        </li>
+        {% if perms.annotations.add_tag %}
+          <li>
+            <a href="{% url 'annotations:tag_home' request.team.slug %}"
+               {% if active_tab == 'tags' %}class="menu-active"{% endif %}>
+              <i class="fa fa-solid fa-tags"></i>
+              {% translate "Manage Tags" %}
+            </a>
+          </li>
+        {% endif %}
+      {% endflag %}
     </ul>
   </li>
   {% flag "flag_pipelines-v2" %}


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
resolves #1718

move source material, surveys, consent forms, and tags out from under Experiments when the chatbot FF is enabled

## User Impact
<!-- Describe the impact of this change on the end-users. -->
UI only

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
FF enabled:
<img width="225" alt="Screenshot 2025-06-05 at 2 18 07 PM" src="https://github.com/user-attachments/assets/a59d0c3d-f1ff-4da4-887d-7fb5371b12ff" />
FF not enabled:
<img width="225" alt="Screenshot 2025-06-05 at 2 23 44 PM" src="https://github.com/user-attachments/assets/3a10fb3c-ffed-4d4b-bd1a-b69b96502ef3" />


### Docs and Changelog
<!--Link to documentation that has been updated.-->
n/a
