### PR TITLE
fix: TimeoutTrigger.timed_out_sessions() fails after publishing new version (OCSBUGS-23)

### DIFF
--- a/apps/events/migrations/0027_timeouttrigger_config_changed_at.py
+++ b/apps/events/migrations/0027_timeouttrigger_config_changed_at.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+
+
+def backfill_config_changed_at(apps, schema_editor):
+    TimeoutTrigger = apps.get_model("events", "TimeoutTrigger")
+    TimeoutTrigger.objects.filter(config_changed_at__isnull=True).update(config_changed_at=models.F("created_at"))
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("events", "0026_timeouttrigger_trigger_from_first_message_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="timeouttrigger",
+            name="config_changed_at",
+            field=models.DateTimeField(
+                help_text=(
+                    "Tracks when trigger config last changed. Prevents retroactive application to old sessions."
+                ),
+                null=True,
+            ),
+        ),
+        migrations.RunPython(backfill_config_changed_at, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="timeouttrigger",
+            name="config_changed_at",
+            field=models.DateTimeField(
+                help_text=(
+                    "Tracks when trigger config last changed. Prevents retroactive application to old sessions."
+                ),
+            ),
+        ),
+    ]

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -197,6 +197,8 @@ class StaticTrigger(BaseModel, VersionsMixin):
 
 
 class TimeoutTrigger(BaseModel, VersionsMixin):
+    CONFIG_FIELDS = frozenset({"delay", "total_num_triggers", "trigger_from_first_message", "action_id"})
+
     action = models.OneToOneField(EventAction, on_delete=models.CASCADE, related_name="timeout_trigger")
     experiment = models.ForeignKey(Experiment, on_delete=models.CASCADE, related_name="timeout_triggers")
     delay = models.PositiveIntegerField(
@@ -224,14 +226,37 @@ class TimeoutTrigger(BaseModel, VersionsMixin):
             " in the conversation rather than the most recent."
         ),
     )
+    config_changed_at = models.DateTimeField(
+        help_text="Tracks when trigger config last changed. Prevents retroactive application to old sessions.",
+    )
+
+    def save(self, *args, **kwargs):
+        if not self.config_changed_at:
+            self.config_changed_at = timezone.now()
+        elif self.pk:
+            try:
+                old = TimeoutTrigger.objects.get(pk=self.pk)
+            except TimeoutTrigger.DoesNotExist:
+                pass
+            else:
+                changed = {f for f in self.CONFIG_FIELDS if getattr(old, f) != getattr(self, f)}
+                if changed:
+                    self.config_changed_at = timezone.now()
+        super().save(*args, **kwargs)
 
     @transaction.atomic()
     def create_new_version(self, new_experiment: Experiment, is_copy: bool = False):  # ty: ignore[invalid-method-override]
         """Create a duplicate and assign the `new_experiment` to it. Also duplicate all EventActions"""
+        config_changed_at = self.config_changed_at
         new_instance = super().create_new_version(save=False, is_copy=is_copy)
         new_instance.experiment = new_experiment
         new_instance.action = new_instance.action.create_new_version(is_copy=is_copy)
         new_instance.save()
+        # Preserve the original config_changed_at after save (auto_now_add only applies on insert
+        # but we need to ensure the working version's timestamp is carried over)
+        if config_changed_at != new_instance.config_changed_at:
+            TimeoutTrigger.objects.filter(pk=new_instance.pk).update(config_changed_at=config_changed_at)
+            new_instance.config_changed_at = config_changed_at
         return new_instance
 
     @property
@@ -314,7 +339,7 @@ class TimeoutTrigger(BaseModel, VersionsMixin):
                 )
             )
             .filter(
-                reference_message_created_at__gte=self.updated_at,
+                reference_message_created_at__gte=self.config_changed_at,
                 # reference message received after trigger config was updated
                 last_event_timestamp__lt=time_window_to_ignore,
                 reference_message_created_at__isnull=False,

--- a/apps/events/tests/test_timeout_trigger.py
+++ b/apps/events/tests/test_timeout_trigger.py
@@ -93,9 +93,9 @@ def test_non_timed_out_sessions(session):
 @mock.patch("apps.events.tasks.fire_trigger.run")
 @pytest.mark.django_db()
 def test_timed_out_sessions_fired(mock_fire_trigger, session):
-    """A human chat message was sent more recently than the timeout"""
+    """Published trigger's timed_out_sessions() returns sessions after publishing a new version"""
     with travel("2024-04-02", tick=False) as frozen_time:
-        timeout_trigger = TimeoutTrigger.objects.create(
+        TimeoutTrigger.objects.create(
             experiment=session.experiment,
             action=EventAction.objects.create(action_type=EventActionType.LOG),
             delay=10 * 60,  # 10 Minutes
@@ -115,10 +115,48 @@ def test_timed_out_sessions_fired(mock_fire_trigger, session):
         trigger_version = experiment_version.timeout_triggers.first()
 
         frozen_time.shift(delta=timedelta(minutes=15))
-        timed_out_sessions = timeout_trigger.timed_out_sessions()
+        # Use the published version, not the working version, to match what enqueue_timed_out_events does
+        timed_out_sessions = trigger_version.timed_out_sessions()
         assert len(timed_out_sessions) == 1
         enqueue_timed_out_events()
         mock_fire_trigger.assert_called_with(trigger_version.id, session.id)
+
+
+@pytest.mark.django_db()
+def test_timed_out_sessions_after_publish(session):
+    """Regression: publishing a new experiment version should not prevent the published trigger
+    from finding sessions that timed out before the publish."""
+    with travel("2024-04-02", tick=False) as frozen_time:
+        timeout_trigger = TimeoutTrigger.objects.create(
+            experiment=session.experiment,
+            action=EventAction.objects.create(action_type=EventActionType.LOG),
+            delay=10 * 60,  # 10 minutes
+        )
+
+        chat = Chat.objects.create(team=session.team)
+        ChatMessage.objects.create(
+            chat=chat,
+            content="Hello",
+            message_type=ChatMessageType.HUMAN,
+        )
+        session.chat = chat
+        session.save()
+
+        # Publish a new version — this creates a new trigger row
+        frozen_time.shift(delta=timedelta(minutes=5))
+        experiment_version = session.experiment.create_new_version(make_default=True)
+        trigger_version = experiment_version.timeout_triggers.first()
+
+        # The published trigger's config_changed_at should match the original, not the publish time
+        assert trigger_version.config_changed_at == timeout_trigger.config_changed_at
+
+        # Advance past the delay
+        frozen_time.shift(delta=timedelta(minutes=10))
+
+        # The published trigger should find the session
+        timed_out_sessions = trigger_version.timed_out_sessions()
+        assert len(timed_out_sessions) == 1
+        assert timed_out_sessions[0] == session
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
### Product Description
Fix a bug where timeout triggers stop firing after publishing a new experiment version. Sessions that sent messages before the publish were silently excluded from timeout detection.

Fixes https://github.com/dimagi/open-chat-studio/issues/3071

### Technical Description
`TimeoutTrigger.timed_out_sessions()` filtered sessions using `self.updated_at` to prevent config changes from retroactively applying. However, `updated_at` is `auto_now=True` and gets reset when `create_new_version()` creates a published copy, causing all pre-publish sessions to be excluded.

**Changes:**
- Added `config_changed_at` field to `TimeoutTrigger` — set on creation, updated only when config fields (`delay`, `total_num_triggers`, `trigger_from_first_message`, `action_id`) actually change
- Added `save()` override to detect config field changes and update `config_changed_at`
- Updated `create_new_version()` to preserve the original `config_changed_at` on published copies
- Replaced `self.updated_at` with `self.config_changed_at` in `timed_out_sessions()` filter
- Fixed `test_timed_out_sessions_fired` to test against the published version (was testing working version, masking the bug)
- Added `test_timed_out_sessions_after_publish` regression test

### Migrations
- [ ] The migrations are backwards compatible

One migration: adds `config_changed_at` (nullable), backfills from `created_at`, then makes non-nullable. Safe to run against current code since existing code uses `updated_at` which still exists.

### Demo
N/A — backend-only fix

### Docs and Changelog
- [x] This PR requires docs/changelog update

Closes #3071