### PR TITLE
update db pool settings and disable pool in celery

### DIFF
--- a/gpt_playground/celery.py
+++ b/gpt_playground/celery.py
@@ -3,8 +3,9 @@ import os
 from celery import Celery
 from celery.app import trace
 
-# Use connection pooling
-# os.environ.setdefault("DJANGO_DATABASE_CONN_MAX_AGE", "10")
+# Don't use connection pooling in Celery
+os.environ["DJANGO_DATABASE_USE_POOL"] = "false"
+os.environ["DJANGO_DATABASE_CONN_MAX_AGE"] = "30"
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gpt_playground.settings")

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -222,13 +222,11 @@ else:
 db_options = DATABASES["default"].setdefault("OPTIONS", {})
 if env.bool("DJANGO_DATABASE_USE_POOL", True):
     DATABASES["default"].pop("CONN_MAX_AGE", None)
+    # See https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool
     db_options["pool"] = {
         "min_size": env.int("DJANGO_DATABASE_POOL_MIN_SIZE", default=2),
         "max_size": env.int("DJANGO_DATABASE_POOL_MAX_SIZE", default=35),
         "timeout": env.int("DJANGO_DATABASE_POOL_TIMEOUT", default=10),
-        "max_idle": 300,
-        "max_lifetime": 3600,
-        "reconnect_failed": True,
     }
 else:
     DATABASES["default"]["CONN_MAX_AGE"] = env.int("DJANGO_DATABASE_CONN_MAX_AGE", 0)

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -220,9 +220,7 @@ else:
     }
 
 db_options = DATABASES["default"].setdefault("OPTIONS", {})
-if conn_max_age := env.int("DJANGO_DATABASE_CONN_MAX_AGE", None):
-    DATABASES["default"]["CONN_MAX_AGE"] = conn_max_age
-else:
+if env.bool("DJANGO_DATABASE_USE_POOL", True):
     DATABASES["default"].pop("CONN_MAX_AGE", None)
     db_options["pool"] = {
         "min_size": env.int("DJANGO_DATABASE_POOL_MIN_SIZE", default=2),
@@ -232,6 +230,8 @@ else:
         "max_lifetime": 3600,
         "reconnect_failed": True,
     }
+else:
+    DATABASES["default"]["CONN_MAX_AGE"] = env.int("DJANGO_DATABASE_CONN_MAX_AGE", 0)
 
 # Auth / login stuff
 

--- a/gpt_playground/settings.py
+++ b/gpt_playground/settings.py
@@ -228,6 +228,9 @@ else:
         "min_size": env.int("DJANGO_DATABASE_POOL_MIN_SIZE", default=2),
         "max_size": env.int("DJANGO_DATABASE_POOL_MAX_SIZE", default=35),
         "timeout": env.int("DJANGO_DATABASE_POOL_TIMEOUT", default=10),
+        "max_idle": 300,
+        "max_lifetime": 3600,
+        "reconnect_failed": True,
     }
 
 # Auth / login stuff


### PR DESCRIPTION
## Description
We are using gevent in Celery with a concurrency of 100 so potentially would need to set the pool size to 100.

Rather than that we've deployed a DB proxy (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) to manage connection pooling.

## User Impact
No more DB connection errors
