### PR TITLE
Chat Widget: Session Persistence

### DIFF
--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -124,15 +124,28 @@ export class OcsChat {
     this.loaded = this.visible;
     if (!this.chatbotId) {
       this.error = 'Chatbot ID is required';
+      return;
+    }
+    // Always try to load existing session if localStorage is available
+    if (this.isLocalStorageAvailable()) {
+      const { sessionId, messages } = this.loadSessionFromStorage();
+      if (sessionId && messages) {
+        this.sessionId = sessionId;
+        this.messages = messages;
+        this.showStarterQuestions = messages.length === 0;
+      }
     }
     this.parseWelcomeMessages();
     this.parseStarterQuestions();
   }
 
   componentDidLoad() {
-    // Auto-start session if visible on load
+    // Only auto-start session if we don't have an existing one
     if (this.visible && !this.sessionId) {
       this.startSession();
+    } else if (this.visible && this.sessionId) {
+      // Resume polling for existing session
+      this.startPolling();
     }
     this.initializePosition();
     window.addEventListener('resize', this.handleWindowResize);

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -218,6 +218,7 @@ export class OcsChat {
 
       const data: ChatStartSessionResponse = await response.json();
       this.sessionId = data.session_id;
+      this.saveSessionToStorage();
 
       // Handle seed message if present
       if (data.seed_message_task_id) {
@@ -261,6 +262,7 @@ export class OcsChat {
         attachments: []
       };
       this.messages = [...this.messages, userMessage];
+      this.saveSessionToStorage();
       this.messageInput = '';
       this.scrollToBottom();
 
@@ -324,6 +326,7 @@ export class OcsChat {
 
         if (data.status === 'complete' && data.message) {
           this.messages = [...this.messages, data.message];
+          this.saveSessionToStorage();
           this.scrollToBottom();
           // Task polling complete, clear typing indicator and resume message polling
           this.isTyping = false;
@@ -394,6 +397,7 @@ export class OcsChat {
 
       if (data.messages.length > 0) {
         this.messages = [...this.messages, ...data.messages];
+        this.saveSessionToStorage();
         this.scrollToBottom();
         this.focusInput();
       }

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -52,6 +52,11 @@ interface PointerEvent {
   clientY: number;
 }
 
+interface SessionStorageData {
+  sessionId?: string;
+  messages: ChatMessage[];
+}
+
 @Component({
   tag: 'open-chat-studio-widget',
   styleUrl: 'ocs-chat.css',
@@ -644,12 +649,24 @@ export class OcsChat {
     }
   }
 
-  private loadSessionFromStorage(): { sessionId?: string; messages: ChatMessage[] } {
+  private loadSessionFromStorage(): SessionStorageData {
     const keys = this.getStorageKeys();
     try {
-      const sessionId = localStorage.getItem(keys.sessionId) || undefined;
+      const storedSessionId = localStorage.getItem(keys.sessionId);
+      const sessionId = storedSessionId ? storedSessionId : undefined;
+
       const messagesJson = localStorage.getItem(keys.messages);
-      const messages = messagesJson ? JSON.parse(messagesJson) : [];
+      let messages: ChatMessage[] = [];
+
+      if (messagesJson) {
+        try {
+          const parsedMessages = JSON.parse(messagesJson);
+          messages = Array.isArray(parsedMessages) ? parsedMessages : [];
+        } catch (parseError) {
+          console.warn('Failed to parse messages from localStorage:', parseError);
+          messages = [];
+        }
+      }
 
       const lastActivity = localStorage.getItem(keys.lastActivity);
       if (lastActivity) {

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -740,20 +740,19 @@ export class OcsChat {
                   <GripDotsVerticalIcon/>
                 </div>
               </div>
-
-              {/* New Chat button */}
-              {this.sessionId && (
-                <button
-                  class="px-3 py-1 text-sm bg-blue-500 hover:bg-blue-600 text-white rounded-md transition-colors duration-200 pointer-events-auto"
-                  onClick={() => this.startNewChat()}
-                  title="Start new chat"
-                  aria-label="Start new chat"
-                >
-                  New Chat
-                </button>
-              )}
-
-              <div class="flex gap-1">
+              <div></div>
+              <div class="flex gap-1 items-center">
+                {/* New Chat button */}
+                {this.sessionId && (
+                  <button
+                    class="px-3 py-1 text-sm bg-blue-500 hover:bg-blue-600 text-white rounded-md transition-colors duration-200 pointer-events-auto"
+                    onClick={() => this.startNewChat()}
+                    title="Start new chat"
+                    aria-label="Start new chat"
+                  >
+                    New Chat
+                  </button>
+                )}
                 <button
                   class="p-1.5 rounded-md transition-colors duration-200 hover:bg-gray-100 text-gray-500"
                   onClick={() => this.toggleSize()}

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -692,13 +692,7 @@ export class OcsChat {
   }
 
   private async startNewChat(): Promise<void> {
-    try {
-      // Clear current session from storage (if available)
-      this.clearSessionStorage();
-    } catch (error) {
-      // If clearing storage fails, continue anyway
-      console.warn('Could not clear localStorage, continuing with new session:', error);
-    }
+    this.clearSessionStorage();
     this.sessionId = undefined;
     this.messages = [];
     this.showStarterQuestions = true;


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
resolves #1910 stores session in local storage for 24 hours or until user indicates "new chat"

## User Impact
<!-- Describe the impact of this change on the end-users. -->
less jarring to restart a convo every time they navigate, etc. 

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
coming shortly

### Docs and Changelog
<!--Link to documentation that has been updated.-->
yes to both
