### PR TITLE
Add tools to allow LLM nodes to manage session state

### DIFF
--- a/apps/chat/agent/schemas.py
+++ b/apps/chat/agent/schemas.py
@@ -108,6 +108,20 @@ class GetSessionStateSchema(BaseModel):
     graph_state: Annotated[dict, InjectedState]
 
 
+class AppendToSessionStateSchema(BaseModel):
+    key: str = Field(description="The key in the session state to append to")
+    value: str | int | list = Field(description="The value to append")
+    tool_call_id: Annotated[str, InjectedToolCallId]
+    graph_state: Annotated[dict, InjectedState]
+
+
+class IncrementSessionStateCounterSchema(BaseModel):
+    counter: str = Field(description="The name of the counter to increment")
+    value: int = Field(description="The value to increment the counter by", default=1)
+    tool_call_id: Annotated[str, InjectedToolCallId]
+    graph_state: Annotated[dict, InjectedState]
+
+
 class CalculatorSchema(BaseModel):
     expression: str = Field(
         description="The mathematical expression to evaluate. "

--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -571,6 +571,70 @@ class GetSessionStateTool(CustomBaseTool):
         return f"The value for key '{key}' is: {value}"
 
 
+class AppendToSessionStateTool(CustomBaseTool):
+    name: str = AgentTools.APPEND_TO_SESSION_STATE
+    description: str = (
+        "Append a value to session state at a specific key. This will convert any existing "
+        "value to a list and append the new value to the end of the list. Use this tool to "
+        "track lists of items within the current session."
+    )
+    requires_session: bool = True
+    args_schema: type[schemas.AppendToSessionStateSchema] = schemas.AppendToSessionStateSchema
+
+    def action(self, key: str, value: str | int | list, tool_call_id: str, graph_state: dict):
+        if key in settings.RESERVED_SESSION_STATE_KEYS:
+            return f"Cannot modify the '{key}' key in session state - this is read-only"
+
+        state = graph_state.get("session_state") or {}
+        value_at_key = state.get(key, [])
+        if not isinstance(value_at_key, list):
+            value_at_key = [value_at_key]
+
+        if isinstance(value, list):
+            value_at_key.extend(value)
+        else:
+            value_at_key.append(value)
+
+        if len(value_at_key) > 10:
+            new_value_msg = f"The last 10 items in the list are: {value_at_key[-10:]}"
+        else:
+            new_value_msg = f"The new list is: {value_at_key}"
+        message = f"The value was appended to the end of the list. {new_value_msg}"
+        return Command(
+            update={
+                "session_state": {key: value_at_key},
+                "messages": [ToolMessage(message, tool_call_id=tool_call_id)],
+            }
+        )
+
+
+class IncrementSessionStateCounterTool(CustomBaseTool):
+    name: str = AgentTools.INCREMENT_SESSION_STATE_COUNTER
+    description: str = "Increment the value of a counter stored in session state."
+    requires_session: bool = True
+    args_schema: type[schemas.IncrementSessionStateCounterSchema] = schemas.IncrementSessionStateCounterSchema
+
+    def action(self, counter: str, value: int, tool_call_id: str, graph_state: dict):
+        namespaced_key = f"_counter_{counter}"
+        if namespaced_key in settings.RESERVED_SESSION_STATE_KEYS:
+            return f"Cannot modify the '{namespaced_key}' key in session state - this is read-only"
+
+        state = graph_state.get("session_state") or {}
+        current_value = state.get(namespaced_key, 0)
+
+        if not isinstance(current_value, int | float):
+            current_value = 0
+
+        new_value = current_value + value
+        message = f"The '{counter}' counter has been successfully incremented. The new value is {new_value}."
+        return Command(
+            update={
+                "session_state": {namespaced_key: new_value},
+                "messages": [ToolMessage(message, tool_call_id=tool_call_id)],
+            }
+        )
+
+
 class CalculatorTool(CustomBaseTool):
     name: str = AgentTools.CALCULATOR
     description: str = (
@@ -650,6 +714,8 @@ TOOL_CLASS_MAP = {
     AgentTools.SEARCH_INDEX_BY_ID: SearchCollectionByIdTool,
     AgentTools.SET_SESSION_STATE: SetSessionStateTool,
     AgentTools.GET_SESSION_STATE: GetSessionStateTool,
+    AgentTools.APPEND_TO_SESSION_STATE: AppendToSessionStateTool,
+    AgentTools.INCREMENT_SESSION_STATE_COUNTER: IncrementSessionStateCounterTool,
     AgentTools.CALCULATOR: CalculatorTool,
 }
 

--- a/apps/chat/tests/test_tools.py
+++ b/apps/chat/tests/test_tools.py
@@ -608,6 +608,101 @@ class TestGetSessionStateTool(BaseTestAgentTool):
         assert "No value found" in response
 
 
+@pytest.mark.django_db()
+class TestAppendToSessionStateTool(BaseTestAgentTool):
+    tool_cls = tools.AppendToSessionStateTool
+
+    def test_append_when_data_does_not_exist(self, session):
+        response = self._invoke_tool(session, key="test", value="new_value", tool_call_id="123", graph_state={})
+        assert (
+            response.update["messages"][-1].content
+            == "The value was appended to the end of the list. The new list is: ['new_value']"
+        )
+        assert response.update["session_state"] == {"test": ["new_value"]}
+
+    def test_append_when_data_exists(self, session):
+        response = self._invoke_tool(
+            session,
+            key="test",
+            value="second_value",
+            tool_call_id="123",
+            graph_state={"session_state": {"test": "first_value"}},
+        )
+        assert (
+            response.update["messages"][-1].content
+            == "The value was appended to the end of the list. The new list is: ['first_value', 'second_value']"
+        )
+        assert response.update["session_state"] == {"test": ["first_value", "second_value"]}
+
+    @pytest.mark.parametrize(
+        ("existing_value", "new_value", "expected_result"),
+        [
+            ("string", "new_value", ["string", "new_value"]),
+            ("string", ["new_value1", "new_value2"], ["string", "new_value1", "new_value2"]),
+            ({"key": "value"}, "new_value", [{"key": "value"}, "new_value"]),
+            (["val1", "val2"], "new_value", ["val1", "val2", "new_value"]),
+        ],
+    )
+    def test_append_different_values(self, session, existing_value, new_value, expected_result):
+        response = self._invoke_tool(
+            session,
+            key="test",
+            value=new_value,
+            tool_call_id="123",
+            graph_state={"session_state": {"test": existing_value}},
+        )
+        assert (
+            response.update["messages"][-1].content
+            == f"The value was appended to the end of the list. The new list is: {expected_result}"
+        )
+        assert response.update["session_state"] == {"test": expected_result}
+
+    def test_reserved_key_rejected(self, session):
+        response = self._invoke_tool(session, key="user_input", value="test", tool_call_id="123", graph_state={})
+        assert response == "Cannot modify the 'user_input' key in session state - this is read-only"
+
+
+@pytest.mark.django_db()
+class TestIncrementSessionStateCounterTool(BaseTestAgentTool):
+    tool_cls = tools.IncrementSessionStateCounterTool
+
+    def test_increment_new_counter(self, session):
+        response = self._invoke_tool(session, counter="test", value=1, tool_call_id="1", graph_state={})
+        assert (
+            response.update["messages"][-1].content
+            == "The 'test' counter has been successfully incremented. The new value is 1."
+        )
+        assert response.update["session_state"] == {"_counter_test": 1}
+
+    def test_increment_existing_counter(self, session):
+        response = self._invoke_tool(
+            session,
+            counter="test",
+            value=3,
+            tool_call_id="1",
+            graph_state={"session_state": {"_counter_test": 5}},
+        )
+        assert (
+            response.update["messages"][-1].content
+            == "The 'test' counter has been successfully incremented. The new value is 8."
+        )
+        assert response.update["session_state"] == {"_counter_test": 8}
+
+    def test_increment_non_numeric_resets_to_zero(self, session):
+        response = self._invoke_tool(
+            session,
+            counter="test",
+            value=1,
+            tool_call_id="1",
+            graph_state={"session_state": {"_counter_test": "not_a_number"}},
+        )
+        assert (
+            response.update["messages"][-1].content
+            == "The 'test' counter has been successfully incremented. The new value is 1."
+        )
+        assert response.update["session_state"] == {"_counter_test": 1}
+
+
 class TestAttachMediaTool(BaseTestAgentTool):
     tool_cls = tools.AttachMediaTool
 

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -498,6 +498,8 @@ class AgentTools(models.TextChoices):
     SEARCH_INDEX_BY_ID = "file-search-by-index", gettext("File Search by index ID")
     SET_SESSION_STATE = "set-session-state", gettext("Set Session State")
     GET_SESSION_STATE = "get-session-state", gettext("Get Session State")
+    APPEND_TO_SESSION_STATE = "append-to-session-state", gettext("Append to Session State")
+    INCREMENT_SESSION_STATE_COUNTER = "increment-session-state-counter", gettext("Increment Session State Counter")
     CALCULATOR = "calculator", gettext("Calculator")
 
     @classmethod
@@ -935,8 +937,8 @@ class Experiment(BaseTeamModel, VersionsMixin):
                 self.pipeline.archive()
 
     def delete_experiment_channels(self):
-        from apps.channels.models import (
-            ExperimentChannel,  # noqa: PLC0415 - circular: channels.models imports experiments.models
+        from apps.channels.models import (  # noqa: PLC0415 - circular: channels.models imports experiments.models
+            ExperimentChannel,
         )
 
         for channel in ExperimentChannel.objects.filter(experiment_id=self.id):
@@ -1075,12 +1077,12 @@ class Experiment(BaseTeamModel, VersionsMixin):
         - If no assistant node is found or if the pipeline is not set, it returns the default assistant associated with
         the instance.
         """
-        from apps.assistants.models import (
-            OpenAiAssistant,  # noqa: PLC0415 - circular: assistants.models imports experiments.models
+        from apps.assistants.models import (  # noqa: PLC0415 - circular: assistants.models imports experiments.models
+            OpenAiAssistant,
         )
         from apps.pipelines.models import Node  # noqa: PLC0415 - circular: pipelines.models imports experiments.models
-        from apps.pipelines.nodes.nodes import (
-            AssistantNode,  # noqa: PLC0415 - circular: pipelines.nodes imports experiments.models
+        from apps.pipelines.nodes.nodes import (  # noqa: PLC0415 - circular: pipelines.nodes imports experiments.models
+            AssistantNode,
         )
 
         if self.pipeline:
@@ -1154,8 +1156,8 @@ class Participant(BaseTeamModel):
         return self.identifier
 
     def get_platform_display(self):
-        from apps.channels.models import (
-            ChannelPlatform,  # noqa: PLC0415 - circular: channels.models imports experiments.models
+        from apps.channels.models import (  # noqa: PLC0415 - circular: channels.models imports experiments.models
+            ChannelPlatform,
         )
 
         try:
@@ -1230,8 +1232,8 @@ class Participant(BaseTeamModel):
         as_dict: If True, the data will be returned as an array of dictionaries, otherwise an an array of strings
         timezone: The timezone to use for the dates. Defaults to the active timezone.
         """
-        from apps.events.models import (
-            ScheduledMessage,  # noqa: PLC0415 - circular: events.models imports experiments.models
+        from apps.events.models import (  # noqa: PLC0415 - circular: events.models imports experiments.models
+            ScheduledMessage,
         )
 
         messages = (
@@ -1472,8 +1474,8 @@ class ExperimentSession(BaseTeamModel):
         """A Channel Session is considered stale if the experiment that the channel points to differs from the
         one that the experiment session points to. This will happen when the user repurposes the channel to point
         to another experiment."""
-        from apps.channels.models import (
-            ChannelPlatform,  # noqa: PLC0415 - circular: channels.models imports experiments.models
+        from apps.channels.models import (  # noqa: PLC0415 - circular: channels.models imports experiments.models
+            ChannelPlatform,
         )
 
         if self.experiment_channel.platform in ChannelPlatform.team_global_platforms():
@@ -1508,11 +1510,11 @@ class ExperimentSession(BaseTeamModel):
         Raises:
             ValueError: If trigger_type is specified but commit is not.
         """
-        from apps.events.models import (
-            StaticTriggerType,  # noqa: PLC0415 - circular: events.models imports experiments.models
+        from apps.events.models import (  # noqa: PLC0415 - circular: events.models imports experiments.models
+            StaticTriggerType,
         )
-        from apps.events.tasks import (
-            enqueue_static_triggers,  # noqa: PLC0415 - circular: events.tasks imports experiments.models
+        from apps.events.tasks import (  # noqa: PLC0415 - circular: events.tasks imports experiments.models
+            enqueue_static_triggers,
         )
 
         if trigger_type and not commit:
@@ -1591,8 +1593,8 @@ class ExperimentSession(BaseTeamModel):
         message. The response from the bot will be saved to the chat history.
         """
         from apps.chat.bots import EventBot  # noqa: PLC0415 - circular: chat.bots imports experiments.models
-        from apps.service_providers.llm_service.history_managers import (
-            ExperimentHistoryManager,  # noqa: PLC0415 - circular: history_managers imports experiments.models
+        from apps.service_providers.llm_service.history_managers import (  # noqa: PLC0415 - circular: history_managers imports experiments.models
+            ExperimentHistoryManager,
         )
 
         experiment = use_experiment or self.experiment
@@ -1655,8 +1657,8 @@ class ExperimentSession(BaseTeamModel):
 
     def requires_participant_data(self) -> bool:
         """Determines if participant data is required for this session"""
-        from apps.assistants.models import (
-            OpenAiAssistant,  # noqa: PLC0415 - circular: assistants.models imports experiments.models
+        from apps.assistants.models import (  # noqa: PLC0415 - circular: assistants.models imports experiments.models
+            OpenAiAssistant,
         )
         from apps.pipelines.nodes.nodes import (  # noqa: PLC0415 - circular: pipelines.nodes imports experiments.models
             AssistantNode,


### PR DESCRIPTION
### Product Description
Add new tools that allow LLM nodes to manage session state, mirroring the existing participant data tools:
- **Append to Session State**: Appends values to a list at a specific key in session state
- **Increment Session State Counter**: Increments a counter stored in session state

### Technical Description
- Added `AppendToSessionStateTool` and `IncrementSessionStateCounterTool` classes in `apps/chat/agent/tools.py`, following the same patterns as `AppendToParticipantDataTool` and `IncrementCounterTool`
- Added corresponding Pydantic schemas (`AppendToSessionStateSchema`, `IncrementSessionStateCounterSchema`) with injected `tool_call_id` and `graph_state` fields
- Added `APPEND_TO_SESSION_STATE` and `INCREMENT_SESSION_STATE_COUNTER` to the `AgentTools` enum
- Both tools include reserved session state key protection
- Fixed pre-existing `PLC0415` noqa comments in `experiments/models.py` by moving them to the `from` line for multi-line imports

### Migrations
- [x] The migrations are backwards compatible
- No migrations needed — `TextChoices` values are not stored as DB constraints

### Demo
N/A

### Docs and Changelog
- [x] This PR requires docs/changelog update

Closes #3027

🤖 Generated with [Claude Code](https://claude.com/claude-code)