### PR TITLE
Fix flaky scheduled messages test ordering

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1362,7 +1362,7 @@ class Participant(BaseTeamModel):
             )
             .select_related("action")
             .prefetch_related("attempts")
-            .order_by("created_at")
+            .order_by("created_at", "id")
         )
         if not include_inactive:
             messages = messages.filter(is_complete=False, cancelled_at=None)


### PR DESCRIPTION
## Summary
- Added `id` as a secondary sort key to the `get_schedules_for_experiment` query to ensure deterministic ordering when `created_at` timestamps are identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)