### PR TITLE
Responses API: Support for downloading generated files

### DIFF
--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -230,7 +230,7 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
         external_ids = []
         ids = []
 
-        metadata_key = ["openai_file_ids", "ocs_attachment_file_ids", "cited_files"]
+        metadata_key = ["openai_file_ids", "ocs_attachment_file_ids", "cited_files", "generated_files"]
         for source in metadata_key:
             # openai_file_ids is a list of external ids
             id_list = external_ids if source == "openai_file_ids" else ids

--- a/apps/service_providers/llm_service/adapters.py
+++ b/apps/service_providers/llm_service/adapters.py
@@ -164,8 +164,10 @@ class ChatAdapter(BaseAdapter):
         """`cited_files` is a list of files that are cited in the response whereas generated files are those generated
         by the LLM
         """
-        self.session.chat.attach_files(attachment_type="file_citation", files=cited_files)
-        self.session.chat.attach_files(attachment_type="openai_file_ids", files=generated_files)
+        if cited_files:
+            self.session.chat.attach_files(attachment_type="file_citation", files=cited_files)
+        if generated_files:
+            self.session.chat.attach_files(attachment_type="openai_file_ids", files=generated_files)
         return {
             "cited_files": [file.id for file in cited_files],
             "openai_file_ids": [file.external_id for file in generated_files],

--- a/apps/service_providers/llm_service/adapters.py
+++ b/apps/service_providers/llm_service/adapters.py
@@ -170,7 +170,7 @@ class ChatAdapter(BaseAdapter):
             self.session.chat.attach_files(attachment_type="code_interpreter", files=generated_files)
         return {
             "cited_files": [file.id for file in cited_files],
-            "openai_file_ids": [file.external_id for file in generated_files],
+            "generated_files": [file.external_id for file in generated_files],
         }
 
     def add_citation_section_from_cited_files(self, ai_message: str, cited_files: list[File]) -> str:

--- a/apps/service_providers/llm_service/adapters.py
+++ b/apps/service_providers/llm_service/adapters.py
@@ -170,7 +170,7 @@ class ChatAdapter(BaseAdapter):
             self.session.chat.attach_files(attachment_type="code_interpreter", files=generated_files)
         return {
             "cited_files": [file.id for file in cited_files],
-            "generated_files": [file.external_id for file in generated_files],
+            "generated_files": [file.id for file in generated_files],
         }
 
     def add_citation_section_from_cited_files(self, ai_message: str, cited_files: list[File]) -> str:

--- a/apps/service_providers/llm_service/adapters.py
+++ b/apps/service_providers/llm_service/adapters.py
@@ -167,7 +167,7 @@ class ChatAdapter(BaseAdapter):
         if cited_files:
             self.session.chat.attach_files(attachment_type="file_citation", files=cited_files)
         if generated_files:
-            self.session.chat.attach_files(attachment_type="openai_file_ids", files=generated_files)
+            self.session.chat.attach_files(attachment_type="code_interpreter", files=generated_files)
         return {
             "cited_files": [file.id for file in cited_files],
             "openai_file_ids": [file.external_id for file in generated_files],

--- a/apps/service_providers/llm_service/adapters.py
+++ b/apps/service_providers/llm_service/adapters.py
@@ -161,7 +161,7 @@ class ChatAdapter(BaseAdapter):
         return self.session.chat.metadata.get("cancelled", False)
 
     def get_output_message_metadata(self, cited_files: set[File], generated_files: set[File]) -> dict:
-        """`cited_files` is a list of files that are cited in the response whereas generated files are those genrated
+        """`cited_files` is a list of files that are cited in the response whereas generated files are those generated
         by the LLM
         """
         self.session.chat.attach_files(attachment_type="file_citation", files=cited_files)

--- a/apps/service_providers/llm_service/adapters.py
+++ b/apps/service_providers/llm_service/adapters.py
@@ -160,13 +160,16 @@ class ChatAdapter(BaseAdapter):
         # TODO: change this to something specific to the current chat message
         return self.session.chat.metadata.get("cancelled", False)
 
-    def get_output_message_metadata(self, cited_files: list[File]) -> dict:
-        """`cited_files` is a list of files that are cited in the response."""
-        if not cited_files:
-            return {}
-
+    def get_output_message_metadata(self, cited_files: set[File], generated_files: set[File]) -> dict:
+        """`cited_files` is a list of files that are cited in the response whereas generated files are those genrated
+        by the LLM
+        """
         self.session.chat.attach_files(attachment_type="file_citation", files=cited_files)
-        return {"cited_files": [file.id for file in cited_files]}
+        self.session.chat.attach_files(attachment_type="openai_file_ids", files=generated_files)
+        return {
+            "cited_files": [file.id for file in cited_files],
+            "openai_file_ids": [file.external_id for file in generated_files],
+        }
 
     def add_citation_section_from_cited_files(self, ai_message: str, cited_files: list[File]) -> str:
         return populate_reference_section_from_citations(text=ai_message, cited_files=cited_files, session=self.session)

--- a/apps/service_providers/llm_service/datamodels.py
+++ b/apps/service_providers/llm_service/datamodels.py
@@ -12,7 +12,7 @@ class LlmChatResponse(BaseModel):
 
     This model is additive, meaning that two instances can be combined
     to create a new instance that contains the combined text and files.
-    This is useful for aggregating responses from multiple LLM calls or messages.
+    This is useful for aggregating streamed responses.
     """
 
     text: str

--- a/apps/service_providers/llm_service/datamodels.py
+++ b/apps/service_providers/llm_service/datamodels.py
@@ -22,7 +22,20 @@ class LlmChatResponse(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __add__(self, other: "LlmChatResponse") -> "LlmChatResponse":
-        """Add two LlmChatResponse instances together by combining their fields."""
+        """
+        Add two LlmChatResponse instances together by combining their fields.
+
+        >>> from apps.files.models import File
+        >>> response1 = LlmChatResponse(text="Hello ", cited_files={File(name="file1.txt")})
+        >>> response2 = LlmChatResponse(text="World!", generated_files={File(name="file2.txt")})
+        >>> combined = response1 + response2
+        >>> combined.text
+        'Hello World!'
+        >>> len(combined.cited_files)
+        1
+        >>> len(combined.generated_files)
+        1
+        """
         if not isinstance(other, LlmChatResponse):
             return Exception("Cannot add LlmChatResponse with non-LlmChatResponse type.")
 

--- a/apps/service_providers/llm_service/datamodels.py
+++ b/apps/service_providers/llm_service/datamodels.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+from apps.files.models import File
+
+
+class LlmChatResponse(BaseModel):
+    """
+    A data model representing a response from a large language model (LLM) chat.
+    It includes the text of the response, and sets for cited and generated files.
+    This model is used to structure the output from LLMs, allowing for easy access
+    to the response text and any associated files.
+
+    This model is additive, meaning that two instances can be combined
+    to create a new instance that contains the combined text and files.
+    This is useful for aggregating responses from multiple LLM calls or messages.
+    """
+
+    text: str
+    cited_files: set[File] = Field(default_factory=set)
+    generated_files: set[File] = Field(default_factory=set)
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def __add__(self, other: "LlmChatResponse") -> "LlmChatResponse":
+        """Add two LlmChatResponse instances together by combining their fields."""
+        if not isinstance(other, LlmChatResponse):
+            return Exception("Cannot add LlmChatResponse with non-LlmChatResponse type.")
+
+        return LlmChatResponse(
+            text="".join([self.text, other.text]),
+            cited_files=self.cited_files | other.cited_files,
+            generated_files=self.generated_files | other.generated_files,
+        )

--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -284,15 +284,6 @@ class OpenAIGenericService(LlmService):
             file_external_id = entry["file_id"]
             container_id = entry["container_id"]
 
-            # Check if file already exists in database
-            existing_file = File.objects.filter(
-                external_id=file_external_id, external_source="openai", team_id=team_id
-            ).first()
-
-            if existing_file:
-                generated_files.append(existing_file)
-                continue
-
             # Retrieve file content from OpenAI container
             try:
                 # Use direct HTTP request for container files until the library supports it and it is working with

--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -195,7 +195,9 @@ class LlmService(pydantic.BaseModel):
                 Q(external_id__in=cited_file_ids_remote) | Q(id__in=cited_file_ids), team_id=session.team_id
             ).all()
 
-        parsed_output = LlmChatResponse(text=final_text, cited_files=cited_files, generated_files=generated_files)
+        parsed_output = LlmChatResponse(
+            text=final_text, cited_files=set(cited_files), generated_files=set(generated_files)
+        )
         return parsed_output
 
     def get_remote_index_manager(self, index_id: str = None) -> "IndexManager":

--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -262,6 +262,9 @@ class OpenAIGenericService(LlmService):
             "openai_api_base": self.openai_api_base,
         }
 
+    def attach_built_in_tools(self, built_in_tools: list[str], config: dict[str, BaseModel] = None) -> list:
+        return []
+
     def get_cited_file_ids(self, annotation_entries: list[dict]) -> list[str]:
         external_ids = [
             entry["file_id"] for entry in annotation_entries if "file_id" in entry and entry["type"] == "file_citation"

--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -223,7 +223,7 @@ class LlmService(pydantic.BaseModel):
     def get_generated_files(self, annotation_entries: list[dict], team_id: int) -> list[File]:
         return []
 
-    def replace_file_links(self, text: str, file: File) -> str:
+    def replace_file_links(self, text: str, file: File, session: ExperimentSession) -> str:
         """
         Replace file links in the text with actual download links.
         """

--- a/apps/service_providers/llm_service/parsers.py
+++ b/apps/service_providers/llm_service/parsers.py
@@ -6,6 +6,7 @@ from langchain_core.agents import AgentAction, AgentFinish
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, ToolCall
 
+from apps.experiments.models import ExperimentSession
 from apps.service_providers.llm_service.datamodels import LlmChatResponse
 
 original_parse = parse_ai_message_to_tool_action
@@ -79,19 +80,19 @@ def custom_parse_ai_message(message) -> list[AgentAction] | AgentFinish:
     return actions
 
 
-def parse_output_for_anthropic(output, team_id: int, include_citations: bool = True) -> LlmChatResponse:
+def parse_output_for_anthropic(output, session: ExperimentSession, include_citations: bool = True) -> LlmChatResponse:
     if output is None or isinstance(output, str):
         return LlmChatResponse(text=output or "")
 
     if isinstance(output, list):
         chat_response = LlmChatResponse(text="")
         for item in output:
-            chat_response += parse_output_for_anthropic(item, include_citations=include_citations, team_id=team_id)
+            chat_response += parse_output_for_anthropic(item, session=session, include_citations=include_citations)
         return chat_response
 
     if isinstance(output, dict):
         if "output" in output:
-            return parse_output_for_anthropic(output["output"], include_citations=include_citations, team_id=team_id)
+            return parse_output_for_anthropic(output["output"], session=session, include_citations=include_citations)
         elif output.get("type") == "text":
             text = output.get("text", "")
             for citation in output.get("citations", []):

--- a/apps/service_providers/llm_service/parsers.py
+++ b/apps/service_providers/llm_service/parsers.py
@@ -6,6 +6,8 @@ from langchain_core.agents import AgentAction, AgentFinish
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, ToolCall
 
+from apps.service_providers.llm_service.datamodels import LlmChatResponse
+
 original_parse = parse_ai_message_to_tool_action
 
 
@@ -77,22 +79,26 @@ def custom_parse_ai_message(message) -> list[AgentAction] | AgentFinish:
     return actions
 
 
-def parse_output_for_anthropic(output):
+def parse_output_for_anthropic(output, team_id: int, include_citations: bool = True) -> LlmChatResponse:
     if output is None or isinstance(output, str):
-        return output or ""
+        return LlmChatResponse(text=output or "")
 
     if isinstance(output, list):
-        return "".join(parse_output_for_anthropic(item) for item in output)
+        chat_response = LlmChatResponse(text="")
+        for item in output:
+            chat_response += parse_output_for_anthropic(item, include_citations=include_citations, team_id=team_id)
+        return chat_response
 
     if isinstance(output, dict):
         if "output" in output:
-            return parse_output_for_anthropic(output["output"])
+            return parse_output_for_anthropic(output["output"], include_citations=include_citations, team_id=team_id)
         elif output.get("type") == "text":
             text = output.get("text", "")
             for citation in output.get("citations", []):
                 if citation.get("title") and citation.get("url"):
                     text += f" [{citation['title']}]({citation['url']})"
-            return text
+            # TODO: Add cited files
+            return LlmChatResponse(text=text)
         else:
-            return ""
-    return ""
+            return LlmChatResponse(text="")
+    return LlmChatResponse(text="")

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -155,7 +155,9 @@ class LLMChat(RunnableSerializable[str, ChainOutput]):
 
             llm_response = self._get_output_check_cancellation(input, merged_config)
             ai_message = llm_response.text
-            ai_message_metadata = self.adapter.get_output_message_metadata(llm_response.cited_files)
+            ai_message_metadata = self.adapter.get_output_message_metadata(
+                cited_files=llm_response.cited_files, generated_files=llm_response.generated_files
+            )
             if self.adapter.expect_citations:
                 ai_message = self.adapter.add_citation_section_from_cited_files(
                     ai_message, cited_files=llm_response.cited_files
@@ -272,9 +274,7 @@ class SimpleLLMChat(LLMChat):
 class AgentLLMChat(LLMChat):
     def _parse_output(self, output) -> LlmChatResponse:
         output_parser = self.adapter.get_llm_service().get_output_parser()
-        return output_parser(
-            output, team_id=self.adapter.session.team_id, include_citations=self.adapter.expect_citations
-        )
+        return output_parser(output, session=self.adapter.session, include_citations=self.adapter.expect_citations)
 
     def _build_chain(self) -> Runnable[dict[str, Any], dict]:
         tools = self.adapter.get_allowed_tools()

--- a/apps/service_providers/llm_service/utils.py
+++ b/apps/service_providers/llm_service/utils.py
@@ -116,6 +116,7 @@ def remove_citations_from_text(text: str) -> str:
 def get_openai_container_file_contents(
     container_id: str, openai_file_id: str, openai_api_key: str, openai_organization: str | None = None
 ) -> BytesIO:
+    # TODO: use the OpenAI Python client library when it supports container files
     headers = {"Authorization": f"Bearer {openai_api_key}", "OpenAI-Organization": openai_organization or ""}
     url = f"https://api.openai.com/v1/containers/{container_id}/files/{openai_file_id}/content"
 

--- a/apps/service_providers/llm_service/utils.py
+++ b/apps/service_providers/llm_service/utils.py
@@ -7,7 +7,7 @@ from apps.experiments.models import ExperimentSession
 from apps.files.models import File
 
 
-def detangle_file_ids(file_ids: str) -> list[str]:
+def detangle_file_ids(file_ids: list[str]) -> list[str]:
     """
     There is a bug in the OpenAI API where separate file ids are sometimes returned concatenated together.
 

--- a/apps/service_providers/llm_service/utils.py
+++ b/apps/service_providers/llm_service/utils.py
@@ -118,6 +118,7 @@ def get_openai_container_file_contents(
 ) -> BytesIO:
     headers = {"Authorization": f"Bearer {openai_api_key}", "OpenAI-Organization": openai_organization or ""}
     url = f"https://api.openai.com/v1/containers/{container_id}/files/{openai_file_id}/content"
-    response = httpx.get(url, headers=headers)
-    response.raise_for_status()
-    return BytesIO(response.content)
+
+    with httpx.stream("GET", url, headers=headers, timeout=30) as response:
+        response.raise_for_status()
+        return BytesIO(response.read())

--- a/apps/service_providers/llm_service/utils.py
+++ b/apps/service_providers/llm_service/utils.py
@@ -1,4 +1,7 @@
 import re
+from io import BytesIO
+
+import httpx
 
 from apps.experiments.models import ExperimentSession
 from apps.files.models import File
@@ -108,3 +111,13 @@ def remove_citations_from_text(text: str) -> str:
 
     citation_pattern = re.compile(OCS_CITATION_PATTERN)
     return citation_pattern.sub("", text)
+
+
+def get_openai_container_file_contents(
+    container_id: str, openai_file_id: str, openai_api_key: str, openai_organization: str | None = None
+) -> BytesIO:
+    headers = {"Authorization": f"Bearer {openai_api_key}", "OpenAI-Organization": openai_organization or ""}
+    url = f"https://api.openai.com/v1/containers/{container_id}/files/{openai_file_id}/content"
+    response = httpx.get(url, headers=headers)
+    response.raise_for_status()
+    return BytesIO(response.content)

--- a/apps/service_providers/tests/test_datamodels.py
+++ b/apps/service_providers/tests/test_datamodels.py
@@ -1,0 +1,46 @@
+import pytest
+
+from apps.service_providers.llm_service.datamodels import LlmChatResponse
+from apps.utils.factories.files import FileFactory
+
+
+@pytest.mark.django_db()
+class TestLlmChatResponse:
+    def test_add_two_responses_with_text_only(self):
+        """Test adding two LlmChatResponse instances with only text."""
+        response1 = LlmChatResponse(text="Hello ")
+        response2 = LlmChatResponse(text="World!")
+
+        result = response1 + response2
+
+        assert result.text == "Hello World!"
+        assert result.cited_files == set()
+        assert result.generated_files == set()
+
+    def test_add_two_responses_with_cited_files(self):
+        """Test adding two LlmChatResponse instances with cited files."""
+        file1 = FileFactory(name="file1.txt")
+        file2 = FileFactory(name="file2.txt")
+
+        response1 = LlmChatResponse(text="Hello ", cited_files={file1})
+        response2 = LlmChatResponse(text="World!", cited_files={file2})
+
+        result = response1 + response2
+
+        assert result.text == "Hello World!"
+        assert result.cited_files == {file1, file2}
+        assert result.generated_files == set()
+
+    def test_add_two_responses_with_generated_files(self):
+        """Test adding two LlmChatResponse instances with generated files."""
+        file1 = FileFactory(name="generated1.txt")
+        file2 = FileFactory(name="generated2.txt")
+
+        response1 = LlmChatResponse(text="Hello ", generated_files={file1})
+        response2 = LlmChatResponse(text="World!", generated_files={file2})
+
+        result = response1 + response2
+
+        assert result.text == "Hello World!"
+        assert result.cited_files == set()
+        assert result.generated_files == {file1, file2}

--- a/apps/service_providers/tests/test_output_parsing.py
+++ b/apps/service_providers/tests/test_output_parsing.py
@@ -2,35 +2,36 @@ from langchain.agents.output_parsers.tools import ToolAgentAction
 from langchain_core.agents import AgentStep
 from langchain_core.messages import AIMessage, FunctionMessage
 
+from apps.service_providers.llm_service.datamodels import LlmChatResponse
 from apps.service_providers.llm_service.parsers import parse_output_for_anthropic
 
 
 class TestParseOutputForAnthropic:
     def test_none_input(self):
-        assert parse_output_for_anthropic(None) == ""
+        assert parse_output_for_anthropic(None, team_id=None) == LlmChatResponse(text="")
 
     def test_empty_string_input(self):
-        assert parse_output_for_anthropic("") == ""
+        assert parse_output_for_anthropic("", team_id=None) == LlmChatResponse(text="")
 
     def test_string_input(self):
         text = "Hello, world!"
-        assert parse_output_for_anthropic(text) == text
+        assert parse_output_for_anthropic(text, team_id=None) == LlmChatResponse(text=text)
 
     def test_dict_with_output_key(self):
         output = {"output": "This is the response"}
-        assert parse_output_for_anthropic(output) == "This is the response"
+        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="This is the response")
 
     def test_dict_with_text_key(self):
         output = {"type": "text", "text": "This is the text content"}
-        assert parse_output_for_anthropic(output) == "This is the text content"
+        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="This is the text content")
 
     def test_dict_without_output_or_text_key(self):
         output = {"some_key": "some_value"}
-        assert parse_output_for_anthropic(output) == ""
+        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="")
 
     def test_list_with_text_objects(self):
         output = [{"text": "Hello", "type": "text", "index": 0}, {"text": " world!", "type": "text", "index": 1}]
-        assert parse_output_for_anthropic(output) == "Hello world!"
+        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="Hello world!")
 
     def test_list_with_text_objects_and_citations(self):
         output = [
@@ -50,8 +51,10 @@ class TestParseOutputForAnthropic:
                 ],
             }
         ]
-        expected = "Here's some information [Weather](https://weather.com/) [Source 2](https://example.com/2)"
-        assert parse_output_for_anthropic(output) == expected
+        expected = LlmChatResponse(
+            text="Here's some information [Weather](https://weather.com/) [Source 2](https://example.com/2)"
+        )
+        assert parse_output_for_anthropic(output, team_id=None) == expected
 
     def test_list_with_mixed_content(self):
         output = [
@@ -59,14 +62,14 @@ class TestParseOutputForAnthropic:
             "String part",
             {"type": "other", "content": "should be ignored"},
         ]
-        assert parse_output_for_anthropic(output) == "Text partString part"
+        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="Text partString part")
 
     def test_list_with_tool_use_objects_are_ignored(self):
         output = [
             {"text": "I'll help you", "type": "text", "index": 0},
             {"id": "tool_123", "name": "update-user-data", "type": "tool_use", "input": {}},
         ]
-        assert parse_output_for_anthropic(output) == "I'll help you"
+        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="I'll help you")
 
     def test_sample_output_with_actions_dict(self):
         result = parse_output_for_anthropic(
@@ -74,9 +77,10 @@ class TestParseOutputForAnthropic:
                 "actions": [
                     {"type": "tool_use", "name": "update-user-data", "input": {"key": "name", "value": "Jack"}},
                 ]
-            }
+            },
+            team_id=None,
         )
-        assert result == ""
+        assert result == LlmChatResponse(text="")
 
     def test_sample_output_with_steps_dict(self):
         result = parse_output_for_anthropic(
@@ -98,9 +102,10 @@ class TestParseOutputForAnthropic:
                         content="Success", additional_kwargs={}, response_metadata={}, name="update-user-data"
                     )
                 ],
-            }
+            },
+            team_id=None,
         )
-        assert result == ""
+        assert result == LlmChatResponse(text="")
 
     def test_sample_output_with_proper_output_dict(self):
         result = parse_output_for_anthropic(
@@ -120,12 +125,13 @@ class TestParseOutputForAnthropic:
                     )
                 ],
             },
+            team_id=None,
         )
-        expected = "Is there anything else you need help with?"
+        expected = LlmChatResponse(text="Is there anything else you need help with?")
         assert result == expected
 
     def test_empty_list(self):
-        assert parse_output_for_anthropic([]) == ""
+        assert parse_output_for_anthropic([], team_id=None) == LlmChatResponse(text="")
 
     def test_list_with_no_valid_items(self):
         output = [
@@ -134,7 +140,7 @@ class TestParseOutputForAnthropic:
             123,  # Non-dict, non-string item
             None,  # None item
         ]
-        assert parse_output_for_anthropic(output) == ""
+        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="")
 
     def test_citations_without_title_or_url(self):
         output = [
@@ -148,5 +154,5 @@ class TestParseOutputForAnthropic:
                 ],
             }
         ]
-        expected = "Text with incomplete citations [Complete](https://example.com/complete)"
-        assert parse_output_for_anthropic(output) == expected
+        expected = LlmChatResponse(text="Text with incomplete citations [Complete](https://example.com/complete)")
+        assert parse_output_for_anthropic(output, team_id=None) == expected

--- a/apps/service_providers/tests/test_output_parsing.py
+++ b/apps/service_providers/tests/test_output_parsing.py
@@ -8,30 +8,30 @@ from apps.service_providers.llm_service.parsers import parse_output_for_anthropi
 
 class TestParseOutputForAnthropic:
     def test_none_input(self):
-        assert parse_output_for_anthropic(None, team_id=None) == LlmChatResponse(text="")
+        assert parse_output_for_anthropic(None, session=None) == LlmChatResponse(text="")
 
     def test_empty_string_input(self):
-        assert parse_output_for_anthropic("", team_id=None) == LlmChatResponse(text="")
+        assert parse_output_for_anthropic("", session=None) == LlmChatResponse(text="")
 
     def test_string_input(self):
         text = "Hello, world!"
-        assert parse_output_for_anthropic(text, team_id=None) == LlmChatResponse(text=text)
+        assert parse_output_for_anthropic(text, session=None) == LlmChatResponse(text=text)
 
     def test_dict_with_output_key(self):
         output = {"output": "This is the response"}
-        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="This is the response")
+        assert parse_output_for_anthropic(output, session=None) == LlmChatResponse(text="This is the response")
 
     def test_dict_with_text_key(self):
         output = {"type": "text", "text": "This is the text content"}
-        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="This is the text content")
+        assert parse_output_for_anthropic(output, session=None) == LlmChatResponse(text="This is the text content")
 
     def test_dict_without_output_or_text_key(self):
         output = {"some_key": "some_value"}
-        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="")
+        assert parse_output_for_anthropic(output, session=None) == LlmChatResponse(text="")
 
     def test_list_with_text_objects(self):
         output = [{"text": "Hello", "type": "text", "index": 0}, {"text": " world!", "type": "text", "index": 1}]
-        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="Hello world!")
+        assert parse_output_for_anthropic(output, session=None) == LlmChatResponse(text="Hello world!")
 
     def test_list_with_text_objects_and_citations(self):
         output = [
@@ -54,7 +54,7 @@ class TestParseOutputForAnthropic:
         expected = LlmChatResponse(
             text="Here's some information [Weather](https://weather.com/) [Source 2](https://example.com/2)"
         )
-        assert parse_output_for_anthropic(output, team_id=None) == expected
+        assert parse_output_for_anthropic(output, session=None) == expected
 
     def test_list_with_mixed_content(self):
         output = [
@@ -62,14 +62,14 @@ class TestParseOutputForAnthropic:
             "String part",
             {"type": "other", "content": "should be ignored"},
         ]
-        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="Text partString part")
+        assert parse_output_for_anthropic(output, session=None) == LlmChatResponse(text="Text partString part")
 
     def test_list_with_tool_use_objects_are_ignored(self):
         output = [
             {"text": "I'll help you", "type": "text", "index": 0},
             {"id": "tool_123", "name": "update-user-data", "type": "tool_use", "input": {}},
         ]
-        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="I'll help you")
+        assert parse_output_for_anthropic(output, session=None) == LlmChatResponse(text="I'll help you")
 
     def test_sample_output_with_actions_dict(self):
         result = parse_output_for_anthropic(
@@ -78,7 +78,7 @@ class TestParseOutputForAnthropic:
                     {"type": "tool_use", "name": "update-user-data", "input": {"key": "name", "value": "Jack"}},
                 ]
             },
-            team_id=None,
+            session=None,
         )
         assert result == LlmChatResponse(text="")
 
@@ -103,7 +103,7 @@ class TestParseOutputForAnthropic:
                     )
                 ],
             },
-            team_id=None,
+            session=None,
         )
         assert result == LlmChatResponse(text="")
 
@@ -125,13 +125,13 @@ class TestParseOutputForAnthropic:
                     )
                 ],
             },
-            team_id=None,
+            session=None,
         )
         expected = LlmChatResponse(text="Is there anything else you need help with?")
         assert result == expected
 
     def test_empty_list(self):
-        assert parse_output_for_anthropic([], team_id=None) == LlmChatResponse(text="")
+        assert parse_output_for_anthropic([], session=None) == LlmChatResponse(text="")
 
     def test_list_with_no_valid_items(self):
         output = [
@@ -140,7 +140,7 @@ class TestParseOutputForAnthropic:
             123,  # Non-dict, non-string item
             None,  # None item
         ]
-        assert parse_output_for_anthropic(output, team_id=None) == LlmChatResponse(text="")
+        assert parse_output_for_anthropic(output, session=None) == LlmChatResponse(text="")
 
     def test_citations_without_title_or_url(self):
         output = [
@@ -155,4 +155,4 @@ class TestParseOutputForAnthropic:
             }
         ]
         expected = LlmChatResponse(text="Text with incomplete citations [Complete](https://example.com/complete)")
-        assert parse_output_for_anthropic(output, team_id=None) == expected
+        assert parse_output_for_anthropic(output, session=None) == expected

--- a/apps/service_providers/tests/test_runnables.py
+++ b/apps/service_providers/tests/test_runnables.py
@@ -376,7 +376,7 @@ def test_cited_files_are_saved_in_metadata(session):
 
     # Assert that the file id is saved as a citation in the metadata of the AI message
     ai_message = session.chat.messages.get(message_type=ChatMessageType.AI)
-    assert ai_message.metadata == {"cited_files": [file.id], "openai_file_ids": []}
+    assert ai_message.metadata == {"cited_files": [file.id], "generated_files": []}
 
 
 @pytest.mark.django_db()

--- a/apps/service_providers/tests/test_runnables.py
+++ b/apps/service_providers/tests/test_runnables.py
@@ -385,8 +385,8 @@ def test_citation_handling(expect_citations, session):
     Test that references are included in the output when expected. When we do not expect file references, any citation
     tags should be stripped and we should not see any file references in the output.
     """
-    file1 = FileFactory(id=123, name="document1.pdf", team=session.team)
-    file2 = FileFactory(id=456, name="document2.txt", team=session.team)
+    FileFactory(id=123, name="document1.pdf", team=session.team)
+    FileFactory(id=456, name="document2.txt", team=session.team)
 
     # Mock the LLM response with citations
     llm_response_text = "This is a fact <CIT 123 />. Another fact <CIT 456 />."
@@ -408,11 +408,9 @@ def test_citation_handling(expect_citations, session):
 
     # Create runnable and invoke
     history_manager = _get_history_manager(session)
-    runnable = SimpleLLMChat(adapter=adapter, history_manager=history_manager)
+    runnable = AgentLLMChat(adapter=adapter, history_manager=history_manager)
 
-    with patch.object(runnable, "_get_cited_files") as _get_cited_files:
-        _get_cited_files.return_value = [file1, file2]
-        result = runnable.invoke("Tell me about the documents")
+    result = runnable.invoke("Tell me about the documents")
 
     if expect_citations:
         # Quick check to see if references are included

--- a/apps/service_providers/tests/test_runnables_cancellation.py
+++ b/apps/service_providers/tests/test_runnables_cancellation.py
@@ -41,6 +41,7 @@ def session(fake_llm_service):
 
 @pytest.mark.django_db()
 @patch("apps.service_providers.llm_service.adapters.get_tools")
+@patch("apps.chat.models.Chat.attach_files", new=Mock())
 def test_simple_runnable_cancellation(get_tools, session, fake_llm_service):
     get_tools.return_value = []
     runnable = _get_runnable_with_mocked_history(session, SimpleLLMChat)
@@ -49,6 +50,7 @@ def test_simple_runnable_cancellation(get_tools, session, fake_llm_service):
 
 @pytest.mark.django_db()
 @patch("apps.service_providers.llm_service.adapters.get_tools")
+@patch("apps.chat.models.Chat.attach_files", new=Mock())
 def test_agent_runnable_cancellation(get_tools, session, fake_llm_service):
     get_tools.return_value = [OneOffReminderTool(experiment_session=session)]
     runnable = _get_runnable_with_mocked_history(session, AgentLLMChat)


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Resolves #1895 
This is a semi-urgent feature. See [this thread](https://dimagi.slack.com/archives/C05PK63Q89H/p1752663055115099).

When using the code execution tool and a file is generated, users will now be able to download it. OCS checks for `container_file_citation` annotations, then create files in OCS for those files and attach them to the message.

This PR also includes a refactor to the code that parses the LLM output.
- `LlmChatResponse` is extended to include generated files
- `_parse_output` now returns `LlmChatResponse`, which is also now addable
```python
LlmChatResponse(text="Hello", cited_files=[File1]) + LlmChatResponse(text=" World", cited_files=[File2]) = LlmChatResponse(text="Hello World", cited_files=[File1, File2])
```

## User Impact
<!-- Describe the impact of this change on the end-users. -->
When using the code execution tool and a file is generated, users will be able to download it.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
Here's some screenshots. As you can see, my spelling is impeccable

<img width="1319" height="497" alt="image" src="https://github.com/user-attachments/assets/0c092ccb-fd85-4b23-8eb2-4c4ea62268aa" />

<img width="1157" height="928" alt="image" src="https://github.com/user-attachments/assets/33291a30-df9c-40f1-8427-ecbb3bfa4d60" />


### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/137