### PR TITLE
Chat widget: error handling

### DIFF
--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -250,7 +250,7 @@ export class OcsChat {
     const errorMessage: ChatMessage = {
       created_at: new Date().toISOString(),
       role: 'system',
-      content: `**Error:** ${errorText}\nPlease try again or contact support if the problem persists.`,
+      content: `**Error:** ${errorText}\nPlease try again.`,
       attachments: []
     };
 

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -246,6 +246,30 @@ export class OcsChat {
     window.removeEventListener('resize', this.handleWindowResize);
   }
 
+  private addErrorMessage(errorText: string): void {
+    const errorMessage: ChatMessage = {
+      created_at: new Date().toISOString(),
+      role: 'system',
+      content: `**Error:** ${errorText}\nPlease try again or contact support if the problem persists.`,
+      attachments: []
+    };
+
+    this.messages = [...this.messages, errorMessage];
+    this.saveSessionToStorage();
+    this.scrollToBottom();
+  }
+
+  private handleError(errorText: string): void {
+    // show as system message
+    this.addErrorMessage(errorText);
+
+    // Clear any loading/typing states
+    this.isLoading = false;
+    this.isTyping = false;
+    this.isUploadingFiles = false;
+    this.currentPollTaskId = '';
+  }
+
   private parseJSONProp(propValue: string | undefined, propName: string): string[] {
     try {
       if (propValue) {

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -1135,7 +1135,8 @@ export class OcsChat {
   }
 
   render() {
-    if (this.error) {
+    // Only show error state for critical errors that prevent the widget from functioning
+    if (this.error && !this.sessionId) {
       return (
         <Host>
           <p class="error-message">{this.error}</p>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
resolves [#2063](https://github.com/dimagi/open-chat-studio/issues/2063)

rather than closing out the chat widget window, it will send the error message as a system message to the user. I opted for this approach because it's clean and uses the existing UI. 


## User Impact
<!-- Describe the impact of this change on the end-users. -->
users will still be able to use the widget even if it errors (for non-critical errors)

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
n/a

### Docs and Changelog
<!--Link to documentation that has been updated.-->
no and no
