### PR TITLE
Exclude eval messages from dashboard stats

### DIFF
--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -16,6 +16,7 @@ from apps.teams.models import Team
 def get_message_stats(start: datetime, end: datetime):
     data = (
         ChatMessage.objects.filter(created_at__gte=start, created_at__lt=end)
+        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
         .annotate(date=TruncDate("created_at"))
         .values("date")
         .annotate(count=Count("id"))
@@ -27,6 +28,7 @@ def get_message_stats(start: datetime, end: datetime):
 def get_participant_stats(start: datetime, end: datetime):
     data = (
         Participant.objects.filter(created_at__gte=start, created_at__lt=end)
+        .exclude(platform=ChannelPlatform.EVALUATIONS)
         .annotate(date=TruncDate("created_at"))
         .values("date")
         .annotate(count=Count("id"))
@@ -43,6 +45,7 @@ def get_usage_data(start: datetime, end: datetime):
     """Usage approximation based on character counts."""
     usage_data = (
         ChatMessage.objects.filter(created_at__gte=start, created_at__lt=end)
+        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
         .values("chat__team__name")
         .annotate(
             msg_count=Count("id"),
@@ -107,6 +110,7 @@ def get_whatsapp_message_stats(start: datetime, end: datetime):
             chat__experiment_session__experiment_channel__platform=ChannelPlatform.WHATSAPP,
             message_type__in=["human", "ai"],
         )
+        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
         .values(
             "chat__team__name",
             "chat__team__slug",
@@ -154,6 +158,7 @@ def get_whatsapp_message_stats(start: datetime, end: datetime):
 def get_top_teams(start: datetime, end: datetime, limit: int = 10):
     msg_data = (
         ChatMessage.objects.filter(created_at__gte=start, created_at__lt=end)
+        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
         .values("chat__team_id", "chat__team__name", "chat__team__slug")
         .annotate(
             msg_count=Count("id"),
@@ -164,6 +169,7 @@ def get_top_teams(start: datetime, end: datetime, limit: int = 10):
 
     participant_data = (
         ExperimentSession.objects.filter(created_at__gte=start, created_at__lt=end)
+        .exclude(platform=ChannelPlatform.EVALUATIONS)
         .values("team_id")
         .annotate(participant_count=Count("participant", distinct=True))
     )
@@ -214,6 +220,7 @@ def get_platform_breakdown(start: datetime, end: datetime):
 def get_team_activity_summary(start: datetime, end: datetime):
     active_team_ids = set(
         ChatMessage.objects.filter(created_at__gte=start, created_at__lt=end)
+        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
         .values_list("chat__team_id", flat=True)
         .distinct()
     )
@@ -231,15 +238,28 @@ def get_team_activity_summary(start: datetime, end: datetime):
 
 def get_period_totals(start: datetime, end: datetime):
     return {
-        "messages": ChatMessage.objects.filter(created_at__gte=start, created_at__lt=end).count(),
-        "participants": Participant.objects.filter(created_at__gte=start, created_at__lt=end).count(),
-        "sessions": ExperimentSession.objects.filter(created_at__gte=start, created_at__lt=end).count(),
+        "messages": (
+            ChatMessage.objects.filter(created_at__gte=start, created_at__lt=end)
+            .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
+            .count()
+        ),
+        "participants": (
+            Participant.objects.filter(created_at__gte=start, created_at__lt=end)
+            .exclude(platform=ChannelPlatform.EVALUATIONS)
+            .count()
+        ),
+        "sessions": (
+            ExperimentSession.objects.filter(created_at__gte=start, created_at__lt=end)
+            .exclude(platform=ChannelPlatform.EVALUATIONS)
+            .count()
+        ),
     }
 
 
 def get_top_experiments(start: datetime, end: datetime, limit: int = 10):
     rows = (
         ChatMessage.objects.filter(created_at__gte=start, created_at__lt=end)
+        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
         .values(
             "chat__experiment_session__experiment__id",
             "chat__experiment_session__experiment__name",

--- a/apps/admin/views.py
+++ b/apps/admin/views.py
@@ -33,6 +33,7 @@ from apps.admin.queries import (
     whatsapp_message_stats_to_csv,
 )
 from apps.admin.serializers import StatsSerializer
+from apps.channels.models import ChannelPlatform
 from apps.experiments.models import Participant
 from apps.teams.flags import get_all_flag_info
 from apps.teams.models import Flag, Team
@@ -131,7 +132,9 @@ def usage_chart(request):
                 "message_data": usage_data.data,
                 "participant_data": {
                     "data": participant_data.data,
-                    "start_value": Participant.objects.filter(created_at__lt=start_timestamp).count(),
+                    "start_value": Participant.objects.filter(created_at__lt=start_timestamp)
+                    .exclude(platform=ChannelPlatform.EVALUATIONS)
+                    .count(),
                 },
                 "start": start.isoformat(),
                 "end": end.isoformat(),


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->

### Technical Description
<!--
A summary of the change, the reason for its implementation, and relevant links.
Include technical details required to understand the change.
-->

All dashboard queries (message stats, participant stats, usage data, top teams, top experiments, period totals, team activity) were including data from evaluation sessions, skewing the metrics. Only get_platform_breakdown had the exclusion. This adds consistent filtering across all queries.


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
N/A

### Docs and Changelog
- [x] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
