### PR TITLE
Exclude evaluation sessions from annotation queues

### DIFF
--- a/apps/experiments/filters.py
+++ b/apps/experiments/filters.py
@@ -158,9 +158,14 @@ class ChannelsFilter(ChoiceColumnFilter):
     label: str = "Channels"
     column: str = "platform"
     description: str = "Filter by messaging platform/channel"
+    exclude_platforms: list[str] = []
 
     def prepare(self, team, **_):
-        self.options = ChannelPlatform.for_filter(team)  # ty: ignore[invalid-assignment]
+        options = ChannelPlatform.for_filter(team)
+        if self.exclude_platforms:
+            excluded_labels = {ChannelPlatform(p).label for p in self.exclude_platforms}
+            options = [o for o in options if o not in excluded_labels]
+        self.options = options  # ty: ignore[invalid-assignment]
 
     def parse_query_value(self, query_value) -> any:
         selected_display_names = self.values_list(query_value)

--- a/apps/human_annotations/filters.py
+++ b/apps/human_annotations/filters.py
@@ -4,7 +4,16 @@ from typing import ClassVar
 from django.contrib.auth import get_user_model
 from django.db.models import Exists, OuterRef, QuerySet
 
+from apps.channels.models import ChannelPlatform
+from apps.experiments.filters import ChannelsFilter, ChatMessageTagsFilter, VersionsFilter
 from apps.web.dynamic_filters.base import ChoiceColumnFilter, ColumnFilter, MultiColumnFilter
+from apps.web.dynamic_filters.column_filters import (
+    ExperimentFilter,
+    ParticipantFilter,
+    RemoteIdFilter,
+    StatusFilter,
+    TimestampFilter,
+)
 
 from .models import Annotation, AnnotationItemStatus, AnnotationStatus
 
@@ -83,4 +92,38 @@ class AnnotationItemFilter(MultiColumnFilter):
     filters: ClassVar[Sequence[ColumnFilter]] = [
         AnnotationItemStatusFilter(),
         ReviewerFilter(),
+    ]
+
+
+class AnnotationSessionFilter(MultiColumnFilter):
+    """Session filter for annotation queues that excludes evaluation sessions from the channels filter."""
+
+    slug: ClassVar[str] = "session"
+    date_range_column: ClassVar[str] = "last_message"
+    filters: ClassVar[Sequence[ColumnFilter]] = [
+        ParticipantFilter(),
+        TimestampFilter(
+            label="Last Message",
+            column="last_activity_at",
+            query_param="last_message",
+            description="Filter by last message time",
+        ),
+        TimestampFilter(
+            label="First Message",
+            column="first_activity_at",
+            query_param="first_message",
+            description="Filter by first message time",
+        ),
+        TimestampFilter(
+            label="Message Date",
+            column="chat__messages__created_at",
+            query_param="message_date",
+            description="Filter by message date",
+        ),
+        ChatMessageTagsFilter(),
+        VersionsFilter(),
+        ChannelsFilter(exclude_platforms=[ChannelPlatform.EVALUATIONS]),
+        ExperimentFilter(),
+        StatusFilter(query_param="state"),
+        RemoteIdFilter(),
     ]

--- a/apps/human_annotations/filters.py
+++ b/apps/human_annotations/filters.py
@@ -98,7 +98,7 @@ class AnnotationItemFilter(MultiColumnFilter):
 class AnnotationSessionFilter(MultiColumnFilter):
     """Session filter for annotation queues that excludes evaluation sessions from the channels filter."""
 
-    slug: ClassVar[str] = "session"
+    slug: ClassVar[str] = "annotation_session"
     date_range_column: ClassVar[str] = "last_message"
     filters: ClassVar[Sequence[ColumnFilter]] = [
         ParticipantFilter(),

--- a/apps/human_annotations/tests/test_views.py
+++ b/apps/human_annotations/tests/test_views.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import Group
 from django.test import Client
 from django.urls import reverse
 
+from apps.channels.models import ChannelPlatform
 from apps.human_annotations.aggregation import compute_aggregates_for_queue
 from apps.human_annotations.models import (
     Annotation,
@@ -888,6 +889,34 @@ def test_queue_sessions_json_excludes_sessions_without_messages(client, team_wit
     url = reverse("human_annotations:queue_sessions_json", args=[team_with_users.slug, queue.pk])
     data = client.get(url).json()
     assert set(data["ids"]) == {str(session_with_messages.external_id)}
+
+
+@pytest.mark.django_db()
+def test_queue_sessions_table_excludes_evaluation_sessions(client, team_with_users, queue):
+
+    normal_session = ExperimentSessionFactory.create(team=team_with_users)
+    ChatMessageFactory.create(chat=normal_session.chat)
+    eval_session = ExperimentSessionFactory.create(team=team_with_users, platform=ChannelPlatform.EVALUATIONS)
+    ChatMessageFactory.create(chat=eval_session.chat)
+
+    url = reverse("human_annotations:queue_sessions_table", args=[team_with_users.slug, queue.pk])
+    response = client.get(url)
+    content = response.content.decode()
+    assert str(normal_session.external_id) in content
+    assert str(eval_session.external_id) not in content
+
+
+@pytest.mark.django_db()
+def test_queue_sessions_json_excludes_evaluation_sessions(client, team_with_users, queue):
+
+    normal_session = ExperimentSessionFactory.create(team=team_with_users)
+    ChatMessageFactory.create(chat=normal_session.chat)
+    eval_session = ExperimentSessionFactory.create(team=team_with_users, platform=ChannelPlatform.EVALUATIONS)
+    ChatMessageFactory.create(chat=eval_session.chat)
+
+    url = reverse("human_annotations:queue_sessions_json", args=[team_with_users.slug, queue.pk])
+    data = client.get(url).json()
+    assert set(data["ids"]) == {str(normal_session.external_id)}
 
 
 # ===== AddSessionsToQueue GET + POST =====

--- a/apps/human_annotations/views/queue_views.py
+++ b/apps/human_annotations/views/queue_views.py
@@ -21,11 +21,12 @@ from django.views.generic import CreateView, DetailView, TemplateView, UpdateVie
 from django_tables2 import LazyPaginator, SingleTableView
 from waffle import flag_is_active
 
+from apps.channels.models import ChannelPlatform
 from apps.chat.models import ChatMessage
-from apps.experiments.filters import ExperimentSessionFilter, get_filter_context_data
+from apps.experiments.filters import get_filter_context_data
 from apps.experiments.models import ExperimentSession
 from apps.filters.models import FilterSet
-from apps.human_annotations.filters import AnnotationItemFilter
+from apps.human_annotations.filters import AnnotationItemFilter, AnnotationSessionFilter
 from apps.teams.decorators import login_and_team_required
 from apps.teams.flags import Flags
 from apps.teams.mixins import LoginAndTeamRequiredMixin
@@ -200,8 +201,8 @@ def _get_base_session_queryset(request, filter_params=None):
     timezone = request.session.get("detected_tz", None)
     if filter_params is None:
         filter_params = FilterParams.from_request(request)
-    queryset = ExperimentSession.objects.filter(team=request.team)
-    session_filter = ExperimentSessionFilter()
+    queryset = ExperimentSession.objects.filter(team=request.team).exclude(platform=ChannelPlatform.EVALUATIONS)
+    session_filter = AnnotationSessionFilter()
     return session_filter.apply(queryset, filter_params=filter_params, timezone=timezone)
 
 
@@ -260,8 +261,8 @@ class AddSessionsToQueue(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Vie
         sessions_json_url = reverse("human_annotations:queue_sessions_json", args=[team_slug, pk])
         filter_context = get_filter_context_data(
             request.team,
-            columns=ExperimentSessionFilter.columns(request.team),
-            filter_class=ExperimentSessionFilter,
+            columns=AnnotationSessionFilter.columns(request.team),
+            filter_class=AnnotationSessionFilter,
             table_url=table_url,
             table_container_id="sessions-table",
             table_type=FilterSet.TableType.SESSIONS,


### PR DESCRIPTION
### Product Description
Prevents evaluation sessions from appearing in annotation queues. Evaluation sessions are
created by the automated evaluation system and should not be mixed in with real user sessions
for human annotation.

### Technical Description
- Added `.exclude(platform=ChannelPlatform.EVALUATIONS)` to the base session queryset used by
  annotation queue views, ensuring evaluation sessions are never available for selection.
- Added `exclude_platforms` field to `ChannelsFilter` so specific platforms can be hidden from
  the filter dropdown.
- Created `AnnotationSessionFilter` that reuses `ExperimentSessionFilter`'s filter set but
  with the Evaluations platform excluded from the channels filter options.
- Updated `AddSessionsToQueue` and related views to use the new filter.

### Migrations
- [x] The migrations are backwards compatible

N/A — no migrations.

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)