### PR TITLE
Enable OAuth application management URLs

### DIFF
--- a/apps/oauth/urls.py
+++ b/apps/oauth/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path(".well-known/jwks.json", oauth2_views.JwksInfoView.as_view(), name="jwks-info"),
     path("o/userinfo/", oauth2_views.UserInfoView.as_view(), name="user-info"),
     path("o/", include(oauth2_urls.base_urlpatterns)),
+    path("o/", include(oauth2_urls.management_urlpatterns)),
 ]


### PR DESCRIPTION
[AI Generated PR with Claude]

Add management_urlpatterns to OAuth URL configuration to allow users to register and manage OAuth applications via the web interface. Previously only base OAuth2 protocol endpoints were available.