### PR TITLE
Smh/widget markdown

### DIFF
--- a/components/chat_widget/package-lock.json
+++ b/components/chat_widget/package-lock.json
@@ -10,10 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.26.0",
+        "dompurify": "^3.0.5",
+        "marked": "^4.3.0",
         "npmrc": "^1.1.1"
       },
       "devDependencies": {
         "@stencil-community/postcss": "^2.2.0",
+        "@tailwindcss/typography": "^0.5.16",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.13.4",
         "autoprefixer": "^10.4.20",
@@ -1180,6 +1183,36 @@
         "npm": ">=7.10.0"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -1296,6 +1329,13 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -2402,6 +2442,15 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4751,6 +4800,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4798,6 +4868,18 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/math-intrinsics": {

--- a/components/chat_widget/package.json
+++ b/components/chat_widget/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@stencil/core": "^4.26.0",
+    "dompurify": "^3.0.5",
     "marked": "^4.3.0",
     "npmrc": "^1.1.1"
   },

--- a/components/chat_widget/package.json
+++ b/components/chat_widget/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@stencil/core": "^4.26.0",
+    "marked": "^4.3.0",
     "npmrc": "^1.1.1"
   },
   "devDependencies": {

--- a/components/chat_widget/package.json
+++ b/components/chat_widget/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@stencil-community/postcss": "^2.2.0",
+    "@tailwindcss/typography": "^0.5.16",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.13.4",
     "autoprefixer": "^10.4.20",

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.css
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.css
@@ -84,3 +84,105 @@ textarea {
 .overflow-y-auto::-webkit-scrollbar-thumb:hover {
   @apply bg-gray-400;
 }
+
+/* Markdown content styling for chat messages */
+.chat-markdown {
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+/* Reset margins for first/last elements */
+.chat-markdown > *:first-child { margin-top: 0; }
+.chat-markdown > *:last-child { margin-bottom: 0; }
+
+.chat-markdown p { margin-bottom: 0.5rem; }
+.chat-markdown p:last-child { margin-bottom: 0; }
+
+.chat-markdown h1, .chat-markdown h2, .chat-markdown h3 {
+  font-weight: 600;
+  margin: 0.75rem 0 0.5rem 0;
+  line-height: 1.25;
+}
+.chat-markdown h1:first-child, .chat-markdown h2:first-child, .chat-markdown h3:first-child { margin-top: 0; }
+
+.chat-markdown h1 { font-size: 1.125rem; }
+.chat-markdown h2 { font-size: 1rem; }
+.chat-markdown h3 { font-size: 0.875rem; font-weight: 500; }
+
+.chat-markdown strong, .chat-markdown b { font-weight: 600; }
+.chat-markdown em, .chat-markdown i { font-style: italic; }
+.chat-markdown u { text-decoration: underline; }
+.chat-markdown del { text-decoration: line-through; }
+
+/* Code elements */
+.chat-markdown code, .chat-markdown pre {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background-color: #f3f4f6;
+  border-radius: 0.25rem;
+}
+
+/* Inline code */
+.chat-markdown code {
+  padding: 0.125rem 0.375rem;
+  font-size: 0.75rem;
+  word-break: break-word;
+}
+
+/* Code blocks */
+.chat-markdown pre {
+  padding: 0.75rem;
+  font-size: 0.75rem;
+  overflow-x: auto;
+  margin-bottom: 0.5rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+}
+.chat-markdown pre code {
+  background: transparent;
+  padding: 0;
+}
+
+/* Lists */
+.chat-markdown ul, .chat-markdown ol {
+  margin-bottom: 0.5rem;
+  padding-left: 1rem;
+}
+.chat-markdown ul { list-style-type: disc; }
+.chat-markdown ol { list-style-type: decimal; }
+.chat-markdown li { margin-bottom: 0.25rem; }
+.chat-markdown li > ul, .chat-markdown li > ol { margin: 0.25rem 0 0 0; }
+
+/* Links */
+.chat-markdown a {
+  color: #2563eb;
+  text-decoration: underline;
+  word-break: break-word;
+}
+.chat-markdown a:hover { color: #1e40af; }
+
+/* Blockquotes */
+.chat-markdown blockquote {
+  border-left: 4px solid #d1d5db;
+  padding-left: 0.75rem;
+  font-style: italic;
+  margin-bottom: 0.5rem;
+  color: #6b7280;
+}
+
+/* User messages (blue background) adjustments */
+.bg-blue-500 .chat-markdown code,
+.bg-blue-500 .chat-markdown pre {
+  background-color: rgba(59, 130, 246, 0.5);
+  color: #dbeafe;
+}
+.bg-blue-500 .chat-markdown pre { border-color: #60a5fa; }
+.bg-blue-500 .chat-markdown blockquote { border-color: #93c5fd; color: #dbeafe; }
+.bg-blue-500 .chat-markdown a { color: #dbeafe; }
+.bg-blue-500 .chat-markdown a:hover { color: #ffffff; }
+
+/* Assistant messages (gray background) adjustments */
+.bg-gray-200 .chat-markdown code,
+.bg-gray-200 .chat-markdown pre {
+  background-color: #ffffff;
+  border: 1px solid #d1d5db;
+}

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.css
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.css
@@ -87,102 +87,31 @@ textarea {
 
 /* Markdown content styling for chat messages */
 .chat-markdown {
-  font-size: 0.875rem;
-  line-height: 1.5;
+  @apply prose prose-sm prose-gray max-w-none;
 }
 
-/* Reset margins for first/last elements */
-.chat-markdown > *:first-child { margin-top: 0; }
-.chat-markdown > *:last-child { margin-bottom: 0; }
-
-.chat-markdown p { margin-bottom: 0.5rem; }
-.chat-markdown p:last-child { margin-bottom: 0; }
-
-.chat-markdown h1, .chat-markdown h2, .chat-markdown h3 {
-  font-weight: 600;
-  margin: 0.75rem 0 0.5rem 0;
-  line-height: 1.25;
-}
-.chat-markdown h1:first-child, .chat-markdown h2:first-child, .chat-markdown h3:first-child { margin-top: 0; }
-
-.chat-markdown h1 { font-size: 1.125rem; }
-.chat-markdown h2 { font-size: 1rem; }
-.chat-markdown h3 { font-size: 0.875rem; font-weight: 500; }
-
-.chat-markdown strong, .chat-markdown b { font-weight: 600; }
-.chat-markdown em, .chat-markdown i { font-style: italic; }
-.chat-markdown u { text-decoration: underline; }
-.chat-markdown del { text-decoration: line-through; }
-
-/* Code elements */
-.chat-markdown code, .chat-markdown pre {
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  background-color: #f3f4f6;
-  border-radius: 0.25rem;
+/* override spacing */
+.chat-markdown > * {
+  margin-top: 0.1rem;
+  margin-bottom: 0.1rem;
 }
 
-/* Inline code */
-.chat-markdown code {
-  padding: 0.125rem 0.375rem;
-  font-size: 0.75rem;
-  word-break: break-word;
+.bg-blue-500 .chat-markdown {
+  @apply prose-invert;
 }
 
-/* Code blocks */
-.chat-markdown pre {
-  padding: 0.75rem;
-  font-size: 0.75rem;
-  overflow-x: auto;
-  margin-bottom: 0.5rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 0.375rem;
-}
-.chat-markdown pre code {
-  background: transparent;
-  padding: 0;
+.bg-blue-500 .chat-markdown code {
+  @apply bg-blue-400/50 text-blue-50;
 }
 
-/* Lists */
-.chat-markdown ul, .chat-markdown ol {
-  margin-bottom: 0.5rem;
-  padding-left: 1rem;
-}
-.chat-markdown ul { list-style-type: disc; }
-.chat-markdown ol { list-style-type: decimal; }
-.chat-markdown li { margin-bottom: 0.25rem; }
-.chat-markdown li > ul, .chat-markdown li > ol { margin: 0.25rem 0 0 0; }
-
-/* Links */
-.chat-markdown a {
-  color: #2563eb;
-  text-decoration: underline;
-  word-break: break-word;
-}
-.chat-markdown a:hover { color: #1e40af; }
-
-/* Blockquotes */
-.chat-markdown blockquote {
-  border-left: 4px solid #d1d5db;
-  padding-left: 0.75rem;
-  font-style: italic;
-  margin-bottom: 0.5rem;
-  color: #6b7280;
-}
-
-/* User messages (blue background) adjustments */
-.bg-blue-500 .chat-markdown code,
 .bg-blue-500 .chat-markdown pre {
-  background-color: rgba(59, 130, 246, 0.5);
-  color: #dbeafe;
+  @apply bg-blue-400/50 border-blue-400;
 }
-.bg-blue-500 .chat-markdown pre { border-color: #60a5fa; }
-.bg-blue-500 .chat-markdown blockquote { border-color: #93c5fd; color: #dbeafe; }
-.bg-blue-500 .chat-markdown a { color: #dbeafe; }
-.bg-blue-500 .chat-markdown a:hover { color: #ffffff; }
 
-/* Assistant messages (gray background) adjustments */
-.bg-gray-200 .chat-markdown code,
+.bg-gray-200 .chat-markdown code {
+  @apply bg-white border border-gray-300;
+}
+
 .bg-gray-200 .chat-markdown pre {
-  background-color: #ffffff;
-  border: 1px solid #d1d5db;
+  @apply bg-white border border-gray-300;
 }

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -5,6 +5,7 @@ import {
   ChevronUpIcon,
   GripDotsVerticalIcon,
 } from './heroicons';
+import { renderMarkdownSync as renderMarkdownComplete } from '../../utils/markdown';
 
 interface ChatMessage {
   created_at: string;
@@ -677,7 +678,10 @@ export class OcsChat {
                       {this.parsedWelcomeMessages.map((message, index) => (
                         <div key={`welcome-${index}`} class="flex justify-start">
                           <div class="bg-gray-200 text-gray-800 max-w-xs lg:max-w-md px-4 py-2 rounded-lg">
-                            <div class="whitespace-pre-wrap">{message}</div>
+                            <div
+                              class="chat-markdown"
+                              innerHTML={renderMarkdownComplete(message)}
+                            ></div>
                           </div>
                         </div>
                       ))}
@@ -701,7 +705,10 @@ export class OcsChat {
                           'bg-gray-100 text-gray-600 text-sm': message.role === 'system'
                         }}
                       >
-                        <div class="whitespace-pre-wrap">{message.content}</div>
+                        <div
+                          class="chat-markdown"
+                          innerHTML={renderMarkdownComplete(message.content)}
+                        ></div>
                         {message.attachments && message.attachments.length > 0 && (
                           <div class="mt-2 space-y-1">
                             {message.attachments.map((attachment, attachmentIndex) => (

--- a/components/chat_widget/src/utils/markdown.ts
+++ b/components/chat_widget/src/utils/markdown.ts
@@ -8,40 +8,6 @@ marked.setOptions({
 });
 
 /**
- * Renders markdown content to sanitized HTML
- * @param content - The markdown content to render
- * @returns Sanitized HTML string
- */
-export async function renderMarkdown(content: string): Promise<string> {
-  if (!content || typeof content !== 'string') {
-    return '';
-  }
-
-  try {
-    const html = await marked(content);
-    return DOMPurify.sanitize(html, {
-      ALLOWED_TAGS: [
-        'p', 'br', 'strong', 'b', 'em', 'i', 'u', 'code', 'pre',
-        'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-        'blockquote', 'a', 'img', 'hr', 'table', 'thead', 'tbody',
-        'tr', 'td', 'th', 'del', 'ins', 'sub', 'sup'
-      ],
-      ALLOWED_ATTR: [
-        'href', 'target', 'rel', 'class', 'src', 'alt', 'title',
-        'width', 'height', 'align', 'colspan', 'rowspan'
-      ],
-      ALLOWED_URI_REGEXP: /^(?:(?:https?|ftp|mailto):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
-      ADD_ATTR: ['target'],
-      FORBID_TAGS: ['script', 'style', 'form', 'input', 'button'],
-      FORBID_ATTR: ['onclick', 'onload', 'onerror', 'onmouseover'],
-    });
-  } catch (error) {
-    console.error('Error rendering markdown:', error);
-    return DOMPurify.sanitize(content);
-  }
-}
-
-/**
  * Post-processes rendered HTML to add additional attributes
  * This is called after DOMPurify to ensure external links open in new tabs
  */
@@ -69,11 +35,6 @@ export function postProcessMarkdownHTML(html: string): string {
     console.error('Error post-processing markdown HTML:', error);
     return html;
   }
-}
-
-export async function renderMarkdownComplete(content: string): Promise<string> {
-  const html = await renderMarkdown(content);
-  return postProcessMarkdownHTML(html);
 }
 
 

--- a/components/chat_widget/src/utils/markdown.ts
+++ b/components/chat_widget/src/utils/markdown.ts
@@ -1,0 +1,109 @@
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+marked.setOptions({
+  breaks: true,
+  gfm: true,
+  smartypants: true,
+});
+
+/**
+ * Renders markdown content to sanitized HTML
+ * @param content - The markdown content to render
+ * @returns Sanitized HTML string
+ */
+export async function renderMarkdown(content: string): Promise<string> {
+  if (!content || typeof content !== 'string') {
+    return '';
+  }
+
+  try {
+    const html = await marked(content);
+    return DOMPurify.sanitize(html, {
+      ALLOWED_TAGS: [
+        'p', 'br', 'strong', 'b', 'em', 'i', 'u', 'code', 'pre',
+        'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'blockquote', 'a', 'img', 'hr', 'table', 'thead', 'tbody',
+        'tr', 'td', 'th', 'del', 'ins', 'sub', 'sup'
+      ],
+      ALLOWED_ATTR: [
+        'href', 'target', 'rel', 'class', 'src', 'alt', 'title',
+        'width', 'height', 'align', 'colspan', 'rowspan'
+      ],
+      ALLOWED_URI_REGEXP: /^(?:(?:https?|ftp|mailto):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+      ADD_ATTR: ['target'],
+      FORBID_TAGS: ['script', 'style', 'form', 'input', 'button'],
+      FORBID_ATTR: ['onclick', 'onload', 'onerror', 'onmouseover'],
+    });
+  } catch (error) {
+    console.error('Error rendering markdown:', error);
+    return DOMPurify.sanitize(content);
+  }
+}
+
+/**
+ * Post-processes rendered HTML to add additional attributes
+ * This is called after DOMPurify to ensure external links open in new tabs
+ */
+export function postProcessMarkdownHTML(html: string): string {
+  if (typeof window === 'undefined') {
+    return html;
+  }
+
+  try {
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = html;
+
+    // Add target="_blank" and rel="noopener noreferrer" to external links
+    const links = tempDiv.querySelectorAll('a[href]');
+    links.forEach((link) => {
+      const href = link.getAttribute('href');
+      if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
+        link.setAttribute('target', '_blank');
+        link.setAttribute('rel', 'noopener noreferrer');
+      }
+    });
+
+    return tempDiv.innerHTML;
+  } catch (error) {
+    console.error('Error post-processing markdown HTML:', error);
+    return html;
+  }
+}
+
+export async function renderMarkdownComplete(content: string): Promise<string> {
+  const html = await renderMarkdown(content);
+  return postProcessMarkdownHTML(html);
+}
+
+
+export function renderMarkdownSync(content: string): string {
+  if (!content || typeof content !== 'string') {
+    return '';
+  }
+
+  try {
+    const html = marked.parse(content);
+    const sanitized = DOMPurify.sanitize(html, {
+      ALLOWED_TAGS: [
+        'p', 'br', 'strong', 'b', 'em', 'i', 'u', 'code', 'pre',
+        'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'blockquote', 'a', 'img', 'hr', 'table', 'thead', 'tbody',
+        'tr', 'td', 'th', 'del', 'ins', 'sub', 'sup'
+      ],
+      ALLOWED_ATTR: [
+        'href', 'target', 'rel', 'class', 'src', 'alt', 'title',
+        'width', 'height', 'align', 'colspan', 'rowspan'
+      ],
+      ALLOWED_URI_REGEXP: /^(?:(?:https?|ftp|mailto):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+      ADD_ATTR: ['target'],
+      FORBID_TAGS: ['script', 'style', 'form', 'input', 'button'],
+      FORBID_ATTR: ['onclick', 'onload', 'onerror', 'onmouseover'],
+    });
+
+    return postProcessMarkdownHTML(sanitized);
+  } catch (error) {
+    console.error('Error rendering markdown sync:', error);
+    return DOMPurify.sanitize(content);
+  }
+}

--- a/components/chat_widget/src/utils/markdown.ts
+++ b/components/chat_widget/src/utils/markdown.ts
@@ -56,7 +56,7 @@ export function renderMarkdownSync(content: string): string {
         'href', 'target', 'rel', 'class', 'src', 'alt', 'title',
         'width', 'height', 'align', 'colspan', 'rowspan'
       ],
-      ALLOWED_URI_REGEXP: /^(?:(?:https?|ftp|mailto):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+      ALLOWED_URI_REGEXP: /^(?:(?:https?):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
       ADD_ATTR: ['target'],
       FORBID_TAGS: ['script', 'style', 'form', 'input', 'button'],
       FORBID_ATTR: ['onclick', 'onload', 'onerror', 'onmouseover'],

--- a/components/chat_widget/tailwind.config.js
+++ b/components/chat_widget/tailwind.config.js
@@ -4,4 +4,7 @@ module.exports = {
   theme: {
     extend: {},
   },
+  plugins: [
+    require('@tailwindcss/typography'),
+  ],
 }


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
resolves [#1896](https://github.com/dimagi/open-chat-studio/issues/1896)

## User Impact
<!-- Describe the impact of this change on the end-users. -->
all cheat messages are rendered in markdown

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
<img width="979" height="692" alt="Screenshot 2025-07-22 at 5 00 09 PM" src="https://github.com/user-attachments/assets/421a15da-70b8-4cb0-9dd1-1be2afebde0d" />

### Docs and Changelog
<!--Link to documentation that has been updated.-->
no, this is how it was before we just need it for the new release
