### PR TITLE
add seed messages to eval dataset history

### DIFF
--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -122,6 +122,16 @@ class EvaluationMessage(BaseModel):
                 context_tags.extend([tag.name for tag in tags if not tag.is_system_tag])
                 existing_context["tags"] = list(dict.fromkeys(context_tags))  # dedupe preserving order
 
+        def _messages_to_history(messages_):
+            return [
+                {
+                    "message_type": msg.message_type,
+                    "content": msg.content,
+                    "summary": getattr(msg, "summary", None),
+                }
+                for msg in messages_
+            ]
+
         messages_by_session = defaultdict(list)
         for message in all_messages:
             messages_by_session[message.chat.experiment_session.external_id].append(message)
@@ -151,33 +161,12 @@ class EvaluationMessage(BaseModel):
                         },
                     )
                     new_messages.append(evaluation_message)
-
-                    history.append(
-                        {
-                            "message_type": current_msg.message_type,
-                            "content": current_msg.content,
-                            "summary": getattr(current_msg, "summary", None),
-                        }
-                    )
-                    history.append(
-                        {
-                            "message_type": next_msg.message_type,
-                            "content": next_msg.content,
-                            "summary": getattr(next_msg, "summary", None),
-                        }
-                    )
-
+                    history.extend(_messages_to_history([current_msg, next_msg]))
                     i += 2
                 else:
                     # Add AI seed messages to the history
                     if current_msg.message_type == ChatMessageType.AI and not history:
-                        history.append(
-                            {
-                                "message_type": current_msg.message_type,
-                                "content": current_msg.content,
-                                "summary": getattr(current_msg, "summary", None),
-                            }
-                        )
+                        history.extend(_messages_to_history([current_msg]))
                     i += 1
         return new_messages
 

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -169,7 +169,15 @@ class EvaluationMessage(BaseModel):
 
                     i += 2
                 else:
-                    # If there is not a (human, ai) pair, move on.
+                    # Add AI seed messages to the history
+                    if current_msg.message_type == ChatMessageType.AI and not history:
+                        history.append(
+                            {
+                                "message_type": current_msg.message_type,
+                                "content": current_msg.content,
+                                "summary": getattr(current_msg, "summary", None),
+                            }
+                        )
                     i += 1
         return new_messages
 

--- a/apps/evaluations/tests/test_models.py
+++ b/apps/evaluations/tests/test_models.py
@@ -18,7 +18,8 @@ def test_create_messages_from_sessions_includes_history():
     ChatMessageFactory(message_type=ChatMessageType.HUMAN, content="session1 message2 human", chat=session_1.chat)
     ChatMessageFactory(message_type=ChatMessageType.AI, content="session1 message2 ai", chat=session_1.chat)
 
-    # One message pair from the second session
+    # One message pair from the second session (with a seed message in the history)
+    ChatMessageFactory(message_type=ChatMessageType.AI, content="session2 message0 ai", chat=session_2.chat)
     ChatMessageFactory(message_type=ChatMessageType.HUMAN, content="session2 message1 human", chat=session_2.chat)
     ChatMessageFactory(message_type=ChatMessageType.AI, content="session2 message1 ai", chat=session_2.chat)
 
@@ -48,8 +49,10 @@ def test_create_messages_from_sessions_includes_history():
     assert eval_messages[1].history[1]["content"] == "session1 message1 ai"
     assert eval_messages[1].full_history == "user: session1 message1 human\nassistant: session1 message1 ai"
 
-    assert eval_messages[2].history == []
-    assert eval_messages[2].full_history == ""
+    assert eval_messages[2].history == [
+        {"message_type": ChatMessageType.AI, "content": "session2 message0 ai", "summary": None}
+    ]
+    assert eval_messages[2].full_history == "assistant: session2 message0 ai"
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
## Description
Fixes https://github.com/dimagi/open-chat-studio/issues/2177

When the first message in a chat is from the AI (a seed message), the evals dataset history was skipping that message.

This PR ensures that the seed message is added to the session history for the messages that come after it.