### PR TITLE
return to celery connection pooling

### DIFF
--- a/gpt_playground/celery.py
+++ b/gpt_playground/celery.py
@@ -3,7 +3,8 @@ import os
 from celery import Celery
 from celery.app import trace
 
-os.environ.setdefault("DJANGO_DATABASE_CONN_MAX_AGE", "10")
+# Use connection pooling
+# os.environ.setdefault("DJANGO_DATABASE_CONN_MAX_AGE", "10")
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gpt_playground.settings")

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -226,7 +226,7 @@ else:
     DATABASES["default"].pop("CONN_MAX_AGE", None)
     db_options["pool"] = {
         "min_size": env.int("DJANGO_DATABASE_POOL_MIN_SIZE", default=2),
-        "max_size": env.int("DJANGO_DATABASE_POOL_MAX_SIZE", default=25),
+        "max_size": env.int("DJANGO_DATABASE_POOL_MAX_SIZE", default=35),
         "timeout": env.int("DJANGO_DATABASE_POOL_TIMEOUT", default=10),
     }
 

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -226,7 +226,7 @@ else:
     DATABASES["default"].pop("CONN_MAX_AGE", None)
     db_options["pool"] = {
         "min_size": env.int("DJANGO_DATABASE_POOL_MIN_SIZE", default=2),
-        "max_size": env.int("DJANGO_DATABASE_POOL_MAX_SIZE", default=20),
+        "max_size": env.int("DJANGO_DATABASE_POOL_MAX_SIZE", default=25),
         "timeout": env.int("DJANGO_DATABASE_POOL_TIMEOUT", default=10),
     }
 


### PR DESCRIPTION
## Description
Removing the connection pool was worse:

<img width="1660" height="469" alt="image" src="https://github.com/user-attachments/assets/cac9a371-be33-4dc7-a5a6-fe178fa7e636" />

