### PR TITLE
Simplify session queryset filtering in dataset views

### DIFF
--- a/apps/evaluations/views/dataset_views.py
+++ b/apps/evaluations/views/dataset_views.py
@@ -8,7 +8,7 @@ from itertools import islice
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
-from django.db.models import Count, Exists, OuterRef
+from django.db.models import Count
 from django.db.models.functions import Coalesce
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
@@ -41,7 +41,6 @@ from apps.evaluations.utils import (
     parse_history_text,
 )
 from apps.experiments.filters import (
-    ChatMessageFilter,
     ExperimentSessionFilter,
     get_filter_context_data,
 )
@@ -244,23 +243,9 @@ def get_base_session_queryset(request):
     """Returns a queryset with filtering applied but without any annotations or related model selection."""
     timezone = request.session.get("detected_tz", None)
     filter_params = FilterParams.from_request(request)
-
-    # Get filtered message IDs more efficiently
-    message_filter = ChatMessageFilter()
-    base_messages = ChatMessage.objects.filter(chat_id=OuterRef("chat_id"))
-    filtered_messages = message_filter.apply(base_messages, filter_params, timezone)
-
-    # Use Exists for filtering instead of Count with IN subquery - avoids cartesian product
-    has_messages = Exists(filtered_messages)
-
-    # Build the query with basic filtering only
-    query_set = ExperimentSession.objects.filter(team=request.team).filter(has_messages)
-
-    # Apply session filter (this will add first_message_created_at)
+    query_set = ExperimentSession.objects.filter(team=request.team)
     session_filter = ExperimentSessionFilter()
-    query_set = session_filter.apply(query_set, filter_params=filter_params, timezone=timezone)
-
-    return query_set
+    return session_filter.apply(query_set, filter_params=filter_params, timezone=timezone)
 
 
 @login_and_team_required


### PR DESCRIPTION
## Summary
- Remove redundant and contradictory message filtering from `get_base_session_queryset`
- Delegate all filtering to `ExperimentSessionFilter`

The message tag filtering required that only sessions which contained messages with matching tags. It can safely be removed because the `ExperimentSessionFilter` already handles tag filtering at the session and message level.

Resolves https://github.com/dimagi/open-chat-studio/issues/2714