### PR TITLE
Validate participant data values are JSON serializable before storing

### DIFF
--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -337,6 +337,11 @@ class UpdateParticipantDataTool(CustomBaseTool):
     args_schema: type[schemas.UpdateUserDataSchema] = schemas.UpdateUserDataSchema
 
     def action(self, key: str, value: Any, tool_call_id: str):
+        try:
+            json.dumps(value)
+        except (TypeError, ValueError, OverflowError):
+            return "Error: The value is not JSON serializable"
+
         return Command(
             update={
                 "participant_data": {key: value},

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -830,6 +830,11 @@ class ExtractParticipantData(
         if self.key_name:
             output_data = {self.key_name: output_data}
 
+        try:
+            json.dumps(output_data)
+        except (TypeError, ValueError, OverflowError) as e:
+            raise ValueError(f"Extracted participant data is not JSON serializable: {e}") from e
+
         return PipelineState.from_node_output(
             node_name=self.name, node_id=self.node_id, output=context.input, participant_data=output_data
         )
@@ -955,9 +960,7 @@ class CodeNode(PipelineNode, OutputMessageTagMixin, RestrictedPythonExecutionMix
             message = get_code_error_message("<inline_code>", self.code)
             raise CodeNodeRunError(message) from exc
 
-        output_metadata = {
-            "console_output": "".join(collector() for collector in print_collectors)
-        }
+        output_metadata = {"console_output": "".join(collector() for collector in print_collectors)}
 
         if isinstance(result, Command):
             return result

--- a/apps/service_providers/llm_service/prompt_context.py
+++ b/apps/service_providers/llm_service/prompt_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
 
 from django.utils import timezone
@@ -188,6 +189,14 @@ class ParticipantDataProxy:
         self._participant_data = pipeline_state.setdefault("participant_data", {})
         self._scheduled_messages = None
 
+    @staticmethod
+    def _ensure_json_serializable(value: Any) -> None:
+        """Raise ValueError if value is not JSON serializable."""
+        try:
+            json.dumps(value)
+        except (TypeError, ValueError, OverflowError) as e:
+            raise ValueError(f"Value is not JSON serializable: {e}") from e
+
     def get(self):
         """Returns the current participant's data as a dictionary."""
         global_data = self.session.participant.global_data
@@ -198,10 +207,12 @@ class ParticipantDataProxy:
         This will only overwrite any matching keys."""
         if not isinstance(data, dict):
             raise ValueError("Data must be a dictionary")
+        self._ensure_json_serializable(data)
         self._participant_data.update(data)
 
     def set_key(self, key: str, value: Any):
         """Set a single key in the participant data."""
+        self._ensure_json_serializable(value)
         self._participant_data[key] = value
 
     def append_to_key(self, key: str, value: Any) -> list[Any]:

--- a/apps/service_providers/tests/test_participant_data_proxy.py
+++ b/apps/service_providers/tests/test_participant_data_proxy.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -153,3 +154,32 @@ class TestParticipantDataProxy:
         proxy.set_key("text_value", "not a number")
         proxy.increment_key("text_value", 3)
         assert input_state["participant_data"] == {"counter": 7, "float_counter": 4.0, "text_value": 3}
+
+    def test_set_rejects_non_json_serializable_data(self):
+        session = ExperimentSessionFactory.create()
+        proxy = ParticipantDataProxy({}, session)
+
+        with pytest.raises(ValueError, match="not JSON serializable"):
+            proxy.set({"timestamp": datetime.now()})
+
+    def test_set_key_rejects_non_json_serializable_value(self):
+        session = ExperimentSessionFactory.create()
+        proxy = ParticipantDataProxy({}, session)
+
+        with pytest.raises(ValueError, match="not JSON serializable"):
+            proxy.set_key("obj", datetime.now())
+
+    def test_append_to_key_rejects_non_json_serializable_value(self):
+        session = ExperimentSessionFactory.create()
+        proxy = ParticipantDataProxy({}, session)
+
+        with pytest.raises(ValueError, match="not JSON serializable"):
+            proxy.append_to_key("items", datetime.now())
+
+    def test_set_accepts_json_serializable_data(self):
+        session = ExperimentSessionFactory.create()
+        input_state = {}
+        proxy = ParticipantDataProxy(input_state, session)
+
+        proxy.set({"str": "hello", "int": 42, "float": 3.14, "bool": True, "none": None, "list": [1, 2]})
+        assert input_state["participant_data"]["str"] == "hello"


### PR DESCRIPTION
Adds JSON serialization checks at all write paths for participant data to prevent non-serializable values (e.g. datetime objects) from being stored, which would cause failures during export or API serialization.

<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->


### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.
-->



### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
