### PR TITLE
fix: delete orphaned CustomActionOperations before adding constraint

### DIFF
--- a/apps/custom_actions/migrations/0005_remove_customactionoperation_unique_experiment_custom_action_operation_and_more.py
+++ b/apps/custom_actions/migrations/0005_remove_customactionoperation_unique_experiment_custom_action_operation_and_more.py
@@ -3,6 +3,15 @@
 from django.db import migrations, models
 
 
+def delete_orphaned_operations(apps, schema_editor):
+    """Delete CustomActionOperation rows that have no assistant or node.
+
+    These rows only had an experiment association which is being removed.
+    """
+    CustomActionOperation = apps.get_model("custom_actions", "CustomActionOperation")
+    CustomActionOperation.objects.filter(assistant__isnull=True, node__isnull=True).delete()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -20,6 +29,7 @@ class Migration(migrations.Migration):
             model_name='customactionoperation',
             name='experiment_or_assistant_or_node_required',
         ),
+        migrations.RunPython(delete_orphaned_operations, migrations.RunPython.noop),
         migrations.RemoveField(
             model_name='customactionoperation',
             name='experiment',


### PR DESCRIPTION
## Summary
- Migration `custom_actions.0005` fails on production because existing `CustomActionOperation` rows only have an `experiment` association (`assistant` and `node` are both null)
- Added a `RunPython` data migration step to delete these orphaned rows before the `assistant_or_node_required` check constraint is applied
- The migration order is now: remove old constraints → delete orphaned rows → remove experiment field → add new constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)