### PR TITLE
refactor(tests): remove TransactionTestCase cascade — move live_server test to integration

### DIFF
--- a/apps/api/tests/test_openai_api.py
+++ b/apps/api/tests/test_openai_api.py
@@ -48,6 +48,7 @@ def api_key(team_with_users):
     return key
 
 
+@pytest.mark.integration
 @django_db_with_data()
 @patch("apps.chat.bots.PipelineBot.process_input")
 def test_chat_completion(bot_process_input, experiment, api_key, live_server):

--- a/apps/conftest.py
+++ b/apps/conftest.py
@@ -48,12 +48,13 @@ def local_index_manager_mock():
 def _django_db_restore_serialized(
     request: pytest.FixtureRequest, django_db_keepdb, django_db_blocker
 ) -> Generator[None]:
-    """Restore database data at the end of the session. This is needed because we use transaction test cases
-    in certain places which flush the DB. Individual tests that require the default DB data should
-    use `apps.utils.pytest.django_db_with_data`.
+    """Restore database data at the end of the session.
 
-    This fixture ensures that the data is preserved between test runs when `reuse-db` (`keepdb`) is being
-    used.
+    Integration tests that use TransactionTestCase (e.g. live_server tests) flush the DB after each
+    test, destroying migration-seeded data. This fixture re-deserializes that data so the DB is clean
+    for the next run when `--reuse-db` (`keepdb`) is active.
+
+    This is only relevant when running integration tests (pytest -m integration) together with --reuse-db.
     """
     yield
 

--- a/apps/events/tests/test_actions.py
+++ b/apps/events/tests/test_actions.py
@@ -13,7 +13,6 @@ from apps.utils.factories.experiment import (
     ExperimentSessionFactory,
 )
 from apps.utils.factories.pipelines import PipelineFactory
-from apps.utils.pytest import django_db_transactional
 
 
 @pytest.fixture()
@@ -27,7 +26,7 @@ def pipeline():
 
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-@django_db_transactional()
+@pytest.mark.django_db()
 def test_end_conversation_runs_pipeline(session, pipeline):
     input = "Does anything get lost going through the pipe?"
     chat = Chat.objects.create(team=session.team)

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -41,7 +41,6 @@ from apps.utils.factories.service_provider_factories import (
     VoiceProviderFactory,
 )
 from apps.utils.factories.team import TeamFactory
-from apps.utils.pytest import django_db_with_data
 
 
 @pytest.fixture()
@@ -50,23 +49,23 @@ def experiment_session():
 
 
 class TestSyntheticVoice:
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_team_scoped_services(self):
         assert [SyntheticVoice.OpenAIVoiceEngine] == SyntheticVoice.TEAM_SCOPED_SERVICES
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_get_for_team_returns_all_general_services(self):
         """General services are those not included in SyntheticVoice.TEAM_SCOPED_SERVICES"""
         voices_queryset = SyntheticVoice.get_for_team(team=None)
         assert voices_queryset.count() == SyntheticVoice.objects.count()
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_get_for_team_excludes_service(self):
         voices_queryset = SyntheticVoice.get_for_team(team=None, exclude_services=[SyntheticVoice.AWS])
         services = set(voices_queryset.values_list("service", flat=True))
         assert services == {SyntheticVoice.OpenAI, SyntheticVoice.Azure}
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_get_for_team_do_not_include_other_team_exclusive_voices(self):
         """Tests that `get_for_team` returns both general and team exclusive synthetic voices. Exclusive synthetic
         voices are those whose service is one of SyntheticVoice.TEAM_SCOPED_SERVICES

--- a/apps/pipelines/tests/test_add_start_end_nodes.py
+++ b/apps/pipelines/tests/test_add_start_end_nodes.py
@@ -10,10 +10,9 @@ from apps.pipelines.migrations.utils.migrate_start_end_nodes import (
 from apps.pipelines.models import Node, Pipeline
 from apps.pipelines.nodes.nodes import EndNode, StartNode
 from apps.pipelines.tests.utils import end_node, passthrough_node, start_node
-from apps.utils.pytest import django_db_transactional
 
 
-@django_db_transactional()
+@pytest.mark.django_db()
 def test_empty_pipeline_gets_start_end_nodes(team):
     pipeline = Pipeline.objects.create(team=team, data={"nodes": [], "edges": []})
     pipeline.update_nodes_from_data()
@@ -25,7 +24,7 @@ def test_empty_pipeline_gets_start_end_nodes(team):
     assert pipeline.node_set.filter(type=EndNode.__name__).exists()
 
 
-@django_db_transactional()
+@pytest.mark.django_db()
 def test_recursive_pipeline_has_start_end_nodes(team):
     passthrough = passthrough_node()
     pipeline = Pipeline.objects.create(
@@ -56,7 +55,7 @@ def test_recursive_pipeline_has_start_end_nodes(team):
     assert pipeline.node_set.filter(type=EndNode.__name__).exists()
 
 
-@django_db_transactional()
+@pytest.mark.django_db()
 def test_dangling_edge_has_start_end_nodes(team):
     passthrough = passthrough_node()
     pipeline = Pipeline.objects.create(
@@ -87,7 +86,7 @@ def test_dangling_edge_has_start_end_nodes(team):
     assert pipeline.node_set.filter(type=EndNode.__name__).exists()
 
 
-@django_db_transactional()
+@pytest.mark.django_db()
 def test_sentry_6107296412(team):
     pipeline = Pipeline.objects.create(
         team=team,
@@ -158,7 +157,7 @@ def test_sentry_6107296412(team):
     assert pipeline.node_set.filter(type=EndNode.__name__).exists()
 
 
-@django_db_transactional()
+@pytest.mark.django_db()
 def test_compliant_pipeline_not_modified(team):
     start = start_node()
     end = end_node()
@@ -182,7 +181,7 @@ def test_compliant_pipeline_not_modified(team):
     assert pipeline.node_set.get(type=EndNode.__name__).flow_id == end["id"]
 
 
-@django_db_transactional()
+@pytest.mark.django_db()
 def test_pipeline_gets_start_end_nodes_with_edges(team):
     passthrough_1 = passthrough_node()
     passthrough_2 = passthrough_node()
@@ -214,7 +213,7 @@ def test_pipeline_gets_start_end_nodes_with_edges(team):
     assert len(pipeline.data["edges"]) == 3
 
 
-@django_db_transactional()
+@pytest.mark.django_db()
 def test_remove_start_end_nodes(team):
     start = start_node()
     end = end_node()
@@ -272,7 +271,7 @@ def test_remove_start_end_nodes(team):
     }
 
 
-@django_db_transactional()
+@pytest.mark.django_db()
 @pytest.mark.parametrize("version_before_removing_node", [True, False])
 def test_remove_nodes(version_before_removing_node, team):
     """
@@ -356,7 +355,7 @@ def test_remove_nodes(version_before_removing_node, team):
         assert Node.objects.get_all().filter(flow_id=passthrough_2["id"]).count() == 0
 
 
-@django_db_transactional()
+@pytest.mark.django_db()
 def test_pipeline_creation_without_llm(team):
     pipeline = Pipeline.create_default(team=team)
 
@@ -370,7 +369,7 @@ def test_pipeline_creation_without_llm(team):
     assert "EndNode" in node_types
 
 
-@django_db_transactional()
+@pytest.mark.django_db()
 def test_pipeline_creation_with_llm(team):
     mock_llm_provider = MagicMock(id=str(uuid4()))
     mock_llm_model = MagicMock(id=str(uuid4()), max_token_limit=2048)
@@ -392,7 +391,7 @@ def test_pipeline_creation_with_llm(team):
     assert params["user_max_token_limit"] == mock_llm_model.max_token_limit
 
 
-@django_db_transactional()
+@pytest.mark.django_db()
 def test_pipeline_edge_connections(team):
     mock_llm_provider = MagicMock(id=str(uuid4()))
     mock_llm_model = MagicMock(id=str(uuid4()), max_token_limit=2048)

--- a/apps/pipelines/tests/test_code_node.py
+++ b/apps/pipelines/tests/test_code_node.py
@@ -24,7 +24,6 @@ from apps.pipelines.tests.utils import (
 from apps.utils.factories.events import EventActionFactory, ScheduledMessageFactory
 from apps.utils.factories.experiment import ExperimentSessionFactory
 from apps.utils.factories.pipelines import PipelineFactory
-from apps.utils.pytest import django_db_with_data
 
 
 @pytest.fixture()
@@ -47,7 +46,7 @@ def main(input, **kwargs):
 """
 
 
-# @django_db_with_data()
+# @pytest.mark.django_db()
 @pytest.mark.parametrize(
     ("code", "user_input", "output"),
     [
@@ -164,7 +163,7 @@ def main(input, **kwargs):
     assert node_output.update["participant_data"]["fun_facts"]["personality"] == output  # ty: ignore[not-subscriptable]
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 def test_participant_data_across_multiple_nodes(pipeline, experiment_session):
     code_set = """
 def main(input, **kwargs):
@@ -189,7 +188,7 @@ def main(input, **kwargs):
     assert node_output["messages"][-1] == "value"
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 def test_temp_state_across_multiple_nodes(pipeline, experiment_session):
     output = "['fun loving', 'likes puppies']"
     code_set = f"""
@@ -215,7 +214,7 @@ def main(input, **kwargs):
     assert node_output["messages"][-1] == output
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 def test_temp_state_get_outputs(pipeline, experiment_session):
     # Temp state contains the outputs of the previous nodes
 

--- a/apps/pipelines/tests/test_models.py
+++ b/apps/pipelines/tests/test_models.py
@@ -30,7 +30,6 @@ from apps.utils.langchain import (
     FakeLlmEcho,
     build_fake_llm_service,
 )
-from apps.utils.pytest import django_db_with_data
 
 
 @pytest.mark.django_db()
@@ -253,7 +252,7 @@ class TestPipeline:
         if participant_exists:
             assert Participant.objects.filter(team=team, user=requesting_user).exists()
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
     def test_simple_invoke_with_pipeline(self, get_llm_service):
         """Test simple invoke with a pipeline that has an LLM node"""

--- a/apps/pipelines/tests/test_nodes_with_tools.py
+++ b/apps/pipelines/tests/test_nodes_with_tools.py
@@ -33,7 +33,6 @@ from apps.utils.factories.service_provider_factories import LlmProviderFactory, 
 from apps.utils.langchain import (
     build_fake_llm_service,
 )
-from apps.utils.pytest import django_db_transactional, django_db_with_data
 
 
 @pytest.fixture()
@@ -97,7 +96,7 @@ def test_assistant_node(patched_invoke, disabled_tools):
         assert args[0]["tools"][0]["function"]["name"] == AgentTools.UPDATE_PARTICIPANT_DATA
 
 
-@django_db_transactional()
+@pytest.mark.django_db()
 @pytest.mark.parametrize(
     "disabled_tools",
     [
@@ -127,7 +126,7 @@ def test_tool_filtering(disabled_tools, provider, provider_model):
     assert not set(disabled_tools) & tool_names
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
 def test_tool_call_with_annotated_inputs(get_llm_service, provider, provider_model):
     service = build_fake_llm_service(
@@ -163,7 +162,7 @@ def test_tool_call_with_annotated_inputs(get_llm_service, provider, provider_mod
     assert output["participant_data"] == {"test": ["123", "next"], "other": "xyz"}
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
 @mock.patch("apps.pipelines.nodes.llm_node._get_configured_tools")
 def test_tool_artifact_response(get_configured_tools, get_llm_service, provider, provider_model):

--- a/apps/pipelines/tests/test_parallel_nodes.py
+++ b/apps/pipelines/tests/test_parallel_nodes.py
@@ -14,7 +14,6 @@ from apps.pipelines.tests.utils import (
 )
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.pipelines import PipelineFactory
-from apps.utils.pytest import django_db_with_data
 
 
 @pytest.fixture()
@@ -32,7 +31,7 @@ def experiment_session(experiment):
     return ExperimentSessionFactory.create(experiment=experiment)
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 def test_parallel_branch_pipeline(pipeline, experiment_session):
     """
     Illustrate and validate what happens with parallel branches.
@@ -65,7 +64,7 @@ def test_parallel_branch_pipeline(pipeline, experiment_session):
     assert output == expected_output
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 def test_parallel_branch_with_merge(pipeline, experiment_session):
     """
     Illustrate and validate what happens with parallel branches with an aggregator node.
@@ -106,7 +105,7 @@ def test_parallel_branch_with_merge(pipeline, experiment_session):
     assert output == expected_output
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 def test_parallel_branch_with_dangling_node(pipeline, experiment_session):
     """Node A does not connect to the end node, but it is still executed.
 
@@ -176,7 +175,7 @@ def main(input, **kwargs):
         assert json_safe["interrupt"] == {"message": "Unsafe input: unsafe", "tag_name": "unsafe_input"}
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 def test_code_node_wait_for_inputs(pipeline, experiment_session):
     """In this test the branches are of unequal length, so the code node will get called twice,
     once when A and C are done, and once when B is done.
@@ -230,7 +229,7 @@ def main(input, **kwargs):
     ]
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 def test_code_node_wait_for_inputs_manually(pipeline, experiment_session):
     """Similar to the previous test but uses `wait_for_next_input`.
 
@@ -263,7 +262,7 @@ def main(input, **kwargs):
     assert PipelineAccessor(output_state).get_node_output("end") == "B: A: Hi,C: Hi"
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 def test_dangling_node_abort_terminates_early(pipeline, experiment_session):
     """Test that an abort from a dangling node does actually abort the pipeline.
 
@@ -287,7 +286,7 @@ def test_dangling_node_abort_terminates_early(pipeline, experiment_session):
     assert "B" not in output_state["outputs"]
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 @pytest.mark.parametrize("safety_check", ["safe", "unsafe"])
 def test_safety_router_abort(pipeline, experiment_session, safety_check):
     """
@@ -312,7 +311,7 @@ def test_safety_router_abort(pipeline, experiment_session, safety_check):
         assert "__interrupt__" in output_state
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 def test_dangling_node_abort_after(pipeline, experiment_session):
     """Test that an abort from a dangling node that is run after the last node still aborts.
 

--- a/apps/pipelines/tests/test_pipeline_history.py
+++ b/apps/pipelines/tests/test_pipeline_history.py
@@ -18,7 +18,6 @@ from apps.utils.langchain import (
     FakeLlmEcho,
     build_fake_llm_service,
 )
-from apps.utils.pytest import django_db_with_data
 
 
 @pytest.fixture()
@@ -41,7 +40,7 @@ def experiment_session():
     return ExperimentSessionFactory.create()
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
 def test_llm_with_node_history(get_llm_service, provider, pipeline, experiment_session, provider_model):
     llm = FakeLlmEcho()
@@ -116,7 +115,7 @@ def test_llm_with_node_history(get_llm_service, provider, pipeline, experiment_s
     ] == expected_call_messages
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
 def test_llm_with_multiple_node_histories(get_llm_service, provider, pipeline, experiment_session, provider_model):
     llm = FakeLlmEcho()
@@ -194,7 +193,7 @@ def test_llm_with_multiple_node_histories(get_llm_service, provider, pipeline, e
     ] == expected_call_messages
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
 def test_global_history(get_llm_service, provider, pipeline, experiment_session, provider_model):
     llm = FakeLlmEcho()
@@ -284,7 +283,7 @@ def test_global_history(get_llm_service, provider, pipeline, experiment_session,
     ] == expected_call_messages
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
 def test_llm_with_named_history(get_llm_service, provider, pipeline, experiment_session, provider_model):
     llm = FakeLlmEcho()
@@ -361,7 +360,7 @@ def test_llm_with_named_history(get_llm_service, provider, pipeline, experiment_
     ] == expected_call_messages
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
 def test_llm_with_no_history(get_llm_service, provider, pipeline, experiment_session, provider_model):
     llm = FakeLlmEcho()

--- a/apps/pipelines/tests/test_pipeline_history_summary.py
+++ b/apps/pipelines/tests/test_pipeline_history_summary.py
@@ -7,7 +7,6 @@ from apps.utils.factories.experiment import (
 )
 from apps.utils.factories.pipelines import PipelineChatHistoryFactory
 from apps.utils.factories.service_provider_factories import LlmProviderFactory
-from apps.utils.pytest import django_db_with_data
 
 
 @pytest.fixture()
@@ -25,7 +24,7 @@ def pipeline_chat_history(experiment_session):
     return PipelineChatHistoryFactory.create(session=experiment_session)
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 def test_no_summary_returns_all_messages(experiment_session):
     history = experiment_session.pipeline_chat_history.create(type=PipelineChatHistoryTypes.NAMED, name="name")
     message1 = history.messages.create(ai_message="I am a robot", human_message="hi, please fetch me a coffee")
@@ -40,7 +39,7 @@ def test_no_summary_returns_all_messages(experiment_session):
     assert expected_messages == summary_messages
 
 
-@django_db_with_data()
+@pytest.mark.django_db()
 def test_get_messages_returns_until_marker(experiment_session):
     history = experiment_session.pipeline_chat_history.create(type=PipelineChatHistoryTypes.NAMED, name="name")
     history.messages.create(ai_message="I am a robot", human_message="hi, please fetch me a coffee")

--- a/apps/pipelines/tests/test_pipeline_runs.py
+++ b/apps/pipelines/tests/test_pipeline_runs.py
@@ -10,7 +10,6 @@ from apps.service_providers.tests.mock_tracer import MockTracer
 from apps.service_providers.tracing import TracingService
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.pipelines import PipelineFactory
-from apps.utils.pytest import django_db_transactional
 
 
 @pytest.fixture()
@@ -28,7 +27,7 @@ def session(experiment):
     return ExperimentSessionFactory.create(experiment=experiment)
 
 
-@django_db_transactional()
+@pytest.mark.django_db()
 def test_save_trace_metadata(pipeline: Pipeline, session: ExperimentSession):
     trace_service = TracingService([MockTracer()], 1, 1)
     with trace_service.trace("test", session):

--- a/apps/pipelines/tests/test_runnable_builder.py
+++ b/apps/pipelines/tests/test_runnable_builder.py
@@ -60,7 +60,6 @@ from apps.utils.langchain import (
     build_fake_llm_echo_service,
     build_fake_llm_service,
 )
-from apps.utils.pytest import django_db_with_data
 
 
 # Helper class used by router node tests
@@ -112,7 +111,7 @@ class TestEmailPipeline:
     """Tests for email-related pipeline functionality"""
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-    @django_db_with_data()
+    @pytest.mark.django_db()
     @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
     def test_full_email_sending_pipeline(self, get_llm_service, provider, provider_model, pipeline):
         service = build_fake_llm_service(responses=['{"summary": "Ice is cold"}'], token_counts=[0])
@@ -138,7 +137,7 @@ class TestEmailPipeline:
         assert mail.outbox[0].to == ["test@example.com"]
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_send_email(self, pipeline):
         nodes = [start_node(), email_node(), end_node()]
         config = {"configurable": {"repo": ORMRepository()}}
@@ -152,7 +151,7 @@ class TestEmailPipeline:
 class TestLLMResponse:
     """Tests for LLM response nodes"""
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
     def test_llm_response(self, get_llm_service, provider, provider_model, pipeline):
         service = build_fake_llm_service(responses=["123"], token_counts=[0])
@@ -170,7 +169,7 @@ class TestLLMResponse:
             == "123"
         )
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
     def test_llm_with_prompt_response(
         self, get_llm_service, provider, provider_model, pipeline, source_material, experiment_session
@@ -214,7 +213,7 @@ class TestLLMResponse:
         )
         assert output == expected_output
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
     def test_end_session_tool(self, get_llm_service, provider, provider_model, pipeline, experiment_session):
         def _tool_call():
@@ -241,7 +240,7 @@ class TestLLMResponse:
         output = runnable.invoke(PipelineState(messages=["a"], experiment_session=experiment_session), config=config)
         assert output["intents"] == [Intents.END_SESSION]
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_llm_model_parameters_with_none_value(self, provider, provider_model):
         """There was a bug where llm_model_parameters being `None` caused validation to fail, because it didn't default
         to a dictionary correctly
@@ -259,7 +258,7 @@ class TestLLMResponse:
 class TestTemplateRendering:
     """Tests for template rendering nodes"""
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_render_template(self, pipeline):
         nodes = [
             start_node(),
@@ -275,7 +274,7 @@ class TestTemplateRendering:
 class TestConditionalNode:
     """Tests for conditional/boolean nodes"""
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_conditional_node(self, pipeline, experiment_session):
         start = start_node()
         boolean = boolean_node(name="boolean")
@@ -383,7 +382,7 @@ class TestRouterNode:
         expected_pd = {"name": experiment_session.participant.name} | participant_data
         assert str(expected_pd) in system_prompt.content
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
     def test_router_node(self, get_llm_service, provider, provider_model, pipeline, experiment_session):
         def _tool_call(route):
@@ -550,7 +549,7 @@ class TestRouterNode:
 class TestStaticRouterNode:
     """Tests for static router nodes (state-based routing without LLM)"""
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_static_router_temp_state(self, pipeline, experiment_session):
         # The static router will switch based on a state key, and pass its input through
 
@@ -607,7 +606,7 @@ def main(input, **kwargs):
         )
         assert output["messages"][-1] == "A Go to Third"
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_static_router_case_sensitive(self, pipeline, experiment_session):
         start = start_node()
         router = state_key_router_node(
@@ -705,7 +704,7 @@ def main(input, **kwargs):
         _check_routing_and_tags("first", "FIRST")
         _check_routing_and_tags("second", "SECOND")
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     @pytest.mark.parametrize(
         "data_source", [StaticRouterNode.DataSource.participant_data, StaticRouterNode.DataSource.session_state]
     )
@@ -758,7 +757,7 @@ def main(input, **kwargs):
 class TestCodeNode:
     """Tests for code execution nodes"""
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_attachments_in_code_node(self, pipeline, experiment_session):
         code_set = """
 def main(input, **kwargs):
@@ -788,7 +787,7 @@ def main(input, **kwargs):
         )
         assert output["messages"][-1] == "test.py,blog.md"
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
     def test_code_node_sets_send_to_llm_false_excludes_attachment(
         self, get_llm_service, provider, provider_model, pipeline
@@ -871,7 +870,7 @@ class TestDataExtraction:
             runnable = create_runnable(pipeline, nodes)
             yield runnable
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_extract_structured_data_no_chunking(self, provider, provider_model, pipeline):
         session = ExperimentSessionFactory.create()
 
@@ -883,7 +882,7 @@ class TestDataExtraction:
             config = {"configurable": {"repo": ORMRepository(session=session)}}
             assert graph.invoke(state, config=config)["messages"][-1] == '{"name": "John"}'
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_extract_structured_data_with_chunking(self, provider, provider_model, pipeline):
         session = ExperimentSessionFactory.create()
         llm = FakeLlmSimpleTokenCount(
@@ -943,7 +942,7 @@ class TestDataExtraction:
         # Expected node output
         assert extracted_data == '{"name": "james"}'
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_extract_participant_data(self, provider, provider_model, pipeline):
         """Test the pipeline to extract and update participant data. First we run it when no data is linked to the
         participant to make sure it creates data. Then we run it again a few times to test that it updates the data
@@ -1110,7 +1109,7 @@ class TestAssistantNode:
         args, kwargs = runnable_mock.invoke.call_args
         assert kwargs["attachments"] == [attachments[1]]
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     @patch("apps.pipelines.nodes.nodes.AssistantNode._get_assistant_runnable")
     def test_assistant_node_raises(self, get_assistant_runnable):
         runnable_mock = runnable_mock = self.assistant_node_runnable_mock(
@@ -1166,31 +1165,31 @@ class TestAssistantNode:
 class TestPipelineValidation:
     """Tests for pipeline structure validation"""
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_start_node_missing(self, pipeline):
         nodes = [passthrough_node(), end_node()]
         with pytest.raises(PipelineBuildError, match="There should be exactly 1 Start node"):
             create_runnable(pipeline, nodes)
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_end_node_missing(self, pipeline):
         nodes = [start_node()]
         with pytest.raises(PipelineBuildError, match="There should be exactly 1 End node"):
             create_runnable(pipeline, nodes)
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_multiple_start_nodes(self, pipeline):
         nodes = [start_node(), start_node(), end_node()]
         with pytest.raises(PipelineBuildError, match="There should be exactly 1 Start node"):
             create_runnable(pipeline, nodes)
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_multiple_end_nodes(self, pipeline):
         nodes = [start_node(), end_node(), end_node()]
         with pytest.raises(PipelineBuildError, match="There should be exactly 1 End node"):
             create_runnable(pipeline, nodes)
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_single_node_unreachable(self, pipeline):
         # The last passthrough node is not reachable, as it doesn't have any incoming or outgoing edges
         nodes = [start_node(), passthrough_node(), end_node(), passthrough_node()]
@@ -1205,7 +1204,7 @@ class TestPipelineValidation:
         # Should not raise a `ValueError`
         create_runnable(pipeline, nodes, edges)
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_subgraph_unreachable_should_build(self, pipeline):
         # The last passthrough nodes are not reachable
         start = start_node()
@@ -1238,7 +1237,7 @@ class TestPipelineValidation:
             ["__start__", start["id"], passthrough["id"], end["id"], "__end__"]
         )
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_split_graphs_should_not_build(self, pipeline):
         # The last passthrough nodes are not reachable
         start = start_node()
@@ -1269,7 +1268,7 @@ class TestPipelineValidation:
         ):
             create_runnable(pipeline, nodes, edges)
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_cyclical_graph(self, pipeline):
         # Ensure that cyclical graphs throw an error
         start = start_node()
@@ -1303,7 +1302,7 @@ class TestPipelineValidation:
         with pytest.raises(PipelineBuildError, match="A cycle was detected"):
             create_runnable(pipeline, nodes, edges)
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_multiple_valid_inputs(self, pipeline):
         """This tests the case where a node has multiple valid inputs to make sure it selects the correct one.
 

--- a/apps/service_providers/tests/test_models.py
+++ b/apps/service_providers/tests/test_models.py
@@ -5,7 +5,6 @@ from apps.service_providers.models import LlmProviderModel
 from apps.utils.factories.assistants import OpenAiAssistantFactory
 from apps.utils.factories.pipelines import PipelineFactory
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
-from apps.utils.pytest import django_db_with_data
 
 
 @pytest.fixture()
@@ -47,7 +46,7 @@ def pipeline(llm_provider, llm_provider_model):
 
 
 class TestServiceProviderModel:
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_provider_models_for_team_includes_global(self, llm_provider_model):
         team_models = LlmProviderModel.objects.for_team(llm_provider_model.team).all()
         # There is a single team model that we just created in the factory
@@ -63,27 +62,27 @@ class TestServiceProviderModel:
         assert len(global_models) == len(team_models) - 1
         assert all(not m.is_custom() for m in global_models)
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_cannot_delete_provider_models_with_associated_models(self, assistant):
         # llm provider models that are associated with another model cannot be deleted
         provider_model = assistant.llm_provider_model
         with pytest.raises(ValidationError):
             provider_model.delete()
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_cannot_delete_provider_models_with_associated_pipeline(self, pipeline):
         node = pipeline.node_set.get(flow_id="1")
         provider_model = LlmProviderModel.objects.get(id=node.params["llm_provider_model_id"])
         with pytest.raises(ValidationError, match=pipeline.name):
             provider_model.delete()
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_can_delete_unassociated_provider_models(self):
         # custom llm provider models that are not attached to experiments can be deleted
         llm_provider_model = LlmProviderModelFactory.create()
         llm_provider_model.delete()
 
-    @django_db_with_data()
+    @pytest.mark.django_db()
     def test_can_delete_unassociated_global_provider_models(self):
         # global provider models can be deleted
         global_llm_provider_model = LlmProviderModelFactory.create(team=None)

--- a/apps/utils/pytest.py
+++ b/apps/utils/pytest.py
@@ -2,30 +2,27 @@ import pytest
 
 
 def django_db_with_data():
-    """Shortcut decorator to mark a test function as requiring the database with data from migrations.
+    """Shortcut decorator for tests that need both a live DB server (TransactionTestCase) and migration data.
 
-    This is needed because of other tests that flush the database after each test
-    e.g. apps.api.tests.test_openai_api.test_chat_completion
+    Use this for tests that use the `live_server` fixture or otherwise require genuine transaction-mode
+    testing (e.g. testing on_commit hooks). These tests are typically marked @pytest.mark.integration.
 
     See also `apps.conftest._django_db_restore_serialized`.
     """
 
     def _inner(func):
         return pytest.mark.django_db(
-            serialized_rollback=True,  # load the serialize DB state
-            transaction=True,  # required for serialized_rollback to work
+            serialized_rollback=True,  # restore serialized DB state after the transaction flush
+            transaction=True,  # required for serialized_rollback to work; also needed for live_server
         )(func)
 
     return _inner
 
 
 def django_db_transactional():
-    """Shortcut decorator to mark a test function as a transactional test.
+    """Shortcut decorator for tests that genuinely need TransactionTestCase semantics.
 
-    This is just an alias for django_db_with_data() but kept separate for clarity.
-
-    An alternative would be to use the pytest.mark.django_db(transaction=True) decorator
-    (without `serialized_rollback=True`), but we rely on
-    the serialized_rollback=True to load the serialized DB state which includes the content types and permissions.
+    Use this only when the test actually requires real DB commits (e.g. testing on_commit callbacks
+    with a live server). For most tests, use @pytest.mark.django_db() instead.
     """
     return django_db_with_data()


### PR DESCRIPTION
Part of #3080

### Product Description
Removes a significant source of test suite slowness: a single live_server test was forcing 90+ other tests to run in TransactionTestCase (slow) mode.

### Technical Description

**Root cause:** `apps/api/tests/test_openai_api.py::test_chat_completion` uses a `live_server` fixture which triggers Django's `TransactionTestCase` behavior — flushing the entire database after the test. This flush destroyed migration-seeded data (content types, permissions, global LLM provider models), forcing all downstream tests that needed that data to use `transaction=True, serialized_rollback=True` to restore it.

**Fix:**
- Mark `test_chat_completion` with `@pytest.mark.integration` so it's excluded from the default test run (`-m "not integration and not eval"`)
- Remove `@django_db_with_data()` / `@django_db_transactional()` from 13 test files that only used these decorators due to the cascade side-effect
- Replace with `@pytest.mark.django_db()` (standard fast test mode)
- Update docstrings in `apps/utils/pytest.py` and `apps/conftest.py`

**Files changed:** 13 test files + 2 support files (utils/pytest.py, conftest.py)

**TransactionTestCase tests eliminated from default run:**
- 95 test functions across 13 files now run as standard Django TestCase
- The 1 genuine live_server test remains correct under `pytest -m integration`

**Expected impact:** TransactionTestCase tests are 2–10× slower than standard tests due to:
1. Full DB flush + restore per test
2. xdist cannot freely parallelise them (serialization constraints)
3. `--reuse-db` is less effective

### Migrations
- [ ] The migrations are backwards compatible

N/A — no model changes.

### Demo
Run default tests: `uv run pytest -n auto` (no live_server, no DB flushes)
Run integration tests: `uv run pytest -m integration` (runs the live_server test)

### Docs and Changelog
- [ ] This PR requires docs/changelog update

N/A — internal test infrastructure change.