### PR TITLE
Translation: show_original_translation hidden when original language selected

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -1252,7 +1252,7 @@ def experiment_session_messages_view(request, team_slug: str, experiment_id: uui
     page = int(request.GET.get("page", 1))
     search = request.GET.get("search", "")
     language = request.GET.get("language", "")
-    show_original_translation = request.GET.get("show_original_translation") == "on"
+    show_original_translation = request.GET.get("show_original_translation") == "on" and language
     page_size = 100
     messages_queryset = (
         ChatMessage.objects.filter(chat=session.chat)


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
show_original_translation should only be true if language is selected

revealed during the demo during the coworking block

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Original message is always hidden when `Original (default)` option is selected for language in translation

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
n/a

### Docs and Changelog
<!--Link to documentation that has been updated.-->
no
