### PR TITLE
Add session ID filter to annotation items table

### DIFF
--- a/apps/human_annotations/filters.py
+++ b/apps/human_annotations/filters.py
@@ -93,6 +93,7 @@ class AnnotationItemFilter(MultiColumnFilter):
     filters: ClassVar[Sequence[ColumnFilter]] = [
         AnnotationItemStatusFilter(),
         ReviewerFilter(),
+        SessionIdFilter(columns=["session__external_id"]),
     ]
 
 

--- a/apps/human_annotations/tests/test_views.py
+++ b/apps/human_annotations/tests/test_views.py
@@ -370,6 +370,23 @@ def test_queue_items_table_filters_by_reviewer(client, team_with_users, queue, u
 
 
 @pytest.mark.django_db()
+def test_queue_items_table_filters_by_session_id(client, team_with_users, queue):
+    item1 = AnnotationItemFactory.create(queue=queue, team=team_with_users)
+    item2 = AnnotationItemFactory.create(queue=queue, team=team_with_users)
+    target_id = str(item1.session.external_id)
+
+    url = reverse("human_annotations:queue_items_table", args=[team_with_users.slug, queue.pk])
+    response = client.get(
+        url,
+        {"filter_0_column": "session_id", "filter_0_operator": "equals", "filter_0_value": target_id},
+    )
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert target_id in content
+    assert str(item2.session.external_id) not in content
+
+
+@pytest.mark.django_db()
 def test_queue_detail_has_filter_context(client, team_with_users, queue):
     url = reverse("human_annotations:queue_detail", args=[team_with_users.slug, queue.pk])
     response = client.get(url)
@@ -961,7 +978,6 @@ def test_queue_sessions_json_excludes_sessions_without_messages(client, team_wit
 
 @pytest.mark.django_db()
 def test_queue_sessions_table_excludes_evaluation_sessions(client, team_with_users, queue):
-
     normal_session = ExperimentSessionFactory.create(team=team_with_users)
     ChatMessageFactory.create(chat=normal_session.chat)
     eval_session = ExperimentSessionFactory.create(team=team_with_users, platform=ChannelPlatform.EVALUATIONS)
@@ -976,7 +992,6 @@ def test_queue_sessions_table_excludes_evaluation_sessions(client, team_with_use
 
 @pytest.mark.django_db()
 def test_queue_sessions_json_excludes_evaluation_sessions(client, team_with_users, queue):
-
     normal_session = ExperimentSessionFactory.create(team=team_with_users)
     ChatMessageFactory.create(chat=normal_session.chat)
     eval_session = ExperimentSessionFactory.create(team=team_with_users, platform=ChannelPlatform.EVALUATIONS)


### PR DESCRIPTION
### Product Description
Follow-up to #3206. The previous PR added a Session ID filter to the session-selection table on the "Add Sessions" page, but the main **Queue Detail** page shows the annotation **items** table (not sessions) — and that table was still missing the new filter. With this change, reviewers working through a queue can filter the items list by session UUID directly from the queue detail page.

### Technical Description
- Adds `SessionIdFilter(columns=["session__external_id"])` to `AnnotationItemFilter` (in `apps/human_annotations/filters.py`). `AnnotationItem.session` is an FK to `ExperimentSession`, so the lookup traverses into `external_id`.
- Reuses the existing `SessionIdFilter` from `apps.web.dynamic_filters.column_filters` — the `columns` list is overridden per instance via pydantic.
- Adds `test_queue_items_table_filters_by_session_id` covering the filter end-to-end through the items table view.

### Migrations
- [x] The migrations are backwards compatible

No migrations in this PR.

### Demo
On the queue detail page, opening the filter panel above the Items table now shows a "Session ID" option alongside Status and Reviewer. Selecting it with `equals` / `contains` / `starts with` / `ends with` filters the items to those whose session's external ID matches.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)