### PR TITLE
Sk/clone tags

### DIFF
--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -109,9 +109,18 @@ class EvaluationMessage(BaseModel):
                 "chat__experiment_session__participant",
                 "chat__experiment_session__experiment",
             )
+            .prefetch_related("comments", "tags")
             .order_by("chat__experiment_session__created_at", "created_at")
             .all()
         )
+
+        def _add_additional_context(msg, existing_context):
+            if comments := list(msg.comments.all()):
+                existing_context.setdefault("comments", []).extend([comment.comment for comment in comments])
+            if tags := list(msg.tags.all()):
+                context_tags = existing_context.get("tags", [])
+                context_tags.extend([tag.name for tag in tags if not tag.is_system_tag])
+                existing_context["tags"] = list(dict.fromkeys(context_tags))  # dedupe preserving order
 
         messages_by_session = defaultdict(list)
         for message in all_messages:
@@ -126,14 +135,15 @@ class EvaluationMessage(BaseModel):
                 next_msg = messages[i + 1]
                 if current_msg.message_type == ChatMessageType.HUMAN and next_msg.message_type == ChatMessageType.AI:
                     session = current_msg.chat.experiment_session
+                    context = {"current_datetime": current_msg.created_at.isoformat()}
+                    _add_additional_context(current_msg, context)
+                    _add_additional_context(next_msg, context)
                     evaluation_message = EvaluationMessage(
                         input_chat_message=current_msg,
                         input=EvaluationMessageContent(content=current_msg.content, role="human").model_dump(),
                         expected_output_chat_message=next_msg,
                         output=EvaluationMessageContent(content=next_msg.content, role="ai").model_dump(),
-                        context={
-                            "current_datetime": current_msg.created_at.isoformat(),
-                        },
+                        context=context,
                         history=[msg.copy() for msg in history],  # Store as JSON list
                         metadata={
                             "session_id": session_id,

--- a/apps/evaluations/views/dataset_views.py
+++ b/apps/evaluations/views/dataset_views.py
@@ -194,6 +194,7 @@ class DatasetSessionsSelectionTableView(LoginAndTeamRequiredMixin, SingleTableVi
             .filter(team=self.request.team)
             .select_related("participant__user", "chat", "experiment")
             .annotate(message_count=Count("chat__messages"))
+            .filter(message_count__gt=0)
             .order_by("experiment__name")
         )
         timezone = self.request.session.get("detected_tz", None)


### PR DESCRIPTION
## Description
Resolves https://github.com/dimagi/open-chat-studio/issues/2152
Resolves https://github.com/dimagi/open-chat-studio/issues/2145

Add message tags and comments to the cloned message context:

```json
{
  "comments": ["comment1", "comment2"],
  "tags": ["tag1", "tag2"],
}
```

## User Impact
Tags and comments are preserved in datasets when cloning from sessions. This additional context can be used in the evaluators.

### Demo
<img width="268" height="139" alt="image" src="https://github.com/user-attachments/assets/10dd3700-7978-4ddb-926c-f0f75967c6fc" />
