### PR TITLE
Rate limit eval single message eval task

### DIFF
--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -33,7 +33,7 @@ from apps.teams.utils import current_team
 logger = logging.getLogger("ocs.evaluations")
 
 
-@shared_task(base=TaskbadgerTask)
+@shared_task(base=TaskbadgerTask, rate_limit="1/s")
 def evaluate_single_message_task(evaluation_run_id, evaluator_ids, message_id):
     """
     Run all evaluations over a single message.


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

Fixes #2291

Use celery's rate limit setting to rate limit `evaluate_single_message_task` by 1/s. This is 1/s for _each worker_. We currently run max 5 celery workers, so worst case will put a load of 5 runs per second = 10 messages per second (AI + human) extra on the system (our normal load in the last 3 months were about 2 messages per second.)

There are other DB calls that are made during this run as well, putting more load on the DB, but I think this is a good starting point. We can always tweak this number. `0.5/s` for instance is allowed.

As for the other things mentioned in the ticket: I don't think using a separate queue is necessary. It's just complicating things unnecessarily

I'm not sure if this is the best long term solution, but for now I think it is enough

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Evals might be slower, but the system will be more stable during this time.

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
Pending