### PR TITLE
fix: update OCS langfuse integration for v4 SDK

### DIFF
--- a/apps/service_providers/management/commands/migrate_langfuse_data.py
+++ b/apps/service_providers/management/commands/migrate_langfuse_data.py
@@ -15,8 +15,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from django.core.management.base import BaseCommand, CommandError
 from langfuse import Langfuse
 from langfuse.api.core.api_error import ApiError
-from langfuse.api.resources.commons.types import Usage
-from langfuse.api.resources.ingestion.types import (
+from langfuse.api.commons.types import Usage
+from langfuse.api.ingestion.types import (
     CreateEventBody,
     CreateGenerationBody,
     CreateSpanBody,

--- a/apps/service_providers/tests/test_langfuse_tracer.py
+++ b/apps/service_providers/tests/test_langfuse_tracer.py
@@ -1,0 +1,117 @@
+from contextlib import contextmanager
+from unittest import mock
+
+import pytest
+
+from apps.service_providers.tracing.base import TraceContext
+from apps.service_providers.tracing.langfuse import LangFuseTracer
+from apps.service_providers.tracing.service import TracingService
+
+
+@pytest.fixture()
+def mock_langfuse_client():
+    client = mock.MagicMock()
+    span = mock.MagicMock()
+    span.trace_id = "trace-abc-123"
+    span.id = "span-abc-123"
+
+    @contextmanager
+    def start_observation(**kwargs):
+        yield span
+
+    client.start_as_current_observation.side_effect = start_observation
+    client.get_current_trace_id.return_value = "trace-abc-123"
+    client.get_trace_url.return_value = "https://langfuse.example/trace/trace-abc-123"
+    return client
+
+
+@pytest.fixture()
+def mock_session():
+    session = mock.MagicMock()
+    session.external_id = "ext-session-id"
+    session.participant = mock.MagicMock(identifier="participant-1")
+    return session
+
+
+@pytest.fixture()
+def patched_tracer(mock_langfuse_client):
+    """A real LangFuseTracer with the ClientManager boundary mocked."""
+    tracer = LangFuseTracer("langfuse", {"public_key": "pk", "secret_key": "sk"})
+    with mock.patch(
+        "apps.service_providers.tracing.langfuse.client_manager.get",
+        return_value=mock_langfuse_client,
+    ):
+        yield tracer
+
+
+def test_get_trace_metadata_returns_langfuse_info(patched_tracer, mock_langfuse_client, mock_session):
+    """get_trace_metadata() must return trace_id/trace_url while trace is active."""
+    trace_context = TraceContext(id=mock.sentinel.trace_id, name="test-trace")
+
+    with patched_tracer.trace(trace_context=trace_context, session=mock_session):
+        metadata = patched_tracer.get_trace_metadata()
+
+    assert metadata == {
+        "trace_id": "trace-abc-123",
+        "trace_url": "https://langfuse.example/trace/trace-abc-123",
+        "trace_provider": "langfuse",
+    }
+
+
+def test_tracing_service_exposes_langfuse_metadata_via_trace_info(patched_tracer, mock_langfuse_client, mock_session):
+    """TracingService.get_trace_metadata() wraps LangFuseTracer output under
+    'trace_info', which is what gets merged into ChatMessage.metadata.
+    """
+    service = TracingService([patched_tracer], experiment_id=1, team_id=1)
+
+    with service.trace("test-trace", session=mock_session):
+        metadata = service.get_trace_metadata()
+
+    assert metadata == {
+        "trace_info": [
+            {
+                "trace_id": "trace-abc-123",
+                "trace_url": "https://langfuse.example/trace/trace-abc-123",
+                "trace_provider": "langfuse",
+            }
+        ]
+    }
+
+
+def test_tracing_service_recovers_when_trace_url_fetch_fails(patched_tracer, mock_langfuse_client, mock_session):
+    """A URL-fetch failure must not drop the whole langfuse entry from trace_info."""
+    mock_langfuse_client.get_trace_url.side_effect = ConnectionError("boom")
+    service = TracingService([patched_tracer], experiment_id=1, team_id=1)
+
+    with service.trace("test-trace", session=mock_session):
+        metadata = service.get_trace_metadata()
+
+    assert metadata.get("trace_info"), "langfuse trace info must survive URL fetch failure"
+    entry = metadata["trace_info"][0]
+    assert entry["trace_id"] == "trace-abc-123"
+    assert entry["trace_provider"] == "langfuse"
+
+
+def test_add_trace_tags_uses_resolved_trace_id(patched_tracer, mock_langfuse_client, mock_session):
+    trace_context = TraceContext(id=mock.sentinel.trace_id, name="test-trace")
+
+    with patched_tracer.trace(trace_context=trace_context, session=mock_session):
+        patched_tracer.add_trace_tags(["tag1", "tag2"])
+
+    mock_langfuse_client._create_trace_tags_via_ingestion.assert_called_once_with(
+        trace_id="trace-abc-123", tags=["tag1", "tag2"]
+    )
+
+
+def test_trace_state_resets_on_exit(patched_tracer, mock_langfuse_client, mock_session):
+    trace_context = TraceContext(id=mock.sentinel.trace_id, name="test-trace")
+
+    with patched_tracer.trace(trace_context=trace_context, session=mock_session):
+        assert patched_tracer.ready
+        assert patched_tracer._langfuse_trace_id == "trace-abc-123"
+
+    assert not patched_tracer.ready
+    assert patched_tracer._langfuse_trace_id is None
+    assert patched_tracer.trace_record is None
+    assert patched_tracer.client is None
+    assert patched_tracer.session is None

--- a/apps/service_providers/tracing/langfuse.py
+++ b/apps/service_providers/tracing/langfuse.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
+from langfuse import propagate_attributes
 from langfuse._client.get_client import _create_client_from_instance
 from langfuse._client.resource_manager import LangfuseResourceManager
 from langfuse.langchain import CallbackHandler
@@ -20,7 +21,7 @@ from .const import SpanLevel
 if TYPE_CHECKING:
     from langchain_core.callbacks.base import BaseCallbackHandler
     from langfuse import Langfuse
-    from langfuse.api.client import FernLangfuse
+    from langfuse.api.client import LangfuseAPI
 
     from apps.experiments.models import ExperimentSession
 
@@ -28,11 +29,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger("ocs.tracing.langfuse")
 
 
-def get_langfuse_api_client(config: dict) -> FernLangfuse:
+def get_langfuse_api_client(config: dict) -> LangfuseAPI:
     """Create a Langfuse management API client for reading trace data."""
-    from langfuse.api.client import FernLangfuse  # noqa: PLC0415 - lazy: test mocks at source module level
+    from langfuse.api.client import LangfuseAPI  # noqa: PLC0415 - lazy: test mocks at source module level
 
-    return FernLangfuse(
+    return LangfuseAPI(
         base_url=config["host"],
         username=config["public_key"],
         password=config["secret_key"],
@@ -79,19 +80,18 @@ class LangFuseTracer(Tracer):
         # Get client and create trace
         self.client = client_manager.get(self.config)
         try:
-            with self.client.start_as_current_span(
-                name=trace_context.name,
-                input=inputs,
-                metadata=metadata,
-            ) as trace:
-                self.trace_record = trace
-                self.trace_record.update_trace(
-                    session_id=str(session.external_id),
-                    user_id=session.participant.identifier,
-                )
-
-                yield trace_context
-                self._update_span_from_context(trace, trace_context)
+            with propagate_attributes(
+                session_id=str(session.external_id),
+                user_id=session.participant.identifier,
+            ):
+                with self.client.start_as_current_observation(
+                    name=trace_context.name,
+                    input=inputs,
+                    metadata=metadata,
+                ) as trace:
+                    self.trace_record = trace
+                    yield trace_context
+                    self._update_span_from_context(trace, trace_context)
         finally:
             if self.trace_record:
                 self.client.flush()
@@ -117,7 +117,7 @@ class LangFuseTracer(Tracer):
             yield span_context
             return
 
-        with self.client.start_as_current_span(
+        with self.client.start_as_current_observation(
             name=span_context.name,
             input=inputs,
             metadata=metadata,
@@ -161,7 +161,8 @@ class LangFuseTracer(Tracer):
     def add_trace_tags(self, tags: list[str]) -> None:
         if not self.ready:
             raise ServiceNotInitializedException("Service not initialized.")
-        self.trace_record.update(tags=tags)
+        # span.update() no longer accepts tags in v4; use the ingestion API directly
+        self.client._create_trace_tags_via_ingestion(trace_id=self.trace_record.trace_id, tags=tags)
 
     def set_output_message_id(self, output_message_id: str) -> None:
         pass

--- a/apps/service_providers/tracing/langfuse.py
+++ b/apps/service_providers/tracing/langfuse.py
@@ -53,6 +53,7 @@ class LangFuseTracer(Tracer):
         super().__init__(type_, config)
         self.client = None
         self.trace_record = None
+        self._langfuse_trace_id: str | None = None
 
     @property
     def ready(self) -> bool:
@@ -90,6 +91,7 @@ class LangFuseTracer(Tracer):
                     metadata=metadata,
                 ) as trace:
                     self.trace_record = trace
+                    self._langfuse_trace_id = self.client.get_current_trace_id()
                     yield trace_context
                     self._update_span_from_context(trace, trace_context)
         finally:
@@ -99,6 +101,7 @@ class LangFuseTracer(Tracer):
             # Reset state
             self.client = None
             self.trace_record = None
+            self._langfuse_trace_id = None
             self.session = None
 
     @contextmanager
@@ -149,11 +152,19 @@ class LangFuseTracer(Tracer):
         if not self.ready:
             raise ServiceNotInitializedException("Service not initialized.")
 
+        # get_trace_url() does a blocking HTTP fetch for project_id; isolate failures
+        # so we still capture trace_id in the chat message metadata.
+        try:
+            trace_url = self.client.get_trace_url(trace_id=self._langfuse_trace_id)
+        except Exception:
+            logger.exception("Failed to fetch Langfuse trace URL for trace_id=%s", self._langfuse_trace_id)
+            trace_url = None
+
         return cast(
             dict[str, str],
             {
-                "trace_id": self.trace_record.trace_id,
-                "trace_url": self.client.get_trace_url(trace_id=self.trace_record.trace_id),
+                "trace_id": self._langfuse_trace_id,
+                "trace_url": trace_url,
                 "trace_provider": self.type,
             },
         )
@@ -162,7 +173,7 @@ class LangFuseTracer(Tracer):
         if not self.ready:
             raise ServiceNotInitializedException("Service not initialized.")
         # span.update() no longer accepts tags in v4; use the ingestion API directly
-        self.client._create_trace_tags_via_ingestion(trace_id=self.trace_record.trace_id, tags=tags)
+        self.client._create_trace_tags_via_ingestion(trace_id=self._langfuse_trace_id, tags=tags)
 
     def set_output_message_id(self, output_message_id: str) -> None:
         pass


### PR DESCRIPTION
Fixes the breaking changes introduced by the langfuse 3→4 SDK upgrade (#3129). Needs to be merged into that branch before #3129 is merged to main.

## Breaking changes addressed

### `apps/service_providers/tracing/langfuse.py`

| v3 | v4 |
|----|----|
| `FernLangfuse` | `LangfuseAPI` |
| `client.start_as_current_span(...)` | `client.start_as_current_observation(...)` |
| `trace.update_trace(session_id=..., user_id=...)` | `propagate_attributes(session_id=..., user_id=...)` wrapping the observation (must be outer context so attrs land on root span) |
| `span.update(tags=tags)` | `client._create_trace_tags_via_ingestion(trace_id=..., tags=tags)` |

### `apps/service_providers/management/commands/migrate_langfuse_data.py`

| v3 | v4 |
|----|----|
| `langfuse.api.resources.commons.types` | `langfuse.api.commons.types` |
| `langfuse.api.resources.ingestion.types` | `langfuse.api.ingestion.types` |

## What was NOT broken
- `LangfuseResourceManager` private API (`_lock`, `_instances`, `reset()`) — still intact in v4 ✅
- `_create_client_from_instance` — still intact ✅
- `span.trace_id`, `client.get_trace_url()` — still intact ✅
- `langfuse.api.core.api_error.ApiError` — still intact ✅
- All `IngestionEvent_*` types — still in `langfuse.api.ingestion.types` ✅
- `LangfuseCallbackHandler._get_parent_observation()` — still intact ✅