### PR TITLE
check session if exists

### DIFF
--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -1194,14 +1194,16 @@ def _start_experiment_session(
             metadata=metadata or {},
         )
 
-        session = ExperimentSession.objects.create(
-            team=team,
-            experiment=working_experiment,
-            experiment_channel=experiment_channel,
-            status=session_status,
-            participant=participant,
+        session, _ = ExperimentSession.objects.get_or_create(
             external_id=session_external_id,
-            chat=chat,
+            defaults={
+                "team": team,
+                "experiment": working_experiment,
+                "experiment_channel": experiment_channel,
+                "status": session_status,
+                "participant": participant,
+                "chat": chat,
+            },
         )
 
         # Record the participant's timezone

--- a/apps/slack/slack_listeners.py
+++ b/apps/slack/slack_listeners.py
@@ -10,7 +10,6 @@ Manage event subscriptions at:
 import logging
 import re
 
-from django.db import IntegrityError
 from django.db.models import Q
 from slack_bolt import BoltContext, BoltResponse
 
@@ -65,17 +64,12 @@ def _respond_to_message(event, channel_id, thread_ts, experiment_channel, experi
 
     if not session:
         external_id = make_session_external_id(channel_id, thread_ts)
-        session = ExperimentSession.objects.filter(external_id=external_id).first()
-        if not session:
-            try:
-                session = SlackChannel.start_new_session(
-                    working_experiment=experiment,
-                    experiment_channel=experiment_channel,
-                    participant_identifier=slack_user,
-                    session_external_id=external_id,
-                )
-            except IntegrityError:
-                session = ExperimentSession.objects.get(external_id=external_id)
+        session = SlackChannel.start_new_session(
+            working_experiment=experiment,
+            experiment_channel=experiment_channel,
+            participant_identifier=slack_user,
+            session_external_id=external_id,
+        )
     # strip out the mention
     message_text = re.sub(rf"<@?{context.bot_user_id}>", "", event["text"])
     message = SlackMessage(


### PR DESCRIPTION
## Description
Did not encounter this exception locally after connecting to Slack. However, this issue could have been caused by a race condition, where multiple messages with the same thread_ts tried to create an ExperimentSession at the same time.
To handle this, I’ve added a check to see if a session already exists before attempting to create a new one. Additionally, if an IntegrityError is raised during creation (due to a concurrent attempt), the existing session is fetched and used instead.

This ensures that only one session is created per unique external_id, avoiding duplicate key errors.
Closes #1729 
## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
