### PR TITLE
All sessions view with filters

### DIFF
--- a/apps/chatbots/urls.py
+++ b/apps/chatbots/urls.py
@@ -77,4 +77,6 @@ urlpatterns = [
         name="settings",
     ),
     path("<int:pk>/copy/", views.copy_chatbot, name="copy"),
+    path("sessions/", views.AllSessionsHome.as_view(), name="all_sessions_home"),
+    path("sessions-list/", views.ChatbotSessionsTableView.as_view(), name="all_sessions_list"),
 ]

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -311,6 +311,9 @@ class ChatbotSessionsTableView(ExperimentSessionsTableView):
     table_class = ChatbotSessionsTable
 
     def get_table(self, **kwargs):
+        """
+        When viewing sessions for a specific chatbot, hide the chatbot column
+        """
         table = super().get_table(**kwargs)
         if self.kwargs.get("experiment_id"):
             table.exclude = ("chatbot",)

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -457,7 +457,7 @@ def home(
 
 class AllSessionsHome(LoginAndTeamRequiredMixin, TemplateView, PermissionRequiredMixin):
     template_name = "generic/object_home.html"
-    permission_required = "experiments.view_participant"
+    permission_required = "experiments.view_experimentsession"
 
     def get_context_data(self, team_slug: str, **kwargs):
         table_url = reverse("chatbots:all_sessions_list", kwargs={"team_slug": team_slug})

--- a/templates/web/components/team_nav.html
+++ b/templates/web/components/team_nav.html
@@ -15,6 +15,14 @@
       <i class="fas fa-comments"></i>
       {% translate "Chatbots" %}
     </a>
+    <ul>
+        <li>
+          <a href="{% url 'chatbots:all_sessions_home' request.team.slug %}" {% if active_tab == 'all_sessions' %}class="menu-active"{% endif %}>
+            <i class="fa fa-users" aria-hidden="true"></i>
+            {% translate "All sessions" %}
+          </a>
+        </li>
+    </ul>
     {% flag "flag_tracing" %}
       {% if perms.trace.view_trace %}
         <ul>
@@ -26,14 +34,6 @@
             </li>
         </ul>
       {% endif %}
-        <ul>
-            <li>
-              <a href="{% url 'chatbots:all_sessions_home' request.team.slug %}" {% if active_tab == 'all_sessions' %}class="menu-active"{% endif %}>
-                <i class="fa fa-users" aria-hidden="true"></i>
-                {% translate "All sessions" %}
-              </a>
-            </li>
-        </ul>
     {% endflag %}
   </li>
   <li>

--- a/templates/web/components/team_nav.html
+++ b/templates/web/components/team_nav.html
@@ -15,14 +15,16 @@
       <i class="fas fa-comments"></i>
       {% translate "Chatbots" %}
     </a>
-    <ul>
-        <li>
-          <a href="{% url 'chatbots:all_sessions_home' request.team.slug %}" {% if active_tab == 'all_sessions' %}class="menu-active"{% endif %}>
-            <i class="fa fa-users" aria-hidden="true"></i>
-            {% translate "All sessions" %}
-          </a>
-        </li>
-    </ul>
+    {% if perms.experiments.view_experimentsession %}
+      <ul>
+          <li>
+            <a href="{% url 'chatbots:all_sessions_home' request.team.slug %}" {% if active_tab == 'all_sessions' %}class="menu-active"{% endif %}>
+              <i class="fa fa-users" aria-hidden="true"></i>
+              {% translate "All sessions" %}
+            </a>
+          </li>
+      </ul>
+    {% endif %}
     {% flag "flag_tracing" %}
       {% if perms.trace.view_trace %}
         <ul>

--- a/templates/web/components/team_nav.html
+++ b/templates/web/components/team_nav.html
@@ -26,6 +26,14 @@
             </li>
         </ul>
       {% endif %}
+        <ul>
+            <li>
+              <a href="{% url 'chatbots:all_sessions_home' request.team.slug %}" {% if active_tab == 'all_sessions' %}class="menu-active"{% endif %}>
+                <i class="fa fa-users" aria-hidden="true"></i>
+                {% translate "All sessions" %}
+              </a>
+            </li>
+        </ul>
     {% endflag %}
   </li>
   <li>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
This is part 1 of this issue: https://github.com/dimagi/open-chat-studio/issues/2146

This adds a new "all sessions" view with filters. This view shows all sessions for this team. This table is the same one used to render the sessions per chatbot, but only with a new column showing the chatbot it belongs to.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
All users will see

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
<img width="1628" height="835" alt="image" src="https://github.com/user-attachments/assets/20db6eea-3296-425b-b1df-8dcf964c03cf" />


### Docs and Changelog
<!--Link to documentation that has been updated.-->
