### PR TITLE
Allow auto-creation of participants in trigger_bot_message API

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -594,15 +594,16 @@ paths:
             examples:
               GenerateBotMessageAndSend:
                 value:
-                  identifier: part1
+                  identifier: '+15556793'
                   experiment: exp1
-                  platform: connect_messaging
+                  platform: whatsapp
                   prompt_text: Tell the user to do something
                   session_data:
                     key: value
                   participant_data:
                     key: value
-                summary: Generates a bot message and sends it to the user
+                summary: Generates a bot message and sends it to the user (auto-creates
+                  participant if needed).
               ParticipantNotFound:
                 value:
                   detail: Participant not found


### PR DESCRIPTION
This change enables the trigger_bot_message API to automatically create participants if they don't exist, supporting the auto-consent flow from CommCare Connect.

Changes:
- Auto-create Participant if it doesn't exist for any platform
- Auto-create ParticipantData for COMMCARE_CONNECT platform
- Call setup_connect_channels_for_bots synchronously to fetch consent status from CCC before proceeding
- Maintain existing consent check to honor consent workflow
- Update API documentation to reflect auto-creation behavior
- Add tests for auto-creation with and without consent

This allows immediate message sending when auto-consent is enabled in CCC, while still enforcing the consent workflow when auto-consent is disabled.

Fixes #2366

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->

### Technical Description
<!--
A summary of the change, the reason for its implementation, and relevant links. 
Include technical details required to understand the change.
-->

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
