### PR TITLE
Sort attachments by name

### DIFF
--- a/apps/api/tests/test_session_api.py
+++ b/apps/api/tests/test_session_api.py
@@ -136,6 +136,7 @@ def test_retrieve_session(session):
 
     for message in response_json.get("messages", []):
         message["created_at"] = "fake date"
+        message["attachments"] = sorted(message["attachments"], key=lambda x: x["name"])
 
     assert response_json == get_session_json(
         session,


### PR DESCRIPTION
I was getting a test failure (that also seems to be present `main`, where these attachments weren't in the same order).