### PR TITLE
Add message id to evaluation run csv download

### DIFF
--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -319,7 +319,7 @@ class EvaluationRun(BaseTeamModel):
         if save:
             self.save(update_fields=["finished_at", "status"])
 
-    def get_table_data(self):
+    def get_table_data(self, include_ids: bool = False):
         results = self.results.select_related("message", "evaluator", "session").all()
         table_by_message = defaultdict(dict)
         for result in results:
@@ -329,6 +329,9 @@ class EvaluationRun(BaseTeamModel):
                 for key, value in result.message.context.items()
                 if key != "current_datetime"
             }
+            if include_ids is True:
+                table_by_message[result.message.id].update({"id": result.message.id})
+
             table_by_message[result.message.id].update(
                 {
                     "Dataset Input": result.message.input.get("content", ""),

--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -235,7 +235,7 @@ def download_evaluation_run_csv(request, team_slug, evaluation_pk, evaluation_ru
         EvaluationRun, id=evaluation_run_pk, config_id=evaluation_pk, team__slug=team_slug
     )
     filename = f"{evaluation_run.config.name}_results_{evaluation_run.id}.csv"
-    table_data = list(evaluation_run.get_table_data())
+    table_data = list(evaluation_run.get_table_data(include_ids=True))
     response = HttpResponse(content_type="text/csv")
     response["Content-Disposition"] = f"attachment; filename={filename}"
     writer = csv.writer(response)


### PR DESCRIPTION
Fixes: https://github.com/dimagi/open-chat-studio/issues/2131

## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

Adds message ids to an evaluation run export
