### PR TITLE
perf(admin): make most admins read-only to fix change-view timeouts

### DIFF
--- a/apps/annotations/admin.py
+++ b/apps/annotations/admin.py
@@ -1,15 +1,17 @@
 from django.contrib import admin
 
+from apps.utils.admin import ReadonlyAdminMixin
+
 from .models import CustomTaggedItem, Tag
 
 
 @admin.register(Tag)
-class TagAdmin(admin.ModelAdmin):
+class TagAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("name", "team", "created_at", "updated_at")
     search_fields = ("name",)
 
 
 @admin.register(CustomTaggedItem)
-class CustomTaggedItemAdmin(admin.ModelAdmin):
+class CustomTaggedItemAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("user", "team")
     search_fields = ("user__name",)

--- a/apps/assistants/admin.py
+++ b/apps/assistants/admin.py
@@ -2,14 +2,15 @@ from django.contrib import admin
 
 from apps.assistants.models import OpenAiAssistant, ToolResources
 from apps.experiments.admin import VersionedModelAdminMixin
+from apps.utils.admin import ReadonlyAdminMixin
 
 
-class ToolResourcesAdmin(admin.TabularInline):
+class ToolResourcesAdmin(ReadonlyAdminMixin, admin.TabularInline):
     model = ToolResources
 
 
 @admin.register(OpenAiAssistant)
-class OpenAiAssistantAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
+class OpenAiAssistantAdmin(ReadonlyAdminMixin, VersionedModelAdminMixin, admin.ModelAdmin):
     list_display = (
         "name",
         "team",

--- a/apps/audit/admin.py
+++ b/apps/audit/admin.py
@@ -1,9 +1,11 @@
 from django.contrib import admin
 from field_audit.models import AuditEvent
 
+from apps.utils.admin import ReadonlyAdminMixin
+
 
 @admin.register(AuditEvent)
-class AuditEventAdmin(admin.ModelAdmin):
+class AuditEventAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = [
         "event_date",
         "object_class_path",

--- a/apps/channels/admin.py
+++ b/apps/channels/admin.py
@@ -2,19 +2,15 @@ from django.contrib import admin
 from django.http.request import HttpRequest
 
 from apps.channels.models import ExperimentChannel
+from apps.utils.admin import ReadonlyAdminMixin
 
 
 @admin.register(ExperimentChannel)
-class ExperimentChannelAdmin(admin.ModelAdmin):
+class ExperimentChannelAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("name", "team", "platform", "deleted", "external_id", "messaging_provider")
     search_fields = ("name", "external_id")
     list_filter = (
         "platform",
-        "created_at",
-        "updated_at",
-    )
-    readonly_fields = (
-        "external_id",
         "created_at",
         "updated_at",
     )

--- a/apps/chat/admin.py
+++ b/apps/chat/admin.py
@@ -1,53 +1,44 @@
 from django.contrib import admin
 
+from apps.utils.admin import ReadonlyAdminMixin
+
 from ..experiments.models import ExperimentSession
 from .models import Chat, ChatAttachment, ChatMessage
 
 
-class ExperimentSessionInline(admin.TabularInline):
+class ExperimentSessionInline(ReadonlyAdminMixin, admin.TabularInline):
     model = ExperimentSession
     fields = (
         "created_at",
         "experiment",
         "participant",
     )
-    readonly_fields = (
-        "created_at",
-        "experiment",
-        "participant",
-    )
     can_delete = False
     extra = 0
     show_change_link = True
 
 
-class ChatMessageInline(admin.TabularInline):
+class ChatMessageInline(ReadonlyAdminMixin, admin.TabularInline):
     model = ChatMessage
     fields = ("created_at", "message_type", "content", "metadata")
-    readonly_fields = ("created_at", "message_type", "content", "metadata")
     can_delete = False
     extra = 0
     show_change_link = True
 
 
-class ChatAttachmentInline(admin.TabularInline):
+class ChatAttachmentInline(ReadonlyAdminMixin, admin.TabularInline):
     model = ChatAttachment
     fields = ("created_at", "tool_type", "files")
-    readonly_fields = ("created_at", "tool_type", "files")
     can_delete = False
     extra = 0
     show_change_link = True
 
 
 @admin.register(Chat)
-class ChatAdmin(admin.ModelAdmin):
+class ChatAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("participant", "team", "created_at", "updated_at")
     search_fields = ("experiment_session__participant__identifier",)
     list_filter = ("team",)
-    readonly_fields = (
-        "created_at",
-        "updated_at",
-    )
     date_hierarchy = "created_at"
     inlines = [
         ExperimentSessionInline,
@@ -61,17 +52,13 @@ class ChatAdmin(admin.ModelAdmin):
 
 
 @admin.register(ChatMessage)
-class ChatMessageAdmin(admin.ModelAdmin):
+class ChatMessageAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("chat", "team", "message_type", "content", "created_at", "updated_at")
     search_fields = (
         "chat__id",
         "content",
     )
     list_filter = ("message_type",)
-    readonly_fields = (
-        "created_at",
-        "updated_at",
-    )
     date_hierarchy = "created_at"
 
     @admin.display(description="Team")
@@ -80,13 +67,9 @@ class ChatMessageAdmin(admin.ModelAdmin):
 
 
 @admin.register(ChatAttachment)
-class ChatAttachmentAdmin(admin.ModelAdmin):
+class ChatAttachmentAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("chat", "team", "tool_type", "created_at")
     list_filter = ("tool_type",)
-    readonly_fields = (
-        "created_at",
-        "updated_at",
-    )
     date_hierarchy = "created_at"
 
     @admin.display(description="Team")

--- a/apps/events/admin.py
+++ b/apps/events/admin.py
@@ -4,17 +4,18 @@ from django.db.models import QuerySet
 from django.http import HttpRequest
 
 from apps.experiments.admin import VersionedModelAdminMixin
+from apps.utils.admin import ReadonlyAdminMixin
 
 from .models import EventAction, EventLog, ScheduledMessage, StaticTrigger, TimeoutTrigger
 
 
-class EventLogInline(GenericTabularInline):
+class EventLogInline(ReadonlyAdminMixin, GenericTabularInline):
     model = EventLog
     extra = 0
 
 
 @admin.register(TimeoutTrigger)
-class TimeoutTriggerAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
+class TimeoutTriggerAdmin(ReadonlyAdminMixin, VersionedModelAdminMixin, admin.ModelAdmin):
     list_display = (
         "action_type",
         "experiment",
@@ -39,7 +40,7 @@ class TimeoutTriggerAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
 
 
 @admin.register(StaticTrigger)
-class StaticTriggerAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
+class StaticTriggerAdmin(ReadonlyAdminMixin, VersionedModelAdminMixin, admin.ModelAdmin):
     list_display = (
         "type",
         "experiment",
@@ -63,10 +64,10 @@ class StaticTriggerAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
 
 
 @admin.register(EventAction)
-class EventActionAdmin(admin.ModelAdmin):
+class EventActionAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ["action_type"]
 
 
 @admin.register(ScheduledMessage)
-class ScheduledMessageAdmin(admin.ModelAdmin):
+class ScheduledMessageAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ["name", "external_id", "is_complete"]

--- a/apps/experiments/admin.py
+++ b/apps/experiments/admin.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.utils.html import format_html
 
 from apps.experiments import models
+from apps.utils.admin import ReadonlyAdminMixin
 
 
 class VersionedModelAdminMixin:
@@ -36,13 +37,13 @@ class VersionedModelAdminMixin:
 
 
 @admin.register(models.PromptBuilderHistory)
-class PromptBuilderHistoryAdmin(admin.ModelAdmin):
+class PromptBuilderHistoryAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("history", "created_at", "owner")
     list_filter = ("owner",)
 
 
 @admin.register(models.SourceMaterial)
-class SourceMaterialAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
+class SourceMaterialAdmin(ReadonlyAdminMixin, VersionedModelAdminMixin, admin.ModelAdmin):
     list_display = (
         "topic",
         "team",
@@ -56,27 +57,26 @@ class SourceMaterialAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
     )
 
 
-class ParticipantDataInline(admin.TabularInline):
+class ParticipantDataInline(ReadonlyAdminMixin, admin.TabularInline):
     model = models.ParticipantData
 
 
 @admin.register(models.Participant)
-class ParticipantAdmin(admin.ModelAdmin):
+class ParticipantAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("identifier", "team", "public_id", "platform")
-    readonly_fields = ("public_id",)
     list_filter = ("team", "platform")
     search_fields = ("external_chat_id",)
     inlines = [ParticipantDataInline]
 
 
 @admin.register(models.ParticipantData)
-class ParticipantData(admin.ModelAdmin):
+class ParticipantData(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("participant", "experiment")
     list_filter = ("participant",)
 
 
 @admin.register(models.Survey)
-class SurveyAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
+class SurveyAdmin(ReadonlyAdminMixin, VersionedModelAdminMixin, admin.ModelAdmin):
     list_display = (
         "name",
         "team",
@@ -86,7 +86,7 @@ class SurveyAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
 
 
 @admin.register(models.Experiment)
-class ExperimentAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
+class ExperimentAdmin(ReadonlyAdminMixin, VersionedModelAdminMixin, admin.ModelAdmin):
     list_display = (
         "name",
         "team",
@@ -97,12 +97,11 @@ class ExperimentAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
         "is_archived",
     )
     list_filter = ("team", "owner", "source_material")
-    readonly_fields = ("public_id",)
     search_fields = ("public_id", "name")
 
 
 @admin.register(models.ExperimentSession)
-class ExperimentSessionAdmin(admin.ModelAdmin):
+class ExperimentSessionAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = (
         "experiment",
         "team",
@@ -112,7 +111,6 @@ class ExperimentSessionAdmin(admin.ModelAdmin):
     )
     search_fields = ("external_id", "experiment__name", "participant__identifier")
     list_filter = ("created_at", "status", "team")
-    readonly_fields = ("external_id",)
 
     @admin.display(description="Team")
     def team(self, obj):
@@ -120,7 +118,7 @@ class ExperimentSessionAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.ConsentForm)
-class ConsentFormAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
+class ConsentFormAdmin(ReadonlyAdminMixin, VersionedModelAdminMixin, admin.ModelAdmin):
     list_display = (
         "team",
         "name",
@@ -129,12 +127,11 @@ class ConsentFormAdmin(VersionedModelAdminMixin, admin.ModelAdmin):
         "version_family",
         "is_archived",
     )
-    readonly_fields = ("is_default",)
     list_filter = ("team",)
 
 
 @admin.register(models.SyntheticVoice)
-class SyntheticVoiceAdmin(admin.ModelAdmin):
+class SyntheticVoiceAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = (
         "service",
         "name",

--- a/apps/files/admin.py
+++ b/apps/files/admin.py
@@ -1,10 +1,12 @@
 from django.contrib import admin
 
+from apps.utils.admin import ReadonlyAdminMixin
+
 from .models import File
 
 
 @admin.register(File)
-class FileAdmin(admin.ModelAdmin):
+class FileAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("name", "external_source", "external_id", "content_size", "content_type")
     search_fields = ("name", "external_source", "external_id")
     list_filter = ("content_type",)

--- a/apps/pipelines/admin.py
+++ b/apps/pipelines/admin.py
@@ -1,11 +1,13 @@
 from django import forms
 from django.contrib import admin
 
+from apps.utils.admin import ReadonlyAdminMixin
+
 from ..utils.json import PrettyJSONEncoder
 from .models import Node, Pipeline, PipelineChatHistory, PipelineChatMessages
 
 
-class PipelineNodeInline(admin.TabularInline):
+class PipelineNodeInline(ReadonlyAdminMixin, admin.TabularInline):
     model = Node
     extra = 0
 
@@ -15,12 +17,12 @@ class PipelineAdminForm(forms.ModelForm):
 
 
 @admin.register(Pipeline)
-class PipelineAdmin(admin.ModelAdmin):
+class PipelineAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     form = PipelineAdminForm
     inlines = [PipelineNodeInline]
 
 
-class PipelineChatMessagesInline(admin.TabularInline):
+class PipelineChatMessagesInline(ReadonlyAdminMixin, admin.TabularInline):
     model = PipelineChatMessages
     extra = 0
 
@@ -30,5 +32,5 @@ class PipelineChatMessagesInline(admin.TabularInline):
 
 
 @admin.register(PipelineChatHistory)
-class PipelineChatHistoryAdmin(admin.ModelAdmin):
+class PipelineChatHistoryAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     inlines = [PipelineChatMessagesInline]

--- a/apps/service_providers/admin.py
+++ b/apps/service_providers/admin.py
@@ -4,6 +4,7 @@ from django.utils.html import format_html
 
 from apps.assistants.models import OpenAiAssistant
 from apps.pipelines.models import Node
+from apps.utils.admin import ReadonlyAdminMixin
 
 from .models import (
     EmbeddingProviderModel,
@@ -16,13 +17,13 @@ from .models import (
 
 
 @admin.register(LlmProvider)
-class ServiceConfigAdmin(admin.ModelAdmin):
+class ServiceConfigAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("name", "team", "type")
     list_filter = ("team", "type")
 
 
 @admin.register(LlmProviderModel)
-class LlmProviderModelAdmin(admin.ModelAdmin):
+class LlmProviderModelAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("name", "type", "max_token_limit", "team")
     list_filter = ("team", "type", "name")
     readonly_fields = ["related_assistants", "related_nodes"]
@@ -50,25 +51,24 @@ class LlmProviderModelAdmin(admin.ModelAdmin):
 
 
 @admin.register(VoiceProvider)
-class VoiceProviderAdmin(admin.ModelAdmin):
+class VoiceProviderAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("name", "team", "type")
     list_filter = ("team", "type")
 
 
 @admin.register(MessagingProvider)
-class MessagingProviderAdmin(admin.ModelAdmin):
+class MessagingProviderAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("name", "team", "type")
     list_filter = ("team", "type")
 
 
 @admin.register(TraceProvider)
-class TraceProviderAdmin(admin.ModelAdmin):
+class TraceProviderAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("name", "team", "type")
     list_filter = ("team", "type")
 
 
 @admin.register(EmbeddingProviderModel)
-class EmbeddingProviderModelAdmin(admin.ModelAdmin):
+class EmbeddingProviderModelAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ("name", "team", "type")
     list_filter = ("team", "type")
-    readonly_fields = ("team",)

--- a/apps/slack/admin.py
+++ b/apps/slack/admin.py
@@ -1,8 +1,9 @@
 from django.contrib import admin
 
 from apps.slack.models import SlackInstallation
+from apps.utils.admin import ReadonlyAdminMixin
 
 
 @admin.register(SlackInstallation)
-class SlackInstallationAdmin(admin.ModelAdmin):
+class SlackInstallationAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ["slack_team_name", "created_at", "slack_team_id"]

--- a/apps/utils/admin.py
+++ b/apps/utils/admin.py
@@ -1,8 +1,12 @@
 class ReadonlyAdminMixin:
+    """Marks every model field as readonly so FK/M2M widgets render as plain
+    text instead of <select> dropdowns, avoiding full-table queries that can
+    time out the admin change view. Merges with any readonly_fields the admin
+    class already declares (e.g. computed display methods)."""
+
     def get_readonly_fields(self, request, obj=None):
-        return list(
-            set(
-                [field.name for field in self.opts.local_fields]
-                + [field.name for field in self.opts.local_many_to_many]
-            )
-        )
+        existing = list(super().get_readonly_fields(request, obj))
+        model_fields = [field.name for field in self.opts.local_fields] + [
+            field.name for field in self.opts.local_many_to_many
+        ]
+        return list(set(existing + model_fields))

--- a/apps/utils/admin.py
+++ b/apps/utils/admin.py
@@ -1,12 +1,16 @@
 class ReadonlyAdminMixin:
-    """Marks every model field as readonly so FK/M2M widgets render as plain
-    text instead of <select> dropdowns, avoiding full-table queries that can
-    time out the admin change view. Merges with any readonly_fields the admin
-    class already declares (e.g. computed display methods)."""
+    """Marks every model field as readonly on the change view so FK/M2M widgets
+    render as plain text instead of <select> dropdowns, avoiding full-table
+    queries that can time out the admin change view. On the add view (obj=None)
+    only returns the admin's declared readonly_fields so required fields remain
+    editable. Merges with any readonly_fields the admin class already declares
+    (e.g. computed display methods), preserving their declared order."""
 
     def get_readonly_fields(self, request, obj=None):
         existing = list(super().get_readonly_fields(request, obj))
+        if obj is None:
+            return existing
         model_fields = [field.name for field in self.opts.local_fields] + [
             field.name for field in self.opts.local_many_to_many
         ]
-        return list(set(existing + model_fields))
+        return existing + [field for field in model_fields if field not in existing]

--- a/apps/utils/tests/test_admin.py
+++ b/apps/utils/tests/test_admin.py
@@ -1,0 +1,37 @@
+from django.contrib import admin
+
+from apps.utils.admin import ReadonlyAdminMixin
+from apps.utils.tests.models import Bot
+
+
+class TestReadonlyAdminMixin:
+    def _build_admin(self, declared_readonly=()):
+        class _BotAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
+            readonly_fields = declared_readonly
+
+            def computed_display(self, obj):
+                return ""
+
+        return _BotAdmin(Bot, admin.site)
+
+    def test_add_view_returns_only_declared_readonly(self):
+        bot_admin = self._build_admin(declared_readonly=["computed_display"])
+        assert bot_admin.get_readonly_fields(request=None, obj=None) == ["computed_display"]
+
+    def test_change_view_appends_model_fields_preserving_declared_order(self):
+        bot_admin = self._build_admin(declared_readonly=["computed_display"])
+        result = bot_admin.get_readonly_fields(request=None, obj=object())
+        assert result[0] == "computed_display"
+        assert set(result[1:]) == {"id", "name", "collection", "tools"}
+        assert len(result) == len(set(result)), "duplicates present"
+
+    def test_change_view_with_no_declared_readonly(self):
+        bot_admin = self._build_admin(declared_readonly=())
+        result = bot_admin.get_readonly_fields(request=None, obj=object())
+        assert set(result) == {"id", "name", "collection", "tools"}
+
+    def test_declared_model_field_is_not_duplicated(self):
+        bot_admin = self._build_admin(declared_readonly=["name"])
+        result = bot_admin.get_readonly_fields(request=None, obj=object())
+        assert result.count("name") == 1
+        assert result[0] == "name"


### PR DESCRIPTION
### Product Description
Django admin pages for several models (notably Pipeline) were timing out when loading the change view because every FK/M2M field was rendered as a `<select>` with options drawn from the full related table. This change makes those admins read-only, which causes Django to render FK/M2M values as plain text instead of dropdowns — eliminating the full-table queries that caused the timeouts.

### Technical Description
- Extended `ReadonlyAdminMixin` (`apps/utils/admin.py`) so it merges with any existing `readonly_fields` on the admin class, preserving computed display methods like `LlmProviderModelAdmin.related_assistants` / `related_nodes`.
- Applied `ReadonlyAdminMixin` to every previously writable `ModelAdmin` and inline across `apps/` **except** for admins that are operationally editable:
  - `CustomUserAdmin` (user/superuser management)
  - `TeamAdmin` / `MembershipAdmin` / `InvitationAdmin`
  - `FlagAdmin` (waffle feature flags)
  - `BannerAdmin`
  - `UserAPIKeyModelAdmin` (API key creation)
- Removed redundant `readonly_fields` tuples that only listed model fields (now covered by the mixin).
- Added a docstring to `ReadonlyAdminMixin` explaining its purpose.

Note: the mixin does not override `has_add/change/delete_permission`; these admins are display-locked, not permission-locked. That matches existing behavior for admins already using the mixin (Traces, Evaluations, etc.).

### Migrations
- [x] The migrations are backwards compatible (no migrations in this PR)

### Demo
N/A — admin-only change. Verified via `python manage.py check` and ruff.

### Docs and Changelog
- [ ] This PR requires docs/changelog update