### PR TITLE
chat widget scroll fixes

### DIFF
--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.css
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.css
@@ -632,7 +632,7 @@ textarea {
 }
 
 .overflow-y-auto::-webkit-scrollbar {
-  @apply w-1.5;
+  @apply w-1.5 h-1.5;
 }
 
 .overflow-y-auto::-webkit-scrollbar-track {

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -774,6 +774,7 @@ export class OcsChat {
     } else if (!visible) {
       this.pauseMessagePolling()
     } else {
+      this.scrollToBottom()
       this.resumeMessagePolling();
     }
   }

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -663,10 +663,29 @@ export class OcsChat {
     }
   }
 
-  private scrollToBottom(): void {
+  /**
+   * Scroll the message container to the bottom.
+   * @param forceEnd When `false`, scroll the top of the last message into view.
+   *    When `true`, scroll all the way to the end of the last message.
+   */
+  private scrollToBottom(forceEnd: boolean =false): void {
     setTimeout(() => {
       if (this.messageListRef) {
-        this.messageListRef.scrollTop = this.messageListRef.scrollHeight;
+        const lastChild = this.messageListRef.lastElementChild;
+        if (!forceEnd && lastChild) {
+          // scroll so that the top of the last message is in the centre of the message container
+          const parentRect = this.messageListRef.getBoundingClientRect();
+          const childRect = lastChild.getBoundingClientRect();
+          const currentScrollTop = this.messageListRef.scrollTop;
+          const childTopRelativeToParent = childRect.top - parentRect.top;
+          const targetScroll = currentScrollTop + childTopRelativeToParent - (parentRect.height / 2);
+          this.messageListRef.scrollTo({
+              top: targetScroll,
+              behavior: 'smooth'
+          });
+        } else {
+          this.messageListRef.scrollTop = this.messageListRef.scrollHeight;
+        }
       }
     }, OcsChat.SCROLL_DELAY_MS);
   }
@@ -774,7 +793,7 @@ export class OcsChat {
     } else if (!visible) {
       this.pauseMessagePolling()
     } else {
-      this.scrollToBottom()
+      this.scrollToBottom(true);
       this.resumeMessagePolling();
     }
   }


### PR DESCRIPTION
## Description
Resolves https://github.com/dimagi/open-chat-studio/issues/2103

* Scroll to the bottom of the view when opening.
* When adding a new message, scroll so that the top of the message is in the middle of the message list (previously it scrolled to the bottom and the user had to scroll up to find the start of the message).
* Update horizontal scrollbar styling (height)

## User Impact
Improved scrolling behaviour in chat widget.