### PR TITLE
Include node data in sentry error

### DIFF
--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, ClassVar
 
 import emoji
 import requests
-import sentry_sdk
 from django.conf import settings
 from django.db import transaction
 from django.http import Http404
@@ -140,7 +139,6 @@ class ChannelBase(ABC):
         self._participant_identifier = experiment_session.participant.identifier if experiment_session else None
         self._is_user_message = False
         self.trace_service = TracingService.create_for_experiment(self.experiment)
-        sentry_sdk.set_context("chatbot", {"team_slug": experiment.team.slug, "experiment": experiment.id})
 
     @property
     def participant_id(self) -> int | None:


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Resolves #2275

I see we do have the experiment id under `Additional Data` most of the time. I suspect that if it's missing there, any custom logging of it will also be missing, which is why I removed logging it in the second commit. Happy to be wrong.

## User Impact
<!-- Describe the impact of this change on the end-users. -->
N/A

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
See https://dimagi.sentry.io/issues/6943776933/?project=4505001320316928&query=is%3Aunresolved&referrer=issue-stream

### Docs and Changelog
<!--Link to documentation that has been updated.-->
N/A