### PR TITLE
Select All Multiselect Filter

### DIFF
--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -85,7 +85,7 @@
                     <span x-text="filter.selectedValues.length ? getSelectedDisplayText(filter) : 'Select'"></span>
                     <i class="fa-solid fa-caret-down fa-sm"></i>
                   </div>
-                  <div x-show="filter.showOptions" @click.outside="filter.showOptions = false" class="absolute z-50 mt-1 bg-base-100 rounded-lg max-h-64 overflow-y-auto w-40 border border-base-300" style="z-index: 9999 !important;">
+                  <div x-show="filter.showOptions" @click.outside="filter.showOptions = false" class="absolute z-50 mt-1 bg-base-100 rounded-lg max-h-64 overflow-y-auto w-48 border border-base-300" style="z-index: 9999 !important;">
                     <div class="sticky top-0 bg-base-100 border-b p-2 z-1">
                       <div class="relative">
                         <input type="text" x-model="filter.searchQuery" @input="filterDropdownOptions(index)" placeholder="Search..." class="input input-sm w-full pl-8 focus:outline-hidden focus:border-primary">

--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -572,6 +572,29 @@
         this.triggerFilterChange();
       },
 
+      selectAllTagOptions(index) {
+        const filter = this.filterData.filters[index];
+        if (filter.column === 'tags') {
+          const allTags = this.filterData.columns['tags'].options || [];
+          filter.selectedValues = [...allTags];
+          this.triggerFilterChange();
+        }
+      },
+
+      clearAllOptions(index) {
+        const filter = this.filterData.filters[index];
+        filter.selectedValues = [];
+        this.triggerFilterChange();
+        }
+      },
+
+      areAllTagsSelected(index) {
+        const filter = this.filterData.filters[index];
+        if (filter.column !== 'tags') return false;
+        const allTags = this.filterData.columns['tags'].options || [];
+        return allTags.length > 0 && filter.selectedValues.length === allTags.length;
+      },
+
       getLastMessageFilterIndex(params) {
         for (const [key, val] of params.entries()) {
           if (key.includes('_column') && val === 'last_message') {

--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -91,6 +91,24 @@
                         <input type="text" x-model="filter.searchQuery" @input="filterDropdownOptions(index)" placeholder="Search..." class="input input-sm w-full pl-8 focus:outline-hidden focus:border-primary">
                       </div>
                     </div>
+                    <div x-show="filter.column === 'tags'" class="border-b p-2 bg-base-50">
+                      <div class="flex gap-2">
+                        <button
+                          type="button"
+                          @click="selectAllTagOptions(index)"
+                          :disabled="areAllTagsSelected(index)"
+                          class="btn btn-xs btn-outline btn-primary flex-1">
+                          Select All
+                        </button>
+                        <button
+                          type="button"
+                          @click="clearAllOptions(index)"
+                          :disabled="filter.selectedValues.length === 0"
+                          class="btn btn-xs btn-outline flex-1">
+                          Clear All
+                        </button>
+                      </div>
+                    </div>
                     <div class="py-1">
                       <template x-for="option in filter.filteredOptions" :key="typeof option === 'object' ? option.id : option">
                         <label :for="`option-${index}-${typeof option === 'object' ? option.id : option}`" class="flex items-center px-4 py-2 hover:bg-base-200 cursor-pointer text-sm">

--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -97,13 +97,15 @@
                           type="button"
                           @click="selectAllTagOptions(index)"
                           :disabled="areAllTagsSelected(index)"
-                          class="btn btn-xs btn-outline btn-primary flex-1">
+                          :class="areAllTagsSelected(index) ? 'btn-disabled' : ''"
+                          class="btn btn-xs btn-outline flex-1">
                           Select All
                         </button>
                         <button
                           type="button"
-                          @click="clearAllOptions(index)"
+                          @click="clearAllTagOptions(index)"
                           :disabled="filter.selectedValues.length === 0"
+                          :class="filter.selectedValues.length === 0 ? 'btn-disabled' : ''"
                           class="btn btn-xs btn-outline flex-1">
                           Clear All
                         </button>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

branches off of https://github.com/dimagi/open-chat-studio/pull/2031

I thought we could apply this to all multiselect filters because at least the "clear all" functionality is helpful and it's nice to keep consistent 

## User Impact
<!-- Describe the impact of this change on the end-users. -->
users don't have to manually select/clear all on multiselect filters

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
see [users don't have to manually select/clear all tags](https://github.com/dimagi/open-chat-studio/pull/2031)

### Docs and Changelog
<!--Link to documentation that has been updated.-->
yes to [changelog](https://github.com/dimagi/open-chat-studio-docs/pull/147) (same as tags one since this "trumps" the tags change)
