### PR TITLE
Small trends update

### DIFF
--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -158,6 +158,12 @@ class ChatbotExperimentTableView(LoginAndTeamRequiredMixin, SingleTableView, Per
     table_class = ChatbotTable
     permission_required = "experiments.view_experiment"
 
+    def get_table(self, **kwargs):
+        table = super().get_table(**kwargs)
+        if not flag_is_active(self.request, "flag_tracing"):
+            table.exclude = ("trends",)
+        return table
+
     def get_queryset(self):
         end_date = timezone.now()
         start_date = end_date - timedelta(days=30)

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 import secrets
+import urllib
 import uuid
 from datetime import UTC, datetime
 from functools import cached_property
@@ -890,6 +891,15 @@ class Experiment(BaseTeamModel, VersionsMixin, CustomActionOperationMixin):
         trend_data = self._calculate_trends()
         cache.set(self.trends_cache_key, trend_data, settings.EXPERIMENT_TREND_CACHE_TIMEOUT)
         return trend_data
+
+    def traces_url(self) -> str:
+        """
+        Returns a URL to the traces page, filtered to show only traces for this experiment.
+        """
+        query_params = urllib.parse.urlencode(
+            {"filter_0_column": "experiment", "filter_0_operator": "any of", "filter_0_value": f"[{self.id}]"}
+        )
+        return reverse("trace:home", kwargs={"team_slug": self.team.slug}) + "?" + query_params
 
     def _calculate_trends(self) -> tuple[list, list]:
         """

--- a/apps/utils/base_experiment_table_view.py
+++ b/apps/utils/base_experiment_table_view.py
@@ -11,6 +11,12 @@ class BaseExperimentTableView(LoginAndTeamRequiredMixin, SingleTableView, Permis
     paginate_by = 25
     template_name = "table/single_table.html"
 
+    def get_table(self, **kwargs):
+        table = super().get_table(**kwargs)
+        if not flag_is_active(self.request, "flag_tracing"):
+            table.exclude = ("trends",)
+        return table
+
     def get_queryset(self):
         chatbots_enabled = flag_is_active(self.request, "flag_chatbots")
         is_experiment = self.kwargs.get("is_experiment", False)

--- a/templates/table/trends_chart.html
+++ b/templates/table/trends_chart.html
@@ -1,6 +1,8 @@
 {% load static %}
 
-<canvas id="{{ record.id }}-trends" class="m-2 max-w-20 max-h-20"></canvas>
+<a href="{{ record.traces_url }}">
+    <canvas id="{{ record.id }}-trends" class="m-2 max-w-20 max-h-20"></canvas>
+</a>
 <script>
     (function() {
         const canvasElement = document.getElementById('{{ record.id }}-trends');


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
See the user description

## User Impact
<!-- Describe the impact of this change on the end-users. -->
- Users will not see trends when the tracing flag is disabled
- When a user click on a specific chatbot's trend graph, it takes them to the traces view, filtered by that specific chatbot. It's a quick way to get to the traces of only that chatbot

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
N/A