### PR TITLE
Upgrade django-allauth from 0.57.2 to 65.13.1

### DIFF
--- a/apps/users/apps.py
+++ b/apps/users/apps.py
@@ -1,4 +1,9 @@
+from allauth.account import app_settings
 from django.apps import AppConfig
+from django.conf import settings
+from django.db import migrations
+from django.db.models.functions import Lower
+from django.db.models.signals import pre_migrate
 
 
 class UserConfig(AppConfig):
@@ -7,3 +12,29 @@ class UserConfig(AppConfig):
 
     def ready(self):
         from . import signals  # noqa  F401
+
+        self._patch_allauth_migration()
+
+    def _patch_allauth_migration(self):
+        """Patch allauth 0006_emailaddress_lower to work with field_audit."""
+
+        def forwards_with_audit(apps, schema_editor):
+            from field_audit.models import AuditAction
+
+            EmailAddress = apps.get_model("account.EmailAddress")
+            User = apps.get_model(settings.AUTH_USER_MODEL)
+            EmailAddress.objects.all().exclude(email=Lower("email")).update(email=Lower("email"))
+            email_field = app_settings.USER_MODEL_EMAIL_FIELD
+            if email_field:
+                User.objects.all().exclude(**{email_field: Lower(email_field)}).update(
+                    **{email_field: Lower(email_field)},
+                    audit_action=AuditAction.IGNORE,
+                )
+
+        def before_migrations(**kwargs):
+            if plan := kwargs.get("plan"):
+                for migration, applied in plan:
+                    if not applied and migration.app_label == "account" and migration.name == "0006_emailaddress_lower":
+                        migration.operations = [migrations.RunPython(forwards_with_audit, migrations.RunPython.noop)]
+
+        pre_migrate.connect(before_migrations)

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,4 +1,4 @@
-from allauth.account.utils import send_email_confirmation
+from allauth.account.models import EmailAddress
 from allauth.mfa.models import Authenticator
 from allauth.mfa.utils import is_mfa_enabled
 from allauth.socialaccount.models import SocialAccount
@@ -39,7 +39,7 @@ def profile(request):
                 # don't change it but instead send a confirmation email
                 # email will be changed by signal when confirmed
                 new_email = user.email
-                send_email_confirmation(request, user, signup=False, email=new_email)
+                EmailAddress.objects.add_email(request, user, new_email, confirm=True)
                 user.email = user_before_update.email
                 # recreate the form to avoid populating the previous email in the returned page
                 form = CustomUserChangeForm(instance=user)

--- a/apps/web/context_processors.py
+++ b/apps/web/context_processors.py
@@ -20,7 +20,9 @@ def project_meta(request):
         # put any settings you want made available to all templates here
         # then reference them as {{ project_settings.MY_VALUE }} in templates
         "project_settings": {
-            "ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE": settings.ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE,
+            "ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE": any(
+                "password2" in field for field in settings.ACCOUNT_SIGNUP_FIELDS
+            ),
         },
         "use_i18n": getattr(settings, "USE_I18N", False) and len(getattr(settings, "LANGUAGES", [])) > 1,
         "signup_enabled": settings.SIGNUP_ENABLED,

--- a/config/settings.py
+++ b/config/settings.py
@@ -249,6 +249,11 @@ AUTH_USER_MODEL = "users.CustomUser"
 LOGIN_URL = "sso:login"
 LOGIN_REDIRECT_URL = "/"
 
+# Migration modules - override allauth.account to fix field_audit compatibility
+MIGRATION_MODULES = {
+    "account": "apps.account.migrations",
+}
+
 # Password validation
 # https://docs.djangoproject.com/en/3.2/ref/settings/#auth-password-validators
 
@@ -273,13 +278,11 @@ if SIGNUP_ENABLED:
     ACCOUNT_ADAPTER = "apps.teams.adapter.AcceptInvitationAdapter"
 else:
     ACCOUNT_ADAPTER = "apps.teams.adapter.NoNewUsersAccountAdapter"
-ACCOUNT_AUTHENTICATION_METHOD = "email"
-ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_LOGIN_METHODS = {"email"}
+ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*"]
 ACCOUNT_EMAIL_SUBJECT_PREFIX = ""
 ACCOUNT_CONFIRM_EMAIL_ON_GET = False
 ACCOUNT_UNIQUE_EMAIL = True
-ACCOUNT_USERNAME_REQUIRED = False
-ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE = False
 ACCOUNT_SESSION_REMEMBER = True
 ACCOUNT_LOGOUT_ON_GET = True
 ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = True

--- a/config/settings.py
+++ b/config/settings.py
@@ -249,11 +249,6 @@ AUTH_USER_MODEL = "users.CustomUser"
 LOGIN_URL = "sso:login"
 LOGIN_REDIRECT_URL = "/"
 
-# Migration modules - override allauth.account to fix field_audit compatibility
-MIGRATION_MODULES = {
-    "account": "apps.account.migrations",
-}
-
 # Password validation
 # https://docs.djangoproject.com/en/3.2/ref/settings/#auth-password-validators
 

--- a/uv.lock
+++ b/uv.lock
@@ -716,19 +716,20 @@ wheels = [
 
 [[package]]
 name = "django-allauth"
-version = "0.57.2"
+version = "65.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "asgiref" },
     { name = "django" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "python3-openid" },
-    { name = "requests" },
-    { name = "requests-oauthlib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/65/254ae01e3f369306989aab401ba1ba6868d14826dc85523a8b11ac5870fe/django-allauth-0.57.2.tar.gz", hash = "sha256:51c400f61bfb15bd08e22543a65d551c8f563254064620c37c49766b1ba7e1ae", size = 858996, upload-time = "2024-02-09T09:15:16.069Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/42a048ba1dedbb6b553f5376a6126b1c753c10c70d1edab8f94c560c8066/django_allauth-65.13.1.tar.gz", hash = "sha256:2af0d07812f8c1a8e3732feaabe6a9db5ecf3fad6b45b6a0f7fd825f656c5a15", size = 1983857, upload-time = "2025-11-20T16:34:40.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/98/9d44ae1468abfdb521d651fb67f914165c7812dfdd97be16190c9b1cc246/django_allauth-65.13.1-py3-none-any.whl", hash = "sha256:2887294beedfd108b4b52ebd182e0ed373deaeb927fc5a22f77bbde3174704a6", size = 1787349, upload-time = "2025-11-20T16:34:37.354Z" },
+]
 
 [package.optional-dependencies]
 mfa = [
+    { name = "fido2" },
     { name = "qrcode" },
 ]
 
@@ -1194,6 +1195,18 @@ name = "ffmpeg"
 version = "1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/cc/3b7408b8ecf7c1d20ad480c3eaed7619857bf1054b690226e906fdf14258/ffmpeg-1.4.tar.gz", hash = "sha256:6931692c890ff21d39938433c2189747815dca0c60ddc7f9bb97f199dba0b5b9", size = 5055, upload-time = "2018-10-08T07:50:05.748Z" }
+
+[[package]]
+name = "fido2"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/b9/6ec8d8ec5715efc6ae39e8694bd48d57c189906f0628558f56688d0447b2/fido2-2.0.0.tar.gz", hash = "sha256:3061cd05e73b3a0ef6afc3b803d57c826aa2d6a9732d16abd7277361f58e7964", size = 274942, upload-time = "2025-05-20T09:45:00.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/7d/a1dba174d7ec4b6b8d6360eed0ac3a4a4e2aa45f234e903592d3184c6c3f/fido2-2.0.0-py3-none-any.whl", hash = "sha256:685f54a50a57e019c6156e2dd699802a603e3abf70bab334f26affdd4fb8d4f7", size = 224761, upload-time = "2025-05-20T09:44:59.029Z" },
+]
 
 [[package]]
 name = "filelock"
@@ -3639,11 +3652,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/4f/e04a8067c7c96c364cef7ef73906504e2f40d690811c021e1a1901473a19/PyJWT-2.8.0-py3-none-any.whl", hash = "sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320", size = 22591, upload-time = "2023-07-18T20:02:21.561Z" },
 ]
 
-[package.optional-dependencies]
-crypto = [
-    { name = "cryptography" },
-]
-
 [[package]]
 name = "pymdown-extensions"
 version = "10.15"
@@ -3806,18 +3814,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
-]
-
-[[package]]
-name = "python3-openid"
-version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "defusedxml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/4a/29feb8da6c44f77007dcd29518fea73a3d5653ee02a587ae1f17f1f5ddb5/python3-openid-3.2.0.tar.gz", hash = "sha256:33fbf6928f401e0b790151ed2b5290b02545e8775f982485205a066f874aaeaf", size = 305600, upload-time = "2020-06-29T12:15:49.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/a5/c6ba13860bdf5525f1ab01e01cc667578d6f1efc8a1dba355700fb04c29b/python3_openid-3.2.0-py3-none-any.whl", hash = "sha256:6626f771e0417486701e0b4daff762e7212e820ca5b29fcc0d05f6f8736dfa6b", size = 133681, upload-time = "2020-06-29T12:15:47.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Technical Description

Resolves https://github.com/dimagi/open-chat-studio/issues/2617

Upgrades django-allauth from 0.57.2 to 65.13.1 to get security fixes and new features.

**Breaking changes addressed:**

1. **Removed function:** `send_email_confirmation` was removed in v65.10.0
   - **Fix:** Replace with `EmailAddress.objects.add_email(request, user, email, confirm=True)`
   - **Location:** apps/users/views.py:38

2. **Deprecated settings:** v65 replaced multiple settings with new consolidated ones
   - `ACCOUNT_AUTHENTICATION_METHOD` → `ACCOUNT_LOGIN_METHODS = {"email"}`
   - `ACCOUNT_EMAIL_REQUIRED`, `ACCOUNT_USERNAME_REQUIRED`, `ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE` → `ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*"]`
   - **Locations:** config/settings.py, apps/web/context_processors.py

3. **Migration conflict with field_audit:** allauth migration 0006_emailaddress_lower calls `User.objects.update()` without `audit_action`, but CustomUser uses `@audit_fields(..., audit_special_queryset_writes=True)`
   - **Fix:** Monkey-patch the migration at `AppConfig.ready()` to inject `audit_action=AuditAction.IGNORE`
   - **Location:** apps/users/apps.py:11-37
   - **Why this approach:** Avoids copying all allauth migrations; self-contained in one file

**References:**
- [Issue #4507: Undocumented removal of send_email_confirmation](https://codeberg.org/allauth/django-allauth/issues/4507)
- [v65.13.1 Release Notes](https://docs.allauth.org/en/dev/release-notes/recent.html)

### Migrations
- [x] The migrations are backwards compatible

No new migrations added. The monkey-patch handles the allauth migration conflict at runtime.