### PR TITLE
Updates to Chat API auth

### DIFF
--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -193,12 +193,6 @@ class ParticipantDataUpdateRequest(serializers.Serializer):
 
 class ChatStartSessionRequest(serializers.Serializer):
     chatbot_id = serializers.UUIDField(label="Chatbot ID")
-    participant_id = serializers.CharField(
-        label="Participant ID",
-        required=False,
-        help_text="Optional participant identifier. If not provided, an anonymous participant will be created. "
-        "This field will be ignored if the request is not authenticated.",
-    )
     session_data = serializers.DictField(
         label="Initial session data",
         required=False,

--- a/apps/api/tests/test_chat_api.py
+++ b/apps/api/tests/test_chat_api.py
@@ -7,6 +7,7 @@ from rest_framework.test import APIClient
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.experiments.models import ExperimentSession, Participant, ParticipantData
 from apps.utils.factories.experiment import ExperimentSessionFactory
+from apps.utils.factories.team import TeamWithUsersFactory
 from apps.utils.tests.clients import ApiTestClient
 
 
@@ -16,9 +17,10 @@ def api_client():
 
 
 @pytest.fixture()
-def authed_client(team_with_users):
-    user = team_with_users.members.first()
-    client = ApiTestClient(user, team_with_users)
+def authed_client():
+    other_team = TeamWithUsersFactory.create()
+    user = other_team.members.first()
+    client = ApiTestClient(user, other_team)
     return client
 
 

--- a/apps/api/tests/test_chat_api_anon.py
+++ b/apps/api/tests/test_chat_api_anon.py
@@ -48,15 +48,6 @@ def test_start_chat_session(team_with_users, api_client, experiment):
 
 
 @pytest.mark.django_db()
-def test_start_chat_session_with_participant_id_without_auth(team_with_users, api_client, experiment):
-    url = reverse("api:chat:start-session")
-    data = {"chatbot_id": experiment.public_id, "participant_id": "123"}
-    response = api_client.post(url, data=data, format="json")
-    assert response.status_code == 201
-    assert response.json()["participant"]["identifier"].startswith("anon:")
-
-
-@pytest.mark.django_db()
 def test_send_message(api_client, session):
     url = reverse("api:chat:send-message", kwargs={"session_id": session.external_id})
     data = {"message": "hi"}
@@ -136,15 +127,10 @@ def test_session_poll_with_messages(api_client, session):
 
 
 @pytest.mark.django_db()
-@pytest.mark.parametrize(("participant_id", "status_code"), [(None, 403), ("", 400), ("123", 403), ("a", 201)])
-def test_start_chat_session_requires_auth_when_not_public(
-    team_with_users, api_client, experiment, participant_id, status_code
-):
+def test_start_chat_session_requires_auth_when_not_public(team_with_users, api_client, experiment):
     url = reverse("api:chat:start-session")
     experiment.participant_allowlist = ["a", "b"]
     experiment.save()
     data = {"chatbot_id": experiment.public_id}
-    if participant_id is not None:
-        data["participant_id"] = participant_id
     response = api_client.post(url, data=data, format="json")
-    assert response.status_code == status_code
+    assert response.status_code == 403

--- a/apps/api/tests/test_chat_api_anon.py
+++ b/apps/api/tests/test_chat_api_anon.py
@@ -5,23 +5,13 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from apps.chat.models import ChatMessage, ChatMessageType
-from apps.experiments.models import ExperimentSession, Participant, ParticipantData
+from apps.experiments.models import ExperimentSession
 from apps.utils.factories.experiment import ExperimentSessionFactory
-from apps.utils.factories.team import TeamWithUsersFactory
-from apps.utils.tests.clients import ApiTestClient
 
 
 @pytest.fixture()
 def api_client():
     return APIClient()
-
-
-@pytest.fixture()
-def authed_client():
-    other_team = TeamWithUsersFactory.create()
-    user = other_team.members.first()
-    client = ApiTestClient(user, other_team)
-    return client
 
 
 @pytest.fixture()
@@ -58,42 +48,12 @@ def test_start_chat_session(team_with_users, api_client, experiment):
 
 
 @pytest.mark.django_db()
-def test_start_chat_session_with_session_state(team_with_users, authed_client, experiment):
-    url = reverse("api:chat:start-session")
-    data = {"chatbot_id": experiment.public_id, "session_data": {"ref": "123"}}
-    response = authed_client.post(url, data=data, format="json")
-    assert response.status_code == 201
-    session = ExperimentSession.objects.get(external_id=response.json()["session_id"])
-    assert session.state == {"ref": "123"}
-
-
-@pytest.mark.django_db()
 def test_start_chat_session_with_participant_id_without_auth(team_with_users, api_client, experiment):
     url = reverse("api:chat:start-session")
     data = {"chatbot_id": experiment.public_id, "participant_id": "123"}
     response = api_client.post(url, data=data, format="json")
     assert response.status_code == 201
     assert response.json()["participant"]["identifier"].startswith("anon:")
-
-
-@pytest.mark.django_db()
-def test_start_chat_session_with_participant_id_with_auth(team_with_users, authed_client, experiment):
-    url = reverse("api:chat:start-session")
-    data = {"chatbot_id": experiment.public_id, "participant_id": authed_client.user.email}
-    response = authed_client.post(url, data=data, format="json")
-    assert response.status_code == 201
-    response_json = response.json()
-    assert response_json["participant"]["identifier"] == authed_client.user.email
-
-
-@pytest.mark.django_db()
-def test_start_chat_session_without_participant_id_with_auth(team_with_users, authed_client, experiment):
-    url = reverse("api:chat:start-session")
-    data = {"chatbot_id": experiment.public_id}
-    response = authed_client.post(url, data=data, format="json")
-    assert response.status_code == 201
-    response_json = response.json()
-    assert response_json["participant"]["identifier"] == authed_client.user.email
 
 
 @pytest.mark.django_db()
@@ -188,39 +148,3 @@ def test_start_chat_session_requires_auth_when_not_public(
         data["participant_id"] = participant_id
     response = api_client.post(url, data=data, format="json")
     assert response.status_code == status_code
-
-
-@pytest.mark.django_db()
-def test_start_chat_session_with_auth(team_with_users, authed_client, experiment):
-    url = reverse("api:chat:start-session")
-    data = {"chatbot_id": experiment.public_id}
-    response = authed_client.post(url, data=data, format="json")
-    assert response.status_code == 201
-
-
-@pytest.mark.django_db()
-def test_start_chat_session_with_remote_id_and_name(team_with_users, authed_client, experiment):
-    url = reverse("api:chat:start-session")
-    remote_id = "test-remote-id-123"
-    name = "John Doe"
-    session_state = {"ref": "abc123"}
-
-    data = {
-        "chatbot_id": experiment.public_id,
-        "participant_remote_id": remote_id,
-        "participant_name": name,
-        "session_data": session_state,
-    }
-
-    response = authed_client.post(url, data=data, format="json")
-    assert response.status_code == 201
-    response_json = response.json()
-
-    participant = Participant.objects.get(identifier=response_json["participant"]["identifier"])
-    assert response_json["participant"]["remote_id"] == remote_id
-
-    participant_data = ParticipantData.objects.get(participant=participant, experiment=experiment, team=team_with_users)
-    assert participant_data.data.get("name") == name
-
-    session = ExperimentSession.objects.get(external_id=response_json["session_id"])
-    assert session.state == session_state

--- a/apps/api/tests/test_chat_api_authed.py
+++ b/apps/api/tests/test_chat_api_authed.py
@@ -1,3 +1,10 @@
+"""Tests for authenticated access to the Chat API.
+
+When access is authenticated, it implies that the chat widget is being hosted on the same
+OCS instance as the bot (to allow the session cookie to work). In this case, we should enforce
+that the `remote_id` matches the authenticated user's email address.
+"""
+
 import pytest
 from django.urls import reverse
 
@@ -97,7 +104,7 @@ def test_start_chat_session_with_name(team_with_users, authed_client, experiment
     response_json = response.json()
 
     participant = Participant.objects.get(identifier=response_json["participant"]["identifier"])
-    assert response_json["participant"]["participant_remote_id"] == ""
+    assert response_json["participant"]["identifier"] == authed_client.user.email
 
     participant_data = ParticipantData.objects.get(participant=participant, experiment=experiment, team=team_with_users)
     assert participant_data.data.get("name") == name

--- a/apps/api/tests/test_chat_api_authed.py
+++ b/apps/api/tests/test_chat_api_authed.py
@@ -1,0 +1,101 @@
+import pytest
+from django.urls import reverse
+
+from apps.experiments.models import ExperimentSession, Participant, ParticipantData
+from apps.utils.factories.experiment import ExperimentSessionFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+from apps.utils.tests.clients import ApiTestClient
+
+
+@pytest.fixture()
+def authed_client():
+    other_team = TeamWithUsersFactory.create()
+    user = other_team.members.first()
+    client = ApiTestClient(user, other_team)
+    return client
+
+
+@pytest.fixture()
+def session(experiment):
+    return ExperimentSessionFactory(experiment=experiment)
+
+
+@pytest.mark.django_db()
+def test_start_chat_session_with_session_state(team_with_users, authed_client, experiment):
+    url = reverse("api:chat:start-session")
+    data = {"chatbot_id": experiment.public_id, "session_data": {"ref": "123"}}
+    response = authed_client.post(url, data=data, format="json")
+    assert response.status_code == 201
+    session = ExperimentSession.objects.get(external_id=response.json()["session_id"])
+    assert session.state == {"ref": "123"}
+
+
+@pytest.mark.django_db()
+def test_start_chat_session_with_participant_id_with_auth(team_with_users, authed_client, experiment):
+    url = reverse("api:chat:start-session")
+    data = {"chatbot_id": experiment.public_id, "participant_id": authed_client.user.email}
+    response = authed_client.post(url, data=data, format="json")
+    assert response.status_code == 201
+    response_json = response.json()
+    assert response_json["participant"]["identifier"] == authed_client.user.email
+
+
+@pytest.mark.django_db()
+def test_start_chat_session_without_participant_id_with_auth(team_with_users, authed_client, experiment):
+    url = reverse("api:chat:start-session")
+    data = {"chatbot_id": experiment.public_id}
+    response = authed_client.post(url, data=data, format="json")
+    assert response.status_code == 201
+    response_json = response.json()
+    assert response_json["participant"]["identifier"] == authed_client.user.email
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(("participant_id", "status_code"), [(None, 403), ("", 400), ("123", 403), ("a", 201)])
+def test_start_chat_session_requires_auth_when_not_public(
+    team_with_users, api_client, experiment, participant_id, status_code
+):
+    url = reverse("api:chat:start-session")
+    experiment.participant_allowlist = ["a", "b"]
+    experiment.save()
+    data = {"chatbot_id": experiment.public_id}
+    if participant_id is not None:
+        data["participant_id"] = participant_id
+    response = api_client.post(url, data=data, format="json")
+    assert response.status_code == status_code
+
+
+@pytest.mark.django_db()
+def test_start_chat_session_with_auth(team_with_users, authed_client, experiment):
+    url = reverse("api:chat:start-session")
+    data = {"chatbot_id": experiment.public_id}
+    response = authed_client.post(url, data=data, format="json")
+    assert response.status_code == 201
+
+
+@pytest.mark.django_db()
+def test_start_chat_session_with_remote_id_and_name(team_with_users, authed_client, experiment):
+    url = reverse("api:chat:start-session")
+    remote_id = "test-remote-id-123"
+    name = "John Doe"
+    session_state = {"ref": "abc123"}
+
+    data = {
+        "chatbot_id": experiment.public_id,
+        "participant_remote_id": remote_id,
+        "participant_name": name,
+        "session_data": session_state,
+    }
+
+    response = authed_client.post(url, data=data, format="json")
+    assert response.status_code == 201
+    response_json = response.json()
+
+    participant = Participant.objects.get(identifier=response_json["participant"]["identifier"])
+    assert response_json["participant"]["remote_id"] == remote_id
+
+    participant_data = ParticipantData.objects.get(participant=participant, experiment=experiment, team=team_with_users)
+    assert participant_data.data.get("name") == name
+
+    session = ExperimentSession.objects.get(external_id=response_json["session_id"])
+    assert session.state == session_state

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -99,17 +99,16 @@ def chat_start_session(request):
             status=status.HTTP_400_BAD_REQUEST,
         )
 
+    team = experiment.team
     if request.user.is_authenticated:
-        team = request.team
         user = request.user
         participant_id = user.email
         if remote_id != participant_id:
             # Enforce this for authenticated users
-            # Currently this only happens if the chat widget is being hosted on OCS
+            # Currently this only happens if the chat widget is being hosted on the same OCS instance as the bot
             return Response({"error": "Remote ID ID must match your email address"}, status=status.HTTP_400_BAD_REQUEST)
         remote_id = ""
     else:
-        team = experiment.team
         user = None
         participant_id = None
 

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema, inline_serializer
 from rest_framework import serializers, status
+from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.response import Response
 
@@ -23,7 +24,7 @@ from apps.experiments.models import Experiment, ExperimentSession, Participant, 
 from apps.experiments.task_utils import get_message_task_response
 from apps.experiments.tasks import get_response_for_webchat_task
 
-AUTH_CLASSES = [ApiKeyAuthentication, BearerTokenAuthentication]
+AUTH_CLASSES = [SessionAuthentication, ApiKeyAuthentication, BearerTokenAuthentication]
 
 
 def check_experiment_access(experiment, participant_id):

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -8,7 +8,6 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.response import Response
 
-from apps.api.permissions import ApiKeyAuthentication, BearerTokenAuthentication
 from apps.api.serializers import (
     ChatPollResponse,
     ChatSendMessageRequest,
@@ -24,7 +23,7 @@ from apps.experiments.models import Experiment, ExperimentSession, Participant, 
 from apps.experiments.task_utils import get_message_task_response
 from apps.experiments.tasks import get_response_for_webchat_task
 
-AUTH_CLASSES = [SessionAuthentication, ApiKeyAuthentication, BearerTokenAuthentication]
+AUTH_CLASSES = [SessionAuthentication]
 
 
 def check_experiment_access(experiment, participant_id):

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -33,10 +33,6 @@ def check_experiment_access(request, experiment, participant_id):
     Returns:
         Response object if access denied, None if access allowed
     """
-    if request.team and experiment.team != request.team:
-        # Authenticated requests must be constrained to their team
-        return Response({"error": "Access denied"}, status=status.HTTP_403_FORBIDDEN)
-
     if not experiment.is_public and not experiment.is_participant_allowed(participant_id):
         return Response({"error": "Access denied"}, status=status.HTTP_403_FORBIDDEN)
 

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -45,7 +45,7 @@ def check_experiment_access(experiment, participant_id):
     return None
 
 
-def check_session_access(request, session):
+def check_session_access(session):
     """
     Check if the request has access to the session based on experiment's public API settings.
 
@@ -208,7 +208,7 @@ def chat_send_message(request, session_id):
 
     session = get_object_or_404(ExperimentSession, external_id=session_id)
 
-    access_response = check_session_access(request, session)
+    access_response = check_session_access(session)
     if access_response:
         return access_response
 
@@ -275,7 +275,7 @@ def chat_poll_task_response(request, session_id, task_id):
     except ExperimentSession.DoesNotExist:
         raise Http404() from None
 
-    access_response = check_session_access(request, session)
+    access_response = check_session_access(session)
     if access_response:
         return access_response
     task_details = get_message_task_response(session.experiment, task_id)
@@ -334,7 +334,7 @@ def chat_poll_response(request, session_id):
     """
     session = get_object_or_404(ExperimentSession, external_id=session_id)
 
-    access_response = check_session_access(request, session)
+    access_response = check_session_access(session)
     if access_response:
         return access_response
     since_param = request.query_params.get("since")

--- a/components/chat_widget/package-lock.json
+++ b/components/chat_widget/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "open-chat-studio-widget",
-  "version": "0.3.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-chat-studio-widget",
-      "version": "0.3.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.26.0",
         "dompurify": "^3.0.5",
+        "js-cookie": "^3.0.5",
         "marked": "^4.3.0",
         "npmrc": "^1.1.1"
       },
@@ -4627,6 +4628,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/components/chat_widget/package.json
+++ b/components/chat_widget/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@stencil/core": "^4.26.0",
     "dompurify": "^3.0.5",
+    "js-cookie": "^3.0.5",
     "marked": "^4.3.0",
     "npmrc": "^1.1.1"
   },
@@ -42,9 +43,9 @@
     "autoprefixer": "^10.4.20",
     "jest": "^29.7.0",
     "jest-cli": "^29.7.0",
+    "npm-run-all": "^4.1.5",
     "postcss-import": "^16.1.0",
     "puppeteer": "^24.2.0",
-    "npm-run-all": "^4.1.5",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.3"
   },

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -4,6 +4,7 @@ import {
   GripDotsVerticalIcon, PencilSquare, ArrowsPointingOutIcon, ArrowsPointingInIcon,
 } from './heroicons';
 import { renderMarkdownSync as renderMarkdownComplete } from '../../utils/markdown';
+import { getCSRFToken } from '../../utils/cookies';
 
 interface ChatMessage {
   created_at: string;
@@ -244,6 +245,19 @@ export class OcsChat {
     return this.apiBaseUrl || window.location.origin;
   }
 
+  private getApiHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    const csrfToken = getCSRFToken(this.getApiBaseUrl());
+    if (csrfToken) {
+      headers['X-CSRFToken'] = csrfToken;
+    }
+
+    return headers;
+  }
+
   private async startSession(): Promise<void> {
     try {
       this.isLoading = true;
@@ -266,9 +280,7 @@ export class OcsChat {
 
       const response = await fetch(`${this.getApiBaseUrl()}/api/chat/start/`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: this.getApiHeaders(),
         body: JSON.stringify(requestBody)
       });
 
@@ -331,9 +343,7 @@ export class OcsChat {
 
       const response = await fetch(`${this.getApiBaseUrl()}/api/chat/${this.sessionId}/message/`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: this.getApiHeaders(),
         body: JSON.stringify({ message: message.trim() })
       });
 

--- a/components/chat_widget/src/utils/cookies.ts
+++ b/components/chat_widget/src/utils/cookies.ts
@@ -1,0 +1,33 @@
+import Cookies from "js-cookie";
+
+
+/**
+ * Get CSRF token from cookies if the current domain matches the API base URL
+ */
+export function getCSRFToken(apiBaseUrl: string): string | undefined {
+  if (!currentDomainMatchesApiBaseUrl(apiBaseUrl)) {
+    return undefined;
+  }
+
+  return Cookies.get('csrftoken')
+}
+
+function currentDomainMatchesApiBaseUrl(apiBaseUrl: string): boolean {
+  const currentDomain = window.location.hostname;
+  const apiDomain = getDomainFromUrl(apiBaseUrl);
+
+  if (!apiDomain) {
+    return false;
+  }
+
+  return currentDomain === apiDomain;
+}
+
+function getDomainFromUrl(url: string): string | null {
+  try {
+    const urlObj = new URL(url);
+    return urlObj.hostname;
+  } catch (error) {
+    return null;
+  }
+}

--- a/templates/web/app/app_base.html
+++ b/templates/web/app/app_base.html
@@ -33,7 +33,10 @@
 {% block footer %}
   {{ block.super }}
   {% if ocs_config.chat_widget.enabled and ocs_config.chat_widget.chatbot_id %}
-    <open-chat-studio-widget {% include "generic/attrs.html" with attrs=ocs_config.chat_widget.get_widget_attributes %}>
+    <open-chat-studio-widget {% include "generic/attrs.html" with attrs=ocs_config.chat_widget.get_widget_attributes %}
+        user-id="{{ request.user.email }}"
+        user-name="{{ request.user.get_display_name }}"
+    >
     </open-chat-studio-widget>
   {% endif %}
 {% endblock footer %}


### PR DESCRIPTION
## Description
Currently when trying to use the help bot on OCS from a team other than the team the bot is hosted in, the request to start the session errors. While looking into this issue I decided to make some other changes to the 'start session' endpoint specifically for the case when the widget is being hosted on the same OCS instance as the bot.

* Remove the participant ID field from the 'chat_start_session' endpoint
  * This should never be provided by the widget
* Remove api key and bearer auth as auth options
  * We either want session auth or anonymous. This API shouldn't be used with API keys.
* Add session auth
* Add `remote-id` and `user-name` fields to widget config in OCS
* Verify that `remote-id` matches `user.email` for authenticated requests.
* Pass CSRF header in widget requests when it's configured API domain matches the current domain.