### PR TITLE
allow setting message and session tags from Python Nodes

### DIFF
--- a/apps/annotations/models.py
+++ b/apps/annotations/models.py
@@ -91,12 +91,21 @@ class TaggedModelMixin(models.Model, AnnotationMixin):
 
     tags = TaggableManager(through=CustomTaggedItem)
 
-    def add_tags(self, tags: list[str], team: Team, added_by: CustomUser):
+    def add_tags(self, tags: list[str], team: Team, added_by: CustomUser = None):
         tag_objs = Tag.objects.filter(team=team, name__in=tags)
         for tag in tag_objs:
             self.add_tag(tag, team, added_by)
 
-    def add_tag(self, tag: Tag, team: Team, added_by: CustomUser):
+    def create_and_add_tag(self, tag: str, team: Team, tag_category: TagCategories, added_by: CustomUser = None):
+        tag, _ = Tag.objects.get_or_create(
+            name=tag,
+            team=team,
+            is_system_tag=bool(tag_category),
+            category=tag_category,
+        )
+        self.add_tag(tag, team=team, added_by=added_by)
+
+    def add_tag(self, tag: Tag, team: Team, added_by: CustomUser = None):
         self.tags.add(tag, through_defaults={"team": team, "user": added_by})
 
     def user_tag_names(self):

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -709,7 +709,7 @@ class ChannelBase(ABC):
         chat_message = ChatMessage.objects.create(
             chat=self.experiment_session.chat, message_type=ChatMessageType.AI, content=self.message.message_text
         )
-        chat_message.create_and_add_tag("unsupported_message_type", TagCategories.ERROR)
+        chat_message.create_and_add_tag("unsupported_message_type", self.experiment.team, TagCategories.ERROR)
         return EventBot(self.experiment_session, self.experiment, trace_info, history_manager).get_user_message(
             UNSUPPORTED_MESSAGE_BOT_PROMPT.format(supported_types=self.supported_message_types)
         )

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -239,20 +239,11 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
     def get_metadata(self, key: str):
         return self.metadata.get(key, None)
 
-    def create_and_add_tag(self, tag: str, tag_category: TagCategories):
-        tag, _ = Tag.objects.get_or_create(
-            name=tag,
-            team=self.chat.team,
-            is_system_tag=bool(tag_category),
-            category=tag_category,
-        )
-        self.add_tag(tag, team=self.chat.team, added_by=None)
-
     def add_version_tag(self, version_number: int, is_a_version: bool):
         tag = f"v{version_number}"
         if not is_a_version:
             tag = f"{tag}-unreleased"
-        self.create_and_add_tag(tag=tag, tag_category=TagCategories.EXPERIMENT_VERSION)
+        self.create_and_add_tag(tag, self.chat.team, TagCategories.EXPERIMENT_VERSION)
 
     def add_rating(self, tag: str):
         tag, _ = Tag.objects.get_or_create(

--- a/apps/chat/tests/test_models.py
+++ b/apps/chat/tests/test_models.py
@@ -44,7 +44,7 @@ class TestChatMessage:
         ai_message_with_tag = ChatMessage.objects.create(
             chat=session.chat, message_type=ChatMessageType.AI, content="Hi"
         )
-        ai_message_with_tag.create_and_add_tag(tag="some-bot", tag_category=TagCategories.BOT_RESPONSE)
+        ai_message_with_tag.create_and_add_tag("some-bot", session.team, tag_category=TagCategories.BOT_RESPONSE)
 
         assert human_message.get_processor_bot_tag_name() is None
         assert ai_message_wo_tag.get_processor_bot_tag_name() is None

--- a/apps/chat/tests/test_pipeline_bot.py
+++ b/apps/chat/tests/test_pipeline_bot.py
@@ -1,0 +1,16 @@
+from unittest import mock
+
+from apps.chat.bots import PipelineBot
+from apps.pipelines.nodes.base import PipelineState
+
+
+def test_session_tags():
+    session = mock.Mock()
+    bot = PipelineBot(session, mock.Mock(), None)
+    bot._save_message_to_history = mock.Mock()
+    bot._save_outputs(
+        input_state=PipelineState(messages=["hi"]),
+        output=PipelineState(messages=["Hello"], session_tags=[("my-tag", None)]),
+        save_input_to_history=False,
+    )
+    session.chat.create_and_add_tag.assert_called_with("my-tag", session.team, tag_category=None)

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -454,7 +454,9 @@ class TestExperimentSession:
             message = ChatMessage.objects.create(
                 message_type=ChatMessageType.AI, content="", chat=experiment_session.chat
             )
-            message.create_and_add_tag(tag=f"v{version}", tag_category=TagCategories.EXPERIMENT_VERSION)
+            message.create_and_add_tag(
+                f"v{version}", experiment_session.team, tag_category=TagCategories.EXPERIMENT_VERSION
+            )
 
         assert experiment_session.experiment_version_for_display == expected_display_val
 

--- a/apps/help/views.py
+++ b/apps/help/views.py
@@ -63,6 +63,8 @@ def code_completion(user_query, current_code, error=None, iteration_count=0) -> 
             - `upload_to_assistant`: Whether the file should be sent to the LLM as an attachment.
             - `read_bytes()`: Reads the attachment content as bytes.
             - `read_text()`: Reads the attachment content as text.
+        - Tags: Tags can be attached to individual messages or to the chat session. Tags are used by bot
+            administrators to analyse bot usage.
 
         The available methods you can use are listed below:
         ```
@@ -104,7 +106,10 @@ def code_completion(user_query, current_code, error=None, iteration_count=0) -> 
             The keys are the node names and the values are the routes chosen by each node.
             
         def add_message_tag(tag_name: str):
-            Adds a tag to the output message. Tags are used by administrators to analyse bot usage.
+            Adds a tag to the output message.
+            
+        def add_session_tag(tag_name: str):
+            Adds the tag to the chat session.
         ```
 
         Return only the Python code and nothing else. Do not enclose it in triple quotes or have any other

--- a/apps/help/views.py
+++ b/apps/help/views.py
@@ -102,6 +102,9 @@ def code_completion(user_query, current_code, error=None, iteration_count=0) -> 
         def get_all_routes() -> dict:
             Returns a dictionary containing all routing decisions in the pipeline.
             The keys are the node names and the values are the routes chosen by each node.
+            
+        def add_message_tag(tag_name: str):
+            Adds a tag to the output message. Tags are used by administrators to analyse bot usage.
         ```
 
         Return only the Python code and nothing else. Do not enclose it in triple quotes or have any other

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -85,6 +85,7 @@ class PipelineState(dict):
     output_message_metadata: Annotated[dict, merge_dicts]
     attachments: list = Field(default=[])
     output_message_tags: Annotated[list[str], operator.add]
+    session_tags: Annotated[list[str], operator.add]
 
     # List of (previous, current, next) tuples used for aiding in routing decisions.
     path: Annotated[Sequence[tuple[str | None, str, list[str]]], operator.add]
@@ -115,7 +116,10 @@ class PipelineState(dict):
         return cls(**kwargs)
 
     def add_message_tag(self, tag: str):
-        self.setdefault("output_message_tags", []).append((None, tag))
+        self.setdefault("output_message_tags", []).append((tag, None))
+
+    def add_session_tag(self, tag: str):
+        self.setdefault("session_tags", []).append((tag, None))
 
     def get_node_id(self, node_name: str):
         """

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -114,6 +114,9 @@ class PipelineState(dict):
 
         return cls(**kwargs)
 
+    def add_message_tag(self, tag: str):
+        self.setdefault("output_message_tags", []).append((None, tag))
+
     def get_node_id(self, node_name: str):
         """
         Helper method to get a node ID from a node name.

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -311,10 +311,9 @@ class PipelineNode(BasePipelineNode, ABC):
         output = self._process(input=state["node_input"], state=state)
         output["path"] = [(state["node_source"], self.node_id, outgoing_edges)]
         get_output_tags_fn = getattr(self, "get_output_tags", None)
+        output.setdefault("output_message_tags", [])
         if callable(get_output_tags_fn):
-            output["output_message_tags"] = get_output_tags_fn()
-        else:
-            output["output_message_tags"] = []
+            output["output_message_tags"].extend(get_output_tags_fn())
         return output
 
     def _process(self, input: str, state: PipelineState) -> PipelineState:

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -1130,6 +1130,7 @@ class CodeNode(PipelineNode, OutputMessageTagMixin):
                 "get_node_path": pipeline_state.get_node_path,
                 "get_all_routes": pipeline_state.get_all_routes,
                 "add_message_tag": pipeline_state.add_message_tag,
+                "add_session_tag": pipeline_state.add_session_tag,
             }
         )
         return custom_globals

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -1129,6 +1129,7 @@ class CodeNode(PipelineNode, OutputMessageTagMixin):
                 "get_selected_route": pipeline_state.get_selected_route,
                 "get_node_path": pipeline_state.get_node_path,
                 "get_all_routes": pipeline_state.get_all_routes,
+                "add_message_tag": pipeline_state.add_message_tag,
             }
         )
         return custom_globals

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -5,7 +5,6 @@ import logging
 import random
 import time
 import unicodedata
-from copy import deepcopy
 from typing import Annotated, Literal, Self
 
 import tiktoken
@@ -1115,7 +1114,7 @@ class CodeNode(PipelineNode, OutputMessageTagMixin):
         custom_globals = safe_globals.copy()
 
         participant_data_proxy = self.get_participant_data_proxy(state)
-        pipeline_state = PipelineState(deepcopy(state))
+        pipeline_state = PipelineState.clone(state)
 
         # copy this from input to output to create a consistent view within the code execution
         output_state["temp_state"] = pipeline_state.get("temp_state") or {}

--- a/apps/pipelines/tests/test_code_node.py
+++ b/apps/pipelines/tests/test_code_node.py
@@ -1,12 +1,14 @@
 import json
 
 import pytest
+from pydantic import ValidationError
 
 from apps.channels.datamodels import Attachment
 from apps.experiments.models import Participant, ParticipantData
 from apps.files.models import File
-from apps.pipelines.exceptions import PipelineNodeBuildError, PipelineNodeRunError
+from apps.pipelines.exceptions import PipelineNodeRunError
 from apps.pipelines.nodes.base import PipelineState
+from apps.pipelines.nodes.nodes import CodeNode, RenderTemplate
 from apps.pipelines.tests.utils import (
     code_node,
     create_runnable,
@@ -40,7 +42,7 @@ def main(input, **kwargs):
 """
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
+# @django_db_with_data(available_apps=("apps.service_providers",))
 @pytest.mark.parametrize(
     ("code", "input", "output"),
     [
@@ -50,18 +52,10 @@ def main(input, **kwargs):
         (IMPORTS, json.dumps({"a": "b"}), str(json.loads('{"a": "b"}'))),  # Importing json will work
     ],
 )
-def test_code_node(pipeline, experiment_session, code, input, output):
-    nodes = [
-        start_node(),
-        code_node(code),
-        end_node(),
-    ]
-    assert (
-        create_runnable(pipeline, nodes).invoke(PipelineState(messages=[input], experiment_session=experiment_session))[
-            "messages"
-        ][-1]
-        == output
-    )
+def test_code_node(code, input, output):
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code)
+    node_output = node._process(input, PipelineState(outputs={}, experiment_session=None))
+    assert node_output["messages"][-1] == output
 
 
 EXTRA_FUNCTION = """
@@ -73,7 +67,6 @@ def main(input, **kwargs):
 """
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
 @pytest.mark.parametrize(
     ("code", "input", "error"),
     [
@@ -100,17 +93,11 @@ def main(input, **kwargs):
         ("import PyPDF2\ndef main(input):\n\treturn input", "", "No module named 'PyPDF2'"),
     ],
 )
-def test_code_node_build_errors(pipeline, code, input, error):
-    nodes = [
-        start_node(),
-        code_node(code),
-        end_node(),
-    ]
-    with pytest.raises(PipelineNodeBuildError, match=error):
-        create_runnable(pipeline, nodes).invoke(PipelineState(messages=[input]))["messages"][-1]
+def test_code_node_build_errors(code, input, error):
+    with pytest.raises(ValidationError, match=error):
+        CodeNode(name="test", node_id="123", django_node=None, code=code)
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
 @pytest.mark.parametrize(
     ("code", "input", "error"),
     [
@@ -122,19 +109,13 @@ def test_code_node_build_errors(pipeline, code, input, error):
         ("def main(input, **kwargs):\n\treturn f'Hello, {blah}!'", "", "name 'blah' is not defined"),
     ],
 )
-def test_code_node_runtime_errors(pipeline, experiment_session, code, input, error):
-    nodes = [
-        start_node(),
-        code_node(code),
-        end_node(),
-    ]
+def test_code_node_runtime_errors(code, input, error):
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code)
     with pytest.raises(PipelineNodeRunError, match=error):
-        create_runnable(pipeline, nodes).invoke(PipelineState(messages=[input], experiment_session=experiment_session))[
-            "messages"
-        ][-1]
+        node._process(input, PipelineState(outputs={}, experiment_session=None))
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
+@pytest.mark.django_db()
 def test_get_participant_data(pipeline, experiment_session):
     ParticipantData.objects.create(
         team=experiment_session.team,
@@ -147,20 +128,12 @@ def test_get_participant_data(pipeline, experiment_session):
 def main(input, **kwargs):
     return get_participant_data()["fun_facts"]["body_type"]
 """
-    nodes = [
-        start_node(),
-        code_node(code),
-        end_node(),
-    ]
-    assert (
-        create_runnable(pipeline, nodes).invoke(PipelineState(experiment_session=experiment_session, messages=["hi"]))[
-            "messages"
-        ][-1]
-        == "robot"
-    )
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code)
+    node_output = node._process("hi", PipelineState(outputs={}, experiment_session=experiment_session))
+    assert node_output["messages"][-1] == "robot"
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
+@pytest.mark.django_db()
 def test_update_participant_data(pipeline, experiment_session):
     output = "moody"
     participant_data = ParticipantData.objects.create(
@@ -177,23 +150,15 @@ def main(input, **kwargs):
     set_participant_data(data)
     return get_participant_data()["fun_facts"]["personality"]
 """
-    nodes = [
-        start_node(),
-        code_node(code),
-        end_node(),
-    ]
-    assert (
-        create_runnable(pipeline, nodes).invoke(PipelineState(experiment_session=experiment_session, messages=["hi"]))[
-            "messages"
-        ][-1]
-        == output
-    )
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code)
+    node_output = node._process(input, PipelineState(outputs={}, experiment_session=experiment_session))
+    assert node_output["messages"][-1] == output
     participant_data.refresh_from_db()
     assert participant_data.data["fun_facts"]["personality"] == output
 
 
 @django_db_with_data(available_apps=("apps.service_providers",))
-def test_temp_state(pipeline, experiment_session):
+def test_temp_state_across_multiple_nodes(pipeline, experiment_session):
     output = "['fun loving', 'likes puppies']"
     code_set = f"""
 def main(input, **kwargs):
@@ -209,15 +174,13 @@ def main(input, **kwargs):
         code_node(code_get),
         end_node(),
     ]
-    assert (
-        create_runnable(pipeline, nodes).invoke(PipelineState(experiment_session=experiment_session, messages=["hi"]))[
-            "messages"
-        ][-1]
-        == output
+    node_output = create_runnable(pipeline, nodes).invoke(
+        PipelineState(experiment_session=experiment_session, messages=["hi"])
     )
+    assert node_output["messages"][-1] == output
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
+@django_db_with_data(available_apps=("apps.service_providers", "apps.experiments", "apps.teams"))
 def test_temp_state_get_outputs(pipeline, experiment_session):
     # Temp state contains the outputs of the previous nodes
 
@@ -245,48 +208,32 @@ def main(input, **kwargs):
     )
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
-def test_temp_state_set_outputs(pipeline, experiment_session):
-    input = "hello"
+def test_temp_state_set_outputs():
     code_set = """
 def main(input, **kwargs):
     set_temp_state_key("outputs", "foobar")
     return input
 """
-    nodes = [
-        start_node(),
-        code_node(code_set),
-        end_node(),
-    ]
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code_set)
     with pytest.raises(PipelineNodeRunError, match="Cannot set the 'outputs' key of the temporary state"):
-        create_runnable(pipeline, nodes).invoke(PipelineState(experiment_session=experiment_session, messages=[input]))[
-            "messages"
-        ][-1]
+        node._process("hi", PipelineState(outputs={}, experiment_session=None))
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
-def test_temp_state_user_input(pipeline, experiment_session):
+def test_temp_state_user_input():
     # Temp state contains the user input
 
-    input = "hello"
+    user_input = "hello"
     code_get = """
 def main(input, **kwargs):
     return str(get_temp_state_key("user_input"))
 """
-    nodes = [
-        start_node(),
-        code_node(code_get),
-        end_node(),
-    ]
-    assert (
-        create_runnable(pipeline, nodes).invoke(PipelineState(experiment_session=experiment_session, messages=[input]))[
-            "messages"
-        ][-1]
-        == input
-    )
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code_get)
+    state = PipelineState(messages=[user_input], outputs={}, experiment_session=None, temp_state={})
+    node_output = node.process(incoming_edges=[], outgoing_edges=[], state=state, config={})
+    assert node_output["messages"][-1] == user_input
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
+@pytest.mark.django_db()
 def test_read_attachments(pipeline, experiment_session):
     file = File.from_content("foo.txt", b"from file", "text/plain", experiment_session.team.id)
 
@@ -294,21 +241,19 @@ def test_read_attachments(pipeline, experiment_session):
 def main(input, **kwargs):
     return f'content {get_temp_state_key("attachments")[0].read_text()}'
 """
-    nodes = [
-        start_node(),
-        code_node(code_get),
-        end_node(),
-    ]
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code_get)
     state = PipelineState(
+        outputs={},
         experiment_session=experiment_session,
         messages=["hi"],
         attachments=[Attachment.from_file(file, "code_interpreter")],
+        temp_state={},
     )
-    assert create_runnable(pipeline, nodes).invoke(state)["messages"][-1] == "content from file"
-    File.objects.get(id=file.id)
+    node_output = node.process(incoming_edges=[], outgoing_edges=[], state=state, config={})
+    assert node_output["messages"][-1] == "content from file"
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
+@pytest.mark.django_db()
 def test_participant_data_proxy_get_includes_global_data(pipeline, experiment_session):
     """
     Test that the get method of ParticipantDataProxy returns a merged dictionary
@@ -328,20 +273,13 @@ def main(input, **kwargs):
     data = get_participant_data()
     return f"Name: {data.get('name')}, Color: {data.get('favorite_color')}"
     """
-    nodes = [
-        start_node(),
-        code_node(code),
-        end_node(),
-    ]
-    assert (
-        create_runnable(pipeline, nodes).invoke(PipelineState(experiment_session=experiment_session, messages=["hi"]))[
-            "messages"
-        ][-1]
-        == "Name: Dimagi, Color: green"
-    )
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code)
+    state = PipelineState(messages=["hi"], outputs={}, experiment_session=experiment_session, temp_state={})
+    node_output = node.process(incoming_edges=[], outgoing_edges=[], state=state, config={})
+    assert node_output["messages"][-1] == "Name: Dimagi, Color: green"
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
+@pytest.mark.django_db()
 def test_participant_data_proxy_set_updates_global_data(pipeline, experiment_session):
     experiment_session.participant.name = "Original Boring Name"
     experiment_session.participant.save()
@@ -359,22 +297,15 @@ def main(input, **kwargs):
     updated = get_participant_data()
     return f"Name: {updated.get('name')}"
     """
-    nodes = [
-        start_node(),
-        code_node(code),
-        end_node(),
-    ]
-    assert (
-        create_runnable(pipeline, nodes).invoke(PipelineState(experiment_session=experiment_session, messages=["hi"]))[
-            "messages"
-        ][-1]
-        == "Name: Updated Exciting Name"
-    )
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code)
+    state = PipelineState(messages=["hi"], outputs={}, experiment_session=experiment_session, temp_state={})
+    node_output = node.process(incoming_edges=[], outgoing_edges=[], state=state, config={})
+    assert node_output["messages"][-1] == "Name: Updated Exciting Name"
     experiment_session.participant.refresh_from_db()
     assert experiment_session.participant.name == "Updated Exciting Name"
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
+@pytest.mark.django_db()
 def test_render_template_with_context_keys(pipeline, experiment_session):
     participant = Participant.objects.create(
         identifier="participant_123",
@@ -395,25 +326,21 @@ def test_render_template_with_context_keys(pipeline, experiment_session):
         temp_state={"my_key": "example_key"},
         outputs={},
     )
-    nodes = [
-        start_node(),
-        render_template_node(
-            "input: {{input}}, temp_state.my_key: {{temp_state.my_key}}, "
-            "participant_id: {{participant_details.identifier}}, "
-            "participant_data: {{participant_data.custom_key}}"
-        ),
-        end_node(),
-    ]
-    result = create_runnable(pipeline, nodes).invoke(state)
-    expected = (
+    template = (
+        "input: {{input}}, temp_state.my_key: {{temp_state.my_key}}, "
+        "participant_id: {{participant_details.identifier}}, "
+        "participant_data: {{participant_data.custom_key}}"
+    )
+    node = RenderTemplate(name="test", node_id="123", django_node=None, template_string=template)
+    node_output = node.process(incoming_edges=[], outgoing_edges=[], state=state, config={})
+    assert node_output["messages"][-1] == (
         "input: Cycling, temp_state.my_key: example_key, "
         "participant_id: participant_123, "
         "participant_data: custom_value"
     )
-    assert result["messages"][-1] == expected
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
+@pytest.mark.django_db()
 def test_get_participant_schedules(pipeline, experiment_session):
     """
     Test that the get_participant_schedules function correctly retrieves
@@ -448,23 +375,13 @@ def main(input, **kwargs):
     schedules = get_participant_schedules()
     return f"Number of schedules: {len(schedules)}"
 """
-    nodes = [
-        start_node(),
-        code_node(code),
-        end_node(),
-    ]
-
-    assert (
-        (
-            create_runnable(pipeline, nodes).invoke(
-                PipelineState(experiment_session=experiment_session, messages=["hi"])
-            )["messages"][-1]
-        )
-        == "Number of schedules: 1"
-    )
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code)
+    state = PipelineState(messages=["hi"], outputs={}, experiment_session=experiment_session, temp_state={})
+    node_output = node.process(incoming_edges=[], outgoing_edges=[], state=state, config={})
+    assert node_output["messages"][-1] == "Number of schedules: 1"
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
+@pytest.mark.django_db()
 def test_get_participant_schedules_empty(pipeline, experiment_session):
     """
     Test that the get_participant_schedules function returns an empty list
@@ -475,57 +392,36 @@ def main(input, **kwargs):
     schedules = get_participant_schedules()
     return f"Number of schedules: {len(schedules)}, Empty list: {schedules == []}"
 """
-    nodes = [
-        start_node(),
-        code_node(code),
-        end_node(),
-    ]
-    assert (
-        (
-            create_runnable(pipeline, nodes).invoke(
-                PipelineState(experiment_session=experiment_session, messages=["hi"])
-            )["messages"][-1]
-        )
-        == "Number of schedules: 0, Empty list: True"
-    )
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code)
+    state = PipelineState(messages=["hi"], outputs={}, experiment_session=experiment_session, temp_state={})
+    node_output = node.process(incoming_edges=[], outgoing_edges=[], state=state, config={})
+    assert node_output["messages"][-1] == "Number of schedules: 0, Empty list: True"
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
+@pytest.mark.django_db()
 def test_get_and_set_session_state(pipeline, experiment_session):
     assert experiment_session.state.get("message_count") is None
-    input = "hello"
-    code_set = """
+    code = """
 def main(input, **kwargs):
     msg_count = get_session_state_key("message_count") or 1
     set_session_state_key("message_count", msg_count + 1)
     return input
     """
-    nodes = [
-        start_node(),
-        code_node(code_set),
-        end_node(),
-    ]
-    create_runnable(pipeline, nodes).invoke(PipelineState(experiment_session=experiment_session, messages=[input]))
-
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code)
+    state = PipelineState(messages=["hi"], outputs={}, experiment_session=experiment_session, temp_state={})
+    node.process(incoming_edges=[], outgoing_edges=[], state=state, config={})
     experiment_session.refresh_from_db()
     assert experiment_session.state["message_count"] == 2
 
 
-@django_db_with_data(available_apps=("apps.service_providers",))
-def test_tags(pipeline, experiment_session):
+def test_tags_mocked():
     code_set = """
 def main(input, **kwargs):
     add_session_tag("session-tag")
     add_message_tag("message-tag")
     return input
     """
-    nodes = [
-        start_node(),
-        code_node(code_set),
-        end_node(),
-    ]
-    output = create_runnable(pipeline, nodes).invoke(
-        PipelineState(experiment_session=experiment_session, messages=["hi"])
-    )
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code_set)
+    output = node._process("hi", PipelineState(outputs={}, experiment_session=None))
     assert output["output_message_tags"] == [("message-tag", None)]
     assert output["session_tags"] == [("session-tag", None)]

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -558,6 +558,13 @@ function CodeNodeEditor(
       detail: "Gets all routing decisions in the pipeline",
       boost: 1
     }),
+
+    add_message_tag: snip("add_message_tag(\"${tag_name}\")", {
+      label: "add_message_tag",
+      type: "function",
+      detail: "Adds the tag to the output message",
+      boost: 1
+    })
   }
 
   function pythonCompletions(context: CompletionContext) {

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -564,6 +564,13 @@ function CodeNodeEditor(
       type: "function",
       detail: "Adds the tag to the output message",
       boost: 1
+    }),
+
+    add_session_tag: snip("add_session_tag(\"${tag_name}\")", {
+      label: "add_session_tag",
+      type: "function",
+      detail: "Adds the tag to the chat session",
+      boost: 1
     })
   }
 


### PR DESCRIPTION
## Description
This adds two new function to the python scope which allows message and session tags to be set from the node.

This also modifies the CodeNode to avoid mutating the input state which is an anti-pattern in langgraph. Instead we use an trimmed state to make updates to and pass that back in the node output.

I have also refactored the 'test_code_node.py' tests to call the code node directly where possible instead of running the full pipeline. This is much faster in tests due to the setup and teardown required to run langgraph (since it is multi-threaded and requires special DB handling).

## User Impact
Users can use Python Nodes to set message and session tags.

### Docs and Changelog
TODO
