### PR TITLE
Make connect channel participant identifiers lower case

### DIFF
--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -343,12 +343,12 @@ def test_update_participant_data_and_setup_connect_channels(httpx_mock):
     # Experiment 3: The participant already have a connect channel set up
     # Expectation: Only 1 channel needs to be set up for this participant
     _setup_channel_participant(
-        experiment1, identifier="CONNECTID_2", channel_platform=ChannelPlatform.COMMCARE_CONNECT, system_metadata={}
+        experiment1, identifier="connectid_2", channel_platform=ChannelPlatform.COMMCARE_CONNECT, system_metadata={}
     )
 
     _setup_channel_participant(
         experiment3,
-        identifier="CONNECTID_2",
+        identifier="connectid_2",
         channel_platform=ChannelPlatform.COMMCARE_CONNECT,
         system_metadata={"commcare_connect_channel_id": "7d6a-fdc93-4e9c"},
     )
@@ -380,10 +380,10 @@ def test_update_participant_data_and_setup_connect_channels(httpx_mock):
     # we expect only one call to the Connect servers to have been made
     request = httpx_mock.get_request()
     request_data = json.loads(request.read())
-    assert request_data["connectid"] == "ConnectID_2"
+    assert request_data["connectid"] == "connectid_2"
     assert request_data["channel_source"] == "bot1"
-    assert Participant.objects.filter(identifier="ConnectID_2").exists()
-    data = ParticipantData.objects.get(participant__identifier="ConnectID_2", experiment_id=experiment1.id)
+    assert Participant.objects.filter(identifier="connectid_2").exists()
+    data = ParticipantData.objects.get(participant__identifier="connectid_2", experiment_id=experiment1.id)
     assert data.system_metadata == {"commcare_connect_channel_id": created_connect_channel_id, "consent": True}
 
 

--- a/apps/api/views/participants.py
+++ b/apps/api/views/participants.py
@@ -89,8 +89,14 @@ def _update_participant_data(request):
     serializer.is_valid(raise_exception=True)
 
     identifier = serializer.data["identifier"]
+
     platform = serializer.data["platform"]
     team = request.team
+
+    if platform == ChannelPlatform.COMMCARE_CONNECT:
+        # CommCare Connect IDs are case insensitive, so we store them in lowercase
+        identifier = identifier.lower()
+
     participant, _ = Participant.objects.get_or_create(identifier=identifier, team=team, platform=platform)
 
     # Update the participant's name if provided

--- a/apps/api/views/participants.py
+++ b/apps/api/views/participants.py
@@ -93,10 +93,7 @@ def _update_participant_data(request):
     platform = serializer.data["platform"]
     team = request.team
 
-    if platform == ChannelPlatform.COMMCARE_CONNECT:
-        # CommCare Connect IDs are case insensitive, so we store them in lowercase
-        identifier = identifier.lower()
-
+    identifier = ChannelPlatform(platform).normalize_identifier(identifier)
     participant, _ = Participant.objects.get_or_create(identifier=identifier, team=team, platform=platform)
 
     # Update the participant's name if provided

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -122,6 +122,13 @@ class ChannelPlatform(models.TextChoices):
         platforms_with_labels.append(cls.EVALUATIONS.label)
         return sorted(platforms_with_labels)
 
+    def normalize_identifier(self, identifier: str) -> str:
+        """Normalize the identifier for storage and comparison purposes"""
+        match self:
+            case self.COMMCARE_CONNECT:
+                return identifier.lower()
+        return identifier
+
 
 class ExperimentChannelObjectManager(AuditingManager):
     def filter_extras(self, team_slug: str, platform: ChannelPlatform, key: str, value: str):

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -123,7 +123,6 @@ class ChannelPlatform(models.TextChoices):
         return sorted(platforms_with_labels)
 
     def normalize_identifier(self, identifier: str) -> str:
-        """Normalize the identifier for storage and comparison purposes"""
         match self:
             case self.COMMCARE_CONNECT:
                 return identifier.lower()

--- a/apps/channels/tests/test_models.py
+++ b/apps/channels/tests/test_models.py
@@ -184,4 +184,5 @@ class TestChannelPlatform:
             if platform == ChannelPlatform.COMMCARE_CONNECT:
                 assert normalized_id == "abc"
             else:
+                # Identifier should be unchanged for other platforms
                 assert normalized_id == "ABC"

--- a/apps/channels/tests/test_models.py
+++ b/apps/channels/tests/test_models.py
@@ -169,3 +169,19 @@ def test_get_team_evaluations_channel(team_with_users):
     # Should return the same channel on subsequent calls
     channel2 = ExperimentChannel.objects.get_team_evaluations_channel(team)
     assert channel.id == channel2.id
+
+
+class TestChannelPlatform:
+    def test_normalize_identifier(self):
+        identifier = "abc"
+        for platform in ChannelPlatform:
+            normalized_id = platform.normalize_identifier(identifier)
+            assert normalized_id == "abc"
+
+        identifier = "ABC"
+        for platform in ChannelPlatform:
+            normalized_id = platform.normalize_identifier(identifier)
+            if platform == ChannelPlatform.COMMCARE_CONNECT:
+                assert normalized_id == "abc"
+            else:
+                assert normalized_id == "ABC"


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Fixes the likes of https://dimagi.sentry.io/issues/6899765887/?alert_rule_id=14063560&alert_type=issue&notification_uuid=895720d3-e699-4bb7-8914-953518595062&project=4505001320316928&referrer=issue_alert-slack

### What happened?
Connect treats connect ids as case insensitive, but OCS did not. So when the first call to register the participant arrived (with uppercase identifier), OCS created the particpant, registered the participant at connect and received a channel ID for this participant. We then stored it in the participant data for this participant.

When the second call came in 28 mins later, the identifier was lower case, so we created a new participant, registered them at connect, but connect returned the same channel ID as before (since it already exists in that world), so we then linked this same channel ID to the new participant's data.

In the failing call, we assume that there's a single participant data record with the received channel ID (which is correct), but OCS now created separate participant data records with the same channel ID

## User Impact
<!-- Describe the impact of this change on the end-users. -->
N/A

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A. See the test

### Docs and Changelog
<!--Link to documentation that has been updated.-->
Pending