### PR TITLE
use GitHub App token for org project GraphQL queries

### DIFF
--- a/.github/workflows/claude-incremental.yml
+++ b/.github/workflows/claude-incremental.yml
@@ -20,7 +20,6 @@ permissions:
   contents: read
   issues: read
   pull-requests: read
-  project: read
 
 jobs:
   check-pending-pr:
@@ -52,10 +51,19 @@ jobs:
       issue_body: ${{ steps.find.outputs.issue_body }}
       issue_title: ${{ steps.find.outputs.issue_title }}
     steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.OCS_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.OCS_AUTOMATION_PEM }}
+          owner: ${{ github.repository_owner }}
+
       - name: Find oldest labeled issue in progress
         id: find
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECT_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           # Use specific issue if provided, otherwise find oldest in "In Progress" status
           if [ -n "${{ inputs.issue_number }}" ]; then
@@ -64,6 +72,7 @@ jobs:
             # Query the GitHub Project to find issues with claude-incremental label
             # that are in "In Progress" status
             # Project: https://github.com/orgs/dimagi/projects/3
+            # Uses a GitHub App token since GITHUB_TOKEN cannot access org-level projects
             QUERY='
             query($org: String!, $projectNumber: Int!) {
               organization(login: $org) {
@@ -96,7 +105,7 @@ jobs:
               }
             }'
 
-            RESULT=$(gh api graphql -f query="$QUERY" -f org="dimagi" -F projectNumber=3)
+            RESULT=$(GH_TOKEN="$PROJECT_TOKEN" gh api graphql -f query="$QUERY" -f org="dimagi" -F projectNumber=3)
 
             # Find the oldest issue that:
             # 1. Is in this repository


### PR DESCRIPTION
### Technical Description
GITHUB_TOKEN cannot access organization-level projects. Use a GitHub App (OCS_AUTOMATION) to generate an installation token for the project query in the claude-incremental workflow.
