### PR TITLE
Self-hosting docs follow-up fixes

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,7 +16,7 @@ x-app: &app
     db:
       condition: service_healthy
     redis:
-      condition: service_started
+      condition: service_healthy
 
 services:
   db:
@@ -40,6 +40,12 @@ services:
     command: redis-server --appendonly yes
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   migrate:
     <<: *app

--- a/docs/hosting/aws.md
+++ b/docs/hosting/aws.md
@@ -70,6 +70,6 @@ ENABLE_JSON_LOGGING=True
 
 The ALB health check should be configured to call `/status` with a token from `HEALTH_CHECK_TOKENS`. Example target group health check path:
 
-```
+```text
 /status?token=your-health-check-token
 ```

--- a/docs/hosting/configuration.md
+++ b/docs/hosting/configuration.md
@@ -102,7 +102,7 @@ Required only if you want users to connect Slack channels to their chatbots.
 | `SLACK_SIGNING_SECRET` | Slack app signing secret |
 | `SLACK_BOT_NAME` | Display name for the Slack bot |
 
-### Observability
+## Observability
 
 | Variable | Description |
 |----------|-------------|
@@ -110,7 +110,7 @@ Required only if you want users to connect Slack channels to their chatbots.
 | `SENTRY_ENVIRONMENT` | Sentry environment tag, e.g. `production`. |
 | `ENABLE_JSON_LOGGING` | Set to `True` for structured JSON log output (recommended for log aggregation). |
 
-### Task Badger (optional)
+## Task Badger (optional)
 
 [Task Badger](https://taskbadger.net/) provides visibility into Celery task execution.
 
@@ -120,13 +120,13 @@ Required only if you want users to connect Slack channels to their chatbots.
 | `TASKBADGER_PROJECT` | Task Badger project slug |
 | `TASKBADGER_API_KEY` | Task Badger API key |
 
-### Analytics
+## Analytics
 
 | Variable | Description |
 |----------|-------------|
 | `GOOGLE_ANALYTICS_ID` | Google Analytics measurement ID |
 
-### Legal / Branding
+## Legal / Branding
 
 | Variable | Description |
 |----------|-------------|

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -89,7 +89,7 @@ The `web` service listens on port `8000` (or `$PORT`). Put a TLS-terminating rev
 
 ### Example: Caddy
 
-```
+```caddyfile
 yourdomain.com {
     reverse_proxy localhost:8000
 }

--- a/docs/hosting/index.md
+++ b/docs/hosting/index.md
@@ -16,11 +16,10 @@ flowchart TD
     RD[("Redis<br>Broker / Cache")]
 
     LB --> WEB
-    WEB --> CW
-    WEB --> CB
+    WEB --> RD
     WEB --> PG
-    CW --> RD
-    CB --> RD
+    RD --> CW
+    RD --> CB
     CW --> PG
     CB --> PG
 ```


### PR DESCRIPTION
### Technical Description

Follow-up to #2989 addressing review feedback and additional improvements to the self-hosting documentation.

**Changes:**
- `docker-compose.prod.yml`: Add Redis healthcheck (`redis-cli ping`) and update the `x-app` shared config to wait for `service_healthy` (matching the db pattern)
- `docs/hosting/index.md`: Fix Mermaid architecture diagram to accurately show `web → Redis → (workers)` flow instead of `web → workers` directly; fix health check docs to correctly state `?token=` query parameter only
- `docs/hosting/configuration.md`: Promote Observability, Task Badger, Analytics, and Legal/Branding to top-level sections (`##` not `###` under Integrations)
- `docs/hosting/docker.md`: Add `caddyfile` language tag to Caddy config example
- `docs/hosting/aws.md`: Add `text` language tag to health check path snippet
- `Dockerfile`: Replace `SECRET_KEY` and `DJANGO_ALLOWED_HOSTS` build args with hardcoded dummy values inline in the `collectstatic` RUN step — no build args required
- `.github/workflows/deploy.yml`: Remove now-unnecessary `build-args` block
- `config/settings_production.py`: Annotate `USE_HTTPS_IN_ABSOLUTE_URLS` as `bool` to fix a pre-existing `ty` type error

### Migrations

N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update