### PR TITLE
Smh/migration tool

### DIFF
--- a/apps/experiments/views/__init__.py
+++ b/apps/experiments/views/__init__.py
@@ -40,6 +40,7 @@ from .experiment import (  # noqa: F401
     get_export_download_link,
     get_message_response,
     get_release_status_badge,
+    migrate_experiment_view,
     poll_messages,
     poll_messages_embed,
     send_invitation,

--- a/templates/experiments/single_experiment_home.html
+++ b/templates/experiments/single_experiment_home.html
@@ -20,6 +20,22 @@
           </div>
         </div>
       </div>
+    {% else %}
+      <div>
+        <div class="alert alert-info alert-vertical sm:alert-horizontal w-full flex items-center justify-between" role="alert">
+          <div>
+            Your experiment is ready to migrate to a chatbot! Chatbots is a new interface for a more streamlined bot building experience. This is a safe operation that will not change the existing functionality. <a href="https://docs.openchatstudio.com/concepts/chatbots/" class="italic" target="_blank" rel="noopener noreferrer">Learn More →</a>
+          </div>
+          <div>
+            <form method="post" action="{% url 'experiments:migrate_experiment' request.team.slug experiment.id %}" style="display: inline;">
+              {% csrf_token %}
+              <button type="submit" class="btn btn-primary">
+                Migrate Experiment
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
     {% endif %}
   {% endflag %}
   <div class="text-sm breadcrumbs" aria-label="breadcrumbs">


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
part of #1664
After pressing banner button to migrate experiment. it navigates to the newly created chatbot
<img width="1188" alt="Screenshot 2025-06-06 at 3 46 20 PM" src="https://github.com/user-attachments/assets/41f7d799-5c9e-42eb-8045-2b8110a3d074" />

## User Impact
<!-- Describe the impact of this change on the end-users. -->
users are able to migrate LLM and Assistant type experiments themselves

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
yes to changelog-- the docs have information about the transition, but I may add something specifically for this migration 
