### PR TITLE
Update contributing docs with recommended agentic development flow

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -28,6 +28,9 @@ Before contributing, please make sure you've set up your development environment
 !!! tip "Discuss before you build"
     For non-trivial or complex changes, please discuss your design plan before writing code. The GitHub issue is the best place to start — add a comment outlining your approach and get feedback from maintainers. For broader ideas without a dedicated issue, open a [GitHub Discussion](https://github.com/dimagi/open-chat-studio/discussions). Aligning on design early avoids wasted effort and makes reviews much smoother.
 
+!!! info "Agentic development workflow"
+    We recommend using an agentic coding tool like Claude Code for development on this project. Our workflow follows a **design-first approach**: produce a design, post it to the GitHub issue for core team review, then implement once approved. See the [AI-Assisted Development](../developer_guides/ai_development.md) guide for the full workflow and setup instructions.
+
 ### Improve Documentation
 
 - **Developer Documentation** needs improvement, and we welcome contributions.
@@ -49,15 +52,6 @@ To contribute, pick a task from the [Good First Issues board](https://github.com
 ### 3. Submit a Pull Request (PR)
 
 Follow our [Pull Request guidelines](./pull_requests.md).
-
-## Agent support
-If you are using an agent other than Claude, consider creating a symbolic link to the CLAUDE.md file, but for your agent. For instance, to create a symlink for Gemini, run
-
-```bash
-ln -s CLAUDE.md GEMINI.md
-```
-
-Be sure add the new "file" to .gitignore.
 
 ## Getting Help
 

--- a/docs/developer_guides/ai_development.md
+++ b/docs/developer_guides/ai_development.md
@@ -1,19 +1,81 @@
 # AI-Assisted Development
 
-This project supports AI-assisted development workflows using Claude Code.
+This project uses an agentic development workflow built around [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview). Other agentic coding tools (Codex, opencode, etc.) can follow the same process.
 
 Our shared Claude workflows, commands, and configuration are maintained in the [dimagi-claude-workflows](https://github.com/dimagi/dimagi-claude-workflows) repository. Refer to that repository for setup instructions and usage guidance.
 
-## Development Workflow
+## Recommended Workflow
 
-The following is the typical development flow we use when working with Claude Code on this project.
+The core principle is **design before code**. Every non-trivial change should go through a design phase where the approach is reviewed by the core team before implementation begins.
 
 ```mermaid
 flowchart TD
-    A([Session Start]) --> B["Design + Plan<br/>Superpowers skill"]
-    B --> C["Review Plan<br/>Validate & Refine"]
-    C --> D["Execute Plan<br/>Build"]
-    D --> E["Code Review<br/>Parallel specialist agents"]
-    E --> F["Resolve<br/>PR comments + CI failures"]
-    F --> G([Complete])
+    A([Pick an Issue]) --> B["Design<br/>Use brainstorming skill"]
+    B --> C["Post Design to Issue<br/>For human review"]
+    C --> D{Core Team Approval?}
+    D -- No --> B
+    D -- Yes --> E["Implementation Plan<br/>Use writing-plans skill"]
+    E --> F["Execute Plan<br/>Build + Test"]
+    F --> G["Code Review<br/>Specialist agents"]
+    G --> H["Open PR<br/>Resolve comments + CI"]
+    H --> I([Complete])
 ```
+
+### 1. Design
+
+When starting work on an issue, use your agentic coding tool to explore the codebase and produce a design document. In Claude Code, the `brainstorming` skill guides this process — it helps you understand the problem, explore approaches, and arrive at a concrete design.
+
+The design should cover:
+
+- What problem is being solved and why
+- The chosen approach and alternatives considered
+- Key technical decisions and trade-offs
+- How the change fits into the existing architecture
+
+### 2. Human Review
+
+Post the design as a comment on the GitHub issue for review by the core team. **Do not proceed to implementation until the design is approved.** This catches misunderstandings and architectural mismatches early, before time is spent writing code.
+
+For simple bug fixes or small changes where the approach is obvious, a brief comment describing the fix is sufficient. The goal is alignment, not ceremony.
+
+### 3. Implementation Planning
+
+Once the design is approved, create a detailed implementation plan. In Claude Code, the `writing-plans` skill produces a step-by-step plan with file-level changes, test requirements, and dependency ordering.
+
+### 4. Execute
+
+Work through the implementation plan. The agentic tool handles code generation, test writing, and iterating on failures. Review the output as you go — the tool is a collaborator, not an autopilot.
+
+### 5. Code Review and PR
+
+Before opening a PR, run the project's linters, type checkers, and tests. Use code review agents to catch issues early. Then open a PR following the project's [pull request guidelines](../contributing/pull_requests.md).
+
+## Setup
+
+### Claude Code
+
+1. Install Claude Code following the [official docs](https://docs.anthropic.com/en/docs/claude-code/overview).
+2. Install the shared workflows from the [dimagi-claude-workflows](https://github.com/dimagi/dimagi-claude-workflows) repository.
+3. The project's `CLAUDE.md` and `AGENTS.md` files provide project-specific context automatically.
+
+### Other Tools
+
+If you use a different agentic coding tool, create a symlink so it picks up the project instructions:
+
+```bash
+ln -s CLAUDE.md GEMINI.md  # or AGENTS.md, depending on your tool
+```
+
+Add the symlink to `.gitignore` — don't commit it.
+
+## Key Skills
+
+These are the Claude Code skills referenced in the workflow above. If your tool has equivalent capabilities, use those instead.
+
+| Skill | Purpose |
+|-------|---------|
+| `brainstorming` | Explore the problem space and produce a design document |
+| `writing-plans` | Create a step-by-step implementation plan from an approved design |
+| `executing-plans` | Execute an implementation plan with review checkpoints |
+| `test-driven-development` | Write tests first, then implement to green |
+| `requesting-code-review` | Run parallel specialist agents to review your changes |


### PR DESCRIPTION
### Product Description
no change

### Technical Description
Expands the AI-Assisted Development guide (`docs/developer_guides/ai_development.md`) from a brief stub into a complete workflow reference covering:

- Design-first workflow with mermaid diagram showing the human review gate
- Step-by-step walkthrough: Design, Human Review, Implementation Planning, Execute, Code Review & PR
- Setup instructions for Claude Code and other agentic tools
- Key skills table (brainstorming, writing-plans, executing-plans, TDD, code review)

Adds an info callout in the contributing guide (`docs/contributing/index.md`) pointing contributors to the AI development workflow. Moves the agent symlink instructions from the contributing page into the AI development guide's "Other Tools" section.

Closes #3092

### Demo
N/A — documentation only

### Docs and Changelog
- [ ] This PR requires docs/changelog update