### PR TITLE
Move exception handling up and let ad_hoc_bot_message fail silently

### DIFF
--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -437,7 +437,7 @@ class ScheduledMessage(BaseTeamModel):
         experiment_session.ad_hoc_bot_message(
             self.params["prompt_text"],
             trace_info,
-            fail_silently=False,
+            fail_silently=True,
             use_experiment=self._get_experiment_to_generate_response(),
         )
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
See [this thread](https://dimagi.slack.com/archives/C05PK63Q89H/p1749719003326789?thread_ts=1749681253.994209&cid=C05PK63Q89H)

Sending attempts are still incremented if there are errors. **I have not tested this manually**

## User Impact
<!-- Describe the impact of this change on the end-users. -->
This should prevent the infinite message issue if the messaging service returns some error

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
