### PR TITLE
Support end session method in code node

### DIFF
--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -83,6 +83,11 @@ class TempState(TypedDict):
     attachments: list
 
 
+def _merge_intents(left: list[Intents], right: list[Intents]) -> list[Intents]:
+    """Merge intents from multiple nodes, deduplicating to prevent the same intent being processed more than once."""
+    return list(dict.fromkeys(left + right))
+
+
 class PipelineState(dict):
     messages: Annotated[Sequence[Any], operator.add]
 
@@ -110,7 +115,7 @@ class PipelineState(dict):
     # source node for the current node
     node_source: str
 
-    intents: Annotated[list[Intents], operator.add]
+    intents: Annotated[list[Intents], _merge_intents]
     synthetic_voice_id: int | None
 
     participant_data: Annotated[dict, operator.or_]

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -41,6 +41,7 @@ from apps.pipelines.models import (
     PipelineChatHistoryTypes,
 )
 from apps.pipelines.nodes.base import (
+    Intents,
     NodeSchema,
     OptionsSource,
     PipelineNode,
@@ -995,6 +996,7 @@ class CodeNode(PipelineNode, OutputMessageTagMixin, RestrictedPythonExecutionMix
         output_state["temp_state"] = pipeline_state.get("temp_state") or {}
         output_state["participant_data"] = pipeline_state.get("participant_data") or {}
         output_state["session_state"] = pipeline_state.get("session_state") or {}
+        output_state["intents"] = pipeline_state.get("intents") or []
 
         # use 'output_state' so that we capture any updates
         participant_data_proxy = PipelineParticipantDataProxy(output_state, context.session, repo=self.repo)
@@ -1035,6 +1037,7 @@ class CodeNode(PipelineNode, OutputMessageTagMixin, RestrictedPythonExecutionMix
             "add_message_tag": output_state.add_message_tag,
             "add_session_tag": output_state.add_session_tag,
             "get_node_output": pipeline_accessor.get_node_output,
+            "end_session": self._end_session(output_state),
             # control flow
             "abort_with_message": self._abort_pipeline(),
             "require_node_outputs": self._require_node_outputs(context),
@@ -1146,3 +1149,9 @@ class CodeNode(PipelineNode, OutputMessageTagMixin, RestrictedPythonExecutionMix
             state["temp_state"][key_name] = value
 
         return set_temp_state_key
+
+    def _end_session(self, state: PipelineState):
+        def end_session():
+            state["intents"] = [Intents.END_SESSION]
+
+        return end_session

--- a/apps/pipelines/tests/test_code_node.py
+++ b/apps/pipelines/tests/test_code_node.py
@@ -562,6 +562,27 @@ def main(input, **kwargs):
     assert output.update["intents"] == ["end_session"]  # ty: ignore[not-subscriptable]
 
 
+@pytest.mark.django_db()
+def test_end_session_deduplicates_across_nodes(pipeline, experiment_session):
+    code_end = """
+def main(input, **kwargs):
+    end_session()
+    return input
+"""
+    nodes = [
+        start_node(),
+        code_node(code_end, name="code1"),
+        code_node(code_end, name="code2"),
+        end_node(),
+    ]
+    config = {"configurable": {"repo": InMemoryPipelineRepository()}}
+    node_output = create_runnable(pipeline, nodes).invoke(
+        PipelineState(experiment_session=experiment_session, messages=["hi"]),
+        config=config,
+    )
+    assert node_output["intents"] == ["end_session"]
+
+
 def test_add_file_attachment_requires_bytes():
     code = """
 def main(input, **kwargs):

--- a/apps/pipelines/tests/test_code_node.py
+++ b/apps/pipelines/tests/test_code_node.py
@@ -549,6 +549,19 @@ def main(input, **kwargs):
     assert outputs["console_output"] == ""
 
 
+def test_end_session():
+    code = """
+def main(input, **kwargs):
+    end_session()
+    return input
+    """
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code)
+    node._repo = InMemoryPipelineRepository()
+    state = PipelineState(outputs={}, experiment_session=None, last_node_input="hi", node_inputs=["hi"])
+    output = node._process(state, NodeContext(state))
+    assert output.update["intents"] == ["end_session"]  # ty: ignore[not-subscriptable]
+
+
 def test_add_file_attachment_requires_bytes():
     code = """
 def main(input, **kwargs):

--- a/assets/javascript/apps/pipeline/components/CodeMirrorEditor.tsx
+++ b/assets/javascript/apps/pipeline/components/CodeMirrorEditor.tsx
@@ -199,7 +199,7 @@ export function CodeNodeEditor(
       boost: 1,
       section: "Flow Control",
     }),
-    end_session: snip("end_session", {
+    end_session: snip("end_session()", {
       label: "end_session",
       type: "function",
       detail: "Ends the session with this response",

--- a/assets/javascript/apps/pipeline/components/CodeMirrorEditor.tsx
+++ b/assets/javascript/apps/pipeline/components/CodeMirrorEditor.tsx
@@ -198,7 +198,14 @@ export function CodeNodeEditor(
       detail: "Abort the current node execution and wait until the node is executed again.",
       boost: 1,
       section: "Flow Control",
-    })
+    }),
+    end_session: snip("end_session", {
+      label: "end_session",
+      type: "function",
+      detail: "Ends the session with this response",
+      boost: 1,
+      section: "Session Control",
+    }),
   }
 
   function pythonCompletions(context: CompletionContext) {


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->
Allow ending session from the pipeline code node. The reason for adding this is to accomodate more complex / deterministic session ending in pipelines.

### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.
-->
This follows the same pattern that the tool's end session does by registering an end session intent.

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
See the test

### Docs and Changelog
- [x] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
