### PR TITLE
drop Django verison to 5.2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "A web application for building and deploying chatbots."
 readme = "README.md"
 license = "BSD-3-Clause"
 dependencies = [
-    "Django",
+    "Django<6",
     "Markdown",
     "anthropic",
     "azure-cognitiveservices-speech",

--- a/uv.lock
+++ b/uv.lock
@@ -797,16 +797,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.2"
+version = "5.2.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/3e/a1c4207c5dea4697b7a3387e26584919ba987d8f9320f59dc0b5c557a4eb/django-6.0.2.tar.gz", hash = "sha256:3046a53b0e40d4b676c3b774c73411d7184ae2745fe8ce5e45c0f33d3ddb71a7", size = 10886874, upload-time = "2026-02-03T13:50:31.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/f2/3e57ef696b95067e05ae206171e47a8e53b9c84eec56198671ef9eaa51a6/django-5.2.11.tar.gz", hash = "sha256:7f2d292ad8b9ee35e405d965fbbad293758b858c34bbf7f3df551aeeac6f02d3", size = 10885017, upload-time = "2026-02-03T13:52:50.554Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/ba/a6e2992bc5b8c688249c00ea48cb1b7a9bc09839328c81dc603671460928/django-6.0.2-py3-none-any.whl", hash = "sha256:610dd3b13d15ec3f1e1d257caedd751db8033c5ad8ea0e2d1219a8acf446ecc6", size = 8339381, upload-time = "2026-02-03T13:50:15.501Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a7/2b112ab430575bf3135b8304ac372248500d99c352f777485f53fdb9537e/django-5.2.11-py3-none-any.whl", hash = "sha256:e7130df33ada9ab5e5e929bc19346a20fe383f5454acb2cc004508f242ee92c0", size = 8291375, upload-time = "2026-02-03T13:52:42.47Z" },
 ]
 
 [[package]]
@@ -3022,7 +3022,7 @@ requires-dist = [
     { name = "celery", extras = ["redis"] },
     { name = "celery-progress" },
     { name = "chardet" },
-    { name = "django" },
+    { name = "django", specifier = "<6" },
     { name = "django-allauth", extras = ["mfa"], specifier = ">=0.56.0" },
     { name = "django-anymail" },
     { name = "django-browser-reload", specifier = ">=1.21.0" },


### PR DESCRIPTION
### Technical Description
Somehow this [PR](https://github.com/dimagi/open-chat-studio/pull/2949) also upgraded Django to v6.

I've downgraded to 5.2 which is still an upgrade from 5.1.x previously. I've reviewed the 5.2 release notes and believe this is a safe upgrade.