### PR TITLE
Use OPENAI_SECRET_KEY env var for LLM provider in bootstrap_data

### DIFF
--- a/apps/web/management/commands/bootstrap_data.py
+++ b/apps/web/management/commands/bootstrap_data.py
@@ -10,6 +10,8 @@ Usage:
     python manage.py bootstrap_data --skip-sample-data  # Only create user/team
 """
 
+import os
+
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management.base import BaseCommand
@@ -147,9 +149,12 @@ class Command(BaseCommand):
         # LLM Provider and Model
         self.stdout.write("")
         self.stdout.write("--- Creating LLM Provider ---")
+        openai_api_key = os.environ.get("OPENAI_SECRET_KEY", "test-key")
         llm_provider, created = LlmProvider.objects.get_or_create(
-            name="OpenAI", team=team, defaults={"type": "openai", "config": {"openai_api_key": "test-key"}}
+            name="OpenAI", team=team, defaults={"type": "openai", "config": {"openai_api_key": openai_api_key}}
         )
+        if created and openai_api_key != "test-key":
+            self.stdout.write(self.style.SUCCESS("  Using OPENAI_SECRET_KEY from environment"))
         self._log_created("LLM provider", llm_provider.name, created)
 
         llm_model = get_first_llm_provider_model(llm_provider, team.id)


### PR DESCRIPTION
If OPENAI_SECRET_KEY is set in the environment, use it as the OpenAI API key when creating the LLM provider during bootstrap, falling back to "test-key" otherwise.

<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->


### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.
-->
Create a legit LLM provider for dev purposes if OPENAI_SECRET_KEY is in the env

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
