### PR TITLE
fix: ensure uv uses pinned Python version in worktree setup

### DIFF
--- a/.claude/hooks/setup-env.sh
+++ b/.claude/hooks/setup-env.sh
@@ -14,8 +14,21 @@ if [ "$CURRENT_PATH" != "$ROOT_WORKTREE_PATH" ]; then
 
     [ -f "$ROOT_WORKTREE_PATH/.env" ]   && [ ! -f ".env" ]   && cp "$ROOT_WORKTREE_PATH/.env"   .env
     [ -f "$ROOT_WORKTREE_PATH/.envrc" ] && [ ! -f ".envrc" ] && cp "$ROOT_WORKTREE_PATH/.envrc" .envrc
-    [ -f "$ROOT_WORKTREE_PATH/.python-version" ] && [ ! -f ".python-version" ] && cp "$ROOT_WORKTREE_PATH/.python-version" .python-version
+    if [ -f "$ROOT_WORKTREE_PATH/.python-version" ] && [ ! -f ".python-version" ]; then
+        cp "$ROOT_WORKTREE_PATH/.python-version" .python-version
+    fi
     command -v direnv &>/dev/null        && direnv allow
+fi
+
+# Set UV_PYTHON from .python-version so uv sync uses the pinned version rather
+# than the latest Python satisfying requires-python in pyproject.toml.
+_PV_FILE="${CURRENT_PATH}/.python-version"
+if [ ! -f "$_PV_FILE" ]; then
+    _PV_FILE="$ROOT_WORKTREE_PATH/.python-version"
+fi
+if [ -f "$_PV_FILE" ]; then
+    export UV_PYTHON
+    UV_PYTHON=$(cat "$_PV_FILE")
 fi
 
 "$ROOT_WORKTREE_PATH/scripts/bootstrap.sh" --force --yes


### PR DESCRIPTION
### Technical Description

Recent uv versions (0.8+) changed how they resolve the Python version when creating new virtual environments. Instead of using `.python-version`, they now use `requires-python` from `pyproject.toml` and select the **latest** installed Python that satisfies the constraint. Since the project has `requires-python = ">=3.13"` and uv has CPython 3.14.2 installed locally, uv was picking 3.14.2 — which fails because packages like `onnxruntime==1.22.1` don't have wheels for Python 3.14.

This was surfacing in worktree setup via `worktrees.json` / `setup-env.sh`: the new worktree has no `.venv`, `VIRTUAL_ENV` points to the main worktree's venv (which uv ignores), and uv creates a fresh venv using 3.14.2.

**Fix:** Set `UV_PYTHON` from the `.python-version` file before calling `bootstrap.sh`, so `uv sync` always uses the project-pinned version (3.13) regardless of uv version behavior. Also replaced the `.python-version` `&&` copy chain with an explicit `if` block for clarity.

### Migrations

N/A

### Demo

N/A — worktree setup now completes successfully instead of failing with:
```
error: Distribution `onnxruntime==1.22.1` can't be installed because it doesn't have a wheel for CPython 3.14
```

### Docs and Changelog
- [ ] This PR requires docs/changelog update