### PR TITLE
filters refactor: include options, operators, labels etc in column schema

### DIFF
--- a/apps/evaluations/views/dataset_views.py
+++ b/apps/evaluations/views/dataset_views.py
@@ -23,7 +23,7 @@ from apps.evaluations.tasks import upload_dataset_csv_task
 from apps.evaluations.utils import generate_csv_column_suggestions, parse_history_text
 from apps.experiments.filters import (
     ExperimentSessionFilter,
-    get_experiment_filter_context_data,
+    get_filter_context_data,
 )
 from apps.experiments.models import ExperimentSession
 from apps.teams.decorators import login_and_team_required
@@ -140,7 +140,13 @@ class CreateDataset(LoginAndTeamRequiredMixin, CreateView, PermissionRequiredMix
 
     def _get_filter_context_data(self):
         table_url = reverse("evaluations:dataset_sessions_selection_list", args=[self.request.team.slug])
-        return get_experiment_filter_context_data(self.request.team, table_url)
+        return get_filter_context_data(
+            self.request.team,
+            ExperimentSessionFilter.columns(self.request.team),
+            "last_message",
+            table_url,
+            "sessions-table",
+        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/apps/experiments/filters.py
+++ b/apps/experiments/filters.py
@@ -60,7 +60,7 @@ def get_experiment_filter_options(team):
 
 
 class ChatMessageTagsFilter(ChoiceColumnFilter):
-    query_param = "tags"
+    query_param: str = "tags"
 
     def apply_any_of(self, queryset, value, timezone=None):
         chat_tags_condition = Q(chat__tags__name__in=value)
@@ -99,7 +99,7 @@ class ChatMessageTagsFilter(ChoiceColumnFilter):
 
 
 class VersionsFilter(ChoiceColumnFilter):
-    query_param = "versions"
+    query_param: str = "versions"
 
     def _get_messages_queryset(self, tags, operator):
         combined_query = Q()
@@ -126,8 +126,8 @@ class VersionsFilter(ChoiceColumnFilter):
 
 
 class ChannelsFilter(ChoiceColumnFilter):
-    query_param = "channels"
-    column = "experiment_channel__platform"
+    query_param: str = "channels"
+    column: str = "experiment_channel__platform"
 
     def parse_query_value(self, query_value) -> any:
         selected_display_names = self.values_list(query_value)
@@ -144,8 +144,8 @@ class ExperimentSessionFilter(MultiColumnFilter):
 
     filters: ClassVar[Sequence[ColumnFilter]] = [
         ParticipantFilter(),
-        TimestampFilter(db_column="last_message_created_at", query_param="last_message"),
-        TimestampFilter(db_column="first_message_created_at", query_param="first_message"),
+        TimestampFilter(column="last_message_created_at", query_param="last_message"),
+        TimestampFilter(column="first_message_created_at", query_param="first_message"),
         ChatMessageTagsFilter(),
         VersionsFilter(),
         ChannelsFilter(),

--- a/apps/experiments/filters.py
+++ b/apps/experiments/filters.py
@@ -8,10 +8,11 @@ from django.db.models import Exists, OuterRef, Q, Subquery
 from apps.annotations.models import CustomTaggedItem
 from apps.channels.models import ChannelPlatform
 from apps.chat.models import Chat, ChatMessage
-from apps.experiments.models import Experiment, SessionStatus
+from apps.experiments.models import Experiment
 from apps.web.dynamic_filters.base import (
     DATE_RANGE_OPTIONS,
     FIELD_TYPE_FILTERS,
+    TYPE_CHOICE,
     ChoiceColumnFilter,
     ColumnFilter,
     MultiColumnFilter,
@@ -23,23 +24,6 @@ from apps.web.dynamic_filters.column_filters import (
     StatusFilter,
     TimestampFilter,
 )
-
-
-def get_experiment_filter_context_data(team, table_url: str, single_experiment=None):
-    context = get_filter_context_data(
-        team, ExperimentSessionFilter.columns(), "last_message", table_url, "sessions-table"
-    )
-    context.update(
-        {
-            "df_state_list": SessionStatus.for_chatbots(),
-            "df_available_tags": [tag.name for tag in team.tag_set.filter(is_system_tag=False)],
-        }
-    )
-
-    context["df_experiment_versions"] = Experiment.objects.get_version_names(team, working_version=single_experiment)
-    if not single_experiment:
-        context["df_experiment_list"] = get_experiment_filter_options(team)
-    return context
 
 
 def get_filter_context_data(team, columns, date_range_column: str, table_url: str, table_container_id: str):
@@ -61,6 +45,11 @@ def get_experiment_filter_options(team):
 
 class ChatMessageTagsFilter(ChoiceColumnFilter):
     query_param: str = "tags"
+    label: str = "Tags"
+    type: str = TYPE_CHOICE
+
+    def prepare(self, team, **kwargs):
+        self.options = [tag.name for tag in team.tag_set.filter(is_system_tag=False)]
 
     def apply_any_of(self, queryset, value, timezone=None):
         chat_tags_condition = Q(chat__tags__name__in=value)
@@ -100,6 +89,11 @@ class ChatMessageTagsFilter(ChoiceColumnFilter):
 
 class VersionsFilter(ChoiceColumnFilter):
     query_param: str = "versions"
+    label: str = "Versions"
+
+    def prepare(self, team, **kwargs):
+        single_experiment = kwargs.get("single_experiment")
+        self.options = Experiment.objects.get_version_names(team, working_version=single_experiment)
 
     def _get_messages_queryset(self, tags, operator):
         combined_query = Q()
@@ -127,7 +121,11 @@ class VersionsFilter(ChoiceColumnFilter):
 
 class ChannelsFilter(ChoiceColumnFilter):
     query_param: str = "channels"
+    label: str = "Channels"
     column: str = "experiment_channel__platform"
+
+    def prepare(self, team, **kwargs):
+        self.options = ChannelPlatform.for_filter(team)
 
     def parse_query_value(self, query_value) -> any:
         selected_display_names = self.values_list(query_value)
@@ -144,8 +142,8 @@ class ExperimentSessionFilter(MultiColumnFilter):
 
     filters: ClassVar[Sequence[ColumnFilter]] = [
         ParticipantFilter(),
-        TimestampFilter(column="last_message_created_at", query_param="last_message"),
-        TimestampFilter(column="first_message_created_at", query_param="first_message"),
+        TimestampFilter(label="Last Message", column="last_message_created_at", query_param="last_message"),
+        TimestampFilter(label="First Message", column="first_message_created_at", query_param="first_message"),
         ChatMessageTagsFilter(),
         VersionsFilter(),
         ChannelsFilter(),

--- a/apps/experiments/filters.py
+++ b/apps/experiments/filters.py
@@ -36,11 +36,6 @@ def get_filter_context_data(team, columns, date_range_column: str, table_url: st
     }
 
 
-def get_experiment_filter_options(team):
-    experiments = Experiment.objects.working_versions_queryset().filter(team=team).values("id", "name").order_by("name")
-    return [{"id": exp["id"], "label": exp["name"]} for exp in experiments]
-
-
 class ChatMessageTagsFilter(ChoiceColumnFilter):
     query_param: str = "tags"
     label: str = "Tags"

--- a/apps/experiments/filters.py
+++ b/apps/experiments/filters.py
@@ -11,7 +11,6 @@ from apps.chat.models import Chat, ChatMessage
 from apps.experiments.models import Experiment
 from apps.web.dynamic_filters.base import (
     DATE_RANGE_OPTIONS,
-    FIELD_TYPE_FILTERS,
     TYPE_CHOICE,
     ChoiceColumnFilter,
     ColumnFilter,
@@ -28,7 +27,6 @@ from apps.web.dynamic_filters.column_filters import (
 
 def get_filter_context_data(team, columns, date_range_column: str, table_url: str, table_container_id: str):
     return {
-        "df_field_type_filters": FIELD_TYPE_FILTERS,
         "df_date_range_options": DATE_RANGE_OPTIONS,
         "df_channel_list": ChannelPlatform.for_filter(team),
         "df_filter_columns": columns,

--- a/apps/experiments/filters.py
+++ b/apps/experiments/filters.py
@@ -41,7 +41,7 @@ class ChatMessageTagsFilter(ChoiceColumnFilter):
     label: str = "Tags"
     type: str = TYPE_CHOICE
 
-    def prepare(self, team, **kwargs):
+    def prepare(self, team, **_):
         self.options = [tag.name for tag in team.tag_set.filter(is_system_tag=False)]
 
     def apply_any_of(self, queryset, value, timezone=None):
@@ -117,7 +117,7 @@ class ChannelsFilter(ChoiceColumnFilter):
     label: str = "Channels"
     column: str = "experiment_channel__platform"
 
-    def prepare(self, team, **kwargs):
+    def prepare(self, team, **_):
         self.options = ChannelPlatform.for_filter(team)
 
     def parse_query_value(self, query_value) -> any:

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -68,7 +68,7 @@ from apps.experiments.decorators import (
 from apps.experiments.email import send_chat_link_email, send_experiment_invitation
 from apps.experiments.filters import (
     ExperimentSessionFilter,
-    get_experiment_filter_context_data,
+    get_filter_context_data,
 )
 from apps.experiments.forms import (
     ConsentForm,
@@ -510,13 +510,8 @@ def base_single_experiment_view(request, team_slug, experiment_id, template_name
     else:
         session_table_url = reverse("chatbots:sessions-list", args=(team_slug, experiment_id))
 
-    context.update(
-        get_experiment_filter_context_data(
-            request.team,
-            session_table_url,
-            single_experiment=experiment,
-        )
-    )
+    columns = ExperimentSessionFilter.columns(request.team, single_experiment=experiment)
+    context.update(get_filter_context_data(request.team, columns, "last_message", session_table_url, "sessions-table"))
 
     return TemplateResponse(request, template_name, context)
 

--- a/apps/trace/filters.py
+++ b/apps/trace/filters.py
@@ -26,7 +26,7 @@ class SpanNameFilter(ChoiceColumnFilter):
     column: str = "spans__name"
     label: str = "Spans Name"
 
-    def prepare(self, team, **kwargs):
+    def prepare(self, team, **_):
         self.options = list(team.span_set.values_list("name", flat=True).order_by("name").distinct())
 
 
@@ -36,7 +36,7 @@ class SpanTagsFilter(ChoiceColumnFilter):
     label: str = "Tags"
     type: str = TYPE_CHOICE
 
-    def prepare(self, team, **kwargs):
+    def prepare(self, team, **_):
         self.options = list(
             team.span_set.filter(tags__is_system_tag=True)
             .values_list("tags__name", flat=True)

--- a/apps/trace/filters.py
+++ b/apps/trace/filters.py
@@ -4,11 +4,9 @@ from typing import ClassVar
 from django.urls import reverse
 
 from apps.experiments.filters import (
-    get_experiment_filter_options,
     get_filter_context_data,
 )
-from apps.trace.models import TraceStatus
-from apps.web.dynamic_filters.base import ChoiceColumnFilter, ColumnFilter, MultiColumnFilter
+from apps.web.dynamic_filters.base import TYPE_CHOICE, ChoiceColumnFilter, ColumnFilter, MultiColumnFilter
 from apps.web.dynamic_filters.column_filters import (
     ExperimentFilter,
     ParticipantFilter,
@@ -19,40 +17,38 @@ from apps.web.dynamic_filters.column_filters import (
 
 
 def get_trace_filter_context_data(team):
-    span_tags = list(
-        team.span_set.filter(tags__is_system_tag=True)
-        .values_list("tags__name", flat=True)
-        .order_by("tags__name")
-        .distinct("tags__name")
-    )
-
     table_url = reverse("trace:table", args=[team.slug])
-    context = get_filter_context_data(team, TraceFilter.columns(), "timestamp", table_url, "data-table")
-    context.update(
-        {
-            "df_span_names": list(team.span_set.values_list("name", flat=True).order_by("name").distinct()),
-            "df_state_list": TraceStatus.values,
-            "df_experiment_list": get_experiment_filter_options(team),
-            "df_available_tags": span_tags,
-        }
-    )
-    return context
+    return get_filter_context_data(team, TraceFilter.columns(team), "timestamp", table_url, "data-table")
 
 
 class SpanNameFilter(ChoiceColumnFilter):
     query_param: str = "span_name"
     column: str = "spans__name"
+    label: str = "Spans Name"
+
+    def prepare(self, team, **kwargs):
+        self.options = list(team.span_set.values_list("name", flat=True).order_by("name").distinct())
 
 
 class SpanTagsFilter(ChoiceColumnFilter):
     query_param: str = "tags"
     column: str = "spans__tags__name"
+    label: str = "Tags"
+    type: str = TYPE_CHOICE
+
+    def prepare(self, team, **kwargs):
+        self.options = list(
+            team.span_set.filter(tags__is_system_tag=True)
+            .values_list("tags__name", flat=True)
+            .order_by("tags__name")
+            .distinct("tags__name")
+        )
 
 
 class TraceFilter(MultiColumnFilter):
     filters: ClassVar[Sequence[ColumnFilter]] = [
         ParticipantFilter(),
-        TimestampFilter(column="timestamp", query_param="timestamp"),
+        TimestampFilter(label="Timestamp", column="timestamp", query_param="timestamp"),
         SpanTagsFilter(),
         SpanNameFilter(),
         RemoteIdFilter(),

--- a/apps/trace/filters.py
+++ b/apps/trace/filters.py
@@ -24,7 +24,7 @@ def get_trace_filter_context_data(team):
 class SpanNameFilter(ChoiceColumnFilter):
     query_param: str = "span_name"
     column: str = "spans__name"
-    label: str = "Spans Name"
+    label: str = "Span Name"
 
     def prepare(self, team, **_):
         self.options = list(team.span_set.values_list("name", flat=True).order_by("name").distinct())

--- a/apps/trace/filters.py
+++ b/apps/trace/filters.py
@@ -40,19 +40,19 @@ def get_trace_filter_context_data(team):
 
 
 class SpanNameFilter(ChoiceColumnFilter):
-    query_param = "span_name"
-    column: ClassVar[str] = "spans__name"
+    query_param: str = "span_name"
+    column: str = "spans__name"
 
 
 class SpanTagsFilter(ChoiceColumnFilter):
-    query_param = "tags"
-    column: ClassVar[str] = "spans__tags__name"
+    query_param: str = "tags"
+    column: str = "spans__tags__name"
 
 
 class TraceFilter(MultiColumnFilter):
     filters: ClassVar[Sequence[ColumnFilter]] = [
         ParticipantFilter(),
-        TimestampFilter(db_column="timestamp", query_param="timestamp"),
+        TimestampFilter(column="timestamp", query_param="timestamp"),
         SpanTagsFilter(),
         SpanNameFilter(),
         RemoteIdFilter(),

--- a/apps/web/dynamic_filters/base.py
+++ b/apps/web/dynamic_filters/base.py
@@ -42,6 +42,7 @@ FIELD_TYPE_FILTERS = {
     ],
     "timestamp": [Operators.ON, Operators.BEFORE, Operators.AFTER, Operators.RANGE],
     "choice": [Operators.ANY_OF, Operators.ALL_OF, Operators.EXCLUDES],
+    "exclusive_choice": [Operators.ANY_OF, Operators.EXCLUDES],
 }
 
 DATE_RANGE_OPTIONS = [

--- a/apps/web/dynamic_filters/base.py
+++ b/apps/web/dynamic_filters/base.py
@@ -141,7 +141,8 @@ class ColumnFilter(BaseModel):
 
         operator = column_filter.operator.replace(" ", "_").lower()
         if method := getattr(self, f"apply_{operator}", None):
-            if parsed_value := self.parse_query_value(column_filter.value):
+            parsed_value = self.parse_query_value(column_filter.value)
+            if parsed_value not in (None, "", []):
                 return method(queryset, parsed_value, timezone)
         return queryset
 

--- a/apps/web/dynamic_filters/base.py
+++ b/apps/web/dynamic_filters/base.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from typing import Any, ClassVar, Literal
 
 from django.db.models import QuerySet
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, Field, computed_field
 
 from .datastructures import FilterParams
 
@@ -149,7 +149,7 @@ class ColumnFilter(BaseModel):
 
 class ChoiceColumnFilter(ColumnFilter):
     type: str = TYPE_EXCLUSIVE_CHOICE
-    options: Sequence[str | dict[str, Any]] = []
+    options: list[str | dict[str, Any]] = Field(default_factory=list)
 
     def parse_query_value(self, query_value) -> any:
         return self.values_list(query_value)

--- a/apps/web/dynamic_filters/base.py
+++ b/apps/web/dynamic_filters/base.py
@@ -77,9 +77,11 @@ class MultiColumnFilter:
 
     @classmethod
     def columns(cls, team, **kwargs) -> dict[str:dict]:
-        for filter_component in cls.filters:
+        # Create per-call copies to avoid mutating shared instances
+        instances = [f.model_copy(deep=True) for f in cls.filters]
+        for filter_component in instances:
             filter_component.prepare(team, **kwargs)
-        return {filter_component.query_param: filter_component.model_dump() for filter_component in cls.filters}
+        return {filter_component.query_param: filter_component.model_dump() for filter_component in instances}
 
     def prepare_queryset(self, queryset):
         """Hook for subclasses to modify the queryset before applying filters."""

--- a/apps/web/dynamic_filters/base.py
+++ b/apps/web/dynamic_filters/base.py
@@ -7,6 +7,7 @@ from enum import StrEnum
 from typing import ClassVar
 
 from django.db.models import QuerySet
+from pydantic import BaseModel
 
 from .datastructures import FilterParams
 
@@ -84,7 +85,7 @@ class MultiColumnFilter:
         return queryset.distinct()
 
 
-class ColumnFilter:
+class ColumnFilter(BaseModel):
     """
     Abstract base class for a single column filter.
 
@@ -97,7 +98,8 @@ class ColumnFilter:
         query_param: The name of the query parameter used in the URL to identify this filter.
     """
 
-    query_param: str = None
+    query_param: str
+    column: str = None
 
     def values_list(self, json_value: str) -> list[str]:
         try:
@@ -123,8 +125,6 @@ class ColumnFilter:
 
 
 class ChoiceColumnFilter(ColumnFilter):
-    column: ClassVar[str]
-
     def parse_query_value(self, query_value) -> any:
         return self.values_list(query_value)
 
@@ -141,8 +141,6 @@ class ChoiceColumnFilter(ColumnFilter):
 
 
 class StringColumnFilter(ColumnFilter):
-    column: ClassVar[str]
-
     def apply_equals(self, queryset, value, timezone=None) -> QuerySet:
         return queryset.filter(**{f"{self.column}": value})
 

--- a/apps/web/dynamic_filters/base.py
+++ b/apps/web/dynamic_filters/base.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from typing import Any, ClassVar, Literal
 
 from django.db.models import QuerySet
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, computed_field
 
 from .datastructures import FilterParams
 
@@ -111,8 +111,12 @@ class ColumnFilter(BaseModel):
     query_param: str
     label: str
     type: TYPE_ANNOTATION
-    operators: list[Operators] = Field(default_factory=lambda data: FIELD_TYPE_FILTERS[data["type"]])
     column: str = None
+
+    @computed_field
+    @property
+    def operators(self) -> list[Operators]:
+        return FIELD_TYPE_FILTERS[self.type]
 
     def prepare(self, team, **kwargs):
         pass

--- a/apps/web/dynamic_filters/base.py
+++ b/apps/web/dynamic_filters/base.py
@@ -127,7 +127,7 @@ class ColumnFilter(BaseModel):
         try:
             return json.loads(json_value)
         except json.JSONDecodeError:
-            logger.error("Failed to decode JSON for chat message tag filter", exc_info=True)
+            logger.exception("Failed to decode JSON for filter value: %s: %s", self.query_param, json_value)
         return []
 
     def parse_query_value(self, query_value) -> any:

--- a/apps/web/dynamic_filters/base.py
+++ b/apps/web/dynamic_filters/base.py
@@ -76,7 +76,7 @@ class MultiColumnFilter:
     filters: ClassVar[Sequence[ColumnFilter]]
 
     @classmethod
-    def columns(cls, team, **kwargs) -> dict[str:dict]:
+    def columns(cls, team, **kwargs) -> dict[str, dict]:
         # Create per-call copies to avoid mutating shared instances
         instances = [f.model_copy(deep=True) for f in cls.filters]
         for filter_component in instances:

--- a/apps/web/dynamic_filters/column_filters.py
+++ b/apps/web/dynamic_filters/column_filters.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from typing import ClassVar
 
 import pytz
 from django.db.models import QuerySet
@@ -8,13 +7,13 @@ from .base import ChoiceColumnFilter, ColumnFilter, StringColumnFilter
 
 
 class ParticipantFilter(StringColumnFilter):
-    query_param = "participant"
-    column: ClassVar[str] = "participant__identifier"
+    query_param: str = "participant"
+    column: str = "participant__identifier"
 
 
 class ExperimentFilter(ChoiceColumnFilter):
-    query_param = "experiment"
-    column: ClassVar[str] = "experiment_id"
+    query_param: str = "experiment"
+    column: str = "experiment_id"
 
     def parse_query_value(self, value) -> list[int]:
         values = []
@@ -27,22 +26,15 @@ class ExperimentFilter(ChoiceColumnFilter):
 
 
 class StatusFilter(ChoiceColumnFilter):
-    column: ClassVar[str] = "status"
-
-    def __init__(self, query_param: str):
-        self.query_param = query_param
+    column: str = "status"
 
 
 class RemoteIdFilter(ChoiceColumnFilter):
-    query_param = "remote_id"
-    column = "participant__remote_id"
+    query_param: str = "remote_id"
+    column: str = "participant__remote_id"
 
 
 class TimestampFilter(ColumnFilter):
-    def __init__(self, db_column: str, query_param: str):
-        self.db_column = db_column
-        self.query_param = query_param
-
     def _get_date_as_utc(self, value) -> datetime:
         try:
             date_value = datetime.fromisoformat(value)
@@ -54,20 +46,20 @@ class TimestampFilter(ColumnFilter):
     def apply_on(self, queryset, value, timezone=None) -> QuerySet:
         """Filter for timestamps on a specific date"""
         if date_value := self._get_date_as_utc(value):
-            return queryset.filter(**{f"{self.db_column}__date": date_value})
+            return queryset.filter(**{f"{self.column}__date": date_value})
         return queryset
 
     def apply_before(self, queryset, value, timezone=None) -> QuerySet:
         """Filter for timestamps before a specific date"""
         if date_value := self._get_date_as_utc(value):
-            return queryset.filter(**{f"{self.db_column}__date__lt": date_value})
+            return queryset.filter(**{f"{self.column}__date__lt": date_value})
         return queryset
 
     def apply_after(self, queryset, value, timezone=None) -> QuerySet:
         """Filter for timestamps after a specific date"""
         if date_value := self._get_date_as_utc(value):
             date_value = date_value.astimezone(pytz.UTC)
-            return queryset.filter(**{f"{self.db_column}__date__gt": date_value})
+            return queryset.filter(**{f"{self.column}__date__gt": date_value})
         return queryset
 
     def apply_range(self, queryset, value, timezone=None) -> QuerySet:
@@ -94,6 +86,6 @@ class TimestampFilter(ColumnFilter):
 
             range_starting_client_time = now_client - delta
             range_starting_utc_time = range_starting_client_time.astimezone(pytz.UTC)
-            return queryset.filter(**{f"{self.db_column}__gte": range_starting_utc_time})
+            return queryset.filter(**{f"{self.column}__gte": range_starting_utc_time})
         except (ValueError, TypeError, pytz.UnknownTimeZoneError):
             return queryset

--- a/apps/web/dynamic_filters/column_filters.py
+++ b/apps/web/dynamic_filters/column_filters.py
@@ -19,7 +19,7 @@ class ExperimentFilter(ChoiceColumnFilter):
     column: str = "experiment_id"
     label: str = "Chatbot"
 
-    def prepare(self, team, **kwargs):
+    def prepare(self, team, **_):
         from apps.experiments.models import Experiment
 
         experiments = (

--- a/docs/developer_guides/dynamic_filters.md
+++ b/docs/developer_guides/dynamic_filters.md
@@ -113,7 +113,7 @@ p_filter = ProductCategoryFilter()
 
 # Alternately, you can construct it directly using kwargs:
 
-p_filter = ChoiceColumnFilter(label="Category", query_param="category", column="category_name", options=[...])
+p_filter = ChoiceColumnFilter(label="Category", query_param="category", column="category__name", options=[...])
 ```
 
 ### Step 2: Create a Multi-Column Filter
@@ -211,7 +211,7 @@ class ProductInventoryView(SingleTableView):
         # Add filter context data using the helper function
         filter_context = get_filter_context_data(
             team=self.request.team,  # Assuming team is available in request
-            columns=ProductInventoryFilter.columns(request.team),
+            columns=ProductInventoryFilter.columns(self.request.team),
             date_range_column="created_date",
             table_url=reverse("inventory:product_table"),  # Your HTMX table URL
             table_container_id="product-table"
@@ -241,35 +241,4 @@ Create the template that includes the filter interface:
 </div>
 
 {% endblock %}
-```
-
-**Update the Shared Filter Template**
-
-Since the filter template is shared across the application, you'll need to update `templates/experiments/filters.html` to include your new filter columns. Add your custom columns to the `allColumns` object in the Alpine.js component.
-
-The frontend configuration maps field types to available operators using the `FIELD_TYPE_FILTERS` constant:
-
-- **`"string"`**: equals, contains, does not contain, starts with, ends with, any of
-- **`"timestamp"`**: on, before, after, range  
-- **`"choice"`**: any of, all of, excludes
-- **`"exclusive_choice"`**: any of, excludes
-
-The `get_filter_context_data()` helper function provides the necessary context variables:
-
-- `df_date_range_options`: Predefined date ranges (1h, 1d, 7d, etc.)
-- `df_filter_columns`: List of column names for this filter
-- `df_date_range_column_name`: Default date column for quick range selection
-- `df_filter_data_source_url`: HTMX endpoint for table updates
-- `df_filter_data_source_container_id`: HTML element ID containing the table
-
-In your template, define the column configuration in JavaScript:
-
-```javascript
-// In templates/experiments/filters.html or your custom template
-{{ df_product_categories|default:"[]"|json_script:"product-categories" }}
-<script>
-    const fieldTypeFilters = JSON.parse(document.getElementById('field-type-filters').textContent);
-    const dateRangeOptions = JSON.parse(document.getElementById('date-range-options').textContent);
-    // ...rest of Alpine.js configuration
-</script>
 ```

--- a/docs/developer_guides/dynamic_filters.md
+++ b/docs/developer_guides/dynamic_filters.md
@@ -256,7 +256,6 @@ The frontend configuration maps field types to available operators using the `FI
 
 The `get_filter_context_data()` helper function provides the necessary context variables:
 
-- `df_field_type_filters`: Maps field types to operators
 - `df_date_range_options`: Predefined date ranges (1h, 1d, 7d, etc.)
 - `df_filter_columns`: List of column names for this filter
 - `df_date_range_column_name`: Default date column for quick range selection

--- a/docs/developer_guides/dynamic_filters.md
+++ b/docs/developer_guides/dynamic_filters.md
@@ -15,7 +15,7 @@ The backend is responsible for defining the filters and applying them to the dat
 
 - **`MultiColumnFilter`**: A container class that holds a list of `ColumnFilter` instances and applies them to a queryset. It provides a `columns()` class method to list available filter column names and handles the orchestration of applying multiple filters.
 
-- **Filter Types**: `StringColumnFilter` and `ChoiceColumnFilter` provide pre-built implementations for common filtering patterns, reducing boilerplate code.
+- **Filter Types**: `StringColumnFilter`, `ChoiceColumnFilter`, and `TimestampFilter` provide pre-built implementations for common filtering patterns, reducing boilerplate code.
 
 - **Filter Implementations**: Concrete implementations of `ColumnFilter` can be found in `apps/web/dynamic_filters/column_filters.py` (base filters like `TimestampFilter`, `ParticipantFilter`) and in app-specific `filters.py` files throughout the project (e.g., `apps/experiments/filters.py`).
 
@@ -81,7 +81,8 @@ The system supports the following operators defined in the `Operators` enum:
 - **Date/time operations**: `on`, `before`, `after`, `range`
 - **Choice operations**: `any of`, `all of`, `excludes`
 
-The frontend automatically shows appropriate operators based on the field type configuration.
+Operators are configured in the `ColumnFilter` class. They are determined automatically based on the filter type but
+can be overridden.
 
 ## Step-by-Step Walkthrough: Creating a Product Inventory Filter
 
@@ -96,10 +97,23 @@ First, let's create a filter for product categories using the existing filter ty
 from apps.web.dynamic_filters.base import ChoiceColumnFilter, StringColumnFilter
 from apps.web.dynamic_filters.column_filters import TimestampFilter
 
-class ProductCategoryFilter(StringColumnFilter, ColumnFilter):
+class ProductCategoryFilter(ChoiceColumnFilter):
     """Filter products by category name."""
-    query_param = "category"
-    column = "category__name"  # Database field path
+    query_param: str = "category"
+    column: str = "category__name"  # Database field path
+    label: str = "Category"
+    
+    def prepare(self, team, **kwargs):
+        self.options = [
+            {"id": cat.id, "label": cat.name} 
+            for cat in Category.objects.filter(team=team).all()
+        ]
+        
+p_filter = ProductCategoryFilter()
+
+# Alternately, you can construct it directly using kwargs:
+
+p_filter = ChoiceColumnFilter(label="Category", query_param="category", column="category_name", options=[...])
 ```
 
 ### Step 2: Create a Multi-Column Filter
@@ -117,8 +131,8 @@ class ProductInventoryFilter(MultiColumnFilter):
     
     filters: ClassVar[Sequence[ColumnFilter]] = [
         ProductCategoryFilter(),
-        TimestampFilter(db_column="created_at", query_param="created_date"),
-        TimestampFilter(db_column="updated_at", query_param="last_updated"),
+        TimestampFilter(label="Created At", column="created_at", query_param="created_date"),
+        TimestampFilter(label="Updated At", column="updated_at", query_param="last_updated"),
         # Add more filters as needed
     ]
 
@@ -197,19 +211,11 @@ class ProductInventoryView(SingleTableView):
         # Add filter context data using the helper function
         filter_context = get_filter_context_data(
             team=self.request.team,  # Assuming team is available in request
-            columns=ProductInventoryFilter.columns(),
+            columns=ProductInventoryFilter.columns(request.team),
             date_range_column="created_date",
             table_url=reverse("inventory:product_table"),  # Your HTMX table URL
             table_container_id="product-table"
         )
-        
-        # Add any additional context specific to your filters
-        filter_context.update({
-            "df_product_categories": [
-                {"id": cat.id, "label": cat.name} 
-                for cat in Category.objects.all()
-            ]
-        })
         
         context.update(filter_context)
         return context
@@ -246,6 +252,7 @@ The frontend configuration maps field types to available operators using the `FI
 - **`"string"`**: equals, contains, does not contain, starts with, ends with, any of
 - **`"timestamp"`**: on, before, after, range  
 - **`"choice"`**: any of, all of, excludes
+- **`"exclusive_choice"`**: any of, excludes
 
 The `get_filter_context_data()` helper function provides the necessary context variables:
 
@@ -262,31 +269,8 @@ In your template, define the column configuration in JavaScript:
 // In templates/experiments/filters.html or your custom template
 {{ df_product_categories|default:"[]"|json_script:"product-categories" }}
 <script>
-    const categories = JSON.parse(document.getElementById('product-categories').textContent);
     const fieldTypeFilters = JSON.parse(document.getElementById('field-type-filters').textContent);
     const dateRangeOptions = JSON.parse(document.getElementById('date-range-options').textContent);
-    
-    const allColumns = {
-        // Existing columns...
-        'category': {
-            type: 'choice', 
-            operators: fieldTypeFilters.choice,
-            options: categories,
-            label: 'Product Category'
-        },
-        'created_date': {
-            type: 'timestamp', 
-            operators: fieldTypeFilters.timestamp, 
-            options: dateRangeOptions,
-            label: 'Created Date'
-        },
-        'last_updated': {
-            type: 'timestamp', 
-            operators: fieldTypeFilters.timestamp, 
-            options: dateRangeOptions,
-            label: 'Last Updated'
-        }
-    }
     // ...rest of Alpine.js configuration
 </script>
 ```

--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -492,8 +492,8 @@
         }).finally(() => {
           this.filterData.loading = false;
           // remove selected value from date range dropdown if range filter is removed
-          const hasLastMessageRange = this.filterData.filters.some(f => f.column === '{{ df_date_range_column_name }}' && f.operator === 'range');
-          if (!hasLastMessageRange) {
+          const hasDateRangeRange = this.filterData.filters.some(f => f.column === '{{ df_date_range_column_name }}' && f.operator === 'range');
+          if (!hasDateRangeRange) {
             this.syncDateRangeDropdown(null);
           }
         });
@@ -502,7 +502,7 @@
       setLabelFromURL() {
         const url = new URL(window.location.href);
         const params = url.searchParams;
-        const matchedIndex = this.getLastMessageFilterIndex(params);
+        const matchedIndex = this.getDateRangeFilterIndex(params);
         if (matchedIndex !== null) {
           const filterValue = params.get(`filter_${matchedIndex}_value`);
           const found = this.dateRangeOptions.find(opt => opt.value === filterValue);
@@ -550,7 +550,7 @@
         return allTags.length > 0 && filter.selectedValues.length === allTags.length;
       },
 
-      getLastMessageFilterIndex(params) {
+      getDateRangeFilterIndex(params) {
         for (const [key, val] of params.entries()) {
           if (key.includes('_column') && val === '{{ df_date_range_column_name }}') {
             const match = key.match(/filter_(\d+)_column/);

--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -79,7 +79,7 @@
           <!-- Value Input (Choice, String, Timestamp) -->
           <template x-if="filter.operator">
             <div class="relative">
-              <template x-if="['choice', 'string'].includes(filterData.columns[filter.column]?.type) && ['any of', 'all of', 'excludes'].includes(filter.operator)">
+              <template x-if="['choice', 'string', 'exclusive_choice'].includes(filterData.columns[filter.column]?.type) && ['any of', 'all of', 'excludes'].includes(filter.operator)">
                 <div class="relative">
                   <div @click="filter.showOptions = !filter.showOptions" class="w-40 px-3 border border-base-200 rounded-lg bg-base-100 text-sm cursor-pointer flex justify-between items-center" style="height: 2rem;">
                     <span x-text="filter.selectedValues.length ? getSelectedDisplayText(filter) : 'Select'"></span>
@@ -194,22 +194,10 @@
 {{ df_field_type_filters|json_script:"field-type-filters" }}
 {{ df_date_range_options|json_script:"date-range-options" }}
 {{ df_filter_columns|json_script:"filter-columns-data" }}
-{{ df_state_list|json_script:"state-data" }}
-{{ df_available_tags|default:""|json_script:"available-tags-data" }}
-{{ df_experiment_versions|default:""|json_script:"experiment-versions-data" }}
-{{ df_channel_list|default:"[]"|json_script:"channel-list-data" }}
-{{ df_span_names|default:"[]"|json_script:"available-span-names-data" }}
-{% if df_experiment_list %}{{ df_experiment_list|json_script:"experiment-list-data" }}{% else %}<script id="experiment-list-data" type="application/json">[]</script>{% endif %}
 <script>
-  const tags = JSON.parse(document.getElementById('available-tags-data').textContent);
-  const span_names = JSON.parse(document.getElementById('available-span-names-data').textContent);
-  const versionsList = JSON.parse(document.getElementById('experiment-versions-data').textContent);
   const fieldTypeFilters = JSON.parse(document.getElementById('field-type-filters').textContent);
-  const channelsList = JSON.parse(document.getElementById('channel-list-data').textContent);
-  const experimentList = JSON.parse(document.getElementById('experiment-list-data').textContent);
   const filterColumns = JSON.parse(document.getElementById('filter-columns-data').textContent);
   const dateRangeOptions = JSON.parse(document.getElementById('date-range-options').textContent);
-  const stateOptions = JSON.parse(document.getElementById('state-data').textContent);
   document.addEventListener('alpine:init', () => {
     Alpine.data('filterComponent', () => ({
       dateRangeOptions,
@@ -217,35 +205,11 @@
         showFilters: false,
         filters: [],
         loading: false,
-        columns: {}
+        columns: filterColumns,
       },
 
       init() {
         const App = SiteJS.app;
-        // Build columns dynamically based on filter_columns context
-        const allColumns = {
-          'experiment': {type: 'choice', operators: fieldTypeFilters.exclusive_choice, options: experimentList, label: 'Experiment'},
-          'participant': {type: 'string', operators: fieldTypeFilters.string, label: 'Participant'},
-          'first_message': {type: 'timestamp', operators: fieldTypeFilters.timestamp, label: 'First Message',  options: dateRangeOptions},
-          'last_message': {type: 'timestamp', operators: fieldTypeFilters.timestamp, label: 'Last Message',  options: dateRangeOptions},
-          'tags': {type: 'choice', operators: fieldTypeFilters.choice, options: tags, label: 'Tags' },
-          'versions': {type: 'choice', operators: fieldTypeFilters.exclusive_choice, options: versionsList, label: 'Versions'},
-          'channels': {type: 'choice', operators: fieldTypeFilters.exclusive_choice, options: channelsList, label: 'Channels'},
-          'state': {type: 'choice', operators: fieldTypeFilters.exclusive_choice, options: stateOptions, label: 'State'},
-          'remote_id': {type: 'choice', operators: fieldTypeFilters.exclusive_choice, label: 'Remote Id'},
-          'timestamp': {type: 'timestamp', operators: fieldTypeFilters.timestamp, label: 'Timestamp',  options: dateRangeOptions},
-          'span_name': {type: 'choice', operators: fieldTypeFilters.choice, options: span_names, label: 'Span Name' },
-          'status': {type: 'choice', operators: fieldTypeFilters.exclusive_choice, options: stateOptions, label: 'Status'},
-        };
-
-        // Only include columns that are in the filterColumns list
-        this.filterData.columns = {};
-        filterColumns.forEach(column => {
-          if (allColumns[column]) {
-            this.filterData.columns[column] = allColumns[column];
-          }
-        });
-
         this.loadFiltersFromUrl();
           // Always trigger a data load on init to ensure correct data is shown
         this.$nextTick(() => {
@@ -320,7 +284,7 @@
           filter.value = '';
           filter.selectedValues = [];
           filter.searchQuery = '';
-          if (['choice', 'string'].includes(this.filterData.columns[column].type)) {
+          if (['choice', 'string', 'exclusive_choice'].includes(this.filterData.columns[column].type)) {
             filter.filteredOptions = [...this.filterData.columns[column].options || []];
           } else {
             filter.filteredOptions = [];

--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -223,20 +223,19 @@
       init() {
         const App = SiteJS.app;
         // Build columns dynamically based on filter_columns context
-        const singleOptionChoice = fieldTypeFilters.choice.filter(op => op === 'any of' || op === 'excludes')
         const allColumns = {
-          'experiment': {type: 'choice', operators: singleOptionChoice, options: experimentList, label: 'Experiment'},
+          'experiment': {type: 'choice', operators: fieldTypeFilters.exclusive_choice, options: experimentList, label: 'Experiment'},
           'participant': {type: 'string', operators: fieldTypeFilters.string, label: 'Participant'},
           'first_message': {type: 'timestamp', operators: fieldTypeFilters.timestamp, label: 'First Message',  options: dateRangeOptions},
           'last_message': {type: 'timestamp', operators: fieldTypeFilters.timestamp, label: 'Last Message',  options: dateRangeOptions},
           'tags': {type: 'choice', operators: fieldTypeFilters.choice, options: tags, label: 'Tags' },
-          'versions': {type: 'choice', operators: singleOptionChoice, options: versionsList, label: 'Versions'},
-          'channels': {type: 'choice', operators: singleOptionChoice, options: channelsList, label: 'Channels'},
-          'state': {type: 'choice', operators: singleOptionChoice, options: stateOptions, label: 'State'},
-          'remote_id': {type: 'choice', operators: singleOptionChoice, label: 'Remote Id'},
+          'versions': {type: 'choice', operators: fieldTypeFilters.exclusive_choice, options: versionsList, label: 'Versions'},
+          'channels': {type: 'choice', operators: fieldTypeFilters.exclusive_choice, options: channelsList, label: 'Channels'},
+          'state': {type: 'choice', operators: fieldTypeFilters.exclusive_choice, options: stateOptions, label: 'State'},
+          'remote_id': {type: 'choice', operators: fieldTypeFilters.exclusive_choice, label: 'Remote Id'},
           'timestamp': {type: 'timestamp', operators: fieldTypeFilters.timestamp, label: 'Timestamp',  options: dateRangeOptions},
           'span_name': {type: 'choice', operators: fieldTypeFilters.choice, options: span_names, label: 'Span Name' },
-          'status': {type: 'choice', operators: singleOptionChoice, options: stateOptions, label: 'Status'},
+          'status': {type: 'choice', operators: fieldTypeFilters.exclusive_choice, options: stateOptions, label: 'Status'},
         };
 
         // Only include columns that are in the filterColumns list

--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -492,7 +492,7 @@
         }).finally(() => {
           this.filterData.loading = false;
           // remove selected value from date range dropdown if range filter is removed
-          const hasLastMessageRange = this.filterData.filters.some(f => f.column === 'last_message' && f.operator === 'range');
+          const hasLastMessageRange = this.filterData.filters.some(f => f.column === '{{ df_date_range_column_name }}' && f.operator === 'range');
           if (!hasLastMessageRange) {
             this.syncDateRangeDropdown(null);
           }
@@ -552,7 +552,7 @@
 
       getLastMessageFilterIndex(params) {
         for (const [key, val] of params.entries()) {
-          if (key.includes('_column') && val === 'last_message') {
+          if (key.includes('_column') && val === '{{ df_date_range_column_name }}') {
             const match = key.match(/filter_(\d+)_column/);
             if (match) {
               return match[1];

--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -516,15 +516,18 @@
 
       selectOption(option) {
         this.selectedLabel = option.label;
-        this.filterData.filters = this.filterData.filters.filter(f => f.column !== '{{ df_date_range_column_name }}');
-        this.filterData.filters.push({
-          column: '{{ df_date_range_column_name }}',
-          operator: 'range',
-          value: option.value,
-          availableOperators: fieldTypeFilters.timestamp,
-        });
-        this.filterData.filters = this.getActiveFilters(this.filterData.filters);
-        this.triggerFilterChange();
+        const column = this.filterData.columns['{{ df_date_range_column_name }}'];
+        if (column) {
+          this.filterData.filters = this.filterData.filters.filter(f => f.column !== column.query_param);
+          this.filterData.filters.push({
+            column: column.query_param,
+            operator: 'range',
+            value: option.value,
+            availableOperators: column.operators,
+          });
+          this.filterData.filters = this.getActiveFilters(this.filterData.filters);
+          this.triggerFilterChange();
+        }
       },
 
       selectAllTagOptions(index) {

--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -191,11 +191,9 @@
   </div>
 </div>
 
-{{ df_field_type_filters|json_script:"field-type-filters" }}
 {{ df_date_range_options|json_script:"date-range-options" }}
 {{ df_filter_columns|json_script:"filter-columns-data" }}
 <script>
-  const fieldTypeFilters = JSON.parse(document.getElementById('field-type-filters').textContent);
   const filterColumns = JSON.parse(document.getElementById('filter-columns-data').textContent);
   const dateRangeOptions = JSON.parse(document.getElementById('date-range-options').textContent);
   document.addEventListener('alpine:init', () => {

--- a/uv.lock
+++ b/uv.lock
@@ -2929,39 +2929,45 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.9.2"
+version = "2.11.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/b7/d9e3f12af310e1120c21603644a1cd86f59060e040ec5c3a80b8f05fae30/pydantic-2.9.2.tar.gz", hash = "sha256:d155cef71265d1e9807ed1c32b4c8deec042a44a50a4188b25ac67ecd81a9c0f", size = 769917, upload-time = "2024-09-17T15:59:54.273Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/5d/09a551ba512d7ca404d785072700d3f6727a02f6f3c24ecfd081c7cf0aa8/pydantic-2.11.9.tar.gz", hash = "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2", size = 788495, upload-time = "2025-09-13T11:26:39.325Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/e4/ba44652d562cbf0bf320e0f3810206149c8a4e99cdbf66da82e97ab53a15/pydantic-2.9.2-py3-none-any.whl", hash = "sha256:f048cec7b26778210e28a0459867920654d48e5e62db0958433636cde4254f12", size = 434928, upload-time = "2024-09-17T15:59:51.827Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d3/108f2006987c58e76691d5ae5d200dd3e0f532cb4e5fa3560751c3a1feba/pydantic-2.11.9-py3-none-any.whl", hash = "sha256:c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2", size = 444855, upload-time = "2025-09-13T11:26:36.909Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.23.4"
+version = "2.33.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/aa/6b6a9b9f8537b872f552ddd46dd3da230367754b6f707b8e1e963f515ea3/pydantic_core-2.23.4.tar.gz", hash = "sha256:2584f7cf844ac4d970fba483a717dbe10c1c1c96a969bf65d61ffe94df1b2863", size = 402156, upload-time = "2024-09-16T16:06:44.786Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/ef/16ee2df472bf0e419b6bc68c05bf0145c49247a1095e85cee1463c6a44a1/pydantic_core-2.23.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7530e201d10d7d14abce4fb54cfe5b94a0aefc87da539d0346a484ead376c3cc", size = 1856143, upload-time = "2024-09-16T16:04:59.062Z" },
-    { url = "https://files.pythonhosted.org/packages/da/fa/bc3dbb83605669a34a93308e297ab22be82dfb9dcf88c6cf4b4f264e0a42/pydantic_core-2.23.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df933278128ea1cd77772673c73954e53a1c95a4fdf41eef97c2b779271bd0bd", size = 1770063, upload-time = "2024-09-16T16:05:00.522Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/48/e813f3bbd257a712303ebdf55c8dc46f9589ec74b384c9f652597df3288d/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cb3da3fd1b6a5d0279a01877713dbda118a2a4fc6f0d821a57da2e464793f05", size = 1790013, upload-time = "2024-09-16T16:05:02.619Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/e0/56eda3a37929a1d297fcab1966db8c339023bcca0b64c5a84896db3fcc5c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42c6dcb030aefb668a2b7009c85b27f90e51e6a3b4d5c9bc4c57631292015b0d", size = 1801077, upload-time = "2024-09-16T16:05:04.154Z" },
-    { url = "https://files.pythonhosted.org/packages/04/be/5e49376769bfbf82486da6c5c1683b891809365c20d7c7e52792ce4c71f3/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:696dd8d674d6ce621ab9d45b205df149399e4bb9aa34102c970b721554828510", size = 1996782, upload-time = "2024-09-16T16:05:06.931Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/24/e3ee6c04f1d58cc15f37bcc62f32c7478ff55142b7b3e6d42ea374ea427c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2971bb5ffe72cc0f555c13e19b23c85b654dd2a8f7ab493c262071377bfce9f6", size = 2661375, upload-time = "2024-09-16T16:05:08.773Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/f8/11a9006de4e89d016b8de74ebb1db727dc100608bb1e6bbe9d56a3cbbcce/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8394d940e5d400d04cad4f75c0598665cbb81aecefaca82ca85bd28264af7f9b", size = 2071635, upload-time = "2024-09-16T16:05:10.456Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/45/bdce5779b59f468bdf262a5bc9eecbae87f271c51aef628d8c073b4b4b4c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0dff76e0602ca7d4cdaacc1ac4c005e0ce0dcfe095d5b5259163a80d3a10d327", size = 1916994, upload-time = "2024-09-16T16:05:12.051Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/fa/c648308fe711ee1f88192cad6026ab4f925396d1293e8356de7e55be89b5/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7d32706badfe136888bdea71c0def994644e09fff0bfe47441deaed8e96fdbc6", size = 1968877, upload-time = "2024-09-16T16:05:14.021Z" },
-    { url = "https://files.pythonhosted.org/packages/16/16/b805c74b35607d24d37103007f899abc4880923b04929547ae68d478b7f4/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed541d70698978a20eb63d8c5d72f2cc6d7079d9d90f6b50bad07826f1320f5f", size = 2116814, upload-time = "2024-09-16T16:05:15.684Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/58/5305e723d9fcdf1c5a655e6a4cc2a07128bf644ff4b1d98daf7a9dbf57da/pydantic_core-2.23.4-cp313-none-win32.whl", hash = "sha256:3d5639516376dce1940ea36edf408c554475369f5da2abd45d44621cb616f769", size = 1738360, upload-time = "2024-09-16T16:05:17.258Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ae/e14b0ff8b3f48e02394d8acd911376b7b66e164535687ef7dc24ea03072f/pydantic_core-2.23.4-cp313-none-win_amd64.whl", hash = "sha256:5a1504ad17ba4210df3a045132a7baeeba5a200e930f57512ee02909fc5c4cb5", size = 1919411, upload-time = "2024-09-16T16:05:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/46/8c/99040727b41f56616573a28771b1bfa08a3d3fe74d3d513f01251f79f172/pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f", size = 2015688, upload-time = "2025-04-23T18:31:53.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cc/5999d1eb705a6cefc31f0b4a90e9f7fc400539b1a1030529700cc1b51838/pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6", size = 1844808, upload-time = "2025-04-23T18:31:54.79Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/a0a7b8885c98889a18b6e376f344da1ef323d270b44edf8174d6bce4d622/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef", size = 1885580, upload-time = "2025-04-23T18:31:57.393Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2a/953581f343c7d11a304581156618c3f592435523dd9d79865903272c256a/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a", size = 1973859, upload-time = "2025-04-23T18:31:59.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/55/f1a813904771c03a3f97f676c62cca0c0a4138654107c1b61f19c644868b/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916", size = 2120810, upload-time = "2025-04-23T18:32:00.78Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/053389835a996e18853ba107a63caae0b9deb4a276c6b472931ea9ae6e48/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a", size = 2676498, upload-time = "2025-04-23T18:32:02.418Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3c/f4abd740877a35abade05e437245b192f9d0ffb48bbbbd708df33d3cda37/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d", size = 2000611, upload-time = "2025-04-23T18:32:04.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a7/63ef2fed1837d1121a894d0ce88439fe3e3b3e48c7543b2a4479eb99c2bd/pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56", size = 2107924, upload-time = "2025-04-23T18:32:06.129Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/2551964ef045669801675f1cfc3b0d74147f4901c3ffa42be2ddb1f0efc4/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5", size = 2063196, upload-time = "2025-04-23T18:32:08.178Z" },
+    { url = "https://files.pythonhosted.org/packages/26/bd/d9602777e77fc6dbb0c7db9ad356e9a985825547dce5ad1d30ee04903918/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e", size = 2236389, upload-time = "2025-04-23T18:32:10.242Z" },
+    { url = "https://files.pythonhosted.org/packages/42/db/0e950daa7e2230423ab342ae918a794964b053bec24ba8af013fc7c94846/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162", size = 2239223, upload-time = "2025-04-23T18:32:12.382Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4d/4f937099c545a8a17eb52cb67fe0447fd9a373b348ccfa9a87f141eeb00f/pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849", size = 1900473, upload-time = "2025-04-23T18:32:14.034Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/75/4a0a9bac998d78d889def5e4ef2b065acba8cae8c93696906c3a91f310ca/pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9", size = 1955269, upload-time = "2025-04-23T18:32:15.783Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/86/1beda0576969592f1497b4ce8e7bc8cbdf614c352426271b1b10d5f0aa64/pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9", size = 1893921, upload-time = "2025-04-23T18:32:18.473Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777, upload-time = "2025-04-23T18:32:25.088Z" },
 ]
 
 [[package]]
@@ -3806,6 +3812,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
This changes how filter column schemas are defined and unifies them with the `ColumnFilter` classes.

A column filter should now include all the data required to display the filter including:
* query_param
* label
* options (optional)
* operators
* type

## User Impact
None