### PR TITLE
ci: replace chrnorm deployment actions with gh api calls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,13 +76,25 @@ jobs:
         echo "DJANGO_STACK_NAME=$APP_NAME-${{ env.DEPLOY_ENV }}-$AWS_REGION-django-stack" >> "$GITHUB_ENV"
 
     - name: Create GitHub deployment
-      uses: chrnorm/deployment-action@v2
       id: deployment
-      with:
-        token: '${{ github.token }}'
-        environment: "aws-${{ env.DEPLOY_ENV }}"
-        production-environment: ${{ env.DEPLOY_ENV == 'prod' }}
-        description: "Deploying ${{ github.head_ref || github.ref }} to AWS ${{ env.DEPLOY_ENV }}"
+      env:
+        GH_TOKEN: ${{ github.token }}
+        DEPLOY_REF: ${{ github.head_ref || github.ref }}
+      run: |
+        DEPLOYMENT_ID=$(gh api -X POST \
+          "/repos/${{ github.repository }}/deployments" \
+          -f ref="${{ github.sha }}" \
+          -f environment="aws-${{ env.DEPLOY_ENV }}" \
+          -F production_environment=${{ env.DEPLOY_ENV == 'prod' }} \
+          -f description="Deploying $DEPLOY_REF to AWS ${{ env.DEPLOY_ENV }}" \
+          -f task=deploy \
+          -F auto_merge=false \
+          -f required_contexts='[]' \
+          --jq '.id')
+        echo "deployment_id=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
+        gh api -X POST \
+          "/repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses" \
+          -f state=in_progress >/dev/null
 
     - name: configure aws credentials
       uses: aws-actions/configure-aws-credentials@v6.0.0
@@ -301,13 +313,14 @@ jobs:
           exit $rc
 
     - name: Update deployment status
-      if: always()
-      uses: chrnorm/deployment-status@v2
-      with:
-        token: '${{ github.token }}'
-        environment-url: ${{ steps.deployment.outputs.environment_url }}
-        deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-        state: ${{ job.status == 'success' && 'success' || 'failure' }}
+      if: always() && steps.deployment.outputs.deployment_id != ''
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        STATE="${{ job.status == 'success' && 'success' || 'failure' }}"
+        gh api -X POST \
+          "/repos/${{ github.repository }}/deployments/${{ steps.deployment.outputs.deployment_id }}/statuses" \
+          -f state="$STATE" >/dev/null
 
     - name: Create Sentry release
       if: success()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,16 +81,13 @@ jobs:
         GH_TOKEN: ${{ github.token }}
         DEPLOY_REF: ${{ github.head_ref || github.ref }}
       run: |
-        DEPLOYMENT_ID=$(gh api -X POST \
-          "/repos/${{ github.repository }}/deployments" \
-          -f ref="${{ github.sha }}" \
-          -f environment="aws-${{ env.DEPLOY_ENV }}" \
-          -F production_environment=${{ env.DEPLOY_ENV == 'prod' }} \
-          -f description="Deploying $DEPLOY_REF to AWS ${{ env.DEPLOY_ENV }}" \
-          -f task=deploy \
-          -F auto_merge=false \
-          -f required_contexts='[]' \
-          --jq '.id')
+        DEPLOYMENT_ID=$(jq -n \
+          --arg ref "${{ github.sha }}" \
+          --arg environment "aws-${{ env.DEPLOY_ENV }}" \
+          --argjson production_environment ${{ env.DEPLOY_ENV == 'prod' && 'true' || 'false' }} \
+          --arg description "Deploying $DEPLOY_REF to AWS ${{ env.DEPLOY_ENV }}" \
+          '{ref: $ref, environment: $environment, production_environment: $production_environment, description: $description, task: "deploy", auto_merge: false, required_contexts: []}' \
+          | gh api -X POST "/repos/${{ github.repository }}/deployments" --input - --jq '.id')
         echo "deployment_id=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
         gh api -X POST \
           "/repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses" \


### PR DESCRIPTION
### Product Description
N/A — internal CI tooling.

### Technical Description
The `chrnorm/deployment-action@v2` and `chrnorm/deployment-status@v2` actions were intermittently failing with `HttpError: Requires authentication` despite a valid `GITHUB_TOKEN` and correct `Deployments: write` permission (see e.g. run [25116583660](https://github.com/dimagi/open-chat-studio/actions/runs/25116583660), which failed within 1s of the create step while the run 2h earlier on the same SHA succeeded with the same token). They also emit Node `punycode` / `url.parse` deprecation warnings, and the upstream is barely maintained — the `v2` tag last moved in March 2026 only to bump `actions/checkout`.

Both steps are now native `gh api` calls:
- **Create GitHub deployment** — posts to `/repos/.../deployments`, captures the deployment id into the step output, then posts an `in_progress` status so the Deployments UI reflects the right state during the run (matches the implicit `pending` status that chrnorm posted on creation).
- **Update deployment status** — gated on `if: always() && steps.deployment.outputs.deployment_id != ''` so a failed creation doesn't trigger a follow-up POST against a missing id.

Behavior preserved: `auto_merge=false` and `required_contexts='[]'` match the chrnorm defaults; `auto_inactive` falls back to the API default (`true` for success states), which matches what chrnorm did. The `environment_url` output was never wired up on the create side, so dropping it from the update step changes nothing.

### Migrations
- [ ] The migrations are backwards compatible

N/A — no DB changes.

### Demo
N/A — verifiable via the next deploy run.

### Docs and Changelog
- [ ] This PR requires docs/changelog update