### PR TITLE
Pipeline as context to the chat widget

### DIFF
--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -47,7 +47,9 @@ from apps.filters.models import FilterSet
 from apps.generics import actions
 from apps.generics.help import render_help_with_link
 from apps.generics.views import paginate_session, render_session_details
+from apps.pipelines.models import Pipeline
 from apps.pipelines.views import (
+    _get_pipeline_chat_widget_context,
     _pipeline_node_default_values,
     _pipeline_node_parameter_values,
     _pipeline_node_schemas,
@@ -349,6 +351,7 @@ class EditChatbot(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateVi
             synthetic_voices = SyntheticVoice.get_for_team(self.request.team, exclude_services=exclude_services)
             synthetic_voices = synthetic_voices.filter(service__iexact=experiment.voice_provider.type)
 
+        pipeline = Pipeline.objects.get(id=experiment.pipeline_id, team=self.request.team)
         return {
             **data,
             "pipeline_id": experiment.pipeline_id,
@@ -365,6 +368,7 @@ class EditChatbot(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateVi
             "origin": "chatbots",
             "allow_edit_name": False,
             "flags_enabled": [flag.name for flag in Flag.objects.all() if flag.is_active_for_team(self.request.team)],
+            "pipeline_chat_widget_context": _get_pipeline_chat_widget_context(pipeline, experiment),
             **llm_model_parameter_context(),
         }
 

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -48,10 +48,10 @@ from apps.generics import actions
 from apps.generics.help import render_help_with_link
 from apps.generics.views import paginate_session, render_session_details
 from apps.pipelines.views import (
-    _get_pipeline_chat_widget_context,
     _pipeline_node_default_values,
     _pipeline_node_parameter_values,
     _pipeline_node_schemas,
+    get_widget_page_context,
     llm_model_parameter_context,
 )
 from apps.service_providers.models import LlmProvider, LlmProviderModel
@@ -368,7 +368,7 @@ class EditChatbot(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateVi
             "origin": "chatbots",
             "allow_edit_name": False,
             "flags_enabled": [flag.name for flag in Flag.objects.all() if flag.is_active_for_team(self.request.team)],
-            "pipeline_chat_widget_context": _get_pipeline_chat_widget_context(experiment.pipeline, experiment),
+            "widget_page_context": get_widget_page_context(experiment.pipeline, experiment),
             **llm_model_parameter_context(),
         }
 

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -47,7 +47,6 @@ from apps.filters.models import FilterSet
 from apps.generics import actions
 from apps.generics.help import render_help_with_link
 from apps.generics.views import paginate_session, render_session_details
-from apps.pipelines.models import Pipeline
 from apps.pipelines.views import (
     _get_pipeline_chat_widget_context,
     _pipeline_node_default_values,
@@ -341,7 +340,9 @@ class EditChatbot(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateVi
         llm_providers = LlmProvider.objects.filter(team=self.request.team).values("id", "name", "type").all()
         llm_provider_models = LlmProviderModel.objects.for_team(self.request.team).all()
         experiment = get_object_or_404(
-            Experiment.objects.get_all().select_related("voice_provider"), id=kwargs["pk"], team=self.request.team
+            Experiment.objects.get_all().select_related("voice_provider", "pipeline"),
+            id=kwargs["pk"],
+            team=self.request.team,
         )
         synthetic_voices = []
         if experiment.voice_provider:
@@ -351,7 +352,6 @@ class EditChatbot(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateVi
             synthetic_voices = SyntheticVoice.get_for_team(self.request.team, exclude_services=exclude_services)
             synthetic_voices = synthetic_voices.filter(service__iexact=experiment.voice_provider.type)
 
-        pipeline = Pipeline.objects.get(id=experiment.pipeline_id, team=self.request.team)
         return {
             **data,
             "pipeline_id": experiment.pipeline_id,
@@ -368,7 +368,7 @@ class EditChatbot(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateVi
             "origin": "chatbots",
             "allow_edit_name": False,
             "flags_enabled": [flag.name for flag in Flag.objects.all() if flag.is_active_for_team(self.request.team)],
-            "pipeline_chat_widget_context": _get_pipeline_chat_widget_context(pipeline, experiment),
+            "pipeline_chat_widget_context": _get_pipeline_chat_widget_context(experiment.pipeline, experiment),
             **llm_model_parameter_context(),
         }
 

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -242,6 +242,15 @@ class Pipeline(BaseTeamModel, VersionsMixin):
 
         return {}
 
+    @property
+    def data_without_positions(self):
+        if not self.data or "nodes" not in self.data:
+            return self.data
+        return {
+            **self.data,
+            "nodes": [{k: v for k, v in node.items() if k != "position"} for node in self.data["nodes"]],
+        }
+
     @cached_property
     def flow_data(self) -> dict:
         flow = Flow(**self.data)

--- a/apps/pipelines/tests/test_views.py
+++ b/apps/pipelines/tests/test_views.py
@@ -1,0 +1,64 @@
+import pytest
+
+from apps.events.models import EventActionType, StaticTriggerType
+from apps.pipelines.views import _get_pipeline_chat_widget_context
+from apps.utils.factories.events import EventActionFactory, StaticTriggerFactory, TimeoutTriggerFactory
+from apps.utils.factories.experiment import ExperimentFactory
+from apps.utils.factories.pipelines import PipelineFactory
+
+
+@pytest.mark.django_db()
+class TestGetPipelineChatWidgetContext:
+    def test_returns_empty_dict_when_pipeline_is_none(self):
+        assert _get_pipeline_chat_widget_context(None) == {}
+
+    def test_serializes_static_triggers(self):
+        pipeline = PipelineFactory()
+        experiment = ExperimentFactory(pipeline=pipeline, team=pipeline.team)
+        action = EventActionFactory(action_type=EventActionType.LOG, params={"key": "value"})
+        StaticTriggerFactory(
+            experiment=experiment,
+            action=action,
+            type=StaticTriggerType.NEW_HUMAN_MESSAGE,
+            is_active=True,
+        )
+
+        result = _get_pipeline_chat_widget_context(pipeline, experiment=experiment)
+        static_triggers = result["experiment_events"]["static_triggers"]
+        assert len(static_triggers) == 1
+        assert static_triggers[0]["type"] == StaticTriggerType.NEW_HUMAN_MESSAGE
+        assert static_triggers[0]["type_label"] == StaticTriggerType.NEW_HUMAN_MESSAGE.label
+        assert static_triggers[0]["is_active"] is True
+        assert static_triggers[0]["action"]["action_type"] == EventActionType.LOG
+        assert static_triggers[0]["action"]["action_type_label"] == EventActionType.LOG.label
+        assert static_triggers[0]["action"]["params"] == {"key": "value"}
+
+    def test_serializes_timeout_triggers(self):
+        pipeline = PipelineFactory()
+        experiment = ExperimentFactory(pipeline=pipeline, team=pipeline.team)
+        action = EventActionFactory(action_type=EventActionType.LOG)
+        TimeoutTriggerFactory(
+            experiment=experiment,
+            action=action,
+            delay=30,
+            total_num_triggers=5,
+            is_active=True,
+        )
+
+        result = _get_pipeline_chat_widget_context(pipeline, experiment=experiment)
+        timeout_triggers = result["experiment_events"]["timeout_triggers"]
+        assert len(timeout_triggers) == 1
+        assert timeout_triggers[0]["delay"] == 30
+        assert timeout_triggers[0]["total_num_triggers"] == 5
+        assert timeout_triggers[0]["is_active"] is True
+        assert timeout_triggers[0]["action"]["action_type"] == EventActionType.LOG
+
+    def test_excludes_archived_triggers(self):
+        pipeline = PipelineFactory()
+        experiment = ExperimentFactory(pipeline=pipeline, team=pipeline.team)
+        StaticTriggerFactory(experiment=experiment, is_archived=True)
+        TimeoutTriggerFactory(experiment=experiment, is_archived=True)
+
+        result = _get_pipeline_chat_widget_context(pipeline, experiment=experiment)
+        assert result["experiment_events"]["static_triggers"] == []
+        assert result["experiment_events"]["timeout_triggers"] == []

--- a/apps/pipelines/tests/test_views.py
+++ b/apps/pipelines/tests/test_views.py
@@ -1,16 +1,43 @@
 import pytest
 
 from apps.events.models import EventActionType, StaticTriggerType
-from apps.pipelines.views import _get_pipeline_chat_widget_context
+from apps.pipelines.views import get_widget_page_context
 from apps.utils.factories.events import EventActionFactory, StaticTriggerFactory, TimeoutTriggerFactory
 from apps.utils.factories.experiment import ExperimentFactory
 from apps.utils.factories.pipelines import PipelineFactory
 
 
 @pytest.mark.django_db()
-class TestGetPipelineChatWidgetContext:
+class TestGetWidgetPageContext:
     def test_returns_empty_dict_when_pipeline_is_none(self):
-        assert _get_pipeline_chat_widget_context(None) == {}
+        assert get_widget_page_context(None) == {}
+
+    def test_strips_node_positions(self):
+        pipeline = PipelineFactory(
+            data={
+                "nodes": [
+                    {
+                        "id": "1",
+                        "type": "pipelineNode",
+                        "position": {"x": 100, "y": 200},
+                        "data": {"id": "1", "type": "LLMResponseNode", "label": "Node 1"},
+                    },
+                    {
+                        "id": "2",
+                        "type": "pipelineNode",
+                        "position": {"x": 300, "y": 400},
+                        "data": {"id": "2", "type": "LLMResponseNode", "label": "Node 2"},
+                    },
+                ],
+                "edges": [{"id": "e1", "source": "1", "target": "2"}],
+            }
+        )
+        result = get_widget_page_context(pipeline)
+        for node in result["pipeline_structure"]["nodes"]:
+            assert "position" not in node
+            assert "id" in node
+            assert "data" in node
+        assert result["pipeline_structure"]["edges"] == [{"id": "e1", "source": "1", "target": "2"}]
 
     def test_serializes_static_triggers(self):
         pipeline = PipelineFactory()
@@ -23,8 +50,8 @@ class TestGetPipelineChatWidgetContext:
             is_active=True,
         )
 
-        result = _get_pipeline_chat_widget_context(pipeline, experiment=experiment)
-        static_triggers = result["experiment_events"]["static_triggers"]
+        result = get_widget_page_context(pipeline, experiment=experiment)
+        static_triggers = result["event_triggers"]["static_triggers"]
         assert len(static_triggers) == 1
         assert static_triggers[0]["type"] == StaticTriggerType.NEW_HUMAN_MESSAGE
         assert static_triggers[0]["type_label"] == StaticTriggerType.NEW_HUMAN_MESSAGE.label
@@ -45,8 +72,8 @@ class TestGetPipelineChatWidgetContext:
             is_active=True,
         )
 
-        result = _get_pipeline_chat_widget_context(pipeline, experiment=experiment)
-        timeout_triggers = result["experiment_events"]["timeout_triggers"]
+        result = get_widget_page_context(pipeline, experiment=experiment)
+        timeout_triggers = result["event_triggers"]["timeout_triggers"]
         assert len(timeout_triggers) == 1
         assert timeout_triggers[0]["delay"] == 30
         assert timeout_triggers[0]["total_num_triggers"] == 5
@@ -59,9 +86,9 @@ class TestGetPipelineChatWidgetContext:
         StaticTriggerFactory(experiment=experiment, is_active=False)
         TimeoutTriggerFactory(experiment=experiment, is_active=False)
 
-        result = _get_pipeline_chat_widget_context(pipeline, experiment=experiment)
-        assert result["experiment_events"]["static_triggers"] == []
-        assert result["experiment_events"]["timeout_triggers"] == []
+        result = get_widget_page_context(pipeline, experiment=experiment)
+        assert result["event_triggers"]["static_triggers"] == []
+        assert result["event_triggers"]["timeout_triggers"] == []
 
     def test_excludes_archived_triggers(self):
         pipeline = PipelineFactory()
@@ -69,6 +96,6 @@ class TestGetPipelineChatWidgetContext:
         StaticTriggerFactory(experiment=experiment, is_archived=True)
         TimeoutTriggerFactory(experiment=experiment, is_archived=True)
 
-        result = _get_pipeline_chat_widget_context(pipeline, experiment=experiment)
-        assert result["experiment_events"]["static_triggers"] == []
-        assert result["experiment_events"]["timeout_triggers"] == []
+        result = get_widget_page_context(pipeline, experiment=experiment)
+        assert result["event_triggers"]["static_triggers"] == []
+        assert result["event_triggers"]["timeout_triggers"] == []

--- a/apps/pipelines/tests/test_views.py
+++ b/apps/pipelines/tests/test_views.py
@@ -28,7 +28,7 @@ class TestGetPipelineChatWidgetContext:
         assert len(static_triggers) == 1
         assert static_triggers[0]["type"] == StaticTriggerType.NEW_HUMAN_MESSAGE
         assert static_triggers[0]["type_label"] == StaticTriggerType.NEW_HUMAN_MESSAGE.label
-        assert static_triggers[0]["is_active"] is True
+        assert "is_active" not in static_triggers[0]
         assert static_triggers[0]["action"]["action_type"] == EventActionType.LOG
         assert static_triggers[0]["action"]["action_type_label"] == EventActionType.LOG.label
         assert static_triggers[0]["action"]["params"] == {"key": "value"}
@@ -50,8 +50,18 @@ class TestGetPipelineChatWidgetContext:
         assert len(timeout_triggers) == 1
         assert timeout_triggers[0]["delay"] == 30
         assert timeout_triggers[0]["total_num_triggers"] == 5
-        assert timeout_triggers[0]["is_active"] is True
+        assert "is_active" not in timeout_triggers[0]
         assert timeout_triggers[0]["action"]["action_type"] == EventActionType.LOG
+
+    def test_excludes_inactive_triggers(self):
+        pipeline = PipelineFactory()
+        experiment = ExperimentFactory(pipeline=pipeline, team=pipeline.team)
+        StaticTriggerFactory(experiment=experiment, is_active=False)
+        TimeoutTriggerFactory(experiment=experiment, is_active=False)
+
+        result = _get_pipeline_chat_widget_context(pipeline, experiment=experiment)
+        assert result["experiment_events"]["static_triggers"] == []
+        assert result["experiment_events"]["timeout_triggers"] == []
 
     def test_excludes_archived_triggers(self):
         pipeline = PipelineFactory()

--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -90,12 +90,15 @@ class CreatePipeline(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Templat
         return redirect(reverse("pipelines:edit", args=args, kwargs={**kwargs, "pk": pipeline.id}))
 
 
-def _get_pipeline_chat_widget_context(pipeline, experiment=None):
-    """Build chat widget context data for the pipeline view.
+def _serialize_event_action(action):
+    return {
+        "action_type": action.action_type,
+        "action_type_label": EventActionType(action.action_type).label,
+        "params": action.params,
+    }
 
-    Returns a dict with pipeline JSON and experiment events to be passed as
-    page context to the chat widget.
-    """
+
+def _get_pipeline_chat_widget_context(pipeline, experiment=None):
     context = {"pipeline_structure": pipeline.data}
 
     if experiment is None:
@@ -117,11 +120,7 @@ def _get_pipeline_chat_widget_context(pipeline, experiment=None):
                     "type": trigger.type,
                     "type_label": StaticTriggerType(trigger.type).label,
                     "is_active": trigger.is_active,
-                    "action": {
-                        "action_type": trigger.action.action_type,
-                        "action_type_label": EventActionType(trigger.action.action_type).label,
-                        "params": trigger.action.params,
-                    },
+                    "action": _serialize_event_action(trigger.action),
                 }
                 for trigger in static_triggers
             ],
@@ -131,11 +130,7 @@ def _get_pipeline_chat_widget_context(pipeline, experiment=None):
                     "total_num_triggers": trigger.total_num_triggers,
                     "is_active": trigger.is_active,
                     "trigger_from_first_message": trigger.trigger_from_first_message,
-                    "action": {
-                        "action_type": trigger.action.action_type,
-                        "action_type_label": EventActionType(trigger.action.action_type).label,
-                        "params": trigger.action.params,
-                    },
+                    "action": _serialize_event_action(trigger.action),
                 }
                 for trigger in timeout_triggers
             ],
@@ -349,7 +344,6 @@ def _pipeline_node_schemas():
 
 
 def _get_node_schema(node_class):
-
     schema = resolve_references(node_class.model_json_schema())
     schema.pop("$defs", None)
 

--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -23,6 +23,7 @@ from apps.assistants.models import OpenAiAssistant
 from apps.custom_actions.form_utils import get_custom_action_operation_choices
 from apps.custom_actions.schema_utils import resolve_references
 from apps.documents.models import Collection
+from apps.events.models import EventActionType, StaticTrigger, StaticTriggerType, TimeoutTrigger
 from apps.experiments.models import AgentTools, BuiltInTools, Experiment, SourceMaterial
 from apps.pipelines.flow import FlowPipelineData
 from apps.pipelines.jinja_utils import djlint_check, parse_jinja_template
@@ -89,6 +90,60 @@ class CreatePipeline(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Templat
         return redirect(reverse("pipelines:edit", args=args, kwargs={**kwargs, "pk": pipeline.id}))
 
 
+def _get_pipeline_chat_widget_context(pipeline, experiment=None):
+    """Build chat widget context data for the pipeline view.
+
+    Returns a dict with pipeline JSON and experiment events to be passed as
+    page context to the chat widget.
+    """
+    context = {"pipeline_structure": pipeline.data}
+
+    if experiment is None:
+        experiment = pipeline.experiment_set.filter(is_archived=False).first()
+
+    if experiment is not None:
+        static_triggers = StaticTrigger.objects.filter(experiment=experiment, is_archived=False).select_related(
+            "action"
+        )
+        timeout_triggers = TimeoutTrigger.objects.filter(experiment=experiment, is_archived=False).select_related(
+            "action"
+        )
+
+        context["experiment_events"] = {
+            "experiment_id": experiment.id,
+            "experiment_name": experiment.name,
+            "static_triggers": [
+                {
+                    "type": trigger.type,
+                    "type_label": StaticTriggerType(trigger.type).label,
+                    "is_active": trigger.is_active,
+                    "action": {
+                        "action_type": trigger.action.action_type,
+                        "action_type_label": EventActionType(trigger.action.action_type).label,
+                        "params": trigger.action.params,
+                    },
+                }
+                for trigger in static_triggers
+            ],
+            "timeout_triggers": [
+                {
+                    "delay": trigger.delay,
+                    "total_num_triggers": trigger.total_num_triggers,
+                    "is_active": trigger.is_active,
+                    "trigger_from_first_message": trigger.trigger_from_first_message,
+                    "action": {
+                        "action_type": trigger.action.action_type,
+                        "action_type_label": EventActionType(trigger.action.action_type).label,
+                        "params": trigger.action.params,
+                    },
+                }
+                for trigger in timeout_triggers
+            ],
+        }
+
+    return context
+
+
 class EditPipeline(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateView):
     permission_required = "pipelines.change_pipeline"
     template_name = "pipelines/pipeline_builder.html"
@@ -114,6 +169,7 @@ class EditPipeline(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateV
             "allow_edit_name": True,
             "flags_enabled": [flag.name for flag in Flag.objects.all() if flag.is_active_for_team(self.request.team)],
             "read_only": pipeline.is_a_version,
+            "pipeline_chat_widget_context": _get_pipeline_chat_widget_context(pipeline),
             **llm_model_parameter_context(),
         }
 

--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -98,11 +98,23 @@ def _serialize_event_action(action):
     }
 
 
-def _get_pipeline_chat_widget_context(pipeline, experiment=None):
+def _get_experiment_settings_context(experiment):
+    return {
+        "tracing_configured": bool(experiment.trace_provider_id),
+        "convert_speech_inputs_to_text": bool(experiment.synthetic_voice_id and experiment.echo_transcript),
+        "convert_output_text_to_speech": bool(experiment.synthetic_voice_id),
+        "user_consent_required": bool(experiment.consent_form_id),
+        "file_uploads_allowed": experiment.file_uploads_enabled,
+    }
+
+
+def get_widget_page_context(pipeline, experiment=None):
     if pipeline is None:
         return {}
 
-    context = {"pipeline_structure": pipeline.data}
+    context = {
+        "pipeline_structure": pipeline.data_without_positions,
+    }
 
     if experiment is not None:
         static_triggers = StaticTrigger.objects.filter(experiment=experiment, is_archived=False).select_related(
@@ -112,9 +124,13 @@ def _get_pipeline_chat_widget_context(pipeline, experiment=None):
             "action"
         )
 
-        context["experiment_events"] = {
-            "chatbot_id": experiment.id,
-            "chatbot_name": experiment.name,
+        context["chatbot"] = {
+            "id": experiment.id,
+            "name": experiment.name,
+            "description": experiment.description,
+            "version": experiment.version_number,
+        }
+        context["event_triggers"] = {
             "static_triggers": [
                 {
                     "type": trigger.type,
@@ -135,6 +151,7 @@ def _get_pipeline_chat_widget_context(pipeline, experiment=None):
                 if trigger.is_active
             ],
         }
+        context["settings"] = _get_experiment_settings_context(experiment)
 
     return context
 
@@ -164,7 +181,7 @@ class EditPipeline(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateV
             "allow_edit_name": True,
             "flags_enabled": [flag.name for flag in Flag.objects.all() if flag.is_active_for_team(self.request.team)],
             "read_only": pipeline.is_a_version,
-            "pipeline_chat_widget_context": _get_pipeline_chat_widget_context(pipeline),
+            "widget_page_context": get_widget_page_context(pipeline),
             **llm_model_parameter_context(),
         }
 

--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -113,26 +113,26 @@ def _get_pipeline_chat_widget_context(pipeline, experiment=None):
         )
 
         context["experiment_events"] = {
-            "experiment_id": experiment.id,
-            "experiment_name": experiment.name,
+            "chatbot_id": experiment.id,
+            "chatbot_name": experiment.name,
             "static_triggers": [
                 {
                     "type": trigger.type,
                     "type_label": StaticTriggerType(trigger.type).label,
-                    "is_active": trigger.is_active,
                     "action": _serialize_event_action(trigger.action),
                 }
                 for trigger in static_triggers
+                if trigger.is_active
             ],
             "timeout_triggers": [
                 {
                     "delay": trigger.delay,
                     "total_num_triggers": trigger.total_num_triggers,
-                    "is_active": trigger.is_active,
                     "trigger_from_first_message": trigger.trigger_from_first_message,
                     "action": _serialize_event_action(trigger.action),
                 }
                 for trigger in timeout_triggers
+                if trigger.is_active
             ],
         }
 

--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -99,10 +99,10 @@ def _serialize_event_action(action):
 
 
 def _get_pipeline_chat_widget_context(pipeline, experiment=None):
-    context = {"pipeline_structure": pipeline.data}
+    if pipeline is None:
+        return {}
 
-    if experiment is None:
-        experiment = pipeline.experiment_set.filter(is_archived=False).first()
+    context = {"pipeline_structure": pipeline.data}
 
     if experiment is not None:
         static_triggers = StaticTrigger.objects.filter(experiment=experiment, is_archived=False).select_related(

--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -98,7 +98,7 @@ def _serialize_event_action(action):
     }
 
 
-def _get_experiment_settings_context(experiment):
+def _get_chatbot_settings_context(experiment):
     return {
         "tracing_configured": bool(experiment.trace_provider_id),
         "convert_speech_inputs_to_text": bool(experiment.synthetic_voice_id and experiment.echo_transcript),
@@ -151,7 +151,7 @@ def get_widget_page_context(pipeline, experiment=None):
                 if trigger.is_active
             ],
         }
-        context["settings"] = _get_experiment_settings_context(experiment)
+        context["settings"] = _get_chatbot_settings_context(experiment)
 
     return context
 

--- a/assets/javascript/apps/pipeline/App.tsx
+++ b/assets/javascript/apps/pipeline/App.tsx
@@ -6,12 +6,8 @@ import usePipelineStore from "./stores/pipelineStore";
 
 type WidgetElement = HTMLElement & { pageContext?: Record<string, unknown> };
 
-let cachedWidget: WidgetElement | null | undefined;
 function getWidget(): WidgetElement | null {
-  if (cachedWidget === undefined) {
-    cachedWidget = document.querySelector("open-chat-studio-widget") as WidgetElement | null;
-  }
-  return cachedWidget;
+  return document.querySelector("open-chat-studio-widget") as WidgetElement | null;
 }
 
 function syncPipelineToWidget(nodes: unknown[], edges: unknown[]) {

--- a/assets/javascript/apps/pipeline/App.tsx
+++ b/assets/javascript/apps/pipeline/App.tsx
@@ -4,6 +4,14 @@ import {apiClient} from "./api/api";
 import Page from "./Page";
 import usePipelineStore from "./stores/pipelineStore";
 
+function syncPipelineToWidget(nodes: unknown[], edges: unknown[]) {
+  const widget = document.querySelector("open-chat-studio-widget") as HTMLElement & { pageContext?: Record<string, unknown> } | null;
+  if (widget) {
+    const existing = widget.pageContext || {};
+    widget.pageContext = { ...existing, pipeline_structure: { nodes, edges } };
+  }
+}
+
 const App = function (props: { team_slug: string, pipelineId: number | undefined}) {
   const isLoading = usePipelineStore((state) => state.isLoading);
   const loadPipeline = usePipelineStore((state) => state.loadPipeline);
@@ -14,6 +22,19 @@ const App = function (props: { team_slug: string, pipelineId: number | undefined
       loadPipeline(props.pipelineId);
     }
   }, []);
+
+  useEffect(() => {
+    let prevNodes = usePipelineStore.getState().nodes;
+    let prevEdges = usePipelineStore.getState().edges;
+    return usePipelineStore.subscribe((state) => {
+      if (state.nodes !== prevNodes || state.edges !== prevEdges) {
+        prevNodes = state.nodes;
+        prevEdges = state.edges;
+        syncPipelineToWidget(state.nodes, state.edges);
+      }
+    });
+  }, []);
+
   return isLoading ? (
     <div><span className="loading loading-spinner loading-sm p-3 ml-4"></span></div>
   ) : (

--- a/assets/javascript/apps/pipeline/App.tsx
+++ b/assets/javascript/apps/pipeline/App.tsx
@@ -4,8 +4,18 @@ import {apiClient} from "./api/api";
 import Page from "./Page";
 import usePipelineStore from "./stores/pipelineStore";
 
+type WidgetElement = HTMLElement & { pageContext?: Record<string, unknown> };
+
+let cachedWidget: WidgetElement | null | undefined;
+function getWidget(): WidgetElement | null {
+  if (cachedWidget === undefined) {
+    cachedWidget = document.querySelector("open-chat-studio-widget") as WidgetElement | null;
+  }
+  return cachedWidget;
+}
+
 function syncPipelineToWidget(nodes: unknown[], edges: unknown[]) {
-  const widget = document.querySelector("open-chat-studio-widget") as HTMLElement & { pageContext?: Record<string, unknown> } | null;
+  const widget = getWidget();
   if (widget) {
     const existing = widget.pageContext || {};
     widget.pageContext = { ...existing, pipeline_structure: { nodes, edges } };

--- a/assets/javascript/apps/pipeline/App.tsx
+++ b/assets/javascript/apps/pipeline/App.tsx
@@ -12,10 +12,21 @@ function getWidget(): WidgetElement | null {
 
 function syncPipelineToWidget(nodes: unknown[], edges: unknown[]) {
   const widget = getWidget();
-  if (widget) {
-    const existing = widget.pageContext || {};
-    widget.pageContext = { ...existing, pipeline_structure: { nodes, edges } };
+  if (!widget) {
+    return;
   }
+
+  const existing = widget.pageContext || {};
+  const existingPipelineStructure =
+    (existing.pipeline_structure as Record<string, unknown> | undefined) || {};
+  widget.pageContext = {
+    ...existing,
+    pipeline_structure: {
+      ...existingPipelineStructure,
+      nodes,
+      edges,
+    },
+  };
 }
 
 const App = function (props: { team_slug: string, pipelineId: number | undefined}) {

--- a/assets/javascript/modules/chat-widget-context.js
+++ b/assets/javascript/modules/chat-widget-context.js
@@ -46,16 +46,29 @@ export function getClientPageContext() {
  * @param {string|null} serverContext.pageTitle - Page title
  * @param {Array} serverContext.messages - Django messages [{text, level}]
  */
+/**
+ * Load widget_page_context from a JSON script tag if present.
+ */
+function getWidgetPageContext() {
+  const el = document.getElementById('widget-page-context');
+  if (!el) {
+    return {};
+  }
+  return JSON.parse(el.textContent) || {};
+}
+
 export function initChatWidgetPageContext(serverContext = {}) {
   const widget = document.querySelector('open-chat-studio-widget');
   if (widget) {
     const clientContext = getClientPageContext();
+    const widgetPageContext = getWidgetPageContext();
     widget.pageContext = {
       ...clientContext,
       team: serverContext.team || null,
       activeTab: serverContext.activeTab || null,
       pageTitle: serverContext.pageTitle || clientContext.title,
-      messages: serverContext.messages || []
+      messages: serverContext.messages || [],
+      ...widgetPageContext,
     };
   }
 }

--- a/templates/pipelines/pipeline_builder.html
+++ b/templates/pipelines/pipeline_builder.html
@@ -49,11 +49,22 @@
   {{ read_only|json_script:"read-only" }}
   {{ llm_model_params|json_script:"llm-model-params" }}
   {{ llm_model_param_schemas|json_script:"llm-model-parameter-schemas" }}
+  {{ pipeline_chat_widget_context|json_script:"pipeline-chat-widget-context" }}
   <script src="{% static 'js/pipeline-bundle.js' %}"></script>
   <script type="module">
     window.DOCUMENTATION_BASE_URL = '{{ docs_base_url }}';
     document.addEventListener('DOMContentLoaded', () => {
       SiteJS.pipeline.renderPipeline("#pipelineBuilder", "{{ request.team.slug }}", {{ pipeline_id }});
+
+      const pipelineContextEl = document.getElementById('pipeline-chat-widget-context');
+      if (pipelineContextEl) {
+        const pipelineContext = JSON.parse(pipelineContextEl.textContent);
+        const widget = document.querySelector('open-chat-studio-widget');
+        if (widget && pipelineContext) {
+          const existingContext = widget.pageContext || {};
+          widget.pageContext = { ...existingContext, ...pipelineContext };
+        }
+      }
     }
     )
   </script>

--- a/templates/pipelines/pipeline_builder.html
+++ b/templates/pipelines/pipeline_builder.html
@@ -49,23 +49,11 @@
   {{ read_only|json_script:"read-only" }}
   {{ llm_model_params|json_script:"llm-model-params" }}
   {{ llm_model_param_schemas|json_script:"llm-model-parameter-schemas" }}
-  {{ pipeline_chat_widget_context|json_script:"pipeline-chat-widget-context" }}
   <script src="{% static 'js/pipeline-bundle.js' %}"></script>
   <script type="module">
     window.DOCUMENTATION_BASE_URL = '{{ docs_base_url }}';
     document.addEventListener('DOMContentLoaded', () => {
       SiteJS.pipeline.renderPipeline("#pipelineBuilder", "{{ request.team.slug }}", {{ pipeline_id }});
-
-      const pipelineContextEl = document.getElementById('pipeline-chat-widget-context');
-      if (pipelineContextEl) {
-        const pipelineContext = JSON.parse(pipelineContextEl.textContent);
-        const widget = document.querySelector('open-chat-studio-widget');
-        if (widget && pipelineContext) {
-          const existingContext = widget.pageContext || {};
-          widget.pageContext = { ...existingContext, ...pipelineContext };
-        }
-      }
-    }
-    )
+    });
   </script>
 {% endblock page_js %}

--- a/templates/web/app/app_base.html
+++ b/templates/web/app/app_base.html
@@ -35,6 +35,7 @@
 {% block footer %}
   {{ block.super }}
   {% if request.user.is_authenticated and ocs_config.chat_widget.enabled and ocs_config.chat_widget.chatbot_id %}
+    {% if widget_page_context %}{{ widget_page_context|json_script:"widget-page-context" }}{% endif %}
     <open-chat-studio-widget {% include "generic/attrs.html" with attrs=ocs_config.chat_widget.get_widget_attributes %}
         api-base-url="{{ request.scheme }}://{{ request.get_host }}"
         user-id="{{ request.user.email }}"

--- a/templates/web/app/app_base.html
+++ b/templates/web/app/app_base.html
@@ -36,6 +36,7 @@
   {{ block.super }}
   {% if request.user.is_authenticated and ocs_config.chat_widget.enabled and ocs_config.chat_widget.chatbot_id %}
     <open-chat-studio-widget {% include "generic/attrs.html" with attrs=ocs_config.chat_widget.get_widget_attributes %}
+        api-base-url="{{ request.scheme }}://{{ request.get_host }}"
         user-id="{{ request.user.email }}"
         user-name="{{ request.user.get_display_name }}"
     >


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->
Out of need, I got claude code to implement this:
We now give pipeline + event data as widget context when viewing a pipeline. The aim of this is to be able to ask the bot questions about the pipeline you see.

### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.
-->
We now give pipeline + event data as widget context. This is updated as the pipeline gets updated to stay current.

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
<img width="1681" height="921" alt="image" src="https://github.com/user-attachments/assets/8c2670d9-003d-4645-b916-191030981270" />


### Docs and Changelog
- [x] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
Pipeline structure + event triggers are given as context to the chat widget in OCS when you're viewing a pipeline.