### PR TITLE
Manually upload Evaluation Run Results

### DIFF
--- a/apps/evaluations/const.py
+++ b/apps/evaluations/const.py
@@ -1,1 +1,3 @@
 PREVIEW_SAMPLE_SIZE = 10
+
+EVALUATION_RUN_FIXED_HEADERS = ["id", "session", "Dataset Input", "Dataset Output", "Generated Response"]

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -405,3 +405,120 @@ def process_csv_rows(dataset, rows, columns, progress_recorder, team):
         progress_recorder.set_progress(progress, 100, f"Processing row {processed_rows}/{total_rows}")
 
     return stats
+
+
+@shared_task(bind=True)
+def upload_evaluation_run_results_task(self, evaluation_run_id, csv_data, team_id, column_mappings=None):
+    """
+    Process CSV upload for evaluation run results asynchronously with progress tracking.
+    csv_data: List of dictionaries representing CSV rows
+    column_mappings: Dictionary mapping column names to evaluator names
+    """
+
+    if not csv_data:
+        return {"success": False, "error": "CSV file is empty"}
+
+    progress_recorder = ProgressRecorder(self)
+
+    try:
+        evaluation_run = EvaluationRun.objects.select_related("team").get(id=evaluation_run_id, team_id=team_id)
+        team = evaluation_run.team
+        with current_team(team):
+            stats = process_evaluation_results_csv_rows(
+                evaluation_run, csv_data, column_mappings or {}, progress_recorder, team
+            )
+            progress_recorder.set_progress(100, 100, "Upload complete")
+            return {
+                "success": True,
+                "updated_count": stats["updated_count"],
+                "created_count": stats["created_count"],
+                "total_processed": stats["updated_count"] + stats["created_count"],
+                "errors": stats["error_messages"],
+            }
+
+    except Exception as e:
+        logger.error(f"Error in CSV upload task for evaluation run {evaluation_run_id}: {str(e)}")
+        return {"success": False, "error": str(e)}
+
+
+def process_evaluation_results_csv_rows(evaluation_run, csv_data, column_mappings, progress_recorder, team):
+    """Process all CSV rows for evaluation results and return statistics."""
+    stats = {"updated_count": 0, "created_count": 0, "error_messages": []}
+    total_rows = len(csv_data)
+
+    columns = list(csv_data[0].keys()) if csv_data else []
+    has_id_column = "id" in columns
+
+    evaluators = Evaluator.objects.filter(team=team).all()
+    evaluator_by_id = {evaluator.id: evaluator for evaluator in evaluators}
+
+    for row_index, row in enumerate(csv_data):
+        try:
+            if not has_id_column or not row.get("id"):
+                stats["error_messages"].append(
+                    f"Row {row_index + 1}: Missing 'id' column - cannot update results without ID"
+                )
+                continue
+
+            try:
+                message_id = int(row["id"])
+            except ValueError:
+                stats["error_messages"].append(f"Row {row_index + 1}: Invalid ID format")
+                continue
+
+            evaluation_results = EvaluationResult.objects.filter(message_id=message_id, run=evaluation_run, team=team)
+
+            if not evaluation_results.exists():
+                stats["error_messages"].append(
+                    f"Row {row_index + 1}: No evaluation results found for message ID {message_id}"
+                )
+                continue
+
+            for column_name, evaluator_id in column_mappings.items():
+                if column_name not in row or row[column_name] is None or row[column_name] == "":
+                    continue
+
+                value = row[column_name]
+                result_key = column_name
+                if "(" in column_name and column_name.endswith(")"):
+                    result_key = column_name[: column_name.rfind("(")].strip()
+
+                try:
+                    evaluator_id = int(evaluator_id)
+                    evaluator = evaluator_by_id.get(evaluator_id)
+                    if not evaluator:
+                        stats["error_messages"].append(
+                            f"Row {row_index + 1}: Evaluator with ID '{evaluator_id}' not found"
+                        )
+                        continue
+                except (ValueError, TypeError):
+                    stats["error_messages"].append(f"Row {row_index + 1}: Invalid evaluator ID '{evaluator_id}'")
+                    continue
+
+                try:
+                    evaluation_result = evaluation_results.get(evaluator=evaluator)
+                    updated_output = evaluation_result.output.copy()
+
+                    if "result" not in updated_output:
+                        updated_output["result"] = {}
+
+                    current_value = updated_output["result"].get(result_key)
+                    if current_value != value:
+                        updated_output["result"][result_key] = value
+                        evaluation_result.output = updated_output
+                        evaluation_result.save()
+                        stats["updated_count"] += 1
+                except EvaluationResult.DoesNotExist:
+                    stats["error_messages"].append(
+                        f"Row {row_index + 1}: No result found for evaluator '{evaluator.name}' "
+                        f"and message {message_id}"
+                    )
+        except Exception as e:
+            stats["error_messages"].append(f"Row {row_index + 1}: {str(e)}")
+            continue
+
+        processed_rows = row_index + 1
+        progress = int(10 + (processed_rows / total_rows) * 85)  # 10-95% for processing
+        progress_recorder.set_progress(progress, 100, f"Processing row {processed_rows}/{total_rows}")
+
+    return stats

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -449,7 +449,7 @@ def process_evaluation_results_csv_rows(evaluation_run, csv_data, column_mapping
     columns = list(csv_data[0].keys()) if csv_data else []
     has_id_column = "id" in columns
 
-    evaluators = Evaluator.objects.filter(team=team).all()
+    evaluators = evaluation_run.config.evaluators.all()
     evaluator_by_id = {evaluator.id: evaluator for evaluator in evaluators}
 
     for row_index, row in enumerate(csv_data):

--- a/apps/evaluations/tests/test_evaluation_run_csv_upload.py
+++ b/apps/evaluations/tests/test_evaluation_run_csv_upload.py
@@ -1,0 +1,233 @@
+from unittest.mock import Mock
+
+import pytest
+
+from apps.evaluations.tasks import process_evaluation_results_csv_rows
+from apps.evaluations.views.evaluation_config_views import generate_evaluation_results_column_suggestions
+from apps.utils.factories.evaluations import (
+    EvaluationConfigFactory,
+    EvaluationDatasetFactory,
+    EvaluationMessageFactory,
+    EvaluationResultFactory,
+    EvaluationRunFactory,
+    EvaluatorFactory,
+)
+from apps.utils.factories.team import TeamWithUsersFactory
+
+
+@pytest.fixture()
+def team_with_users():
+    return TeamWithUsersFactory()
+
+
+@pytest.fixture()
+def evaluation_setup(team_with_users, db):
+    """Create a complete evaluation setup with evaluators, run, and results"""
+    # Create evaluators
+    evaluator1 = EvaluatorFactory(team=team_with_users, name="GPT-4 Evaluator")
+    evaluator2 = EvaluatorFactory(team=team_with_users, name="Claude Evaluator")
+
+    # Create dataset with message
+    message = EvaluationMessageFactory()
+    dataset = EvaluationDatasetFactory(team=team_with_users, messages=[message])
+
+    # Create config with evaluators
+    config = EvaluationConfigFactory(team=team_with_users, dataset=dataset)
+    config.evaluators.add(evaluator1, evaluator2)
+
+    # Create evaluation run
+    run = EvaluationRunFactory(team=team_with_users, config=config)
+
+    # Create evaluation results
+    result1 = EvaluationResultFactory(
+        team=team_with_users, evaluator=evaluator1, message=message, run=run, output={"result": {"existing_score": 8.5}}
+    )
+    result2 = EvaluationResultFactory(
+        team=team_with_users, evaluator=evaluator2, message=message, run=run, output={"result": {"existing_score": 7.0}}
+    )
+
+    return {
+        "team": team_with_users,
+        "evaluator1": evaluator1,
+        "evaluator2": evaluator2,
+        "message": message,
+        "dataset": dataset,
+        "config": config,
+        "run": run,
+        "result1": result1,
+        "result2": result2,
+    }
+
+
+@pytest.mark.django_db()
+def test_generate_column_suggestions(evaluation_setup):
+    """Test that column suggestions correctly match evaluator names in parentheses"""
+
+    setup = evaluation_setup
+    result_columns = [
+        "accuracy_score (GPT-4 Evaluator)",
+        "relevance_score (Claude Evaluator)",
+        "some_other_score",
+    ]
+
+    suggestions = generate_evaluation_results_column_suggestions(result_columns, setup["run"])
+
+    assert suggestions["accuracy_score (GPT-4 Evaluator)"] == setup["evaluator1"].id
+    assert suggestions["relevance_score (Claude Evaluator)"] == setup["evaluator2"].id
+    assert suggestions["some_other_score"] is None
+
+    # Columns that aren't valid evaluators
+    result_columns = [
+        "random_column",
+        "another_column (Unknown Evaluator)",
+    ]
+
+    suggestions = generate_evaluation_results_column_suggestions(result_columns, setup["run"])
+
+    assert suggestions["random_column"] is None
+    assert suggestions["another_column (Unknown Evaluator)"] is None
+
+
+@pytest.mark.django_db()
+def test_process_csv_with_valid_mapping(evaluation_setup):
+    """Test CSV processing with valid evaluator mappings"""
+    setup = evaluation_setup
+
+    csv_data = [
+        {
+            "id": str(setup["message"].id),
+            "accuracy_score": "9.0",
+            "relevance_score": "8.5",
+        }
+    ]
+
+    column_mappings = {
+        "accuracy_score": setup["evaluator1"].id,
+        "relevance_score": setup["evaluator2"].id,
+    }
+
+    progress_recorder = Mock()
+    stats = process_evaluation_results_csv_rows(
+        setup["run"], csv_data, column_mappings, progress_recorder, setup["team"]
+    )
+
+    assert stats["updated_count"] == 2
+    assert stats["created_count"] == 0
+    assert len(stats["error_messages"]) == 0
+
+    # Verify the updates
+    setup["result1"].refresh_from_db()
+    setup["result2"].refresh_from_db()
+
+    assert setup["result1"].output["result"]["accuracy_score"] == "9.0"
+    assert setup["result2"].output["result"]["relevance_score"] == "8.5"
+
+
+@pytest.mark.django_db()
+def test_process_csv_with_missing_id(evaluation_setup):
+    """Test CSV processing with missing ID column"""
+    setup = evaluation_setup
+
+    csv_data = [
+        {
+            "accuracy_score": "9.0",
+            # Missing 'id' field
+        }
+    ]
+
+    column_mappings = {
+        "accuracy_score": setup["evaluator1"].id,
+    }
+
+    progress_recorder = Mock()
+    stats = process_evaluation_results_csv_rows(
+        setup["run"], csv_data, column_mappings, progress_recorder, setup["team"]
+    )
+
+    assert stats["updated_count"] == 0
+    assert stats["created_count"] == 0
+    assert len(stats["error_messages"]) == 1
+    assert "Missing 'id' column" in stats["error_messages"][0]
+
+
+@pytest.mark.django_db()
+def test_process_csv_with_invalid_evaluator_id(evaluation_setup):
+    """Test CSV processing with invalid evaluator ID"""
+    setup = evaluation_setup
+
+    csv_data = [
+        {
+            "id": str(setup["message"].id),
+            "accuracy_score": "9.0",
+        }
+    ]
+
+    column_mappings = {
+        "accuracy_score": 99999,  # Non-existent evaluator ID
+    }
+
+    progress_recorder = Mock()
+    stats = process_evaluation_results_csv_rows(
+        setup["run"], csv_data, column_mappings, progress_recorder, setup["team"]
+    )
+
+    assert stats["updated_count"] == 0
+    assert stats["created_count"] == 0
+    assert len(stats["error_messages"]) == 1
+    assert "Evaluator with ID '99999' not found" in stats["error_messages"][0]
+
+
+@pytest.mark.django_db()
+def test_process_csv_with_non_existent_message(evaluation_setup):
+    """Test CSV processing with non-existent message ID"""
+    setup = evaluation_setup
+
+    csv_data = [
+        {
+            "id": "99999",  # Non-existent message ID
+            "accuracy_score": "9.0",
+        }
+    ]
+
+    column_mappings = {
+        "accuracy_score": setup["evaluator1"].id,
+    }
+
+    progress_recorder = Mock()
+    stats = process_evaluation_results_csv_rows(
+        setup["run"], csv_data, column_mappings, progress_recorder, setup["team"]
+    )
+
+    assert stats["updated_count"] == 0
+    assert stats["created_count"] == 0
+    assert len(stats["error_messages"]) == 1
+    assert "No evaluation results found for message ID 99999" in stats["error_messages"][0]
+
+
+@pytest.mark.django_db()
+def test_process_csv_no_update_when_value_unchanged(evaluation_setup):
+    """Test that no database update occurs when value hasn't changed"""
+    setup = evaluation_setup
+
+    setup["result1"].output["result"]["accuracy_score"] = "8.5"
+    setup["result1"].save()
+
+    csv_data = [
+        {
+            "id": str(setup["message"].id),
+            "accuracy_score": "8.5",
+        }
+    ]
+
+    column_mappings = {
+        "accuracy_score": setup["evaluator1"].id,
+    }
+
+    progress_recorder = Mock()
+    stats = process_evaluation_results_csv_rows(
+        setup["run"], csv_data, column_mappings, progress_recorder, setup["team"]
+    )
+
+    assert stats["updated_count"] == 0
+    assert stats["created_count"] == 0
+    assert len(stats["error_messages"]) == 0

--- a/apps/evaluations/urls.py
+++ b/apps/evaluations/urls.py
@@ -88,7 +88,7 @@ urlpatterns = [
         name="parse_csv_columns",
     ),
     path(
-        "parse_evaluation_results_csv_columns/",
+        "<int:evaluation_pk>/evaluation_runs/<int:evaluation_run_pk>/parse_csv_columns/",
         evaluation_config_views.parse_evaluation_results_csv_columns,
         name="parse_evaluation_results_csv_columns",
     ),

--- a/apps/evaluations/urls.py
+++ b/apps/evaluations/urls.py
@@ -48,6 +48,11 @@ urlpatterns = [
         name="evaluation_run_download",
     ),
     path(
+        "<int:evaluation_pk>/evaluation_runs/<int:evaluation_run_pk>/update",
+        evaluation_config_views.update_evaluation_run_results,
+        name="evaluation_run_update",
+    ),
+    path(
         "sessions_selection_table",
         dataset_views.DatasetSessionsSelectionTableView.as_view(),
         name="dataset_sessions_selection_list",
@@ -81,6 +86,11 @@ urlpatterns = [
         "parse_csv_columns/",
         dataset_views.parse_csv_columns,
         name="parse_csv_columns",
+    ),
+    path(
+        "parse_evaluation_results_csv_columns/",
+        evaluation_config_views.parse_evaluation_results_csv_columns,
+        name="parse_evaluation_results_csv_columns",
     ),
     path(
         "dataset/<int:pk>/download/",

--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -1,23 +1,30 @@
 import csv
+import json
+import logging
 from functools import cached_property
+from io import StringIO
 
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
-from django.views.decorators.http import require_http_methods
+from django.views.decorators.http import require_http_methods, require_POST
 from django.views.generic import CreateView, TemplateView, UpdateView
 from django_tables2 import SingleTableView, columns, tables
 
+from apps.evaluations.const import EVALUATION_RUN_FIXED_HEADERS
 from apps.evaluations.forms import EvaluationConfigForm, get_experiment_version_choices
-from apps.evaluations.models import EvaluationConfig, EvaluationRun, EvaluationRunStatus, EvaluationRunType
+from apps.evaluations.models import EvaluationConfig, EvaluationRun, EvaluationRunStatus, EvaluationRunType, Evaluator
 from apps.evaluations.tables import EvaluationConfigTable, EvaluationRunTable
+from apps.evaluations.tasks import upload_evaluation_run_results_task
 from apps.evaluations.utils import get_evaluators_with_schema
 from apps.experiments.models import Experiment
 from apps.generics import actions
 from apps.teams.decorators import login_and_team_required
 from apps.teams.mixins import LoginAndTeamRequiredMixin
+
+logger = logging.getLogger(__name__)
 
 
 class EvaluationHome(LoginAndTeamRequiredMixin, TemplateView, PermissionRequiredMixin):
@@ -248,9 +255,8 @@ def download_evaluation_run_csv(request, team_slug, evaluation_pk, evaluation_ru
     for row in table_data:
         all_headers.update(row.keys())
 
-    fixed_headers = ["id", "session", "Dataset Input", "Dataset Output", "Generated Response"]
-    other_headers = sorted([h for h in all_headers if h not in fixed_headers and h != "error"])
-    headers = [h for h in fixed_headers if h in all_headers] + other_headers + ["error"]
+    other_headers = sorted([h for h in all_headers if h not in EVALUATION_RUN_FIXED_HEADERS and h != "error"])
+    headers = [h for h in EVALUATION_RUN_FIXED_HEADERS if h in all_headers] + other_headers + ["error"]
     writer.writerow(headers)
 
     for row in table_data:
@@ -299,3 +305,88 @@ def load_experiment_versions(request, team_slug: str):
         "help_text": "Specific chatbot version to use for evaluation.",
     }
     return render(request, "evaluations/partials/version_select.html", context)
+
+
+@login_and_team_required
+@permission_required("evaluations.change_evaluationrun")
+def update_evaluation_run_results(request, team_slug: str, evaluation_pk: int, evaluation_run_pk: int):
+    """Upload CSV to update evaluation run results"""
+    evaluation_run = get_object_or_404(
+        EvaluationRun, id=evaluation_run_pk, config_id=evaluation_pk, team__slug=team_slug
+    )
+    if request.method == "GET":
+        context = {
+            "active_tab": "evaluations",
+            "title": "Upload Results",
+            "evaluation_run": evaluation_run,
+            "all_team_evaluators": Evaluator.objects.filter(team=request.team),
+        }
+        return render(request, "evaluations/evaluation_run_update.html", context)
+    elif request.method == "POST":
+        try:
+            payload = json.loads(request.body)
+            csv_data = payload.get("csv_data", [])
+            column_mappings = payload.get("column_mappings", {})
+
+            task = upload_evaluation_run_results_task.delay(
+                evaluation_run.id, csv_data, request.team.id, column_mappings
+            )
+            return JsonResponse({"success": True, "task_id": task.id})
+        except Exception as e:
+            logger.error(f"Error starting CSV upload for evaluation run {evaluation_run.id}: {str(e)}")
+            return JsonResponse({"error": "An error occurred while starting the CSV upload"}, status=500)
+
+
+@login_and_team_required
+@require_POST
+def parse_evaluation_results_csv_columns(request, team_slug: str):
+    """Parse uploaded CSV and return column names and sample data for evaluation results."""
+    try:
+        csv_file = request.FILES.get("csv_file")
+        if not csv_file:
+            return JsonResponse({"error": "No CSV file provided"}, status=400)
+
+        file_content = csv_file.read().decode("utf-8")
+        csv_reader = csv.DictReader(StringIO(file_content))
+        columns = csv_reader.fieldnames or []
+
+        all_rows = list(csv_reader)
+        sample_rows = all_rows[:3]
+        total_rows = len(all_rows)
+
+        protected_columns = set(EVALUATION_RUN_FIXED_HEADERS) | set(["error"])
+
+        result_columns = [col for col in columns if col not in protected_columns]
+        suggestions = generate_evaluation_results_column_suggestions(result_columns, request.team)
+        return JsonResponse(
+            {
+                "columns": columns,
+                "result_columns": result_columns,
+                "sample_rows": sample_rows,
+                "all_rows": all_rows,
+                "total_rows": total_rows,
+                "suggestions": suggestions,
+            }
+        )
+
+    except Exception:
+        logger.warning("Error parsing evaluation results CSV")
+        return JsonResponse({"error": "An error occurred while parsing the CSV file."}, status=400)
+
+
+def generate_evaluation_results_column_suggestions(result_columns, team):
+    """Generate suggestions for mapping result columns to evaluators."""
+    evaluators = Evaluator.objects.filter(team=team)
+    evaluator_name_to_id = {evaluator.name: evaluator.id for evaluator in evaluators}
+
+    suggestions = {}
+
+    for column in result_columns:
+        suggested_evaluator_id = None
+        if " (" in column and column.endswith(")"):
+            evaluator_name_in_column = column[column.rfind("(") + 1 : -1]
+            if evaluator_name_in_column in evaluator_name_to_id:
+                suggested_evaluator_id = evaluator_name_to_id[evaluator_name_in_column]
+        suggestions[column] = suggested_evaluator_id
+
+    return suggestions

--- a/templates/evaluations/evaluation_result_home.html
+++ b/templates/evaluations/evaluation_result_home.html
@@ -36,7 +36,12 @@
           <a href="{% url 'evaluations:evaluation_run_download' request.team.slug evaluation_run.config_id evaluation_run.id %}"
              class="btn btn-primary">
             <i class="fa-solid fa-download"></i>
-            Download CSV
+            Download Results
+          </a>
+          <a href="{% url 'evaluations:evaluation_run_update' request.team.slug evaluation_run.config_id evaluation_run.id %}"
+             class="btn btn-outline">
+            <i class="fa-solid fa-upload"></i>
+            Edit Results
           </a>
         </div>
       {% endif %}

--- a/templates/evaluations/evaluation_run_update.html
+++ b/templates/evaluations/evaluation_run_update.html
@@ -1,0 +1,288 @@
+{% extends "web/app/app_base.html" %}
+{% load static %}
+{% load i18n %}
+
+{% block page_head %}
+  {{ block.super }}
+  <script src="{% static 'celery_progress/celery_progress.js' %}"></script>
+{% endblock page_head %}
+
+{% block breadcrumbs %}
+  <div class="text-sm breadcrumbs" aria-label="breadcrumbs">
+    <ul>
+      <li><a href="{% url 'evaluations:home' request.team.slug %}">{% trans "Evaluations" %}</a></li>
+      <li><a href="{% url 'evaluations:evaluation_runs_home' request.team.slug evaluation_run.config_id %}">{{ evaluation_run.config.name }} {% trans "Runs" %}</a></li>
+      <li><a href="{% url 'evaluations:evaluation_results_home' request.team.slug evaluation_run.config_id evaluation_run.id %}">{% trans "Run" %} {{ evaluation_run.id }}</a></li>
+      <li class="pg-breadcrumb-active" aria-current="page">{% trans "Edit Results" %}</li>
+    </ul>
+  </div>
+{% endblock breadcrumbs %}
+
+{% block app %}
+  <div class="container mx-auto px-4 py-8" x-data="uploadResultsData()"
+>
+
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-2xl font-bold">{{ title }}</h1>
+      <a href="{% url 'evaluations:evaluation_results_home' request.team.slug evaluation_run.config_id evaluation_run.id %}"
+         class="btn btn-outline">
+        <i class="fa-solid fa-arrow-left"></i>
+        {% trans "Back to Results" %}
+      </a>
+    </div>
+
+    <div class="card bg-base-100 shadow-xl">
+      <div class="card-body">
+      <!-- File Upload Section -->
+      <div x-show="!csvParsed">
+        <h2 class="text-lg font-medium mb-4">{% trans "Upload CSV File" %}</h2>
+
+        <form @submit.prevent="">
+          {% csrf_token %}
+          <div class="mb-4">
+            <label for="csv-file" class="block text-sm font-medium mb-2">{% trans "CSV File" %}</label>
+            <input type="file"
+                   id="csv-file"
+                   name="csv_file"
+                   accept=".csv"
+                   class="file-input file-input-bordered w-full"
+                   @change="parseCSV"
+                   required>
+          </div>
+
+          <div class="flex gap-2">
+            <a href="{% url 'evaluations:evaluation_run_download' request.team.slug evaluation_run.config_id evaluation_run.id %}"
+               class="btn btn-outline">
+              <i class="fa-solid fa-download"></i> {% trans "Download Template" %}
+            </a>
+          </div>
+        </form>
+      </div>
+
+      <!-- Column Mapping Section -->
+      <div x-show="csvParsed" class="space-y-6">
+        <div class="card bg-base-200 shadow">
+          <div class="card-body">
+            <h4 class="font-medium mb-2">{% trans "CSV Preview" %}</h4>
+            <p class="text-sm text-base-content/70 mb-3">
+            {% trans "Found" %} <span x-text="csvData?.total_rows || 0"></span> {% trans "rows" %}
+          </p>
+
+          <!-- Sample data table -->
+          <div class="overflow-x-auto">
+            <table class="table table-xs w-full">
+              <thead>
+                <tr class="bg-base-300">
+                  <template x-for="column in csvData?.columns || []">
+                    <th x-text="column" class="font-medium"></th>
+                  </template>
+                </tr>
+              </thead>
+              <tbody>
+                <template x-for="(row, idx) in csvData?.sample_rows || []">
+                  <tr>
+                    <template x-for="column in csvData?.columns || []">
+                      <td x-text="row[column]" class="text-xs truncate" style="max-width: 200px;"></td>
+                    </template>
+                  </tr>
+                </template>
+              </tbody>
+            </table>
+          </div>
+          </div>
+        </div>
+
+        <!-- Column mapping controls -->
+        <div class="space-y-4">
+          <h4 class="font-medium">{% trans "Map Result Columns to Evaluators" %}</h4>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
+            <div>
+              <h5 class="text-sm font-semibold text-base-content/70">{% trans "CSV Column" %}</h5>
+            </div>
+            <div>
+              <h5 class="text-sm font-semibold text-base-content/70">{% trans "Save to Evaluator result" %}</h5>
+            </div>
+          </div>
+
+          <template x-for="column in csvData?.result_columns || []">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
+              <div>
+                <label class="block text-sm font-medium" x-text="column"></label>
+              </div>
+              <div>
+                <select x-model="columnMapping[column]" class="select select-bordered w-full">
+                  <option value="">{% trans "Skip this column" %}</option>
+                  <template x-for="evaluator in evaluators">
+                    <option :value="evaluator.id" x-text="evaluator.name"></option>
+                  </template>
+                </select>
+              </div>
+            </div>
+          </template>
+        </div>
+
+        <!-- Upload button -->
+        <div class="flex gap-2">
+          <button @click="submitUpload"
+                  :disabled="uploading"
+                  class="btn btn-primary">
+            <i class="fa-solid fa-upload"></i>
+            <span x-text="uploading ? '{% trans "Uploading..." %}' : '{% trans "Upload Results" %}'"></span>
+          </button>
+          <button @click="csvParsed = false; csvData = null" class="btn btn-outline">
+            <i class="fa-solid fa-arrow-left"></i> {% trans "Choose Different File" %}
+          </button>
+        </div>
+      </div>
+
+      <!-- Upload Status -->
+      <div x-show="uploadStatus" class="mt-4">
+        <div class="alert" :class="uploadStatus?.type === 'success' ? 'alert-success' : 'alert-error'">
+          <div x-text="uploadStatus?.message"></div>
+        </div>
+      </div>
+
+      <!-- Progress Bar -->
+      <div x-show="progressVisible" class="mt-4">
+        <div class="progress-wrapper">
+          <div id="progress-bar" class="progress-bar h-4 bg-blue-200 dark:bg-blue-700 rounded-full overflow-hidden">
+            <div class="bg-blue-600 dark:bg-blue-400 h-full transition-all duration-300" style="width: 0%"></div>
+          </div>
+        </div>
+        <div id="progress-bar-message" class="mt-2 text-sm text-center">{% trans "Processing CSV..." %}</div>
+      </div>
+      </div>
+    </div>
+  </div>
+{% endblock app %}
+
+{% block page_js %}
+  {{ block.super }}
+  <script>
+    function uploadResultsData() {
+      return {
+        csvData: null,
+        csvParsed: false,
+        columnMapping: {},
+        evaluators: [
+          {% for evaluator in all_team_evaluators %}
+            { id: {{ evaluator.id }}, name: '{{ evaluator.name|escapejs }}' }{% if not forloop.last %},{% endif %}
+          {% endfor %}
+        ],
+        uploading: false,
+        uploadStatus: null,
+        progressVisible: false,
+
+        async parseCSV(event) {
+          const formData = new FormData();
+          formData.append('csv_file', event.target.files[0]);
+
+          try {
+            const response = await fetch('{% url 'evaluations:parse_evaluation_results_csv_columns' request.team.slug %}', {
+              method: 'POST',
+              body: formData,
+              headers: {
+                'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
+              }
+            });
+
+            const data = await response.json();
+
+            if (!response.ok) {
+              throw new Error(data.error || '{% trans "Failed to parse CSV" %}');
+            }
+
+            this.csvData = data;
+            this.csvParsed = true;
+
+            // Initialize column mappings with suggestions
+            if (data.suggestions) {
+              this.columnMapping = {};
+              this.$nextTick(() => {
+                this.columnMapping = {...data.suggestions};
+              });
+            } else {
+              this.columnMapping = {};
+            }
+          } catch (error) {
+            alert('{% trans "Error parsing CSV" %}: ' + error.message);
+          }
+        },
+
+        async submitUpload() {
+          if (!this.csvData) return;
+          this.uploading = true;
+          this.progressVisible = true;
+          const filteredColumnMapping = {};
+          for (const [column, evaluator] of Object.entries(this.columnMapping)) {
+            if (evaluator) {
+              filteredColumnMapping[column] = evaluator;
+            }
+          }
+          const payload = {
+            csv_data: this.csvData.all_rows,
+            column_mappings: filteredColumnMapping
+          };
+
+          try {
+            const response = await fetch('{% url 'evaluations:evaluation_run_update' request.team.slug evaluation_run.config_id evaluation_run.id %}', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
+              },
+              body: JSON.stringify(payload)
+            });
+
+            const data = await response.json();
+            if (data.success && data.task_id) {
+              const progressUrl = `/celery-progress/${data.task_id}/`;
+              CeleryProgressBar.initProgressBar(progressUrl, {
+                pollInterval: 1000,
+                onSuccess: (progressBarElement, progressBarMessageElement, result) => {
+                  this.progressVisible = false;
+                  this.uploading = false;
+
+                  if (result && result.success) {
+                    this.uploadStatus = {
+                      type: 'success',
+                      message: `{% trans "Successfully processed" %} ${result.total_processed} {% trans "results" %}: ${result.updated_count} {% trans "updated" %}, ${result.created_count} {% trans "created" %}.`
+                    };
+                  } else {
+                    this.uploadStatus = {
+                      type: 'error',
+                      message: result?.error || '{% trans "Upload completed with errors" %}'
+                    };
+                  }
+                },
+                onError: (progressBarElement, progressBarMessageElement, excMessage) => {
+                  this.progressVisible = false;
+                  this.uploading = false;
+                  this.uploadStatus = {
+                    type: 'error',
+                    message: '{% trans "Error during upload" %}: ' + excMessage
+                  };
+                }
+              });
+            } else {
+              this.progressVisible = false;
+              this.uploading = false;
+              this.uploadStatus = {
+                type: 'error',
+                message: data.error || '{% trans "An error occurred while uploading the CSV." %}'
+              };
+            }
+          } catch (error) {
+            this.progressVisible = false;
+            this.uploading = false;
+            this.uploadStatus = {
+              type: 'error',
+              message: '{% trans "An error occurred while uploading the CSV." %}'
+            };
+          }
+        }
+      };
+    }
+  </script>
+{% endblock page_js %}

--- a/templates/evaluations/evaluation_run_update.html
+++ b/templates/evaluations/evaluation_run_update.html
@@ -166,7 +166,7 @@
         csvParsed: false,
         columnMapping: {},
         evaluators: [
-          {% for evaluator in all_team_evaluators %}
+          {% for evaluator in evaluation_run.config.evaluators.all %}
             { id: {{ evaluator.id }}, name: '{{ evaluator.name|escapejs }}' }{% if not forloop.last %},{% endif %}
           {% endfor %}
         ],
@@ -179,7 +179,7 @@
           formData.append('csv_file', event.target.files[0]);
 
           try {
-            const response = await fetch('{% url 'evaluations:parse_evaluation_results_csv_columns' request.team.slug %}', {
+            const response = await fetch('{% url 'evaluations:parse_evaluation_results_csv_columns' request.team.slug evaluation_run.config_id evaluation_run.id %}', {
               method: 'POST',
               body: formData,
               headers: {


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

This allows the user to upload run results manually, for future use in aggregations, etc.

It doesn't allow updating the messages, only evaluator values.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->


https://github.com/user-attachments/assets/50c61453-1905-4832-90c7-2c0ddbca6b58
