### PR TITLE
feat: add --fake option to IdempotentCommand

### DIFF
--- a/apps/data_migrations/management/commands/base.py
+++ b/apps/data_migrations/management/commands/base.py
@@ -3,7 +3,7 @@ import contextlib
 from django.core.management.base import BaseCommand
 from field_audit import disable_audit
 
-from apps.data_migrations.utils.migrations import is_migration_applied, run_once
+from apps.data_migrations.utils.migrations import is_migration_applied, mark_migration_applied, run_once
 
 
 class IdempotentCommand(BaseCommand):
@@ -15,6 +15,11 @@ class IdempotentCommand(BaseCommand):
         - atomic: Set to False to disable atomic migration
         - disable_audit: Set to True to disable model auditing for this migration
         - perform_migration(): Method containing the actual migration logic
+
+    Command options:
+        --dry-run: Preview changes without applying them or marking as complete
+        --force: Re-run even if already applied
+        --fake: Mark migration as complete without running it
 
     Example:
         class Command(IdempotentCommand):
@@ -42,6 +47,11 @@ class IdempotentCommand(BaseCommand):
             action="store_true",
             help="Preview changes without applying them",
         )
+        parser.add_argument(
+            "--fake",
+            action="store_true",
+            help="Mark migration as complete without running it",
+        )
 
     def handle(self, *args, **options):
         # Validate that migration_name is defined
@@ -50,6 +60,16 @@ class IdempotentCommand(BaseCommand):
 
         force = options.get("force", False)
         dry_run = options.get("dry_run", False)
+        fake = options.get("fake", False)
+
+        # Handle fake mode: mark as complete without running
+        if fake:
+            if is_migration_applied(self.migration_name):
+                self.stdout.write(self.style.WARNING(f"Migration '{self.migration_name}' is already marked as applied"))
+            else:
+                mark_migration_applied(self.migration_name)
+                self.stdout.write(self.style.SUCCESS(f"Migration '{self.migration_name}' marked as applied (fake)"))
+            return
 
         # Check if migration already applied (unless force flag is set)
         if not force and is_migration_applied(self.migration_name):


### PR DESCRIPTION
### Technical Description
Add --fake flag to mark migrations as applied without running them. Useful when manually applying equivalent changes outside the migration.
