### PR TITLE
Langfuse v3

### DIFF
--- a/apps/service_providers/tests/test_langfuse_client_manager.py
+++ b/apps/service_providers/tests/test_langfuse_client_manager.py
@@ -34,7 +34,13 @@ def mock_client_registry():
 @pytest.fixture()
 def langfuse_mock(mock_client_registry):
     """Mock the Langfuse client."""
-    with mock.patch("langfuse.Langfuse", side_effect=mock_client_registry) as mock_langfuse:
+    with (
+        mock.patch(
+            "apps.service_providers.tracing.langfuse._create_client_from_instance",
+            new=lambda instance, public_key: instance,
+        ),
+        mock.patch("langfuse.Langfuse", side_effect=mock_client_registry) as mock_langfuse,
+    ):
         yield mock_langfuse
 
 

--- a/apps/service_providers/tests/test_langfuse_client_manager.py
+++ b/apps/service_providers/tests/test_langfuse_client_manager.py
@@ -4,21 +4,46 @@ import time
 from unittest import mock
 
 import pytest
+from langfuse._client.resource_manager import LangfuseResourceManager
 
 from apps.service_providers.tracing.langfuse import ClientManager
 
 
+def mock_client_factory():
+    """Factory method that creates mock clients and 'registers' them with the LangfuseResourceManager"""
+
+    def mock_register_client(**kwargs):
+        public_key = kwargs["public_key"]
+        if public_key not in mock_register_client.registry:
+            mock_register_client.registry[public_key] = mock.MagicMock(name=public_key)
+            with LangfuseResourceManager._lock:
+                LangfuseResourceManager._instances[public_key] = mock_register_client.registry[public_key]
+
+        return mock_register_client.registry[public_key]
+
+    mock_register_client.registry = {}
+
+    return mock_register_client
+
+
 @pytest.fixture()
-def langfuse_mock():
+def mock_client_registry():
+    return mock_client_factory()
+
+
+@pytest.fixture()
+def langfuse_mock(mock_client_registry):
     """Mock the Langfuse client."""
-    with mock.patch("langfuse.Langfuse") as mock_langfuse:
+    with mock.patch("langfuse.Langfuse", side_effect=mock_client_registry) as mock_langfuse:
         yield mock_langfuse
 
 
 @pytest.fixture()
 def client_manager():
     """Return a ClientManager with a short timeout for testing."""
-    return ClientManager(stale_timeout=1)
+    manager = ClientManager(stale_timeout=0.5)
+    yield manager
+    manager.shutdown()
 
 
 @pytest.fixture()
@@ -27,13 +52,14 @@ def config():
     return {"public_key": "test_key", "secret_key": "test_secret"}
 
 
-def test_get_creates_new_client(client_manager, config, langfuse_mock):
+def test_get_creates_new_client(client_manager, config, langfuse_mock, mock_client_registry):
     # Act
     client = client_manager.get(config)
 
     # Assert
     langfuse_mock.assert_called_with(**config)
-    assert client == langfuse_mock.return_value
+    assert len(mock_client_registry.registry) == 1
+    assert client == mock_client_registry.registry[config["public_key"]]
     assert len(client_manager.clients) == 1
 
 
@@ -54,15 +80,6 @@ def test_get_creates_different_clients_for_different_configs(client_manager, con
     # Arrange
     other_config = {"public_key": "other_key", "secret_key": "other_secret"}
 
-    # Need different return values for different configs
-    def side_effect(**kwargs):
-        if kwargs["public_key"] == "test_key":
-            return mock.MagicMock(name="client1")
-        else:
-            return mock.MagicMock(name="client2")
-
-    langfuse_mock.side_effect = side_effect
-
     # Act
     first_client = client_manager.get(config)
     second_client = client_manager.get(other_config)
@@ -73,59 +90,37 @@ def test_get_creates_different_clients_for_different_configs(client_manager, con
 
 
 def test_prune_stale_clients(client_manager, config, langfuse_mock):
-    # Set up different clients for different configs
-    def side_effect(**kwargs):
-        if kwargs["public_key"] == "test_key":
-            return mock.MagicMock(name="client1")
-        else:
-            return mock.MagicMock(name="client2")
-
-    langfuse_mock.side_effect = side_effect
-
     # Arrange
     other_config = {"public_key": "other_key", "secret_key": "other_secret"}
     first_client = client_manager.get(config)
 
-    time.sleep(0.5)
+    time.sleep(0.4)
     client_manager.get(other_config)  # Get second client
     assert len(client_manager.clients) == 2
 
-    # Act
-    time.sleep(0.6)  # Sleep longer than the stale timeout
+    time.sleep(0.1)  # Sleep longer than the stale timeout
     client_manager._prune_stale()
 
-    # Assert
     assert len(client_manager.clients) == 1
     first_client.shutdown.assert_called_once()
 
 
-def test_max_clients_limit(client_manager, langfuse_mock):
+def test_max_clients_limit(client_manager, langfuse_mock, mock_client_registry):
     """Test that the max_clients limit is enforced by removing oldest client."""
     # Arrange
     client_manager.max_clients = 3
 
     # Create unique mock clients that return different timestamps
-    clients = []
     configs = []
 
     for i in range(4):
         config = {"public_key": f"key_{i}", "secret_key": f"secret_{i}"}
         configs.append(config)
 
-        client = mock.MagicMock(name=f"client{i}")
-        clients.append(client)
-
-    def side_effect(**kwargs):
-        for i, c in enumerate(configs):
-            if kwargs["public_key"] == c["public_key"]:
-                return clients[i]
-        return mock.MagicMock()
-
-    langfuse_mock.side_effect = side_effect
-
     # Add clients with increasing timestamps
+    clients = []
     for config in configs:
-        client_manager.get(config)
+        clients.append(client_manager.get(config))
         time.sleep(0.1)  # Ensure timestamps are different
 
     assert len(client_manager.clients) == 4
@@ -138,10 +133,10 @@ def test_max_clients_limit(client_manager, langfuse_mock):
     clients[0].shutdown.assert_called_once()  # The oldest client should be shut down
 
     # The remaining clients should be the newer ones
-    remaining_clients = [c[1] for c in client_manager.clients.values()]
-    assert clients[1] in remaining_clients
-    assert clients[2] in remaining_clients
-    assert clients[3] in remaining_clients
+    assert configs[0]["public_key"] not in client_manager.clients
+    assert configs[1]["public_key"] in client_manager.clients
+    assert configs[2]["public_key"] in client_manager.clients
+    assert configs[3]["public_key"] in client_manager.clients
 
 
 def test_prune_thread_starts_automatically(langfuse_mock):
@@ -159,10 +154,9 @@ def test_prune_thread_starts_automatically(langfuse_mock):
         thread_mock.return_value.start.assert_called_once()
 
 
-def test_thread_safety_with_concurrent_access(langfuse_mock):
+def test_thread_safety_with_concurrent_access(client_manager, langfuse_mock):
     """Test that the ClientManager is thread-safe with concurrent access."""
     # Arrange
-    client_manager = ClientManager()
     configs = [{"public_key": f"key_{i}", "secret_key": f"secret_{i}"} for i in range(10)]
 
     results = []

--- a/apps/service_providers/tracing/langfuse.py
+++ b/apps/service_providers/tracing/langfuse.py
@@ -38,7 +38,6 @@ class LangFuseTracer(Tracer):
         super().__init__(type_, config)
         self.client = None
         self.trace_record = None
-        self.spans: dict[UUID, Any] = {}
 
     @property
     def ready(self) -> bool:
@@ -99,7 +98,6 @@ class LangFuseTracer(Tracer):
                 # Reset state
                 self.client = None
                 self.trace_record = None
-                self.spans.clear()
                 self.trace_record_name = None
                 self.trace_record_id = None
                 self.session = None
@@ -126,12 +124,9 @@ class LangFuseTracer(Tracer):
             metadata=metadata,
             level=level,
         ) as span:
-            self.spans[span_context.id] = span
-
             try:
                 yield span_context
             finally:
-                self.spans.pop(span_context.id, None)
                 if output := span_context.outputs:
                     span.update(output=output.copy())
 

--- a/apps/service_providers/tracing/langfuse.py
+++ b/apps/service_providers/tracing/langfuse.py
@@ -210,7 +210,8 @@ class ClientManager:
             self.key_timestamps.pop(public_key)
 
     def shutdown(self):
-        logger.debug("Shutting down all langfuse clients (%s)", len(self.key_timestamps))
+        if self.key_timestamps:
+            logger.debug("Shutting down all langfuse clients (%s)", len(self.key_timestamps))
         with LangfuseResourceManager._lock:
             LangfuseResourceManager.reset()
             self.key_timestamps.clear()

--- a/apps/service_providers/tracing/service.py
+++ b/apps/service_providers/tracing/service.py
@@ -120,7 +120,6 @@ class TracingService:
                         )
                     except Exception:
                         logger.exception("Error initializing tracer %s", tracer.__class__.__name__)
-                        # ExitStack ensures already-entered tracers get cleaned up
 
                 sentry_sdk.set_context("Traces", self.get_trace_metadata())
 

--- a/uv.lock
+++ b/uv.lock
@@ -1590,6 +1590,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
+]
+
+[[package]]
 name = "inflection"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1877,21 +1889,23 @@ wheels = [
 
 [[package]]
 name = "langfuse"
-version = "2.60.7"
+version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
     { name = "backoff" },
     { name = "httpx" },
-    { name = "idna" },
+    { name = "openai" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "packaging" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/f6/536ac1159e90d6ed16da10fd27225d523c01727e55e557c07b7c5ec5b201/langfuse-2.60.7.tar.gz", hash = "sha256:440783af444cc74efabfcd5c018d3da6080deaea2c9fb3ed3e40c47454250ede", size = 152436, upload-time = "2025-05-27T11:04:59.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/c6/1bdb6c68ebc2b7d3875861cf99715e227bcd909a758df8af329f81f6e7af/langfuse-3.9.0.tar.gz", hash = "sha256:ed02744ab184a320dba5662be09be21441a467cc84db7e9a67c8bb6baec9fb5c", size = 201850, upload-time = "2025-11-03T10:25:49.577Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/e6/62091c18531bd2024d28851ca6eb79668f1835c5376769ce4b0b285d6838/langfuse-2.60.7-py3-none-any.whl", hash = "sha256:9434cd2a8858b6a656ea0de9ad0b469dc5211d6e32a0d5e27aff56034f8d0e41", size = 275447, upload-time = "2025-05-27T11:04:57.394Z" },
+    { url = "https://files.pythonhosted.org/packages/66/de/66ab298aecc0b50465824e7db5df77e43f872dcd8642d3c91d11be3ac6f7/langfuse-3.9.0-py3-none-any.whl", hash = "sha256:de46c47717822de46ad4a2563be5d775ca896dc4d0955a83b4d12e1ce5e249a9", size = 369620, upload-time = "2025-11-03T10:25:47.747Z" },
 ]
 
 [[package]]
@@ -2671,6 +2685,88 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/d8/0f354c375628e048bd0570645b310797299754730079853095bf000fba69/opentelemetry_api-1.38.0.tar.gz", hash = "sha256:f4c193b5e8acb0912b06ac5b16321908dd0843d75049c091487322284a3eea12", size = 65242, upload-time = "2025-10-16T08:35:50.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a2/d86e01c28300bd41bab8f18afd613676e2bd63515417b77636fc1add426f/opentelemetry_api-1.38.0-py3-none-any.whl", hash = "sha256:2891b0197f47124454ab9f0cf58f3be33faca394457ac3e09daba13ff50aa582", size = 65947, upload-time = "2025-10-16T08:35:30.23Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/83/dd4660f2956ff88ed071e9e0e36e830df14b8c5dc06722dbde1841accbe8/opentelemetry_exporter_otlp_proto_common-1.38.0.tar.gz", hash = "sha256:e333278afab4695aa8114eeb7bf4e44e65c6607d54968271a249c180b2cb605c", size = 20431, upload-time = "2025-10-16T08:35:53.285Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/9e/55a41c9601191e8cd8eb626b54ee6827b9c9d4a46d736f32abc80d8039fc/opentelemetry_exporter_otlp_proto_common-1.38.0-py3-none-any.whl", hash = "sha256:03cb76ab213300fe4f4c62b7d8f17d97fcfd21b89f0b5ce38ea156327ddda74a", size = 18359, upload-time = "2025-10-16T08:35:34.099Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0a/debcdfb029fbd1ccd1563f7c287b89a6f7bef3b2902ade56797bfd020854/opentelemetry_exporter_otlp_proto_http-1.38.0.tar.gz", hash = "sha256:f16bd44baf15cbe07633c5112ffc68229d0edbeac7b37610be0b2def4e21e90b", size = 17282, upload-time = "2025-10-16T08:35:54.422Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/77/154004c99fb9f291f74aa0822a2f5bbf565a72d8126b3a1b63ed8e5f83c7/opentelemetry_exporter_otlp_proto_http-1.38.0-py3-none-any.whl", hash = "sha256:84b937305edfc563f08ec69b9cb2298be8188371217e867c1854d77198d0825b", size = 19579, upload-time = "2025-10-16T08:35:36.269Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/14/f0c4f0f6371b9cb7f9fa9ee8918bfd59ac7040c7791f1e6da32a1839780d/opentelemetry_proto-1.38.0.tar.gz", hash = "sha256:88b161e89d9d372ce723da289b7da74c3a8354a8e5359992be813942969ed468", size = 46152, upload-time = "2025-10-16T08:36:01.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/6a/82b68b14efca5150b2632f3692d627afa76b77378c4999f2648979409528/opentelemetry_proto-1.38.0-py3-none-any.whl", hash = "sha256:b6ebe54d3217c42e45462e2a1ae28c3e2bf2ec5a5645236a490f55f45f1a0a18", size = 72535, upload-time = "2025-10-16T08:35:45.749Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/cb/f0eee1445161faf4c9af3ba7b848cc22a50a3d3e2515051ad8628c35ff80/opentelemetry_sdk-1.38.0.tar.gz", hash = "sha256:93df5d4d871ed09cb4272305be4d996236eedb232253e3ab864c8620f051cebe", size = 171942, upload-time = "2025-10-16T08:36:02.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/2e/e93777a95d7d9c40d270a371392b6d6f1ff170c2a3cb32d6176741b5b723/opentelemetry_sdk-1.38.0-py3-none-any.whl", hash = "sha256:1c66af6564ecc1553d72d811a01df063ff097cdc82ce188da9951f93b8d10f6b", size = 132349, upload-time = "2025-10-16T08:35:46.995Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.59b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/bc/8b9ad3802cd8ac6583a4eb7de7e5d7db004e89cb7efe7008f9c8a537ee75/opentelemetry_semantic_conventions-0.59b0.tar.gz", hash = "sha256:7a6db3f30d70202d5bf9fa4b69bc866ca6a30437287de6c510fb594878aed6b0", size = 129861, upload-time = "2025-10-16T08:36:03.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/7d/c88d7b15ba8fe5c6b8f93be50fc11795e9fc05386c44afaf6b76fe191f9b/opentelemetry_semantic_conventions-0.59b0-py3-none-any.whl", hash = "sha256:35d3b8833ef97d614136e253c1da9342b4c3c083bbaf29ce31d572a1c3825eed", size = 207954, upload-time = "2025-10-16T08:35:48.054Z" },
 ]
 
 [[package]]
@@ -4183,6 +4279,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/76/13/12b65dca23b1fb8ae44269a4d24048fd32ac90b445c985b0a46fdfa30cfe/yarl-1.18.0-cp313-cp313-win32.whl", hash = "sha256:14408cc4d34e202caba7b5ac9cc84700e3421a9e2d1b157d744d101b061a4a88", size = 309888, upload-time = "2024-11-21T15:05:09.121Z" },
     { url = "https://files.pythonhosted.org/packages/f6/60/478d3d41a4bf0b9e7dca74d870d114e775d1ff7156b7d1e0e9972e8f97fd/yarl-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1db1537e9cb846eb0ff206eac667f627794be8b71368c1ab3207ec7b6f8c5afc", size = 315459, upload-time = "2024-11-21T15:05:12.352Z" },
     { url = "https://files.pythonhosted.org/packages/30/9c/3f7ab894a37b1520291247cbc9ea6756228d098dae5b37eec848d404a204/yarl-1.18.0-py3-none-any.whl", hash = "sha256:dbf53db46f7cf176ee01d8d98c39381440776fcda13779d269a8ba664f69bec0", size = 44840, upload-time = "2024-11-21T15:05:55.655Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Technical Description

This PR upgrades the Langfuse integration from version 2.60.7 to 3.9.0, which introduces significant architectural changes based on OpenTelemetry standards. This builds on PR #2416's context manager refactoring.

Resolves #2141

**Key Changes:**

1. **Langfuse v3 API Migration:**
   - Replaces manual trace/span creation with `client.start_as_current_span()` context managers
   - Uses Langfuse's internal `LangfuseResourceManager` singleton for client management

2. **Simplified Architecture:**
   - Removes manual span hierarchy tracking (eliminated `self.spans` dict)
   - Removes `_get_current_observation()` method - context propagation now handled by Langfuse v3
   - ClientManager now delegates to Langfuse's `LangfuseResourceManager` instead of maintaining separate registry
   - Uses `public_key` for client lookup instead of config hash

3. **Test Updates:**
   - Refactored tests to work with Langfuse v3's singleton pattern
   - Improved test cleanup with proper manager shutdown

**Impact:**
- Internal implementation change only - no user-facing changes
- All existing tracing functionality preserved
- Tests updated and passing
