### PR TITLE
fix: last activity column blank due to PostgreSQL NULLS FIRST ordering

### DIFF
--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -232,7 +232,7 @@ class ChatbotExperimentTableView(LoginAndTeamRequiredMixin, SingleTableView, Per
         last_activity_subquery = (
             ExperimentSession.objects.filter(experiment_id=OuterRef("pk"))
             .exclude(platform=ChannelPlatform.EVALUATIONS)
-            .order_by("-last_activity_at")
+            .order_by(F("last_activity_at").desc(nulls_last=True))
             .values("last_activity_at")[:1]
         )
 


### PR DESCRIPTION
### Technical Description

The **Last Activity** column in the chatbot table was blank for some chatbots despite them having recent sessions.

**Root cause:** `ChatbotExperimentTableView.get_queryset()` uses a subquery to find the most recent `last_activity_at` across a chatbot's sessions. The subquery used `.order_by("-last_activity_at")` which in PostgreSQL defaults to `NULLS FIRST` for `DESC` ordering. Any chatbot with at least one session where `last_activity_at IS NULL` (e.g. a bot-initiated session that never received a human reply, or a session predating the backfill migration) would cause the subquery to return `NULL`, making the whole column blank for that chatbot — even if other sessions had valid timestamps.

**Fix:** Use `F("last_activity_at").desc(nulls_last=True)` in the subquery, consistent with the `NULLS LAST` behaviour already applied to the outer queryset ordering.

Note: `last_activity_at` is set by the `update_session_last_activity` signal (in `apps/channels/signals.py`) whenever a `ChatMessageType.HUMAN` message is created. This fires for all channel types (web, API, Slack, Twilio, Telegram, etc.) since they all create messages via `ChatMessage.objects.create()` through `ChannelBase._add_message_to_history`. No issue was found with signal coverage across platforms.

### Migrations

N/A — no migrations.

### Demo

Before: chatbots with any session lacking `last_activity_at` (e.g. bot-initiated sessions) showed a blank Last Activity column.  
After: the column correctly shows the most recent non-null `last_activity_at` across all sessions.

### Docs and Changelog
- [ ] This PR requires docs/changelog update