### PR TITLE
Block CustomAction deletion when refer referenced

### DIFF
--- a/apps/assistants/views.py
+++ b/apps/assistants/views.py
@@ -6,11 +6,10 @@ from django.db import models, transaction
 from django.db.models import Q
 from django.http import FileResponse, Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
-from django.template.loader import render_to_string
 from django.urls import reverse
 from django.views import View
 from django.views.generic import CreateView, FormView, TemplateView, UpdateView
-from django_htmx.http import HttpResponseClientRefresh, reswap
+from django_htmx.http import HttpResponseClientRefresh
 from django_tables2 import SingleTableView
 
 from apps.chat.agent.tools import get_assistant_tools
@@ -24,6 +23,7 @@ from apps.web.waf import WafRule, waf_allow
 
 from ..files.models import File
 from ..generics.chips import Chip
+from ..generics.referenced_objects import render_referenced_objects_modal
 from ..teams.decorators import login_and_team_required, team_required
 from .forms import ImportAssistantForm, OpenAiAssistantForm, ToolResourceFileFormsets
 from .models import OpenAiAssistant, ToolResources
@@ -235,15 +235,11 @@ class LocalDeleteOpenAiAssistant(LoginAndTeamRequiredMixin, PermissionRequiredMi
                 )
                 for experiment in assistant.get_related_experiments_with_pipeline_queryset(assistant_ids=version_query)
             ]
-            response = render_to_string(
-                "generic/referenced_objects.html",
-                context={
-                    "object_name": "assistant",
-                    "pipeline_nodes": pipeline_nodes,
-                    "experiments_with_pipeline_nodes": experiments_with_pipeline_nodes,
-                },
+            return render_referenced_objects_modal(
+                "assistant",
+                pipeline_nodes=pipeline_nodes,
+                experiments_with_pipeline_nodes=experiments_with_pipeline_nodes,
             )
-            return reswap(HttpResponse(response, status=400), "none")
 
 
 class SyncOpenAiAssistant(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):

--- a/apps/custom_actions/management/commands/cleanup_stale_custom_action_refs.py
+++ b/apps/custom_actions/management/commands/cleanup_stale_custom_action_refs.py
@@ -1,0 +1,130 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from apps.custom_actions.models import CustomAction
+from apps.pipelines.models import Node, Pipeline
+from apps.pipelines.nodes.nodes import LLMResponseWithPrompt
+
+BATCH_SIZE = 500
+CUSTOM_ACTIONS_FIELD = "custom_actions"
+
+
+class Command(BaseCommand):
+    help = (
+        "Strip references to deleted CustomActions from pipeline Node.params['custom_actions'] "
+        "and Pipeline.data['nodes'][*]['data']['params']['custom_actions']. Idempotent."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would change without writing to the database.",
+        )
+
+    def handle(self, *args, dry_run: bool = False, **options):
+        self.existing_ids = set(CustomAction.objects.values_list("id", flat=True))
+
+        with transaction.atomic():
+            nodes_updated, affected_pipeline_ids = self._scrub_nodes(dry_run)
+            pipelines_updated = self._scrub_pipelines(dry_run, affected_pipeline_ids)
+
+            if dry_run:
+                transaction.set_rollback(True)
+
+        verb = "would update" if dry_run else "updated"
+        self.stdout.write(self.style.SUCCESS(f"{verb} {nodes_updated} node(s) and {pipelines_updated} pipeline(s)."))
+
+    def _is_stale(self, ref) -> bool:
+        if not isinstance(ref, str):
+            return False
+        head, _, _ = ref.partition(":")
+        try:
+            return int(head) not in self.existing_ids
+        except ValueError:
+            return False
+
+    def _partition_refs(self, refs):
+        cleaned, dropped = [], []
+        for ref in refs:
+            (dropped if self._is_stale(ref) else cleaned).append(ref)
+        return cleaned, dropped
+
+    @staticmethod
+    def _llm_nodes_with_custom_actions():
+        # Skip empty lists and nulls at the DB level so unrelated rows never leave Postgres.
+        return (
+            Node.objects.filter(type=LLMResponseWithPrompt.__name__)
+            .exclude(params__custom_actions__isnull=True)
+            .exclude(params__custom_actions=[])
+        )
+
+    def _scrub_nodes(self, dry_run):
+        qs = self._llm_nodes_with_custom_actions().only("id", "pipeline_id", "flow_id", "params")
+
+        updated = 0
+        pending = []
+        affected_pipeline_ids = set()
+        for node in qs.iterator(chunk_size=BATCH_SIZE):
+            refs = node.params.get(CUSTOM_ACTIONS_FIELD) or []
+            if not isinstance(refs, list):
+                continue
+            cleaned, dropped = self._partition_refs(refs)
+            if not dropped:
+                continue
+            self.stdout.write(
+                f"Node id={node.id} pipeline={node.pipeline_id} flow_id={node.flow_id}: dropping {dropped}"
+            )
+            node.params[CUSTOM_ACTIONS_FIELD] = cleaned
+            affected_pipeline_ids.add(node.pipeline_id)
+            updated += 1
+            pending.append(node)
+            if not dry_run and len(pending) >= BATCH_SIZE:
+                Node.objects.bulk_update(pending, ["params"])
+                pending.clear()
+
+        if not dry_run and pending:
+            Node.objects.bulk_update(pending, ["params"])
+
+        return updated, affected_pipeline_ids
+
+    def _scrub_pipelines(self, dry_run, seed_pipeline_ids):
+        # Union of pipelines we just cleaned + pipelines still referencing any CustomAction,
+        # to catch drift where Pipeline.data holds a ref that its child Node no longer does.
+        referencing_pipeline_ids = set(self._llm_nodes_with_custom_actions().values_list("pipeline_id", flat=True))
+        candidate_ids = seed_pipeline_ids | referencing_pipeline_ids
+        if not candidate_ids:
+            return 0
+
+        qs = Pipeline.objects.filter(id__in=candidate_ids).only("id", "data")
+
+        to_update = []
+        updated = 0
+        for pipeline in qs.iterator(chunk_size=BATCH_SIZE):
+            if not self._scrub_pipeline_data(pipeline):
+                continue
+            updated += 1
+            to_update.append(pipeline)
+            if not dry_run and len(to_update) >= BATCH_SIZE:
+                Pipeline.objects.bulk_update(to_update, ["data"])
+                to_update.clear()
+
+        if not dry_run and to_update:
+            Pipeline.objects.bulk_update(to_update, ["data"])
+
+        return updated
+
+    def _scrub_pipeline_data(self, pipeline) -> bool:
+        changed = False
+        for flow_node in (pipeline.data or {}).get("nodes", []) or []:
+            params = (flow_node.get("data") or {}).get("params") or {}
+            refs = params.get(CUSTOM_ACTIONS_FIELD)
+            if not isinstance(refs, list) or not refs:
+                continue
+            cleaned, dropped = self._partition_refs(refs)
+            if not dropped:
+                continue
+            self.stdout.write(f"Pipeline id={pipeline.id} flow_id={flow_node.get('id')}: dropping {dropped}")
+            params[CUSTOM_ACTIONS_FIELD] = cleaned
+            changed = True
+        return changed

--- a/apps/custom_actions/management/commands/cleanup_stale_custom_action_refs.py
+++ b/apps/custom_actions/management/commands/cleanup_stale_custom_action_refs.py
@@ -1,9 +1,13 @@
+import logging
+
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from apps.custom_actions.models import CustomAction
 from apps.pipelines.models import Node, Pipeline
 from apps.pipelines.nodes.nodes import LLMResponseWithPrompt
+
+log = logging.getLogger(__name__)
 
 BATCH_SIZE = 500
 CUSTOM_ACTIONS_FIELD = "custom_actions"
@@ -22,7 +26,8 @@ class Command(BaseCommand):
             help="Report what would change without writing to the database.",
         )
 
-    def handle(self, *args, dry_run: bool = False, **options):
+    def handle(self, *args, dry_run: bool = False, verbosity: int = 1, **options):
+        self.verbosity = verbosity
         self.existing_ids = set(CustomAction.objects.values_list("id", flat=True))
 
         with transaction.atomic():
@@ -33,15 +38,19 @@ class Command(BaseCommand):
                 transaction.set_rollback(True)
 
         verb = "would update" if dry_run else "updated"
-        self.stdout.write(self.style.SUCCESS(f"{verb} {nodes_updated} node(s) and {pipelines_updated} pipeline(s)."))
+        summary = f"{verb} {nodes_updated} node(s) and {pipelines_updated} pipeline(s)."
+        log.info("cleanup_stale_custom_action_refs: %s (dry_run=%s)", summary, dry_run)
+        self.stdout.write(self.style.SUCCESS(summary))
 
     def _is_stale(self, ref) -> bool:
         if not isinstance(ref, str):
+            log.warning("cleanup_stale_custom_action_refs: non-string ref skipped: %r", ref)
             return False
         head, _, _ = ref.partition(":")
         try:
             return int(head) not in self.existing_ids
         except ValueError:
+            log.warning("cleanup_stale_custom_action_refs: unparseable ref skipped: %r", ref)
             return False
 
     def _partition_refs(self, refs):
@@ -72,9 +81,10 @@ class Command(BaseCommand):
             cleaned, dropped = self._partition_refs(refs)
             if not dropped:
                 continue
-            self.stdout.write(
-                f"Node id={node.id} pipeline={node.pipeline_id} flow_id={node.flow_id}: dropping {dropped}"
-            )
+            msg = f"Node id={node.id} pipeline={node.pipeline_id} flow_id={node.flow_id}: dropping {dropped}"
+            log.info("cleanup_stale_custom_action_refs: %s", msg)
+            if self.verbosity >= 2:
+                self.stdout.write(msg)
             node.params[CUSTOM_ACTIONS_FIELD] = cleaned
             affected_pipeline_ids.add(node.pipeline_id)
             updated += 1
@@ -124,7 +134,10 @@ class Command(BaseCommand):
             cleaned, dropped = self._partition_refs(refs)
             if not dropped:
                 continue
-            self.stdout.write(f"Pipeline id={pipeline.id} flow_id={flow_node.get('id')}: dropping {dropped}")
+            msg = f"Pipeline id={pipeline.id} flow_id={flow_node.get('id')}: dropping {dropped}"
+            log.info("cleanup_stale_custom_action_refs: %s", msg)
+            if self.verbosity >= 2:
+                self.stdout.write(msg)
             params[CUSTOM_ACTIONS_FIELD] = cleaned
             changed = True
         return changed

--- a/apps/custom_actions/tests/test_deletion.py
+++ b/apps/custom_actions/tests/test_deletion.py
@@ -1,0 +1,178 @@
+import pytest
+from django.core.management import call_command
+from django.urls import reverse
+from field_audit.models import AuditAction
+
+from apps.custom_actions.models import CustomAction, CustomActionOperation
+from apps.pipelines.models import Node, Pipeline
+from apps.pipelines.nodes.nodes import EndNode, LLMResponseWithPrompt, StartNode
+from apps.utils.factories.custom_actions import CustomActionFactory
+from apps.utils.factories.pipelines import PipelineFactory
+from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
+
+
+@pytest.fixture()
+def authed_client(team_with_users, client):
+    user = team_with_users.members.first()
+    client.force_login(user)
+    return client
+
+
+def _force_delete_custom_action(action):
+    """Bypass the DeleteCustomAction view guard to simulate data left over from before the guard existed."""
+    CustomActionOperation.objects.filter(custom_action=action).delete()
+    CustomAction.objects.filter(pk=action.pk).delete(audit_action=AuditAction.AUDIT)
+
+
+def _pipeline_data_referencing_action(custom_action, llm_provider, llm_provider_model, extra_actions=()):
+    llm_node_id = "llm-node"
+    custom_actions = [f"{custom_action.id}:weather_get"] + [f"{extra.id}:weather_get" for extra in extra_actions]
+    return {
+        "edges": [
+            {"id": "start->llm", "source": "start", "target": llm_node_id},
+            {"id": "llm->end", "source": llm_node_id, "target": "end"},
+        ],
+        "nodes": [
+            {"id": "start", "data": {"id": "start", "type": StartNode.__name__}},
+            {
+                "id": llm_node_id,
+                "data": {
+                    "id": llm_node_id,
+                    "type": LLMResponseWithPrompt.__name__,
+                    "label": "LLM",
+                    "params": {
+                        "name": llm_node_id,
+                        "llm_provider_id": llm_provider.id,
+                        "llm_provider_model_id": llm_provider_model.id,
+                        "prompt": "You are a helpful assistant.",
+                        "custom_actions": custom_actions,
+                    },
+                },
+            },
+            {"id": "end", "data": {"id": "end", "type": EndNode.__name__}},
+        ],
+    }
+
+
+@pytest.mark.django_db()
+def test_delete_view_succeeds_when_no_references(team_with_users, authed_client):
+    action = CustomActionFactory.create(team=team_with_users)
+    url = reverse("custom_actions:delete", kwargs={"team_slug": team_with_users.slug, "pk": action.pk})
+
+    response = authed_client.delete(url)
+
+    assert response.status_code == 200
+    assert not CustomAction.objects.filter(pk=action.pk).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_view_blocks_when_referenced_by_pipeline(team_with_users, authed_client):
+    action = CustomActionFactory.create(team=team_with_users)
+    llm_provider = LlmProviderFactory.create(team=team_with_users)
+    llm_provider_model = LlmProviderModelFactory.create(team=team_with_users)
+
+    pipeline = PipelineFactory.create(
+        team=team_with_users,
+        data=_pipeline_data_referencing_action(action, llm_provider, llm_provider_model),
+    )
+    assert CustomActionOperation.objects.filter(custom_action=action).exists()
+
+    url = reverse("custom_actions:delete", kwargs={"team_slug": team_with_users.slug, "pk": action.pk})
+    response = authed_client.delete(url)
+
+    assert response.status_code == 200
+    assert response["HX-Retarget"] == "body"
+    assert response["HX-Reswap"] == "beforeend"
+    assert CustomAction.objects.filter(pk=action.pk).exists()
+    body = response.content.decode()
+    assert "custom-action-referenced-modal" in body
+    assert "custom action" in body.lower()
+    assert pipeline.name in body
+
+
+@pytest.mark.django_db()
+def test_delete_view_does_not_block_when_only_archived_pipeline_references_action(team_with_users, authed_client):
+    action = CustomActionFactory.create(team=team_with_users)
+    llm_provider = LlmProviderFactory.create(team=team_with_users)
+    llm_provider_model = LlmProviderModelFactory.create(team=team_with_users)
+    pipeline = PipelineFactory.create(
+        team=team_with_users,
+        data=_pipeline_data_referencing_action(action, llm_provider, llm_provider_model),
+    )
+    # Archived pipelines/assistants/experiments are acceptable to break on cascade.
+    Pipeline.objects.filter(pk=pipeline.pk).update(is_archived=True)
+
+    url = reverse("custom_actions:delete", kwargs={"team_slug": team_with_users.slug, "pk": action.pk})
+    response = authed_client.delete(url)
+
+    assert response.status_code == 200
+    assert not CustomAction.objects.filter(pk=action.pk).exists()
+
+
+@pytest.mark.django_db()
+def test_cleanup_command_strips_stale_refs_from_node_and_pipeline(team_with_users):
+    stale_action = CustomActionFactory.create(team=team_with_users)
+    live_action = CustomActionFactory.create(team=team_with_users)
+    llm_provider = LlmProviderFactory.create(team=team_with_users)
+    llm_provider_model = LlmProviderModelFactory.create(team=team_with_users)
+    pipeline = PipelineFactory.create(
+        team=team_with_users,
+        data=_pipeline_data_referencing_action(
+            stale_action, llm_provider, llm_provider_model, extra_actions=[live_action]
+        ),
+    )
+    node = pipeline.node_set.get(type=LLMResponseWithPrompt.__name__)
+    stale_ref = f"{stale_action.id}:weather_get"
+    live_ref = f"{live_action.id}:weather_get"
+    assert node.params["custom_actions"] == [stale_ref, live_ref]
+    assert CustomActionOperation.objects.filter(node=node, custom_action=live_action).exists()
+
+    # Forcibly break the invariant: delete the CustomActionOperation rows + CustomAction
+    # without going through the view (simulates data left over from before the guard existed).
+    _force_delete_custom_action(stale_action)
+
+    node.refresh_from_db()
+    pipeline.refresh_from_db()
+    assert node.params["custom_actions"] == [stale_ref, live_ref]
+    assert pipeline.data["nodes"][1]["data"]["params"]["custom_actions"] == [stale_ref, live_ref]
+
+    call_command("cleanup_stale_custom_action_refs")
+
+    node.refresh_from_db()
+    pipeline.refresh_from_db()
+    assert node.params["custom_actions"] == [live_ref]
+    assert pipeline.data["nodes"][1]["data"]["params"]["custom_actions"] == [live_ref]
+    # The still-live operation must survive the cleanup.
+    assert CustomActionOperation.objects.filter(node=node, custom_action=live_action).exists()
+
+
+@pytest.mark.django_db()
+def test_cleanup_command_is_idempotent_and_dry_run_leaves_data_untouched(team_with_users):
+    action = CustomActionFactory.create(team=team_with_users)
+    llm_provider = LlmProviderFactory.create(team=team_with_users)
+    llm_provider_model = LlmProviderModelFactory.create(team=team_with_users)
+    pipeline = PipelineFactory.create(
+        team=team_with_users,
+        data=_pipeline_data_referencing_action(action, llm_provider, llm_provider_model),
+    )
+    node = pipeline.node_set.get(type=LLMResponseWithPrompt.__name__)
+    stale_ref = f"{action.id}:weather_get"
+
+    _force_delete_custom_action(action)
+
+    call_command("cleanup_stale_custom_action_refs", "--dry-run")
+    node.refresh_from_db()
+    pipeline.refresh_from_db()
+    assert node.params["custom_actions"] == [stale_ref]
+    assert pipeline.data["nodes"][1]["data"]["params"]["custom_actions"] == [stale_ref]
+
+    call_command("cleanup_stale_custom_action_refs")
+    call_command("cleanup_stale_custom_action_refs")
+    node.refresh_from_db()
+    pipeline.refresh_from_db()
+    assert node.params["custom_actions"] == []
+    assert pipeline.data["nodes"][1]["data"]["params"]["custom_actions"] == []
+    # Ensure there are no orphan CustomActionOperation rows referencing the deleted action.
+    assert not CustomActionOperation.objects.filter(custom_action_id=action.id).exists()
+    assert Node.objects.filter(pk=node.pk).exists()
+    assert Pipeline.objects.filter(pk=pipeline.pk).exists()

--- a/apps/custom_actions/tests/test_deletion.py
+++ b/apps/custom_actions/tests/test_deletion.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from django.core.management import call_command
 from django.urls import reverse
@@ -7,6 +9,7 @@ from apps.custom_actions.models import CustomAction, CustomActionOperation
 from apps.pipelines.models import Node, Pipeline
 from apps.pipelines.nodes.nodes import EndNode, LLMResponseWithPrompt, StartNode
 from apps.utils.factories.custom_actions import CustomActionFactory
+from apps.utils.factories.experiment import ExperimentFactory
 from apps.utils.factories.pipelines import PipelineFactory
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 
@@ -88,6 +91,92 @@ def test_delete_view_blocks_when_referenced_by_pipeline(team_with_users, authed_
     assert "custom-action-referenced-modal" in body
     assert "custom action" in body.lower()
     assert pipeline.name in body
+
+
+def _strip_custom_actions_from_working_pipeline(working_pipeline):
+    """Simulate a user removing the CustomAction from the working pipeline while versioned
+    pipelines still reference it. This mirrors the real-world path where the user edits the
+    working pipeline (which saves clean) but published versions retain the snapshotted ref."""
+    for flow_node in working_pipeline.data.get("nodes", []):
+        params = (flow_node.get("data") or {}).get("params") or {}
+        if "custom_actions" in params:
+            params["custom_actions"] = []
+    working_pipeline.save(update_fields=["data"])
+    for node in working_pipeline.node_set.filter(type=LLMResponseWithPrompt.__name__):
+        node.params["custom_actions"] = []
+        node.save(update_fields=["params"])
+        CustomActionOperation.objects.filter(node=node).delete()
+
+
+@pytest.mark.django_db()
+def test_delete_view_blocks_when_only_versioned_pipeline_references_action(team_with_users, authed_client):
+    """The fix for the case where a published experiment's versioned pipeline still holds a
+    CustomActionOperation, but the working pipeline no longer references the action. The old
+    implementation collapsed the versioned pipeline to its working version and missed the
+    published experiment entirely, silently permitting a delete that would CASCADE-break the
+    versioned Node's custom_action_operation row."""
+    action = CustomActionFactory.create(team=team_with_users)
+    llm_provider = LlmProviderFactory.create(team=team_with_users)
+    llm_provider_model = LlmProviderModelFactory.create(team=team_with_users)
+    working_pipeline = PipelineFactory.create(
+        team=team_with_users,
+        data=_pipeline_data_referencing_action(action, llm_provider, llm_provider_model),
+    )
+    pipeline_v1 = working_pipeline.create_new_version()
+    assert CustomActionOperation.objects.filter(custom_action=action, node__pipeline=pipeline_v1).exists()
+
+    _strip_custom_actions_from_working_pipeline(working_pipeline)
+    assert not CustomActionOperation.objects.filter(custom_action=action, node__pipeline=working_pipeline).exists()
+
+    working_experiment = ExperimentFactory.create(
+        team=team_with_users, pipeline=working_pipeline, public_id=uuid.uuid4()
+    )
+    versioned_experiment = ExperimentFactory.create(
+        team=team_with_users,
+        name=working_experiment.name,
+        pipeline=pipeline_v1,
+        working_version=working_experiment,
+        version_number=1,
+        is_default_version=True,
+        public_id=uuid.uuid4(),
+    )
+
+    url = reverse("custom_actions:delete", kwargs={"team_slug": team_with_users.slug, "pk": action.pk})
+    response = authed_client.delete(url)
+
+    assert response.status_code == 200
+    assert response["HX-Retarget"] == "body"
+    assert CustomAction.objects.filter(pk=action.pk).exists()
+    body = response.content.decode()
+    # Specific version (v1) is shown, not the working version name alone, so the user can
+    # identify which experiment version is affected.
+    assert f"{versioned_experiment.name} (v1)" in body
+
+
+@pytest.mark.django_db()
+def test_delete_view_allows_delete_when_only_orphan_versioned_pipeline_references_action(
+    team_with_users, authed_client
+):
+    """A non-archived versioned pipeline with a CA op but no live experiment using it is
+    treated as an orphan — deletion is allowed, matching the ``_is_actively_used`` semantics
+    used elsewhere. The ``cleanup_stale_custom_action_refs`` command is expected to mop up
+    the resulting stale Node.params/Pipeline.data entries."""
+    action = CustomActionFactory.create(team=team_with_users)
+    llm_provider = LlmProviderFactory.create(team=team_with_users)
+    llm_provider_model = LlmProviderModelFactory.create(team=team_with_users)
+    working_pipeline = PipelineFactory.create(
+        team=team_with_users,
+        data=_pipeline_data_referencing_action(action, llm_provider, llm_provider_model),
+    )
+    working_pipeline.create_new_version()
+    _strip_custom_actions_from_working_pipeline(working_pipeline)
+    # No Experiment points at the versioned pipeline → orphan.
+
+    url = reverse("custom_actions:delete", kwargs={"team_slug": team_with_users.slug, "pk": action.pk})
+    response = authed_client.delete(url)
+
+    assert response.status_code == 200
+    assert not CustomAction.objects.filter(pk=action.pk).exists()
 
 
 @pytest.mark.django_db()

--- a/apps/custom_actions/tests/test_deletion.py
+++ b/apps/custom_actions/tests/test_deletion.py
@@ -88,7 +88,7 @@ def test_delete_view_blocks_when_referenced_by_pipeline(team_with_users, authed_
     assert response["HX-Reswap"] == "beforeend"
     assert CustomAction.objects.filter(pk=action.pk).exists()
     body = response.content.decode()
-    assert "custom-action-referenced-modal" in body
+    assert "referenced-objects-modal" in body
     assert "custom action" in body.lower()
     assert pipeline.name in body
 

--- a/apps/custom_actions/views.py
+++ b/apps/custom_actions/views.py
@@ -7,6 +7,7 @@ from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.views import View
 from django.views.generic import CreateView, TemplateView, UpdateView
@@ -14,9 +15,11 @@ from django_tables2 import SingleTableView
 from waffle import flag_is_active
 
 from apps.custom_actions.forms import CustomActionForm
-from apps.custom_actions.models import CustomAction, HealthCheckStatus
+from apps.custom_actions.models import CustomAction, CustomActionOperation, HealthCheckStatus
 from apps.custom_actions.tables import CustomActionTable
 from apps.custom_actions.tasks import check_single_custom_action_health
+from apps.experiments.models import Experiment
+from apps.generics.chips import Chip
 from apps.teams.flags import Flags
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 
@@ -92,12 +95,60 @@ class EditCustomAction(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Updat
         return reverse("single_team:manage_team", args=[self.request.team.slug])
 
 
+def _collect_live_working_versions(objs):
+    """Collapse an iterable of versioned objects to their unique, non-archived working versions."""
+    by_id = {}
+    for obj in objs:
+        live = obj.get_working_version()
+        if not live.is_archived:
+            by_id[live.id] = live
+    return list(by_id.values())
+
+
 class DeleteCustomAction(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
     permission_required = "custom_actions.delete_customaction"
 
     def delete(self, request, team_slug: str, pk: int):
-        consent_form = get_object_or_404(CustomAction, id=pk, team=request.team)
-        consent_form.delete()
+        custom_action = get_object_or_404(CustomAction, id=pk, team=request.team)
+
+        # ``CustomActionOperation.custom_action`` is CASCADE (unlike SET_NULL
+        # service-provider FKs), so we block while any live pipeline/assistant/
+        # experiment references the action. Archived references are allowed to
+        # cascade away.
+        operations = CustomActionOperation.objects.filter(custom_action=custom_action).select_related(
+            "node__pipeline__working_version", "assistant__working_version"
+        )
+        pipelines = _collect_live_working_versions(
+            op.node.pipeline for op in operations if op.node_id and op.node.pipeline_id
+        )
+        assistants = _collect_live_working_versions(op.assistant for op in operations if op.assistant_id)
+        experiments = []
+        if pipelines:
+            experiments = _collect_live_working_versions(
+                Experiment.objects.filter(pipeline__in=pipelines, is_archived=False).select_related("working_version")
+            )
+
+        if pipelines or assistants or experiments:
+            modal_html = render_to_string(
+                "custom_actions/referenced_objects_modal.html",
+                context={
+                    "object_name": "custom action",
+                    "pipeline_nodes": [Chip(label=p.name, url=p.get_absolute_url()) for p in pipelines],
+                    "experiments_with_pipeline_nodes": [
+                        Chip(label=e.name, url=e.get_absolute_url()) for e in experiments
+                    ],
+                    "assistants": [Chip(label=a.name, url=a.get_absolute_url()) for a in assistants],
+                },
+            )
+            # Retarget so the dialog is OOB-appended to <body> instead of swapping
+            # the table row with raw HTML. The dialog auto-opens via Alpine and
+            # removes itself on close.
+            response = HttpResponse(modal_html)
+            response["HX-Retarget"] = "body"
+            response["HX-Reswap"] = "beforeend"
+            return response
+
+        custom_action.delete()
         messages.success(request, "Custom Action Deleted")
         return HttpResponse()
 

--- a/apps/custom_actions/views.py
+++ b/apps/custom_actions/views.py
@@ -8,7 +8,6 @@ from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db import transaction
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
-from django.template.loader import render_to_string
 from django.urls import reverse
 from django.views import View
 from django.views.generic import CreateView, TemplateView, UpdateView
@@ -21,6 +20,7 @@ from apps.custom_actions.tables import CustomActionTable
 from apps.custom_actions.tasks import check_single_custom_action_health
 from apps.experiments.models import Experiment
 from apps.generics.chips import Chip
+from apps.generics.referenced_objects import render_referenced_objects_modal
 from apps.pipelines.models import Node
 from apps.teams.flags import Flags
 from apps.teams.mixins import LoginAndTeamRequiredMixin
@@ -171,21 +171,12 @@ class DeleteCustomAction(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Vie
             pipelines, assistants, experiments = _find_live_custom_action_references(custom_action)
 
             if pipelines or assistants or experiments:
-                modal_html = render_to_string(
-                    "custom_actions/referenced_objects_modal.html",
-                    context={
-                        "object_name": "custom action",
-                        "pipeline_nodes": [Chip(label=p.name, url=p.get_absolute_url()) for p in pipelines],
-                        "experiments_with_pipeline_nodes": [
-                            Chip(label=str(e), url=e.get_absolute_url()) for e in experiments
-                        ],
-                        "assistants": [Chip(label=a.name, url=a.get_absolute_url()) for a in assistants],
-                    },
+                return render_referenced_objects_modal(
+                    "custom action",
+                    pipeline_nodes=[Chip(label=p.name, url=p.get_absolute_url()) for p in pipelines],
+                    experiments_with_pipeline_nodes=[Chip(label=str(e), url=e.get_absolute_url()) for e in experiments],
+                    assistants=[Chip(label=a.name, url=a.get_absolute_url()) for a in assistants],
                 )
-                response = HttpResponse(modal_html)
-                response["HX-Retarget"] = "body"
-                response["HX-Reswap"] = "beforeend"
-                return response
 
             custom_action.delete()
 

--- a/apps/custom_actions/views.py
+++ b/apps/custom_actions/views.py
@@ -5,6 +5,7 @@ from urllib.parse import quote
 import httpx
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.db import transaction
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.template.loader import render_to_string
@@ -20,6 +21,7 @@ from apps.custom_actions.tables import CustomActionTable
 from apps.custom_actions.tasks import check_single_custom_action_health
 from apps.experiments.models import Experiment
 from apps.generics.chips import Chip
+from apps.pipelines.models import Node
 from apps.teams.flags import Flags
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 
@@ -95,60 +97,98 @@ class EditCustomAction(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Updat
         return reverse("single_team:manage_team", args=[self.request.team.slug])
 
 
-def _collect_live_working_versions(objs):
-    """Collapse an iterable of versioned objects to their unique, non-archived working versions."""
-    by_id = {}
-    for obj in objs:
-        live = obj.get_working_version()
-        if not live.is_archived:
-            by_id[live.id] = live
-    return list(by_id.values())
+def _find_live_custom_action_references(custom_action):
+    """Return (working_pipelines, working_assistants, experiments) that would be silently
+    broken by CASCADE if this CustomAction were deleted.
+
+    - Working pipelines / working assistants with a live op are returned directly (the user
+      can edit them to remove the ref).
+    - Versioned pipelines / versioned assistants with a live op are surfaced as the
+      non-archived Experiment version(s) that still reference them, so the user can see
+      exactly which experiment version is affected.
+    """
+    operations = CustomActionOperation.objects.filter(custom_action=custom_action).select_related(
+        "node__pipeline", "assistant"
+    )
+
+    working_pipelines = {}
+    versioned_pipeline_ids = set()
+    working_assistants = {}
+    versioned_assistant_ids = set()
+
+    for op in operations:
+        if op.node_id and op.node and op.node.pipeline_id:
+            pipeline = op.node.pipeline
+            if pipeline.is_archived:
+                continue
+            if pipeline.is_working_version:
+                working_pipelines[pipeline.id] = pipeline
+            else:
+                versioned_pipeline_ids.add(pipeline.id)
+        elif op.assistant_id and op.assistant:
+            assistant = op.assistant
+            if assistant.is_archived:
+                continue
+            if assistant.is_working_version:
+                working_assistants[assistant.id] = assistant
+            else:
+                versioned_assistant_ids.add(assistant.id)
+
+    experiments = {}
+    target_pipeline_ids = set(working_pipelines) | versioned_pipeline_ids
+    if target_pipeline_ids:
+        for exp in Experiment.objects.filter(pipeline_id__in=target_pipeline_ids, is_archived=False):
+            experiments[exp.id] = exp
+
+    if versioned_assistant_ids:
+        pipeline_ids_via_assistants = set(
+            Node.objects.assistant_nodes()
+            .filter(
+                params__assistant_id__in=[str(aid) for aid in versioned_assistant_ids],
+                is_archived=False,
+                pipeline__is_archived=False,
+            )
+            .values_list("pipeline_id", flat=True)
+        )
+        if pipeline_ids_via_assistants:
+            for exp in Experiment.objects.filter(pipeline_id__in=pipeline_ids_via_assistants, is_archived=False):
+                experiments.setdefault(exp.id, exp)
+
+    return list(working_pipelines.values()), list(working_assistants.values()), list(experiments.values())
 
 
 class DeleteCustomAction(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
     permission_required = "custom_actions.delete_customaction"
 
     def delete(self, request, team_slug: str, pk: int):
-        custom_action = get_object_or_404(CustomAction, id=pk, team=request.team)
-
         # ``CustomActionOperation.custom_action`` is CASCADE (unlike SET_NULL
         # service-provider FKs), so we block while any live pipeline/assistant/
-        # experiment references the action. Archived references are allowed to
-        # cascade away.
-        operations = CustomActionOperation.objects.filter(custom_action=custom_action).select_related(
-            "node__pipeline__working_version", "assistant__working_version"
-        )
-        pipelines = _collect_live_working_versions(
-            op.node.pipeline for op in operations if op.node_id and op.node.pipeline_id
-        )
-        assistants = _collect_live_working_versions(op.assistant for op in operations if op.assistant_id)
-        experiments = []
-        if pipelines:
-            experiments = _collect_live_working_versions(
-                Experiment.objects.filter(pipeline__in=pipelines, is_archived=False).select_related("working_version")
-            )
+        # experiment references the action. Wrap in a transaction with a row-level
+        # lock so a concurrent pipeline save can't slip a new ref in between the
+        # reference check and the delete.
+        with transaction.atomic():
+            custom_action = get_object_or_404(CustomAction.objects.select_for_update(), id=pk, team=request.team)
+            pipelines, assistants, experiments = _find_live_custom_action_references(custom_action)
 
-        if pipelines or assistants or experiments:
-            modal_html = render_to_string(
-                "custom_actions/referenced_objects_modal.html",
-                context={
-                    "object_name": "custom action",
-                    "pipeline_nodes": [Chip(label=p.name, url=p.get_absolute_url()) for p in pipelines],
-                    "experiments_with_pipeline_nodes": [
-                        Chip(label=e.name, url=e.get_absolute_url()) for e in experiments
-                    ],
-                    "assistants": [Chip(label=a.name, url=a.get_absolute_url()) for a in assistants],
-                },
-            )
-            # Retarget so the dialog is OOB-appended to <body> instead of swapping
-            # the table row with raw HTML. The dialog auto-opens via Alpine and
-            # removes itself on close.
-            response = HttpResponse(modal_html)
-            response["HX-Retarget"] = "body"
-            response["HX-Reswap"] = "beforeend"
-            return response
+            if pipelines or assistants or experiments:
+                modal_html = render_to_string(
+                    "custom_actions/referenced_objects_modal.html",
+                    context={
+                        "object_name": "custom action",
+                        "pipeline_nodes": [Chip(label=p.name, url=p.get_absolute_url()) for p in pipelines],
+                        "experiments_with_pipeline_nodes": [
+                            Chip(label=str(e), url=e.get_absolute_url()) for e in experiments
+                        ],
+                        "assistants": [Chip(label=a.name, url=a.get_absolute_url()) for a in assistants],
+                    },
+                )
+                response = HttpResponse(modal_html)
+                response["HX-Retarget"] = "body"
+                response["HX-Reswap"] = "beforeend"
+                return response
 
-        custom_action.delete()
+            custom_action.delete()
+
         messages.success(request, "Custom Action Deleted")
         return HttpResponse()
 

--- a/apps/documents/tests/test_views.py
+++ b/apps/documents/tests/test_views.py
@@ -127,7 +127,9 @@ class TestDeleteCollection:
         url = reverse("documents:collection_delete", args=[collection.team.slug, collection.id])
         # Case 1 - The pipeline is using the collection
         response = client.delete(url)
-        assert response.status_code == 400
+        assert response.status_code == 200
+        assert response["HX-Retarget"] == "body"
+        assert response["HX-Reswap"] == "beforeend"
 
         # Case 2 - Remove the collection from the node so that only a pipeline version is using it
         create_remote_index.return_value = "v-321"
@@ -136,7 +138,9 @@ class TestDeleteCollection:
         node.save()
 
         response = client.delete(url)
-        assert response.status_code == 400
+        assert response.status_code == 200
+        assert response["HX-Retarget"] == "body"
+        assert response["HX-Reswap"] == "beforeend"
 
     @pytest.mark.usefixtures("remote_index_manager_mock")
     @pytest.mark.parametrize("is_index", [True, False])

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -11,13 +11,12 @@ from django.db import transaction
 from django.db.models import Case, CharField, Count, Func, IntegerField, OuterRef, Q, Subquery, Value, When
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
-from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views import View
 from django.views.decorators.http import require_http_methods, require_POST
 from django.views.generic import CreateView, FormView, ListView, TemplateView, UpdateView
-from django_htmx.http import HttpResponseClientRedirect, reswap
+from django_htmx.http import HttpResponseClientRedirect
 from django_tables2 import SingleTableView
 
 from apps.documents import tasks
@@ -45,6 +44,7 @@ from apps.files.models import File, FileChunkEmbedding
 from apps.generics import actions
 from apps.generics.chips import Chip
 from apps.generics.help import render_help_with_link
+from apps.generics.referenced_objects import render_referenced_objects_modal
 from apps.service_providers.models import LlmProviderTypes
 from apps.service_providers.utils import get_embedding_provider_choices
 from apps.teams.decorators import login_and_team_required
@@ -629,15 +629,11 @@ class DeleteCollection(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View)
                         ]
                     )
 
-            response = render_to_string(
-                "generic/referenced_objects.html",
-                context={
-                    "object_name": "collection",
-                    "pipeline_nodes": pipeline_node_chips,
-                    "experiments_with_pipeline_nodes": experiment_chips,
-                },
+            return render_referenced_objects_modal(
+                "collection",
+                pipeline_nodes=pipeline_node_chips,
+                experiments_with_pipeline_nodes=experiment_chips,
             )
-            return reswap(HttpResponse(response, status=400), "none")
 
 
 @require_POST

--- a/apps/files/views.py
+++ b/apps/files/views.py
@@ -9,12 +9,10 @@ from django.db.models import Exists, OuterRef
 from django.http import FileResponse, Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template import loader
-from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.generic import CreateView, TemplateView, UpdateView
-from django_htmx.http import reswap
 from django_tables2 import SingleTableView
 
 from apps.documents.models import CollectionFile
@@ -22,6 +20,7 @@ from apps.files.forms import FileForm, MultipleFileFieldForm
 from apps.files.models import File
 from apps.files.tables import FilesTable
 from apps.generics.chips import Chip
+from apps.generics.referenced_objects import render_referenced_objects_modal
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 from apps.utils.search import similarity_search
 
@@ -257,14 +256,10 @@ class DeleteFile(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
         file = get_object_or_404(File, team__slug=team_slug, id=pk)
 
         if collections := file.get_collection_references():
-            response = render_to_string(
-                "generic/referenced_objects.html",
-                context={
-                    "object_name": "file",
-                    "pipeline_nodes": [Chip(label=col.name, url=col.get_absolute_url()) for col in collections],
-                },
+            return render_referenced_objects_modal(
+                "file",
+                pipeline_nodes=[Chip(label=col.name, url=col.get_absolute_url()) for col in collections],
             )
-            return reswap(HttpResponse(response, status=400), "none")
         else:
             file.delete_or_archive()
             messages.success(request, "File deleted")

--- a/apps/generics/referenced_objects.py
+++ b/apps/generics/referenced_objects.py
@@ -1,0 +1,33 @@
+from django.http import HttpResponse
+from django.template.loader import render_to_string
+
+
+def render_referenced_objects_modal(
+    object_name: str,
+    *,
+    experiments: list | None = None,
+    pipeline_nodes: list | None = None,
+    experiments_with_pipeline_nodes: list | None = None,
+    static_trigger_experiments: list | None = None,
+    assistants: list | None = None,
+) -> HttpResponse:
+    """Render a modal listing the objects still referencing ``object_name``.
+
+    Returns an HTMX response that appends the modal to ``<body>`` so it pops
+    over whatever page the delete was triggered from.
+    """
+    html = render_to_string(
+        "generic/referenced_objects_modal.html",
+        context={
+            "object_name": object_name,
+            "experiments": experiments or [],
+            "pipeline_nodes": pipeline_nodes or [],
+            "experiments_with_pipeline_nodes": experiments_with_pipeline_nodes or [],
+            "static_trigger_experiments": static_trigger_experiments or [],
+            "assistants": assistants or [],
+        },
+    )
+    response = HttpResponse(html)
+    response["HX-Retarget"] = "body"
+    response["HX-Reswap"] = "beforeend"
+    return response

--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -10,13 +10,11 @@ from django.db import transaction
 from django.db.models import QuerySet, Subquery
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
-from django.template.loader import render_to_string
 from django.urls import reverse
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
-from django_htmx.http import reswap
 from django_tables2 import SingleTableView
 
 from apps.assistants.models import OpenAiAssistant
@@ -40,6 +38,7 @@ from apps.web.waf import WafRule, waf_allow
 
 from ..generics.chips import Chip
 from ..generics.help import render_help_with_link
+from ..generics.referenced_objects import render_referenced_objects_modal
 from ..utils.prompt import PromptVars
 
 
@@ -138,16 +137,11 @@ class DeletePipeline(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
                 for experiment in Experiment.objects.filter(id__in=Subquery(query)).all()
             ]
 
-            response = render_to_string(
-                "generic/referenced_objects.html",
-                context={
-                    "object_name": "pipeline",
-                    "experiments": experiments,
-                    "static_trigger_experiments": static_trigger_experiments,
-                },
+            return render_referenced_objects_modal(
+                "pipeline",
+                experiments=experiments,
+                static_trigger_experiments=static_trigger_experiments,
             )
-
-        return reswap(HttpResponse(response, status=400), "none")
 
 
 def _pipeline_node_parameter_values(team, llm_providers, llm_provider_models, synthetic_voices, include_versions=False):
@@ -293,7 +287,6 @@ def _pipeline_node_schemas():
 
 
 def _get_node_schema(node_class):
-
     schema = resolve_references(node_class.model_json_schema())
     schema.pop("$defs", None)
 

--- a/apps/service_providers/views.py
+++ b/apps/service_providers/views.py
@@ -9,10 +9,8 @@ from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import transaction
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render, resolve_url
-from django.template.loader import render_to_string
 from django.urls import reverse
 from django.views.decorators.http import require_http_methods, require_POST
-from django_htmx.http import reswap
 from django_tables2 import SingleTableView
 from waffle import flag_is_active
 
@@ -30,6 +28,7 @@ from apps.service_providers.models import (
 from apps.utils.deletion import get_related_objects
 
 from ..generics.chips import Chip
+from ..generics.referenced_objects import render_referenced_objects_modal
 from ..generics.views import BaseTypeSelectFormView
 from ..teams.decorators import login_and_team_required
 from ..teams.mixins import LoginAndTeamRequiredMixin
@@ -90,15 +89,12 @@ def delete_service_provider(request, team_slug: str, provider_type: str, pk: int
             Chip(label=assistant.name, url=assistant.get_absolute_url())
             for assistant in [obj for obj in filtered_objects if isinstance(obj, OpenAiAssistant)]
         ]
-        response = render_to_string(
-            "generic/referenced_objects.html",
-            context={
-                "object_name": "service provider",
-                "experiments": related_experiments,
-                "assistants": related_assistants,
-            },
-        )
-        return reswap(HttpResponse(response, status=400), "none")
+        if related_experiments or related_assistants:
+            return render_referenced_objects_modal(
+                "service provider",
+                experiments=related_experiments,
+                assistants=related_assistants,
+            )
     service_config.delete()
     return HttpResponse()
 

--- a/templates/custom_actions/referenced_objects_modal.html
+++ b/templates/custom_actions/referenced_objects_modal.html
@@ -1,0 +1,20 @@
+<dialog id="custom-action-referenced-modal"
+        class="modal"
+        x-data
+        x-init="$el.showModal()"
+        @close="$el.remove()">
+  <div class="modal-box max-w-2xl">
+    <h3 class="font-bold text-lg">Cannot delete custom action</h3>
+    <div class="py-2">
+      {% include "generic/referenced_objects.html" %}
+    </div>
+    <div class="modal-action">
+      <form method="dialog">
+        <button class="btn">Close</button>
+      </form>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>

--- a/templates/custom_actions/referenced_objects_modal.html
+++ b/templates/custom_actions/referenced_objects_modal.html
@@ -1,7 +1,7 @@
 <dialog id="custom-action-referenced-modal"
         class="modal"
         x-data
-        x-init="$el.showModal()"
+        x-init="document.querySelectorAll('#custom-action-referenced-modal').forEach(el => { if (el !== $el) el.remove() }); $el.showModal()"
         @close="$el.remove()">
   <div class="modal-box max-w-2xl">
     <h3 class="font-bold text-lg">Cannot delete custom action</h3>

--- a/templates/generic/referenced_objects_modal.html
+++ b/templates/generic/referenced_objects_modal.html
@@ -1,10 +1,10 @@
-<dialog id="custom-action-referenced-modal"
+<dialog id="referenced-objects-modal"
         class="modal"
         x-data
-        x-init="document.querySelectorAll('#custom-action-referenced-modal').forEach(el => { if (el !== $el) el.remove() }); $el.showModal()"
+        x-init="document.querySelectorAll('#referenced-objects-modal').forEach(el => { if (el !== $el) el.remove() }); $el.showModal()"
         @close="$el.remove()">
   <div class="modal-box max-w-2xl">
-    <h3 class="font-bold text-lg">Cannot delete custom action</h3>
+    <h3 class="font-bold text-lg">Cannot delete {{ object_name }}</h3>
     <div class="py-2">
       {% include "generic/referenced_objects.html" %}
     </div>


### PR DESCRIPTION
Prevent deletion when a CustomAction is still referenced by a non-archived pipeline, assistant, or experiment, and surface the referring objects in a modal so the user can clear them first. Add an idempotent management command to strip stale refs from Node.params and Pipeline.data for data left over from before the guard existed.

<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->
Resolves #3186 

Also fixes existing related object modals not showing correctly

### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.
-->

#### Why not reuse `get_related_objects` (as used by LLM providers, assistants, etc.)?

The shared helper in `apps/utils/deletion.py` handles two cases: reverse FK relations, and a JSON-param lookup via `get_related_pipelines_queryset` that matches a **scalar** value at `params__<key>`. Custom actions don't fit either cleanly:

- `params["custom_actions"]` on `LLMResponseWithPrompt` nodes is a **list**, not a scalar — so a scalar-equality lookup won't match.
- Each list entry is a compound string `"{action_id}:{operation_id}"`, not a bare id — so even the existing `get_related_pipelines_queryset_for_list_param` (`__contains`) won't match on the action id alone without risking false positives.
- The `CustomActionOperation` FKs to `Node` and `OpenAiAssistant` already give us the real reverse relations, which is more reliable than pattern-matching JSON blobs.

So this PR deliberately keeps the FK-based path (walking `CustomActionOperation → Node/Assistant → Pipeline/Experiment`) rather than extending `get_related_objects`. If we later want list-view "in use" badges or uniform behaviour across resources, we can add a `get_related_pipelines_queryset_for_prefixed_list_param` helper to `deletion.py` without changing this guard.

### Migrations
<!--
There may be a potentially long window during the deployment where migrations are applied, but the old code is still running. We need to ensure that migrations can be applied to the current running code without breaking it, to the extent possible.

Delete this section if there are no migration.
 -->
- [ ] The migrations are backwards compatible


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
