### PR TITLE
parse multiselect correctly

### DIFF
--- a/assets/javascript/dashboard/main.js
+++ b/assets/javascript/dashboard/main.js
@@ -267,7 +267,7 @@ function dashboard() {
             }
             
             const sanitizedParams = this.sanitizeParams({...this.filters, ...params});
-            const urlParams = new URLSearchParams(sanitizedParams);
+            const urlParams = new URLSearchParams();
 
             for (const [key, value] of Object.entries(sanitizedParams)) {
                 if (Array.isArray(value)) {


### PR DESCRIPTION
## Description
Multiple Select is not working because the params are sent like this experiments = ['517,617']. Closes #1868 

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
