### PR TITLE
Convert Excel and word docs to text before sending to LLM

### DIFF
--- a/apps/service_providers/tests/llm_service/test_utils.py
+++ b/apps/service_providers/tests/llm_service/test_utils.py
@@ -4,7 +4,6 @@ import pytest
 from langchain_core.messages import HumanMessage
 
 from apps.service_providers.llm_service.utils import (
-    MARKITDOWN_CONVERTIBLE_MIME_TYPES,
     detangle_file_ids,
     extract_file_ids_from_ocs_citations,
     format_multimodal_input,
@@ -134,12 +133,6 @@ def test_populate_reference_section_with_custom_citation():
 )
 def test_remove_citations_from_text(input_text, expected_output):
     assert remove_citations_from_text(input_text) == expected_output
-
-
-class TestMarkitdownConvertibleMimeTypes:
-    def test_pdf_not_in_convertible_types(self):
-        # PDF is natively supported by LLM APIs, should not be in convertible types
-        assert "application/pdf" not in MARKITDOWN_CONVERTIBLE_MIME_TYPES
 
 
 class TestFormatMultimodalInput:


### PR DESCRIPTION
### Technical Description

Resolves #2476 

Most LLM APIs only support PDF and image attachments directly. Other attachments need to be converted to text before being sent.

This PR converts all other document attachment types to text.

In the long term we can look at the following alternatives if we need to do more document analysis:

**Code interpreter**
To pass files to code interpreter you need to create the container, upload your file into it, then pass the container to responses API to process.

**File search**
Create a vector store, upload the file to it and pass the vector store to the responses API