### PR TITLE
Fix size of loading indicator

### DIFF
--- a/assets/styles/site-tailwind.css
+++ b/assets/styles/site-tailwind.css
@@ -111,12 +111,35 @@ open-chat-studio-widget {
   @apply w-full ml-0!;
 }
 
+/* Fix oversized wrapper when loading class is added */
+.ts-wrapper.loading {
+  height: auto !important;
+  min-height: 2.75rem !important;
+  max-height: 2.75rem !important;
+}
+
+.ts-wrapper.loading .ts-control {
+  height: auto !important;
+  min-height: 2.75rem !important;
+  max-height: 2.75rem !important;
+}
+
+/* Constrain the loading spinner itself */
+.ts-wrapper.loading::after,
+.ts-wrapper.loading .ts-control::after {
+  width: 1rem !important;
+  height: 1rem !important;
+  max-width: 1rem !important;
+  max-height: 1rem !important;
+}
+
 .ts-control {
   @apply
     rounded-lg
     bg-white
     py-2
     px-3;
+  position: relative;
 
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
     background-position: right 0.5rem center;
@@ -168,7 +191,7 @@ open-chat-studio-widget {
   @apply  bg-zinc-600 text-gray-100;
 }
 
-input[type=number]::-webkit-inner-spin-button, 
+input[type=number]::-webkit-inner-spin-button,
 input[type=number]::-webkit-outer-spin-button {
   display: none;
 }


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
resolves [#1915](https://github.com/dimagi/open-chat-studio/issues/1915)

### Technical Description
<!--
A summary of the change, the reason for its implementation, and relevant links. 
Include technical details required to understand the change.
-->
Before the indicator would make the size of the element be a square (so if the input was 636x36 when the loading indicator was showing it would then be size 636x636)
this limits the height of that indicator


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
(the indicator doesn't show properly on my local environment, but look at the white space)
before:

https://github.com/user-attachments/assets/e071e3e3-908f-480c-aea0-b1911e5b1fff


after:

https://github.com/user-attachments/assets/2547a45c-7935-4e3d-b0fd-a7138ed1a23e


### Docs and Changelog
- [X] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
most visible on the feature flag page when adding a team or user