### PR TITLE
Remove file input from the file form

### DIFF
--- a/apps/files/forms.py
+++ b/apps/files/forms.py
@@ -54,11 +54,7 @@ class MultipleFileFieldForm(forms.Form):
 class FileForm(forms.ModelForm):
     class Meta:
         model = File
-        fields = ["name", "summary", "file"]
+        fields = ["name", "summary"]
         help_texts = {
             "summary": "This is only needed when the file will not be used for RAG",
         }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["file"].widget.attrs.update({"class": "file-input"})


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Resolves #1940 

Removes the file input to prevent users from changing the underlying file. I don't think it makes sense to allow them to do it at this level. All the necessary logic around indexing etc sits on the collection level, so users should rather just remove + upload a file if they want to change a file.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
User will not see the file input when navigating to a collection's file anymore.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
I don't think a changelog entry is necesary?