### PR TITLE
Fix: Default to a dictionary even if the value of llm_model_parameter

### DIFF
--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -162,7 +162,9 @@ class LLMResponseMixin(BaseModel):
         if llm_provider_model_id := data.get("llm_provider_model_id"):
             model = get_llm_provider_model(llm_provider_model_id)
             params_cls = LLM_MODEL_PARAMETERS.get(model.name, BasicParameters)
-            data["llm_model_parameters"] = params_cls.model_validate(data.get("llm_model_parameters", {})).model_dump()
+            # Handle None explicitly by treating it as empty dict
+            param_value = data.get("llm_model_parameters") or {}
+            data["llm_model_parameters"] = params_cls.model_validate(param_value).model_dump()
         else:
             data["llm_model_parameters"] = {}
         return data


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->

### Technical Description
<!--
A summary of the change, the reason for its implementation, and relevant links. 
Include technical details required to understand the change.
-->
Default to a dictionary even if the value of `llm_model_parameters` is explicitly `None`.

Related to https://github.com/dimagi/open-chat-studio/issues/2529.

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
N/A

### Docs and Changelog
N/A

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
