### PR TITLE
fix: repair worktrunk DB hooks for worktree create/remove

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -2,7 +2,7 @@
 bootstrap = ".claude/hooks/setup-env.sh"
 
 [[pre-start]]
-database-url = "sed -i 's|^DATABASE_URL=.*|DATABASE_URL=postgres://postgres:postgres@localhost:5432/{{ branch | sanitize_db }}|' .env"
+database-url = "if grep -q '^DATABASE_URL=' .env; then sed -i.bak 's|^DATABASE_URL=.*|DATABASE_URL=postgres://postgres:postgres@localhost:5432/{{ branch | sanitize_db }}|' .env && rm -f .env.bak; else echo 'DATABASE_URL=postgres://postgres:postgres@localhost:5432/{{ branch | sanitize_db }}' >> .env; fi"
 
 [[pre-start]]
 create-database = "PGPASSWORD=postgres psql -h localhost -U postgres -tAc \"SELECT 1 FROM pg_database WHERE datname='{{ branch | sanitize_db }}'\" | grep -q 1 || PGPASSWORD=postgres psql -h localhost -U postgres -c 'CREATE DATABASE {{ branch | sanitize_db }}'"

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,12 +1,15 @@
-# Worktrunk Project Configuration
-[pre-start]
+[[pre-start]]
 bootstrap = ".claude/hooks/setup-env.sh"
-database-url = "echo 'DATABASE_URL=postgres://postgres:postgres@localhost:5432/{{ branch | sanitize_db }}' >> .env"
-create-database = "docker exec postgres psql -U postgres -c 'CREATE DATABASE {{ branch | sanitize_db }}'"
+
+[[pre-start]]
+database-url = "sed -i 's|^DATABASE_URL=.*|DATABASE_URL=postgres://postgres:postgres@localhost:5432/{{ branch | sanitize_db }}|' .env"
+
+[[pre-start]]
+create-database = "PGPASSWORD=postgres psql -h localhost -U postgres -tAc \"SELECT 1 FROM pg_database WHERE datname='{{ branch | sanitize_db }}'\" | grep -q 1 || PGPASSWORD=postgres psql -h localhost -U postgres -c 'CREATE DATABASE {{ branch | sanitize_db }}'"
 
 [post-start]
 compile-styles = "npm run dev"
 migrate-and-bootstrap = "uv run python manage.py migrate && uv run python manage.py bootstrap_data --email test@example.com --password letmein --superuser"
 
-[pre-remove]
-db-remove = "docker exec postgres psql -U postgres -c \"DROP DATABASE IF EXISTS \\\"{{ branch | sanitize_db }}\\\" WITH (FORCE)\""
+[post-remove]
+db-remove = "PGPASSWORD=postgres psql -h localhost -U postgres -c \"DROP DATABASE IF EXISTS \\\"{{ branch | sanitize_db }}\\\" WITH (FORCE)\" || true"


### PR DESCRIPTION
### Product Description
Worktree DB lifecycle hooks (worktrunk) have been broken for some time: removing a worktree would intermittently fail with errors like `Error response from daemon: No such container: postgres`, leaving worktrees orphaned. Per-branch databases were also never being created — the relevant hook block was silently ignored.

### Technical Description
Several layered issues in `.config/wt.toml`:

1. **`[pre-start]` was the wrong shape on older worktrunk versions** (treated as unknown field, silently skipped) — so `bootstrap`, `database-url`, and `create-database` never ran. Per-worktree DBs were never created.
2. **`docker exec postgres ...`** referenced a container name that varies by docker compose project name. Default `inv up` produces `open-chat-studio-db-1`, not `postgres` — so both creation (when it eventually ran) and removal failed.
3. **`db-remove` lived under `[pre-remove]`** which is blocking + fail-fast in worktrunk, so any psql/docker error aborted the entire `wt remove`.
4. **`database-url` used `>> .env`**, appending duplicate `DATABASE_URL=` lines on every run.

Changes:
- Migrate to pipeline form (`[[pre-start]]`) so serial execution survives the upcoming worktrunk semantic change for table form.
- Replace `docker exec <container>` with `psql -h localhost` against the host-exposed port — independent of compose project naming.
- Use in-place `sed` to overwrite the existing `DATABASE_URL=` line instead of appending duplicates.
- Make `create-database` idempotent via a `pg_database` precheck — re-running pre-start hooks or hitting an orphaned DB no longer aborts worktree creation.
- Move `db-remove` to `[post-remove]` with `|| true` — `wt remove` no longer blocks on Postgres being unreachable or on the DB already being gone. Matches worktrunk's own example pattern. Failures are still captured in `.git/wt/logs/`.

### Migrations
- [x] The migrations are backwards compatible

(No DB migrations; tooling-only change.)

### Demo
N/A — local dev tooling. Verified locally:
- `wt hook show` recognizes all hooks with no warnings.
- The previously-failing `DROP DATABASE IF EXISTS "rm_voyage_ai_embeddings_gdu" WITH (FORCE)` runs cleanly against the host port.
- Idempotency precheck: `grep -q 1` succeeds for an existing DB and fails for a missing one, so `||` correctly skips/runs the CREATE.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)