### PR TITLE
Add XSS security tests for chat widget markdown sanitization

### DIFF
--- a/components/chat_widget/package-lock.json
+++ b/components/chat_widget/package-lock.json
@@ -22,6 +22,7 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^22.13.4",
         "autoprefixer": "^10.4.20",
+        "happy-dom": "^20.8.4",
         "jest": "^29.7.0",
         "jest-cli": "^29.7.0",
         "npm-run-all": "^4.1.5",
@@ -90,6 +91,7 @@
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1154,6 +1156,7 @@
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.36.3.tgz",
       "integrity": "sha512-C9DOaAjm+hSYRuVoUuYWG/lrYT8+4DG0AL0m1Ea9+G5v2Y6ApVpNJLbXvFlRZIdDMGecH86s6v0Gp39uockLxg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -1500,6 +1503,7 @@
       "integrity": "sha512-5PpLYhCAwf9SJEeIsSmCDLgyVfdBhdBpzX1OJ87anT9IVR0Z9pjM0FNixCAUAHGnMBGB8K99SwAheXrT0Kh6QQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.1.12",
@@ -1662,6 +1666,23 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -1688,6 +1709,16 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-escapes": {
@@ -2132,6 +2163,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -2549,14 +2581,14 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -2886,7 +2918,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1402036.tgz",
       "integrity": "sha512-JwAYQgEvm3yD45CHB+RmF5kMbWtXBaOGwuxa87sZogHcLCv8c/IqnThaoQ1y60d7pXWjSKWQphPEc+1rAScVdg==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -3724,6 +3757,47 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/happy-dom": {
+      "version": "20.8.4",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.4.tgz",
+      "integrity": "sha512-GKhjq4OQCYB4VLFBzv8mmccUadwlAusOZOI7hC1D9xDIT5HhzkJK17c4el2f6R6C715P9xB4uiMxeKUa2nHMwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -3831,6 +3905,34 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -5602,9 +5704,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -6213,44 +6315,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/pac-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/pac-resolver": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
@@ -6460,6 +6524,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7111,44 +7176,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/proxy-agent/node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/proxy-agent/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -7215,28 +7242,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/pure-rand": {
@@ -7697,16 +7702,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/socks-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8058,7 +8053,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.12.tgz",
       "integrity": "sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.2.3",
@@ -8294,6 +8290,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8553,6 +8550,28 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/components/chat_widget/package.json
+++ b/components/chat_widget/package.json
@@ -21,6 +21,7 @@
   ],
   "scripts": {
     "test": "stencil test --spec -- --forceExit",
+    "test:security": "node --test src/utils/markdown-security.test.mjs",
     "build": "stencil build --docs",
     "start": "stencil build --dev --watch --serve",
     "generate": "stencil generate",
@@ -45,6 +46,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.13.4",
     "autoprefixer": "^10.4.20",
+    "happy-dom": "^20.8.4",
     "jest": "^29.7.0",
     "jest-cli": "^29.7.0",
     "npm-run-all": "^4.1.5",

--- a/components/chat_widget/src/utils/markdown-security.test.mjs
+++ b/components/chat_widget/src/utils/markdown-security.test.mjs
@@ -1,0 +1,236 @@
+/**
+ * XSS security tests for the markdown sanitization config.
+ *
+ * These tests run outside Stencil's test environment (which uses a mock DOM
+ * that doesn't support DOMPurify) using Node's built-in test runner with
+ * happy-dom for a real DOM implementation.
+ *
+ * Run: npm run test:security
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { Window } from 'happy-dom';
+import createDOMPurify from 'dompurify';
+import { marked } from 'marked';
+
+// Mirror the config from markdown.ts — keep in sync!
+const SANITIZE_CONFIG = {
+  ALLOWED_TAGS: [
+    'p', 'br', 'strong', 'b', 'em', 'i', 'u', 'code', 'pre',
+    'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'blockquote', 'a', 'img', 'hr', 'table', 'thead', 'tbody',
+    'tr', 'td', 'th', 'del', 'ins', 'sub', 'sup'
+  ],
+  ALLOWED_ATTR: [
+    'href', 'target', 'rel', 'class', 'src', 'alt', 'title',
+    'width', 'height', 'align', 'colspan', 'rowspan'
+  ],
+  ALLOWED_URI_REGEXP: /^(?:(?:https?):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i,
+  ADD_ATTR: ['target'],
+  FORBID_TAGS: ['script', 'style', 'form', 'input', 'button', 'iframe', 'object', 'embed', 'svg', 'math'],
+  FORBID_ATTR: ['onclick', 'onload', 'onerror', 'onmouseover'],
+};
+
+const window = new Window();
+const DOMPurify = createDOMPurify(window);
+
+function sanitizeMarkdown(content) {
+  const html = marked.parse(content);
+  return DOMPurify.sanitize(html, SANITIZE_CONFIG);
+}
+
+function sanitizeHTML(content) {
+  return DOMPurify.sanitize(content, SANITIZE_CONFIG);
+}
+
+function assertNotContains(result, substring, msg) {
+  assert.ok(!result.includes(substring), msg || `Expected "${result}" not to contain "${substring}"`);
+}
+
+function assertContains(result, substring, msg) {
+  assert.ok(result.includes(substring), msg || `Expected "${result}" to contain "${substring}"`);
+}
+
+describe('markdown sanitization - valid rendering', () => {
+  it('renders plain text as a paragraph', () => {
+    assertContains(sanitizeMarkdown('Hello world'), '<p>Hello world</p>');
+  });
+
+  it('renders bold text', () => {
+    assertContains(sanitizeMarkdown('**bold**'), '<strong>bold</strong>');
+  });
+
+  it('renders links', () => {
+    const result = sanitizeMarkdown('[link](https://example.com)');
+    assertContains(result, 'href="https://example.com"');
+    assertContains(result, '<a');
+  });
+
+  it('renders images', () => {
+    const result = sanitizeMarkdown('![alt](https://example.com/img.png)');
+    assertContains(result, '<img');
+    assertContains(result, 'src="https://example.com/img.png"');
+  });
+
+  it('renders code blocks', () => {
+    assertContains(sanitizeMarkdown('```\ncode\n```'), '<code>');
+  });
+
+  it('renders tables', () => {
+    const result = sanitizeMarkdown('| A | B |\n|---|---|\n| 1 | 2 |');
+    assertContains(result, '<table>');
+    assertContains(result, '<td>');
+  });
+});
+
+describe('XSS prevention - script injection', () => {
+  it('strips script tags', () => {
+    const result = sanitizeHTML('<script>alert("XSS")</script>');
+    assertNotContains(result, '<script');
+    assertNotContains(result, 'alert');
+  });
+
+  it('strips nested script tags (content is HTML-escaped, not executable)', () => {
+    const result = sanitizeHTML('<scr<script>ipt>alert(1)</scr</script>ipt>');
+    assertNotContains(result, '<script');
+    // The text "alert(" may appear HTML-escaped — that's safe.
+    // Verify no unescaped script tag remains.
+    assert.ok(!/<script/i.test(result), `No script tags should remain: ${result}`);
+  });
+});
+
+describe('XSS prevention - event handlers', () => {
+  it('strips onerror on images', () => {
+    const result = sanitizeHTML('<img src=x onerror=alert("XSS")>');
+    assertNotContains(result, 'onerror');
+    assertNotContains(result, 'alert');
+  });
+
+  it('strips onclick on links', () => {
+    const result = sanitizeHTML('<a href="#" onclick="alert(1)">click</a>');
+    assertNotContains(result, 'onclick');
+  });
+
+  it('strips onmouseover on allowed tags', () => {
+    const result = sanitizeHTML('<p onmouseover="alert(1)">hover me</p>');
+    assertNotContains(result, 'onmouseover');
+  });
+
+  it('strips onclick on allowed tags', () => {
+    const result = sanitizeHTML('<p onclick="alert(1)">text</p>');
+    assertNotContains(result, 'onclick');
+  });
+
+  it('strips onload on svg', () => {
+    const result = sanitizeHTML('<svg onload=alert("XSS")>');
+    assertNotContains(result, '<svg');
+    assertNotContains(result, 'onload');
+  });
+});
+
+describe('XSS prevention - dangerous URIs', () => {
+  it('blocks javascript: URIs in raw HTML links', () => {
+    const result = sanitizeHTML('<a href="javascript:alert(1)">click</a>');
+    assertNotContains(result, 'javascript:');
+  });
+
+  it('blocks javascript: URIs in markdown links', () => {
+    const result = sanitizeMarkdown('[click](javascript:alert(1))');
+    assertNotContains(result, 'javascript:');
+  });
+
+  it('blocks encoded javascript: URIs', () => {
+    const result = sanitizeHTML('<a href="&#106;avascript:alert(1)">click</a>');
+    assertNotContains(result, 'javascript');
+  });
+});
+
+describe('XSS prevention - forbidden tags', () => {
+  it('strips style tags', () => {
+    const result = sanitizeHTML('<style>body{background:red}</style>');
+    assertNotContains(result, '<style');
+  });
+
+  it('strips form elements', () => {
+    const result = sanitizeHTML('<form action="https://evil.com"><input type="text"></form>');
+    assertNotContains(result, '<form');
+  });
+
+  it('strips input elements', () => {
+    const result = sanitizeHTML('<input type="text" value="XSS">');
+    assertNotContains(result, '<input');
+  });
+
+  it('strips button elements', () => {
+    const result = sanitizeHTML('<button onclick="alert(1)">Click</button>');
+    assertNotContains(result, '<button');
+  });
+
+  it('strips iframe tags', () => {
+    const result = sanitizeHTML('<iframe src="https://evil.com"></iframe>');
+    assertNotContains(result, '<iframe');
+  });
+
+  it('strips object tags', () => {
+    const result = sanitizeHTML('<object data="evil.swf"></object>');
+    assertNotContains(result, '<object');
+  });
+
+  it('strips embed tags', () => {
+    const result = sanitizeHTML('<embed src="evil.swf">');
+    assertNotContains(result, '<embed');
+  });
+
+  it('strips svg tags', () => {
+    const result = sanitizeHTML('<svg><circle cx="50" cy="50" r="40"/></svg>');
+    assertNotContains(result, '<svg');
+  });
+
+  it('strips math tags', () => {
+    const result = sanitizeHTML('<math><mrow><mi>x</mi></mrow></math>');
+    assertNotContains(result, '<math');
+  });
+});
+
+describe('XSS prevention - mutation XSS', () => {
+  it('handles mXSS via math/style nesting', () => {
+    const result = sanitizeHTML(
+      '<math><mtext><table><mglyph><style><!--</style><img src=x onerror=alert(1)>'
+    );
+    assertNotContains(result, 'onerror');
+    assertNotContains(result, 'alert');
+    assertNotContains(result, '<style');
+    assertNotContains(result, '<math');
+  });
+});
+
+describe('safe content is preserved', () => {
+  it('preserves bold and italic', () => {
+    const result = sanitizeHTML('<strong>bold</strong> and <em>italic</em>');
+    assertContains(result, '<strong>bold</strong>');
+    assertContains(result, '<em>italic</em>');
+  });
+
+  it('preserves safe links', () => {
+    const result = sanitizeHTML('<a href="https://example.com">safe</a>');
+    assertContains(result, 'href="https://example.com"');
+  });
+
+  it('preserves safe images', () => {
+    const result = sanitizeHTML('<img src="https://example.com/img.png" alt="pic">');
+    assertContains(result, 'src="https://example.com/img.png"');
+    assertContains(result, 'alt="pic"');
+  });
+
+  it('preserves headings', () => {
+    const result = sanitizeMarkdown('# Title\n## Subtitle');
+    assertContains(result, '<h1');
+    assertContains(result, '<h2');
+  });
+
+  it('preserves lists', () => {
+    const result = sanitizeMarkdown('- item 1\n- item 2');
+    assertContains(result, '<ul>');
+    assertContains(result, '<li>');
+  });
+});

--- a/components/chat_widget/src/utils/markdown.ts
+++ b/components/chat_widget/src/utils/markdown.ts
@@ -38,6 +38,23 @@ export function postProcessMarkdownHTML(html: string): string {
 }
 
 
+export const SANITIZE_CONFIG = {
+  ALLOWED_TAGS: [
+    'p', 'br', 'strong', 'b', 'em', 'i', 'u', 'code', 'pre',
+    'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'blockquote', 'a', 'img', 'hr', 'table', 'thead', 'tbody',
+    'tr', 'td', 'th', 'del', 'ins', 'sub', 'sup'
+  ],
+  ALLOWED_ATTR: [
+    'href', 'target', 'rel', 'class', 'src', 'alt', 'title',
+    'width', 'height', 'align', 'colspan', 'rowspan'
+  ],
+  ALLOWED_URI_REGEXP: /^(?:(?:https?):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i,
+  ADD_ATTR: ['target'],
+  FORBID_TAGS: ['script', 'style', 'form', 'input', 'button', 'iframe', 'object', 'embed', 'svg', 'math'],
+  FORBID_ATTR: ['onclick', 'onload', 'onerror', 'onmouseover'],
+};
+
 export function renderMarkdownSync(content: string): string {
   if (!content || typeof content !== 'string') {
     return '';
@@ -45,22 +62,7 @@ export function renderMarkdownSync(content: string): string {
 
   try {
     const html = marked.parse(content);
-    const sanitized = DOMPurify.sanitize(html, {
-      ALLOWED_TAGS: [
-        'p', 'br', 'strong', 'b', 'em', 'i', 'u', 'code', 'pre',
-        'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-        'blockquote', 'a', 'img', 'hr', 'table', 'thead', 'tbody',
-        'tr', 'td', 'th', 'del', 'ins', 'sub', 'sup'
-      ],
-      ALLOWED_ATTR: [
-        'href', 'target', 'rel', 'class', 'src', 'alt', 'title',
-        'width', 'height', 'align', 'colspan', 'rowspan'
-      ],
-      ALLOWED_URI_REGEXP: /^(?:(?:https?):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i,
-      ADD_ATTR: ['target'],
-      FORBID_TAGS: ['script', 'style', 'form', 'input', 'button'],
-      FORBID_ATTR: ['onclick', 'onload', 'onerror', 'onmouseover'],
-    });
+    const sanitized = DOMPurify.sanitize(html, SANITIZE_CONFIG);
 
     return postProcessMarkdownHTML(sanitized);
   } catch (error) {


### PR DESCRIPTION
### Product Description
Add automated security tests to verify the chat widget's markdown rendering is resilient against XSS attacks, and harden the DOMPurify sanitization config with additional forbidden tags.

### Technical Description
- Extract `SANITIZE_CONFIG` from inline usage in `renderMarkdownSync` into an exported constant for testability
- Expand `FORBID_TAGS` to include `iframe`, `object`, `embed`, `svg`, and `math` as defense-in-depth
- Add 31 security tests in `markdown-security.test.mjs` covering:
  - Script injection (direct and nested)
  - Event handler stripping (onerror, onclick, onmouseover, onload)
  - Dangerous URI blocking (javascript:, encoded javascript:)
  - Forbidden tag removal (script, style, form, input, button, iframe, object, embed, svg, math)
  - Mutation XSS (mXSS via math/style nesting)
  - Safe content preservation (bold, italic, links, images, headings, lists)
- Tests use Node's built-in test runner with `happy-dom` because Stencil's mock DOM doesn't support DOMPurify's sanitization APIs
- New `npm run test:security` script in the chat widget package

### Migrations
- [ ] The migrations are backwards compatible

N/A — no migrations

### Demo
```
$ npm run test:security
▶ XSS prevention - script injection
  ✔ strips script tags
  ✔ strips nested script tags
▶ XSS prevention - event handlers
  ✔ strips onerror on images
  ✔ strips onclick on links
  ...
ℹ tests 31, pass 31, fail 0
```

### Docs and Changelog
- [ ] This PR requires docs/changelog update


🤖 Generated with [Claude Code](https://claude.com/claude-code)