### PR TITLE
Chat widget: polling modifications

### DIFF
--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -64,7 +64,7 @@ interface SessionStorageData {
 })
 export class OcsChat {
 
-  private static readonly TASK_POLLING_MAX_ATTEMPTS = 120; // Changed from 30 to 120 for 120 second timeout
+  private static readonly TASK_POLLING_MAX_ATTEMPTS = 120;
   private static readonly TASK_POLLING_INTERVAL_MS = 1000;
   private static readonly MESSAGE_POLLING_INTERVAL_MS = 30000;
 

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -64,7 +64,7 @@ interface SessionStorageData {
 })
 export class OcsChat {
 
-  private static readonly TASK_POLLING_MAX_ATTEMPTS = 30;
+  private static readonly TASK_POLLING_MAX_ATTEMPTS = 120;
   private static readonly TASK_POLLING_INTERVAL_MS = 1000;
   private static readonly MESSAGE_POLLING_INTERVAL_MS = 30000;
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
resolves [#2053](https://github.com/dimagi/open-chat-studio/issues/2053)

opted for a system message for easy traceability of what happened in the session history and for a nicely formatted response rather than an error message, but let me know if an error message makes more sense to you in this case

## User Impact
<!-- Describe the impact of this change on the end-users. -->
polling time increased to 120 seconds (120 intervals of 1 second)

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
no docs but yes changelog
