### PR TITLE
file search tool prompt and output formatting tweaks

### DIFF
--- a/apps/chat/agent/schemas.py
+++ b/apps/chat/agent/schemas.py
@@ -68,4 +68,8 @@ class AttachMediaSchema(BaseModel):
 
 
 class SearchIndexSchema(BaseModel):
-    query: str = Field(description="The search query to use. Keep this query as close to the user's query as possible")
+    query: str = Field(
+        description="A natural language query to search for relevant information in the documents. "
+        "Be specific and use keywords related to the information you're looking for. "
+        "The query will be used for semantic similarity matching against the file contents."
+    )

--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -44,7 +44,8 @@ CHUNK_TEMPLATE = """
 <file>
   <file_id>{file_id}</file_id>
   <filename>{file_name}</filename>
-  <context>{chunk}
+  <context>
+    <![CDATA[{chunk}]]>
   </context>
 </file>
 """

--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -69,6 +69,17 @@ source document.
 Failure to include proper citations will result in an incomplete response.
 """
 
+SEARCH_TOOL_HEADER = (
+    "A semantic search was executed and retrieved the following context inside <context></context> XML tags."
+)
+SEARCH_TOOL_FOOTER = """
+Use the context as your learned knowledge to better answer the user.
+
+In your response, remember to follow these guidelines:
+- If you don't know the answer, simply say that you don't know.
+- If you are unsure how to answer, ask for clarification.
+"""
+
 
 @dataclass
 class SearchToolConfig:
@@ -348,11 +359,12 @@ class SearchIndexTool(CustomBaseTool):
 {citation_prompt}
 <context>{retrieved_chunks}
 </context>
+{footer}
 """
         citation_prompt = CITATION_PROMPT if self.search_config.generate_citations else ""
         return response_template.format(
-            header="A semantic search was executed and retrieved the following context inside "
-            "<context></context> XML tags.",
+            header=SEARCH_TOOL_HEADER,
+            footer=SEARCH_TOOL_FOOTER,
             retrieved_chunks=retrieved_chunks,
             citation_prompt=citation_prompt,
         )

--- a/apps/chat/tests/test_tools.py
+++ b/apps/chat/tests/test_tools.py
@@ -14,12 +14,14 @@ from apps.chat.agent import tools
 from apps.chat.agent.schemas import WeekdaysEnum
 from apps.chat.agent.tools import (
     CITATION_PROMPT,
+    SEARCH_TOOL_HEADER,
     TOOL_CLASS_MAP,
     DeleteReminderTool,
     SearchIndexTool,
     SearchToolConfig,
     UpdateParticipantDataTool,
     _convert_to_sync_tool,
+    _get_search_tool_footer,
     _move_datetime_to_new_weekday_and_time,
     create_schedule_message,
     get_mcp_tool_instances,
@@ -487,33 +489,46 @@ class TestSearchIndexTool:
         local_index_manager_mock.get_embedding_vector.return_value = vector_data["What are great fruit?"]
         search_config = SearchToolConfig(index_id=collection.id, max_results=2, generate_citations=generate_citations)
         result = SearchIndexTool(search_config=search_config).action(query="What are great fruit?")
+        footer = _get_search_tool_footer(generate_citations)
         if generate_citations:
             expected_result = f"""
-# Retrieved chunks
-
-## File name: the_greatness_of_fruit.txt, file_id={file.id}
-### Content
-Apples are great
-
-## File name: the_greatness_of_fruit.txt, file_id={file.id}
-### Content
-Oranges are nice
-
+{SEARCH_TOOL_HEADER}
 {CITATION_PROMPT}
+<context>
+<file>
+  <file_id>{file.id}</file_id>
+  <filename>the_greatness_of_fruit.txt</filename>
+  <context>Apples are great
+  </context>
+</file>
+<file>
+  <file_id>{file.id}</file_id>
+  <filename>the_greatness_of_fruit.txt</filename>
+  <context>Oranges are nice
+  </context>
+</file>
+</context>
+{footer}
 """
         else:
             expected_result = f"""
-# Retrieved chunks
+{SEARCH_TOOL_HEADER}
 
-## File name: the_greatness_of_fruit.txt, file_id={file.id}
-### Content
-Apples are great
-
-## File name: the_greatness_of_fruit.txt, file_id={file.id}
-### Content
-Oranges are nice
-
-
+<context>
+<file>
+  <file_id>{file.id}</file_id>
+  <filename>the_greatness_of_fruit.txt</filename>
+  <context>Apples are great
+  </context>
+</file>
+<file>
+  <file_id>{file.id}</file_id>
+  <filename>the_greatness_of_fruit.txt</filename>
+  <context>Oranges are nice
+  </context>
+</file>
+</context>
+{footer}
 """
         assert result == expected_result
 

--- a/apps/chat/tests/test_tools.py
+++ b/apps/chat/tests/test_tools.py
@@ -490,44 +490,34 @@ class TestSearchIndexTool:
         search_config = SearchToolConfig(index_id=collection.id, max_results=2, generate_citations=generate_citations)
         result = SearchIndexTool(search_config=search_config).action(query="What are great fruit?")
         footer = _get_search_tool_footer(generate_citations)
+        context_block = f"""<context>
+<file>
+  <file_id>{file.id}</file_id>
+  <filename>the_greatness_of_fruit.txt</filename>
+  <context>
+    <![CDATA[Apples are great]]>
+  </context>
+</file>
+<file>
+  <file_id>{file.id}</file_id>
+  <filename>the_greatness_of_fruit.txt</filename>
+  <context>
+    <![CDATA[Oranges are nice]]>
+  </context>
+</file>
+</context>"""
         if generate_citations:
             expected_result = f"""
 {SEARCH_TOOL_HEADER}
 {CITATION_PROMPT}
-<context>
-<file>
-  <file_id>{file.id}</file_id>
-  <filename>the_greatness_of_fruit.txt</filename>
-  <context>Apples are great
-  </context>
-</file>
-<file>
-  <file_id>{file.id}</file_id>
-  <filename>the_greatness_of_fruit.txt</filename>
-  <context>Oranges are nice
-  </context>
-</file>
-</context>
+{context_block}
 {footer}
 """
         else:
             expected_result = f"""
 {SEARCH_TOOL_HEADER}
 
-<context>
-<file>
-  <file_id>{file.id}</file_id>
-  <filename>the_greatness_of_fruit.txt</filename>
-  <context>Apples are great
-  </context>
-</file>
-<file>
-  <file_id>{file.id}</file_id>
-  <filename>the_greatness_of_fruit.txt</filename>
-  <context>Oranges are nice
-  </context>
-</file>
-</context>
+{context_block}
 {footer}
 """
         assert result == expected_result

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -580,7 +580,7 @@ class AgentTools(models.TextChoices):
     INCREMENT_PARTICIPANT_DATA = "increment-participant-data", gettext("Increment Participant Data")
     ATTACH_MEDIA = "attach-media", gettext("Attach Media")
     END_SESSION = "end-session", gettext("End Session")
-    SEARCH_INDEX = "search-index", gettext("Search Index")
+    SEARCH_INDEX = "file-search", gettext("File Search")
 
     @classmethod
     def reminder_tools(cls) -> list[Self]:


### PR DESCRIPTION
## Description
After playing with citations a bit and looking at traces and also looking at how other systems do this I've made some tweaks to the 'search-index' tool. I also decided to rename the tool to 'file-search' for consistency with other systems.

The main changes are:
1. Move the citations prompt above the result data
2. Use XML to wrap the content
   * Previously we used markdown but this get's confusing when the content is also markdown
3. Add a new footer to the response
4. Updated the tool description and query parameter description

## User Impact
Hopefully more reliable citations.