### PR TITLE
fix: Handle localStorage access errors in theme management and user ID generation

### DIFF
--- a/assets/javascript/theme-toggle.js
+++ b/assets/javascript/theme-toggle.js
@@ -2,8 +2,24 @@ const darkTheme = 'dark';
 const lightTheme = 'light';
 const systemTheme = 'system';
 
+function readStoredTheme() {
+  try {
+    return localStorage.getItem('theme');
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredTheme(theme) {
+  try {
+    localStorage.setItem('theme', theme);
+  } catch {
+    // ignore
+  }
+}
+
 function syncDarkMode() {
-  const theme = localStorage.getItem('theme') || systemTheme;
+  const theme = readStoredTheme() || systemTheme;
   setTheme(theme);
 }
 
@@ -27,7 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementsByName("theme-dropdown").forEach((element) => {
     element.addEventListener('change', (event) => {
       const theme = event.target.value;
-      localStorage.setItem('theme', theme);
+      writeStoredTheme(theme);
       setTheme(theme);
     })
   })

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -1424,7 +1424,12 @@ export class OcsChat {
     }
 
     const storageKey = `ocs-user-id`;
-    const stored = localStorage.getItem(storageKey);
+    let stored: string | null = null;
+    try {
+      stored = localStorage.getItem(storageKey);
+    } catch {
+      // localStorage blocked; fall through to in-memory id generation
+    }
     if (stored) {
       this.generatedUserId = stored;
       return stored;
@@ -1435,7 +1440,11 @@ export class OcsChat {
     const randomString = Array.from(array, byte => byte.toString(36)).join('').substr(0, 9);
     const newUserId = `ocs:${Date.now()}_${randomString}`;
     this.generatedUserId = newUserId;
-    localStorage.setItem(storageKey, newUserId);
+    try {
+      localStorage.setItem(storageKey, newUserId);
+    } catch {
+      // localStorage blocked; the generated id lives in component state for this page
+    }
 
     return newUserId;
   }

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat_session_handling.spec.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat_session_handling.spec.tsx
@@ -451,3 +451,83 @@ describe('ocs-chat progress message during polling', () => {
     expect(typingText).toBeFalsy();
   });
 });
+
+describe('ocs-chat localStorage blocked (SecurityError)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockStartSession.mockResolvedValue({session_id: 'test-session-id'});
+    mockSendMessage.mockResolvedValue({status: 'success', task_id: 'test-task-id'});
+    mockPollTask.mockReturnValue({cancel: jest.fn()});
+    mockStartMessagePolling.mockReturnValue({stop: jest.fn()});
+
+    global.fetch = setupFetchMock();
+
+    const throwSecurityError = () => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    };
+    const localStorageMock = {
+      getItem: jest.fn(throwSecurityError),
+      setItem: jest.fn(throwSecurityError),
+      removeItem: jest.fn(throwSecurityError),
+      clear: jest.fn(throwSecurityError),
+    };
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true,
+    });
+
+    Object.defineProperty(window, 'crypto', {
+      value: {
+        getRandomValues: jest.fn((arr: Uint8Array) => {
+          for (let i = 0; i < arr.length; i++) {
+            arr[i] = Math.floor(Math.random() * 256);
+          }
+          return arr;
+        }),
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+    jest.restoreAllMocks();
+  });
+
+  it('starts a session successfully when localStorage throws on read and write', async () => {
+    const page = await newSpecPage({
+      components: [OcsChat],
+      html: '<open-chat-studio-widget chatbot-id="test-bot" visible="true"></open-chat-studio-widget>',
+    });
+    await page.waitForChanges();
+
+    await page.rootInstance.sendMessage('Hello');
+    await page.waitForChanges();
+
+    expect(page.rootInstance.sessionId).toBe('test-session-id');
+    expect(page.rootInstance.error).toBeFalsy();
+    expect(page.rootInstance.generatedUserId).toMatch(/^ocs:\d+_.+/);
+  });
+
+  it('reuses the same in-memory user id across calls when localStorage is blocked', async () => {
+    const page = await newSpecPage({
+      components: [OcsChat],
+      html: '<open-chat-studio-widget chatbot-id="test-bot" visible="true"></open-chat-studio-widget>',
+    });
+    await page.waitForChanges();
+
+    const firstId = page.rootInstance.getOrGenerateUserId();
+    const secondId = page.rootInstance.getOrGenerateUserId();
+
+    expect(firstId).toMatch(/^ocs:\d+_.+/);
+    expect(secondId).toBe(firstId);
+  });
+
+  it('does not throw during componentWillLoad when localStorage is blocked', async () => {
+    await expect(newSpecPage({
+      components: [OcsChat],
+      html: '<open-chat-studio-widget chatbot-id="test-bot" visible="true" persistent-session="true"></open-chat-studio-widget>',
+    })).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
### Product Description
Both the OCS web app and the chat widget now degrade gracefully when the browser blocks `localStorage` access (sandboxed iframes, enterprise browser policies, certain incognito configurations). Previously the page would throw an uncaught `SecurityError` during script load, and the chat widget would silently fail to start a session with a misleading "Failed to start chat session" message. After this change, the theme toggle continues to work (persisted via the existing cookie) and the chat widget starts and runs normally with a per-page in-memory participant id.

### Technical Description
Two unrelated unprotected `localStorage` call sites were causing `SecurityError` to surface in environments where storage access is denied:

1. **`assets/javascript/theme-toggle.js`** — `syncDarkMode()` is invoked at module top level (`syncDarkMode()` on the last line) and runs on every page that loads the global `site` bundle (`templates/web/base.html` → `site-bundle.js` → `theme-toggle.js`). With `localStorage` blocked, the read at line 6 threw an uncaught `SecurityError` during module evaluation, before `DOMContentLoaded`. Wrapped the read and the dropdown-change write in small `readStoredTheme` / `writeStoredTheme` helpers that swallow the error. The existing `theme=...` cookie set in `setTheme()` already provides SSR persistence, so the user's preference still survives the current page; only cross-reload memory is lost when storage is blocked.

2. **`components/chat_widget/src/components/ocs-chat/ocs-chat.tsx::getOrGenerateUserId()`** — the only widget storage helper that was neither feature-detected via `isLocalStorageAvailable()` nor wrapped in `try`/`catch`. Because it's called from `startSession()` and `uploadFiles()`, a blocked `localStorage` made the chat unusable: every send produced a generic error toast. Wrapped both `localStorage.getItem` and `localStorage.setItem` in `try`/`catch`. The component already has a `@State() generatedUserId` field, which now acts as the in-memory fallback for the page lifetime when persistence is unavailable. No other widget call site needed changes — `saveSessionToStorage`, `loadSessionFromStorage`, `saveVisibleState`, `restoreVisibleState`, and `clearSessionStorage` already had their own `try`/`catch` blocks.

Tests: a new `describe('ocs-chat localStorage blocked (SecurityError)', ...)` block in `ocs-chat_session_handling.spec.tsx` covers three regressions:
- `sendMessage` succeeds when `localStorage.getItem`/`setItem`/`removeItem`/`clear` all throw `SecurityError`, with `sessionId` set and `generatedUserId` matching the expected `ocs:<ts>_<rand>` pattern.
- A second call to `getOrGenerateUserId()` returns the same in-memory id.
- `componentWillLoad` mounts the widget without throwing when `persistent-session="true"` and storage is blocked.

### Demo
To reproduce the original bug in DevTools:
1. Open the OCS app or any page embedding the chat widget.
2. In Chrome DevTools → Application → Storage → "Clear site data" then check **Block all third-party cookies / Block site data**, OR run in an iframe with `sandbox` (no `allow-same-origin`).
3. Reload — without the fix, the console shows an uncaught `SecurityError` from `theme-toggle.js`, and the chat widget toasts `Failed to start chat session` on first send.
4. With the fix, no console error, theme toggle works, chat starts and replies normally.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Changelog notes for Claude: User-facing fix — "Chat widget and main app no longer break when browser storage (`localStorage`) is unavailable. The widget falls back to a per-page participant id; theme preference falls back to the existing cookie-based persistence."
