### PR TITLE
Use responses API for gpt-5-pro

### DIFF
--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -258,8 +258,10 @@ class OpenAIGenericService(LlmService):
             # Remove the temperature parameter for custom reasoning models
             model_kwargs.pop("temperature")
 
-        use_responses_api = llm_model in ["gpt-5-pro"]
-        model = ChatOpenAI(model=llm_model, **model_kwargs, use_responses_api=use_responses_api)
+        if llm_model in ["gpt-5-pro"]:
+            model_kwargs["use_responses_api"] = True
+
+        model = ChatOpenAI(model=llm_model, **model_kwargs)
         try:
             model.get_num_tokens_from_messages([HumanMessage("Hello")])
         except Exception:


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->

### Technical Description
<!--
A summary of the change, the reason for its implementation, and relevant links. 
Include technical details required to understand the change.
-->
Temporary fix for https://github.com/dimagi/open-chat-studio/issues/2464, since only the gpt-5-pro model wants to use the responses API.

I think a better fix is to call .text() on the `AIMessage` object, instead of calling .content, but there are a few other places that needs to be checked out first to make sure that calling .text() will still work as expected.

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
