### PR TITLE
Bdr/newlines not spaces

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -544,14 +544,14 @@ class BuiltInTools(models.TextChoices):
                         "type": "expandable_text",
                         "label": "Allowed Domains",
                         "helpText": "Add domains without https from which you want the search results. "
-                        "Use space to add multiple domains",
+                        "Use newlines to add multiple domains",
                     },
                     {
                         "name": "blocked_domains",
                         "type": "expandable_text",
                         "label": "Blocked Domains",
                         "helpText": "Add domains without https from which you don't want the search results."
-                        " Use space to add multiple domains",
+                        " Use newlines to add multiple domains",
                     },
                 ],
             }

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -543,15 +543,13 @@ class BuiltInTools(models.TextChoices):
                         "name": "allowed_domains",
                         "type": "expandable_text",
                         "label": "Allowed Domains",
-                        "helpText": "Add domains without https from which you want the search results. "
-                        "Use newlines to add multiple domains",
+                        "helpText": "Only search these domains (e.g. example.com or example.com/blog). Separate entries with newlines.",
                     },
                     {
                         "name": "blocked_domains",
                         "type": "expandable_text",
                         "label": "Blocked Domains",
-                        "helpText": "Add domains without https from which you don't want the search results."
-                        " Use newlines to add multiple domains",
+                        "helpText": "Exclude these domains from search. Separate entries with newlines.", 
                     },
                 ],
             }

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -1033,7 +1033,11 @@ function BuiltInToolsWidget(props: WidgetParams) {
       if (!next.data.params.tool_config[toolName]) {
         next.data.params.tool_config[toolName] = {};
       }
-      next.data.params.tool_config[toolName][name] = value.split(" ").map(value => value.trim());
+      next.data.params.tool_config[toolName][name] = value.split("\n").map(url => {
+        const trimmedUrl = url.trim();
+        // Strip http:// or https:// prefixes
+        return trimmedUrl.replace(/^https?:\/\//, '');
+      }).filter(url => url.length > 0);
     }))
   }
   return (
@@ -1070,7 +1074,7 @@ function BuiltInToolsWidget(props: WidgetParams) {
                 name: widget.name,
                 label: widget.label,
                 helpText: widget.helpText ?? "",
-                paramValue: Array.isArray(value) ? value.join(" ") : value,
+                paramValue: Array.isArray(value) ? value.join("\n") : value,
                 updateParamValue: (event) => onConfigUpdate(toolKey, event),
                 inputError: error,
               };


### PR DESCRIPTION
## Description
change the allow and exclude lists for claude web search to be newline delimited instead of space.

## User Impact
Slightly easier to read / use

### Demo
n/a

### Docs and Changelog
Inline on the node
