### PR TITLE
fix eval form bug with version selection

### DIFF
--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -272,7 +272,7 @@ def load_experiment_versions(request, team_slug: str):
             id=experiment_id,
             team=request.team,
         )
-        versions = Experiment.objects.all_versions_queryset(experiment).filter(team=request.team)
+        versions = Experiment.objects.all_versions_queryset(experiment.id).filter(team=request.team)
         choices = get_experiment_version_choices(versions)
         version_choices = [{"value": value, "label": label} for value, label in choices]
 

--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -268,23 +268,10 @@ def load_experiment_versions(request, team_slug: str):
         return render(request, "evaluations/partials/version_select.html", context)
 
     try:
-        experiment = Experiment.objects.working_versions_queryset().get(
+        Experiment.objects.working_versions_queryset().exists(
             id=experiment_id,
             team=request.team,
         )
-        versions = Experiment.objects.all_versions_queryset(experiment.id).filter(team=request.team)
-        choices = get_experiment_version_choices(versions)
-        version_choices = [{"value": value, "label": label} for value, label in choices]
-
-        context = {
-            "empty_message": "Select a version...",
-            "field_name": "experiment_version",
-            "field_id": "id_experiment_version",
-            "versions": version_choices,
-            "help_text": "Specific chatbot version to use for evaluation.",
-        }
-        return render(request, "evaluations/partials/version_select.html", context)
-
     except Experiment.DoesNotExist:
         context = {
             "empty_message": "Chatbot not found",
@@ -293,3 +280,16 @@ def load_experiment_versions(request, team_slug: str):
             "versions": [],
         }
         return render(request, "evaluations/partials/version_select.html", context)
+
+    versions = Experiment.objects.all_versions_queryset(experiment_id).filter(team=request.team)
+    choices = get_experiment_version_choices(versions)
+    version_choices = [{"value": value, "label": label} for value, label in choices]
+
+    context = {
+        "empty_message": "Select a version...",
+        "field_name": "experiment_version",
+        "field_id": "id_experiment_version",
+        "versions": version_choices,
+        "help_text": "Specific chatbot version to use for evaluation.",
+    }
+    return render(request, "evaluations/partials/version_select.html", context)

--- a/apps/experiments/versioning.py
+++ b/apps/experiments/versioning.py
@@ -413,9 +413,8 @@ class VersionsObjectManagerMixin:
         """Returns a queryset with only working versions"""
         return self.get_queryset().filter(working_version=None)
 
-    def all_versions_queryset(self, source: "VersionsMixin"):
-        working_version_id = source.get_working_version_id()
+    def all_versions_queryset(self, working_version_id: int):
         queryset = self.get_queryset().filter(Q(working_version_id=working_version_id) | Q(id=working_version_id))
-        if hasattr(source, "version_number"):
+        if hasattr(self.model, "version_number"):
             queryset = queryset.order_by("-version_number")
         return queryset


### PR DESCRIPTION
## Description
When creating a new eval config you can't select an experiment version because the queryset for the field isn't initialized.

This PR fixes that by initializing the queryset when an experiment has been selected.
