### PR TITLE
Add help link to the "Create from assistant" view

### DIFF
--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -388,6 +388,7 @@ class CreateCollectionFromAssistant(LoginAndTeamRequiredMixin, FormView, Permiss
         "title": "Create Collection from Assistant",
         "button_text": "Create Collection",
         "active_tab": "collections",
+        "title_help_content": render_help_with_link("", "migrate_from_assistant"),
     }
     object = None
 

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -613,6 +613,7 @@ DOCUMENTATION_LINKS = {
     "node_update_participant_data": "/concepts/pipelines/nodes/#update-participant-data",
     "chatbots": "/concepts/chatbots/",
     "collections": "/concepts/collections/",
+    "migrate_from_assistant": "/how-to/migrate_from_assistant_to_collection/",
 }
 # Available in templates as `docs_base_url`. Also see `apps.generics.help` and `generics/help.html`
 DOCUMENTATION_BASE_URL = env("DOCUMENTATION_BASE_URL", default="https://docs.openchatstudio.com")

--- a/templates/documents/create_from_assistant_form.html
+++ b/templates/documents/create_from_assistant_form.html
@@ -6,7 +6,10 @@
   <div class="app-card">
     <div class="grid grid-cols-6">
       <div class="col-span-5">
-        <h1 class="pg-title">{{ title }}</h1>
+        <div class="flex flex-row">
+          <h1 class="pg-title">{{ title }}</h1>
+          {% include "generic/help.html" with help_content=title_help_content %}
+        </div>
         <span class="text-neutral-500">Create an indexed collection from an OpenAI assistant's file search tools</span>
       </div>
     </div>


### PR DESCRIPTION
The help link points to the migration guide

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
I'm also planning to edit the warning banner that is shown on the assistants page and add
> Consult the [migration guide](https://docs.openchatstudio.com/how-to/migrate_from_assistant_to_collection/) for more information.

This is what is will look like:

<img width="1390" height="190" alt="image" src="https://github.com/user-attachments/assets/5d30e840-e954-43c2-8e69-10030d61a999" />


## User Impact
<!-- Describe the impact of this change on the end-users. -->
User should have enough guidence on migrating their assistants to an indexed collection

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
N/A