### PR TITLE
override loading

### DIFF
--- a/assets/styles/site-tailwind.css
+++ b/assets/styles/site-tailwind.css
@@ -179,3 +179,6 @@ input[type=number]::-webkit-outer-spin-button {
 .markdown a {
   @apply underline
 }
+.loading {
+  @apply w-5 h-5 border-2 border-blue-500 rounded-full animate-spin;
+}


### PR DESCRIPTION
## Description
Currently, whenever we start typing and an API call is made, the loading class is applied, which causes a large-sized loader to appear. I have overridden the loading classd
## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
[Demo](https://drive.google.com/file/d/1FfHacIOy2KeJfj61JYaEKi7JsAcSxnyV/view?usp=drive_link)

### Docs and Changelog
<!--Link to documentation that has been updated.-->
