### PR TITLE
Fix form submit button and filter dialogs

### DIFF
--- a/templates/evaluations/dataset_create_form.html
+++ b/templates/evaluations/dataset_create_form.html
@@ -20,9 +20,9 @@
           <div class="mb-4">
             <div class="flex items-center justify-between">
               <div>
-                {% include "experiments/filters.html" %}
+                {% include "experiments/filters.html" with skip_dialogs=True %}
               </div>
-              
+
               <div class="flex items-center gap-3">
                 <div x-show="selectedSessionIds.size + filteredSessionIds.size > 0" class="text-sm font-medium">
                   <span x-text="selectedSessionIds.size + filteredSessionIds.size"></span> session<span x-show="selectedSessionIds.size + filteredSessionIds.size !== 1">s</span> selected
@@ -303,6 +303,15 @@
     </dialog>
   </div> <!-- End of datasetBuilder div -->
 {% endblock form %}
+
+{% block post_form %}
+  {# Filter dialogs must be outside form to avoid nested forms but need filterComponent context #}
+  {# Create a separate filterComponent instance - it will sync via API and URL params #}
+  <div x-data="filterComponent">
+    {% include "filters/saved_filters_dialog.html" %}
+    {% include "filters/save_filter_dialog.html" %}
+  </div>
+{% endblock post_form %}
 
 {% block page_js %}
   <script src="{% static 'js/editors-bundle.js' %}"></script>
@@ -926,4 +935,3 @@
 
   </script>
 {% endblock page_js %}
-

--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -220,8 +220,10 @@
       </div>
     </div>
   </div>
-  {% include "filters/saved_filters_dialog.html" %}
-  {% include "filters/save_filter_dialog.html" %}
+  {% if not skip_dialogs %}
+    {% include "filters/saved_filters_dialog.html" %}
+    {% include "filters/save_filter_dialog.html" %}
+  {% endif %}
 </div>
 
 {{ df_date_range_options|json_script:"date-range-options" }}

--- a/templates/filters/save_filter_dialog.html
+++ b/templates/filters/save_filter_dialog.html
@@ -3,7 +3,7 @@
   <dialog id="saveFilterDialog" class="modal">
     <div class="modal-box max-w-md bg-base-100 border border-base-300">
       <div class="flex items-center justify-between mb-6">
-        <h3 class="font-bold text-lg text-base-content">{% trans "Create Filter Set" %}</h3>
+        <h3 class="font-bold text-lg text-base-content">{% translate "Create Filter Set" %}</h3>
         <form method="dialog">
           <button class="btn btn-sm btn-ghost text-base-content hover:bg-base-200">✕</button>
         </form>
@@ -14,13 +14,13 @@
         {% csrf_token %}
         <input type="hidden" name="filter_query_string" value="{{ request.GET.urlencode }}" />
         <div class="mb-6">
-          <label class="block text-sm font-medium text-base-content mb-2">{% trans "Name" %}</label>
+          <label class="block text-sm font-medium text-base-content mb-2">{% translate "Name" %}</label>
           <input
             type="text" 
             x-model="filterName"
             id="filterSetName" 
             class="input input-bordered w-full bg-base-100 border-base-300 text-base-content placeholder-base-content/60 focus:border-primary" 
-            placeholder='{% trans "Name" %}'
+            placeholder='{% translate "Name" %}'
             required>
         </div>
         
@@ -30,7 +30,7 @@
               type="button"
               @click="closeDialog()"
               class="btn btn-ghost text-base-content hover:bg-base-200">
-              {% trans "Cancel" %}
+              {% translate "Cancel" %}
             </button>
           </form>
           <button 
@@ -39,7 +39,7 @@
             :class="{ 'loading': isLoading }"
             :disabled="isLoading"
             id="saveFilterBtn">
-            <span x-show="!isLoading">{% trans "Save" %}</span>
+            <span x-show="!isLoading">{% translate "Save" %}</span>
             <span x-show="isLoading">Saving...</span>
           </button>
         </div>
@@ -78,7 +78,7 @@
           });
           this.response = await response.json();
           this.savedFilters.push(this.response.filter_set)
-          
+
           if (response.ok) {
             alertify.notify('Filter saved!', 'success', 10);
             this.closeDialog();


### PR DESCRIPTION
### Technical Description
The filters.html template includes dialog templates that contain form elements. When filters.html was included inside the dataset creation form, this created nested forms which is invalid HTML. Browsers automatically close the outer form when encountering a nested form, causing the submit button to end up outside the form element.

Additionally, the filter dialogs need access to the filterComponent Alpine.js context for their bindings to work.

Solution:
- Add skip_dialogs parameter to filters.html include
- Conditionally skip dialog includes in filters.html when skip_dialogs=True
- Include filter dialogs in post_form block (outside main form)
- Wrap dialogs with filterComponent Alpine context using x-data

The separate filterComponent instance in post_form will stay in sync with the one inside the form via shared API calls and URL parameters.

#### Consequences
One consequence of this is that the dialogs have separate Apline contexts from the main filters dropdown so updates made in the dialogs don't propagate e.g. starring a filter set doesn't update in the filter view without a refresh.

This seems acceptable for now.

### Docs and Changelog
- [x] This PR requires docs/changelog update