### PR TITLE
Add migrate_langfuse_data management command

### DIFF
--- a/apps/service_providers/management/commands/migrate_langfuse_data.py
+++ b/apps/service_providers/management/commands/migrate_langfuse_data.py
@@ -55,17 +55,25 @@ def _parse_datetime(datetime_str):
 
 def _load_checkpoint(filepath: str) -> tuple[set, str | None]:
     """Load checkpoint state. Returns (migrated_ids, resume_from_timestamp)."""
+    from django.core.management.base import CommandError
+
     if not os.path.exists(filepath):
         return set(), None
-    with open(filepath) as f:
-        data = json.load(f)
+    try:
+        with open(filepath, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        raise CommandError(f"Invalid checkpoint file '{filepath}'. Use --reset-checkpoint to start fresh.") from e
     return set(data.get("migrated_ids", [])), data.get("resume_from_timestamp")
 
 
 def _save_checkpoint(filepath: str, migrated_ids: set, resume_from_timestamp: str | None = None) -> None:
-    """Write checkpoint state to file."""
-    with open(filepath, "w") as f:
-        json.dump({"migrated_ids": list(migrated_ids), "resume_from_timestamp": resume_from_timestamp}, f, indent=2)
+    """Write checkpoint state to file atomically to avoid corruption on interruption."""
+    tmp_path = f"{filepath}.tmp"
+    payload = {"migrated_ids": list(migrated_ids), "resume_from_timestamp": resume_from_timestamp}
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+    os.replace(tmp_path, filepath)
 
 
 def _transform_trace_to_ingestion_batch(source_trace):
@@ -178,8 +186,8 @@ def _transform_trace_to_ingestion_batch(source_trace):
             ingestion_events.append(
                 ingestion_event_type(id=str(uuid.uuid4()), timestamp=event_specific_timestamp, body=event_body)
             )
-        except Exception:
-            continue
+        except Exception as e:
+            raise ValueError(f"Failed to transform observation {source_obs.id} (type: {source_obs.type})") from e
 
     for source_score in source_trace.scores:
         new_observation_id = obs_id_map.get(source_score.observation_id) if source_score.observation_id else None
@@ -221,8 +229,8 @@ def _transform_trace_to_ingestion_batch(source_trace):
             ingestion_events.append(
                 IngestionEvent_ScoreCreate(id=str(uuid.uuid4()), timestamp=event_timestamp_str, body=score_body)
             )
-        except Exception:
-            continue
+        except Exception as e:
+            raise ValueError(f"Failed to transform score {source_score.id}") from e
 
     return ingestion_events
 
@@ -386,6 +394,8 @@ class Command(BaseCommand):
             raise CommandError(f"Could not parse --from-timestamp: '{from_timestamp_str}'")
         if to_timestamp_str and not to_timestamp:
             raise CommandError(f"Could not parse --to-timestamp: '{to_timestamp_str}'")
+        if from_timestamp and to_timestamp and from_timestamp > to_timestamp:
+            raise CommandError("--from-timestamp must be earlier than or equal to --to-timestamp")
 
         migrated_ids, resume_from_timestamp = _load_checkpoint(checkpoint_file)
         if migrated_ids:
@@ -523,8 +533,8 @@ class Command(BaseCommand):
                     self.stdout.write(f"        Max retries reached fetching details for {trace_id}.")
                     return None
                 else:
-                    self.stdout.write(f"        Non-rate-limit error for {trace_id}. Failing this trace.")
-                    return None
+                    self.stdout.write(f"        Transient error for {trace_id}, retrying...")
+                    time.sleep(2**attempt)
         return None
 
     def _push_batch_with_retry(


### PR DESCRIPTION
### Technical Description

Based on scripts here: https://langfuse.com/guides/cookbook/example_data_migration#section-ii--migrating-traces-observations--scores

Adds a `migrate_langfuse_data` Django management command that migrates Langfuse traces between projects. Unlike the standalone script (`migrate_template.py`), this command integrates with the Django ORM to fetch credentials from encrypted `TraceProvider` records rather than requiring env vars.

**Usage:**
```
python manage.py migrate_langfuse_data <team-slug> [options]
```

**Features:**
- Looks up the team by slug and lists all Langfuse `TraceProvider`s for that team
- Prompts interactively to select source and destination providers, with host-based defaults:
  - Source defaults to a provider with host `langfuse.openchatstudio.com`
  - Destination defaults to a provider with host `cloud.langfuse.com`
- Checkpoint file is scoped to the team slug (`.migration_checkpoint_<team_slug>.json`) to avoid cross-team collisions
- Supports `--dry-run`, `--from-timestamp`/`--to-timestamp` filtering, `--reset-checkpoint`, and rate-limit retry tuning (`--sleep-get`, `--sleep-batch`, `--max-retries`)
- Preserves original trace IDs; warns about potential ID collisions before proceeding

### Migrations

N/A — no database changes.

### Demo

```
$ python manage.py migrate_langfuse_data my-team --dry-run

Langfuse TraceProviders for team 'My Team':

  [1] OCS Langfuse  (https://langfuse.openchatstudio.com)
  [2] Cloud Langfuse  (https://cloud.langfuse.com)

Select source provider [1-2] (default: 1): 
Select destination provider [1-2] (default: 2): 

WARNING: Migrates full trace data. PRESERVES ORIGINAL TRACE IDs.
Ensure no ID collisions in the destination project!

Source:      OCS Langfuse  (https://langfuse.openchatstudio.com)
Destination: Cloud Langfuse  (https://cloud.langfuse.com)
Mode:        DRY RUN
Checkpoint:  .migration_checkpoint_my-team.json

Proceed with trace migration? (yes/no): yes
```

### Docs and Changelog
- [ ] This PR requires docs/changelog update