### PR TITLE
Ensure connect id is always lower case

### DIFF
--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -34,7 +34,7 @@ def generate_key(request: Request):
     response = httpx.get(settings.COMMCARE_CONNECT_GET_CONNECT_ID_URL, headers={"AUTHORIZATION": token})
     connect_logger.info(f"CommCare Connect response: {response.status_code}")
     response.raise_for_status()
-    connect_id = response.json().get("sub")
+    connect_id = response.json().get("sub").lower()
 
     try:
         participant_data = ParticipantData.objects.defer("data").get(

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -135,6 +135,7 @@ def trigger_bot_message(request):
     data = serializer.data
     platform = data["platform"]
     identifier = data["identifier"]
+    identifier = ChannelPlatform(platform).normalize_identifier(identifier)
     experiment_public_id = data["experiment"]
 
     experiment = get_object_or_404(Experiment, public_id=experiment_public_id, team=request.team)


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
I found another place where the connect id can be upper case. Since we now always expect the lower case version of the connect id, we should always make sure to use the lower case.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users whose phone sends upper case connect ids should continue to work as normal.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
Pending