### PR TITLE
ci(cypress): increase timeouts, wait for postgres, collectstatic, see…

### DIFF
--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           uv run python manage.py migrate
           uv run python cypress/create_test_user.py
+          uv run python cypress/seed_test_data.py
         env:
           DEBUG: 'true'
           USE_DEBUG_TOOLBAR: 'false'


### PR DESCRIPTION
…d test data

- Increase wait-on timeout to 120s (from 60s)
- Add Postgres health check before migrations
- Run collectstatic after frontend build
- Seed test data after creating test user
- Set explicit DJANGO_DATABASE_HOST=localhost

<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->

### Technical Description
<!--
A summary of the change, the reason for its implementation, and relevant links. 
Include technical details required to understand the change.
-->


### Migrations
<!-- 
There may be a potentially long window during the deployment where migrations are applied, but the old code is still running. We need to ensure that migrations can be applied to the current running code without breaking it, to the extent possible.

Delete this section if there are no migration.
 -->
- [ ] The migrations are backwards compatible


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
