### PR TITLE
increase default timeout to 30s

### DIFF
--- a/apps/service_providers/auth_service/main.py
+++ b/apps/service_providers/auth_service/main.py
@@ -3,17 +3,16 @@ from typing import Any
 import httpx
 import pydantic
 import tenacity
+from django.conf import settings
 
 from apps.service_providers.auth_service.schemes import CommCareAuth, HeaderAuth
-
-DEFAULT_TIMEOUT = 30
 
 
 class AuthService(pydantic.BaseModel):
     def get_http_client(self) -> httpx.Client:
         kwargs = {
             **self._get_http_client_kwargs(),
-            "timeout": DEFAULT_TIMEOUT,
+            "timeout": settings.RESTRICTED_HTTP_MAX_TIMEOUT,
             "limits": httpx.Limits(max_keepalive_connections=5, max_connections=10),
         }
         return httpx.Client(**kwargs)


### PR DESCRIPTION
### Product Description
Increase the timeout for Custom Action HTTP calls from 10s to 30s to accommodate more complex processing.

### Docs and Changelog
- [x] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
