### PR TITLE
fix tests

### DIFF
--- a/apps/human_annotations/tests/test_views.py
+++ b/apps/human_annotations/tests/test_views.py
@@ -320,8 +320,8 @@ def test_queue_items_table_filters_by_status(client, team_with_users, queue):
     )
     assert response.status_code == 200
     content = response.content.decode()
-    assert str(pending_item) in content
-    assert str(completed_item) not in content
+    assert str(pending_item.session.external_id) in content
+    assert str(completed_item.session.external_id) not in content
 
     # Filter by completed
     response = client.get(
@@ -330,15 +330,15 @@ def test_queue_items_table_filters_by_status(client, team_with_users, queue):
     )
     assert response.status_code == 200
     content = response.content.decode()
-    assert str(completed_item) in content
-    assert str(pending_item) not in content
+    assert str(completed_item.session.external_id) in content
+    assert str(pending_item.session.external_id) not in content
 
     # No filter - should contain both
     response = client.get(url)
     assert response.status_code == 200
     content = response.content.decode()
-    assert str(pending_item) in content
-    assert str(completed_item) in content
+    assert str(pending_item.session.external_id) in content
+    assert str(completed_item.session.external_id) in content
 
 
 @pytest.mark.django_db()
@@ -362,8 +362,8 @@ def test_queue_items_table_filters_by_reviewer(client, team_with_users, queue, u
     )
     assert response.status_code == 200
     content = response.content.decode()
-    assert str(item1) in content
-    assert str(item2) not in content
+    assert str(item1.session.external_id) in content
+    assert str(item2.session.external_id) not in content
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->


### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.
-->
The tests checked for str(item) which returns "Session {uuid}" but the table template renders only the session's external_id without the prefix.


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
