### PR TITLE
Remove experiment and safety layers from sidebar nav

### DIFF
--- a/templates/web/components/team_nav.html
+++ b/templates/web/components/team_nav.html
@@ -125,21 +125,6 @@
       </a>
     </li>
   {% endflag %}
-  <li>
-    <a href="{% url 'experiments:experiments_home' request.team.slug %}"{% if active_tab == 'experiments' %}class="menu-active"{% endif %}>
-      <i class="fa fa-flask fa-fw"></i>
-      {% translate "Experiments" %}
-    </a>
-    <ul>
-      <li>
-        <a href="{% url 'experiments:safety_home' request.team.slug %}"
-           {% if active_tab == 'safety_layers' %}class="menu-active"{% endif %}>
-          <i class="fa fa-shield fa-fw"></i>
-          {% translate "Safety Layers" %}
-        </a>
-      </li>
-    </ul>
-  </li>
   {% flag "flag_evaluations" %}
     <li>
       <a href="{% url 'evaluations:home' request.team.slug %}" {% if active_tab == 'evaluations' %}class="menu-active"{% endif %}>


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
<img width="298" height="691" alt="Screenshot 2025-10-06 at 12 30 49 PM" src="https://github.com/user-attachments/assets/f6424761-933a-401a-9157-b817aefdea99" />
removes "Experiments" and the nested "Safety Layers"

## User Impact
<!-- Describe the impact of this change on the end-users. -->
can no longer navigate from the sidebar navigation

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/181
