### PR TITLE
chore: migrate gemini-3-pro-preview to gemini-3.1-pro-preview

### DIFF
--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -113,7 +113,7 @@ DEFAULT_LLM_PROVIDER_MODELS = {
         Model("gemini-2.0-flash", 1048576, deprecated=True),
     ],
     "google_vertex_ai": [
-        Model("gemini-3-pro-preview", 1048576),
+        Model("gemini-3.1-pro-preview", 1048576),
         Model("gemini-2.5-pro", 1048576, is_translation_default=True),
         Model("gemini-2.5-flash", 1048576, is_default=True),
         Model("gemini-2.5-flash-lite", 1048576),
@@ -161,6 +161,8 @@ DELETED_MODELS = [
     ("google", "gemini-1.5-flash"),
     ("google", "gemini-1.5-flash-8b"),
     ("google", "gemini-1.5-pro"),
+    # Google Vertex AI
+    ("google_vertex_ai", "gemini-3-pro-preview", "gemini-3.1-pro-preview"),
 ]
 
 

--- a/apps/service_providers/migrations/0043_migrate_gemini_3_pro_preview.py
+++ b/apps/service_providers/migrations/0043_migrate_gemini_3_pro_preview.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+from apps.data_migrations.utils.migrations import RunDataMigration
+from apps.service_providers.migration_utils import llm_model_migration
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("service_providers", "0042_add_claude_sonnet_4_6"),
+    ]
+
+    operations = [
+        llm_model_migration(),
+        RunDataMigration("remove_deprecated_models", command_options={"force": True}),
+    ]


### PR DESCRIPTION
Fixes #2953

### Technical Description

Migrates `gemini-3-pro-preview` to `gemini-3.1-pro-preview` for the Google Vertex AI provider ahead of the March 26, 2026 deprecation deadline.

Changes:
- Replaced `gemini-3-pro-preview` with `gemini-3.1-pro-preview` in `DEFAULT_LLM_PROVIDER_MODELS`
- Added `gemini-3-pro-preview` to `DELETED_MODELS` with `gemini-3.1-pro-preview` as replacement for auto-migration
- Created Django migration that updates the model list and auto-migrates all existing references

### Migrations
- [x] The migrations are backwards compatible

Generated with [Claude Code](https://claude.ai/code)