### PR TITLE
remove default session filters + cleanup

### DIFF
--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -239,21 +239,6 @@
         });
 
         this.loadFiltersFromUrl();
-        let defaultFilterApplied = false;
-        // set default filter to exclude API sessions
-        if (this.filterData.filters.length === 1 && !this.filterData.filters[0].column) {
-          this.filterData.filters = [{
-            column: 'channels',
-            operator: 'excludes',
-            value: '',
-            selectedValues: ['API', 'Evaluations'],
-            availableOperators: ['any of', 'all of', 'excludes'],
-            showOptions: false,
-            searchQuery: '',
-            filteredOptions: channelsList
-          }];
-          defaultFilterApplied = true;
-        }
         const urlParams = new URLSearchParams(window.location.search);
         const showAllCheckbox = document.querySelector('input[name="show-all"]');
         if (urlParams.has('show-all') && showAllCheckbox) {
@@ -267,7 +252,7 @@
 
           // Always trigger a data load on init to ensure correct data is shown
         this.$nextTick(() => {
-          this.triggerFilterChange(defaultFilterApplied); // Don't update URL again since we just loaded from it
+          this.triggerFilterChange(false); // Don't update URL again since we just loaded from it
         });
         // for date range dropdown
         this.setLabelFromURL();

--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -239,17 +239,6 @@
         });
 
         this.loadFiltersFromUrl();
-        const urlParams = new URLSearchParams(window.location.search);
-        const showAllCheckbox = document.querySelector('input[name="show-all"]');
-        if (urlParams.has('show-all') && showAllCheckbox) {
-          showAllCheckbox.checked = true;
-        }
-        if (showAllCheckbox) {
-          showAllCheckbox.addEventListener('change', () => {
-            this.triggerFilterChange();
-          });
-        }
-
           // Always trigger a data load on init to ensure correct data is shown
         this.$nextTick(() => {
           this.triggerFilterChange(false); // Don't update URL again since we just loaded from it
@@ -493,13 +482,6 @@
           }
         });
 
-        const showAllCheckbox = document.querySelector('input[name="show-all"]');
-        if (showAllCheckbox && showAllCheckbox.checked) {
-          params.set('show-all', 'on');
-        } else {
-          params.delete('show-all');
-        }
-
         const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '') + window.location.hash;
         window.history.replaceState({}, '', newUrl);
       },
@@ -529,10 +511,6 @@
           }
         });
         const sessionsTableUrl = document.getElementById('sessions-table').dataset.url;
-        const showAllCheckbox = document.querySelector('input[name="show-all"]');
-        if (showAllCheckbox && showAllCheckbox.checked) {
-          filterParams['show-all'] = 'on';
-        }
         if (updateUrl) {
           this.updateUrlWithFilters(activeFilters);
         }


### PR DESCRIPTION
## Description
Remove the default "API" filter for sessions. This has been requested by users because chat widget sessions are currently using the API channel. This will change once https://github.com/dimagi/open-chat-studio/issues/1970 is rolled out.

## User Impact
All sessions will be displayed by default.

### Docs and Changelog
TODO
