### PR TITLE
Move djlint to prod requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ dependencies = [
     "python-json-logger>=3.2.1",
     "chardet",
     "dictdiffer>=0.9.0",
+    "djlint>=1.36.4",
 ]
 
 [project.urls]
@@ -163,7 +164,6 @@ dev = [
     "pytest-cov",
     "pytest-xdist",
     "django-debug-toolbar>=5.2.0",
-    "djlint>=1.36.4",
     "prek>=0.3.2",
     "django-types",
     "ty",

--- a/uv.lock
+++ b/uv.lock
@@ -2946,6 +2946,7 @@ dependencies = [
     { name = "django-watchfiles" },
     { name = "djangorestframework" },
     { name = "djangorestframework-api-key" },
+    { name = "djlint" },
     { name = "drf-spectacular" },
     { name = "emoji" },
     { name = "fbmessenger" },
@@ -2996,7 +2997,6 @@ dependencies = [
 dev = [
     { name = "django-debug-toolbar" },
     { name = "django-types" },
-    { name = "djlint" },
     { name = "factory-boy" },
     { name = "invoke" },
     { name = "mock" },
@@ -3058,6 +3058,7 @@ requires-dist = [
     { name = "django-watchfiles", specifier = ">=1.4.0" },
     { name = "djangorestframework" },
     { name = "djangorestframework-api-key" },
+    { name = "djlint", specifier = ">=1.36.4" },
     { name = "drf-spectacular" },
     { name = "emoji" },
     { name = "fbmessenger" },
@@ -3108,7 +3109,6 @@ requires-dist = [
 dev = [
     { name = "django-debug-toolbar", specifier = ">=5.2.0" },
     { name = "django-types" },
-    { name = "djlint", specifier = ">=1.36.4" },
     { name = "factory-boy" },
     { name = "invoke" },
     { name = "mock" },


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->
No change

### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.
-->
See https://github.com/dimagi/open-chat-studio/actions/runs/23181720627.

djlint had to be a non-dev dependency. 

### Migrations
<!--
There may be a potentially long window during the deployment where migrations are applied, but the old code is still running. We need to ensure that migrations can be applied to the current running code without breaking it, to the extent possible.

Delete this section if there are no migration.
 -->
- [ ] The migrations are backwards compatible


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
