### PR TITLE
allow new line in allowed and blocked domains

### DIFF
--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -1051,7 +1051,7 @@ function BuiltInToolsWidget(props: WidgetParams) {
         const trimmedUrl = url.trim();
         // Strip http:// or https:// prefixes
         return trimmedUrl.replace(/^https?:\/\//, '');
-      }).filter(url => url.length > 0);
+      });
     }))
   }
   return (


### PR DESCRIPTION
## Description
Allow new line in tool configs.
I have tested the final configs value that gets added to the web search tool. new empty line with blank value do not appear in the tool config

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
[Demo](https://drive.google.com/file/d/17BD2N87azFzHnUNgR0bxd_-SsEmXGf9r/view?usp=drive_link)

### Docs and Changelog
<!--Link to documentation that has been updated.-->
