### PR TITLE
Add Claude Opus 4.7 model support

### DIFF
--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -11,6 +11,7 @@ from apps.service_providers.llm_service.model_parameters import (
     ClaudeHaikuLatestParameters,
     ClaudeOpus4_20250514Parameters,
     ClaudeOpus46Parameters,
+    ClaudeOpus47Parameters,
     ClaudeSonnet46Parameters,
     GPT5Parameters,
     GPT5ProParameters,
@@ -50,7 +51,7 @@ DEFAULT_LLM_PROVIDER_MODELS = {
         Model("gpt-4o", 128000),
     ],
     "anthropic": [
-        Model("claude-opus-4-7", k(1000), parameters=ClaudeOpus46Parameters),
+        Model("claude-opus-4-7", k(1000), parameters=ClaudeOpus47Parameters),
         Model("claude-opus-4-6", k(200), parameters=ClaudeOpus46Parameters),
         Model("claude-sonnet-4-6", k(200), is_default=True, parameters=ClaudeSonnet46Parameters),
         Model("claude-sonnet-4-5-20250929", k(200), parameters=AnthropicReasoningParameters),

--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -50,6 +50,7 @@ DEFAULT_LLM_PROVIDER_MODELS = {
         Model("gpt-4o", 128000),
     ],
     "anthropic": [
+        Model("claude-opus-4-7", k(1000), parameters=ClaudeOpus46Parameters),
         Model("claude-opus-4-6", k(200), parameters=ClaudeOpus46Parameters),
         Model("claude-sonnet-4-6", k(200), is_default=True, parameters=ClaudeSonnet46Parameters),
         Model("claude-sonnet-4-5-20250929", k(200), parameters=AnthropicReasoningParameters),

--- a/apps/service_providers/llm_service/model_parameters.py
+++ b/apps/service_providers/llm_service/model_parameters.py
@@ -41,6 +41,14 @@ class Claude46EffortParameter(TextChoices):
     MAX = "max", "Max"
 
 
+class Claude47EffortParameter(TextChoices):
+    LOW = "low", "Low"
+    MEDIUM = "medium", "Medium"
+    HIGH = "high", "High"
+    XHIGH = "xhigh", "XHigh"
+    MAX = "max", "Max"
+
+
 class OpenAIVerbosityParameter(TextChoices):
     LOW = "low", "Low"
     MEDIUM = "medium", "Medium"
@@ -289,6 +297,38 @@ class ClaudeSonnet46Parameters(ClaudeOpus46Parameters):
         description="The maximum number of tokens to generate in the completion.",
         ge=1,
         le=64000,
+    )
+
+
+class ClaudeOpus47Parameters(LLMModelParamBase):
+    """Parameters for Claude Opus 4.7.
+
+    Unlike Opus 4.6, Opus 4.7 does not accept temperature, top_p, or top_k — setting any of
+    these to a non-default value returns a 400 error. Temperature is therefore not exposed here.
+    Opus 4.7 also introduces the 'xhigh' effort level for adaptive thinking.
+    """
+
+    max_tokens: int = Field(
+        title="Max Output Tokens",
+        default=32000,
+        description="The maximum number of tokens to generate in the completion.",
+        ge=1,
+        le=128000,
+    )
+    effort: Claude47EffortParameter = Field(
+        title="Reasoning Effort",
+        default=Claude47EffortParameter.HIGH,
+        description="Control intelligence, speed, and cost tradeoffs with adaptive thinking. "
+        "Use 'xhigh' for coding and agentic use cases.",
+        json_schema_extra=UiSchema(widget=Widgets.select, enum_labels=Claude47EffortParameter.labels),
+    )
+    adaptive_thinking: bool = Field(
+        title="Enable Adaptive Thinking",
+        default=False,
+        description="Let Claude dynamically decide when and how much to think with adaptive thinking mode. "
+        "At the default effort level (high), Claude will almost always think. "
+        "At lower effort levels, Claude may skip thinking for simpler problems.",
+        json_schema_extra=UiSchema(widget=Widgets.toggle),
     )
 
 

--- a/apps/service_providers/migrations/0047_add_claude_opus_4_7.py
+++ b/apps/service_providers/migrations/0047_add_claude_opus_4_7.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+from apps.service_providers.migration_utils import llm_model_migration
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('service_providers', '0046_alter_voiceprovider_type'),
+    ]
+
+    operations = [
+        llm_model_migration(),
+    ]


### PR DESCRIPTION
### Product Description
Adds `claude-opus-4-7` as a supported LLM model in Open Chat Studio.

Closes #3181

### Technical Description
- Added `claude-opus-4-7` to `DEFAULT_LLM_PROVIDER_MODELS` in `default_models.py` with a 1M token context window (`k(1000)`) and `ClaudeOpus46Parameters` (same adaptive thinking support, 128k max output)
- Created migration `0047_add_claude_opus_4_7.py` to register the model in the database

### Migrations
- [ ] The migrations are backwards compatible

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update