### PR TITLE
Update default vertex location to global

### DIFF
--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -513,7 +513,13 @@ class GoogleVertexAILlmService(LlmService):
     api_transport: Literal["grpc", "rest"] = "grpc"
 
     def get_chat_model(self, llm_model: str, **kwargs) -> ChatVertexAI:
-        return ChatVertexAI(model=llm_model, credentials=self.credentials, api_transport=self.api_transport, **kwargs)
+        return ChatVertexAI(
+                model=llm_model, 
+                credentials=self.credentials, 
+                location="global", 
+                api_transport=self.api_transport, 
+                **kwargs
+                )
 
     def get_callback_handler(self, model: str) -> BaseCallbackHandler:
         chat_model = self.get_chat_model(llm_model=model)


### PR DESCRIPTION
### Technical Description
Initial fix for https://github.com/dimagi/open-chat-studio/issues/2556

Updates the default GCP location for Vertex AI to `global` for all requests to support Gemini 3 Pro Preview. 

Tested locally after replicating the failing calls. 