### PR TITLE
Add key attribute to widget

### DIFF
--- a/components/chat_widget/src/components.d.ts
+++ b/components/chat_widget/src/components.d.ts
@@ -44,6 +44,10 @@ export namespace Components {
          */
         "iconUrl"?: string;
         /**
+          * Authentication key for embedded channels
+         */
+        "embedKey"?: string;
+        /**
           * The language code for the widget UI (e.g., 'en', 'es', 'fr'). Defaults to en
          */
         "language"?: string;
@@ -145,6 +149,10 @@ declare namespace LocalJSX {
           * URL of the icon to display on the button. If not provided, uses the default OCS logo.
          */
         "iconUrl"?: string;
+        /**
+          * Authentication key for embedded channels
+         */
+        "embedKey"?: string;
         /**
           * The language code for the widget UI (e.g., 'en', 'es', 'fr'). Defaults to en
          */

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -117,6 +117,11 @@ export class OcsChat {
   @Prop() iconUrl?: string;
 
   /**
+   * Authentication key for embedded channels
+   */
+  @Prop() embedKey?: string;
+
+  /**
    * The shape of the chat button. 'round' makes it circular, 'square' keeps it rectangular.
    */
   @Prop() buttonShape: 'round' | 'square' = 'square';
@@ -363,7 +368,9 @@ export class OcsChat {
     if (csrfToken) {
       headers['X-CSRFToken'] = csrfToken;
     }
-
+    if (this.embedKey) {
+      headers['X-Embed-Key'] = this.embedKey;
+    }
     return headers;
   }
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
widget only related functionality paired with https://github.com/dimagi/open-chat-studio/pull/2150

This should be merged prior to other PR, then a new widget release, then the other PR can be merged

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Users can add an `embed_key` attribute

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->

### Docs and Changelog
<!--Link to documentation that has been updated.-->
yes https://github.com/dimagi/open-chat-studio-docs/compare/widget-docs?expand=1 
