### PR TITLE
Limit LLM provider set to those with embedding models

### DIFF
--- a/apps/documents/forms.py
+++ b/apps/documents/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.db.models import Subquery
+from django.db.models import Q, Subquery
 
 from apps.assistants.models import OpenAiAssistant, ToolResources
 from apps.documents.models import Collection
@@ -23,10 +23,16 @@ class CollectionForm(forms.ModelForm):
 
     def __init__(self, request, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        embedding_model_provider_types = EmbeddingProviderModel.objects.values_list("type").distinct()
+        embedding_model_provider_queryset = EmbeddingProviderModel.objects.filter(
+            Q(team_id=None) | Q(team_id=request.team.id)
+        )
+
+        embedding_model_provider_types = embedding_model_provider_queryset.values_list("type").distinct()
         self.fields["llm_provider"].queryset = request.team.llmprovider_set.filter(
             type__in=Subquery(embedding_model_provider_types)
         ).all()
+
+        self.fields["embedding_provider_model"].queryset = embedding_model_provider_queryset
         self.fields["embedding_provider_model"].widget.template_name = "django/forms/widgets/select_dynamic.html"
 
         # Alpine.js bindings

--- a/apps/documents/forms.py
+++ b/apps/documents/forms.py
@@ -1,7 +1,9 @@
 from django import forms
+from django.db.models import Subquery
 
 from apps.assistants.models import OpenAiAssistant, ToolResources
 from apps.documents.models import Collection
+from apps.service_providers.models import EmbeddingProviderModel
 
 
 class CollectionForm(forms.ModelForm):
@@ -21,7 +23,10 @@ class CollectionForm(forms.ModelForm):
 
     def __init__(self, request, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["llm_provider"].queryset = request.team.llmprovider_set.all()
+        embedding_model_provider_types = EmbeddingProviderModel.objects.values_list("type").distinct()
+        self.fields["llm_provider"].queryset = request.team.llmprovider_set.filter(
+            type__in=Subquery(embedding_model_provider_types)
+        ).all()
         self.fields["embedding_provider_model"].widget.template_name = "django/forms/widgets/select_dynamic.html"
 
         # Alpine.js bindings

--- a/apps/documents/tests/test_forms.py
+++ b/apps/documents/tests/test_forms.py
@@ -1,10 +1,12 @@
 from unittest.mock import Mock
 
 import pytest
+from django.db.models import Q
 
 from apps.documents.forms import CollectionForm
 from apps.service_providers.models import LlmProviderTypes
 from apps.utils.factories.service_provider_factories import EmbeddingProviderModelFactory, LlmProviderFactory
+from apps.utils.factories.team import TeamFactory
 
 
 @pytest.mark.django_db()
@@ -75,10 +77,22 @@ class TestCollectionForm:
         request = Mock(team=team)
         openai_provider = LlmProviderFactory(team=team, type=LlmProviderTypes.openai)
         LlmProviderFactory(team=team, type=LlmProviderTypes.perplexity)
+
+        # Global provider
+        EmbeddingProviderModelFactory(type=LlmProviderTypes.openai)
+
+        # Team specific providers
         EmbeddingProviderModelFactory(team=team, type=LlmProviderTypes.openai)
+
+        team_b = TeamFactory()
+        EmbeddingProviderModelFactory(team=team_b, type=LlmProviderTypes.openai)
 
         form = CollectionForm(request=request)
         assert form.fields["llm_provider"].queryset.count() == 1
         assert form.fields["llm_provider"].queryset.first() == openai_provider, (
             "LlmProvider queryset should only contain OpenAI provider"
+        )
+
+        assert form.fields["llm_provider"].queryset.exclude(Q(team_id=None) | Q(team_id=team.id)).exists() is False, (
+            "Team specific models are not scoped to a team"
         )


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Limit LLM provider set to those with embedding models

## User Impact
<!-- Describe the impact of this change on the end-users. -->
This should prevent confusion when users try to select a provider with no embedding models.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/127