### PR TITLE
add docs links

### DIFF
--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -394,7 +394,10 @@ REST_FRAMEWORK = {
         "apps.api.permissions.ApiKeyAuthentication",
         "apps.api.permissions.BearerTokenAuthentication",
     ],
-    "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated", "apps.api.permissions.ReadOnlyAPIKeyPermission"],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+        "apps.api.permissions.ReadOnlyAPIKeyPermission",
+    ],
     "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer"],
     "DEFAULT_PARSER_CLASSES": ["rest_framework.parsers.JSONParser"],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
@@ -493,6 +496,7 @@ PROJECT_METADATA = {
     "IMAGE": "https://chatbots.dimagi.com/static/images/logo.png",
     "TERMS_URL": env("TERMS_URL", default=""),
     "PRIVACY_POLICY_URL": env("PRIVACY_POLICY_URL", default=""),
+    "DOCS_URL": env("DOCS_URL", default="https://docs.openchatstudio.com"),
 }
 
 USE_HTTPS_IN_ABSOLUTE_URLS = False  # set this to True in production to have URLs generated with https instead of http

--- a/templates/web/components/hero.html
+++ b/templates/web/components/hero.html
@@ -11,14 +11,18 @@
         <h2 class="text-2xl">
           {{ project_meta.DESCRIPTION }}
         </h2>
-        <p class="mt-4 flex grow">
+        <p class="mt-4 flex grow gap-2">
           {% if signup_enabled %}
-            <a class="btn btn-outline" href="{% url 'account_signup' %}">
+            <a class="btn btn-outline btn-primary" href="{% url 'account_signup' %}">
               {% translate "Create account" %}
             </a>
           {% endif %}
           <a class="btn btn-outline btn-secondary w-44" href="{% url login_url_name|default:"account_login" %}">
             {% translate "Sign In" %}
+          </a>
+          <a class="btn btn-ghost" href="{{ project_meta.DOCS_URL }}" target="_blank">
+            {% translate "Docs" %}
+            <i class="fa-solid fa-up-right-from-square"></i>
           </a>
         </p>
       </div>

--- a/templates/web/components/team_nav_items.html
+++ b/templates/web/components/team_nav_items.html
@@ -32,3 +32,9 @@
     </a>
   </li>
 {% endif %}
+ <li>
+   <a href="{{ project_meta.DOCS_URL }}" target="_blank">
+    <i class="fa-solid fa-circle-question"></i>
+    {% translate "Docs" %}
+   </a>
+</li>

--- a/templates/web/components/top_nav.html
+++ b/templates/web/components/top_nav.html
@@ -3,9 +3,11 @@
   <div class="navbar bg-base-100 shadow-md">
     <div class="navbar-start">
     </div>
-    <div class="navbar-end">
-      {% if user.is_authenticated %}
-      {% else %}
+    <div class="navbar-end gap-2">
+      {% if not user.is_authenticated %}
+        <a class="font-semibold" href="{{ project_meta.DOCS_URL }}" target="_blank">
+            {% translate "Docs" %}
+        </a>
         {% if signup_enabled %}
           <a href="{% url 'account_signup' %}" class="btn btn-primary">
             {% translate "Sign Up" %}


### PR DESCRIPTION
## Description
Add links to the docs from the landing page and also the team dropdown menu (not the most ideal place but our sidebar is already quite full).

## User Impact
User's can discover the docs and get easier access to them.

### Demo
<img width="274" height="183" alt="image" src="https://github.com/user-attachments/assets/e6d6d1ca-771f-46db-aaf1-3381d4d6d7ce" />
<img width="301" height="77" alt="image" src="https://github.com/user-attachments/assets/8c3e1e8f-7a24-433d-8546-a21b8d05a982" />
<img width="198" height="91" alt="image" src="https://github.com/user-attachments/assets/ac605a88-742a-436c-be9e-d31789cd6960" />
