### PR TITLE
restore custom action operation formatter

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -106,6 +106,12 @@ class VersionFieldDisplayFormatters:
         """code_interpreter, file_search -> Code Interpreter, File Search"""
         return ", ".join([tool.replace("_", " ").capitalize() for tool in tools])
 
+    @staticmethod
+    def format_custom_action_operation(op) -> str:
+        action = op.custom_action
+        op_details = action.get_operations_by_id().get(op.operation_id)
+        return f"{action.name}: {op_details}"
+
 
 class PromptObjectManager(AuditingManager):
     pass


### PR DESCRIPTION
### Technical Description
Restore the formatter for custom actions which was removed in https://github.com/dimagi/open-chat-studio/commit/1c920294f25da043ad7c59ff2d3ca2f20e3f7f94 as part of experiment cleanup.

