### PR TITLE
Use a raw string for regex with an escape sequence

### DIFF
--- a/apps/web/urls.py
+++ b/apps/web/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
     path("sudo/<slug:slug>/", views.acquire_superuser_powers, name="sudo"),
     path("sudo/<slug:slug>/release/", views.release_superuser_powers, name="release_sudo"),
     path("search", views.global_search, name="global_search"),
-    re_path("celery_group_status/(?P<group_id>[\w-]+)/", views.celery_task_group_status, name="celery_group_status"),
+    re_path(r"celery_group_status/(?P<group_id>[\w-]+)/", views.celery_task_group_status, name="celery_group_status"),
 ]
 
 team_urlpatterns = (


### PR DESCRIPTION
Fixes the `SyntaxWarning`:
```
/home/farid/dev/dimagi/open-chat-studio/apps/web/urls.py:15: SyntaxWarning: invalid escape sequence '\w'
  re_path("celery_group_status/(?P<group_id>[\w-]+)/", 
```
