### PR TITLE
Isolated database per worktree

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,3 +1,12 @@
 # Worktrunk Project Configuration
-[post-create]
+[pre-start]
 bootstrap = ".claude/hooks/setup-env.sh"
+database-url = "echo 'DATABASE_URL=postgres://postgres:postgres@localhost:5432/{{ branch | sanitize_db }}' >> .env"
+create-database = "docker exec postgres psql -U postgres -c 'CREATE DATABASE {{ branch | sanitize_db }}'"
+
+[post-start]
+compile-styles = "npm run dev"
+migrate-and-bootstrap = "uv run python manage.py migrate && uv run python manage.py bootstrap_data --email dev@gmail.com --password letmein"
+
+[pre-remove]
+db-remove = "docker exec postgres psql -U postgres -c \"DROP DATABASE IF EXISTS \\\"{{ branch | sanitize_db }}\\\" WITH (FORCE)\""


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->


### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.
-->
Development-only change. Worktrunk hooks for setting up an isolated database per worktree (see [the docs](https://worktrunk.dev/tips-patterns/#database-per-worktree)). This assumes
1. postgres is running inside docker
2. the `postgres` user is the root user (safe to assume, since the docker-compose file does the same)

Migrating and bootstrapping the database with data must run as a single command. It seems like the `post-start` call runs each step concurrently, which causes the bootstrap data one to fail when the migration is not yet done.


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
