### PR TITLE
fix: use gzip.open() context manager for reliable compressed export

### DIFF
--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -4,6 +4,7 @@ import io
 import json
 import tempfile
 from collections.abc import Generator, Iterator
+from typing import BinaryIO
 
 _SPOOLED_MAX_BYTES = 10 * 1024 * 1024  # 10 MB threshold before spilling to disk
 
@@ -226,7 +227,7 @@ def export_rows_to_csv_stream(rows: Iterator[list]) -> Generator[str, None, None
 
 def export_to_tempfile(
     experiment, sessions_queryset, translation_language=None, compress=False
-) -> tempfile.SpooledTemporaryFile | tempfile.TemporaryFile:
+) -> BinaryIO:
     """Write the CSV export to a temporary file and return it, seeked to 0.
 
     Use as a context manager (``with export_to_tempfile(...) as tmp:``) so that

--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -226,40 +226,43 @@ def export_rows_to_csv_stream(rows: Iterator[list]) -> Generator[str, None, None
 
 def export_to_tempfile(
     experiment, sessions_queryset, translation_language=None, compress=False
-) -> tempfile.SpooledTemporaryFile:
-    """Write the CSV export to a spooled temporary file and return it, seeked to 0.
+) -> tempfile.SpooledTemporaryFile | tempfile.TemporaryFile:
+    """Write the CSV export to a temporary file and return it, seeked to 0.
 
     Use as a context manager (``with export_to_tempfile(...) as tmp:``) so that
-    the file is closed and any spilled data on disk is removed automatically.
-    Using a spooled file means small exports stay in memory while large ones spill
-    to disk automatically, avoiding a single large in-memory allocation.
+    the file is closed and any on-disk data is cleaned up automatically.
 
     The returned file is opened in binary mode (``mode="wb+"``); callers should
     read raw bytes from it (e.g. ``tmp.read()`` returns ``bytes``).
 
-    If ``compress=True``, the data is written as a gzip-compressed stream.  CSV
-    data compresses very well (typically 80–90% reduction), which significantly
-    reduces both storage and download time for large exports.
-    """
-    tmp = tempfile.SpooledTemporaryFile(max_size=_SPOOLED_MAX_BYTES, mode="wb+")
+    If ``compress=False`` (default), a SpooledTemporaryFile is used so small
+    exports stay in memory while large ones spill to disk automatically.
 
+    If ``compress=True``, the data is written as a gzip-compressed stream using a
+    regular TemporaryFile (always disk-backed).  CSV data compresses very well
+    (typically 80–90% reduction), which significantly reduces both S3 storage and
+    download time for large exports.  The gzip stream is finalised (trailer written)
+    before returning so the file is a valid, complete .gz archive.
+    """
     if compress:
-        # Write CSV rows through a GzipFile so the spooled file holds compressed
-        # bytes.  GzipFile must be explicitly closed to flush its trailer before
-        # we seek back to the start; detach the TextIOWrapper first so it doesn't
-        # try to close the GzipFile a second time on garbage collection.
-        gz = gzip.GzipFile(fileobj=tmp, mode="wb")
-        text_wrapper = io.TextIOWrapper(gz, encoding="utf-8", newline="")
-        writer = csv.writer(text_wrapper, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
-        for row in generate_export_rows(experiment, sessions_queryset, translation_language):
-            writer.writerow(row)
-        text_wrapper.flush()
-        text_wrapper.detach()
-        gz.close()  # finalises the gzip stream and writes the trailing checksum
+        # Use a plain TemporaryFile rather than SpooledTemporaryFile.  The
+        # SpooledTemporaryFile + GzipFile combination has known edge cases around
+        # flushing and the gzip trailer.  For compressed exports the file is always
+        # large enough to justify disk storage anyway.
+        #
+        # gzip.open() used as a context manager closes the GzipFile (writing the
+        # gzip trailer) but does NOT close the underlying TemporaryFile because we
+        # passed a file object rather than a filename.  tmp stays open and seekable.
+        tmp = tempfile.TemporaryFile(mode="wb+")
+        with gzip.open(tmp, "wt", encoding="utf-8", newline="") as gz:
+            writer = csv.writer(gz, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
+            for row in generate_export_rows(experiment, sessions_queryset, translation_language):
+                writer.writerow(row)
     else:
         # Wrap in a TextIOWrapper so csv.writer receives a text-mode file object.
-        # detach=False: the wrapper does not close the underlying SpooledTemporaryFile
-        # when it is itself garbage-collected, preserving the caller's ability to seek/read.
+        # detach() releases the wrapper without closing the underlying SpooledTemporaryFile,
+        # preserving the caller's ability to seek/read.
+        tmp = tempfile.SpooledTemporaryFile(max_size=_SPOOLED_MAX_BYTES, mode="wb+")
         text_wrapper = io.TextIOWrapper(tmp, encoding="utf-8", newline="")
         writer = csv.writer(text_wrapper, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
         for row in generate_export_rows(experiment, sessions_queryset, translation_language):


### PR DESCRIPTION
## Problem

The export files were being saved as raw CSV despite having a `.csv.gz` extension. The previous implementation used `GzipFile(fileobj=SpooledTemporaryFile)` with a manual `flush/detach/close` sequence. `SpooledTemporaryFile` doesn't implement the full file-like interface that `GzipFile` expects, so the gzip stream was silently not being written correctly — the file came out as uncompressed CSV.

## Fix

Switch to `gzip.open(tmp, "wt", ...)` as a context manager on a plain `tempfile.TemporaryFile`:

- `gzip.open()` handles the `TextIOWrapper` internally — no manual layering needed
- The context manager exit flushes and closes the `GzipFile` (writes the gzip trailer), but does **not** close the underlying `TemporaryFile` (because we pass a file object, not a filename — `myfileobj` stays `None`)
- `tmp.seek(0)` after the `with` block leaves a complete, valid `.gz` archive ready to read

Switched from `SpooledTemporaryFile` to plain `TemporaryFile` for the compressed path — for large exports it would spill to disk anyway, and the plain file avoids the compatibility issues.

## Verified

Locally confirmed the output starts with gzip magic bytes `1f 8b` and decompresses back to the original CSV content.