### PR TITLE
Prefetch tags in more places

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1254,7 +1254,18 @@ def experiment_session_messages_view(request, team_slug: str, experiment_id: uui
     language = request.GET.get("language", "")
     show_original_translation = request.GET.get("show_original_translation") == "on"
     page_size = 100
-    messages_queryset = ChatMessage.objects.filter(chat=session.chat).all().order_by("created_at")
+    messages_queryset = (
+        ChatMessage.objects.filter(chat=session.chat)
+        .order_by("created_at")
+        .prefetch_related(
+            Prefetch(
+                "tagged_items",
+                queryset=CustomTaggedItem.objects.select_related("tag", "user"),
+                to_attr="prefetched_tagged_items",
+            )
+        )
+    )
+
     available_languages, translatable_languages = _get_languages_for_chat(session)
     has_missing_translations = False
     translate_form_all = TranslateMessagesForm(


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
[Related ticket](https://dimagi.atlassian.net/browse/OCSBUGS-16?focusedCommentId=388034&sourceType=mention)
The issue came down to missing prefetched data

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Message and session level tags are now displayed again

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
![demo](https://github.com/user-attachments/assets/502587a8-bc99-4aea-95fe-9322bb17381a)

### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/131