### PR TITLE
widget header footer

### DIFF
--- a/components/chat_widget/package.json
+++ b/components/chat_widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-chat-studio-widget",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Chat component for Open Chat Studio",
   "main": "dist/index.cjs.js",
   "exports": "./dist/esm/open-chat-studio-widget.js",

--- a/components/chat_widget/src/components.d.ts
+++ b/components/chat_widget/src/components.d.ts
@@ -28,6 +28,10 @@ export namespace Components {
          */
         "chatbotId": string;
         /**
+          * The text to place in the header.
+         */
+        "headerText": '';
+        /**
           * URL of the icon to display on the button. If not provided, uses the default OCS logo.
          */
         "iconUrl"?: string;
@@ -98,6 +102,10 @@ declare namespace LocalJSX {
           * The ID of the chatbot to connect to.
          */
         "chatbotId": string;
+        /**
+          * The text to place in the header.
+         */
+        "headerText"?: '';
         /**
           * URL of the icon to display on the button. If not provided, uses the default OCS logo.
          */

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.css
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.css
@@ -34,7 +34,7 @@
     * @prop --header-padding: Header padding (0.5em)
     * @prop --header-font-size: Header font size (1em)
     * @prop --header-button-icon-size: Icon size for buttons in the header (1.5em)
-    * @prop --header-text-font-size: Font size for the text in the header (--header-font-size)
+    * @prop --header-text-font-size: Font size for the text in the header (1em)
     * @prop --header-text-color: Color for the text in the header (#525762)
     *
     * @prop --starter-question-bg-color: Starter question background color (transparent)
@@ -125,7 +125,7 @@
   --header-button-bg-hover-color: #f3f4f6;
   --header-padding: 0.5em;
   --header-font-size: 1em;
-  --header-text-font-size: var(--header-font-size);
+  --header-text-font-size: 1em;
   --header-text-color: #525762;
   --header-button-icon-size: 1.5em;
 
@@ -200,6 +200,11 @@
 }
 
 @layer components {
+  #ocs-chat-window {
+    z-index: var(--chat-z-index);
+    font-size: var(--chat-window-font-size);
+  }
+
   .starter-question {
     @apply text-left rounded-lg duration-200;
     padding: var(--starter-question-padding, 0.75em);
@@ -219,6 +224,8 @@
     background-color: var(--button-background-color, white);
     border: 1px solid var(--button-border-color);
     z-index: var(--chat-z-index, 50);
+    font-size: var(--button-font-size);
+    padding: var(--button-padding, 0.75em);
   }
 
   .chat-btn-text:hover, .chat-btn-icon:hover {
@@ -229,9 +236,7 @@
   /* Button with text and icon */
   .chat-btn-text {
     @apply flex gap-[8px] items-center;
-    padding: var(--button-padding, 0.75em);
     color: var(--button-text-color, #111827);
-    font-size: var(--button-font-size);
   }
 
   .chat-btn-text span {
@@ -244,8 +249,6 @@
 
   /* Icon-only button */
   .chat-btn-icon {
-    font-size: var(--button-font-size);
-    padding: var(--button-padding, 0.75em);
   }
 
   .chat-btn-icon img {
@@ -267,7 +270,6 @@
   .chat-window-fullscreen {
     @apply fixed inset-0 w-full h-full max-h-full border-0 shadow-lg transition-shadow duration-200 rounded-none overflow-hidden flex flex-col z-[9999];
     background-color: var(--chat-window-bg-color);
-    font-size: var(--chat-window-font-size);
     max-width: var(--chat-window-fullscreen-width);
   }
 
@@ -439,7 +441,6 @@
   .starter-questions {
     @apply space-y-2;
     padding: var(--container-padding, 1em);
-    font-size: var(--chat-window-font-size);
   }
 
   .starter-question-row {
@@ -451,7 +452,6 @@
     padding: var(--container-padding, 1em) var(--container-padding, 1em) 0 var(--container-padding, 1em);
     background-color: var(--input-bg-color);
     border-top: 1px solid var(--input-border-color);
-    font-size: var(--chat-window-font-size);
   }
 
   .input-container {
@@ -472,7 +472,6 @@
   .send-button {
     @apply rounded-md font-medium transition-colors duration-200;
     padding: var(--send-button-padding-y, 0.5em) var(--send-button-padding-x, 1em);
-    font-size: var(--chat-window-font-size);
   }
 
   .send-button-enabled {
@@ -489,10 +488,6 @@
     background-color: var(--send-button-bg-disabled-color);
     color: var(--send-button-text-disabled-color);
   }
-}
-
-#ocs-chat-window {
-  z-index: var(--chat-z-index);
 }
 
 textarea {
@@ -526,7 +521,7 @@ textarea {
 /* Markdown content styling for chat messages */
 .chat-markdown {
   @apply prose prose-sm prose-gray max-w-none;
-  font-size: var(--chat-window-font-size);
+  font-size: 1em;
   --tw-prose-body: var(--message-assistant-text-color);
   --tw-prose-headings: var(--message-assistant-text-color);
   --tw-prose-lead: var(--message-assistant-text-color);

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.css
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.css
@@ -33,6 +33,9 @@
     * @prop --header-button-bg-hover-color: Header button background on hover (#f3f4f6)
     * @prop --header-padding: Header padding (0.5em)
     * @prop --header-font-size: Header font size (1em)
+    * @prop --header-button-icon-size: Icon size for buttons in the header (1.5em)
+    * @prop --header-text-font-size: Font size for the text in the header (--header-font-size)
+    * @prop --header-text-color: Color for the text in the header (#525762)
     *
     * @prop --starter-question-bg-color: Starter question background color (transparent)
     * @prop --starter-question-bg-hover-color: Starter question background on hover (#eff6ff)
@@ -122,6 +125,8 @@
   --header-button-bg-hover-color: #f3f4f6;
   --header-padding: 0.5em;
   --header-font-size: 1em;
+  --header-text-font-size: var(--header-font-size);
+  --header-text-color: #525762;
   --header-button-icon-size: 1.5em;
 
   /* Starter question variables */
@@ -289,6 +294,12 @@
     font-size: var(--header-font-size);
   }
 
+  .header-text {
+    @apply flex items-center justify-center;
+    font-size: var(--header-text-font-size);
+    color: var(--header-text-color);
+  }
+
   .chat-header:hover,
   .chat-header:active {
     background-color: var(--header-bg-hover-color);
@@ -308,10 +319,6 @@
 
   .drag-dots {
     @apply flex gap-[2px] ml-[2px] pointer-events-none;
-  }
-
-  .drag-spacer {
-    @apply sm:hidden;
   }
 
   .header-buttons {

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.css
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.css
@@ -448,7 +448,7 @@
 
   /* Input area */
   .input-area {
-    padding: var(--container-padding, 1em);
+    padding: var(--container-padding, 1em) var(--container-padding, 1em) 0 var(--container-padding, 1em);
     background-color: var(--input-bg-color);
     border-top: 1px solid var(--input-border-color);
     font-size: var(--chat-window-font-size);

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -1100,7 +1100,7 @@ export class OcsChat {
                   </div>
                 </div>
               )}
-              <div class="flex items-center justify-center text-[0.7em] font-light w-full text-slate-500 py-[2px]">
+              <div class="flex items-center justify-center text-[0.8em] font-light w-full text-slate-500 py-[2px]">
                 <p>Powered by <a class="underline" href="https://www.dimagi.com" target="_blank">Dimagi</a></p>
               </div>
             </div>

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -1100,6 +1100,9 @@ export class OcsChat {
                   </div>
                 </div>
               )}
+              <div class="flex items-center justify-center text-[0.7em] font-light w-full text-slate-500 py-[2px]">
+                <p>Powered by <a class="underline" href="https://www.dimagi.com" target="_blank">Dimagi</a></p>
+              </div>
             </div>
           </div>
         )}

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -101,6 +101,11 @@ export class OcsChat {
   @Prop() buttonShape: 'round' | 'square' = 'square';
 
   /**
+   * The text to place in the header.
+   */
+  @Prop() headerText: '';
+
+  /**
    * Whether the chat widget is visible on load.
    */
   @Prop({ mutable: true }) visible: boolean = false;
@@ -931,7 +936,7 @@ export class OcsChat {
                   <GripDotsVerticalIcon/>
                 </div>
               </div>
-              <div class="drag-spacer"></div>
+              <div class="header-text">{this.headerText}</div>
               <div class="header-buttons">
                 {/* Fullscreen toggle button */}
                 {this.allowFullScreen && <button

--- a/components/chat_widget/src/components/ocs-chat/readme.md
+++ b/components/chat_widget/src/components/ocs-chat/readme.md
@@ -16,6 +16,7 @@ For more information, see the [Open Chat Studio documentation](https://docs.open
 | `buttonShape`             | `button-shape`              | The shape of the chat button. 'round' makes it circular, 'square' keeps it rectangular.                                           | `"round" \| "square"`           | `'square'`                      |
 | `buttonText`              | `button-text`               | The text to display on the button.                                                                                                | `string`                        | `undefined`                     |
 | `chatbotId` _(required)_  | `chatbot-id`                | The ID of the chatbot to connect to.                                                                                              | `string`                        | `undefined`                     |
+| `headerText`              | `header-text`               | The text to place in the header.                                                                                                  | `""`                            | `undefined`                     |
 | `iconUrl`                 | `icon-url`                  | URL of the icon to display on the button. If not provided, uses the default OCS logo.                                             | `string`                        | `undefined`                     |
 | `persistentSession`       | `persistent-session`        | Whether to persist session data to local storage to allow resuming previous conversations after page reload.                      | `boolean`                       | `true`                          |
 | `persistentSessionExpire` | `persistent-session-expire` | Minutes since the most recent message after which the session data in local storage will expire. Set this to `0` to never expire. | `number`                        | `60 * 24`                       |
@@ -62,9 +63,12 @@ For more information, see the [Open Chat Studio documentation](https://docs.open
 | `--header-bg-hover-color`               | Header background color on hover (#f9fafb)                                       |
 | `--header-border-color`                 | Header border color (#f3f4f6)                                                    |
 | `--header-button-bg-hover-color`        | Header button background on hover (#f3f4f6)                                      |
+| `--header-button-icon-size`             | Icon size for buttons in the header (1.5em)                                      |
 | `--header-button-text-color`            | Header button text color (#6b7280)                                               |
 | `--header-font-size`                    | Header font size (1em)                                                           |
 | `--header-padding`                      | Header padding (0.5em)                                                           |
+| `--header-text-color`                   | Color for the text in the header (#525762)                                       |
+| `--header-text-font-size`               | Font size for the text in the header (--header-font-size)                        |
 | `--input-bg-color`                      | Input area background color (transparent)                                        |
 | `--input-border-color`                  | Input field border color (#d1d5db)                                               |
 | `--input-outline-focus-color`           | Input field focus ring color (#3b82f6)                                           |

--- a/components/chat_widget/src/index.html
+++ b/components/chat_widget/src/index.html
@@ -1,30 +1,100 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
-    <title>Stencil Component Starter</title>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"/>
+  <title>Stencil Component Starter</title>
 
-    <script type="module" src="/build/open-chat-studio-widget.esm.js"></script>
-    <script nomodule src="/build/open-chat-studio-widget.js"></script>
-  </head>
-  <style>
-    open-chat-studio-widget {
-        position: static;
-    }
-  </style>
-  <body style="background-color: #98dbcc">
-    <open-chat-studio-widget
-      api-base-url="http://localhost:8000"
-      visible="false"
-      chatbot-id="183312ac-cbe5-4c91-9e7b-d9df96b088e4"
-      button-text="Let's Chat"
-      expanded="true"
-      position="center"
-      welcome-messages="['Hi there! Welcome to OpenChatStudio! This is a very long welcome message used to illustrate the max message width.', 'How can we help you today?\n* list\n* list\n# Header L1\n\n## Header L2\n\n```\nsome code\nmore code\n```\n']"
-      starter-questions="['I would like a OpenChatStudio demo', 'How can we help you today?\n* list\n* list\n# Header L1\n\n## Header L2\n\n```\nsome code\nmore code\n```\n']"
-      persistent-session="true"
-      persistent-session-expire="100"
-      ></open-chat-studio-widget>
-  </body>
+  <script type="module" src="/build/open-chat-studio-widget.esm.js"></script>
+  <script nomodule src="/build/open-chat-studio-widget.js"></script>
+</head>
+<style>
+  .widget-demo {
+    margin-left: 20px;
+    margin-button: 20px;
+    padding: 0px 10px 20px 10px;
+    border: 1px solid black;
+    border-radius: 5px;
+    max-width: 300px;
+  }
+
+  .widget {
+    position: static;
+  }
+
+  .regular-button {
+  }
+
+  .large-button {
+    --button-font-size: 2em;
+    --chat-window-bg-color: #00dfff;
+  }
+
+  .round-button {
+    --chat-window-font-size: 1.5rem;
+    --header-font-size: 1.5em;
+    --chat-window-width: 50%;
+    --chat-window-fullscreen-width: 100%;
+  }
+
+  .square-button-large {
+    --button-font-size: 2rem;
+    --message-assistant-text-color: red;
+    --message-user-text-color: yellow;
+  }
+</style>
+<body style="background-color: #98dbcc; gap: 10px; display: flex; flex-direction: column;">
+<div class="widget-demo">
+  <p>Regular button, default styling</p>
+  <open-chat-studio-widget
+    class="widget regular-button"
+    api-base-url="http://localhost:8000"
+    visible="false"
+    chatbot-id="183312ac-cbe5-4c91-9e7b-d9df96b088e4"
+    button-text="Let's Chat"
+    header-text="Regular"
+    position="center"
+    welcome-messages="['Hi there! Welcome to OpenChatStudio! This is a very long welcome message used to illustrate the max message width.', 'How can we help you today?\n* list\n* list\n# Header L1\n\n## Header L2\n\n```\nsome code\nmore code\n```\n']"
+    starter-questions="['I would like a OpenChatStudio demo', 'How can we help you today?\n* list\n* list\n# Header L1\n\n## Header L2\n\n```\nsome code\nmore code\n```\n']"
+    persistent-session="true"
+    persistent-session-expire="100"
+  ></open-chat-studio-widget>
+</div>
+
+<div class="widget-demo">
+  <p>Large button, blue window background</p>
+  <open-chat-studio-widget
+    class="widget large-button"
+    api-base-url="http://localhost:8000"
+    visible="false"
+    chatbot-id="183312ac-cbe5-4c91-9e7b-d9df96b088e4"
+    button-text="Let's Chat"
+    header-text="Large button, bg blue"
+  ></open-chat-studio-widget>
+</div>
+
+<div class="widget-demo">
+  <p>Round button, large window font, wide window, max fullscreen</p>
+  <open-chat-studio-widget
+    class="widget round-button"
+    api-base-url="http://localhost:8000"
+    visible="false"
+    chatbot-id="183312ac-cbe5-4c91-9e7b-d9df96b088e4"
+    button-text=""
+    button-shape="round"
+    header-text="Round button, large font, wide window, max fullscreen"
+  ></open-chat-studio-widget>
+</div>
+<div class="widget-demo">
+  <p>Large square button, red & yellow message font</p>
+  <open-chat-studio-widget
+    class="widget square-button-large"
+    api-base-url="http://localhost:8000"
+    visible="false"
+    chatbot-id="183312ac-cbe5-4c91-9e7b-d9df96b088e4"
+    button-text=""
+    header-text="Square button, red & yellow font"
+  ></open-chat-studio-widget>
+</div>
+</body>
 </html>

--- a/components/chat_widget/src/index.html
+++ b/components/chat_widget/src/index.html
@@ -32,7 +32,6 @@
 
   .round-button {
     --chat-window-font-size: 1.5rem;
-    --header-font-size: 1.5em;
     --chat-window-width: 50%;
     --chat-window-fullscreen-width: 100%;
   }
@@ -70,6 +69,8 @@
     chatbot-id="183312ac-cbe5-4c91-9e7b-d9df96b088e4"
     button-text="Let's Chat"
     header-text="Large button, bg blue"
+    welcome-messages="['Hi there! Welcome to OpenChatStudio! This is a very long welcome message used to illustrate the max message width.', 'How can we help you today?\n* list\n* list\n# Header L1\n\n## Header L2\n\n```\nsome code\nmore code\n```\n']"
+    starter-questions="['I would like a OpenChatStudio demo', 'How can we help you today?\n* list\n* list\n# Header L1\n\n## Header L2\n\n```\nsome code\nmore code\n```\n']"
   ></open-chat-studio-widget>
 </div>
 
@@ -83,6 +84,8 @@
     button-text=""
     button-shape="round"
     header-text="Round button, large font, wide window, max fullscreen"
+    welcome-messages="['Hi there! Welcome to OpenChatStudio! This is a very long welcome message used to illustrate the max message width.', 'How can we help you today?\n* list\n* list\n# Header L1\n\n## Header L2\n\n```\nsome code\nmore code\n```\n']"
+    starter-questions="['I would like a OpenChatStudio demo', 'How can we help you today?\n* list\n* list\n# Header L1\n\n## Header L2\n\n```\nsome code\nmore code\n```\n']"
   ></open-chat-studio-widget>
 </div>
 <div class="widget-demo">
@@ -94,6 +97,8 @@
     chatbot-id="183312ac-cbe5-4c91-9e7b-d9df96b088e4"
     button-text=""
     header-text="Square button, red & yellow font"
+    welcome-messages="['Hi there! Welcome to OpenChatStudio! This is a very long welcome message used to illustrate the max message width.', 'How can we help you today?\n* list\n* list\n# Header L1\n\n## Header L2\n\n```\nsome code\nmore code\n```\n']"
+    starter-questions="['I would like a OpenChatStudio demo', 'How can we help you today?\n* list\n* list\n# Header L1\n\n## Header L2\n\n```\nsome code\nmore code\n```\n']"
   ></open-chat-studio-widget>
 </div>
 </body>


### PR DESCRIPTION
## Description
* Add an optional `header-text` attribute to place text in the widget header.
* Add a 'Powered by Dimagi' footer.

### Demo
<img width="496" height="390" alt="image" src="https://github.com/user-attachments/assets/d375665e-2f7e-4647-ba3a-f5686c8d2ab3" />


### Docs and Changelog
https://github.com/dimagi/open-chat-studio-docs/pull/148
