### PR TITLE
Always use the responses API for OpenAI invocations

### DIFF
--- a/apps/analysis/tasks.py
+++ b/apps/analysis/tasks.py
@@ -124,7 +124,7 @@ def process_transcript_analysis(self, analysis_id):
                     try:
                         # Process with LLM
                         response = llm.invoke(prompt)
-                        answer = response.content
+                        answer = response.text()
 
                         # Add to row
                         session_row.append(answer)

--- a/apps/analysis/tests/test_translations.py
+++ b/apps/analysis/tests/test_translations.py
@@ -56,7 +56,7 @@ class TestTranslateMessagesWithLLM(TestCase):
         """Test successful translation of messages"""
 
         mock_llm_response = Mock()
-        mock_llm_response.content = json.dumps(
+        mock_llm_response.text.return_value = json.dumps(
             [{"id": "1", "translation": "Hola, ¿cómo estás?"}, {"id": "2", "translation": "¡Estoy bien, gracias!"}]
         )
 
@@ -85,7 +85,7 @@ class TestTranslateMessagesWithLLM(TestCase):
         self.mock_message1.translations = {"spa": "Hola, ¿cómo estás?"}
 
         mock_llm_response = Mock()
-        mock_llm_response.content = json.dumps([{"id": "2", "translation": "¡Estoy bien, gracias!"}])
+        mock_llm_response.text.return_value = json.dumps([{"id": "2", "translation": "¡Estoy bien, gracias!"}])
         mock_llm = Mock()
         mock_llm.invoke.return_value = mock_llm_response
         mock_llm_service = Mock()

--- a/apps/analysis/translation.py
+++ b/apps/analysis/translation.py
@@ -63,7 +63,7 @@ def translate_messages_with_llm(messages, target_language, llm_provider, llm_pro
 
             response = llm.invoke(prompt)
             try:
-                translated_data = json.loads(response.content)
+                translated_data = json.loads(response.text())
             except json.JSONDecodeError as e:
                 raise TranslationError(
                     f"Failed to parse LLM response as JSON for {target_language} translation. Error: {str(e)}"

--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -592,9 +592,9 @@ class EventBot:
                 ],
                 config=config,
             )
-            span.set_outputs({"response": response.content})
+            span.set_outputs({"response": response.text()})
 
-            message = response.content
+            message = response.text()
             if self.history_manager:
                 self.history_manager.save_message_to_history(message, type_=ChatMessageType.AI)
         return message

--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -258,10 +258,7 @@ class OpenAIGenericService(LlmService):
             # Remove the temperature parameter for custom reasoning models
             model_kwargs.pop("temperature")
 
-        if llm_model in ["gpt-5-pro"]:
-            model_kwargs["use_responses_api"] = True
-
-        model = ChatOpenAI(model=llm_model, **model_kwargs)
+        model = ChatOpenAI(model=llm_model, **model_kwargs, use_responses_api=True)
         try:
             model.get_num_tokens_from_messages([HumanMessage("Hello")])
         except Exception:


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
fixes #2464 

### Technical Description
<!--
A summary of the change, the reason for its implementation, and relevant links. 
Include technical details required to understand the change.
-->
Accessing the response via `.content` returns the raw response from the API. In the responses API's case, it's a list of objects. We can get the text of the message by calling [.text()](https://github.com/langchain-ai/langchain/blob/52b1516d44897e3961781b1ed36f48eaa51b8b33/libs/core/langchain_core/messages/base.py#L264), which is a method available on `BaseMessage` - the base class of `AIMessage`.

Note that calling `.text()` [is deprecated](https://github.com/langchain-ai/langchain/blob/52b1516d44897e3961781b1ed36f48eaa51b8b33/libs/core/langchain_core/messages/base.py#L82) since version 1 and looks like it will be removed in version 2. So when [this PR](https://github.com/dimagi/open-chat-studio/pull/2467/files) is merged, we'll need to update this.

I have tested normal chatting, running evals, translations, the event bot and session analysis with these changes. Am I missing something?

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
