### PR TITLE
Bdr/add session tags api

### DIFF
--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -100,10 +100,11 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
     experiment = ExperimentSerializer(read_only=True)
     participant = ParticipantSerializer(read_only=True)
     messages = serializers.SerializerMethodField()
+    tags = TagListSerializerField(source="chat.tags")
 
     class Meta:
         model = ExperimentSession
-        fields = ["url", "id", "team", "experiment", "participant", "created_at", "updated_at", "messages"]
+        fields = ["url", "id", "team", "experiment", "participant", "created_at", "updated_at", "messages", "tags"]
 
     def __init__(self, *args, **kwargs):
         self._include_messages = kwargs.pop("include_messages", False)

--- a/apps/api/tests/test_session_api.py
+++ b/apps/api/tests/test_session_api.py
@@ -75,7 +75,7 @@ def test_list_sessions_with_tag(experiment):
     }
 
 
-def get_session_json(session, expected_messages=None):
+def get_session_json(session, expected_messages=None, expected_tags=None):
     experiment = session.experiment
     data = {
         "url": f"http://testserver/api/sessions/{session.external_id}/",
@@ -97,6 +97,8 @@ def get_session_json(session, expected_messages=None):
     }
     if expected_messages is not None:
         data["messages"] = expected_messages
+    if expected_tags is not None:
+        data["tags"] = expected_tags
     return data
 
 
@@ -114,6 +116,8 @@ def test_retrieve_session(session):
     session.chat.messages.create(message_type="ai", content="hi")
     message1 = session.chat.messages.create(message_type="human", content="hello")
     files = _create_attachments(session.chat, message1)
+
+    session.chat.add_tag(tags[0], session.team, user)
 
     message = session.chat.messages.create(message_type="human", content="rabbit in a hat", summary="Abracadabra")
     message.add_tag(tags[0], session.team, user)
@@ -176,6 +180,7 @@ def test_retrieve_session(session):
                 "attachments": [],
             },
         ],
+        expected_tags=["tag1"],
     )
 
 


### PR DESCRIPTION
## Description
Add session-level tags to the `/api/sessions/{id}/` end point.

## User Impact
Can now get session-level tags in addition to message-level tags.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
I assume it automatically update the `/api/docs`
