### PR TITLE
Add collection chips to file form view

### DIFF
--- a/apps/files/views.py
+++ b/apps/files/views.py
@@ -229,6 +229,13 @@ class EditFile(LoginAndTeamRequiredMixin, UpdateView):
         "form_attrs": {"enctype": "multipart/form-data"},
     }
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Add collection chips for the file
+        collections = self.object.get_collection_references()
+        context['collection_chips'] = [Chip(label=col.name, url=col.get_absolute_url()) for col in collections]
+        return context
+
     def get_queryset(self):
         return File.objects.filter(team=self.request.team)
 

--- a/templates/documents/file_form.html
+++ b/templates/documents/file_form.html
@@ -14,6 +14,19 @@
   </div>
 {% endblock breadcrumbs %}
 
+{% block pre_form %}
+  {% if object.id and collection_chips %}
+    <div class="mb-4">
+      <h3 class="text-sm font-medium text-gray-700 mb-2">Collections</h3>
+      <div class="flex flex-wrap gap-2">
+        {% for chip in collection_chips %}
+          {% include "generic/chip.html" with chip=chip %}
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
+{% endblock pre_form %}
+
 {% block form %}
   {% render_form_fields form %}
 {% endblock form %}


### PR DESCRIPTION
Display collection chips on the file edit form to show which collections the file belongs to. Chips are clickable and link to the collection detail pages.

Resolves request from # PR 1948 (See https://github.com/dimagi/open-chat-studio/pull/1948#issuecomment-3126239396)

Generated with [Claude Code](https://claude.ai/code)

<img width="1195" height="588" alt="image" src="https://github.com/user-attachments/assets/2d6f93d9-2b54-4ade-b03a-6e41adacdde4" />
