### PR TITLE
fix: drop orphaned FK columns before removing deprecated LLM models

### DIFF
--- a/apps/experiments/migrations/0131_drop_llm_provider_columns.py
+++ b/apps/experiments/migrations/0131_drop_llm_provider_columns.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Drop llm_provider and llm_provider_model columns from experiments_experiment.
+
+    Migration 0130 removed these fields from Django's state using SeparateDatabaseAndState
+    but left the actual DB columns and FK constraints in place. This migration completes
+    the removal by dropping the columns from the database.
+    """
+
+    dependencies = [
+        ("experiments", "0130_remove_experiment_llm_provider_and_more"),
+        ("service_providers", "0043_migrate_gemini_3_pro_preview"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="ALTER TABLE experiments_experiment DROP COLUMN IF EXISTS llm_provider_model_id;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE experiments_experiment DROP COLUMN IF EXISTS llm_provider_id;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/apps/service_providers/migrations/0044_update_openai_models.py
+++ b/apps/service_providers/migrations/0044_update_openai_models.py
@@ -7,6 +7,7 @@ from apps.service_providers.migration_utils import llm_model_migration
 class Migration(migrations.Migration):
     dependencies = [
         ("service_providers", "0043_migrate_gemini_3_pro_preview"),
+        ("experiments", "0131_drop_llm_provider_columns"),
     ]
 
     operations = [


### PR DESCRIPTION
### Technical Description

Migration `0130` (experiments) used `SeparateDatabaseAndState` to remove `llm_provider_model` and `llm_provider` from Django's ORM state but left the actual DB columns and FK constraints in place. When `service_providers/0044` ran the `remove_deprecated_models` data migration, Django's ORM didn't see the FK on `experiments_experiment.llm_provider_model_id`, so it skipped nulling it out — but PostgreSQL still enforced the constraint, causing a `ForeignKeyViolation` on commit.

**Changes:**
- `apps/experiments/migrations/0131_drop_llm_provider_columns.py` — completes what 0130 should have done: drops both `llm_provider_model_id` and `llm_provider_id` columns from the DB using `DROP COLUMN IF EXISTS`
- `apps/service_providers/migrations/0044_update_openai_models.py` — adds dependency on `experiments.0131` so columns are dropped before `remove_deprecated_models` attempts to delete `LlmProviderModel` records

### Migrations
- [x] The migrations are backwards compatible

### Demo

Before: `migrate` fails with:
```
django.db.utils.IntegrityError: update or delete on table "service_providers_llmprovidermodel" violates foreign key constraint "experiments_experime_llm_provider_model_i_561e7954_fk_service_p" on table "experiments_experiment"
```

After: migrations apply cleanly.

### Docs and Changelog
- [ ] This PR requires docs/changelog update