### PR TITLE
fix: use storage._normalize_name() for S3 presigned URL key

### DIFF
--- a/apps/files/views.py
+++ b/apps/files/views.py
@@ -44,7 +44,7 @@ def _get_s3_presigned_url(file_field, filename, content_type, expires_in=3600):
     try:
         params = {
             "Bucket": storage.bucket.name,
-            "Key": file_field.name,
+            "Key": storage._normalize_name(file_field.name),
             "ResponseContentDisposition": f'attachment; filename="{filename}"',
         }
         if content_type:


### PR DESCRIPTION
## Summary

Fixes a `NoSuchKey` error introduced in #3235.

`file_field.name` returns the bare filename (e.g. `export.csv`), but the actual S3 object key includes the storage location prefix (e.g. `media/export.csv`).  The presigned URL was being generated with the wrong key, causing S3 to return a `NoSuchKey` error when the client tried to download.

**Fix:** use `storage._normalize_name(file_field.name)` to resolve the full key before generating the presigned URL.