### PR TITLE
perf: stream and chunk session exports for large datasets

### DIFF
--- a/apps/analysis/views.py
+++ b/apps/analysis/views.py
@@ -2,7 +2,7 @@ from functools import cached_property
 
 from django.conf import settings
 from django.contrib import messages
-from django.http import FileResponse, HttpResponse, JsonResponse
+from django.http import FileResponse, HttpResponse, JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.views.decorators.http import require_POST
@@ -11,7 +11,7 @@ from django_htmx.http import HttpResponseClientRedirect, HttpResponseClientRefre
 from django_tables2 import RequestConfig, SingleTableView
 
 from apps.chatbots.tables import ChatbotSessionsTable
-from apps.experiments.export import filtered_export_to_csv
+from apps.experiments.export import export_rows_to_csv_stream, generate_export_rows
 from apps.experiments.models import Experiment, ExperimentSession
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 
@@ -153,11 +153,10 @@ def download_analysis_results(request, team_slug, pk):
 def export_sessions(request, team_slug, pk):
     analysis = get_object_or_404(TranscriptAnalysis, id=pk, team__slug=team_slug)
     sessions = analysis.sessions.all()
-    csv_content = filtered_export_to_csv(
+    rows = generate_export_rows(
         analysis.experiment, sessions, translation_language=analysis.translation_language
     )
-
-    response = HttpResponse(csv_content.getvalue(), content_type="text/csv")
+    response = StreamingHttpResponse(export_rows_to_csv_stream(rows), content_type="text/csv")
     response["Content-Disposition"] = f'attachment; filename="{analysis.name}_sessions_export.csv"'
     return response
 

--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -111,6 +111,67 @@ def _get_export_header(translation_language=None):
     return header
 
 
+def _build_session_cache_entry(session) -> dict:
+    """Compute and return the per-session values used in every export row for that session."""
+    return {
+        "platform": session.get_platform_name(),
+        "session_tags": _format_tags(session.chat.tags.all()),
+        "session_comments": _format_comments(session.chat.comments.all()),
+        "external_id": session.external_id,
+        "state": json.dumps(session.state),
+        "participant_name": session.participant.name,
+        "participant_identifier": session.participant.identifier,
+        "participant_public_id": session.participant.public_id,
+    }
+
+
+def _build_message_row(message, participant_data, sc, experiment, trace_id, translation_language) -> list | None:
+    """Return an export row list for *message*, or None if the message is absent."""
+    if message is None:
+        return None
+    content = get_message_content(message, translation_language) if translation_language else message.content
+    row = [
+        message.id,
+        message.created_at,
+        message.message_type,
+        content,
+        sc["platform"],
+        sc["session_tags"],
+        sc["session_comments"],
+        sc["external_id"],
+        sc["state"],
+        experiment.public_id,
+        experiment.name,
+        sc["participant_name"],
+        sc["participant_identifier"],
+        sc["participant_public_id"],
+        _format_tags(message.tags.all()),
+        _format_comments(message.comments.all()),
+        trace_id,
+        json.dumps(participant_data),
+    ]
+    if translation_language:
+        row.append(translation_language)
+        row.append(message.content)
+    return row
+
+
+def _yield_rows_for_trace(trace, session_cache, experiment, translation_language) -> Generator[list, None, None]:
+    """Yield one export row per message (input + output) for a single trace."""
+    start_data, end_data = _get_participant_data_for_trace(trace)
+    trace_id = _get_trace_id_for_export(trace.input_message)
+    session = trace.session
+
+    if session.id not in session_cache:
+        session_cache[session.id] = _build_session_cache_entry(session)
+    sc = session_cache[session.id]
+
+    for message, participant_data in [(trace.input_message, start_data), (trace.output_message, end_data)]:
+        row = _build_message_row(message, participant_data, sc, experiment, trace_id, translation_language)
+        if row is not None:
+            yield row
+
+
 def generate_export_rows(
     experiment, sessions_queryset, translation_language=None
 ) -> Generator[list, None, None]:
@@ -126,9 +187,8 @@ def generate_export_rows(
 
     base_qs = _build_trace_queryset(sessions_queryset)
     last_pk = 0
-    # Cache computed per-session values to avoid redundant work across many traces
-    # from the same session.  The cache stores plain strings/dicts, not ORM objects,
-    # so its memory footprint is small even for experiments with many sessions.
+    # Cache stores plain strings/dicts (not ORM objects) so its footprint is small
+    # even for experiments with many sessions.
     session_cache: dict[int, dict] = {}
 
     while True:
@@ -137,57 +197,7 @@ def generate_export_rows(
             break
 
         for trace in chunk:
-            start_data, end_data = _get_participant_data_for_trace(trace)
-            trace_id = _get_trace_id_for_export(trace.input_message)
-            session = trace.session
-
-            if session.id not in session_cache:
-                session_cache[session.id] = {
-                    "platform": session.get_platform_name(),
-                    "session_tags": _format_tags(session.chat.tags.all()),
-                    "session_comments": _format_comments(session.chat.comments.all()),
-                    "external_id": session.external_id,
-                    "state": json.dumps(session.state),
-                    "participant_name": session.participant.name,
-                    "participant_identifier": session.participant.identifier,
-                    "participant_public_id": session.participant.public_id,
-                }
-            sc = session_cache[session.id]
-
-            for message, participant_data in [
-                (trace.input_message, start_data),
-                (trace.output_message, end_data),
-            ]:
-                if message is None:
-                    continue
-
-                content = (
-                    get_message_content(message, translation_language) if translation_language else message.content
-                )
-                row = [
-                    message.id,
-                    message.created_at,
-                    message.message_type,
-                    content,
-                    sc["platform"],
-                    sc["session_tags"],
-                    sc["session_comments"],
-                    sc["external_id"],
-                    sc["state"],
-                    experiment.public_id,
-                    experiment.name,
-                    sc["participant_name"],
-                    sc["participant_identifier"],
-                    sc["participant_public_id"],
-                    _format_tags(message.tags.all()),
-                    _format_comments(message.comments.all()),
-                    trace_id,
-                    json.dumps(participant_data),
-                ]
-                if translation_language:
-                    row.append(translation_language)
-                    row.append(message.content)
-                yield row
+            yield from _yield_rows_for_trace(trace, session_cache, experiment, translation_language)
 
         last_pk = chunk[-1].pk
         if len(chunk) < EXPORT_CHUNK_SIZE:

--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -2,7 +2,9 @@ import csv
 import io
 import json
 import tempfile
-from typing import Generator, Iterator
+from collections.abc import Generator, Iterator
+
+_SPOOLED_MAX_BYTES = 10 * 1024 * 1024  # 10 MB threshold before spilling to disk
 
 import dictdiffer
 
@@ -224,14 +226,24 @@ def export_rows_to_csv_stream(rows: Iterator[list]) -> Generator[str, None, None
 def export_to_tempfile(experiment, sessions_queryset, translation_language=None) -> tempfile.SpooledTemporaryFile:
     """Write the CSV export to a spooled temporary file and return it, seeked to 0.
 
-    The caller is responsible for closing the file.  Using a spooled file means
-    small exports stay in memory while large ones spill to disk automatically,
-    avoiding a single large in-memory allocation.
+    Use as a context manager (``with export_to_tempfile(...) as tmp:``) so that
+    the file is closed and any spilled data on disk is removed automatically.
+    Using a spooled file means small exports stay in memory while large ones spill
+    to disk automatically, avoiding a single large in-memory allocation.
+
+    The returned file is opened in binary mode (``mode="wb+"``); callers should
+    read raw bytes from it (e.g. ``tmp.read()`` returns ``bytes``).
     """
-    tmp = tempfile.SpooledTemporaryFile(max_size=10 * 1024 * 1024, mode="w+", encoding="utf-8", newline="")
-    writer = csv.writer(tmp, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
+    tmp = tempfile.SpooledTemporaryFile(max_size=_SPOOLED_MAX_BYTES, mode="wb+")
+    # Wrap in a TextIOWrapper so csv.writer receives a text-mode file object.
+    # detach=False: the wrapper does not close the underlying SpooledTemporaryFile
+    # when it is itself garbage-collected, preserving the caller's ability to seek/read.
+    text_wrapper = io.TextIOWrapper(tmp, encoding="utf-8", newline="")
+    writer = csv.writer(text_wrapper, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
     for row in generate_export_rows(experiment, sessions_queryset, translation_language):
         writer.writerow(row)
+    text_wrapper.flush()
+    text_wrapper.detach()  # release the wrapper without closing the underlying file
     tmp.seek(0)
     return tmp
 

--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -1,6 +1,8 @@
 import csv
 import io
 import json
+import tempfile
+from typing import Generator, Iterator
 
 import dictdiffer
 
@@ -11,6 +13,8 @@ from apps.experiments.models import ExperimentSession
 from apps.service_providers.tracing import OCS_TRACE_PROVIDER
 from apps.trace.models import Trace
 from apps.web.dynamic_filters.datastructures import FilterParams
+
+EXPORT_CHUNK_SIZE = 1000
 
 
 def _format_tags(tags: list[Tag]) -> str:
@@ -50,13 +54,9 @@ def _get_participant_data_for_trace(trace):
     return start_data, end_data
 
 
-def filtered_export_to_csv(experiment, sessions_queryset, translation_language=None):
-    csv_in_memory = io.StringIO()
-    writer = csv.writer(csv_in_memory, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
-
-    # NOTE: This export is trace-driven rather than message-driven. Each trace produces two rows
-    # (input + output). Messages not associated with a trace will not appear in the export.
-    traces = (
+def _build_trace_queryset(sessions_queryset):
+    """Return the base Trace queryset for export, ordered by pk for keyset pagination."""
+    return (
         Trace.objects.filter(
             session__in=sessions_queryset,
             input_message__isnull=False,
@@ -67,6 +67,7 @@ def filtered_export_to_csv(experiment, sessions_queryset, translation_language=N
             "session",
             "session__participant",
             "session__experiment_channel",
+            "session__chat",  # OneToOneField: explicit JOIN beats implicit prefetch
         )
         .prefetch_related(
             "input_message__tags",
@@ -79,9 +80,11 @@ def filtered_export_to_csv(experiment, sessions_queryset, translation_language=N
             "session__chat__comments",
             "session__chat__comments__user",
         )
-        .order_by("timestamp")
+        .order_by("pk")
     )
 
+
+def _get_export_header(translation_language=None):
     header = [
         "Message ID",
         "Message Date",
@@ -105,49 +108,135 @@ def filtered_export_to_csv(experiment, sessions_queryset, translation_language=N
     if translation_language:
         header.append("Message Language")
         header.append("Original Message")
+    return header
 
-    writer.writerow(header)
 
-    for trace in traces:
-        start_data, end_data = _get_participant_data_for_trace(trace)
-        trace_id = _get_trace_id_for_export(trace.input_message)  # safe: filtered out NULLs above
-        session = trace.session
+def generate_export_rows(
+    experiment, sessions_queryset, translation_language=None
+) -> Generator[list, None, None]:
+    """Yield the header row, then one data row per message across all matching traces.
 
-        for message, participant_data in [
-            (trace.input_message, start_data),
-            (trace.output_message, end_data),
-        ]:
-            if message is None:
-                continue
+    Traces are processed in chunks of EXPORT_CHUNK_SIZE using keyset pagination so
+    that memory usage stays bounded regardless of dataset size.  Session-level values
+    (platform name, state JSON, participant fields, chat tags/comments) are cached the
+    first time each session is encountered so they are serialised only once no matter
+    how many traces belong to that session.
+    """
+    yield _get_export_header(translation_language)
 
-            if translation_language:
-                content = get_message_content(message, translation_language)
-            else:
-                content = message.content
-            row = [
-                message.id,
-                message.created_at,
-                message.message_type,
-                content,
-                session.get_platform_name(),
-                _format_tags(session.chat.tags.all()),
-                _format_comments(session.chat.comments.all()),
-                session.external_id,
-                json.dumps(session.state),
-                experiment.public_id,
-                experiment.name,
-                session.participant.name,
-                session.participant.identifier,
-                session.participant.public_id,
-                _format_tags(message.tags.all()),
-                _format_comments(message.comments.all()),
-                trace_id,
-                json.dumps(participant_data),
-            ]
-            if translation_language:
-                row.append(translation_language)
-                row.append(message.content)
-            writer.writerow(row)
+    base_qs = _build_trace_queryset(sessions_queryset)
+    last_pk = 0
+    # Cache computed per-session values to avoid redundant work across many traces
+    # from the same session.  The cache stores plain strings/dicts, not ORM objects,
+    # so its memory footprint is small even for experiments with many sessions.
+    session_cache: dict[int, dict] = {}
+
+    while True:
+        chunk = list(base_qs.filter(pk__gt=last_pk)[:EXPORT_CHUNK_SIZE])
+        if not chunk:
+            break
+
+        for trace in chunk:
+            start_data, end_data = _get_participant_data_for_trace(trace)
+            trace_id = _get_trace_id_for_export(trace.input_message)
+            session = trace.session
+
+            if session.id not in session_cache:
+                session_cache[session.id] = {
+                    "platform": session.get_platform_name(),
+                    "session_tags": _format_tags(session.chat.tags.all()),
+                    "session_comments": _format_comments(session.chat.comments.all()),
+                    "external_id": session.external_id,
+                    "state": json.dumps(session.state),
+                    "participant_name": session.participant.name,
+                    "participant_identifier": session.participant.identifier,
+                    "participant_public_id": session.participant.public_id,
+                }
+            sc = session_cache[session.id]
+
+            for message, participant_data in [
+                (trace.input_message, start_data),
+                (trace.output_message, end_data),
+            ]:
+                if message is None:
+                    continue
+
+                content = (
+                    get_message_content(message, translation_language) if translation_language else message.content
+                )
+                row = [
+                    message.id,
+                    message.created_at,
+                    message.message_type,
+                    content,
+                    sc["platform"],
+                    sc["session_tags"],
+                    sc["session_comments"],
+                    sc["external_id"],
+                    sc["state"],
+                    experiment.public_id,
+                    experiment.name,
+                    sc["participant_name"],
+                    sc["participant_identifier"],
+                    sc["participant_public_id"],
+                    _format_tags(message.tags.all()),
+                    _format_comments(message.comments.all()),
+                    trace_id,
+                    json.dumps(participant_data),
+                ]
+                if translation_language:
+                    row.append(translation_language)
+                    row.append(message.content)
+                yield row
+
+        last_pk = chunk[-1].pk
+        if len(chunk) < EXPORT_CHUNK_SIZE:
+            # Partial chunk means we've reached the end; skip the extra query.
+            break
+
+
+def export_rows_to_csv_stream(rows: Iterator[list]) -> Generator[str, None, None]:
+    """Convert an iterable of row lists into a stream of CSV-formatted strings.
+
+    Each yielded string is one complete CSV line.  Suitable for use with
+    Django's StreamingHttpResponse so the response is sent to the client
+    incrementally rather than buffered entirely in memory.
+    """
+    buffer = io.StringIO()
+    writer = csv.writer(buffer, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
+    for row in rows:
+        writer.writerow(row)
+        yield buffer.getvalue()
+        buffer.seek(0)
+        buffer.truncate(0)
+
+
+def export_to_tempfile(experiment, sessions_queryset, translation_language=None) -> tempfile.SpooledTemporaryFile:
+    """Write the CSV export to a spooled temporary file and return it, seeked to 0.
+
+    The caller is responsible for closing the file.  Using a spooled file means
+    small exports stay in memory while large ones spill to disk automatically,
+    avoiding a single large in-memory allocation.
+    """
+    tmp = tempfile.SpooledTemporaryFile(max_size=10 * 1024 * 1024, mode="w+", encoding="utf-8", newline="")
+    writer = csv.writer(tmp, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
+    for row in generate_export_rows(experiment, sessions_queryset, translation_language):
+        writer.writerow(row)
+    tmp.seek(0)
+    return tmp
+
+
+def filtered_export_to_csv(experiment, sessions_queryset, translation_language=None):
+    """Build a complete CSV in a StringIO buffer and return it.
+
+    For large datasets prefer generate_export_rows() + export_rows_to_csv_stream()
+    to avoid buffering the entire export in memory.  This function is retained for
+    backward compatibility with callers that expect a StringIO return value.
+    """
+    csv_in_memory = io.StringIO()
+    writer = csv.writer(csv_in_memory, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
+    for row in generate_export_rows(experiment, sessions_queryset, translation_language):
+        writer.writerow(row)
     return csv_in_memory
 
 

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -34,7 +34,7 @@ def async_export_chat(self, experiment_id: int, query_params: dict, time_zone) -
             name=filename,
             team=experiment.team,
             content_type="text/csv",
-            file=ContentFile(tmp.read().encode("utf-8"), name=filename),
+            file=ContentFile(tmp.read(), name=filename),
         )
     return {"file_id": file_obj.id}
 

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -10,7 +10,7 @@ from taskbadger.celery import Task as TaskbadgerTask
 from apps.channels.channels_v2.web_channel import WebChannel
 from apps.channels.datamodels import Attachment, BaseMessage
 from apps.chat.bots import create_conversation
-from apps.experiments.export import filtered_export_to_csv, get_filtered_sessions
+from apps.experiments.export import export_to_tempfile, get_filtered_sessions
 from apps.experiments.models import Experiment, ExperimentSession, PromptBuilderHistory, SourceMaterial
 from apps.files.models import File
 from apps.service_providers.llm_service.retry import with_llm_retry
@@ -26,14 +26,16 @@ logger = get_task_logger("ocs.experiments")
 def async_export_chat(self, experiment_id: int, query_params: dict, time_zone) -> dict:
     experiment = Experiment.objects.get(id=experiment_id)
     filtered_sessions = get_filtered_sessions(experiment, query_params, time_zone)
-    csv_in_memory = filtered_export_to_csv(experiment, filtered_sessions)
     filename = f"{experiment.name} Chat Export {timezone.now().strftime('%Y-%m-%d_%H-%M-%S')}.csv"
-    file_obj = File.objects.create(
-        name=filename,
-        team=experiment.team,
-        content_type="text/csv",
-        file=ContentFile(csv_in_memory.getvalue().encode("utf-8"), name=filename),
-    )
+    # Use a spooled temp file so small exports stay in memory while large ones spill
+    # to disk, avoiding a single large in-memory allocation for the whole CSV.
+    with export_to_tempfile(experiment, filtered_sessions) as tmp:
+        file_obj = File.objects.create(
+            name=filename,
+            team=experiment.team,
+            content_type="text/csv",
+            file=ContentFile(tmp.read().encode("utf-8"), name=filename),
+        )
     return {"file_id": file_obj.id}
 
 

--- a/apps/experiments/tests/test_export.py
+++ b/apps/experiments/tests/test_export.py
@@ -1,7 +1,7 @@
 import csv
 import io
 import json
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -297,10 +297,15 @@ def test_trace_id_export():
 
     experiment = Mock(public_id="exp123", name="Test Experiment")
 
-    mock_traces_qs = Mock()
+    # Build a chainable mock queryset that supports the keyset-pagination pattern:
+    # Trace.objects.filter(...).select_related(...).prefetch_related(...).order_by("pk")
+    # then base_qs.filter(pk__gt=last_pk)[:CHUNK_SIZE] → [trace1, trace2]
+    mock_traces_qs = MagicMock()
     mock_traces_qs.select_related.return_value = mock_traces_qs
     mock_traces_qs.prefetch_related.return_value = mock_traces_qs
-    mock_traces_qs.order_by.return_value = [trace1, trace2]
+    mock_traces_qs.order_by.return_value = mock_traces_qs
+    # .filter(pk__gt=...) returns a sliceable mock; [:chunk_size] yields the two traces
+    mock_traces_qs.filter.return_value.__getitem__ = Mock(return_value=[trace1, trace2])
 
     with patch("apps.experiments.export.Trace.objects.filter", return_value=mock_traces_qs):
         csv_in_memory = filtered_export_to_csv(experiment, Mock())


### PR DESCRIPTION
Closes #3232

## Summary

Session exports were slow and memory-intensive for large datasets. This PR addresses the root causes identified in #3232 by introducing chunked DB reads and streaming CSV output.

## Changes

### `apps/experiments/export.py`

- **`generate_export_rows()`** (new): generator that yields the header row then one data row per message. Traces are fetched in batches of 1,000 using keyset pagination (`pk__gt` + `LIMIT`), so ORM objects for the full dataset are never in memory simultaneously.
- **Per-session value cache**: `json.dumps(session.state)`, `session.get_platform_name()`, participant fields, and chat tags/comments are computed once per session and reused for every trace in that session. A busy session with 100 exchanges previously hit those 5 serialisation calls 200 times; now it's 1.
- **`session__chat` in `select_related`**: `ExperimentSession.chat` is a `OneToOneField`; adding it to `select_related` gives a single JOIN rather than relying on the implicit intermediate prefetch step.
- **`export_rows_to_csv_stream()`** (new): wraps any row iterator into a generator of CSV-formatted strings, suitable for `StreamingHttpResponse`.
- **`export_to_tempfile()`** (new): writes the export to a `SpooledTemporaryFile` (stays in memory up to 10 MB, spills to disk beyond that) and returns it seeked to 0.
- **`filtered_export_to_csv()`** retained for backward compatibility — now implemented via `generate_export_rows()`.

### `apps/experiments/tasks.py`

- `async_export_chat`: switched from `filtered_export_to_csv` + `StringIO` to `export_to_tempfile`. The intermediate CSV now spills to disk for large exports rather than requiring one large in-memory buffer.

### `apps/analysis/views.py`

- `export_sessions`: switched from `HttpResponse` with a fully-buffered `StringIO` to `StreamingHttpResponse` + `export_rows_to_csv_stream(generate_export_rows())`. The response now streams to the client line-by-line without accumulating the full CSV in memory first.

### Tests

- Updated `test_trace_id_export` mock to support the new `.filter(pk__gt=...).[:chunk_size]` keyset-pagination call chain.

## What's not in this PR (follow-up in #3232)

- Async-ifying the analysis `export_sessions` view (currently synchronous in the request cycle — covered by #3232 notes)
- Database composite index on `Trace(session_id, input_message_id)`
