### PR TITLE
Truncate queryset results more than 10

### DIFF
--- a/apps/experiments/versioning.py
+++ b/apps/experiments/versioning.py
@@ -82,11 +82,18 @@ class VersionField:
         if self.queryset is None:
             return []
 
+        return [VersionField(raw_value=record, to_display=self.to_display) for record in self.queryset.all()]
+
+    @property
+    def queryset_results_for_display(self) -> list["VersionField"]:
+        """
+        This method is used to display queryset results in the version comparison UI. It limits the number of results
+        shown for performance reasons.
+        """
+        # Start by showing those fields that changed
         self.num_results_truncated = max(0, self.queryset.count() - self.NUM_QUERYSET_RESULTS_TO_SHOW)
-        return [
-            VersionField(raw_value=record, to_display=self.to_display)
-            for record in self.queryset.all()[: self.NUM_QUERYSET_RESULTS_TO_SHOW]
-        ]
+        changed_results = sorted(self.queryset_results, key=lambda x: x.changed, reverse=True)
+        return changed_results[: self.NUM_QUERYSET_RESULTS_TO_SHOW]
 
     def __post_init__(self):
         self.label = self.name.replace("_", " ").title()

--- a/templates/experiments/components/versions/compare.html
+++ b/templates/experiments/components/versions/compare.html
@@ -13,7 +13,7 @@
                                     <dd class="pl-3 overflow-y-auto">
                                         {% if field.queryset_results %}
                                             <div class="flex flex-col gap-1">
-                                                {% for result in field.queryset_results %}
+                                                {% for result in field.queryset_results_for_display %}
                                                     {% include "experiments/components/versions/version_field.html" with field=result %}
                                                 {% endfor %}
                                             </div>


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->

### Technical Description
<!--
A summary of the change, the reason for its implementation, and relevant links. 
Include technical details required to understand the change.
-->
Fixes #2382 

With large queryset result sets for a versioned field, the versioning UI becomes unresponsive. This has been pinpointed to codemirror having to create an instance for each result in the result set which causes the page to break. Assuming that users are not going to be looking at each result in large result sets, we now truncate those result sets to only show 10 items and inform the user about how many were truncated.

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
<img width="1182" height="502" alt="image" src="https://github.com/user-attachments/assets/14e82caa-a072-44a6-aa0b-ab24892513fe" />


### Docs and Changelog
- [x] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
