### PR TITLE
save media in chatobjects and metadata

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1262,6 +1262,11 @@ def experiment_session_messages_view(request, team_slug: str, experiment_id: uui
     start_idx = (page - 1) * page_size
     end_idx = start_idx + page_size
     paginated_messages = messages_queryset[start_idx:end_idx]
+    for message in paginated_messages:
+        message.attached_files = []
+        for file in message.get_attached_files():
+            file.download_url = file.download_link(session.id)
+            message.attached_files.append(file)
     context = {
         "experiment_session": session,
         "experiment": experiment,

--- a/templates/experiments/components/experiment_chat.html
+++ b/templates/experiments/components/experiment_chat.html
@@ -75,7 +75,9 @@
                       <div class="flex flex-col">
                         {% for file in message.get_attached_files %}
                           <div class="inline text-sm p-1">
-                            <i class="fa-solid fa-file fa-sm"></i> {{ file.name }}
+                            <a href="{{ file.download_url }}" target="_blank" class="text-blue-600 underline">
+                              <i class="fa-solid fa-file fa-sm mr-1"></i>{{ file.name }}
+                            </a>
                           </div>
                         {% endfor %}
                       </div>


### PR DESCRIPTION
## Description
Save user sent media in chatattachment and chat metadata. Closes #1748 
## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
