### PR TITLE
cater for None values

### DIFF
--- a/apps/pipelines/migrations/0023_make_router_keywords_lower.py
+++ b/apps/pipelines/migrations/0023_make_router_keywords_lower.py
@@ -8,7 +8,7 @@ def _convert_keywords_to_lower(apps, schema_editor):
     queryset = Node.objects.filter(type__in=["RouterNode", "StaticRouterNode"]).iterator(chunk_size=100)
     for idx, node in enumerate(queryset):
         if "keywords" in node.params:
-            node.params["keywords"] = [kw.lower() for kw in node.params.get("keywords", [])]
+            node.params["keywords"] = [kw.lower() for kw in node.params.get("keywords", []) or []]
             nodes_to_update.append(node)
         
         if len(nodes_to_update) >= 100:


### PR DESCRIPTION

### Technical Description
<!--
A summary of the change, the reason for its implementation, and relevant links. 
Include technical details required to understand the change.
-->
This is embarrasing. The `.get(...)` change catered for _missing_ values whereas the values causing the issue was `None`. This should fix it.

### Migrations
<!-- 
There may be a potentially long window during the deployment where migrations are applied, but the old code is still running. We need to ensure that migrations can be applied to the current running code without breaking it, to the extent possible.

Delete this section if there are no migration.
 -->
- [ ] The migrations are backwards compatible


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
