### PR TITLE
widget styles iii

### DIFF
--- a/components/chat_widget/src/components/ocs-chat/heroicons.tsx
+++ b/components/chat_widget/src/components/ocs-chat/heroicons.tsx
@@ -1,8 +1,7 @@
 import {h} from "@stencil/core";
 
 export const XMarkIcon = () => {
-  return <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-              stroke="currentColor" class="size-6">
+  return <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
     <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
   </svg>;
 }
@@ -13,7 +12,6 @@ export const GripDotsVerticalIcon = () => {
       xmlns="http://www.w3.org/2000/svg"
       fill="currentColor"
       viewBox="0 0 24 24"
-      class="size-6"
     >
       {/* Left column of dots */}
       <circle cx="8" cy="6" r="1.5" />
@@ -30,8 +28,7 @@ export const GripDotsVerticalIcon = () => {
 
 export const PencilSquare = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-         class="size-6">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round"
             d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"/>
     </svg>
@@ -40,8 +37,7 @@ export const PencilSquare = () => {
 
 export const ArrowsPointingOutIcon = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-         class="size-6">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round"
             d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15"/>
     </svg>
@@ -50,8 +46,7 @@ export const ArrowsPointingOutIcon = () => {
 
 export const ArrowsPointingInIcon = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-         class="size-6">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round"
             d="M9 9V4.5M9 9H4.5M9 9 3.75 3.75M15 9h4.5M15 9V4.5M15 9l5.25-5.25M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 15h4.5M15 15v4.5m0-4.5 5.25 5.25"/>
     </svg>

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.css
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.css
@@ -506,11 +506,9 @@ textarea {
 }
 
 .loading-spinner {
-  @apply border-2 rounded-full animate-spin;
+  @apply border-2 rounded-full animate-spin size-[var(--loading-spinner-size)];
   border-color: var(--loading-spinner-track-color);
   border-top-color: var(--loading-spinner-fill-color);
-  width: var(--loading-spinner-size, 1.25em);
-  height: var(--loading-spinner-size, 1.25em);
 }
 
 .overflow-y-auto::-webkit-scrollbar {

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.css
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.css
@@ -38,6 +38,7 @@
     * @prop --header-button-text-color: Header button text color (#6b7280)
     * @prop --header-button-bg-hover-color: Header button background on hover (#f3f4f6)
     * @prop --header-padding: Header padding (0.5em)
+    * @prop --header-font-size: Header font size (1em)
     *
     * Starter Question Variables
     * @prop --starter-question-bg-color: Starter question background color (transparent)
@@ -137,6 +138,8 @@
   --header-button-text-color: #6b7280;
   --header-button-bg-hover-color: #f3f4f6;
   --header-padding: 0.5em;
+  --header-font-size: 1em;
+  --header-button-icon-size: 1.5em;
 
   /* Starter question variables */
   --starter-question-bg-color: transparent;
@@ -302,6 +305,7 @@
     padding: var(--header-padding, 0.5em);
     background-color: var(--header-bg-color);
     border-bottom: 1px solid var(--header-border-color);
+    font-size: var(--header-font-size);
   }
 
   .chat-header:hover,
@@ -336,8 +340,12 @@
   /* Header button classes */
   .header-button {
     @apply rounded-md transition-colors duration-200;
-    padding: var(--button-padding-sm, 0.375em);
+    padding: 0.375em;
     color: var(--header-button-text-color);
+  }
+
+  .header-button svg {
+    @apply size-[var(--header-button-icon-size)];
   }
 
   .header-button:hover {

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.css
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.css
@@ -16,10 +16,8 @@
     * @prop --button-border-color: Button border color (#6b7280)
     * @prop --button-border-color-hover: Button border color on hover (#374151)
     * @prop --button-padding: Button padding (0.75em)
-    * @prop --button-padding-sm: Small button padding (0.375em)
     * @prop --button-font-size: Button text font size (0.875em)
-    * @prop --button-icon-width: Button icon width (1.5em)
-    * @prop --button-icon-height: Button icon height (1.5em)
+    * @prop --button-icon-size: Button icon size (1.5em)
     *
     * Chat Window Variables
     * @prop --chat-window-height: Chat window height in pixels or percent (60%)
@@ -113,13 +111,11 @@
   --button-background-color-hover: #f3f4f6;
   --button-text-color: #111827;
   --button-text-color-hover: #1d4ed8;
-  --button-border-color: #6b7280;
-  --button-border-color-hover: #374151;
-  --button-padding: 0.75em;
-  --button-padding-sm: 0.375em;
+  --button-border-color: transparent;
+  --button-border-color-hover: #d1d5db;
+  --button-padding: 0.5em;
   --button-font-size: 0.875em; /* text-sm */
-  --button-icon-width: 1.5em;
-  --button-icon-height: 1.5em;
+  --button-icon-size: 1.5em;
 
   /* Chat window variables */
   --chat-window-height: 60%;
@@ -229,7 +225,13 @@
   .chat-btn-icon {
     @apply shadow-lg border-0 transition-all duration-200 ease-in-out transform hover:scale-105 rounded-lg;
     background-color: var(--button-background-color, white);
+    border: 1px solid var(--button-border-color);
     z-index: var(--chat-z-index, 50);
+  }
+
+  .chat-btn-text:hover, .chat-btn-icon:hover {
+    color: var(--button-text-color-hover, #1d4ed8);
+    border: 1px solid var(--button-border-color-hover);
   }
 
   /* Button with text and icon */
@@ -237,39 +239,31 @@
     @apply flex gap-[8px] items-center;
     padding: var(--button-padding, 0.75em);
     color: var(--button-text-color, #111827);
-  }
-
-  .chat-btn-text:hover {
-    color: var(--button-text-color-hover, #1d4ed8);
+    font-size: var(--button-font-size);
   }
 
   .chat-btn-text span {
     @apply font-medium whitespace-nowrap;
-    font-size: var(--button-font-size);
   }
 
   .chat-btn-text img {
-    @apply object-contain flex-shrink-0;
-    width: var(--button-icon-width, 1.5em);
-    height: var(--button-icon-height, 1.5em);
+    @apply object-contain flex-shrink-0 size-[var(--button-icon-size)];
   }
 
   /* Icon-only button */
   .chat-btn-icon {
+    font-size: var(--button-font-size);
     padding: var(--button-padding, 0.75em);
-    width: 56px;
-    height: 56px;
   }
 
   .chat-btn-icon img {
-    @apply w-full h-full object-contain;
+    @apply size-[var(--button-icon-size)] object-contain;
   }
 
   .chat-btn-text.round,
   .chat-btn-icon.round {
     @apply rounded-full;
   }
-
 
   /* Error message styling */
   .error-message {

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.css
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.css
@@ -4,11 +4,9 @@
 
 :host {
   /**
-    * Global Variables
     * @prop --chat-z-index: Z-index for chat widget (50)
     * @prop --container-padding: General container padding (1em)
     *
-    * Button Variables
     * @prop --button-background-color: Button background color (#ffffff)
     * @prop --button-background-color-hover: Button background color on hover (#f3f4f6)
     * @prop --button-text-color: Button text color (#111827)
@@ -19,7 +17,6 @@
     * @prop --button-font-size: Button text font size (0.875em)
     * @prop --button-icon-size: Button icon size (1.5em)
     *
-    * Chat Window Variables
     * @prop --chat-window-height: Chat window height in pixels or percent (60%)
     * @prop --chat-window-width: Chat window width in pixels or percent (25%)
     * @prop --chat-window-fullscreen-width: Chat window fullscreen width in pixels or percent (80%)
@@ -29,7 +26,6 @@
     * @prop --chat-window-font-size: Default font size for text in the chat window (0.875em)
     * @prop --chat-window-font-size-sm: Font size for small text in the chat window (0.75em)
     *
-    * Header Variables
     * @prop --header-bg-color: Header background color (transparent)
     * @prop --header-bg-hover-color: Header background color on hover (#f9fafb)
     * @prop --header-border-color: Header border color (#f3f4f6)
@@ -38,7 +34,6 @@
     * @prop --header-padding: Header padding (0.5em)
     * @prop --header-font-size: Header font size (1em)
     *
-    * Starter Question Variables
     * @prop --starter-question-bg-color: Starter question background color (transparent)
     * @prop --starter-question-bg-hover-color: Starter question background on hover (#eff6ff)
     * @prop --starter-question-text-color: Starter question text color (#3b82f6)
@@ -46,7 +41,6 @@
     * @prop --starter-question-border-hover-color: Starter question border on hover (#2563eb)
     * @prop --starter-question-padding: Starter question padding (0.75em)
     *
-    * Message Bubble Variables
     * @prop --message-user-bg-color: User message background color (#3b82f6)
     * @prop --message-user-text-color: User message text color (#ffffff)
     * @prop --message-assistant-bg-color: Assistant message background color (#e5e7eb)
@@ -58,7 +52,6 @@
     * @prop --message-padding-x: Message horizontal padding (1em)
     * @prop --message-padding-y: Message vertical padding (0.5em)
     *
-    * Input Area Variables
     * @prop --input-bg-color: Input area background color (transparent)
     * @prop --input-border-color: Input field border color (#d1d5db)
     * @prop --input-text-color: Input text color (#111827)
@@ -67,7 +60,6 @@
     * @prop --input-textarea-padding-x: Input textarea horizontal padding (0.75em)
     * @prop --input-textarea-padding-y: Input textarea vertical padding (0.5em)
     *
-    * Send Button Variables
     * @prop --send-button-bg-color: Send button background color (#3b82f6)
     * @prop --send-button-bg-hover-color: Send button background on hover (#2563eb)
     * @prop --send-button-text-color: Send button text color (#ffffff)
@@ -76,25 +68,20 @@
     * @prop --send-button-padding-x: Send button horizontal padding (1em)
     * @prop --send-button-padding-y: Send button vertical padding (0.5em)
     *
-    * Loading Variables
     * @prop --loading-text-color: Loading text color (#6b7280)
     * @prop --loading-spinner-track-color: Loading spinner track color (#e5e7eb)
     * @prop --loading-spinner-fill-color: Loading spinner fill color (#3b82f6)
     * @prop --loading-spinner-size: Loading spinner size (1.25em)
     *
-    * Typing Indicator Variables
     * @prop --typing-progress-bg-color: Typing progress bar background color (#ade3ff)
     *
-    * Scrollbar Variables
     * @prop --scrollbar-track-color: Scrollbar track color (#f3f4f6)
     * @prop --scrollbar-thumb-color: Scrollbar thumb color (#d1d5db)
     * @prop --scrollbar-thumb-hover-color: Scrollbar thumb hover color (#9ca3af)
     *
-    * Error Variables
     * @prop --error-text-color: Error text color (#ef4444)
     * @prop --error-message-padding: Error message padding (0.5em)
     *
-    * Markdown Code Variables
     * @prop --code-bg-user-color: Code background in user messages (--message-user-bg-color + 20% white)
     * @prop --code-text-user-color: Code text color in user messages (--message-user-text-color)
     * @prop --code-border-user-color: Code border in user messages (--message-user-bg-color + 20% black)

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -927,7 +927,7 @@ export class OcsChat {
             >
               {/* Drag indicator */}
               <div class="drag-indicator">
-                <div class="drag-dots">
+                <div class="drag-dots header-button">
                   <GripDotsVerticalIcon/>
                 </div>
               </div>

--- a/components/chat_widget/src/components/ocs-chat/readme.md
+++ b/components/chat_widget/src/components/ocs-chat/readme.md
@@ -36,14 +36,14 @@ For more information, see the [Open Chat Studio documentation](https://docs.open
 | `--button-border-color`                 | Button border color (#6b7280)                                                    |
 | `--button-border-color-hover`           | Button border color on hover (#374151)                                           |
 | `--button-font-size`                    | Button text font size (0.875em)                                                  |
-| `--button-icon-size`                    | Button icon size (1.5em) Chat Window Variables                                   |
+| `--button-icon-size`                    | Button icon size (1.5em)                                                         |
 | `--button-padding`                      | Button padding (0.75em)                                                          |
 | `--button-text-color`                   | Button text color (#111827)                                                      |
 | `--button-text-color-hover`             | Button text color on hover (#1d4ed8)                                             |
 | `--chat-window-bg-color`                | Chat window background color (#ffffff)                                           |
 | `--chat-window-border-color`            | Chat window border color (#d1d5db)                                               |
 | `--chat-window-font-size`               | Default font size for text in the chat window (0.875em)                          |
-| `--chat-window-font-size-sm`            | Font size for small text in the chat window (0.75em) Header Variables            |
+| `--chat-window-font-size-sm`            | Font size for small text in the chat window (0.75em)                             |
 | `--chat-window-fullscreen-width`        | Chat window fullscreen width in pixels or percent (80%)                          |
 | `--chat-window-height`                  | Chat window height in pixels or percent (60%)                                    |
 | `--chat-window-shadow-color`            | Chat window shadow color (rgba(0, 0, 0, 0.1))                                    |
@@ -55,15 +55,15 @@ For more information, see the [Open Chat Studio documentation](https://docs.open
 | `--code-border-user-color`              | Code border in user messages (--message-user-bg-color + 20% black)               |
 | `--code-text-assistant-color`           | Code text color in assistant messages (--message-assistant-text-color)           |
 | `--code-text-user-color`                | Code text color in user messages (--message-user-text-color)                     |
-| `--container-padding`                   | General container padding (1em) Button Variables                                 |
-| `--error-message-padding`               | Error message padding (0.5em) Markdown Code Variables                            |
+| `--container-padding`                   | General container padding (1em)                                                  |
+| `--error-message-padding`               | Error message padding (0.5em)                                                    |
 | `--error-text-color`                    | Error text color (#ef4444)                                                       |
 | `--header-bg-color`                     | Header background color (transparent)                                            |
 | `--header-bg-hover-color`               | Header background color on hover (#f9fafb)                                       |
 | `--header-border-color`                 | Header border color (#f3f4f6)                                                    |
 | `--header-button-bg-hover-color`        | Header button background on hover (#f3f4f6)                                      |
 | `--header-button-text-color`            | Header button text color (#6b7280)                                               |
-| `--header-font-size`                    | Header font size (1em) Starter Question Variables                                |
+| `--header-font-size`                    | Header font size (1em)                                                           |
 | `--header-padding`                      | Header padding (0.5em)                                                           |
 | `--input-bg-color`                      | Input area background color (transparent)                                        |
 | `--input-border-color`                  | Input field border color (#d1d5db)                                               |
@@ -71,15 +71,15 @@ For more information, see the [Open Chat Studio documentation](https://docs.open
 | `--input-placeholder-color`             | Input placeholder text color (#6b7280)                                           |
 | `--input-text-color`                    | Input text color (#111827)                                                       |
 | `--input-textarea-padding-x`            | Input textarea horizontal padding (0.75em)                                       |
-| `--input-textarea-padding-y`            | Input textarea vertical padding (0.5em) Send Button Variables                    |
+| `--input-textarea-padding-y`            | Input textarea vertical padding (0.5em)                                          |
 | `--loading-spinner-fill-color`          | Loading spinner fill color (#3b82f6)                                             |
-| `--loading-spinner-size`                | Loading spinner size (1.25em) Typing Indicator Variables                         |
+| `--loading-spinner-size`                | Loading spinner size (1.25em)                                                    |
 | `--loading-spinner-track-color`         | Loading spinner track color (#e5e7eb)                                            |
 | `--loading-text-color`                  | Loading text color (#6b7280)                                                     |
 | `--message-assistant-bg-color`          | Assistant message background color (#e5e7eb)                                     |
 | `--message-assistant-text-color`        | Assistant message text color (#1f2937)                                           |
 | `--message-padding-x`                   | Message horizontal padding (1em)                                                 |
-| `--message-padding-y`                   | Message vertical padding (0.5em) Input Area Variables                            |
+| `--message-padding-y`                   | Message vertical padding (0.5em)                                                 |
 | `--message-system-bg-color`             | System message background color (#f3f4f6)                                        |
 | `--message-system-text-color`           | System message text color (#4b5563)                                              |
 | `--message-timestamp-assistant-color`   | Assistant message timestamp color (rgba(75, 85, 99, 0.7))                        |
@@ -87,22 +87,22 @@ For more information, see the [Open Chat Studio documentation](https://docs.open
 | `--message-user-bg-color`               | User message background color (#3b82f6)                                          |
 | `--message-user-text-color`             | User message text color (#ffffff)                                                |
 | `--scrollbar-thumb-color`               | Scrollbar thumb color (#d1d5db)                                                  |
-| `--scrollbar-thumb-hover-color`         | Scrollbar thumb hover color (#9ca3af) Error Variables                            |
+| `--scrollbar-thumb-hover-color`         | Scrollbar thumb hover color (#9ca3af)                                            |
 | `--scrollbar-track-color`               | Scrollbar track color (#f3f4f6)                                                  |
 | `--send-button-bg-color`                | Send button background color (#3b82f6)                                           |
 | `--send-button-bg-disabled-color`       | Send button background when disabled (#d1d5db)                                   |
 | `--send-button-bg-hover-color`          | Send button background on hover (#2563eb)                                        |
 | `--send-button-padding-x`               | Send button horizontal padding (1em)                                             |
-| `--send-button-padding-y`               | Send button vertical padding (0.5em) Loading Variables                           |
+| `--send-button-padding-y`               | Send button vertical padding (0.5em)                                             |
 | `--send-button-text-color`              | Send button text color (#ffffff)                                                 |
 | `--send-button-text-disabled-color`     | Send button text when disabled (#6b7280)                                         |
 | `--starter-question-bg-color`           | Starter question background color (transparent)                                  |
 | `--starter-question-bg-hover-color`     | Starter question background on hover (#eff6ff)                                   |
 | `--starter-question-border-color`       | Starter question border color (#3b82f6)                                          |
 | `--starter-question-border-hover-color` | Starter question border on hover (#2563eb)                                       |
-| `--starter-question-padding`            | Starter question padding (0.75em) Message Bubble Variables                       |
+| `--starter-question-padding`            | Starter question padding (0.75em)                                                |
 | `--starter-question-text-color`         | Starter question text color (#3b82f6)                                            |
-| `--typing-progress-bg-color`            | Typing progress bar background color (#ade3ff) Scrollbar Variables               |
+| `--typing-progress-bg-color`            | Typing progress bar background color (#ade3ff)                                   |
 
 
 ----------------------------------------------

--- a/components/chat_widget/src/components/ocs-chat/readme.md
+++ b/components/chat_widget/src/components/ocs-chat/readme.md
@@ -36,10 +36,8 @@ For more information, see the [Open Chat Studio documentation](https://docs.open
 | `--button-border-color`                 | Button border color (#6b7280)                                                    |
 | `--button-border-color-hover`           | Button border color on hover (#374151)                                           |
 | `--button-font-size`                    | Button text font size (0.875em)                                                  |
-| `--button-icon-height`                  | Button icon height (1.5em) Chat Window Variables                                 |
-| `--button-icon-width`                   | Button icon width (1.5em)                                                        |
+| `--button-icon-size`                    | Button icon size (1.5em) Chat Window Variables                                   |
 | `--button-padding`                      | Button padding (0.75em)                                                          |
-| `--button-padding-sm`                   | Small button padding (0.375em)                                                   |
 | `--button-text-color`                   | Button text color (#111827)                                                      |
 | `--button-text-color-hover`             | Button text color on hover (#1d4ed8)                                             |
 | `--chat-window-bg-color`                | Chat window background color (#ffffff)                                           |
@@ -65,7 +63,8 @@ For more information, see the [Open Chat Studio documentation](https://docs.open
 | `--header-border-color`                 | Header border color (#f3f4f6)                                                    |
 | `--header-button-bg-hover-color`        | Header button background on hover (#f3f4f6)                                      |
 | `--header-button-text-color`            | Header button text color (#6b7280)                                               |
-| `--header-padding`                      | Header padding (0.5em) Starter Question Variables                                |
+| `--header-font-size`                    | Header font size (1em) Starter Question Variables                                |
+| `--header-padding`                      | Header padding (0.5em)                                                           |
 | `--input-bg-color`                      | Input area background color (transparent)                                        |
 | `--input-border-color`                  | Input field border color (#d1d5db)                                               |
 | `--input-outline-focus-color`           | Input field focus ring color (#3b82f6)                                           |


### PR DESCRIPTION
## Description
* Merge with & height vars:
    * `--button-icon-width`, `--button-icon-height` -> `--button-icon-size` 
* Fix launch button styling.
    * Correctly apply font size and borders.
* Add variables to control header font and icon size:
    * `--header-font-size` 
    * `--header-button-icon-size` 

### Docs and Changelog
https://github.com/dimagi/open-chat-studio-docs/pull/148
