### PR TITLE
Run cleanup_stale_custom_action_refs as data migration

### DIFF
--- a/apps/pipelines/migrations/0025_cleanup_stale_custom_action_refs.py
+++ b/apps/pipelines/migrations/0025_cleanup_stale_custom_action_refs.py
@@ -1,0 +1,18 @@
+from django.core.management import call_command
+from django.db import migrations
+
+
+def cleanup_stale_custom_action_refs(apps, schema_editor):
+    call_command("cleanup_stale_custom_action_refs")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pipelines", "0024_make_router_keywords_upper"),
+        ("custom_actions", "0006_remove_customactionoperation_experiment_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(cleanup_stale_custom_action_refs, reverse_code=migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->
N/A

### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.
-->
Runs the data migration command from https://github.com/dimagi/open-chat-studio/pull/3187 in a migration. (I already ran this command on prod, so this migration will not take long - and is idempotent)

### Migrations
<!--
There may be a potentially long window during the deployment where migrations are applied, but the old code is still running. We need to ensure that migrations can be applied to the current running code without breaking it, to the extent possible.

Delete this section if there are no migration.
 -->
- [x] The migrations are backwards compatible


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update
N/A

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
