### PR TITLE
limit evals to 10 concurrent tasks

### DIFF
--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -1,5 +1,6 @@
 import csv
 import logging
+import math
 from collections import defaultdict
 from collections.abc import Iterable
 from datetime import timedelta
@@ -189,7 +190,7 @@ def run_evaluation_task(evaluation_run_id):
 
             # Create chord with group and callback
             concurrency_limit = 10
-            chunk_size = max(1, len(messages) // concurrency_limit)
+            chunk_size = math.ceil(len(messages) / concurrency_limit)
             evaluator_ids = [e.id for e in evaluators]
             chord_result = chord(
                 evaluate_single_message_task.chunks(


### PR DESCRIPTION
## Description
The previous implementation chunked the tasks into groups of 5 so for a dataset with 500 messages that would be 100 concurrent tasks.

This changes that to limit the number of chunks to a maximum of 10.

## User Impact
Slower evals but less overall load on the system.

