### PR TITLE
[Docs] Formatting and links to DeepWiki for architecture page

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -6,7 +6,7 @@ hide:
 
 This section provides an overview of the Open Chat Studio architecture, explaining the core concepts and components that make up the system.
 
-For AI generated architecture diagrams based on this GitHub repo, visit 
+For AI-generated architecture diagrams based on this GitHub repo, visit
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/dimagi/open-chat-studio)
 
 ## System Overview
@@ -23,21 +23,21 @@ Open Chat Studio is built as a Django web application with a modular design. It 
 
 ## Key Concepts
 
-Concepts User Documentation [Concepts](https://docs.openchatstudio.com/concepts/)
+[Concepts User Documentation](https://docs.openchatstudio.com/concepts/)
 
 - **Experiments/Chatbots** - The term 'Experiments' is a legacy term. On the user interface side, they are referred to as ['Chatbots'](https://docs.openchatstudio.com/concepts/chatbots/). They are configurations for AI chat experiences. They include:
   - Prompts and LLM configurations
   - Channel connections
   - Data collection settings
 - **Channels** - [Channels](https://docs.openchatstudio.com/concepts/channels/) are communication interfaces that connect users to the chat system. These include: Web chat, WhatsApp etc
-- **Service Providers** - Service providers enable integration with external services including LLMs, authentication, messaging, voice, tracing etc
+- **Service Providers** - Service providers enable integration with external services including LLMs, authentication, messaging, voice, tracing etc.
 - **Pipelines** - [Pipelines](https://docs.openchatstudio.com/concepts/pipelines/) allow for the creation of complex workflows with multiple nodes and processing steps.
 
 ## Project structure
 
-The project is organized into several Django apps, each responsible for a specific functionality. Apps are placed in the `apps` folder, and each app has its own models, views, serializers, and tests. 
+The project is organized into several Django apps, each responsible for a specific functionality. Apps are placed in the `apps` folder, and each app has its own models, views, serializers, and tests.
 
- - **Django Templates** - Templates as well as static files are centralized in the `templates` and `assets` folders, respectively. Templates specific to an app should be placed in the `templates/{app_name}` directory.
+- **Django Templates** - Templates as well as static files are centralized in the `templates` and `assets` folders, respectively. Templates specific to an app should be placed in the `templates/{app_name}` directory.
 
 - **Static Files** - The `assets` folder contains JavaScript, CSS. The `assets/styles` folder contains Tailwind CSS configurations, while the `assets/javascript` folder contains JavaScript modules. These files are processed and bundled using Webpack to create the final static assets served to users. Other static assets like images are placed directly in the `static/` folder.
 
@@ -75,16 +75,16 @@ The frontend uses a combination of Django templates, Tailwind CSS, and JavaScrip
 
 ### [Sentry](https://sentry.io/)
 
-- Purpose: Error reporting and tracking  
+- Purpose: Error reporting and tracking
 - Used for: Identifying and debugging production issues
 
 ### [Task Badger](https://taskbadger.net/)
 
-- Purpose: Celery task monitoring  
+- Purpose: Celery task monitoring
 - Used for: Monitoring asynchronous task execution and performance
 
 ### [BetterStack](https://betterstack.com/)
 
-- Purpose: Uptime monitoring and status page  
-- Status Page: [status.openchatstudio.com](https://status.openchatstudio.com/)  
+- Purpose: Uptime monitoring and status page
+- Status Page: [status.openchatstudio.com](https://status.openchatstudio.com/)
 - Used for: Monitoring system availability and communicating status to users

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,8 @@ Welcome to the Open Chat Studio developer documentation. This guide is designed 
 
 Open Chat Studio is a platform for building, deploying, and evaluating AI-powered chat experiences. It provides tools for working with various LLMs (Language Learning Models), creating chatbots, managing conversations, and integrating with different messaging platforms.
 
-- For user facing documentation, please visit [docs.openchatstudio.com](https://docs.openchatstudio.com).
-- For AI generated technical documentation, visit 
+- For user-facing documentation, please visit [docs.openchatstudio.com](https://docs.openchatstudio.com).
+- For AI-generated technical documentation, visit
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/dimagi/open-chat-studio)
 
 ## Key Features


### PR DESCRIPTION
###
Technical Description
As a new user reading the tech docs, I have found formatting issues and ideas on how to make the Architecture docs more readable as it was the 1st page I read.
And added more links to DeepWiki and user docs - so that reference information rather than repeat it
And naming section "Monitoring & Observability external services" makes this searchable

### Docs and Changelog
- [ ] This PR requires docs/changelog update
