### PR TITLE
Fix: Cleanup local index embeddings when deleting a file

### DIFF
--- a/apps/assistants/sync.py
+++ b/apps/assistants/sync.py
@@ -420,7 +420,7 @@ def remove_files_from_tool(ocs_resource: ToolResources, files: list[int]):
         if file in file_references:
             if ocs_resource.extra.get("vector_store_id") and file.external_id:
                 index_manager = OpenAIRemoteIndexManager(client, index_id=ocs_resource.extra.get("vector_store_id"))
-                index_manager.delete_file_from_index(file_id=file.external_id)
+                index_manager.pluck_file_from_index(file_id=file.external_id)
         else:
             # The file doesn't have related objects, so it's safe to remove it completely
             delete_file_from_openai(client, file)
@@ -449,7 +449,7 @@ def _get_files_missing_from_vector_store(client, vector_store_id, file_ids: list
 
     vector_store_manager = OpenAIRemoteIndexManager(client, index_id=vector_store_id)
     for file_id in to_delete_remote:
-        vector_store_manager.delete_file_from_index(file_id=file_id)
+        vector_store_manager.pluck_file_from_index(file_id=file_id)
 
     return file_ids
 

--- a/apps/assistants/tests/test_sync.py
+++ b/apps/assistants/tests/test_sync.py
@@ -355,7 +355,7 @@ def test_vector_store_create_batch_files(create_file_batch, create_vector_store,
 
 @pytest.mark.django_db()
 @patch("apps.assistants.sync.delete_file_from_openai")
-@patch("apps.assistants.sync.OpenAIRemoteIndexManager.delete_file_from_index")
+@patch("apps.assistants.sync.OpenAIRemoteIndexManager.pluck_file_from_index")
 def test_remove_files_from_tool(delete_file, delete_file_from_openai):
     collection = CollectionFactory()
     resource = ToolResources.objects.create(

--- a/apps/assistants/tests/test_views.py
+++ b/apps/assistants/tests/test_views.py
@@ -23,7 +23,7 @@ class TestDeleteFileFromAssistant:
             assistant=assistant, tool_type="code_interpreter", extra={"vector_store_id": "vs-123"}
         )
 
-    @patch("apps.assistants.sync.OpenAIRemoteIndexManager.delete_file_from_index")
+    @patch("apps.assistants.sync.OpenAIRemoteIndexManager.pluck_file_from_index")
     def test_delete_file_removes_relationship_and_keeps_file_when_used_elsewhere(
         self, delete_file, assistant, resource, client
     ):
@@ -52,7 +52,7 @@ class TestDeleteFileFromAssistant:
         delete_file.assert_called_once_with(file_id="file_123")
 
     @patch("apps.assistants.sync.delete_file_from_openai")
-    @patch("apps.assistants.sync.OpenAIRemoteIndexManager.delete_file_from_index")
+    @patch("apps.assistants.sync.OpenAIRemoteIndexManager.pluck_file_from_index")
     def test_delete_file_removes_file_when_no_other_references(
         self, delete_file, mock_delete_from_openai, assistant, resource, client
     ):

--- a/apps/documents/tests/test_views.py
+++ b/apps/documents/tests/test_views.py
@@ -237,7 +237,7 @@ class TestDeleteCollectionFile:
 
             if is_remote_index:
                 remote_index_manager_mock.delete_files.assert_not_called()
-                remote_index_manager_mock.delete_file_from_index.assert_called()
+                remote_index_manager_mock.pluck_file_from_index.assert_called()
             else:
                 local_index_manager_mock.delete_files.assert_not_called()
                 local_index_manager_mock.delete_embeddings.assert_called()

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -211,8 +211,9 @@ def delete_collection_file(request, team_slug: str, pk: int, file_id: int):
             index_manager = collection.get_index_manager()
             if collection.is_remote_index:
                 # Remove it from the index only
-                index_manager.delete_file_from_index(file_id=file.external_id)
+                index_manager.pluck_file_from_index(file_id=file.external_id)
             else:
+                # The collection file is already deleted, so we just remove the remaining embeddings
                 index_manager.delete_embeddings(file_id=file.id)
     else:
         # Nothing else is using it

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -208,9 +208,12 @@ def delete_collection_file(request, team_slug: str, pk: int, file_id: int):
 
     if file.is_used():
         if collection.is_index:
-            # Remove it from the index only
             index_manager = collection.get_index_manager()
-            index_manager.delete_file_from_index(file_id=file.external_id)
+            if collection.is_remote_index:
+                # Remove it from the index only
+                index_manager.delete_file_from_index(file_id=file.external_id)
+            else:
+                index_manager.delete_embeddings(file_id=file.id)
     else:
         # Nothing else is using it
         if collection.is_index:

--- a/apps/service_providers/llm_service/index_managers.py
+++ b/apps/service_providers/llm_service/index_managers.py
@@ -317,7 +317,7 @@ class LocalIndexManager(IndexManager):
             files: List of File instances to delete from the local index.
         """
         for file in files:
-            FileChunkEmbedding.objects.filter(file=file).delete()
+            self.delete_embeddings(file_id=file.id)
             file.external_id = ""
         File.objects.bulk_update(files, fields=["external_id"])
 

--- a/apps/service_providers/llm_service/index_managers.py
+++ b/apps/service_providers/llm_service/index_managers.py
@@ -31,7 +31,7 @@ class IndexManager(metaclass=ABCMeta):
         pass
 
 
-class RemoteIndexManager(metaclass=ABCMeta):
+class RemoteIndexManager(IndexManager):
     """
     Abstract base class for managing vector stores in remote indexing services.
 
@@ -231,7 +231,7 @@ class OpenAIRemoteIndexManager(RemoteIndexManager):
         File.objects.bulk_update(files, fields=["external_id"])
 
 
-class LocalIndexManager(metaclass=ABCMeta):
+class LocalIndexManager(IndexManager):
     """
     Abstract base class for managing local embedding operations.
 
@@ -320,6 +320,10 @@ class LocalIndexManager(metaclass=ABCMeta):
             FileChunkEmbedding.objects.filter(file=file).delete()
             file.external_id = ""
         File.objects.bulk_update(files, fields=["external_id"])
+
+    def delete_embeddings(self, file_id: str):
+        """Deleting a file from the local index doesn't really make"""
+        FileChunkEmbedding.objects.filter(file__id=file_id).delete()
 
 
 class OpenAILocalIndexManager(LocalIndexManager):

--- a/apps/service_providers/llm_service/index_managers.py
+++ b/apps/service_providers/llm_service/index_managers.py
@@ -108,7 +108,7 @@ class RemoteIndexManager(IndexManager):
         ...
 
     @abstractmethod
-    def delete_file_from_index(self, file_id: str):
+    def pluck_file_from_index(self, file_id: str):
         """Disassociates the file with the vector store"""
 
     def add_files(
@@ -178,7 +178,7 @@ class OpenAIRemoteIndexManager(RemoteIndexManager):
         with contextlib.suppress(openai.NotFoundError):
             self.client.vector_stores.delete(vector_store_id=self.index_id)
 
-    def delete_file_from_index(self, file_id: str):
+    def pluck_file_from_index(self, file_id: str):
         """Disassociates the file with the vector store"""
         try:
             self.client.vector_stores.files.delete(vector_store_id=self.index_id, file_id=file_id)

--- a/apps/service_providers/tests/test_index_managers.py
+++ b/apps/service_providers/tests/test_index_managers.py
@@ -101,6 +101,22 @@ class TestLocalIndexManager:
         collection_file.refresh_from_db()
         assert collection_file.status == FileStatus.FAILED
 
+    def test_delete_embeddings(self, local_index_instance):
+        file = FileFactory()
+        embedding = FileChunkEmbedding.objects.create(
+            team=file.team,
+            file=file,
+            collection=local_index_instance,
+            chunk_number=1,
+            page_number=1,
+            text="test embedding",
+            embedding=[0.1] * settings.EMBEDDING_VECTOR_SIZE,
+        )
+        local_index_instance.get_index_manager().delete_embeddings(file.id)
+
+        with pytest.raises(FileChunkEmbedding.DoesNotExist):
+            embedding.refresh_from_db()
+
 
 @pytest.mark.django_db()
 class TestRemoteIndexManager:

--- a/apps/service_providers/tests/test_index_managers.py
+++ b/apps/service_providers/tests/test_index_managers.py
@@ -48,7 +48,7 @@ class RemoteIndexManagerMock(RemoteIndexManager):
 
     def delete_remote_index(self): ...
 
-    def delete_file_from_index(self, *args, **kwargs): ...
+    def pluck_file_from_index(self, *args, **kwargs): ...
 
     def link_files_to_remote_index(self, *args, **kwargs): ...
     def file_exists_at_remote(self, *args, **kwargs) -> bool: ...
@@ -201,7 +201,7 @@ class TestOpenAIRemoteIndexManager:
 
     def test_delete_file_success(self, index_manager, provider_client_mock):
         """Test successful file deletion from vector store"""
-        index_manager.delete_file_from_index("file-123")
+        index_manager.pluck_file_from_index("file-123")
 
         provider_client_mock.vector_stores.files.delete.assert_called_once_with(
             vector_store_id="vs-test-123", file_id="file-123"
@@ -214,7 +214,7 @@ class TestOpenAIRemoteIndexManager:
         )
 
         # Should not raise exception, just log warning
-        index_manager.delete_file_from_index("file-123")
+        index_manager.pluck_file_from_index("file-123")
 
         provider_client_mock.vector_stores.files.delete.assert_called_once_with(
             vector_store_id="vs-test-123", file_id="file-123"


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Fixes https://dimagi.sentry.io/issues/6774487268/?alert_rule_id=14063560&alert_type=issue&notification_uuid=55facddf-2efe-4719-86a1-90342be00eaa&project=4505001320316928&referrer=issue_alert-slack

The issue was that we didn't handle file deletions for local indexes properly. A file is considered used when another object is using the file. This can be an assistant, or a `chat_attachment` (when a file was referenced in a response, we create these). We now remove the file chunk embeddings when removing the file while it is being used. Note that if the file is not used, we do the same, but we also clear out the file's external id, which we don't want to do in the case where the file is being used.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users will now be able to remove _all_ file from local indexes again

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
Pending