### PR TITLE
Prefix ANYMAIL_WEBHOOK_SECRET with "anymail:"

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -405,7 +405,9 @@ EMAIL_BACKEND = env("DJANGO_EMAIL_BACKEND", default="django.core.mail.backends.c
 # use in production
 # see https://github.com/anymail/django-anymail for more details/examples
 # EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
-ANYMAIL_WEBHOOK_SECRET = f"anymail:{env('ANYMAIL_WEBHOOK_SECRET', default='')}"
+ANYMAIL_WEBHOOK_SECRET = env("ANYMAIL_WEBHOOK_SECRET", default=None)
+if ANYMAIL_WEBHOOK_SECRET:
+    ANYMAIL_WEBHOOK_SECRET = f"anymail:{ANYMAIL_WEBHOOK_SECRET}"
 
 # Django sites
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -405,7 +405,7 @@ EMAIL_BACKEND = env("DJANGO_EMAIL_BACKEND", default="django.core.mail.backends.c
 # use in production
 # see https://github.com/anymail/django-anymail for more details/examples
 # EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
-ANYMAIL_WEBHOOK_SECRET = env("ANYMAIL_WEBHOOK_SECRET", default=None)
+ANYMAIL_WEBHOOK_SECRET = f"anymail:{env('ANYMAIL_WEBHOOK_SECRET', default='')}"
 
 # Django sites
 

--- a/config/settings_production.py
+++ b/config/settings_production.py
@@ -39,7 +39,7 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 # Your email config goes here.
 # see https://github.com/anymail/django-anymail for more details / examples
 EMAIL_BACKEND = env("DJANGO_EMAIL_BACKEND", default="anymail.backends.mailgun.EmailBackend")
-_ANYMAIL_WEBHOOK_SECRET = env("ANYMAIL_WEBHOOK_SECRET", default=None)
+_ANYMAIL_WEBHOOK_SECRET = f"anymail:{env('ANYMAIL_WEBHOOK_SECRET', default='')}"
 match EMAIL_BACKEND:
     case "anymail.backends.mailgun.EmailBackend":
         ANYMAIL = {

--- a/config/settings_production.py
+++ b/config/settings_production.py
@@ -39,7 +39,9 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 # Your email config goes here.
 # see https://github.com/anymail/django-anymail for more details / examples
 EMAIL_BACKEND = env("DJANGO_EMAIL_BACKEND", default="anymail.backends.mailgun.EmailBackend")
-_ANYMAIL_WEBHOOK_SECRET = f"anymail:{env('ANYMAIL_WEBHOOK_SECRET', default='')}"
+_ANYMAIL_WEBHOOK_SECRET = env("ANYMAIL_WEBHOOK_SECRET", default=None)
+if _ANYMAIL_WEBHOOK_SECRET:
+    _ANYMAIL_WEBHOOK_SECRET = f"anymail:{_ANYMAIL_WEBHOOK_SECRET}"
 match EMAIL_BACKEND:
     case "anymail.backends.mailgun.EmailBackend":
         ANYMAIL = {


### PR DESCRIPTION
### Product Description
N/A — internal config change.

### Technical Description
Updates `ANYMAIL_WEBHOOK_SECRET` in both `config/settings.py` and `config/settings_production.py` so the value is formatted as `anymail:<secret>` rather than the raw env var.

### Migrations
- [x] The migrations are backwards compatible (no migrations)

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)