### PR TITLE
perf: gzip-compress chat exports to reduce size and download time

### DIFF
--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -1,4 +1,5 @@
 import csv
+import gzip
 import io
 import json
 import tempfile
@@ -223,7 +224,9 @@ def export_rows_to_csv_stream(rows: Iterator[list]) -> Generator[str, None, None
         buffer.truncate(0)
 
 
-def export_to_tempfile(experiment, sessions_queryset, translation_language=None) -> tempfile.SpooledTemporaryFile:
+def export_to_tempfile(
+    experiment, sessions_queryset, translation_language=None, compress=False
+) -> tempfile.SpooledTemporaryFile:
     """Write the CSV export to a spooled temporary file and return it, seeked to 0.
 
     Use as a context manager (``with export_to_tempfile(...) as tmp:``) so that
@@ -233,17 +236,37 @@ def export_to_tempfile(experiment, sessions_queryset, translation_language=None)
 
     The returned file is opened in binary mode (``mode="wb+"``); callers should
     read raw bytes from it (e.g. ``tmp.read()`` returns ``bytes``).
+
+    If ``compress=True``, the data is written as a gzip-compressed stream.  CSV
+    data compresses very well (typically 80–90% reduction), which significantly
+    reduces both storage and download time for large exports.
     """
     tmp = tempfile.SpooledTemporaryFile(max_size=_SPOOLED_MAX_BYTES, mode="wb+")
-    # Wrap in a TextIOWrapper so csv.writer receives a text-mode file object.
-    # detach=False: the wrapper does not close the underlying SpooledTemporaryFile
-    # when it is itself garbage-collected, preserving the caller's ability to seek/read.
-    text_wrapper = io.TextIOWrapper(tmp, encoding="utf-8", newline="")
-    writer = csv.writer(text_wrapper, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
-    for row in generate_export_rows(experiment, sessions_queryset, translation_language):
-        writer.writerow(row)
-    text_wrapper.flush()
-    text_wrapper.detach()  # release the wrapper without closing the underlying file
+
+    if compress:
+        # Write CSV rows through a GzipFile so the spooled file holds compressed
+        # bytes.  GzipFile must be explicitly closed to flush its trailer before
+        # we seek back to the start; detach the TextIOWrapper first so it doesn't
+        # try to close the GzipFile a second time on garbage collection.
+        gz = gzip.GzipFile(fileobj=tmp, mode="wb")
+        text_wrapper = io.TextIOWrapper(gz, encoding="utf-8", newline="")
+        writer = csv.writer(text_wrapper, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
+        for row in generate_export_rows(experiment, sessions_queryset, translation_language):
+            writer.writerow(row)
+        text_wrapper.flush()
+        text_wrapper.detach()
+        gz.close()  # finalises the gzip stream and writes the trailing checksum
+    else:
+        # Wrap in a TextIOWrapper so csv.writer receives a text-mode file object.
+        # detach=False: the wrapper does not close the underlying SpooledTemporaryFile
+        # when it is itself garbage-collected, preserving the caller's ability to seek/read.
+        text_wrapper = io.TextIOWrapper(tmp, encoding="utf-8", newline="")
+        writer = csv.writer(text_wrapper, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
+        for row in generate_export_rows(experiment, sessions_queryset, translation_language):
+            writer.writerow(row)
+        text_wrapper.flush()
+        text_wrapper.detach()
+
     tmp.seek(0)
     return tmp
 

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -26,14 +26,16 @@ logger = get_task_logger("ocs.experiments")
 def async_export_chat(self, experiment_id: int, query_params: dict, time_zone) -> dict:
     experiment = Experiment.objects.get(id=experiment_id)
     filtered_sessions = get_filtered_sessions(experiment, query_params, time_zone)
-    filename = f"{experiment.name} Chat Export {timezone.now().strftime('%Y-%m-%d_%H-%M-%S')}.csv"
+    filename = f"{experiment.name} Chat Export {timezone.now().strftime('%Y-%m-%d_%H-%M-%S')}.csv.gz"
     # Use a spooled temp file so small exports stay in memory while large ones spill
     # to disk, avoiding a single large in-memory allocation for the whole CSV.
-    with export_to_tempfile(experiment, filtered_sessions) as tmp:
+    # compress=True writes a gzip stream, reducing file size by ~80–90% for typical
+    # chat exports and dramatically cutting S3 storage and download time.
+    with export_to_tempfile(experiment, filtered_sessions, compress=True) as tmp:
         file_obj = File.objects.create(
             name=filename,
             team=experiment.team,
-            content_type="text/csv",
+            content_type="application/gzip",
             file=ContentFile(tmp.read(), name=filename),
         )
     return {"file_id": file_obj.id}


### PR DESCRIPTION
## Summary

CSV exports compress very well (~80–90% reduction) because the data is highly repetitive — experiment names, participant IDs, message types, state JSON, etc. appear across thousands of rows.

A **327 MB export** becomes roughly **30–50 MB**, turning a ~20 minute download into a couple of minutes.

## Changes

**`apps/experiments/export.py`**
- Added `compress=False` parameter to `export_to_tempfile()`
- When `compress=True`, rows are written through `gzip.GzipFile` so the spooled temp file holds compressed bytes rather than raw CSV
- `gz.close()` is called explicitly before `tmp.seek(0)` to flush the gzip trailing checksum

**`apps/experiments/tasks.py`**
- `async_export_chat` now calls `export_to_tempfile(compress=True)`
- Filename changed from `.csv` → `.csv.gz`
- Content type changed to `application/gzip`

## Compatibility

- Existing callers of `export_to_tempfile()` are unaffected (`compress` defaults to `False`)
- **macOS / Linux:** `.csv.gz` files auto-open natively (double-click or `gunzip`)
- **Windows 11:** handles `.gz` files natively without third-party tools
- Pairs with the S3 presigned URL redirect from #3235 — the presigned URL already passes `ResponseContentType` from `file.content_type`, so `application/gzip` is set correctly