### PR TITLE
fix: show all session statuses with labels in session filter

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1376,10 +1376,6 @@ class SessionStatus(models.TextChoices):
     # CANCELLED = "cancelled", gettext("Cancelled")  # not used anywhere yet
     UNKNOWN = "unknown", gettext("Unknown")
 
-    @classmethod
-    def for_chatbots(cls):
-        return [cls.ACTIVE.value, cls.COMPLETE.value]
-
 
 class ExperimentSessionQuerySet(models.QuerySet):
     def annotate_with_message_count(self):

--- a/apps/web/dynamic_filters/column_filters.py
+++ b/apps/web/dynamic_filters/column_filters.py
@@ -58,8 +58,8 @@ class ExperimentFilter(ChoiceColumnFilter):
 class StatusFilter(ChoiceColumnFilter):
     column: str = "status"
     label: str = "Status"
-    options: list[str] = SessionStatus.for_chatbots()
-    description: str = "Filter by session status (e.g. active, complete)"
+    options: list[str | dict] = [{"id": value, "label": label} for value, label in SessionStatus.choices]
+    description: str = "Filter by session status (e.g. active, complete, pending-review)"
 
 
 class RemoteIdFilter(ChoiceColumnFilter):


### PR DESCRIPTION
## Problem

The session status filter only offered `active` and `complete` as options (via `SessionStatus.for_chatbots()`), missing statuses like `pending-review` ("Awaiting final review"), `pending`, `setup`, etc. It also displayed raw DB values to the user instead of human-readable labels.

## Changes

**`apps/web/dynamic_filters/column_filters.py`**
- Replace `SessionStatus.for_chatbots()` with all `SessionStatus.choices` formatted as `{"id": value, "label": label}` dicts — the same pattern used by `ExperimentFilter`. The UI now shows labels (e.g. "Awaiting final review.") while the filter sends the correct DB value (e.g. `pending-review`).

**`apps/experiments/models.py`**
- Remove the now-unused `SessionStatus.for_chatbots()` classmethod.

## Status options now available

| Label | Value |
|-------|-------|
| Setting Up | `setup` |
| Awaiting participant | `pending` |
| Awaiting pre-survey | `pending-pre-survey` |
| Active | `active` |
| Awaiting final review. | `pending-review` |
| Complete | `complete` |
| Unknown | `unknown` |