### PR TITLE
Restrict "Manage FF" button when creating a new team

### DIFF
--- a/templates/teams/manage_team.html
+++ b/templates/teams/manage_team.html
@@ -14,12 +14,14 @@
 {% endblock %}
 {% block app %}
   <section class="app-card">
-    <div class="flex justify-between">
-      <h3 class="pg-subtitle">
-        {% translate "Team Details" %}
-      </h3>
-      <a href="{% url "single_team:feature_flags" request.team.slug %}" class="btn btn-primary">Manage Feature Flags</a>
-    </div>
+    {% if not create %}
+      <div class="flex justify-between">
+        <h3 class="pg-subtitle">
+          {% translate "Team Details" %}
+        </h3>
+        <a href="{% url "single_team:feature_flags" request.team.slug %}" class="btn btn-primary">Manage Feature Flags</a>
+      </div>
+    {% endif %}
     <form method="post">
       {% csrf_token %}
       {% render_form_fields team_form %}


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
followup to #1837 

## User Impact
<!-- Describe the impact of this change on the end-users. -->
users can navigate to the manage FF view when creating a new team

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
n/a

### Docs and Changelog
<!--Link to documentation that has been updated.-->
n/a
