### PR TITLE
Fix: Use correct lookup in annotation for any cited and generated files

### DIFF
--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -285,10 +285,10 @@ class OpenAIGenericService(LlmService):
         """Returns the file ids from the annotation entries of type file_citation
 
         Expected format for annotation_entries:
-        [{type: "file_citation", "file_id": "file-xxx", ...}]
+        [{"type: "citation", "extras": {"file_id": "file-xxx"}}, ...]
         """
         external_ids = [
-            entry["file_id"] for entry in annotation_entries if "file_id" in entry and entry["type"] == "file_citation"
+            entry.get("extras", {}).get("file_id") for entry in annotation_entries if entry["type"] == "citation"
         ]
         return detangle_file_ids(external_ids)
 
@@ -298,14 +298,30 @@ class OpenAIGenericService(LlmService):
         """
         Create file records for all generated files in the output.
 
-        Annotation entried for OpenAI generated files look like:
+        Annotation entries for OpenAI generated files look like:
         [
             {"type": "container_file_citation", "file_id": "file-xxx", "container_id": "cont-xxx", ...}
+        ]
+
+        but Langchain transforms unknown annotation types into dicts with a "value" key and the type as
+        `non_standard_annotation`. See
+        https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/messages/block_translators/openai.py#L602-L607
+        so we expect to find entries like this:
+        [
+            {
+                "type": "non_standard_annotation",
+                "value": {"type": "container_file_citation", "file_id": "file-xxx", "container_id": "cont-xxx", ...}
+            }
         ]
         """
         generated_files = []
 
         for entry in annotation_entries:
+            # We know to look for container_file_citation entries in entries for type = non_standard_annotation
+            if entry.get("type", "") != "non_standard_annotation":
+                continue
+
+            entry = entry.get("value", entry)
             if entry.get("type") != "container_file_citation":
                 continue
 


### PR DESCRIPTION
### Technical Description
<!--
A summary of the change, the reason for its implementation, and relevant links. 
Include technical details required to understand the change.
-->
Fixes #2679 

The issue was that the expected structure of the `annotations` object that was being parsed did not match the actual structure. Langchain parses the response from OpenAI to standardize the structure.

The tests are now also updated to use the same parsing code that langchain uses to convert the `annotations` object from the openai response into the expected structure.

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
For what it's worth, this is the code running. You'll see a cited file as well as a generated file being made available for download (my spelling is horrible, but who cares, it's for testing):

<img width="829" height="572" alt="image" src="https://github.com/user-attachments/assets/09ebbc37-a08b-4288-b8ea-95e9abcc2ab8" />


### Docs and Changelog
- [x] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
