### PR TITLE
perf: redirect large file downloads to S3 presigned URLs

### DIFF
--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -431,7 +431,7 @@ def get_export_download_link(request, team_slug: str, experiment_id: str, task_i
     context: dict[str, object] = {"experiment": experiment}
     if info["complete"] and info["success"]:
         file_id = info["result"]["file_id"]
-        download_url = reverse("files:base", kwargs={"team_slug": team_slug, "pk": file_id})
+        download_url = reverse("files:base", kwargs={"team_slug": team_slug, "pk": file_id}) + "?allow_s3=1"
         context["export_download_url"] = download_url
     else:
         context["task_id"] = task_id

--- a/apps/files/views.py
+++ b/apps/files/views.py
@@ -27,6 +27,38 @@ from apps.utils.search import similarity_search
 logger = logging.getLogger("ocs.files")
 
 
+def _get_s3_presigned_url(file_field, filename, content_type, expires_in=3600):
+    """Return a presigned S3 URL for direct client download, or None if not applicable.
+
+    When the storage backend is S3 (django-storages S3Boto3Storage), this generates a
+    presigned GET URL with ``Content-Disposition: attachment`` so the browser downloads
+    the file directly from S3 — bypassing the Django app tier entirely.  This is
+    significantly faster for large files and avoids unnecessary bandwidth through Fargate.
+
+    Falls back gracefully: returns None for local/non-S3 storage, or if presigned URL
+    generation fails for any reason (e.g. missing IAM permissions).
+    """
+    storage = file_field.storage
+    if not hasattr(storage, "bucket"):
+        return None
+    try:
+        params = {
+            "Bucket": storage.bucket.name,
+            "Key": file_field.name,
+            "ResponseContentDisposition": f'attachment; filename="{filename}"',
+        }
+        if content_type:
+            params["ResponseContentType"] = content_type
+        return storage.bucket.meta.client.generate_presigned_url(
+            "get_object",
+            Params=params,
+            ExpiresIn=expires_in,
+        )
+    except Exception:
+        logger.exception("Failed to generate S3 presigned URL for %s", file_field.name)
+        return None
+
+
 class FileView(LoginAndTeamRequiredMixin, View):
     @method_decorator(permission_required("files.view_file"))
     def get(self, request, team_slug: str, pk: int):
@@ -40,6 +72,11 @@ class FileView(LoginAndTeamRequiredMixin, View):
         file = get_object_or_404(File, id=pk, team=request.team)
         if not file.file:
             return _not_found()
+
+        if "allow_s3" in request.GET:
+            presigned_url = _get_s3_presigned_url(file.file, file.name, file.content_type)
+            if presigned_url:
+                return redirect(presigned_url)
 
         try:
             return FileResponse(


### PR DESCRIPTION
## Summary

Large chat exports (e.g. 327 MB CSVs) were downloading slowly because the file was being proxied through Django/Fargate rather than served directly from S3.

### Changes

**`apps/files/views.py`**
- Added `_get_s3_presigned_url()` helper that generates a presigned S3 GET URL with `Content-Disposition: attachment`, bypassing the Django app tier entirely
- Added `?allow_s3` GET param handling to `FileView`: when present and storage is S3-backed, redirects the client to the presigned URL for a direct S3 download
- Fallback: if storage is not S3 (local dev) or presigned URL generation fails, the view falls through to the original `FileResponse` behaviour unchanged

**`apps/experiments/views/experiment.py`**
- Export download link now appends `?allow_s3=1` so large CSV exports download directly from S3

### Why `allow_s3` opt-in flag?

`FileView` is generic and used for many purposes. The S3 redirect is appropriate for user-triggered downloads of large files but may not be desirable everywhere (e.g. files embedded in page content). The flag keeps existing callers unaffected.

### Before / After

| | Before | After |
|---|---|---|
| 327 MB export | proxied through Fargate (slow) | direct S3 download (fast) |
| Local dev | `FileResponse` | `FileResponse` (unchanged) |
| Other `FileView` callers | `FileResponse` | `FileResponse` (unchanged) |