### PR TITLE
fix: use TraceStatus options in trace status filter

### DIFF
--- a/apps/experiments/filters.py
+++ b/apps/experiments/filters.py
@@ -20,7 +20,7 @@ from apps.web.dynamic_filters.column_filters import (
     ParticipantFilter,
     RemoteIdFilter,
     SessionIdFilter,
-    StatusFilter,
+    SessionStatusFilter,
     TimestampFilter,
 )
 
@@ -207,7 +207,7 @@ class ExperimentSessionFilter(MultiColumnFilter):
         VersionsFilter(),
         ChannelsFilter(),
         ExperimentFilter(),
-        StatusFilter(query_param="state"),
+        SessionStatusFilter(query_param="state"),
         RemoteIdFilter(),
         SessionIdFilter(),
     ]

--- a/apps/human_annotations/filters.py
+++ b/apps/human_annotations/filters.py
@@ -12,7 +12,7 @@ from apps.web.dynamic_filters.column_filters import (
     ParticipantFilter,
     RemoteIdFilter,
     SessionIdFilter,
-    StatusFilter,
+    SessionStatusFilter,
     TimestampFilter,
 )
 
@@ -126,7 +126,7 @@ class AnnotationSessionFilter(MultiColumnFilter):
         VersionsFilter(),
         ChannelsFilter(exclude_platforms=[ChannelPlatform.EVALUATIONS]),
         ExperimentFilter(),
-        StatusFilter(query_param="state"),
+        SessionStatusFilter(query_param="state"),
         RemoteIdFilter(),
         SessionIdFilter(),
     ]

--- a/apps/trace/filters.py
+++ b/apps/trace/filters.py
@@ -9,12 +9,12 @@ from apps.experiments.filters import (
 )
 from apps.experiments.models import Experiment
 from apps.filters.models import FilterSet
+from apps.trace.models import TraceStatus
 from apps.web.dynamic_filters.base import TYPE_CHOICE, ChoiceColumnFilter, ColumnFilter, MultiColumnFilter
 from apps.web.dynamic_filters.column_filters import (
     ExperimentFilter,
     ParticipantFilter,
     RemoteIdFilter,
-    StatusFilter,
     TimestampFilter,
 )
 
@@ -75,6 +75,14 @@ class ExperimentVersionsFilter(ChoiceColumnFilter):
         self.options = Experiment.objects.get_version_names(team)
 
 
+class TraceStatusFilter(ChoiceColumnFilter):
+    query_param: str = "status"
+    column: str = "status"
+    label: str = "Status"
+    options: list[str | dict] = [{"id": value, "label": label} for value, label in TraceStatus.choices]
+    description: str = "Filter by trace status (e.g. success, error, pending)"
+
+
 class TraceFilter(MultiColumnFilter):
     slug: ClassVar[str] = "trace"
     date_range_column: ClassVar[str] = "timestamp"
@@ -85,5 +93,5 @@ class TraceFilter(MultiColumnFilter):
         RemoteIdFilter(),
         ExperimentFilter(),
         ExperimentVersionsFilter(),
-        StatusFilter(query_param="status"),
+        TraceStatusFilter(),
     ]

--- a/apps/web/dynamic_filters/column_filters.py
+++ b/apps/web/dynamic_filters/column_filters.py
@@ -55,7 +55,7 @@ class ExperimentFilter(ChoiceColumnFilter):
         return queryset.exclude(self._get_filter_clause(value))
 
 
-class StatusFilter(ChoiceColumnFilter):
+class SessionStatusFilter(ChoiceColumnFilter):
     column: str = "status"
     label: str = "Status"
     options: list[str | dict] = [{"id": value, "label": label} for value, label in SessionStatus.choices]


### PR DESCRIPTION
## Problem

`TraceFilter` was using the shared `StatusFilter` (from `column_filters.py`), which shows `SessionStatus` options — Active, Complete, Awaiting final review, etc. But the `Trace` model has its own `TraceStatus` with completely different values: `success`, `pending`, `error`.

This meant the trace status filter dropdown showed the wrong options to the user, and filtering by them would produce incorrect results.

## Fix

Add a `TraceStatusFilter` local to `apps/trace/filters.py` with options derived from `TraceStatus.choices`, using the same `{"id": value, "label": label}` dict format from #3247. Replace the mismatched `StatusFilter` import.

## Status options now shown

| Label | Value |
|-------|-------|
| Success | `success` |
| Pending | `pending` |
| Error | `error` |