### PR TITLE
fix file download link and displays images in chats

### DIFF
--- a/apps/experiments/urls.py
+++ b/apps/experiments/urls.py
@@ -187,6 +187,7 @@ urlpatterns = [
         name="experiment_route_delete",
     ),
     path("<int:session_id>/file/<int:pk>/", views.download_file, name="download_file"),
+    path("<int:session_id>/image/<int:pk>/html/", views.get_image_html, name="get_image_html"),
     path(
         "e/<uuid:experiment_id>/verify_token/<str:token>/",
         views.verify_public_chat_token,

--- a/apps/experiments/views/__init__.py
+++ b/apps/experiments/views/__init__.py
@@ -36,6 +36,7 @@ from .experiment import (  # noqa: F401
     experiments_home,
     generate_chat_export,
     get_export_download_link,
+    get_image_html,
     get_message_response,
     get_release_status_badge,
     migrate_experiment_view,

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1388,6 +1388,27 @@ def download_file(request, team_slug: str, session_id: int, pk: int):
         raise Http404() from None
 
 
+@team_required
+def get_image_html(request, team_slug: str, session_id: int, pk: int):
+    """Return HTML for displaying an image attachment."""
+    resource = get_object_or_404(
+        File, id=pk, team__slug=team_slug, chatattachment__chat__experiment_session__id=session_id
+    )
+
+    if not resource.is_image:
+        raise Http404("File is not an image")
+
+    # Generate the image URL
+    image_url = reverse("experiments:download_file", args=[team_slug, session_id, pk])
+
+    # Return HTML for the image
+    html = format_html(
+        '<img src="{}" alt="{}" class="max-w-md max-h-64 rounded border shadow-sm mt-2">', image_url, resource.name
+    )
+
+    return HttpResponse(html)
+
+
 @require_POST
 @transaction.atomic
 @login_and_team_required

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1268,11 +1268,6 @@ def experiment_session_messages_view(request, team_slug: str, experiment_id: uui
     start_idx = (page - 1) * page_size
     end_idx = start_idx + page_size
     paginated_messages = messages_queryset[start_idx:end_idx]
-    for message in paginated_messages:
-        message.attached_files = []
-        for file in message.get_attached_files():
-            file.download_url = file.download_link(session.id)
-            message.attached_files.append(file)
     context = {
         "experiment_session": session,
         "experiment": experiment,

--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -99,6 +99,10 @@ class File(BaseTeamModel, VersionsMixin):
             return "application/octet-stream"
 
     @property
+    def is_image(self):
+        return self.content_type.startswith("image/")
+
+    @property
     def display_size(self):
         return humanize_bytes(self.content_size)
 

--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -12,7 +12,7 @@ from pgvector.django import HalfVectorField
 from apps.experiments.versioning import VersionDetails, VersionField, VersionsMixin, VersionsObjectManagerMixin
 from apps.generics.chips import Chip
 from apps.teams.models import BaseTeamModel
-from apps.utils.conversions import bytes_to_megabytes
+from apps.utils.conversions import bytes_to_megabytes, humanize_bytes
 from apps.utils.deletion import get_related_m2m_objects
 from apps.web.meta import absolute_url
 
@@ -97,6 +97,10 @@ class File(BaseTeamModel, VersionsMixin):
             return mimetypes.guess_type(filename)[0] or "application/octet-stream"
         except Exception:
             return "application/octet-stream"
+
+    @property
+    def display_size(self):
+        return humanize_bytes(self.content_size)
 
     @property
     def size_mb(self) -> float:

--- a/apps/utils/conversions.py
+++ b/apps/utils/conversions.py
@@ -1,3 +1,20 @@
-def bytes_to_megabytes(bytes: int) -> float:
+MEGA = 1000000
+KILO = 1000
+
+
+def humanize_bytes(num: int):
+    if num < KILO:
+        return f"{num} B"
+    if num < MEGA:
+        return f"{bytes_to_kilobytes(num)} KB"
+    return f"{bytes_to_megabytes(num)} MB"
+
+
+def bytes_to_kilobytes(num: int) -> float:
+    """Converts bytes to kilobytes. Base 10 is used, since this is the default for most technologies"""
+    return round(num / KILO, 2)
+
+
+def bytes_to_megabytes(num: int) -> float:
     """Converts bytes to megabytes. Base 10 is used, since this is the default for most technologies"""
-    return round(bytes / 1000000, 2)
+    return round(num / MEGA, 2)

--- a/templates/experiments/components/experiment_chat.html
+++ b/templates/experiments/components/experiment_chat.html
@@ -79,6 +79,29 @@
                               <i class="fa-solid fa-file fa-sm mr-1"></i>{{ file.name }}
                             </a>
                             ({{ file.display_size }})
+                            {% if file.is_image %}
+                              <div class="mt-1" x-data="{ showImage: false }">
+                                <button
+                                  @click="showImage = !showImage"
+                                  class="btn btn-ghost btn-xs"
+                                  :class="showImage ? 'text-primary' : 'text-gray-500'">
+                                  <i class="fa-solid fa-image fa-sm mr-1"></i>
+                                  <span x-text="showImage ? 'Hide Image' : 'Show Image'"></span>
+                                </button>
+                                <div
+                                  x-show="showImage"
+                                  x-transition
+                                  class="mt-2"
+                                  hx-get="{% url 'experiments:get_image_html' request.team.slug experiment_session.id file.id %}"
+                                  hx-trigger="intersect once"
+                                  hx-swap="innerHTML">
+                                  <div class="flex items-center gap-2 text-xs text-gray-500">
+                                    <i class="fa-solid fa-spinner fa-spin"></i>
+                                    Loading image...
+                                  </div>
+                                </div>
+                              </div>
+                            {% endif %}
                           </div>
                         {% endfor %}
                       </div>

--- a/templates/experiments/components/experiment_chat.html
+++ b/templates/experiments/components/experiment_chat.html
@@ -75,7 +75,7 @@
                       <div class="flex flex-col">
                         {% for file in message.get_attached_files %}
                           <div class="inline text-sm p-1">
-                            <a href="{{ file.download_url }}" target="_blank" class="text-blue-600 underline">
+                            <a href="{% url "experiments:download_file" request.team.slug experiment_session.id file.id %}" target="_blank" class="link link-primary">
                               <i class="fa-solid fa-file fa-sm mr-1"></i>{{ file.name }}
                             </a>
                           </div>

--- a/templates/experiments/components/experiment_chat.html
+++ b/templates/experiments/components/experiment_chat.html
@@ -78,6 +78,7 @@
                             <a href="{% url "experiments:download_file" request.team.slug experiment_session.id file.id %}" target="_blank" class="link link-primary">
                               <i class="fa-solid fa-file fa-sm mr-1"></i>{{ file.name }}
                             </a>
+                            ({{ file.display_size }})
                           </div>
                         {% endfor %}
                       </div>


### PR DESCRIPTION
## Description
Fixes the attachment download link in the chat transcript view. Previously it was using `file.download_url` which does not exist. There was some code that added that field in the view but since the template was using `file.get_attached_files`, this property was not set on those files.

## User Impact
Users can download attachments and view image attachments

## Demo

### Image not shown
![Screenshot from 2025-06-27 13-34-47](https://github.com/user-attachments/assets/ee7ec178-8886-4164-becf-c27aae0e208c)

### Image shown
![Screenshot from 2025-06-27 13-35-52](https://github.com/user-attachments/assets/86ee020c-9e88-4f33-b9c9-e7915c3bc519)


### Docs and Changelog
TODO
