### PR TITLE
config: add CodeScene custom quality gates and tuned code health rules

### DIFF
--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -6,13 +6,13 @@
       "matching_content_path_doc": "Relaxed rules for test files. Long test methods and setup duplication are normal.",
       "thresholds": [
         {"name": "function_lines_of_code_warning", "value": 150},
-        {"name": "function_max_arguments", "value": 6},
         {"name": "unit_test_consecutive_asserts_for_large_block", "value": 10},
         {"name": "unit_test_suite_number_of_large_assertion_blocks", "value": 8},
         {"name": "function_duplication_min_lines_of_code_for_check", "value": 25}
       ],
+      "thresholds_doc": "Defaults: function_lines_of_code_warning=70, unit_test_consecutive_asserts_for_large_block=4, unit_test_suite_number_of_large_assertion_blocks=4, function_duplication_min_lines_of_code_for_check=10",
       "rules": [
-        {"name": "Code Duplication", "weight": 0.0},
+        {"name": "Code Duplication", "weight": 0.1},
         {"name": "Large Method", "weight": 0.5}
       ]
     },
@@ -24,7 +24,8 @@
         {"name": "function_bumpy_road_bumps_for_warning", "value": 3},
         {"name": "function_cyclomatic_complexity_warning", "value": 11},
         {"name": "function_lines_of_code_warning", "value": 80}
-      ]
+      ],
+      "thresholds_doc": "Defaults: function_max_arguments=4, function_bumpy_road_bumps_for_warning=2, function_cyclomatic_complexity_warning=9, function_lines_of_code_warning=70"
     }
   ]
 }

--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -1,0 +1,30 @@
+{
+  "usage": "Persist this file inside your repositories as .codescene/code-health-rules.json",
+  "rule_sets": [
+    {
+      "matching_content_path": "**/tests/**",
+      "matching_content_path_doc": "Relaxed rules for test files. Long test methods and setup duplication are normal.",
+      "thresholds": [
+        {"name": "function_lines_of_code_warning", "value": 150},
+        {"name": "function_max_arguments", "value": 6},
+        {"name": "unit_test_consecutive_asserts_for_large_block", "value": 10},
+        {"name": "unit_test_suite_number_of_large_assertion_blocks", "value": 8},
+        {"name": "function_duplication_min_lines_of_code_for_check", "value": 25}
+      ],
+      "rules": [
+        {"name": "Code Duplication", "weight": 0.0},
+        {"name": "Large Method", "weight": 0.5}
+      ]
+    },
+    {
+      "matching_content_path": "*/**",
+      "matching_content_path_doc": "Production code. Thresholds tuned for Python/Django patterns.",
+      "thresholds": [
+        {"name": "function_max_arguments", "value": 6},
+        {"name": "function_bumpy_road_bumps_for_warning", "value": 3},
+        {"name": "function_cyclomatic_complexity_warning", "value": 11},
+        {"name": "function_lines_of_code_warning", "value": 80}
+      ]
+    }
+  ]
+}

--- a/.codescene/custom-quality-gates.json
+++ b/.codescene/custom-quality-gates.json
@@ -1,0 +1,31 @@
+{
+  "usage": "Persist this file inside your repositories as .codescene/custom-quality-gates.json",
+  "rule_sets": [
+    {
+      "quality_gates": {
+        "hotspot_decline": false,
+        "critical_health_rules": false,
+        "advisory_health_rules": false,
+        "new_code_health": false,
+        "refactoring_goals": false,
+        "supervise_goals": false,
+        "codeowners_for_critical_code": false
+      },
+      "matching_content_path": "**/tests/**",
+      "matching_content_path_doc": "No gates on test files — large methods and duplication are expected in tests."
+    },
+    {
+      "quality_gates": {
+        "hotspot_decline": true,
+        "critical_health_rules": true,
+        "advisory_health_rules": true,
+        "new_code_health": false,
+        "refactoring_goals": false,
+        "supervise_goals": false,
+        "codeowners_for_critical_code": false
+      },
+      "matching_content_path": "*/**",
+      "matching_content_path_doc": "Production code: enforce critical + advisory rules (thresholds tuned in code-health-rules.json) and hotspot decline. Disable new_code_health (10.0 requirement is too strict for an established codebase)."
+    }
+  ]
+}

--- a/.codescene/custom-quality-gates.json
+++ b/.codescene/custom-quality-gates.json
@@ -25,7 +25,7 @@
         "codeowners_for_critical_code": false
       },
       "matching_content_path": "*/**",
-      "matching_content_path_doc": "Production code: enforce critical + advisory rules (thresholds tuned in code-health-rules.json) and hotspot decline. Disable new_code_health (10.0 requirement is too strict for an established codebase)."
+      "matching_content_path_doc": "Production code: critical + advisory rules + hotspot decline enabled. new_code_health is disabled because it requires a perfect 10.0 score on every new file — too strict for an established codebase where scores of 9.7-9.9 are acceptable. Revisit once the codebase baseline is well-understood. refactoring_goals and supervise_goals are disabled until Goals are configured in the CodeScene UI."
     }
   ]
 }


### PR DESCRIPTION
Adds two config files under `.codescene/` based on analysis of recent PR failures.

## What was failing and why

| PR | File | Gate | Root cause |
|---|---|---|---|
| #3245 | `json_collection.py` | critical + new_code_health | Bumpy Road Ahead; new file score 9.84 (below 10.0) |
| #3238 | `export.py` | critical | Bumpy Road Ahead |
| #3235 | `views.py` | advisory | Complex Method |
| #3233 | `test_export.py` | advisory | Large Method in a *test file* |
| #3233 | `export.py` | advisory | Excess Number of Function Arguments |

## `.codescene/custom-quality-gates.json`

| Path | Gates |
|---|---|
| `**/tests/**` | All off — large methods and duplication are expected in tests |
| `*/**` | `critical_health_rules` ✅ `advisory_health_rules` ✅ `hotspot_decline` ✅ |

`new_code_health` disabled globally — it requires a perfect 10.0 score on every new file, which is too strict for an established codebase. `refactoring_goals` / `supervise_goals` disabled until Goals are configured in the CodeScene UI.

## `.codescene/code-health-rules.json`

**Test files** (`**/tests/**`):
- `function_lines_of_code_warning`: 70 → **150** (thorough tests are long)
- `function_max_arguments`: 4 → **6**
- `unit_test_consecutive_asserts_for_large_block`: 4 → **10**
- `unit_test_suite_number_of_large_assertion_blocks`: 4 → **8**
- `function_duplication_min_lines_of_code_for_check`: 10 → **25**
- `Code Duplication` weight: **0.0** (disabled — fixture/setup repetition is normal)
- `Large Method` weight: **0.5** (tracked but not a hard fail)

**Production code** (`*/**`):
- `function_max_arguments`: 4 → **6** (Django views, Celery tasks, serializers)
- `function_bumpy_road_bumps_for_warning`: 2 → **3** (reduces noise in views/exports)
- `function_cyclomatic_complexity_warning`: 9 → **11**
- `function_lines_of_code_warning`: 70 → **80**

These are conservative bumps — enough to stop the noise from legitimate Django patterns without masking real problems.