### PR TITLE
Disable Uvicorn lifespan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,4 +91,4 @@ USER django
 
 ENV PORT=8000
 
-CMD ["sh", "-c", "gunicorn --bind 0.0.0.0:${PORT} --workers 1 --threads 8 --timeout 0 gpt_playground.asgi:application -k uvicorn.workers.UvicornWorker"]
+CMD ["sh", "-c", "gunicorn --bind 0.0.0.0:${PORT} --workers 1 --threads 8 --timeout 0 gpt_playground.asgi:application -k uvicorn.workers.UvicornWorker --worker-class gpt_playground.worker_class.DjangoUvicornWorker"]

--- a/gpt_playground/worker_class.py
+++ b/gpt_playground/worker_class.py
@@ -1,0 +1,11 @@
+from uvicorn.workers import UvicornWorker
+
+
+class DjangoUvicornWorker(UvicornWorker):
+    """
+    See https://stackoverflow.com/questions/75217343/django-can-only-handle-asgi-http-connections-not-lifespan-in-uvicorn
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.config.lifespan = "off"

--- a/heroku.yml
+++ b/heroku.yml
@@ -16,7 +16,7 @@ release:
 run:
   web:
     command:
-      - gunicorn --bind 0.0.0.0:$PORT --workers 1 --threads 8 --timeout 0 gpt_playground.asgi:application -k uvicorn.workers.UvicornWorker
+      - gunicorn --bind 0.0.0.0:$PORT --workers 1 --threads 8 --timeout 0 gpt_playground.asgi:application -k uvicorn.workers.UvicornWorker --worker-class gpt_playground.worker_class.DjangoUvicornWorker
     image: django
   worker:
     command:


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Should resolve https://dimagi.sentry.io/issues/6783748751/?alert_rule_id=14063560&alert_type=issue&notification_uuid=b5fd17bb-4789-4719-92dd-001504715d23&project=4505001320316928&referrer=issue_alert-slack

Apparently django doesn't support the lifespan protocol, so it should be fine to disable it I think

## User Impact
<!-- Describe the impact of this change on the end-users. -->

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
