### PR TITLE
Fix: Evals page is sometimes getting stuck in pending

### DIFF
--- a/templates/evaluations/evaluation_result_home.html
+++ b/templates/evaluations/evaluation_result_home.html
@@ -5,7 +5,7 @@
   {{ block.super }}
   {% if group_job_id %}
     <script src="{% static 'celery_progress/celery_progress.js' %}"></script>
-  {% elif evaluation_run.status == "pending" %}
+  {% elif evaluation_run.status == "pending" or evaluation_run.status == "processing" %}
      <meta http-equiv="refresh" content="2" />
   {% endif %}
 {% endblock page_head %}


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Fixes #2183

See [this code](https://github.com/dimagi/open-chat-studio/blob/fdb59cc8da9734b13aedf54b29dff06320bdedf3/templates/evaluations/evaluation_result_home.html#L4-L11) for context. We currently tell the browser to refresh every 2 seconds when `group_job_id` is missing and the eval's run status is `pending`. When a [preview run is spawned](https://github.com/dimagi/open-chat-studio/blob/c7bef3cb8d0126cbe7ba2ef35d36baee978866bc/apps/evaluations/models.py#L306-L308), it creates a run with status `pending` and then calls the `run_evaluation_task` task. This task then updates the status to `processing` [here](https://github.com/dimagi/open-chat-studio/blob/a37d569992c925497ebb824af9c271527f3d0282/apps/evaluations/tasks.py#L172-L173). At this time, the `group_job_id` is still empty. This only gets updated [later in this task](https://github.com/dimagi/open-chat-studio/blob/a37d569992c925497ebb824af9c271527f3d0282/apps/evaluations/tasks.py#L200). When [the code inbetween](https://github.com/dimagi/open-chat-studio/blob/a37d569992c925497ebb824af9c271527f3d0282/apps/evaluations/tasks.py#L175-L198) is being executed and the browser happens to reload the page at the same time, it creates a condition where [both conditions](https://github.com/dimagi/open-chat-studio/blob/fdb59cc8da9734b13aedf54b29dff06320bdedf3/templates/evaluations/evaluation_result_home.html#L4-L11)  evaluate to `False`, so the brower will never know that it should fetch the page again or check the celery progress.

By including a check for the `processing` status, the browser will be instructed to reload the page when the `group_job_id` is missing and the status is `processing`.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
User should be able to see the browser reload until the celery task progress is being shown.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/182