### PR TITLE
Update deploy to run migrations in a separate step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,13 +156,20 @@ jobs:
     - name: Get stack outputs for network config
       id: stack-outputs
       run: |
+        set -e
         OUTPUTS=$(aws cloudformation describe-stacks \
           --stack-name "$DJANGO_STACK_NAME" \
           --query 'Stacks[0].Outputs' \
-          --output json)
+          --output json) || { echo "Failed to retrieve CloudFormation stack outputs"; exit 1; }
 
-        echo "subnets=$(echo $OUTPUTS | jq -r '.[] | select(.OutputKey | endswith("PrivateSubnets")) | .OutputValue')" >> $GITHUB_OUTPUT
-        echo "security_group=$(echo $OUTPUTS | jq -r '.[] | select(.OutputKey | endswith("ServiceSecurityGroup")) | .OutputValue')" >> $GITHUB_OUTPUT
+        SUBNETS=$(echo "$OUTPUTS" | jq -r '.[] | select(.OutputKey | endswith("PrivateSubnets")) | .OutputValue')
+        SG=$(echo "$OUTPUTS" | jq -r '.[] | select(.OutputKey | endswith("ServiceSecurityGroup")) | .OutputValue')
+        
+        [[ -z "$SUBNETS" ]] && { echo "Error: Could not find subnets in stack outputs"; exit 1; }
+        [[ -z "$SG" ]] && { echo "Error: Could not find security group in stack outputs"; exit 1; }
+        
+        echo "subnets=$SUBNETS" >> $GITHUB_OUTPUT
+        echo "security_group=$SG" >> $GITHUB_OUTPUT
 
     - name: Run migration task
       id: run-migration


### PR DESCRIPTION
### Technical Description
The main takeway from the recent outage was to separate the database migrations from the web container to prevent the migrations from being run multiple times in parallel.

This PR in conjunction with https://github.com/dimagi/ocs-deploy/pull/18 resolves that issue.


Resolves: https://github.com/dimagi/open-chat-studio/issues/2492

> [!WARNING]
> Merge immediately after https://github.com/dimagi/ocs-deploy/pull/18 has been applied.

