### PR TITLE
fix: prevent S3 auto-decompression of gzipped CSV exports

### DIFF
--- a/apps/web/storage_backends.py
+++ b/apps/web/storage_backends.py
@@ -10,6 +10,15 @@ class PrivateMediaStorage(S3Storage):
     file_overwrite = False
     custom_domain = False
 
+    def get_object_parameters(self, name):
+        params = super().get_object_parameters(name)
+        # For .gz uploads, set ContentType explicitly so django-storages skips its
+        # filename-based auto-detection — which would otherwise set Content-Encoding: gzip
+        # and cause HTTP clients to transparently decompress the file on download.
+        if name.lower().endswith(".gz") and "ContentType" not in params:
+            params["ContentType"] = "application/gzip"
+        return params
+
 
 def get_public_media_storage():
     return storages["public"]

--- a/apps/web/tests/test_storage_backends.py
+++ b/apps/web/tests/test_storage_backends.py
@@ -1,0 +1,23 @@
+from apps.web.storage_backends import PrivateMediaStorage
+
+
+def test_gz_uploads_do_not_set_content_encoding():
+    """Regression: django-storages auto-detects ContentEncoding=gzip from a .gz filename
+    and HTTP clients then auto-decompress on download, defeating the point of compression
+    for our gzipped CSV exports.
+    """
+    storage = PrivateMediaStorage(bucket_name="test-bucket")
+
+    params = storage._get_write_parameters("exports/chat-export.csv.gz")
+
+    assert params["ContentType"] == "application/gzip"
+    assert "ContentEncoding" not in params
+
+
+def test_non_gz_uploads_use_default_detection():
+    storage = PrivateMediaStorage(bucket_name="test-bucket")
+
+    params = storage._get_write_parameters("exports/chat-export.csv")
+
+    assert params["ContentType"] == "text/csv"
+    assert "ContentEncoding" not in params


### PR DESCRIPTION
### Product Description
Chat exports downloaded from S3 are now delivered as actual `.csv.gz` archives, matching the filename. Previously they were being transparently decompressed by browsers/HTTP clients, so users got a plain CSV despite the `.gz` extension and the compression work happening server-side.

### Technical Description
`export_to_tempfile(..., compress=True)` writes a valid gzip stream and uploads the bytes via the `File` model. The bytes on S3 were correct, but django-storages' `S3Storage._get_write_parameters` was inferring metadata from the filename:

```python
mimetypes.guess_type("foo.csv.gz")  # → ('text/csv', 'gzip')
```

resulting in `ContentType: text/csv` + `ContentEncoding: gzip` on the S3 object. When fetched via the presigned URL (`apps/files/views.py`), browsers/curl/boto3 honored the `Content-Encoding` header and decompressed automatically.

The fix overrides `get_object_parameters` on `PrivateMediaStorage` to explicitly set `ContentType: application/gzip` for any `.gz` upload. Per django-storages' own contract, populating `ContentType` in the params dict short-circuits the auto-detection block, so no `ContentEncoding` is set and the bytes are served as-is.

A regression test asserts both the `.gz` and non-`.gz` cases.

Note: existing exports already on S3 still carry `Content-Encoding: gzip` metadata; only newly created exports get the corrected headers. Backfill is not included — re-copying old objects with `--metadata-directive REPLACE` is only worth it if users are actively pulling old exports.

### Migrations
- [x] The migrations are backwards compatible (no migrations)

### Demo
N/A — header-level fix. Verifiable via `aws s3api head-object` on a new export: `ContentType` should be `application/gzip` and `ContentEncoding` should be absent.

### Docs and Changelog
- [ ] This PR requires docs/changelog update