### PR TITLE
Fix teams Feature Flag crash

### DIFF
--- a/apps/teams/flags.py
+++ b/apps/teams/flags.py
@@ -35,6 +35,7 @@ class Flags(FlagInfo, Enum):
         "flag_pipelines-v2",
         "Second version of pipeline functionality with enhanced features",
         "pipelines",
+        [],
         False,
         True,
     )


### PR DESCRIPTION
The PIPELINES_V2 flag definition never had a newly added 'requires' parameter added to its definition, so it both wasn't getting properly removed (since the managed by teams parameter was misinterpreted) and would crash if assigned.  

### Technical Description
Adds the missing required parameter to the pipelines flag with no values set. 

I tested this on my prod account (https://www.openchatstudio.com/a/<myteam>/team/flags/) and confirmed the incorrect behavior. 

After this change the team flags page doesn't contain the flag at all, which I assume is correct based on the existing parameters. Updating the remaining flag works as expected. 
<img width="1498" height="514" alt="image" src="https://github.com/user-attachments/assets/743a1cd2-bc60-43e9-94a7-14eb201bec80" />

### Docs and Changelog
- [ ] This PR requires docs/changelog update
