### PR TITLE
Point _iter_unpack_sequence_ to guarded_iter_unpack_sequence

### DIFF
--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -1156,6 +1156,9 @@ class CodeNode(PipelineNode, OutputMessageTagMixin):
             default_guarded_getitem,
             default_guarded_getiter,
         )
+        from RestrictedPython.Guards import (
+            guarded_iter_unpack_sequence,
+        )
 
         custom_globals = safe_globals.copy()
 
@@ -1175,6 +1178,7 @@ class CodeNode(PipelineNode, OutputMessageTagMixin):
                 "time": time,
                 "_getitem_": default_guarded_getitem,
                 "_getiter_": default_guarded_getiter,
+                "_iter_unpack_sequence_": guarded_iter_unpack_sequence,
                 "_write_": lambda x: x,
                 "get_participant_data": participant_data_proxy.get,
                 "set_participant_data": participant_data_proxy.set,


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
I mapped `_iter_unpack_sequence_` to `RestrictedPython.Guards.guarded_iter_unpack_sequence()`. According to https://restrictedpython.readthedocs.io/en/latest/usage/basic_usage.html#necessary-setup this should be done. The reason I looked into this is that someone faced this issue when looping in the code node:
> name 'iter_unpack_sequence' is not defined

This has been causing trouble for some users when using for loops. I am not sure why this isn't always causing issues.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
N/A

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
Pending