### PR TITLE
Make GCP Location for Vertex Configurable

### DIFF
--- a/apps/service_providers/forms.py
+++ b/apps/service_providers/forms.py
@@ -154,6 +154,17 @@ class GoogleVertexAIConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
         ),
         initial="grpc",
     )
+    location = forms.CharField(
+        label=_("Google Cloud Platform Location"),
+        help_text=render_help_with_link(
+            _("Model availability may vary by region, see "),
+            "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#google_model_endpoint_locations",
+            link_text="Google documentation",
+            line_break=False,
+        ),
+        initial="global",
+    )
+
     credentials_json = forms.JSONField(
         # expect credentials to be ~13 lines of JSON
         label=_("Service Account Key (JSON)"),

--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -510,10 +510,17 @@ class GoogleLlmService(LlmService):
 
 class GoogleVertexAILlmService(LlmService):
     credentials_json: dict
+    location: str = "global"
     api_transport: Literal["grpc", "rest"] = "grpc"
 
     def get_chat_model(self, llm_model: str, **kwargs) -> ChatVertexAI:
-        return ChatVertexAI(model=llm_model, credentials=self.credentials, api_transport=self.api_transport, **kwargs)
+        return ChatVertexAI(
+            model=llm_model,
+            credentials=self.credentials,
+            location=self.location,
+            api_transport=self.api_transport,
+            **kwargs
+        )
 
     def get_callback_handler(self, model: str) -> BaseCallbackHandler:
         chat_model = self.get_chat_model(llm_model=model)


### PR DESCRIPTION
### Technical Description
More thorough fix for https://github.com/dimagi/open-chat-studio/issues/2556

Updates the default GCP location for Vertex AI to `global` for all requests to support Gemini 3 Pro Preview, and allows users to configure the GCP location for requests with a pointer to the docs. 

<img width="778" height="287" alt="image" src="https://github.com/user-attachments/assets/ddefc0cf-f173-4b41-be99-b0f22894f983" />

Tested locally. Confirmed that the default `global` location works without config errors for already-existing VertexAI LLM implementations (matching the UI experience for users). No migration required, and since Vertex implementation is new/internal I don't think we need a changelog. 

Note: This PR will opt-in any existing VertexAI endpoints into 'global', even if that was not their previous implementation. Since the default region is ambiguous, I think this is net better. 