### PR TITLE
fix: Guard notifications link when request.team is None

### DIFF
--- a/templates/web/components/app_nav_menu_items.html
+++ b/templates/web/components/app_nav_menu_items.html
@@ -7,12 +7,14 @@
   <span>{% translate "My Account" %}</span>
 </li>
 <ul class="menu">
+  {% if request.team %}
   <li>
     <a href="{% url 'ocs_notifications:notifications_home' request.team.slug %}" {% if active_tab == 'notifications' %}class="menu-active"{% endif %}>
       <i class="fa-solid fa-bell"></i>
       {% translate "Notifications" %} {% if unread_notifications_count %}<span class="badge badge-xs badge-error">{{ unread_notifications_count }}</span>{% endif %}
     </a>
   </li>
+  {% endif %}
   <li>
     <a href="{% url 'users:user_profile' %}" {% if active_tab == 'profile' %}class="menu-active"{% endif %}>
       <i class="fa fa-user h-4 w-4"></i>


### PR DESCRIPTION
Fix NoReverseMatch error on /teams/create/ by wrapping the notifications link in `{% if request.team %}` in `app_nav_menu_items.html`.

The notifications link was using `request.team.slug` without checking if `request.team` exists, causing a NoReverseMatch error for users without a team (e.g. on the /teams/create/ page).

The fix matches the existing pattern used in `team_nav.html` where all team-scoped links are already guarded this way.

Closes #2911

Generated with [Claude Code](https://claude.ai/code)