### PR TITLE
Dataset Table View: Update only single row

### DIFF
--- a/apps/evaluations/views/dataset_views.py
+++ b/apps/evaluations/views/dataset_views.py
@@ -370,7 +370,7 @@ def update_message(request, team_slug, message_id):
 
     if errors:
         update_url = reverse("evaluations:update_message", args=[team_slug, message_id])
-        response = render(
+        return render(
             request,
             "evaluations/edit_message_modal_content.html",
             {
@@ -381,10 +381,8 @@ def update_message(request, team_slug, message_id):
             },
             status=200,
         )
-        response = retarget(response, "#editMessageModal")
-        response = reswap(response, "innerHTML")
-        return response
 
+    # Update the message
     for attr, val in data.items():
         setattr(message, attr, val)
     message.input_chat_message = None
@@ -396,8 +394,11 @@ def update_message(request, team_slug, message_id):
 
     dataset = message.evaluationdataset_set.first()
     if dataset:
-        return render_table_row(request, DatasetMessagesTable, message)
-
+        response = render_table_row(request, DatasetMessagesTable, message)
+        # Change target to the table row for successful updates
+        response = retarget(response, f"#record-{message_id}")
+        response = reswap(response, "outerHTML")
+        return response
     return HttpResponse("", status=200)
 
 

--- a/templates/evaluations/dataset_edit.html
+++ b/templates/evaluations/dataset_edit.html
@@ -284,8 +284,10 @@
         if (event.detail.xhr.status === 200 && event.detail.target.id === 'editMessageModal') {
           // Check if the response contains validation errors
           const modalBox = event.detail.target.querySelector('.modal-box');
-          const hasErrors = modalBox && modalBox.hasAttribute('data-has-errors');
-
+          if (!modalBox) {
+            return;
+          }
+          const hasErrors = modalBox.hasAttribute('data-has-errors');
           if (hasErrors) {
             // Don't close modal or refresh table if there are validation errors
             return;
@@ -293,7 +295,11 @@
 
           document.getElementById('editMessageModal').close();
           htmx.trigger(document.body, 'refreshTable');
-      }});
+        }
+        if (event.detail.xhr.status === 200 && event.detail.target.id.startsWith('record-')) {
+          document.getElementById('editMessageModal')?.close();
+        }
+      });
     });
   </script>
 {% endblock page_js %}

--- a/templates/evaluations/edit_message_modal_content.html
+++ b/templates/evaluations/edit_message_modal_content.html
@@ -8,10 +8,8 @@
   <!-- Form content -->
   <form
     hx-post="{{ update_url }}"
-    hx-target="#record-{{ message.id }}"
-    hx-select="#record-{{ message.id }}"
-    hx-swap="outerHTML"
-    hx-on::after-request="if(event.detail.successful) document.getElementById('editMessageModal').close()"
+    hx-target="#editMessageModal"
+    hx-swap="innerHTML"
     class="space-y-6"
   >
     {% csrf_token %}


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
Resolves https://github.com/dimagi/open-chat-studio/issues/2419
When you edit a message in the dataset table, only that specific row now updates instead of reloading the entire table.

### Technical Description
<!--
A summary of the change, the reason for its implementation, and relevant links. 
Include technical details required to understand the change.
-->

1. `views.py`:
   - Return status 200 (instead of 400) when validation errors occur
   - Use HTMX response headers (`retarget`, `reswap`) to dynamically change the swap target:
     - **On error**: Target `#editMessageModal`, swap modal content with error messages
     - **On success**: Target `#record-{id}`, swap the updated table row

2. JS Changes:
   - changed event listener to handle both scenarios:
     - When target is `#editMessageModal`: Check for `data-has-errors` attribute to decide whether to close modal
     - When target is a table row (`#record-*`): Close modal and skip table refresh (row already updated)

3. `edit_message_modal_content.html`:
   - Simplified form to use default target `#editMessageModal`
   - Removed complex client-side retargeting logic (now handled by server)

- With validation errors: Modal stays open, displays inline error messages, allows user to correct and resubmit
- Without errors: Modal closes automatically, table row updates in place without full table refresh

### Testing
- Submit with empty required field → errors display in modal, modal stays open
- Fix errors and resubmit → modal closes, table row updates
- Submit valid data initially → modal closes, table row updates

### Demo

[Loom](https://www.loom.com/share/8e0919b24a234cb4ba17386dde1efe99)

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
no
