### PR TITLE
[Chat Widget] allow dragging window instead of specific doc positions

### DIFF
--- a/components/chat_widget/src/components/ocs-chat/heroicons.tsx
+++ b/components/chat_widget/src/components/ocs-chat/heroicons.tsx
@@ -20,3 +20,9 @@ export const ChevronDownIcon = () => {
     <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
   </svg>;
 }
+
+export const EllipsisHorizontalIcon = () => {
+   return <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
+  </svg>
+}

--- a/components/chat_widget/src/components/ocs-chat/heroicons.tsx
+++ b/components/chat_widget/src/components/ocs-chat/heroicons.tsx
@@ -21,8 +21,23 @@ export const ChevronDownIcon = () => {
   </svg>;
 }
 
-export const EllipsisHorizontalIcon = () => {
-   return <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
-  </svg>
-}
+export const GripDotsVerticalIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      class="size-6"
+    >
+      {/* Left column of dots */}
+      <circle cx="8" cy="6" r="1.5" />
+      <circle cx="8" cy="12" r="1.5" />
+      <circle cx="8" cy="18" r="1.5" />
+
+      {/* Right column of dots */}
+      <circle cx="16" cy="6" r="1.5" />
+      <circle cx="16" cy="12" r="1.5" />
+      <circle cx="16" cy="18" r="1.5" />
+    </svg>
+  );
+};

--- a/components/chat_widget/src/components/ocs-chat/heroicons.tsx
+++ b/components/chat_widget/src/components/ocs-chat/heroicons.tsx
@@ -1,35 +1,5 @@
 import {h} from "@stencil/core";
 
-export const ArrowLeftEndOnRectangleIcon = () => {
-  return <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-       class="size-6">
-    <path stroke-linecap="round" stroke-linejoin="round"
-          d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15M12 9l-3 3m0 0 3 3m-3-3h12.75"/>
-  </svg>;
-}
-
-export const ArrowRightEndOnRectangleIcon = () => {
-  return <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-              stroke="currentColor" class="size-6">
-    <path stroke-linecap="round" stroke-linejoin="round"
-          d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15M12 9l3 3m0 0-3 3m3-3H2.25"/>
-  </svg>;
-}
-
-export const ArrowDownOnSquareIcon = () => {
-  return <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width={1.5} stroke="currentColor" class="size-6">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M9 8.25H7.5a2.25 2.25 0 0 0-2.25 2.25v9a2.25 2.25 0 0 0 2.25 2.25h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25H15M9 12l3 3m0 0 3-3m-3 3V2.25" />
-  </svg>
-}
-
-export const ViewfinderCircleIcon = () => {
-  return <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-              stroke="currentColor" class="size-6">
-    <path stroke-linecap="round" stroke-linejoin="round"
-          d="M7.5 3.75H6A2.25 2.25 0 0 0 3.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0 1 20.25 6v1.5m0 9V18A2.25 2.25 0 0 1 18 20.25h-1.5m-9 0H6A2.25 2.25 0 0 1 3.75 18v-1.5M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
-  </svg>;
-}
-
 export const XMarkIcon = () => {
   return <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="size-6">

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -531,13 +531,13 @@ export class OcsChat {
           >
             {/* Header */}
             <div
-              class={`flex justify-between items-center px-2 py-2 border-b border-gray-100 sm:cursor-grab sm:select-none ${this.isDragging ? 'sm:cursor-grabbing' : ''} active:bg-gray-50 sm:hover:bg-gray-25 transition-colors duration-150`}
+              class={`flex justify-between items-center px-2 py-2 border-b border-gray-100 sm:${this.isDragging ? 'cursor-grabbing' : 'cursor-grab'} active:bg-gray-50 sm:hover:bg-gray-25 transition-colors duration-150`}
               onMouseDown={this.handleMouseDown}
               onTouchStart={this.handleTouchStart}
             >
               {/* Drag indicator */}
-              <div class="hidden sm:flex items-center gap-1">
-                <div class="flex items-center gap-0.5 ml-2 pointer-events-none">
+              <div class="hidden sm:flex gap-1">
+                <div class="flex gap-0.5 ml-2 pointer-events-none">
                   <EllipsisHorizontalIcon/>
                 </div>
               </div>

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -3,6 +3,7 @@ import {
   XMarkIcon,
   ChevronDownIcon,
   ChevronUpIcon,
+  EllipsisHorizontalIcon
 } from './heroicons';
 
 interface ChatMessage {
@@ -537,10 +538,7 @@ export class OcsChat {
               {/* Drag indicator */}
               <div class="hidden sm:flex items-center gap-1">
                 <div class="flex items-center gap-0.5 ml-2 pointer-events-none">
-                  <div class="w-1 h-1 bg-gray-300 rounded-full"></div>
-                  <div class="w-1 h-1 bg-gray-300 rounded-full"></div>
-                  <div class="w-1 h-1 bg-gray-300 rounded-full"></div>
-                  <div class="w-1 h-1 bg-gray-300 rounded-full"></div>
+                  <EllipsisHorizontalIcon/>
                 </div>
               </div>
               <div class="flex gap-1">

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -3,7 +3,7 @@ import {
   XMarkIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-  EllipsisHorizontalIcon
+  GripDotsVerticalIcon,
 } from './heroicons';
 
 interface ChatMessage {
@@ -538,7 +538,7 @@ export class OcsChat {
               {/* Drag indicator */}
               <div class="hidden sm:flex gap-1">
                 <div class="flex gap-0.5 ml-2 pointer-events-none">
-                  <EllipsisHorizontalIcon/>
+                  <GripDotsVerticalIcon/>
                 </div>
               </div>
               <div class="flex gap-1">

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -401,24 +401,30 @@ export class OcsChat {
     const windowHeight = window.innerHeight;
     const chatWidth = windowWidth < 640 ? windowWidth : 450;
     const chatHeight = this.expanded ? (windowHeight * 0.83) : (windowHeight * 0.6);
+    const isMobile = windowWidth < 640;
 
+    if (isMobile) {
+      this.windowPosition = { x: 0, y: 0 };
+      return;
+    }
+    const margin = 20;
     switch (this.position) {
       case 'left':
         this.windowPosition = {
-          x: windowWidth < 640 ? 0 : 20,
-          y: windowWidth < 640 ? 0 : windowHeight - chatHeight - 20
+          x: margin,
+          y: windowHeight - chatHeight - margin
         };
         break;
       case 'right':
         this.windowPosition = {
-          x: windowWidth < 640 ? 0 : windowWidth - chatWidth - 20,
-          y: windowWidth < 640 ? 0 : windowHeight - chatHeight - 20
+          x: windowWidth - chatWidth - margin,
+          y: windowHeight - chatHeight - margin
         };
         break;
       case 'center':
         this.windowPosition = {
-          x: windowWidth < 640 ? 0 : (windowWidth - chatWidth) / 2,
-          y: windowWidth < 640 ? 0 : (windowHeight - chatHeight) / 2
+          x: (windowWidth - chatWidth) / 2,
+          y: (windowHeight - chatHeight) / 2
         };
         break;
     }


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
resolves https://github.com/dimagi/open-chat-studio/issues/1828

adding horizontal ellipsis to indicate it's movable:
<img width="496" alt="Screenshot 2025-07-09 at 3 28 53 PM" src="https://github.com/user-attachments/assets/dda186b0-6d1e-4aad-99f6-6bf6ff398a99" />

## User Impact
<!-- Describe the impact of this change on the end-users. -->
user can freely drag chat widget within the limits of the screen

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
[Loom](https://www.loom.com/share/c0f7c64e0eb44bd5ab0cb75ed6487f63?sid=0c1e3cc5-756b-43bc-8369-26ef8640a716)

### Docs and Changelog
<!--Link to documentation that has been updated.-->
yes to changelog
