### PR TITLE
Add session ID filter to annotation and experiment session tables

### DIFF
--- a/apps/experiments/filters.py
+++ b/apps/experiments/filters.py
@@ -19,6 +19,7 @@ from apps.web.dynamic_filters.column_filters import (
     ExperimentFilter,
     ParticipantFilter,
     RemoteIdFilter,
+    SessionIdFilter,
     StatusFilter,
     TimestampFilter,
 )
@@ -208,6 +209,7 @@ class ExperimentSessionFilter(MultiColumnFilter):
         ExperimentFilter(),
         StatusFilter(query_param="state"),
         RemoteIdFilter(),
+        SessionIdFilter(),
     ]
 
 

--- a/apps/experiments/tests/test_filters.py
+++ b/apps/experiments/tests/test_filters.py
@@ -349,6 +349,33 @@ class TestExperimentSessionFilters:
         filtered = session_filter.apply(session_queryset, FilterParams(_get_querydict(params)))
         assert all(s.participant.remote_id != test_id for s in filtered)
 
+    def test_session_id_filters(self, sessions_with_statuses):
+        sessions = sessions_with_statuses
+        session_queryset = sessions[0].experiment.sessions.all()
+        target = sessions[0]
+        target_external_id = str(target.external_id)
+
+        params = {
+            "filter_0_column": "session_id",
+            "filter_0_operator": Operators.EQUALS,
+            "filter_0_value": target_external_id,
+        }
+        session_filter = ExperimentSessionFilter()
+        filtered = session_filter.apply(session_queryset, FilterParams(_get_querydict(params)))
+        assert list(filtered) == [target]
+
+        params["filter_0_operator"] = Operators.STARTS_WITH
+        params["filter_0_value"] = target_external_id[:8]
+        session_filter = ExperimentSessionFilter()
+        filtered = session_filter.apply(session_queryset, FilterParams(_get_querydict(params)))
+        assert target in filtered
+
+        params["filter_0_operator"] = Operators.DOES_NOT_CONTAIN
+        params["filter_0_value"] = target_external_id
+        session_filter = ExperimentSessionFilter()
+        filtered = session_filter.apply(session_queryset, FilterParams(_get_querydict(params)))
+        assert target not in filtered
+
 
 @pytest.mark.django_db()
 class TestParticipantFilter:

--- a/apps/experiments/tests/test_filters.py
+++ b/apps/experiments/tests/test_filters.py
@@ -364,6 +364,12 @@ class TestExperimentSessionFilters:
         filtered = session_filter.apply(session_queryset, FilterParams(_get_querydict(params)))
         assert list(filtered) == [target]
 
+        params["filter_0_operator"] = Operators.EQUALS
+        params["filter_0_value"] = target_external_id.upper()
+        session_filter = ExperimentSessionFilter()
+        filtered = session_filter.apply(session_queryset, FilterParams(_get_querydict(params)))
+        assert list(filtered) == [target], "EQUALS should be case-insensitive"
+
         params["filter_0_operator"] = Operators.STARTS_WITH
         params["filter_0_value"] = target_external_id[:8]
         session_filter = ExperimentSessionFilter()

--- a/apps/human_annotations/filters.py
+++ b/apps/human_annotations/filters.py
@@ -11,6 +11,7 @@ from apps.web.dynamic_filters.column_filters import (
     ExperimentFilter,
     ParticipantFilter,
     RemoteIdFilter,
+    SessionIdFilter,
     StatusFilter,
     TimestampFilter,
 )
@@ -126,4 +127,5 @@ class AnnotationSessionFilter(MultiColumnFilter):
         ExperimentFilter(),
         StatusFilter(query_param="state"),
         RemoteIdFilter(),
+        SessionIdFilter(),
     ]

--- a/apps/web/dynamic_filters/column_filters.py
+++ b/apps/web/dynamic_filters/column_filters.py
@@ -75,6 +75,9 @@ class SessionIdFilter(StringColumnFilter):
     label: str = "Session ID"
     description: str = "Filter by the session's external ID (UUID)"
 
+    def apply_equals(self, queryset, value, timezone=None) -> QuerySet:
+        return self._apply_with_lookup(queryset, "iexact", value)
+
 
 class TimestampFilter(ColumnFilter):
     type: str = TYPE_TIMESTAMP

--- a/apps/web/dynamic_filters/column_filters.py
+++ b/apps/web/dynamic_filters/column_filters.py
@@ -25,7 +25,6 @@ class ExperimentFilter(ChoiceColumnFilter):
     )
 
     def prepare(self, team, **_):
-
         experiments = (
             Experiment.objects.working_versions_queryset().filter(team=team).values("id", "name").order_by("name")
         )
@@ -68,6 +67,13 @@ class RemoteIdFilter(ChoiceColumnFilter):
     column: str = "participant__remote_id"
     label: str = "Remote ID"
     description: str = "Filter by participant's remote/external ID"
+
+
+class SessionIdFilter(StringColumnFilter):
+    query_param: str = "session_id"
+    columns: list[str] = ["external_id"]
+    label: str = "Session ID"
+    description: str = "Filter by the session's external ID (UUID)"
 
 
 class TimestampFilter(ColumnFilter):

--- a/apps/web/tests/test_dynamic_filters.py
+++ b/apps/web/tests/test_dynamic_filters.py
@@ -61,6 +61,7 @@ class TestExperimentSessionFilterSchema:
             "experiment",
             "state",
             "remote_id",
+            "session_id",
         }
         assert set(schema.keys()) == expected_keys
 


### PR DESCRIPTION
Fixes https://github.com/dimagi/open-chat-studio/issues/3204

### Product Description
Users can now filter session tables (both the annotation queue session picker and the general experiment sessions table) by **Session ID**. This makes it much easier to locate a specific session — for example, when jumping from a support ticket or log entry that references a session's external UUID — without having to scroll or filter by participant.

### Technical Description
- Adds `SessionIdFilter` (a `StringColumnFilter` targeting `ExperimentSession.external_id`) in `apps/web/dynamic_filters/column_filters.py`.
- Wires it into `AnnotationSessionFilter` (`apps/human_annotations/filters.py`) and `ExperimentSessionFilter` (`apps/experiments/filters.py`) — both were extended to keep the two sibling filter sets in sync.
- No UI/template changes required: the existing dynamic filters UI renders `string`-type filters generically (equals / contains / does_not_contain / starts_with / ends_with).
- New test `test_session_id_filters` covers equals, starts_with, and does_not_contain operators.
- Updated `test_schema_has_all_columns` to include the new `session_id` key.

### Migrations
- [x] The migrations are backwards compatible

No migrations in this PR.

### Demo
The new "Session ID" filter appears in the filter dropdown on the annotation queue "Add Sessions" selection table and on the experiment sessions table. Selecting it exposes standard string operators and filters the list by matching against the session's external ID.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)