### PR TITLE
Check all collections for provider compatability

### DIFF
--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -578,18 +578,17 @@ class LLMResponseWithPrompt(LLMResponse, HistoryMixin, OutputMessageTagMixin):
                 f"Local collections: {', '.join(local_collections)}.",
             )
 
-        if all(is_remote_flags):
-            # Validate that all remote collections use the same LLM provider as this node
-            incompatible_collections = [
-                collection.name for collection in collections.values() if collection.llm_provider_id != llm_provider_id
-            ]
-            if incompatible_collections:
-                raise PydanticCustomError(
-                    "invalid_collection_index",
-                    f"All collection indexes must use the same LLM provider as the node. "
-                    f"Incompatible collections: {', '.join(incompatible_collections)}",
-                )
-        else:
+        # Validate that all remote collections use the same LLM provider as this node
+        incompatible_collections = [
+            collection.name for collection in collections.values() if collection.llm_provider_id != llm_provider_id
+        ]
+        if incompatible_collections:
+            raise PydanticCustomError(
+                "invalid_collection_index",
+                f"All collection indexes must use the same LLM provider as the node. "
+                f"Incompatible collections: {', '.join(incompatible_collections)}",
+            )
+        if len(collections) > 1 and not all(is_remote_flags):
             # local indexes must have a summary
             missing_summary = [collection.name for collection in collections.values() if not collection.summary]
             if missing_summary:


### PR DESCRIPTION
### Technical Description
<!--
A summary of the change, the reason for its implementation, and relevant links. 
Include technical details required to understand the change.
-->
Fixes https://dimagi.sentry.io/issues/7197121251/?referrer=issue_alert-slack&notification_uuid=ac16323a-0677-436e-9b8c-78120d1b9fad&alert_rule_id=14063560&alert_type=issue.

- Root cause: The system only checked for provider compatability between an LLM node and the set of indexed collections it uses if there are more than 1 indexed collection, missing it if there are only one.
- This PR fixed this by removing the restriction and now check compatability irrespective of how many collections are used.

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
N/A

### Docs and Changelog
- [x] This PR requires docs/changelog update
<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
