### PR TITLE
feat: add versionNumber prop to chat widget

### DIFF
--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -174,6 +174,13 @@ export class OcsChat {
    */
   @Prop({ mutable: true }) pageContext?: Record<string, any>;
 
+  /**
+   * @internal
+   * Optional version number of the chatbot to use. Requires authentication.
+   * This is for internal use only and is not intended for public-facing widgets.
+   */
+  @Prop() versionNumber?: number;
+
   @State() error: string = "";
   @State() messages: ChatMessage[] = [];
   @State() sessionId?: string;
@@ -420,6 +427,10 @@ export class OcsChat {
         requestBody.participant_name = this.userName;
       }
 
+      if (this.versionNumber != null) {
+        requestBody.version_number = this.versionNumber;
+      }
+
       const data = await this.getChatService().startSession(requestBody);
       this.sessionId = data.session_id;
       this.saveSessionToStorage();
@@ -523,6 +534,9 @@ export class OcsChat {
       }
       if (this.internalPageContext) {
         requestBody.context = this.internalPageContext;
+      }
+      if (this.versionNumber != null) {
+        requestBody.version_number = this.versionNumber;
       }
 
       const data = await this.getChatService().sendMessage(this.sessionId, requestBody);


### PR DESCRIPTION
### Product Description
Allow the chat widget to target a specific chatbot version by passing a `version-number` attribute. This is for internal use by authenticated users (e.g. testing draft versions in the widget before publishing).

### Technical Description
- Added `versionNumber` prop to the `OcsChat` StencilJS component, marked `@internal` in JSDoc
- When set, `version_number` is included in the request body for both the `startSession` (`POST /api/chat/start/`) and `sendMessage` (`POST /api/chat/{session_id}/message/`) API calls
- The backend already supports `version_number` in both endpoints and enforces authentication

### Migrations
- [ ] The migrations are backwards compatible

N/A — no migrations

### Demo
```html
<open-chat-studio-widget
  chatbot-id="..."
  version-number="2"
></open-chat-studio-widget>
```

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)