### PR TITLE
Ensure timeout triggers are spaced out by the delay amount

### DIFF
--- a/apps/events/tests/test_timeout_trigger.py
+++ b/apps/events/tests/test_timeout_trigger.py
@@ -142,10 +142,13 @@ def test_trigger_count_reached(session):
         session.save()
         frozen_time.shift(delta=timedelta(minutes=11))
 
-        timeout_trigger.event_logs.create(session=session, chat_message=message, status=EventLogStatusChoices.SUCCESS)
         assert len(timeout_trigger.timed_out_sessions()) == 1
+
+        # Suppose there's a failed attempt, then the timeout should still trigger
         timeout_trigger.event_logs.create(session=session, chat_message=message, status=EventLogStatusChoices.FAILURE)
         assert len(timeout_trigger.timed_out_sessions()) == 1
+
+        # Suppose there's a success attempt, then the timeout should not trigger
         timeout_trigger.event_logs.create(session=session, chat_message=message, status=EventLogStatusChoices.SUCCESS)
         assert len(timeout_trigger.timed_out_sessions()) == 0
 


### PR DESCRIPTION
## Description
<!-- A summary of the change, the reason for its implementation, and relevent links. 
Include technical details required to understand the change. -->
Fixes #2352

Testing the behaviour of the timeout feature, I noticed that the timeout trigger respects the delay time only once and after that the trigger is triggered **each time** the timeout task runs. This is because we only considered the time when the human message was created and compare that to the delay. This doesn't seem right to me, because the bot is sending messages each time the timeout task runs after the first trigger.

#### The new behaviour
The timeout trigger now respects the delay constantly.

```
if successful timeout log exists for this message and successful timeout log was created before "timeout delay" seconds ago:
    trigger
else if last human message created at before "timeout delay" seconds ago
    trigger
```

## User Impact
<!-- Describe the impact of this change on the end-users. -->
Timeout triggers will be spaced out by "delay seconds".

### Demo
<!-- If relevent, include screenshots or a loom video to demonstrate the new behavior
**Include step-by-step instructions to enable functionality of the change-->
N/A

### Docs and Changelog
<!--Link to documentation that has been updated.-->
https://github.com/dimagi/open-chat-studio-docs/pull/193