### PR TITLE
feat: add optional Claude Code launch prompt after worktree setup

### DIFF
--- a/.claude/hooks/setup-env.sh
+++ b/.claude/hooks/setup-env.sh
@@ -35,14 +35,19 @@ fi
 
 echo "[ocs] Setup complete."
 
-# Ask the user if they want to run Claude Code
-read -r -p "[ocs] Do you want to run Claude Code? (y/N): " RUN_CLAUDE
-if [[ "$RUN_CLAUDE" =~ ^[Yy]$ ]]; then
-    read -rep "[ocs] Enter your prompt: " CLAUDE_PROMPT
-    read -rep "[ocs] Run with all permissions (--dangerously-skip-permissions)? (y/N): " SKIP_PERMS
-    if [[ "$SKIP_PERMS" =~ ^[Yy]$ ]]; then
-        claude --dangerously-skip-permissions "$CLAUDE_PROMPT"
-    else
-        claude "$CLAUDE_PROMPT"
+# Ask the user if they want to run Claude Code.
+# Only prompt when stdin/stdout are a TTY (interactive terminal) and guard
+# against recursive re-entry when `claude` is launched from this hook.
+if [[ -t 0 && -t 1 && -z "${OCS_CLAUDE_LAUNCH_HANDLED:-}" ]]; then
+    export OCS_CLAUDE_LAUNCH_HANDLED=1
+    read -r -p "[ocs] Do you want to run Claude Code? (y/N): " RUN_CLAUDE || true
+    if [[ "$RUN_CLAUDE" =~ ^[Yy]$ ]]; then
+        read -rep "[ocs] Enter your prompt: " CLAUDE_PROMPT || true
+        read -rep "[ocs] Run with all permissions (--dangerously-skip-permissions)? (y/N): " SKIP_PERMS || true
+        if [[ "$SKIP_PERMS" =~ ^[Yy]$ ]]; then
+            claude --dangerously-skip-permissions "$CLAUDE_PROMPT"
+        else
+            claude "$CLAUDE_PROMPT"
+        fi
     fi
 fi


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->

### Technical Description
<!--
A summary of the change, the reason for its implementation, and relevant links.
Include technical details required to understand the change.
-->
Adds an interactive prompt at the end of the setup hook that asks if the user wants to launch Claude Code with an initial prompt.

 I initially wanted to write my own thing, but after thinking about more use cases and edge cases, I realized it might be easier and best to just use the existing worktree-cli tool.

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
The best way is to test it yourself

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
