### PR TITLE
keep evals sessions for 30 days (instead of 7)

### DIFF
--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -33,7 +33,7 @@ from apps.experiments.models import Experiment, ExperimentSession, Participant
 from apps.files.models import File
 from apps.teams.utils import current_team
 
-EVAL_SESSIONS_TTL_DAYS = 7
+EVAL_SESSIONS_TTL_DAYS = 30
 
 logger = logging.getLogger("ocs.evaluations")
 


### PR DESCRIPTION
### Technical Description
Update the TTL for evals sessions from 7 days to 30 days. 

### Docs and Changelog
- [x] This PR requires docs/changelog update

Sessions generated during evaluation runs are deleted permanently after 30 days. This does not affect the source sessions, only the session generated by the evals themselves.