### PR TITLE
Remove unused OpenAPI schema test fixtures

### DIFF
--- a/apps/custom_actions/tests/test_versioning.py
+++ b/apps/custom_actions/tests/test_versioning.py
@@ -4,49 +4,6 @@ from apps.custom_actions.models import CustomActionOperation
 from apps.utils.factories.custom_actions import CustomActionFactory
 from apps.utils.factories.pipelines import NodeFactory, PipelineFactory
 
-EXPECTED_POLLEN_GET_SCHEMA = {
-    "openapi": "3.0.0",
-    "info": {
-        "title": "Weather API - get /pollen",
-        "version": "1.0.0",
-        "description": "Standalone OpenAPI spec for get /pollen",
-    },
-    "servers": [{"url": "https://api.weather.com"}],
-    "paths": {
-        "/pollen": {
-            "get": {
-                "summary": "Get pollen count",
-            }
-        },
-    },
-}
-
-EXPECTED_WEATHER_GET_SCHEMA = {
-    "openapi": "3.0.0",
-    "info": {
-        "title": "Weather API - get /weather",
-        "version": "1.0.0",
-        "description": "Standalone OpenAPI spec for get /weather",
-    },
-    "servers": [{"url": "https://api.weather.com"}],
-    "paths": {
-        "/weather": {
-            "get": {
-                "summary": "Get weather",
-                "parameters": [
-                    {
-                        "name": "location",
-                        "in": "query",
-                        "required": True,
-                        "schema": {"type": "string"},
-                        "description": "The location to get the weather for",
-                    }
-                ],
-            },
-        },
-    },
-}
-
 
 @pytest.fixture()
 def custom_action():


### PR DESCRIPTION
### Technical Description

Removed two unused test fixture constants (`EXPECTED_POLLEN_GET_SCHEMA` and `EXPECTED_WEATHER_GET_SCHEMA`) from the versioning test module. These schema definitions were not referenced by any tests in the file and appear to be leftover from previous test implementations.

This is a cleanup change that reduces test file clutter and removes dead code without affecting any functionality.

### Migrations

N/A

### Demo

N/A

### Docs and Changelog

- [ ] This PR requires docs/changelog update

https://claude.ai/code/session_01KfJCWf9C9Qh4syb6xoSPnD