### PR TITLE
Add worktree invoke task for dev environment setup

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -236,13 +236,31 @@ def npm(c: Context, watch=False, install=False):
 
 
 @task(
+    aliases=["wt"],
     help={
         "branch": "Branch name to check out (created if it doesn't exist)",
         "path": "Worktree directory (default: ../open-chat-studio-<branch>)",
-    }
+        "list_": "List all worktrees",
+        "delete": "Interactively select a worktree to remove",
+    },
 )
-def worktree(c: Context, branch, path=None):
-    """Create a git worktree and bootstrap it for development."""
+def worktree(c: Context, branch=None, path=None, list_=False, delete=False):
+    """Create, list, or delete git worktrees for development."""
+    if list_:
+        _worktree_list(c)
+        return
+
+    if delete:
+        _worktree_delete(c)
+        return
+
+    if not branch:
+        raise Exit("Provide --branch to create, --list to list, or --delete to remove a worktree.", -1)
+
+    _worktree_create(c, branch, path)
+
+
+def _worktree_create(c: Context, branch, path=None):
     repo_dir = Path.cwd()
     safe_branch = branch.replace("/", "-")
     worktree_path = Path(path) if path else repo_dir.parent / f"open-chat-studio-{safe_branch}"
@@ -278,6 +296,83 @@ def worktree(c: Context, branch, path=None):
 
     cprint(f"\nWorktree ready at {worktree_path}", "green")
     cprint(f"  cd {worktree_path}", "cyan")
+
+
+def _parse_worktrees(c: Context):
+    """Parse ``git worktree list --porcelain`` into a list of dicts."""
+    result = c.run("git worktree list --porcelain", hide=True)
+    worktrees = []
+    current: dict = {}
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            current = {"path": line.split(" ", 1)[1]}
+        elif line.startswith("branch "):
+            current["branch"] = line.split(" ", 1)[1].removeprefix("refs/heads/")
+        elif line == "bare":
+            current["bare"] = True
+        elif line == "" and current:
+            worktrees.append(current)
+            current = {}
+    if current:
+        worktrees.append(current)
+    return worktrees
+
+
+def _worktree_list(c: Context):
+    worktrees = _parse_worktrees(c)
+    if not worktrees:
+        cprint("No worktrees found", "yellow")
+        return
+
+    for i, wt in enumerate(worktrees):
+        branch = wt.get("branch", "(detached)")
+        bare = " [bare]" if wt.get("bare") else ""
+        main = " (main)" if i == 0 else ""
+        cprint(f"  {wt['path']}  [{branch}]{bare}{main}", "green" if i == 0 else "white")
+
+
+def _worktree_delete(c: Context):
+    worktrees = _parse_worktrees(c)
+    # Exclude the main worktree (first entry)
+    candidates = worktrees[1:]
+    if not candidates:
+        raise Exit("No secondary worktrees to remove.", -1)
+
+    cprint("Select a worktree to remove:\n", "green")
+    for i, wt in enumerate(candidates, 1):
+        branch = wt.get("branch", "(detached)")
+        cprint(f"  {i}) {wt['path']}  [{branch}]", "white")
+
+    cprint("")
+    choice = input("Enter number (or q to cancel): ").strip()
+    if choice.lower() == "q" or not choice:
+        raise Exit("Cancelled", -1)
+
+    try:
+        idx = int(choice) - 1
+        selected = candidates[idx]
+    except (ValueError, IndexError) as err:
+        raise Exit("Invalid selection", -1) from err
+
+    branch = selected.get("branch", "(detached)")
+    if not _confirm(f"Remove worktree at {selected['path']} [{branch}]?", _exit=False):
+        raise Exit("Cancelled", -1)
+
+    result = c.run(f"git worktree remove {selected['path']}", echo=True, warn=True)
+    if result.ok:
+        cprint(f"Removed worktree [{branch}]", "green")
+        return
+
+    if "modified or untracked" in result.stderr:
+        cprint("\nWorktree has uncommitted changes:", "yellow")
+        c.run(f"git -C {selected['path']} status --short", echo=False)
+        cprint("")
+
+    if _confirm("Force remove?", _exit=False):
+        c.run(f"git worktree remove --force {selected['path']}", echo=True)
+        cprint(f"Force removed worktree [{branch}]", "green")
+    else:
+        raise Exit("Aborted", -1)
 
 
 def _confirm(message, _exit=True, exit_message="Done"):


### PR DESCRIPTION
### Technical Description

Adds an `inv worktree` (aliased as `inv wt`) invoke task that creates git worktrees bootstrapped for development. This replaces the need to manually set up worktrees by automating:

- **Create** (`inv wt -b <branch>`): Creates a worktree, copies gitignored config files (`.env`, `.envrc`, `.python-version`), and runs `scripts/bootstrap.sh` to install Python/Node dependencies.
- **List** (`inv wt --list`): Shows all worktrees with branch names in a formatted view.
- **Delete** (`inv wt --delete`): Interactive picker to select and remove a worktree. Shows `git status` for dirty worktrees before offering force removal.

### Demo

```
# Create a new worktree
$ inv wt -b sk/my-feature

# List worktrees
$ inv wt --list
  /home/user/open-chat-studio  [main] (main)
  /home/user/open-chat-studio-sk-my-feature  [sk/my-feature]

# Delete a worktree interactively
$ inv wt --delete
Select a worktree to remove:

  1) /home/user/open-chat-studio-sk-my-feature  [sk/my-feature]

Enter number (or q to cancel):
```

### Docs and Changelog
- [ ] This PR requires docs/changelog update