### PR TITLE
ci: fix stuck pending GitHub Deployments in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -283,8 +283,6 @@ jobs:
         wait-for-service-stability: false
 
     - name: Wait for service stability
-      env:
-        AWS_MAX_ATTEMPTS: 80
       run: |
           # Run the three waiters in parallel. `set -e` (default in GH Actions bash)
           # doesn't apply to background processes, so we capture each exit code via

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.environment }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -283,26 +283,33 @@ jobs:
         wait-for-service-stability: false
 
     - name: Wait for service stability
+      env:
+        AWS_MAX_ATTEMPTS: 80
       run: |
-          aws ecs wait services-stable --cluster $ECS_CLUSTER --services $ECS_SERVICE_DJANGO $ECS_SERVICE_CELERY $ECS_SERVICE_CELERY_BEAT
+          # Run the three waiters in parallel. `set -e` (default in GH Actions bash)
+          # doesn't apply to background processes, so we capture each exit code via
+          # `wait <pid>` and fail only after all three have finished.
+          aws ecs wait services-stable --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE_DJANGO" &
+          pid_django=$!
+          aws ecs wait services-stable --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE_CELERY" &
+          pid_celery=$!
+          aws ecs wait services-stable --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE_CELERY_BEAT" &
+          pid_celery_beat=$!
 
-    - name: Update deployment status (success)
-      if: success()
+          rc=0
+          wait "$pid_django"      || { echo "Django service failed to stabilise"; rc=1; }
+          wait "$pid_celery"      || { echo "Celery service failed to stabilise"; rc=1; }
+          wait "$pid_celery_beat" || { echo "CeleryBeat service failed to stabilise"; rc=1; }
+          exit $rc
+
+    - name: Update deployment status
+      if: always()
       uses: chrnorm/deployment-status@v2
       with:
         token: '${{ github.token }}'
         environment-url: ${{ steps.deployment.outputs.environment_url }}
         deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-        state: 'success'
-
-    - name: Update deployment status (failure)
-      if: failure()
-      uses: chrnorm/deployment-status@v2
-      with:
-        token: '${{ github.token }}'
-        environment-url: ${{ steps.deployment.outputs.environment_url }}
-        deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-        state: 'failure'
+        state: ${{ job.status == 'success' && 'success' || 'failure' }}
 
     - name: Create Sentry release
       if: success()


### PR DESCRIPTION
### Product Description
No user-facing change. Improves reliability of our CI deploy pipeline and the DORA metrics that key off GitHub Deployment terminal states.

### Technical Description
Fixes GitHub Deployments occasionally getting stuck in `pending`, which breaks DORA tooling that expects a terminal `success` / `failure` / `error` / `inactive` state. Previously the job was cancelled (concurrency or timeout) before either `if: success()` or `if: failure()` status step could run, so no terminal status was ever emitted.

Changes to `.github/workflows/deploy.yml`:

- **Parallelise the ECS waits.** `aws ecs wait services-stable` now runs concurrently for Django / Celery / CeleryBeat, with per-waiter exit codes collected via `wait <pid>`. Wall-clock drops from ~3× slowest service to ~1×.
- **Raise the waiter budget.** `AWS_MAX_ATTEMPTS: 80` scoped to the wait step only — roughly 20 min per service.
- **Always emit a terminal deployment status.** The two `if: success()` / `if: failure()` steps collapse into a single `if: always()` step whose state is `job.status == 'success' && 'success' || 'failure'`. Cancelled jobs now emit `failure` instead of leaving the Deployment in `pending`.
- **Stop killing in-flight deploys.** `concurrency.cancel-in-progress: true` → `false`. GitHub's pending-run coalescing already caps the queue at 1, so rapid merges don't pile up redundant deploys, but running deploys aren't interrupted mid-rollout.

### Migrations
- [ ] The migrations are backwards compatible

_No DB migrations in this PR._

### Demo
N/A — CI-only change. Verified `deploy.yml` parses as valid YAML; `actionlint` not available locally.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

_No docs or changelog update needed._

🤖 Generated with [Claude Code](https://claude.com/claude-code)