### PR TITLE
#2157 Add support for light mode on schedule messages

### DIFF
--- a/templates/participants/partials/participant_schedule_single.html
+++ b/templates/participants/partials/participant_schedule_single.html
@@ -105,7 +105,7 @@
           </div>
 
           {% for attempt in schedule.attempts %}
-            <div class="flex w-full justify-between px-4 py-2 border border-gray-600 rounded text-sm {% cycle '' 'bg-sky-100/40 dark:bg-sky-950/40' %}">
+            <div class="flex w-full justify-between px-4 py-2 border border-gray-300 rounded text-sm {% cycle '' 'bg-sky-100/40 dark:bg-sky-950/40' %}">
               <div class="w-40">{{ attempt.updated_at|date:"DATETIME_FORMAT" }}</div>
               <div class="w-20">#{{ attempt.trigger_number }}</div>
               <div class="w-20">#{{ attempt.attempt_number }}</div>
@@ -114,7 +114,7 @@
                 {% if attempt.log_message %}
                   <details>
                     <summary class="cursor-pointer underline text-blue-400">View Log</summary>
-                  <pre class="mt-1 p-2 dark:bg-gray-900 rounded text-xs dark:text-gray-100 whitespace-pre-wrap border border-gray-600">{{ attempt.log_message }}</pre>
+                  <pre class="mt-1 p-2 dark:bg-gray-900 rounded text-xs dark:text-gray-100 whitespace-pre-wrap border border-gray-300">{{ attempt.log_message }}</pre>
                   </details>
                 {% else %}
                   —


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->

### Technical Description
- Add support for light mode on schedule messages 


### Demo
Dark mode: 
<img width="1062" height="624" alt="image" src="https://github.com/user-attachments/assets/41dad9a0-faaa-42e5-802a-0aaced41d912" />

Light mode:
<img width="1062" height="624" alt="image" src="https://github.com/user-attachments/assets/7df6b93a-2a40-4431-8d30-81f326d69c7d" />

