### PR TITLE
Teams managed chatbot rollout

### DIFF
--- a/apps/admin/urls.py
+++ b/apps/admin/urls.py
@@ -11,9 +11,9 @@ urlpatterns = [
     path("export/whatsapp/", views.export_whatsapp, name="export_whatsapp"),
     # Feature Flags
     path("flags/", views.flags_home, name="flags_home"),
-    path("flags/<int:flag_id>/", views.flag_detail, name="flag_detail"),
-    path("flags/<int:flag_id>/update/", views.update_flag, name="update_flag"),
-    path("flags/<int:flag_id>/history/", views.flag_history, name="flag_history"),
+    path("flags/<str:flag_name>/", views.flag_detail, name="flag_detail"),
+    path("flags/<str:flag_name>/update/", views.update_flag, name="update_flag"),
+    path("flags/<str:flag_name>/history/", views.flag_history, name="flag_history"),
     # API endpoints for TomSelect
     path("api/teams/", views.teams_api, name="teams_api"),
     path("api/users/", views.users_api, name="users_api"),

--- a/apps/admin/views.py
+++ b/apps/admin/views.py
@@ -136,8 +136,8 @@ def flags_home(request):
 
 
 @is_superuser
-def flag_detail(request, flag_id):
-    flag = get_object_or_404(Flag, id=flag_id)
+def flag_detail(request, flag_name):
+    flag = get_object_or_404(Flag, name=flag_name)
     flag_info_map = get_all_flag_info()
 
     audit_events = AuditEvent.objects.filter(object_class_path="apps.teams.models.Flag", object_pk=flag.pk).order_by(
@@ -157,8 +157,8 @@ def flag_detail(request, flag_id):
 
 
 @is_superuser
-def flag_history(request, flag_id):
-    flag = get_object_or_404(Flag, id=flag_id)
+def flag_history(request, flag_name):
+    flag = get_object_or_404(Flag, name=flag_name)
 
     audit_events = AuditEvent.objects.filter(object_class_path="apps.teams.models.Flag", object_pk=flag.pk).order_by(
         "-event_date"
@@ -247,8 +247,8 @@ def users_api(request):
 
 @is_superuser
 @require_http_methods(["POST"])
-def update_flag(request, flag_id):
-    flag = get_object_or_404(Flag, id=flag_id)
+def update_flag(request, flag_name):
+    flag = get_object_or_404(Flag, name=flag_name)
 
     form = FlagUpdateForm(request.POST)
     if not form.is_valid():

--- a/apps/admin/views.py
+++ b/apps/admin/views.py
@@ -144,10 +144,6 @@ def flag_detail(request, flag_id):
         "-event_date"
     )[:50]  # Last 50 changes
 
-    audit_events = AuditEvent.objects.filter(object_class_path="apps.teams.models.Flag", object_pk=flag.pk).order_by(
-        "-event_date"
-    )[:50]  # Last 50 changes
-
     return TemplateResponse(
         request,
         "admin/flags/detail.html",

--- a/apps/banners/models.py
+++ b/apps/banners/models.py
@@ -1,5 +1,10 @@
+import logging
+
 from django.db import models
+from django.template import engines
 from django.utils import timezone
+
+logger = logging.getLogger("ocs.banners")
 
 
 class Banner(models.Model):
@@ -65,3 +70,15 @@ class Banner(models.Model):
     def is_visible(self):
         now = timezone.now()
         return self.is_active and self.start_date <= now and self.end_date > now
+
+    def get_formatted_message(self, request):
+        try:
+            django_engine = engines["django"]
+            template = django_engine.from_string(self.message)
+            return template.render({"request": request})
+        except Exception as e:
+            logger.exception("Error rendering banner")
+            if request.user.is_superuser:
+                return f"ERROR: {str(e)}"
+
+        return ""

--- a/apps/banners/services.py
+++ b/apps/banners/services.py
@@ -42,7 +42,7 @@ class BannerService:
                 banners.append(
                     {
                         "title": banner.title,
-                        "message": banner.get_formatted_message(request),
+                        "message": message,
                         "type": banner.banner_type,
                         "id": banner.id,
                         "end_date": banner.end_date,

--- a/apps/banners/services.py
+++ b/apps/banners/services.py
@@ -35,16 +35,17 @@ class BannerService:
         dismissed_ids_raw = request.COOKIES.get("dismissed_banners", "[]")
         dismissed_ids = unquote(dismissed_ids_raw)
         team = getattr(request, "team", None)
-        banners = BannerService.get_active_banners(dismissed_ids, location, team)
-        return {
-            "banners": [
-                {
-                    "title": banner.title,
-                    "message": banner.message,
-                    "type": banner.banner_type,
-                    "id": banner.id,
-                    "end_date": banner.end_date,
-                }
-                for banner in banners
-            ],
-        }
+        banners = []
+        for banner in BannerService.get_active_banners(dismissed_ids, location, team):
+            message = banner.get_formatted_message(request)
+            if message:
+                banners.append(
+                    {
+                        "title": banner.title,
+                        "message": banner.get_formatted_message(request),
+                        "type": banner.banner_type,
+                        "id": banner.id,
+                        "end_date": banner.end_date,
+                    }
+                )
+        return {"banners": banners}

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -52,10 +52,9 @@ class DashboardService:
             start_date = end_date - timedelta(days=30)
 
         base_filters = {"created_at__gte": start_date, "created_at__lte": end_date}
-        print(base_filters, experiment_ids, platform_names)
 
         # Base querysets
-        experiments = Experiment.objects.filter(team=self.team, is_archived=False, working_version=None)
+        experiments = Experiment.objects.filter(team=self.team, is_archived=False)
         sessions = ExperimentSession.objects.filter(team=self.team, **base_filters)
         messages = ChatMessage.objects.filter(chat__team=self.team, **base_filters)
         participants = Participant.objects.filter(team=self.team)

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -52,9 +52,10 @@ class DashboardService:
             start_date = end_date - timedelta(days=30)
 
         base_filters = {"created_at__gte": start_date, "created_at__lte": end_date}
+        print(base_filters, experiment_ids, platform_names)
 
         # Base querysets
-        experiments = Experiment.objects.filter(team=self.team, is_archived=False)
+        experiments = Experiment.objects.filter(team=self.team, is_archived=False, working_version=None)
         sessions = ExperimentSession.objects.filter(team=self.team, **base_filters)
         messages = ChatMessage.objects.filter(chat__team=self.team, **base_filters)
         participants = Participant.objects.filter(team=self.team)

--- a/apps/teams/flags.py
+++ b/apps/teams/flags.py
@@ -21,6 +21,9 @@ class FlagInfo:
     requires: list[str] = field(default_factory=list)
     """Other feature flags that should be enabled with this flag."""
 
+    teams_can_manage: bool = False
+    """Whether team admins can enable / disable this flag themselves"""
+
 
 class Flags(FlagInfo, Enum):
     """All feature flags with their metadata."""
@@ -36,6 +39,7 @@ class Flags(FlagInfo, Enum):
         "Enables simplified chatbot creation and management interface",
         "chatbots",
         ["flag_pipelines-v2"],
+        True,
     )
 
     TEAM_DASHBOARD = ("flag_team_dashboard", "Enables new team dashboard with analytics and overview", "")

--- a/apps/teams/flags.py
+++ b/apps/teams/flags.py
@@ -8,44 +8,51 @@ Developers should add new flags here when introducing new features.
 from dataclasses import dataclass
 from enum import Enum
 
+from django.conf import settings
+
 
 @dataclass
 class FlagInfo:
     """Information about a feature flag."""
 
-    name: str
+    slug: str
     description: str
-    docs_url: str = ""
+    docs_slug: str = ""
 
 
-class Flags(Enum):
+class Flags(FlagInfo, Enum):
     """All feature flags with their metadata."""
 
-    PIPELINES_V2 = FlagInfo(
+    PIPELINES_V2 = (
         "flag_pipelines-v2",
         "Second version of pipeline functionality with enhanced features",
-        "https://docs.openchatstudio.com/concepts/pipelines/",
+        "pipelines",
     )
 
-    CHATBOTS = FlagInfo(
+    CHATBOTS = (
         "flag_chatbots",
         "Enables simplified chatbot creation and management interface",
-        "https://docs.openchatstudio.com/concepts/chatbots/",
+        "chatbots",
     )
 
-    TEAM_DASHBOARD = FlagInfo("flag_team_dashboard", "Enables new team dashboard with analytics and overview", "")
+    TEAM_DASHBOARD = ("flag_team_dashboard", "Enables new team dashboard with analytics and overview", "")
 
-    OPEN_AI_VOICE_ENGINE = FlagInfo(
-        "flag_open_ai_voice_engine", "Enables OpenAI voice synthesis for audio responses", ""
-    )
+    OPEN_AI_VOICE_ENGINE = ("flag_open_ai_voice_engine", "Enables OpenAI voice synthesis for audio responses", "")
 
-    SESSION_ANALYSIS = FlagInfo("flag_session-analysis", "Enables detailed session analysis and reporting", "")
+    SESSION_ANALYSIS = ("flag_session-analysis", "Enables detailed session analysis and reporting", "")
 
-    EVENTS = FlagInfo("flag_events", "Enables event-driven triggers and scheduled messages", "")
+    EVENTS = ("flag_events", "Enables event-driven triggers and scheduled messages", "")
 
-    SSO_LOGIN = FlagInfo("flag_sso_login", "Enables Single Sign-On authentication integration", "")
+    SSO_LOGIN = ("flag_sso_login", "Enables Single Sign-On authentication integration", "")
 
-    COMMCARE_CONNECT = FlagInfo("flag_commcare_connect", "Enables integration with CommCare Connect platform", "")
+    COMMCARE_CONNECT = ("flag_commcare_connect", "Enables integration with CommCare Connect platform", "")
+
+    @property
+    def docs_url(self):
+        docs_link = settings.DOCUMENTATION_LINKS.get(self.docs_slug, None)
+        if docs_link:
+            return f"{settings.DOCUMENTATION_BASE_URL}{docs_link}"
+        return None
 
 
 def get_flag_info(flag_name: str) -> FlagInfo | None:
@@ -59,8 +66,8 @@ def get_flag_info(flag_name: str) -> FlagInfo | None:
         FlagInfo object if found, None otherwise
     """
     for flag in Flags:
-        if flag.value.name == flag_name:
-            return flag.value
+        if flag.slug == flag_name:
+            return flag
     return None
 
 
@@ -71,7 +78,7 @@ def get_all_flag_info() -> dict[str, FlagInfo]:
     Returns:
         Dictionary mapping flag names to FlagInfo objects
     """
-    return {flag.value.name: flag.value for flag in Flags}
+    return {flag.slug: flag for flag in Flags}
 
 
 def get_undefined_flags(existing_flag_names: list[str]) -> list[str]:
@@ -84,5 +91,5 @@ def get_undefined_flags(existing_flag_names: list[str]) -> list[str]:
     Returns:
         List of flag names not defined in Flags enum
     """
-    defined_flags = {flag.value.name for flag in Flags}
+    defined_flags = {flag.slug for flag in Flags}
     return [name for name in existing_flag_names if name not in defined_flags]

--- a/apps/teams/flags.py
+++ b/apps/teams/flags.py
@@ -21,9 +21,17 @@ class FlagInfo:
 class Flags(Enum):
     """All feature flags with their metadata."""
 
-    PIPELINES_V2 = FlagInfo("flag_pipelines-v2", "Second version of pipeline functionality with enhanced features", "")
+    PIPELINES_V2 = FlagInfo(
+        "flag_pipelines-v2",
+        "Second version of pipeline functionality with enhanced features",
+        "https://docs.openchatstudio.com/concepts/pipelines/",
+    )
 
-    CHATBOTS = FlagInfo("flag_chatbots", "Enables simplified chatbot creation and management interface", "")
+    CHATBOTS = FlagInfo(
+        "flag_chatbots",
+        "Enables simplified chatbot creation and management interface",
+        "https://docs.openchatstudio.com/concepts/chatbots/",
+    )
 
     TEAM_DASHBOARD = FlagInfo("flag_team_dashboard", "Enables new team dashboard with analytics and overview", "")
 

--- a/apps/teams/flags.py
+++ b/apps/teams/flags.py
@@ -5,7 +5,7 @@ This module contains all feature flag definitions with their descriptions and do
 Developers should add new flags here when introducing new features.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 from django.conf import settings
@@ -18,6 +18,8 @@ class FlagInfo:
     slug: str
     description: str
     docs_slug: str = ""
+    requires: list[str] = field(default_factory=list)
+    """Other feature flags that should be enabled with this flag."""
 
 
 class Flags(FlagInfo, Enum):
@@ -33,6 +35,7 @@ class Flags(FlagInfo, Enum):
         "flag_chatbots",
         "Enables simplified chatbot creation and management interface",
         "chatbots",
+        ["flag_pipelines-v2"],
     )
 
     TEAM_DASHBOARD = ("flag_team_dashboard", "Enables new team dashboard with analytics and overview", "")

--- a/apps/teams/flags.py
+++ b/apps/teams/flags.py
@@ -82,17 +82,3 @@ def get_all_flag_info() -> dict[str, FlagInfo]:
         Dictionary mapping flag names to FlagInfo objects
     """
     return {flag.slug: flag for flag in Flags}
-
-
-def get_undefined_flags(existing_flag_names: list[str]) -> list[str]:
-    """
-    Get list of flag names that exist in database but not in Flags enum.
-
-    Args:
-        existing_flag_names: List of flag names from database
-
-    Returns:
-        List of flag names not defined in Flags enum
-    """
-    defined_flags = {flag.slug for flag in Flags}
-    return [name for name in existing_flag_names if name not in defined_flags]

--- a/apps/teams/flags.py
+++ b/apps/teams/flags.py
@@ -62,7 +62,7 @@ class Flags(FlagInfo, Enum):
         return None
 
 
-def get_flag_info(flag_name: str) -> FlagInfo | None:
+def get_flag_info(flag_name: str) -> Flags | None:
     """
     Get flag information by flag name.
 
@@ -78,7 +78,7 @@ def get_flag_info(flag_name: str) -> FlagInfo | None:
     return None
 
 
-def get_all_flag_info() -> dict[str, FlagInfo]:
+def get_all_flag_info() -> dict[str, Flags]:
     """
     Get all flag information as a dictionary.
 

--- a/apps/teams/urls.py
+++ b/apps/teams/urls.py
@@ -20,6 +20,7 @@ team_urlpatterns = (
         path("invite/<slug:invitation_id>/", views.resend_invitation, name="resend_invitation"),
         path("invite/", views.send_invitation_view, name="send_invitation"),
         path("invite/cancel/<slug:invitation_id>/", views.cancel_invitation_view, name="cancel_invitation"),
+        path("flags/", views.feature_flags, name="feature_flags"),
     ],
     "single_team",
 )

--- a/apps/teams/views/__init__.py
+++ b/apps/teams/views/__init__.py
@@ -1,3 +1,6 @@
 from .invitation_views import *  # noqa F401
 from .manage_team_views import *  # noqa F401
 from .membership_views import *  # noqa F401
+from .feature_flags import feature_flags
+
+__all__ = ["feature_flags"]

--- a/apps/teams/views/feature_flags.py
+++ b/apps/teams/views/feature_flags.py
@@ -1,0 +1,79 @@
+from django import forms
+from django.contrib import messages
+from django.shortcuts import redirect, render
+from django.utils.translation import gettext_lazy as _
+
+from apps.teams.decorators import login_and_team_required
+from apps.teams.flags import get_all_flag_info
+from apps.teams.models import Flag
+
+
+class FeatureFlagForm(forms.Form):
+    """Form for managing team feature flags."""
+
+    def __init__(self, *args, **kwargs):
+        self.team = kwargs.pop("team", None)
+        super().__init__(*args, **kwargs)
+
+        # Get all available flags
+        flag_info = get_all_flag_info()
+
+        # Create boolean fields for each flag
+        for flag_name, info in flag_info.items():
+            self.fields[flag_name] = forms.BooleanField(
+                label=info.description,
+                required=False,
+                help_text=f"Flag: {flag_name}",
+                initial=self._is_flag_active_for_team(flag_name),
+            )
+
+    def _is_flag_active_for_team(self, flag_name):
+        """Check if a flag is active for the current team."""
+        if not self.team:
+            return False
+
+        try:
+            flag = Flag.objects.get(name=flag_name)
+            return flag.is_active_for_team(self.team)
+        except Flag.DoesNotExist:
+            return False
+
+    def save(self):
+        """Save the form by updating team flag associations."""
+        if not self.team:
+            return
+
+        for flag_name, is_enabled in self.cleaned_data.items():
+            flag, _created = Flag.objects.get_or_create(name=flag_name, defaults={"everyone": False})
+
+            if is_enabled:
+                flag.teams.add(self.team)
+            else:
+                flag.teams.remove(self.team)
+
+            # Clear the cache to ensure the flag state is updated
+            flag.flush()
+
+
+@login_and_team_required
+def feature_flags(request, team_slug):
+    """Manage feature flags for the current team."""
+    team = request.team
+
+    if request.method == "POST":
+        form = FeatureFlagForm(request.POST, team=team)
+        if form.is_valid():
+            form.save()
+            messages.success(request, _("Feature flags updated successfully."))
+            return redirect("web_team:feature_flags", team_slug=team.slug)
+    else:
+        form = FeatureFlagForm(team=team)
+
+    return render(
+        request,
+        "teams/feature_flags.html",
+        {
+            "form": form,
+            "team": team,
+        },
+    )

--- a/apps/teams/views/feature_flags.py
+++ b/apps/teams/views/feature_flags.py
@@ -19,10 +19,8 @@ class FeatureFlagForm(forms.Form):
 
         self._all_flags = None
 
-        # Get all available flags
         flag_info = get_all_flag_info()
 
-        # Create boolean fields for each flag
         for flag_name, info in flag_info.items():
             if not info.teams_can_manage:
                 continue
@@ -59,7 +57,7 @@ class FeatureFlagForm(forms.Form):
         for flag_name, is_enabled in self.cleaned_data.items():
             flag_info = flag_infos.get(flag_name)
             if not flag_info or not flag_info.teams_can_manage:
-                continue  # Skip flags that teams cannot manage
+                continue
 
             flag = self._get_or_create_flag(flag_name)
             if is_enabled:

--- a/apps/teams/views/feature_flags.py
+++ b/apps/teams/views/feature_flags.py
@@ -22,6 +22,9 @@ class FeatureFlagForm(forms.Form):
 
         # Create boolean fields for each flag
         for flag_name, info in flag_info.items():
+            if not info.teams_can_manage:
+                continue
+
             self.fields[flag_name] = forms.BooleanField(
                 label=info.description,
                 required=False,

--- a/apps/teams/views/feature_flags.py
+++ b/apps/teams/views/feature_flags.py
@@ -1,6 +1,8 @@
 from django import forms
 from django.contrib import messages
 from django.shortcuts import redirect, render
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
 from apps.teams.decorators import login_and_team_required
@@ -25,10 +27,14 @@ class FeatureFlagForm(forms.Form):
             if not info.teams_can_manage:
                 continue
 
+            label = flag_name.split("_", 1)[-1]
+            help_text = f"Flag: {label}"
+            if info.docs_slug:
+                help_text += format_html(' (<a class="link" target="_blank" href="{}">docs</a>)', info.docs_url)
             self.fields[flag_name] = forms.BooleanField(
                 label=info.description,
                 required=False,
-                help_text=f"Flag: {flag_name}",
+                help_text=mark_safe(help_text),
                 initial=self._is_flag_active_for_team(flag_name),
             )
 

--- a/apps/teams/views/feature_flags.py
+++ b/apps/teams/views/feature_flags.py
@@ -78,8 +78,9 @@ class FeatureFlagForm(forms.Form):
 def feature_flags(request, team_slug):
     """Manage feature flags for the current team."""
     team = request.team
+    is_team_admin = request.team_membership.is_team_admin
 
-    if request.method == "POST":
+    if request.method == "POST" and is_team_admin:
         form = FeatureFlagForm(request.POST, team=team)
         if form.is_valid():
             form.save()
@@ -94,5 +95,6 @@ def feature_flags(request, team_slug):
         {
             "form": form,
             "team": team,
+            "is_team_admin": is_team_admin,
         },
     )

--- a/assets/styles/site-tailwind.css
+++ b/assets/styles/site-tailwind.css
@@ -175,3 +175,7 @@ input[type=number]::-webkit-outer-spin-button {
 .menu-active {
   background-color: oklch(0.313815 0.021108 254.139);
 }
+
+.markdown a {
+  @apply underline
+}

--- a/templates/admin/flags/detail.html
+++ b/templates/admin/flags/detail.html
@@ -21,7 +21,14 @@
             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0 stroke-current" fill="none" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
-            <span>This flag depends on the following flags: {{ flag_info.requires|join:", " }}</span>
+            <div>
+              <span>This flag depends on the following flags:</span>
+              <ul class="list-inside list-disc">
+                {% for requires in flag_info.requires %}
+                  <li><a href="{% url "ocs_admin:flag_detail" requires %}">{{ requires }}</a></li>
+                {% endfor %}
+              </ul>
+            </div>
           </div>
         {% endif %}
       {% else %}

--- a/templates/admin/flags/detail.html
+++ b/templates/admin/flags/detail.html
@@ -202,7 +202,7 @@
 
             <div
               id="flag-history-section"
-              hx-get="{% url 'ocs_admin:flag_history' flag.id %}"
+              hx-get="{% url 'ocs_admin:flag_history' flag.name %}"
               hx-trigger="load, refreshHistory from:body"
               hx-swap="innerHTML"
             >

--- a/templates/admin/flags/detail.html
+++ b/templates/admin/flags/detail.html
@@ -3,27 +3,33 @@
 
 {% block app %}
   <section class="app-card">
-    <div class="flex justify-between items-center mb-6">
-      <div>
-        <a href="{% url 'ocs_admin:flags_home' %}" class="text-sm text-base-content/70 hover:text-base-content mb-2 inline-block">
-          ← {% translate "Back to Flags" %}
-        </a>
-        <h1 class="pg-title">{{ flag.name }}</h1>
-        {% if flag_info %}
-          <p class="text-base-content/80 mt-2">{{ flag_info.description }}</p>
-          {% if flag_info.docs_url %}
-            <a href="{{ flag_info.docs_url }}" target="_blank" class="text-sm text-primary hover:text-primary-focus mt-1 inline-flex items-center">
-              <i class="fa fa-external-link mr-1" aria-hidden="true"></i>
-              View Documentation
-            </a>
-          {% endif %}
-        {% else %}
-          <p class="text-warning text-sm mt-2">
-            <i class="fa fa-warning mr-1" aria-hidden="true"></i>
-            No description defined for this flag
-          </p>
+    <div>
+      <a href="{% url 'ocs_admin:flags_home' %}" class="text-sm text-base-content/70 hover:text-base-content mb-2 inline-block">
+        ← {% translate "Back to Flags" %}
+      </a>
+      <h1 class="pg-title">{{ flag.name }}</h1>
+      {% if flag_info %}
+        <p class="text-base-content/80 mt-2">{{ flag_info.description }}</p>
+        {% if flag_info.docs_url %}
+          <a href="{{ flag_info.docs_url }}" target="_blank" class="text-sm text-primary hover:text-primary-focus mt-1 inline-flex items-center">
+            <i class="fa fa-external-link mr-1" aria-hidden="true"></i>
+            View Documentation
+          </a>
         {% endif %}
-      </div>
+        {% if flag_info.requires %}
+          <div role="alert" class="alert alert-warning">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0 stroke-current" fill="none" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            <span>This flag depends on the following flags: {{ flag_info.requires|join:", " }}</span>
+          </div>
+        {% endif %}
+      {% else %}
+        <p class="text-warning text-sm mt-2">
+          <i class="fa fa-warning mr-1" aria-hidden="true"></i>
+          No description defined for this flag
+        </p>
+      {% endif %}
     </div>
 
     <div

--- a/templates/admin/flags/home.html
+++ b/templates/admin/flags/home.html
@@ -86,7 +86,7 @@
                       {% endif %}
                     </div>
                     <div class="flex items-center space-x-2">
-                      <a href="{% url 'ocs_admin:flag_detail' flag.id %}" class="btn btn-sm">
+                      <a href="{% url 'ocs_admin:flag_detail' flag.name %}" class="btn btn-sm">
                         <i class="fa fa-pencil" aria-hidden="true"></i>
                       </a>
                     </div>

--- a/templates/admin/flags/home.html
+++ b/templates/admin/flags/home.html
@@ -86,7 +86,7 @@
                       {% endif %}
                     </div>
                     <div class="flex items-center space-x-2">
-                      <a href="{% url 'ocs_admin:flag_detail' flag.name %}" class="btn btn-sm">
+                      <a href="{% url 'ocs_admin:flag_detail' flag.name %}" class="btn btn-sm" aria-label="Edit flag">
                         <i class="fa fa-pencil" aria-hidden="true"></i>
                       </a>
                     </div>

--- a/templates/banners/banner.html
+++ b/templates/banners/banner.html
@@ -9,7 +9,7 @@
                     {% endif %}
                     <div class="markdown">{{ banner.message|render_markdown }}</div>
                 </div>
-                <button class="btn btn-sm btn-ghost dismiss-banner ml-4"
+                <button class="btn btn-sm btn-ghost dismiss-banner ml-4" aria-label="Dismiss banner"
                         data-banner-id="{{ banner.id }}"
                         aria-label="Close">×</button>
             </div>

--- a/templates/banners/banner.html
+++ b/templates/banners/banner.html
@@ -7,7 +7,7 @@
                     {% if banner.title %}
                         <strong>{{ banner.title }}</strong>:
                     {% endif %}
-                    {{ banner.message|render_markdown }}
+                    <div class="markdown">{{ banner.message|render_markdown }}</div>
                 </div>
                 <button class="btn btn-sm btn-ghost dismiss-banner ml-4"
                         data-banner-id="{{ banner.id }}"

--- a/templates/teams/feature_flags.html
+++ b/templates/teams/feature_flags.html
@@ -1,0 +1,57 @@
+{% extends 'web/app/app_base.html' %}
+{% load form_tags %}
+
+{% block app %}
+  <div class="app-card max-w-5xl mx-auto">
+    <div class="flex">
+      <div class="flex-1">
+        <h1 class="pg-title">Feature Flags</h1>
+        <p class="text-base-content/70 mt-1">
+          Enable or disable experimental features for your team.
+        </p>
+      </div>
+    </div>
+
+    <div class="mt-6">
+      <form method="post" class="my-2">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+
+        <div class="grid gap-4">
+          {% for field in form %}
+            <div class="form-control">
+              <label class="label cursor-pointer justify-start gap-4">
+                <input type="checkbox" name="{{ field.name }}" class="checkbox checkbox-primary"
+                       {% if field.value %}checked{% endif %}>
+                <div class="flex-1">
+                  <div class="label-text font-medium">{{ field.label }}</div>
+                  <div class="label-text-alt text-base-content/60">{{ field.help_text }}</div>
+                </div>
+              </label>
+            </div>
+          {% endfor %}
+        </div>
+
+        <div class="mt-6 flex gap-2">
+          <input type="submit" class="btn btn-primary" value="Save Changes">
+          <a href="{% url 'web_team:home' team.slug %}" class="btn btn-outline">Cancel</a>
+        </div>
+      </form>
+    </div>
+
+    <div class="mt-8">
+      <div class="alert alert-info">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+        </svg>
+        <div>
+          <h3 class="font-medium">About Feature Flags</h3>
+          <p class="text-sm mt-1">
+            Feature flags allow you to enable experimental features for your team.
+            Changes will take effect immediately for all team members.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/templates/teams/feature_flags.html
+++ b/templates/teams/feature_flags.html
@@ -34,7 +34,7 @@
 
         <div class="mt-6 flex gap-2">
           <input type="submit" class="btn btn-primary" value="Save Changes">
-          <a href="{% url 'web_team:home' team.slug %}" class="btn btn-outline">Cancel</a>
+          <a href="{% url 'single_team:manage_team' team.slug %}" class="btn btn-outline">Cancel</a>
         </div>
       </form>
     </div>

--- a/templates/teams/feature_flags.html
+++ b/templates/teams/feature_flags.html
@@ -13,6 +13,20 @@
     </div>
 
     <div class="mt-6">
+      {% if not is_team_admin %}
+        <div class="alert alert-warning mb-4">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.5 0L4.268 16.5c-.77.833.192 2.5 1.732 2.5z"></path>
+          </svg>
+          <div>
+            <h3 class="font-medium">Read-only View</h3>
+            <p class="text-sm mt-1">
+              Only team administrators can modify feature flags. Contact your team admin to make changes.
+            </p>
+          </div>
+        </div>
+      {% endif %}
+
       <form method="post" class="my-2">
         {% csrf_token %}
         {{ form.non_field_errors }}
@@ -22,7 +36,8 @@
             <div class="form-control">
               <label class="label cursor-pointer justify-start gap-4">
                 <input type="checkbox" name="{{ field.name }}" class="checkbox checkbox-primary"
-                       {% if field.value %}checked{% endif %}>
+                       {% if field.value %}checked{% endif %}
+                       {% if not is_team_admin %}disabled{% endif %}>
                 <div class="flex-1">
                   <div class="label-text font-medium">{{ field.label }}</div>
                   <div class="label-text-alt text-base-content/60">{{ field.help_text }}</div>
@@ -33,8 +48,12 @@
         </div>
 
         <div class="mt-6 flex gap-2">
-          <input type="submit" class="btn btn-primary" value="Save Changes">
-          <a href="{% url 'single_team:manage_team' team.slug %}" class="btn btn-outline">Cancel</a>
+          {% if is_team_admin %}
+            <input type="submit" class="btn btn-primary" value="Save Changes">
+          {% endif %}
+          <a href="{% url 'single_team:manage_team' team.slug %}" class="btn btn-outline">
+            {% if is_team_admin %}Cancel{% else %}Back{% endif %}
+          </a>
         </div>
       </form>
     </div>

--- a/templates/teams/manage_team.html
+++ b/templates/teams/manage_team.html
@@ -14,9 +14,12 @@
 {% endblock %}
 {% block app %}
   <section class="app-card">
-    <h3 class="pg-subtitle">
-      {% translate "Team Details" %}
-    </h3>
+    <div class="flex justify-between">
+      <h3 class="pg-subtitle">
+        {% translate "Team Details" %}
+      </h3>
+      <a href="{% url "single_team:feature_flags" request.team.slug %}" class="btn btn-primary">Manage Feature Flags</a>
+    </div>
     <form method="post">
       {% csrf_token %}
       {% render_form_fields team_form %}


### PR DESCRIPTION
## Description
The changes in this PR are designed to give teams more control of the chatbots rollout:

#### Banners are templates
Banner messages are now treated as Django templates. The only context is `request` but this allows generating URLs in banners e.g. 

```
Try the new Chatbots experience. <a href="{% url "single_team:feature_flags" request.team.slug %}" target="_blank">Click here to enable it</a>
```

#### Team managed feature flags view
A new view is added which allows team admins to turn on and off selected features flags.

#### Additional stuff
* Add docs links to some flags
* Support the concept of dependent flags (A requires B)

## User Impact
Teams have more control over the chatbots rollout.

### Demo
COMMING

### Docs and Changelog
https://github.com/dimagi/open-chat-studio-docs/pull/125
