### PR TITLE
remove rate limit from evals task

### DIFF
--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -47,7 +47,7 @@ def _save_dataset_error(dataset: EvaluationDataset, error_message: str):
     dataset.save(update_fields=["status", "error_message", "job_id"])
 
 
-@shared_task(base=TaskbadgerTask, rate_limit="0.5/s")
+@shared_task(base=TaskbadgerTask)
 def evaluate_single_message_task(evaluation_run_id, evaluator_ids, message_id):
     """
     Run all evaluations over a single message.


### PR DESCRIPTION
### Technical Description
Evals tasks have been rate limited to one every 2s. I think this dates back to prior configurations and I don't think it's relevant currently.

If we need to re-introduce it, it should be per team, not a global limit.
