### PR TITLE
allow excluding files in github repo loader

### DIFF
--- a/apps/documents/datamodels.py
+++ b/apps/documents/datamodels.py
@@ -14,7 +14,9 @@ class CollectionFileMetadata(pydantic.BaseModel):
 class GitHubSourceConfig(pydantic.BaseModel):
     repo_url: HttpUrl = pydantic.Field(description="GitHub repository URL")
     branch: str = pydantic.Field(default="main", description="Branch to sync from")
-    file_pattern: str = pydantic.Field(default="*.md", description="File pattern to match (e.g., *.md, src/*.py)")
+    file_pattern: str = pydantic.Field(
+        default="*.md", description="File pattern to match (e.g., *.md, src/*.py, !test_*)"
+    )
     path_filter: str = pydantic.Field(default="", description="Optional path prefix filter")
 
     def __str__(self):

--- a/apps/documents/forms.py
+++ b/apps/documents/forms.py
@@ -175,7 +175,8 @@ class GithubDocumentSourceForm(DocumentSourceForm):
         required=False,
         initial="*.md",
         label="File Pattern",
-        help_text="File patterns to include (comma-separated, e.g., *.md, *.txt)",
+        help_text="File patterns to include. Prefix with '!' to exclude matching files. "
+        "(comma-separated, e.g., *.md, *.txt, !test_*)",
         widget=forms.TextInput(attrs={"placeholder": "*.md, *.txt"}),
     )
     path_filter = forms.CharField(

--- a/apps/documents/source_loaders/github.py
+++ b/apps/documents/source_loaders/github.py
@@ -61,7 +61,11 @@ class GitHubDocumentLoader(BaseDocumentLoader[GitHubSourceConfig]):
         if self.config.path_filter and not file_path.startswith(self.config.path_filter):
             return False
         patterns = [p.strip() for p in self.config.file_pattern.split(",")]
-        return any(fnmatch.fnmatch(file_path, pattern) for pattern in patterns)
+        include_patterns = [p for p in patterns if not p.startswith("!")]
+        exclude_patterns = [p[1:] for p in patterns if p.startswith("!")]
+        return any(fnmatch.fnmatch(file_path, pattern) for pattern in include_patterns) and not any(
+            fnmatch.fnmatch(file_path, pattern) for pattern in exclude_patterns
+        )
 
     def should_update_document(self, document: Document, existing_file: CollectionFile) -> bool:
         """

--- a/apps/documents/tests/test_github_loader.py
+++ b/apps/documents/tests/test_github_loader.py
@@ -30,15 +30,22 @@ class TestGitHubDocumentLoader:
         assert not loader._matches_pattern("script.py")
         assert not loader._matches_pattern("README.txt")
 
-    def test_matches_multiple_patterns(self):
+    def test_matches_multiple_patterns_and_exclude(self):
         config = GitHubSourceConfig(
-            repo_url="https://github.com/test/repo", branch="main", file_pattern="*.md, *.txt, *.py"
+            repo_url="https://github.com/test/repo",
+            branch="main",
+            file_pattern="!*_test.py, *.md, *.txt, *.py, !test.py",
         )
         loader = GitHubDocumentLoader(Mock(), config, None)
 
         assert loader._matches_pattern("README.md")
         assert loader._matches_pattern("notes.txt")
+        assert loader._matches_pattern("docs/index.md")
         assert loader._matches_pattern("script.py")
+        assert loader._matches_pattern("src/test.py")  # not matched because of the subdirectory
+        assert not loader._matches_pattern("test.py")
+        assert not loader._matches_pattern("hello_test.py")
+        assert not loader._matches_pattern("tests/docs_test.py")
         assert not loader._matches_pattern("image.png")
 
     def test_load_documents(self, github_config):


### PR DESCRIPTION
## Description
Allow providing negated filename patters to exclude files loaded into a Collection from a GitHub repo.

e.g. `*.md, !changelog.md`

## User Impact
Users have more control over which files are included.

### Docs and Changelog
TODO
