### PR TITLE
bump max db connection pool size

### DIFF
--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -223,7 +223,7 @@ db_options = DATABASES["default"].setdefault("OPTIONS", {})
 db_options.pop("CONN_MAX_AGE", None)  # remove connection age since it's not compatible with connection pooling
 db_options["pool"] = {
     "min_size": env.int("DJANGO_DATABASE_POOL_MIN_SIZE", default=2),
-    "max_size": env.int("DJANGO_DATABASE_POOL_MAX_SIZE", default=10),
+    "max_size": env.int("DJANGO_DATABASE_POOL_MAX_SIZE", default=20),
     "timeout": env.int("DJANGO_DATABASE_POOL_TIMEOUT", default=10),
 }
 


### PR DESCRIPTION
Possibly aid in resolving the `OperationalError: couldn't get a connection after 10.00 sec` issue

[OPEN-CHAT-STUDIO-173](https://dimagi.sentry.io/issues/6871918533/events/b78c804a38b140b783b9d2a0fc13e133/)