### PR TITLE
close db connections more actively in Celery

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -1,7 +1,8 @@
 import os
 
-from celery import Celery
+from celery import Celery, signals
 from celery.app import trace
+from django import db
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
@@ -25,3 +26,18 @@ Task %(name)s[%(id)s] succeeded in %(runtime)ss\
 
 worker_max_tasks_per_child = 100  # Restart worker periodically
 task_acks_late = True
+
+
+@signals.task_postrun.connect
+def close_db_connection(**kwargs):
+    # Copied from https://github.com/celery/celery/blob/main/celery/fixups/django.py
+    # Can be removed when upgrading Celery > 5.5.3
+    for conn in db.connections.all():
+        try:
+            conn.close()
+        except db.InterfaceError:
+            pass
+        except db.DatabaseError as exc:
+            str_exc = str(exc)
+            if "closed" not in str_exc and "not connected" not in str_exc:
+                raise


### PR DESCRIPTION
### Technical Description

1. Allow customization of Django settings via env without forced overrides in Celery.py

2. Force close all DB connections after each task. Celery already does this but `close_if_unusable_or_obsolete` which doesn't always work (See https://github.com/celery/celery/commit/da4a80dc449301fde4355153b47af8c42caed37c).
