### PR TITLE
Fix 404 error in feature flag admin UI editing

### DIFF
--- a/templates/admin/flags/detail.html
+++ b/templates/admin/flags/detail.html
@@ -42,6 +42,7 @@
     <div
       x-data="flagManager({
               flagId: {{ flag.id }},
+              flagName: '{{ flag.name }}',
               initialData: {
               everyone: {{ flag.everyone|yesno:'true,false' }},
               testing: {{ flag.testing|yesno:'true,false' }},
@@ -242,6 +243,7 @@
     function flagManager(config) {
       return {
         flagId: config.flagId,
+        flagName: config.flagName,
         formData: { ...config.initialData },
         originalData: { ...config.initialData },
         loading: false,
@@ -314,7 +316,7 @@
 
           try {
             const formData = this.buildFormData();
-            const response = await fetch(`/admin/flags/${this.flagId}/update/`, {
+            const response = await fetch(`/admin/flags/${this.flagName}/update/`, {
               method: 'POST',
               body: formData
             });


### PR DESCRIPTION
## Summary
- Fixed 404 error when editing feature flags in the admin UI
- The JavaScript was using flag ID instead of flag name in the POST URL

## Changes
- Pass flag name to flagManager Alpine.js component
- Use flag name instead of flag ID in fetch URL  
- Update URL from `/admin/flags/${flagId}/update/` to `/admin/flags/${flagName}/update/`

## Test plan
- [ ] Navigate to admin feature flags page
- [ ] Click on any feature flag to edit it
- [ ] Make changes to the flag settings
- [ ] Click save - should now work without 404 error

🤖 Generated with [Claude Code](https://claude.ai/code)