### PR TITLE
Load alpine store for spans into the page header

### DIFF
--- a/templates/trace/trace_detail.html
+++ b/templates/trace/trace_detail.html
@@ -131,23 +131,26 @@
         </div>
     </div>
 </div>
-
-<script>
-    document.addEventListener('alpine:init', () => {
-        Alpine.store('spanDrawer', {
-            isOpen: false,
-            spanId: null,
-
-            open(spanId) {
-                this.spanId = spanId;
-                this.isOpen = true;
-            },
-
-            close() {
-                this.isOpen = false;
-                this.spanId = null;
-            }
-        });
-    });
-</script>
 {% endblock app %}
+
+{% block page_head %}
+    {{ block.super }}
+    <script>
+        document.addEventListener('alpine:init', () => {
+            Alpine.store('spanDrawer', {
+                isOpen: false,
+                spanId: null,
+
+                open(spanId) {
+                    this.spanId = spanId;
+                    this.isOpen = true;
+                },
+
+                close() {
+                    this.isOpen = false;
+                    this.spanId = null;
+                }
+            });
+        });
+    </script>
+{% endblock page_head %}


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->

In the dimagi-dev group, we noticed this error when loading a trace:
<img width="654" height="172" alt="image" src="https://github.com/user-attachments/assets/fa5339a3-b860-4946-aa77-0ba5a3183ac7" />

I hope this will fix this issue. I suspect a script load timing issue

## User Impact
<!-- Describe the impact of this change on the end-users. -->
We'll see

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
N/A