### PR TITLE
Update Datasets with CSV files

### DIFF
--- a/apps/evaluations/forms.py
+++ b/apps/evaluations/forms.py
@@ -13,6 +13,7 @@ from apps.evaluations.models import (
     Evaluator,
     ExperimentVersionSelection,
 )
+from apps.evaluations.utils import parse_history_text
 from apps.experiments.models import Experiment, ExperimentSession
 
 
@@ -273,8 +274,13 @@ class EvaluationDatasetForm(forms.ModelForm):
     populate_history = forms.BooleanField(
         required=False,
         initial=False,
-        label="Populate conversation history",
+        label="Automatically populate history",
         help_text="When enabled, each message will include the conversation history from previous rows in the CSV.",
+    )
+
+    history_column = forms.CharField(
+        widget=forms.HiddenInput(),
+        required=False,
     )
 
     class Meta:
@@ -300,9 +306,10 @@ class EvaluationDatasetForm(forms.ModelForm):
         elif mode == "manual":
             cleaned_data["message_pairs"] = self._clean_manual()
         elif mode == "csv":
-            csv_data, column_mapping = self._clean_csv()
+            csv_data, column_mapping, history_column = self._clean_csv()
             cleaned_data["csv_data"] = csv_data
             cleaned_data["column_mapping"] = column_mapping
+            cleaned_data["history_column"] = history_column
         return cleaned_data
 
     def _clean_clone(self):
@@ -365,6 +372,9 @@ class EvaluationDatasetForm(forms.ModelForm):
     def _clean_csv(self):
         column_mapping_str = self.data.get("column_mapping", "")
         csv_data_str = self.data.get("csv_data", "")
+        history_column = self.data.get("history_column", "").strip()
+        populate_history = self.data.get("populate_history") == "on"
+
         if not csv_data_str:
             raise forms.ValidationError("Please upload a CSV file.")
         column_mapping = {}
@@ -384,8 +394,17 @@ class EvaluationDatasetForm(forms.ModelForm):
         if not column_mapping.get("input") or not column_mapping.get("output"):
             raise forms.ValidationError("Both input and output columns must be mapped.")
 
+        if populate_history and history_column:
+            raise forms.ValidationError(
+                "Cannot both automatically populate history and use a history column. Please choose one option."
+            )
+
         csv_columns = set(csv_data[0].keys()) if csv_data else set()
         mapped_columns = {col for col in column_mapping.values() if col}
+
+        if history_column:
+            mapped_columns.add(history_column)
+
         missing_columns = mapped_columns - csv_columns
         if missing_columns:
             raise forms.ValidationError(f"Columns not found in CSV file: {', '.join(sorted(missing_columns))}")
@@ -409,7 +428,7 @@ class EvaluationDatasetForm(forms.ModelForm):
         if valid_rows == 0:
             raise forms.ValidationError("No valid message pairs found in CSV data.")
 
-        return csv_data, column_mapping
+        return csv_data, column_mapping, history_column
 
     def _is_valid_python_identifier(self, name):
         """Check if a string is a valid Python identifier."""
@@ -463,9 +482,11 @@ class EvaluationDatasetForm(forms.ModelForm):
         csv_data = self.cleaned_data.get("csv_data", [])
         column_mapping = self.cleaned_data.get("column_mapping", {})
         populate_history = self.cleaned_data.get("populate_history", False)
+        history_column = self.cleaned_data.get("history_column", "")
 
         evaluation_messages = []
-        history = []
+        auto_history = []  # For auto-populate mode
+
         for row in csv_data:
             # Extract mapped columns
             input_content = row.get(column_mapping.get("input", ""), "").strip()
@@ -478,25 +499,35 @@ class EvaluationDatasetForm(forms.ModelForm):
                 if field_name not in ["input", "output"] and csv_column in row:
                     context[field_name] = row[csv_column]
 
+            message_history = []
+            if populate_history:
+                # Use auto-populated history from previous messages
+                message_history = [msg.copy() for msg in auto_history]
+            elif history_column and history_column in row:
+                # Parse history from CSV column
+                history_text = row[history_column].strip()
+                if history_text:
+                    message_history = parse_history_text(history_text)
+
             evaluation_messages.append(
                 EvaluationMessage(
                     input=EvaluationMessageContent(content=input_content, role="human").model_dump(),
                     output=EvaluationMessageContent(content=output_content, role="ai").model_dump(),
                     context=context,
-                    history=[msg.copy() for msg in history] if populate_history else [],
+                    history=message_history,
                     metadata={"created_mode": "csv"},
                 )
             )
 
             if populate_history:
-                history.append(
+                auto_history.append(
                     {
                         "message_type": "HUMAN",
                         "content": input_content.strip(),
                         "summary": None,
                     }
                 )
-                history.append(
+                auto_history.append(
                     {
                         "message_type": "AI",
                         "content": output_content.strip(),

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -197,8 +197,7 @@ class EvaluationMessage(BaseModel):
         for message in self.history:
             message_type = message.get("message_type", "")
             content = message.get("content", "")
-            display_type = ChatMessageType(message_type).role
-            history_lines.append(f"{display_type}: {content}")
+            history_lines.append(f"{message_type}: {content}")
 
         return "\n".join(history_lines)
 

--- a/apps/evaluations/tables.py
+++ b/apps/evaluations/tables.py
@@ -187,6 +187,12 @@ class EvaluationDatasetTable(tables.Table):
     actions = actions.ActionsColumn(
         actions=[
             actions.edit_action(url_name="evaluations:dataset_edit"),
+            actions.Action(
+                url_name="evaluations:dataset_download",
+                url_factory=lambda url_name, request, record, _: reverse(url_name, args=[request.team.slug, record.id]),
+                icon_class="fa-solid fa-download",
+                title="Download CSV",
+            ),
             actions.AjaxAction(
                 "evaluations:dataset_delete",
                 title="Delete",

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -315,15 +315,20 @@ def _update_existing_message(dataset, message_id, row_data, team):
 
     old_input_content = message.input.get("content", "")
     old_output_content = message.output.get("content", "")
+    old_history = message.history
     new_input_content = row_data["input_content"]
     new_output_content = row_data["output_content"]
+    new_history = row_data["history"]
 
     input_content_changed = old_input_content != new_input_content
     output_content_changed = old_output_content != new_output_content
-    any_content_changed = input_content_changed or output_content_changed
+    history_changed = old_history != new_history
+    any_content_changed = input_content_changed or output_content_changed or history_changed
 
     message.context = row_data["context"]
-    message.history = row_data["history"]
+
+    if history_changed:
+        message.history = new_history
 
     if input_content_changed:
         message.input = EvaluationMessageContent(content=new_input_content, role="human").model_dump()

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -1,9 +1,13 @@
+import csv
 import logging
+import re
 from collections.abc import Iterable
 from datetime import timedelta
+from io import StringIO
 from typing import cast
 
 from celery import chord, shared_task
+from celery_progress.backend import ProgressRecorder
 from django.utils import timezone
 
 from apps.channels.models import ChannelPlatform, ExperimentChannel
@@ -11,7 +15,9 @@ from apps.channels.tasks import handle_evaluation_message
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
 from apps.evaluations.const import PREVIEW_SAMPLE_SIZE
 from apps.evaluations.models import (
+    EvaluationDataset,
     EvaluationMessage,
+    EvaluationMessageContent,
     EvaluationResult,
     EvaluationRun,
     EvaluationRunStatus,
@@ -231,3 +237,202 @@ def cleanup_old_preview_evaluation_runs():
 
     deleted_preview_runs = old_preview_runs.delete()
     logger.info(f"Cleanup completed: deleted {deleted_preview_runs[0]} preview evaluation runs")
+
+
+@shared_task(bind=True)
+def upload_dataset_csv_task(self, dataset_id, csv_content, team_id):
+    """
+    Process CSV upload for dataset asynchronously with progress tracking.
+    """
+    progress_recorder = ProgressRecorder(self)
+
+    try:
+        dataset = EvaluationDataset.objects.select_related("team").get(id=dataset_id, team_id=team_id)
+        team = dataset.team
+
+        with current_team(team):
+            rows, columns = _parse_csv_content(csv_content, progress_recorder)
+            if not rows:
+                return {"success": False, "error": "CSV file is empty"}
+
+            stats = _process_csv_rows(dataset, rows, columns, progress_recorder, team)
+            progress_recorder.set_progress(100, 100, "Upload complete")
+
+            return {
+                "success": True,
+                "updated_count": stats["updated_count"],
+                "created_count": stats["created_count"],
+                "total_processed": stats["updated_count"] + stats["created_count"],
+                "errors": stats["error_messages"],
+            }
+
+    except Exception as e:
+        logger.error(f"Error in CSV upload task for dataset {dataset_id}: {str(e)}")
+        return {"success": False, "error": str(e)}
+
+
+def _parse_csv_content(csv_content, progress_recorder):
+    """Parse CSV content and return rows and columns."""
+    csv_reader = csv.DictReader(StringIO(csv_content))
+    columns = csv_reader.fieldnames or []
+    rows = list(csv_reader)
+    progress_recorder.set_progress(5, 100, "Parsing CSV...")
+    return rows, columns
+
+
+def _extract_row_data(row, row_index):
+    """Extract and validate data from a CSV row."""
+    input_content = row.get("input_content", "").strip()
+    output_content = row.get("output_content", "").strip()
+
+    if not input_content or not output_content:
+        raise ValueError("Missing input or output content")
+
+    # Extract context from context.* columns
+    context = {}
+    for col_name, value in row.items():
+        if col_name.startswith("context.") and value:
+            context_key = col_name[8:]  # Remove "context." prefix
+            context[context_key] = value
+
+    # Parse history if present
+    history = []
+    history_text = row.get("history", "").strip()
+    if history_text:
+        history = _parse_history_text(history_text)
+
+    return {
+        "input_content": input_content,
+        "output_content": output_content,
+        "context": context,
+        "history": history,
+    }
+
+
+def _update_existing_message(dataset, message_id, row_data, team):
+    """Update an existing message with new data."""
+    message = EvaluationMessage.objects.get(id=message_id, evaluationdataset=dataset, evaluationdataset__team=team)
+
+    old_input_content = message.input.get("content", "")
+    old_output_content = message.output.get("content", "")
+    new_input_content = row_data["input_content"]
+    new_output_content = row_data["output_content"]
+
+    input_content_changed = old_input_content != new_input_content
+    output_content_changed = old_output_content != new_output_content
+    any_content_changed = input_content_changed or output_content_changed
+
+    message.context = row_data["context"]
+    message.history = row_data["history"]
+
+    if input_content_changed:
+        message.input = EvaluationMessageContent(content=new_input_content, role="human").model_dump()
+        message.input_chat_message = None
+
+    if output_content_changed:
+        message.output = EvaluationMessageContent(content=new_output_content, role="ai").model_dump()
+        message.expected_output_chat_message = None
+
+    if any_content_changed and message.metadata:
+        message.metadata.pop("session_id", None)
+        message.metadata.pop("experiment_id", None)
+        message.metadata.update({"last_modified": "csv_upload"})
+
+    message.save()
+
+    return any_content_changed
+
+
+def _create_new_message(dataset, row_data):
+    """Create a new message and add it to the dataset."""
+    message = EvaluationMessage.objects.create(
+        input=EvaluationMessageContent(content=row_data["input_content"], role="human").model_dump(),
+        output=EvaluationMessageContent(content=row_data["output_content"], role="ai").model_dump(),
+        context=row_data["context"],
+        history=row_data["history"],
+        metadata={"created_mode": "csv_upload"},
+    )
+    dataset.messages.add(message)
+
+
+def _process_csv_rows(dataset, rows, columns, progress_recorder, team):
+    """Process all CSV rows and return statistics."""
+    stats = {"updated_count": 0, "created_count": 0, "error_messages": []}
+    total_rows = len(rows)
+    has_id_column = "id" in columns
+
+    for row_index, row in enumerate(rows):
+        try:
+            row_data = _extract_row_data(row, row_index)
+
+            updating_existing_message = has_id_column and row.get("id")
+            if updating_existing_message:
+                try:
+                    message_id = int(row["id"])
+                except ValueError:
+                    stats["error_messages"].append(f"Row {row_index + 1}: Invalid ID format")
+                    continue
+
+                try:
+                    if _update_existing_message(dataset, message_id, row_data, team):
+                        stats["updated_count"] += 1
+                except EvaluationMessage.DoesNotExist:
+                    stats["error_messages"].append(
+                        f"Row {row_index + 1}: Message with ID {message_id} not found for this team"
+                    )
+                    continue
+            else:
+                _create_new_message(dataset, row_data)
+                stats["created_count"] += 1
+
+        except Exception as e:
+            stats["error_messages"].append(f"Row {row_index + 1}: {str(e)}")
+            continue
+
+        processed_rows = row_index + 1
+        progress = int(10 + (processed_rows / total_rows) * 85)  # 10-95% for processing
+        progress_recorder.set_progress(progress, 100, f"Processing row {processed_rows}/{total_rows}")
+
+    return stats
+
+
+def _parse_history_text(history_text: str) -> list:
+    """Parse history text back into JSON format for EvaluationMessage.history field."""
+
+    history = []
+    if not history_text.strip():
+        return history
+
+    # Use regex to find role markers at the start of lines
+    # This pattern matches "human:" or "ai:" at the start of a line (case-insensitive)
+    pattern = r"^(human|ai):\s*(.*)$"
+
+    current_message = None
+
+    for line in history_text.split("\n"):
+        line_stripped = line.strip()
+        if not line_stripped:
+            continue
+
+        match = re.match(pattern, line_stripped, re.IGNORECASE)
+        if match:
+            # Save previous message if exists
+            if current_message:
+                history.append(current_message)
+
+            # Start new message
+            role = match.group(1).lower()
+            content = match.group(2)
+            current_message = {
+                "message_type": role,
+                "content": content,
+                "summary": None,
+            }
+        elif current_message:
+            # Continuation of current message content
+            current_message["content"] += "\n" + line_stripped
+
+    if current_message:
+        history.append(current_message)
+
+    return history

--- a/apps/evaluations/tests/test_dataset_csv_download.py
+++ b/apps/evaluations/tests/test_dataset_csv_download.py
@@ -1,0 +1,99 @@
+import csv
+import io
+
+import pytest
+from django.urls import reverse
+
+from apps.evaluations.models import EvaluationDataset, EvaluationMessage, EvaluationMessageContent
+
+
+@pytest.mark.django_db()
+def test_download_dataset_csv_with_context_and_metadata(client, team_with_users):
+    """Test CSV download with expanded context."""
+    dataset = EvaluationDataset.objects.create(name="Test Dataset", team=team_with_users)
+
+    message1 = EvaluationMessage.objects.create(
+        input=EvaluationMessageContent(content="What is AI?", role="human").model_dump(),
+        output=EvaluationMessageContent(content="AI stands for Artificial Intelligence", role="ai").model_dump(),
+        context={"current_datetime": "2023-01-01T10:00:00", "user_location": "USA"},
+        history=[
+            {"message_type": "human", "content": "Hello", "summary": None},
+            {"message_type": "ai", "content": "Hi there!", "summary": None},
+        ],
+    )
+
+    message2 = EvaluationMessage.objects.create(
+        input=EvaluationMessageContent(content="Tell me about Python", role="human").model_dump(),
+        output=EvaluationMessageContent(content="Python is a programming language", role="ai").model_dump(),
+        context={"current_datetime": "2023-01-01T11:00:00", "topic": "programming"},
+        history=[],
+    )
+
+    dataset.messages.add(message1, message2)
+
+    user = team_with_users.members.first()
+    client.force_login(user)
+
+    url = reverse("evaluations:dataset_download", args=[team_with_users.slug, dataset.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/csv"
+    assert "attachment" in response["Content-Disposition"]
+
+    content = response.content.decode("utf-8")
+    csv_reader = csv.DictReader(io.StringIO(content))
+    rows = list(csv_reader)
+
+    headers = csv_reader.fieldnames
+    expected_headers = [
+        "id",
+        "input_content",
+        "output_content",
+        "context.current_datetime",
+        "context.topic",
+        "context.user_location",
+        "history",
+    ]
+    assert headers == expected_headers
+
+    assert len(rows) == 2
+
+    row1 = rows[0]
+    assert row1["id"] == str(message1.id)
+    assert row1["input_content"] == "What is AI?"
+    assert row1["output_content"] == "AI stands for Artificial Intelligence"
+    assert row1["context.current_datetime"] == "2023-01-01T10:00:00"
+    assert row1["context.user_location"] == "USA"
+    assert row1["context.topic"] == ""  # Empty for missing keys
+    assert row1["history"] == "user: Hello\nassistant: Hi there!"
+
+    row2 = rows[1]
+    assert row2["id"] == str(message2.id)
+    assert row2["input_content"] == "Tell me about Python"
+    assert row2["output_content"] == "Python is a programming language"
+    assert row2["context.current_datetime"] == "2023-01-01T11:00:00"
+    assert row2["context.topic"] == "programming"
+    assert row2["context.user_location"] == ""  # Empty for missing keys
+    assert row2["history"] == ""  # Empty history
+
+
+@pytest.mark.django_db()
+def test_download_empty_dataset_csv(client, team_with_users):
+    """Test CSV download for empty dataset returns minimal headers."""
+    dataset = EvaluationDataset.objects.create(name="Empty Dataset", team=team_with_users)
+    user = team_with_users.members.first()
+    client.force_login(user)
+
+    url = reverse("evaluations:dataset_download", args=[team_with_users.slug, dataset.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/csv"
+
+    content = response.content.decode("utf-8")
+    csv_reader = csv.reader(io.StringIO(content))
+    rows = list(csv_reader)
+
+    assert len(rows) == 1
+    assert rows[0] == ["id", "input_content", "output_content", "history"]

--- a/apps/evaluations/tests/test_dataset_csv_upload.py
+++ b/apps/evaluations/tests/test_dataset_csv_upload.py
@@ -1,0 +1,401 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from apps.chat.models import Chat, ChatMessage, ChatMessageType
+from apps.evaluations.models import EvaluationDataset, EvaluationMessage, EvaluationMessageContent
+from apps.evaluations.tasks import _parse_history_text, _update_existing_message
+from apps.utils.factories.team import TeamWithUsersFactory
+
+
+@pytest.mark.django_db()
+def test_upload_dataset_csv_task_start(client, team_with_users):
+    """Test that CSV upload task starts correctly."""
+    dataset = EvaluationDataset.objects.create(name="Test Dataset", team=team_with_users)
+
+    csv_content = "id,input_content,output_content,context.topic,history\n"
+    csv_content += "999,What is AI?,AI is Artificial Intelligence,technology,\n"  # Non-existent ID
+    csv_content += (
+        ",Tell me about Python,Python is a programming language,programming,user: Hello\\nassistant: Hi there!\n"
+    )
+
+    csv_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
+
+    user = team_with_users.members.first()
+    client.force_login(user)
+
+    url = reverse("evaluations:dataset_upload", args=[team_with_users.slug, dataset.id])
+    response = client.post(url, {"csv_file": csv_file})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert "task_id" in data
+
+
+@pytest.mark.django_db()
+def test_upload_dataset_csv_with_existing_messages(client, team_with_users):
+    """Test CSV upload with existing messages to update."""
+    dataset = EvaluationDataset.objects.create(name="Test Dataset", team=team_with_users)
+
+    existing_message = EvaluationMessage.objects.create(
+        input=EvaluationMessageContent(content="Original question", role="human").model_dump(),
+        output=EvaluationMessageContent(content="Original answer", role="ai").model_dump(),
+        context={"topic": "original"},
+        metadata={"created_mode": "manual"},
+    )
+    dataset.messages.add(existing_message)
+
+    csv_content = "id,input_content,output_content,context.topic,history\n"
+    csv_content += (
+        f"{existing_message.id},Updated question,Updated answer,updated,user: Previous\\nassistant: Response\n"
+    )
+
+    csv_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
+
+    user = team_with_users.members.first()
+    client.force_login(user)
+
+    url = reverse("evaluations:dataset_upload", args=[team_with_users.slug, dataset.id])
+    response = client.post(url, {"csv_file": csv_file})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert "task_id" in data
+
+
+@pytest.mark.django_db()
+def test_upload_csv_security_check(client, team_with_users):
+    """Test that CSV upload properly validates team access."""
+
+    dataset = EvaluationDataset.objects.create(name="Test Dataset", team=team_with_users)
+
+    # Create second team
+    other_team = TeamWithUsersFactory.create()
+    other_user = other_team.members.first()
+
+    csv_content = "id,input_content,output_content\n1,Test,Test\n"
+    csv_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
+
+    # Login as user from different team
+    client.force_login(other_user)
+
+    # Try to upload CSV to first team's dataset
+    url = reverse("evaluations:dataset_upload", args=[team_with_users.slug, dataset.id])
+    response = client.post(url, {"csv_file": csv_file})
+
+    # Should be denied access
+    assert response.status_code == 404  # get_object_or_404 returns 404 for security
+
+
+@pytest.mark.django_db()
+def test_upload_csv_validation(client, team_with_users):
+    """Test CSV upload validation."""
+    dataset = EvaluationDataset.objects.create(name="Test Dataset", team=team_with_users)
+    user = team_with_users.members.first()
+    client.force_login(user)
+
+    url = reverse("evaluations:dataset_upload", args=[team_with_users.slug, dataset.id])
+
+    # Test empty file
+    response = client.post(url, {})
+    assert response.status_code == 400
+    assert "No CSV file provided" in response.json()["error"]
+
+    # Test empty CSV
+    empty_csv = SimpleUploadedFile("empty.csv", b"", content_type="text/csv")
+    response = client.post(url, {"csv_file": empty_csv})
+    assert response.status_code == 400
+    assert "empty" in response.json()["error"]
+
+
+@pytest.mark.django_db()
+def test_parse_history_functionality():
+    """Test the history parsing functionality."""
+
+    # Test empty history
+    assert _parse_history_text("") == []
+
+    # Test single line history
+    history_text = "human: Hello there"
+    result = _parse_history_text(history_text)
+    assert len(result) == 1
+    assert result[0]["message_type"] == "human"
+    assert result[0]["content"] == "Hello there"
+
+    # Test multi-line history
+    history_text = "human: Hello\nai: Hi there!\nhuman: How are you?"
+    result = _parse_history_text(history_text)
+    assert len(result) == 3
+    assert result[0]["message_type"] == "human"
+    assert result[1]["message_type"] == "ai"
+    assert result[2]["message_type"] == "human"
+
+    # Test message with newlines in content
+    history_text = "human: This is a multi-line\nmessage with newlines\nai: I understand your\nmulti-line message"
+    result = _parse_history_text(history_text)
+    assert len(result) == 2
+    assert result[0]["message_type"] == "human"
+    assert result[0]["content"] == "This is a multi-line\nmessage with newlines"
+    assert result[1]["message_type"] == "ai"
+    assert result[1]["content"] == "I understand your\nmulti-line message"
+
+    # Test garbled messages (lines that don't start with role markers)
+    history_text = (
+        "This is garbled text\nhuman: Hello\nsome random text without role\nai: Hi there!\nmore garbled content"
+    )
+    result = _parse_history_text(history_text)
+    assert len(result) == 2  # Only the valid human/ai messages should be parsed
+    assert result[0]["message_type"] == "human"
+    assert result[0]["content"] == "Hello\nsome random text without role"  # Continuation line included
+    assert result[1]["message_type"] == "ai"
+    assert result[1]["content"] == "Hi there!\nmore garbled content"  # Continuation line included
+
+    # Test different casings (HUMAN, Human, AI, Ai, etc.)
+    history_text = "HUMAN: Hello from uppercase\nAi: Mixed case response\nhuman: lowercase again"
+    result = _parse_history_text(history_text)
+    assert len(result) == 3
+    assert result[0]["message_type"] == "human"  # Always normalized to lowercase
+    assert result[0]["content"] == "Hello from uppercase"
+    assert result[1]["message_type"] == "ai"
+    assert result[1]["content"] == "Mixed case response"
+    assert result[2]["message_type"] == "human"
+    assert result[2]["content"] == "lowercase again"
+
+
+@pytest.mark.django_db()
+def test_update_message_preserves_chat_references_when_content_unchanged():
+    """Test that chat message references are preserved when content doesn't change."""
+
+    team = TeamWithUsersFactory.create()
+    dataset = EvaluationDataset.objects.create(name="Test Dataset", team=team)
+
+    # Create chat messages to reference
+    chat = Chat.objects.create(team=team)
+    input_chat_msg = ChatMessage.objects.create(chat=chat, content="Test question", message_type=ChatMessageType.HUMAN)
+    output_chat_msg = ChatMessage.objects.create(chat=chat, content="Test answer", message_type=ChatMessageType.AI)
+
+    # Create message with chat references
+    message = EvaluationMessage.objects.create(
+        input=EvaluationMessageContent(content="Test question", role="human").model_dump(),
+        output=EvaluationMessageContent(content="Test answer", role="ai").model_dump(),
+        context={"topic": "test"},
+        input_chat_message=input_chat_msg,
+        expected_output_chat_message=output_chat_msg,
+        metadata={"created_mode": "manual"},
+    )
+    dataset.messages.add(message)
+
+    row_data_unchanged = {
+        "input_content": "Test question",  # Same as original
+        "output_content": "Test answer",  # Same as original
+        "context": {"topic": "updated"},
+        "history": [],
+    }
+
+    _update_existing_message(dataset, message.id, row_data_unchanged, team)
+    message.refresh_from_db()
+
+    assert message.input_chat_message == input_chat_msg
+    assert message.expected_output_chat_message == output_chat_msg
+    assert message.context == {"topic": "updated"}  # Non-content fields should still update
+
+    row_data_changed = {
+        "input_content": "Changed question",  # Different from original
+        "output_content": "Test answer",  # Same as original
+        "context": {"topic": "changed"},
+        "history": [],
+    }
+
+    _update_existing_message(dataset, message.id, row_data_changed, team)
+    message.refresh_from_db()
+
+    assert message.input_chat_message is None
+    assert message.expected_output_chat_message is not None  # Shouldn't be removed
+    assert message.input["content"] == "Changed question"
+    assert message.context == {"topic": "changed"}
+
+
+@pytest.mark.django_db()
+def test_update_message_clears_chat_references_when_output_changed():
+    """Test that chat message references are cleared when output content changes."""
+
+    team = TeamWithUsersFactory.create()
+    dataset = EvaluationDataset.objects.create(name="Test Dataset", team=team)
+
+    chat = Chat.objects.create(team=team)
+    input_chat_msg = ChatMessage.objects.create(chat=chat, content="Test question", message_type=ChatMessageType.HUMAN)
+    output_chat_msg = ChatMessage.objects.create(chat=chat, content="Test answer", message_type=ChatMessageType.AI)
+
+    message = EvaluationMessage.objects.create(
+        input=EvaluationMessageContent(content="Test question", role="human").model_dump(),
+        output=EvaluationMessageContent(content="Test answer", role="ai").model_dump(),
+        context={"topic": "test"},
+        input_chat_message=input_chat_msg,
+        expected_output_chat_message=output_chat_msg,
+        metadata={"created_mode": "manual"},
+    )
+    dataset.messages.add(message)
+
+    row_data_changed = {
+        "input_content": "Test question",  # Same as original
+        "output_content": "Changed answer",  # Different from original
+        "context": {"topic": "test"},
+        "history": [],
+    }
+
+    _update_existing_message(dataset, message.id, row_data_changed, team)
+    message.refresh_from_db()
+
+    assert message.input_chat_message is not None  # Same as before
+    assert message.expected_output_chat_message is None
+    assert message.output["content"] == "Changed answer"
+
+
+@pytest.mark.django_db()
+def test_csv_upload_comprehensive_scenarios(client, team_with_users):
+    """Test comprehensive CSV upload scenarios:
+    1. Create new row with history and context
+    2. Update existing message with context changes (additions, deletions, modifications)
+    3. Try to update message from different team (should fail)
+    """
+    dataset = EvaluationDataset.objects.create(name="Test Dataset", team=team_with_users)
+
+    # Create existing message with initial context
+    existing_message = EvaluationMessage.objects.create(
+        input=EvaluationMessageContent(content="Original question", role="human").model_dump(),
+        output=EvaluationMessageContent(content="Original answer", role="ai").model_dump(),
+        context={"topic": "tech", "difficulty": "easy", "old_field": "to_be_removed"},
+        history=[],
+        metadata={"created_mode": "manual"},
+    )
+    dataset.messages.add(existing_message)
+
+    # Create a second team and message that shouldn't be accessible
+    other_team = TeamWithUsersFactory.create()
+    other_dataset = EvaluationDataset.objects.create(name="Other Dataset", team=other_team)
+    other_message = EvaluationMessage.objects.create(
+        input=EvaluationMessageContent(content="Other question", role="human").model_dump(),
+        output=EvaluationMessageContent(content="Other answer", role="ai").model_dump(),
+        context={"topic": "other"},
+        metadata={"created_mode": "manual"},
+    )
+    other_dataset.messages.add(other_message)
+
+    # CSV content with:
+    # 1. New row with history and context
+    # 2. Update existing message with context changes
+    # 3. Attempt to update message from different team
+    csv_content = "id,input_content,output_content,context.topic,context.difficulty,context.new_field,history\n"
+
+    # New message with history and context
+    csv_content += (
+        ",New question with history,New answer,science,hard,added_value,"
+        '"human: Hello\nai: Hi there!\nhuman: How are you?"\n'
+    )
+
+    # Update existing message with context changes
+    csv_content += (
+        f"{existing_message.id},Updated question,Updated answer,science,medium,new_added_field,"
+        '"human: Previous chat\nai: Previous response"\n'
+    )
+
+    # Try to update message from different team (should fail)
+    csv_content += f'{other_message.id},Hack attempt,Hacked,hacking,expert,malicious,"human: Bad\nai: Very bad"\n'
+
+    csv_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
+
+    user = team_with_users.members.first()
+    client.force_login(user)
+
+    url = reverse("evaluations:dataset_upload", args=[team_with_users.slug, dataset.id])
+    response = client.post(url, {"csv_file": csv_file})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert "task_id" in data
+
+    # Since we can't wait for the actual task to complete in the test,
+    # let's directly test the helper functions used by the task
+    from apps.evaluations.tasks import _create_new_message, _extract_row_data, _update_existing_message
+
+    # Test scenario 1: New message with history and context
+    new_row = {
+        "id": "",
+        "input_content": "New question with history",
+        "output_content": "New answer",
+        "context.topic": "science",
+        "context.difficulty": "hard",
+        "context.new_field": "added_value",
+        "history": "human: Hello\nai: Hi there!\nhuman: How are you?",
+    }
+
+    row_data = _extract_row_data(new_row, 0)
+    _create_new_message(dataset, row_data)
+
+    # Verify new message was created correctly
+    new_message = EvaluationMessage.objects.filter(input__content="New question with history").first()
+    assert new_message is not None
+    assert new_message.input["content"] == "New question with history"
+    assert new_message.output["content"] == "New answer"
+    assert new_message.context == {"topic": "science", "difficulty": "hard", "new_field": "added_value"}
+    assert len(new_message.history) == 3
+    assert new_message.history[0]["message_type"] == "human"
+    assert new_message.history[0]["content"] == "Hello"
+    assert new_message.history[1]["message_type"] == "ai"
+    assert new_message.history[1]["content"] == "Hi there!"
+    assert new_message.history[2]["message_type"] == "human"
+    assert new_message.history[2]["content"] == "How are you?"
+
+    # Test scenario 2: Update existing message with context changes
+    update_row = {
+        "id": str(existing_message.id),
+        "input_content": "Updated question",
+        "output_content": "Updated answer",
+        "context.topic": "science",  # changed from "tech"
+        "context.difficulty": "medium",  # changed from "easy"
+        "context.new_field": "new_added_field",  # new field added
+        # Note: "old_field" is missing, so it should be removed
+        "history": "human: Previous chat\nai: Previous response",
+    }
+
+    update_row_data = _extract_row_data(update_row, 1)
+    _update_existing_message(dataset, existing_message.id, update_row_data, team_with_users)
+
+    # Verify existing message was updated correctly
+    existing_message.refresh_from_db()
+    assert existing_message.input["content"] == "Updated question"
+    assert existing_message.output["content"] == "Updated answer"
+    assert existing_message.context == {
+        "topic": "science",  # changed
+        "difficulty": "medium",  # changed
+        "new_field": "new_added_field",  # added
+        # "old_field" should be removed
+    }
+    assert "old_field" not in existing_message.context
+    assert len(existing_message.history) == 2
+    assert existing_message.history[0]["message_type"] == "human"
+    assert existing_message.history[0]["content"] == "Previous chat"
+
+    # Test scenario 3: Try to update message from different team (should fail)
+    cross_team_row = {
+        "id": str(other_message.id),
+        "input_content": "Hack attempt",
+        "output_content": "Hacked",
+        "context.topic": "hacking",
+        "history": "human: Bad\nai: Very bad",
+    }
+
+    cross_team_row_data = _extract_row_data(cross_team_row, 2)
+
+    # This should raise EvaluationMessage.DoesNotExist because of team filtering
+    with pytest.raises(EvaluationMessage.DoesNotExist):
+        _update_existing_message(dataset, other_message.id, cross_team_row_data, team_with_users)
+
+    # Verify the other team's message was not modified
+    other_message.refresh_from_db()
+    assert other_message.input["content"] == "Other question"  # unchanged
+    assert other_message.output["content"] == "Other answer"  # unchanged
+    assert other_message.context == {"topic": "other"}  # unchanged

--- a/apps/evaluations/urls.py
+++ b/apps/evaluations/urls.py
@@ -82,6 +82,11 @@ urlpatterns = [
         dataset_views.parse_csv_columns,
         name="parse_csv_columns",
     ),
+    path(
+        "dataset/<int:pk>/download/",
+        dataset_views.download_dataset_csv,
+        name="dataset_download",
+    ),
 ]
 
 urlpatterns.extend(make_crud_urls(evaluation_config_views, "Evaluation", delete=False))

--- a/apps/evaluations/urls.py
+++ b/apps/evaluations/urls.py
@@ -87,6 +87,11 @@ urlpatterns = [
         dataset_views.download_dataset_csv,
         name="dataset_download",
     ),
+    path(
+        "dataset/<int:pk>/upload/",
+        dataset_views.upload_dataset_csv,
+        name="dataset_upload",
+    ),
 ]
 
 urlpatterns.extend(make_crud_urls(evaluation_config_views, "Evaluation", delete=False))

--- a/apps/evaluations/views/dataset_views.py
+++ b/apps/evaluations/views/dataset_views.py
@@ -406,6 +406,9 @@ def _generate_column_suggestions(columns):
         elif col_lower == "id":
             # Skip suggesting ID columns as context
             continue
+        elif col_lower == "history":
+            # History has its own suggestion mechanism
+            suggestions["history"] = col
         else:
             # Clean up column name for context field suggestion
             clean_name = _clean_context_field_name(col)

--- a/templates/evaluations/dataset_edit.html
+++ b/templates/evaluations/dataset_edit.html
@@ -2,6 +2,11 @@
 {% load i18n %}
 {% load static %}
 
+{% block page_head %}
+  {{ block.super }}
+  <script src="{% static 'celery_progress/celery_progress.js' %}"></script>
+{% endblock page_head %}
+
 {% block post_form %}
   <h2 class="pg-subtitle">{% trans "Dataset Messages" %}</h2>
   <div id="dataset-messages-table"
@@ -16,6 +21,52 @@
 
   {% include "evaluations/components/add_message_form.html" %}
 
+  <div class="mt-8">
+    <h3 class="text-lg font-medium mb-4">{% trans "Upload CSV" %}</h3>
+    <div class="bg-gray-50 dark:bg-gray-800 p-4 rounded-lg">
+      <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+        {% trans "Upload a CSV file to update this dataset. Include an 'id' column to update existing messages, or omit it to create new messages." %}
+      </p>
+
+      <form id="csv-upload-form" enctype="multipart/form-data">
+        {% csrf_token %}
+        <div class="mb-4">
+          <label for="csv-file" class="block text-sm font-medium mb-2">{% trans "CSV File" %}</label>
+          <input type="file"
+                 id="csv-file"
+                 name="csv_file"
+                 accept=".csv"
+                 class="file-input file-input-bordered w-full"
+                 required>
+        </div>
+
+        <div class="flex gap-2">
+          <button type="submit" class="btn btn-primary">
+            <i class="fa-solid fa-upload"></i> {% trans "Upload CSV" %}
+          </button>
+          <a href="{% url 'evaluations:dataset_download' request.team.slug object.id %}" class="btn btn-secondary">
+            <i class="fa-solid fa-download"></i> {% trans "Download Template" %}
+          </a>
+        </div>
+      </form>
+
+      <div id="upload-status" class="mt-4 hidden">
+        <div class="alert" id="upload-alert">
+          <div id="upload-message"></div>
+        </div>
+      </div>
+
+      <div id="progress-wrapper" class="mt-4 hidden">
+        <div class="progress-wrapper">
+          <div id="progress-bar" class="progress-bar h-4 bg-blue-200 dark:bg-blue-700 rounded-full overflow-hidden">
+            <div class="bg-blue-600 dark:bg-blue-400 h-full transition-all duration-300" style="width: 0%"></div>
+          </div>
+        </div>
+        <div id="progress-bar-message" class="mt-2 text-sm text-center">Processing CSV...</div>
+      </div>
+    </div>
+  </div>
+
   <dialog id="editMessageModal" class="modal"></dialog>
 {% endblock post_form %}
 
@@ -24,6 +75,90 @@
   <script src="{% static 'js/editors-bundle.js' %}"></script>
   <script>
     SiteJS.editors.initJsonEditors();
+
+    // CSV upload functionality
+    const uploadForm = document.getElementById('csv-upload-form');
+    const uploadStatus = document.getElementById('upload-status');
+    const uploadAlert = document.getElementById('upload-alert');
+    const uploadMessage = document.getElementById('upload-message');
+    const progressWrapper = document.getElementById('progress-wrapper');
+
+    uploadForm.addEventListener('submit', async function(e) {
+      e.preventDefault();
+
+      const formData = new FormData(uploadForm);
+      const uploadUrl = "{% url 'evaluations:dataset_upload' request.team.slug object.id %}";
+
+      // Show progress
+      uploadStatus.classList.add('hidden');
+      progressWrapper.classList.remove('hidden');
+
+      try {
+        const response = await fetch(uploadUrl, {
+          method: 'POST',
+          body: formData,
+          headers: {
+            'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
+          }
+        });
+
+        const data = await response.json();
+
+        if (data.success && data.task_id) {
+          const progressUrl = `/celery-progress/${data.task_id}/`;
+          CeleryProgressBar.initProgressBar(progressUrl, {
+            pollInterval: 1000,
+            onSuccess: (progressBarElement, progressBarMessageElement, result) => {
+              progressWrapper.classList.add('hidden');
+              uploadStatus.classList.remove('hidden');
+
+              if (result && result.success) {
+                uploadAlert.className = 'alert alert-success';
+                let message = `Successfully processed ${result.total_processed} rows: `;
+                message += `${result.updated_count} updated, ${result.created_count} created.`;
+
+                if (result.errors && result.errors.length > 0) {
+                  message += `\n\nErrors:\n${result.errors.join('\n')}`;
+                }
+                uploadMessage.textContent = message;
+                const tableContainer = document.getElementById('dataset-messages-table');
+                if (tableContainer) {
+                  const tableUrl = tableContainer.getAttribute('hx-get');
+                  htmx.ajax('GET', tableUrl, {
+                    target: '#dataset-messages-table',
+                    swap: 'innerHTML'
+                  });
+                }
+
+                uploadForm.reset();
+              } else {
+                uploadAlert.className = 'alert alert-error';
+                uploadMessage.textContent = result?.error || 'Upload completed with errors';
+              }
+            },
+            onError: (progressBarElement, progressBarMessageElement, excMessage) => {
+              progressWrapper.classList.add('hidden');
+              uploadStatus.classList.remove('hidden');
+              uploadAlert.className = 'alert alert-error';
+              uploadMessage.textContent = 'Error during upload: ' + excMessage;
+            }
+          });
+        } else {
+          progressWrapper.classList.add('hidden');
+          uploadStatus.classList.remove('hidden');
+          uploadAlert.className = 'alert alert-error';
+          uploadMessage.textContent = data.error || 'An error occurred while uploading the CSV.';
+        }
+
+      } catch (error) {
+        console.error('Upload error:', error);
+        progressWrapper.classList.add('hidden');
+        uploadStatus.classList.remove('hidden');
+        uploadAlert.className = 'alert alert-error';
+        uploadMessage.textContent = 'An error occurred while uploading the CSV.';
+      }
+    });
+
     document.addEventListener('htmx:afterRequest', function(event) {
       if (event.detail.xhr.status === 200 && (event.detail.target.id === 'editMessageModal' || event.detail.requestConfig.verb === 'delete')) {
         const tableContainer = document.getElementById('dataset-messages-table');

--- a/templates/evaluations/dataset_from_sessions_form.html
+++ b/templates/evaluations/dataset_from_sessions_form.html
@@ -254,11 +254,35 @@
                 </div>
               </div>
 
-              <!-- Populate history option -->
+              <!-- History configuration -->
               <div class="pt-4 border-t">
-                <div class="form-control">
+                <h4 class="font-medium mb-3">{% trans "History Configuration" %}</h4>
+
+                <!-- Automatically populate history checkbox -->
+                <div class="form-control mb-4">
                   {% render_form_fields form "populate_history" %}
                 </div>
+
+                <!-- History column mapping -->
+                <div class="mb-4">
+                  <label class="block text-sm font-medium mb-1">{% trans "Or select history column from CSV" %}</label>
+                  <select x-model="historyColumn"
+                          @change="updateHistoryColumn()"
+                          :disabled="populateHistory"
+                          class="select select-bordered w-full"
+                          :class="populateHistory ? 'select-disabled' : ''">
+                    <option value="">{% trans "Select column..." %}</option>
+                    <template x-for="column in csvData?.columns || []">
+                      <option :value="column" x-text="column"></option>
+                    </template>
+                  </select>
+                  <div class="text-xs text-gray-500 mt-1">
+                    {% trans "Choose a column that contains conversation history text" %}
+                  </div>
+                </div>
+
+                <!-- Hidden field for form submission -->
+                <input type="hidden" name="history_column" x-model="historyColumn">
               </div>
             </div>
 
@@ -306,6 +330,8 @@
         columnMappingJson: '{}',
         csvDataJson: '[]',
         contextMappings: [],
+        historyColumn: '',
+        populateHistory: false,
 
         init() {
           // Watch for mode changes
@@ -334,6 +360,18 @@
             }
           }
           this.updateMessagesJson();
+
+          // Initialize history settings for CSV mode
+          const populateHistoryCheckbox = document.querySelector('input[name="populate_history"]');
+          if (populateHistoryCheckbox) {
+            this.populateHistory = populateHistoryCheckbox.checked;
+            populateHistoryCheckbox.addEventListener('change', () => {
+              this.populateHistory = populateHistoryCheckbox.checked;
+              if (this.populateHistory) {
+                this.historyColumn = ''; // Clear history column when auto-populate is enabled
+              }
+            });
+          }
 
           // Form submission validation
           const form = document.querySelector('form');
@@ -495,6 +533,11 @@
                   fieldNameError: ''
                 }));
               }
+
+              // Pre-populate history column if suggested
+              if (data.suggestions.history) {
+                this.historyColumn = data.suggestions.history;
+              }
             }
 
             this.updateColumnMapping();
@@ -512,6 +555,7 @@
           this.csvData = null;
           this.columnMapping = { input: '', output: '' };
           this.contextMappings = [];
+          this.historyColumn = '';
           this.updateColumnMapping();
           document.querySelector('input[type="file"]').value = '';
         },
@@ -554,6 +598,17 @@
             if (i !== index && this.contextMappings[i].fieldName.trim() === fieldName) {
               mapping.fieldNameError = 'Field name already used';
               return;
+            }
+          }
+        },
+
+        updateHistoryColumn() {
+          if (this.historyColumn) {
+            // Disable populate history checkbox when a column is selected
+            const populateHistoryCheckbox = document.querySelector('input[name="populate_history"]');
+            if (populateHistoryCheckbox) {
+              populateHistoryCheckbox.checked = false;
+              this.populateHistory = false;
             }
           }
         },


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

Base branch: fr/csv-upload

This allows downloading datasets as CSV, modifying the CSV then re-uploading it. This includes adding and changing context variables, history, etc. 
If the text of a message changes, and that message was previously linked to a ChatMessage, this link is broken. 

2ac9e8147ea4c870361cffad7127a20538e825a4 adds the ability to populate history with a history column in a CSV file when creating a dataset. 

