### PR TITLE
Improve dev bootstrap data and isolate Redis per worktree

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -5,6 +5,9 @@ bootstrap = ".claude/hooks/setup-env.sh"
 database-url = "if grep -q '^DATABASE_URL=' .env; then sed -i.bak 's|^DATABASE_URL=.*|DATABASE_URL=postgres://postgres:postgres@localhost:5432/{{ branch | sanitize_db }}|' .env && rm -f .env.bak; else echo 'DATABASE_URL=postgres://postgres:postgres@localhost:5432/{{ branch | sanitize_db }}' >> .env; fi"
 
 [[pre-start]]
+redis-url = "REDIS_DB=$(echo '{{ branch | sanitize_db }}' | cksum | awk '{print ($1 % 15) + 1}'); if grep -q '^REDIS_URL=' .env; then sed -i.bak \"s|^REDIS_URL=.*|REDIS_URL=redis://localhost:6379/${REDIS_DB}|\" .env && rm -f .env.bak; else echo \"REDIS_URL=redis://localhost:6379/${REDIS_DB}\" >> .env; fi"
+
+[[pre-start]]
 create-database = "PGPASSWORD=postgres psql -h localhost -U postgres -tAc \"SELECT 1 FROM pg_database WHERE datname='{{ branch | sanitize_db }}'\" | grep -q 1 || PGPASSWORD=postgres psql -h localhost -U postgres -c 'CREATE DATABASE {{ branch | sanitize_db }}'"
 
 [post-start]
@@ -13,3 +16,4 @@ migrate-and-bootstrap = "uv run python manage.py migrate && uv run python manage
 
 [post-remove]
 db-remove = "PGPASSWORD=postgres psql -h localhost -U postgres -c \"DROP DATABASE IF EXISTS \\\"{{ branch | sanitize_db }}\\\" WITH (FORCE)\" || true"
+redis-flush = "REDIS_DB=$(echo '{{ branch | sanitize_db }}' | cksum | awk '{print ($1 % 15) + 1}'); redis-cli -n ${REDIS_DB} FLUSHDB || true"

--- a/.env.example
+++ b/.env.example
@@ -103,3 +103,38 @@ SYSTEM_AGENT_MODELS_LOW=
 SYSTEM_AGENT_API_KEYS=
 # Cloudflare Tunnel token (from Cloudflare dashboard > Networks > Tunnels)
 CLOUDFLARE_TUNNEL_TOKEN=
+
+## LLM Provider credentials (optional - used by `bootstrap_data` to seed
+## providers and by integration tests in apps/service_providers/tests/test_llm_integration.py).
+## Set the keys for whichever providers you want available; unset providers are skipped.
+
+# OpenAI
+# OPENAI_API_KEY=
+# OPENAI_API_BASE=
+# OPENAI_ORGANIZATION=
+
+# Anthropic
+# ANTHROPIC_API_KEY=
+# ANTHROPIC_API_BASE=https://api.anthropic.com
+
+# Google Gemini
+# GOOGLE_API_KEY=
+
+# Google Vertex AI (credentials must be a single-line JSON blob from a service-account key file)
+# GOOGLE_VERTEX_AI_CREDENTIALS_JSON=
+# GOOGLE_VERTEX_AI_LOCATION=global
+# GOOGLE_VERTEX_AI_API_TRANSPORT=rest
+
+# DeepSeek
+# DEEPSEEK_API_KEY=
+
+# Azure OpenAI
+# AZURE_OPENAI_API_KEY=
+# AZURE_OPENAI_ENDPOINT=
+# AZURE_OPENAI_API_VERSION=2024-02-15-preview
+
+# Groq
+# GROQ_API_KEY=
+
+# Perplexity
+# PERPLEXITY_API_KEY=

--- a/apps/service_providers/llm_service/credentials.py
+++ b/apps/service_providers/llm_service/credentials.py
@@ -1,0 +1,134 @@
+"""Load LLM provider credentials from environment variables.
+
+Used by the `bootstrap_data` management command and the integration test
+fixtures so the same env var → config mapping is shared between dev seeding
+and live integration tests.
+
+Each loader returns config dicts whose keys match the corresponding
+`apps.service_providers.forms.*ConfigForm`, so the result can be assigned
+straight to `LlmProvider.config`.
+"""
+
+import json
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from apps.service_providers.models import LlmProviderTypes
+
+
+@dataclass(frozen=True)
+class ProviderCredentials:
+    type: LlmProviderTypes
+    name: str
+    config: dict
+
+
+def _openai() -> ProviderCredentials | None:
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        return None
+    config = {"openai_api_key": api_key}
+    if api_base := os.environ.get("OPENAI_API_BASE"):
+        config["openai_api_base"] = api_base
+    if organization := os.environ.get("OPENAI_ORGANIZATION"):
+        config["openai_organization"] = organization
+    return ProviderCredentials(LlmProviderTypes.openai, "OpenAI", config)
+
+
+def _anthropic() -> ProviderCredentials | None:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        return None
+    return ProviderCredentials(
+        LlmProviderTypes.anthropic,
+        "Anthropic",
+        {
+            "anthropic_api_key": api_key,
+            "anthropic_api_base": os.environ.get("ANTHROPIC_API_BASE", "https://api.anthropic.com"),
+        },
+    )
+
+
+def _google() -> ProviderCredentials | None:
+    api_key = os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        return None
+    return ProviderCredentials(LlmProviderTypes.google, "Google Gemini", {"google_api_key": api_key})
+
+
+def _google_vertex_ai() -> ProviderCredentials | None:
+    credentials_json = os.environ.get("GOOGLE_VERTEX_AI_CREDENTIALS_JSON")
+    if not credentials_json:
+        return None
+    try:
+        credentials = json.loads(credentials_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"GOOGLE_VERTEX_AI_CREDENTIALS_JSON is not valid JSON: {exc}") from exc
+    return ProviderCredentials(
+        LlmProviderTypes.google_vertex_ai,
+        "Google Vertex AI",
+        {
+            "credentials_json": credentials,
+            "location": os.environ.get("GOOGLE_VERTEX_AI_LOCATION", "global"),
+            "api_transport": os.environ.get("GOOGLE_VERTEX_AI_API_TRANSPORT", "rest"),
+        },
+    )
+
+
+def _deepseek() -> ProviderCredentials | None:
+    api_key = os.environ.get("DEEPSEEK_API_KEY")
+    if not api_key:
+        return None
+    return ProviderCredentials(LlmProviderTypes.deepseek, "DeepSeek", {"deepseek_api_key": api_key})
+
+
+def _azure() -> ProviderCredentials | None:
+    api_key = os.environ.get("AZURE_OPENAI_API_KEY")
+    endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT")
+    if not (api_key and endpoint):
+        return None
+    return ProviderCredentials(
+        LlmProviderTypes.azure,
+        "Azure OpenAI",
+        {
+            "openai_api_key": api_key,
+            "openai_api_base": endpoint,
+            "openai_api_version": os.environ.get("AZURE_OPENAI_API_VERSION", "2024-02-15-preview"),
+        },
+    )
+
+
+def _groq() -> ProviderCredentials | None:
+    api_key = os.environ.get("GROQ_API_KEY")
+    if not api_key:
+        return None
+    return ProviderCredentials(LlmProviderTypes.groq, "Groq", {"openai_api_key": api_key})
+
+
+def _perplexity() -> ProviderCredentials | None:
+    api_key = os.environ.get("PERPLEXITY_API_KEY")
+    if not api_key:
+        return None
+    return ProviderCredentials(LlmProviderTypes.perplexity, "Perplexity", {"openai_api_key": api_key})
+
+
+_LOADERS: list[Callable[[], ProviderCredentials | None]] = [
+    _openai,
+    _anthropic,
+    _google,
+    _google_vertex_ai,
+    _deepseek,
+    _azure,
+    _groq,
+    _perplexity,
+]
+
+
+def get_provider_credentials_from_env() -> list[ProviderCredentials]:
+    """Return one entry per LLM provider that has its env vars configured."""
+    return [creds for loader in _LOADERS if (creds := loader())]
+
+
+def get_provider_credentials_for_type(provider_type: LlmProviderTypes) -> ProviderCredentials | None:
+    return next((c for c in get_provider_credentials_from_env() if c.type == provider_type), None)

--- a/apps/service_providers/tests/test_llm_credentials.py
+++ b/apps/service_providers/tests/test_llm_credentials.py
@@ -1,0 +1,101 @@
+import json
+
+import pytest
+
+from apps.service_providers.llm_service.credentials import (
+    get_provider_credentials_for_type,
+    get_provider_credentials_from_env,
+)
+from apps.service_providers.models import LlmProviderTypes
+
+_PROVIDER_VARS = [
+    "OPENAI_API_KEY",
+    "OPENAI_API_BASE",
+    "OPENAI_ORGANIZATION",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_API_BASE",
+    "GOOGLE_API_KEY",
+    "GOOGLE_VERTEX_AI_CREDENTIALS_JSON",
+    "GOOGLE_VERTEX_AI_LOCATION",
+    "GOOGLE_VERTEX_AI_API_TRANSPORT",
+    "DEEPSEEK_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_OPENAI_ENDPOINT",
+    "AZURE_OPENAI_API_VERSION",
+    "GROQ_API_KEY",
+    "PERPLEXITY_API_KEY",
+]
+
+
+@pytest.fixture()
+def clean_env(monkeypatch):
+    """Strip all provider env vars so tests start from a known state."""
+    for var in _PROVIDER_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+def test_returns_empty_when_no_env_vars_set(clean_env):
+    assert get_provider_credentials_from_env() == []
+
+
+def test_openai_minimal_config(clean_env):
+    clean_env.setenv("OPENAI_API_KEY", "sk-test")
+    creds = get_provider_credentials_for_type(LlmProviderTypes.openai)
+    assert creds is not None
+    assert creds.config == {"openai_api_key": "sk-test"}
+
+
+def test_openai_optional_fields_only_included_when_set(clean_env):
+    clean_env.setenv("OPENAI_API_KEY", "sk-test")
+    clean_env.setenv("OPENAI_API_BASE", "https://proxy.example.com")
+    clean_env.setenv("OPENAI_ORGANIZATION", "org-1")
+    creds = get_provider_credentials_for_type(LlmProviderTypes.openai)
+    assert creds.config == {
+        "openai_api_key": "sk-test",
+        "openai_api_base": "https://proxy.example.com",
+        "openai_organization": "org-1",
+    }
+
+
+def test_anthropic_uses_default_api_base(clean_env):
+    clean_env.setenv("ANTHROPIC_API_KEY", "sk-ant")
+    creds = get_provider_credentials_for_type(LlmProviderTypes.anthropic)
+    assert creds.config == {
+        "anthropic_api_key": "sk-ant",
+        "anthropic_api_base": "https://api.anthropic.com",
+    }
+
+
+def test_azure_requires_both_api_key_and_endpoint(clean_env):
+    clean_env.setenv("AZURE_OPENAI_API_KEY", "key")
+    assert get_provider_credentials_for_type(LlmProviderTypes.azure) is None
+
+    clean_env.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com/")
+    creds = get_provider_credentials_for_type(LlmProviderTypes.azure)
+    assert creds is not None
+    assert creds.config["openai_api_base"] == "https://example.openai.azure.com/"
+    assert creds.config["openai_api_version"] == "2024-02-15-preview"
+
+
+def test_google_vertex_ai_parses_credentials_json(clean_env):
+    payload = {"type": "service_account", "project_id": "test"}
+    clean_env.setenv("GOOGLE_VERTEX_AI_CREDENTIALS_JSON", json.dumps(payload))
+    creds = get_provider_credentials_for_type(LlmProviderTypes.google_vertex_ai)
+    assert creds.config["credentials_json"] == payload
+    assert creds.config["location"] == "global"
+    assert creds.config["api_transport"] == "rest"
+
+
+def test_google_vertex_ai_invalid_json_raises(clean_env):
+    clean_env.setenv("GOOGLE_VERTEX_AI_CREDENTIALS_JSON", "{not valid json")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        get_provider_credentials_for_type(LlmProviderTypes.google_vertex_ai)
+
+
+def test_returns_one_entry_per_configured_provider(clean_env):
+    clean_env.setenv("OPENAI_API_KEY", "k1")
+    clean_env.setenv("ANTHROPIC_API_KEY", "k2")
+    clean_env.setenv("GROQ_API_KEY", "k3")
+    slugs = sorted(creds.type.slug for creds in get_provider_credentials_from_env())
+    assert slugs == ["anthropic", "groq", "openai"]

--- a/apps/service_providers/tests/test_llm_integration.py
+++ b/apps/service_providers/tests/test_llm_integration.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 import environ
@@ -13,6 +12,7 @@ from apps.pipelines.tests.utils import (
     llm_response_with_prompt_node,
     start_node,
 )
+from apps.service_providers.llm_service.credentials import get_provider_credentials_for_type
 from apps.service_providers.llm_service.default_models import get_default_model
 from apps.service_providers.models import LlmProvider, LlmProviderModel, LlmProviderTypes
 from apps.service_providers.tracing import TracingService
@@ -21,115 +21,59 @@ from apps.utils.factories.pipelines import PipelineFactory
 
 pytestmark = pytest.mark.integration
 
-# Load environment variables using django-environ
-env = environ.Env()
+# Load env file (.env.integration if present, else .env) so the credentials helper can read os.environ.
+_env_file = os.path.join(settings.BASE_DIR, ".env.integration")
+if not os.path.exists(_env_file):
+    _env_file = os.path.join(settings.BASE_DIR, ".env")
+environ.Env().read_env(_env_file)
 
-# Try to load .env.integration if it exists, otherwise use regular .env
-integration_env = os.path.join(settings.BASE_DIR, ".env.integration")
-if os.path.exists(integration_env):
-    env.read_env(integration_env)
-else:
-    env.read_env(os.path.join(settings.BASE_DIR, ".env"))
+
+def _credentials_or_skip(provider_type: LlmProviderTypes, missing_env: str) -> dict:
+    """Return the provider config from env, or skip the test if it isn't configured."""
+    creds = get_provider_credentials_for_type(provider_type)
+    if not creds:
+        pytest.skip(f"{missing_env} not set")
+    return creds.config
 
 
 @pytest.fixture()
 def openai_credentials():
-    """Get real OpenAI credentials from environment"""
-    api_key = env.str("OPENAI_API_KEY", default=None)
-    if not api_key:
-        pytest.skip("OPENAI_API_KEY not set")
-    return {
-        "openai_api_key": api_key,
-        "openai_api_base": env.str("OPENAI_API_BASE", default=None),
-        "openai_organization": env.str("OPENAI_ORGANIZATION", default=None),
-    }
+    return _credentials_or_skip(LlmProviderTypes.openai, "OPENAI_API_KEY")
 
 
 @pytest.fixture()
 def anthropic_credentials():
-    """Get real Anthropic credentials from environment"""
-    api_key = env.str("ANTHROPIC_API_KEY", default=None)
-    if not api_key:
-        pytest.skip("ANTHROPIC_API_KEY not set")
-    return {"anthropic_api_key": api_key, "anthropic_api_base": "https://api.anthropic.com"}
+    return _credentials_or_skip(LlmProviderTypes.anthropic, "ANTHROPIC_API_KEY")
 
 
 @pytest.fixture()
 def google_credentials():
-    """Get real Google Gemini credentials from environment"""
-    api_key = env.str("GOOGLE_API_KEY", default=None)
-    if not api_key:
-        pytest.skip("GOOGLE_API_KEY not set")
-    return {
-        "google_api_key": api_key,
-    }
+    return _credentials_or_skip(LlmProviderTypes.google, "GOOGLE_API_KEY")
 
 
 @pytest.fixture()
 def google_vertex_ai_credentials():
-    """Get real Google Vertex AI credentials from environment"""
-
-    credentials_json_str = env.str("GOOGLE_VERTEX_AI_CREDENTIALS_JSON", default=None)
-    if not credentials_json_str:
-        pytest.skip("GOOGLE_VERTEX_AI_CREDENTIALS_JSON not set")
-
-    try:
-        credentials_json = json.loads(credentials_json_str)
-    except json.JSONDecodeError:
-        pytest.skip("GOOGLE_VERTEX_AI_CREDENTIALS_JSON is not valid JSON")
-
-    return {
-        "credentials_json": credentials_json,
-        "location": env.str("GOOGLE_VERTEX_AI_LOCATION", default="global"),
-        "api_transport": env.str("GOOGLE_VERTEX_AI_API_TRANSPORT", default="rest"),
-    }
+    return _credentials_or_skip(LlmProviderTypes.google_vertex_ai, "GOOGLE_VERTEX_AI_CREDENTIALS_JSON")
 
 
 @pytest.fixture()
 def deepseek_credentials():
-    """Get real DeepSeek credentials from environment"""
-    api_key = env.str("DEEPSEEK_API_KEY", default=None)
-    if not api_key:
-        pytest.skip("DEEPSEEK_API_KEY not set")
-    return {
-        "deepseek_api_key": api_key,
-    }
+    return _credentials_or_skip(LlmProviderTypes.deepseek, "DEEPSEEK_API_KEY")
 
 
 @pytest.fixture()
 def azure_credentials():
-    """Get real Azure OpenAI credentials from environment"""
-    api_key = env.str("AZURE_OPENAI_API_KEY", default=None)
-    endpoint = env.str("AZURE_OPENAI_ENDPOINT", default=None)
-    if not (api_key and endpoint):
-        pytest.skip("AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT not set")
-    return {
-        "openai_api_key": api_key,
-        "openai_api_base": endpoint,
-        "openai_api_version": env.str("AZURE_OPENAI_API_VERSION", default="2024-02-15-preview"),
-    }
+    return _credentials_or_skip(LlmProviderTypes.azure, "AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT")
 
 
 @pytest.fixture()
 def groq_credentials():
-    """Get real Groq credentials from environment"""
-    api_key = env.str("GROQ_API_KEY", default=None)
-    if not api_key:
-        pytest.skip("GROQ_API_KEY not set")
-    return {
-        "openai_api_key": api_key,
-    }
+    return _credentials_or_skip(LlmProviderTypes.groq, "GROQ_API_KEY")
 
 
 @pytest.fixture()
 def perplexity_credentials():
-    """Get real Perplexity credentials from environment"""
-    api_key = env.str("PERPLEXITY_API_KEY", default=None)
-    if not api_key:
-        pytest.skip("PERPLEXITY_API_KEY not set")
-    return {
-        "openai_api_key": api_key,
-    }
+    return _credentials_or_skip(LlmProviderTypes.perplexity, "PERPLEXITY_API_KEY")
 
 
 def _run_llm_pipeline_test(

--- a/apps/web/management/commands/bootstrap_data.py
+++ b/apps/web/management/commands/bootstrap_data.py
@@ -37,6 +37,38 @@ from apps.teams import backends
 from apps.teams.models import Membership, Team
 from apps.trace.models import Trace, TraceStatus
 
+_PIPELINE_NAMES = [
+    "Customer Support Pipeline",
+    "Language Learning Pipeline",
+    "Health Advisory Pipeline",
+    "Programming Help Pipeline",
+]
+_CHATBOT_NAMES = [
+    "Customer Support Bot",
+    "Language Tutor",
+    "Health Assistant",
+    "Programming Helper",
+]
+_TAG_NAMES = ["urgent", "resolved", "needs-review", "feedback"]
+_PARTICIPANT_DATA = [
+    {"name": "Alice Johnson", "identifier": "alice.johnson@example.com", "platform": "web"},
+    {"name": "Bob Smith", "identifier": "bob.smith@example.com", "platform": "web"},
+    {"name": "Carol Williams", "identifier": "carol.williams@example.com", "platform": "api"},
+    {"name": "David Brown", "identifier": "david.brown@example.com", "platform": "web"},
+    {"name": "Eve Davis", "identifier": "eve.davis@example.com", "platform": "api"},
+]
+_FILE_DATA = [
+    ("documentation.pdf", "application/pdf", b"Sample PDF content for testing"),
+    ("data.csv", "text/csv", b"name,age,city\nAlice,30,NYC\nBob,25,LA\n"),
+    ("report.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", b"Sample DOCX"),
+    ("image.png", "image/png", b"\x89PNG\r\n\x1a\n..."),
+]
+_EVALUATION_DATASET_MESSAGES = [
+    ("My order arrived broken!", "I'm so sorry — let me get a replacement out today."),
+    ("Thanks for the fast shipping!", "Glad to hear it — enjoy!"),
+    ("This product doesn't match the description.", "I understand, let me help you with a return."),
+]
+
 
 class Command(BaseCommand):
     help = "Seeds the database with sample data for development and E2E testing."
@@ -154,9 +186,18 @@ class Command(BaseCommand):
         return user, team
 
     def _seed_sample_data(self, user, team):
-        """Create sample pipelines, experiments, participants, files, etc."""
+        """Orchestrate creation of sample pipelines, experiments, tags, sessions, traces, etc."""
+        llm_provider, llm_model = self._seed_llm_providers(team)
+        pipelines = self._seed_pipelines(team, llm_provider, llm_model)
+        experiments = self._seed_experiments(user, team, pipelines)
+        tags = self._seed_tags(user, team)
+        sessions = self._seed_participants_and_sessions(user, team, experiments, tags)
+        self._seed_traces(team, sessions)
+        files = self._seed_files(team)
+        self._seed_collection(team, files)
+        self._seed_evaluation(team, llm_provider, llm_model)
 
-        # LLM Providers (one per configured env var set; falls back to a placeholder)
+    def _seed_llm_providers(self, team):
         self.stdout.write("")
         self.stdout.write("--- Creating LLM Providers ---")
         provider_credentials = get_provider_credentials_from_env()
@@ -175,50 +216,38 @@ class Command(BaseCommand):
                 )
             ]
 
-        llm_providers = []
-        for creds in provider_credentials:
-            provider, created = LlmProvider.objects.get_or_create(
-                team=team,
-                type=str(creds.type),
-                defaults={"name": creds.name, "config": creds.config},
-            )
-            self._log_created("LLM provider", f"{provider.name} ({creds.type})", created)
-            llm_providers.append(provider)
-
-        # Use the first provider as the default for chatbots and assistants
+        llm_providers = [self._get_or_create_llm_provider(team, creds) for creds in provider_credentials]
         llm_provider = llm_providers[0]
-        llm_model = get_first_llm_provider_model(llm_provider, team.id)
+        return llm_provider, get_first_llm_provider_model(llm_provider, team.id)
 
-        # Pipelines
+    def _get_or_create_llm_provider(self, team, creds: ProviderCredentials) -> LlmProvider:
+        # LlmProvider has no unique constraint on (team, type), so a manually-created
+        # provider of the same type would make get_or_create raise MultipleObjectsReturned.
+        provider = LlmProvider.objects.filter(team=team, type=str(creds.type)).first()
+        if provider is None:
+            provider = LlmProvider.objects.create(team=team, type=str(creds.type), name=creds.name, config=creds.config)
+            self._log_created("LLM provider", f"{provider.name} ({creds.type})", True)
+        else:
+            self._log_created("LLM provider", f"{provider.name} ({creds.type})", False)
+        return provider
+
+    def _seed_pipelines(self, team, llm_provider, llm_model):
         self.stdout.write("")
         self.stdout.write("--- Creating Pipelines ---")
-        pipeline_names = [
-            "Customer Support Pipeline",
-            "Language Learning Pipeline",
-            "Health Advisory Pipeline",
-            "Programming Help Pipeline",
-        ]
-
         pipelines = []
-        for name in pipeline_names:
+        for name in _PIPELINE_NAMES:
             pipeline = Pipeline.create_default(
                 team=team, name=name, llm_provider_id=llm_provider.id, llm_provider_model=llm_model
             )
             self._log_created("pipeline", name, True)
             pipelines.append(pipeline)
+        return pipelines
 
-        # Experiments (Chatbots)
+    def _seed_experiments(self, user, team, pipelines):
         self.stdout.write("")
         self.stdout.write("--- Creating Chatbots (Experiments) ---")
-        chatbot_names = [
-            "Customer Support Bot",
-            "Language Tutor",
-            "Health Assistant",
-            "Programming Helper",
-        ]
-
         experiments = []
-        for i, (name, pipeline) in enumerate(zip(chatbot_names, pipelines, strict=True), 1):
+        for i, (name, pipeline) in enumerate(zip(_CHATBOT_NAMES, pipelines, strict=True), 1):
             experiment, created = Experiment.objects.get_or_create(
                 team=team,
                 name=name,
@@ -230,13 +259,13 @@ class Command(BaseCommand):
             )
             self._log_created("experiment", name, created)
             experiments.append(experiment)
+        return experiments
 
-        # Tags
+    def _seed_tags(self, user, team):
         self.stdout.write("")
         self.stdout.write("--- Creating Tags ---")
-        tag_names = ["urgent", "resolved", "needs-review", "feedback"]
         tags = []
-        for tag_name in tag_names:
+        for tag_name in _TAG_NAMES:
             tag, created = Tag.objects.get_or_create(
                 team=team,
                 name=tag_name,
@@ -246,92 +275,82 @@ class Command(BaseCommand):
             )
             self._log_created("tag", tag_name, created)
             tags.append(tag)
+        return tags
 
-        # Participants with Sessions (spread across experiments, tagged for variety)
+    def _seed_participants_and_sessions(self, user, team, experiments, tags) -> list[ExperimentSession]:
         self.stdout.write("")
         self.stdout.write("--- Creating Participants with Sessions ---")
-        participant_data = [
-            {"name": "Alice Johnson", "identifier": "alice.johnson@example.com", "platform": "web"},
-            {"name": "Bob Smith", "identifier": "bob.smith@example.com", "platform": "web"},
-            {"name": "Carol Williams", "identifier": "carol.williams@example.com", "platform": "api"},
-            {"name": "David Brown", "identifier": "david.brown@example.com", "platform": "web"},
-            {"name": "Eve Davis", "identifier": "eve.davis@example.com", "platform": "api"},
-        ]
-
         seeded_sessions = []
-        for idx, data in enumerate(participant_data):
+        for idx, data in enumerate(_PARTICIPANT_DATA):
             participant, created = Participant.objects.get_or_create(
                 team=team,
                 platform=data["platform"],
                 identifier=data["identifier"],
                 defaults={"name": data["name"]},
             )
-
             if not created:
                 self._log_created("participant", data["name"], created)
                 continue
 
             self._log_created("participant", f"{data['name']} ({data['identifier']})", created)
             target_experiment = experiments[idx % len(experiments)]
-            session = ExperimentSession.objects.create(team=team, experiment=target_experiment, participant=participant)
-            ChatMessage.objects.create(
-                chat=session.chat,
-                message_type=ChatMessageType.HUMAN,
-                content=f"Hello, I'm {data['name']}. Can you help me?",
-            )
-            ChatMessage.objects.create(
-                chat=session.chat,
-                message_type=ChatMessageType.AI,
-                content=f"Hello {data['name']}! I'd be happy to help. What do you need?",
-            )
-            ChatMessage.objects.create(
-                chat=session.chat,
-                message_type=ChatMessageType.HUMAN,
-                content="I have a question about your service.",
-            )
-            session.chat.add_tag(tags[idx % len(tags)], team=team, added_by=user)
+            tag = tags[idx % len(tags)]
+            session = self._create_session_with_messages(user, team, target_experiment, participant, data, tag)
             seeded_sessions.append(session)
-            self.stdout.write(
-                f"    Session for {data['name']} → {target_experiment.name} (tag: {tags[idx % len(tags)].name})"
+            self.stdout.write(f"    Session for {data['name']} → {target_experiment.name} (tag: {tag.name})")
+        return seeded_sessions
+
+    def _create_session_with_messages(self, user, team, experiment, participant, data, tag) -> ExperimentSession:
+        session = ExperimentSession.objects.create(team=team, experiment=experiment, participant=participant)
+        ChatMessage.objects.create(
+            chat=session.chat,
+            message_type=ChatMessageType.HUMAN,
+            content=f"Hello, I'm {data['name']}. Can you help me?",
+        )
+        ChatMessage.objects.create(
+            chat=session.chat,
+            message_type=ChatMessageType.AI,
+            content=f"Hello {data['name']}! I'd be happy to help. What do you need?",
+        )
+        ChatMessage.objects.create(
+            chat=session.chat,
+            message_type=ChatMessageType.HUMAN,
+            content="I have a question about your service.",
+        )
+        session.chat.add_tag(tag, team=team, added_by=user)
+        return session
+
+    def _seed_traces(self, team, sessions: list[ExperimentSession]) -> None:
+        if not sessions:
+            return
+        self.stdout.write("")
+        self.stdout.write("--- Creating Traces ---")
+        for session in sessions:
+            messages = list(session.chat.messages.order_by("created_at"))
+            input_msg = next((m for m in messages if m.message_type == ChatMessageType.HUMAN), None)
+            output_msg = next((m for m in messages if m.message_type == ChatMessageType.AI), None)
+            Trace.objects.create(
+                team=team,
+                experiment=session.experiment,
+                session=session,
+                participant=session.participant,
+                input_message=input_msg,
+                output_message=output_msg,
+                status=TraceStatus.SUCCESS,
+                duration=1234,
+                n_turns=1,
+                n_toolcalls=0,
+                n_total_tokens=250,
+                n_prompt_tokens=200,
+                n_completion_tokens=50,
             )
+        self.stdout.write(self.style.SUCCESS(f"  Created {len(sessions)} trace(s)"))
 
-        # Traces (one per seeded session, with realistic-looking metrics)
-        if seeded_sessions:
-            self.stdout.write("")
-            self.stdout.write("--- Creating Traces ---")
-            for session in seeded_sessions:
-                messages = list(session.chat.messages.order_by("created_at"))
-                input_msg = next((m for m in messages if m.message_type == ChatMessageType.HUMAN), None)
-                output_msg = next((m for m in messages if m.message_type == ChatMessageType.AI), None)
-                Trace.objects.create(
-                    team=team,
-                    experiment=session.experiment,
-                    session=session,
-                    participant=session.participant,
-                    input_message=input_msg,
-                    output_message=output_msg,
-                    status=TraceStatus.SUCCESS,
-                    duration=1234,
-                    n_turns=1,
-                    n_toolcalls=0,
-                    n_total_tokens=250,
-                    n_prompt_tokens=200,
-                    n_completion_tokens=50,
-                )
-            self.stdout.write(self.style.SUCCESS(f"  Created {len(seeded_sessions)} trace(s)"))
-
-        # Files
+    def _seed_files(self, team) -> list[File]:
         self.stdout.write("")
         self.stdout.write("--- Creating Files ---")
-        file_data = [
-            ("documentation.pdf", "application/pdf", b"Sample PDF content for testing"),
-            ("data.csv", "text/csv", b"name,age,city\nAlice,30,NYC\nBob,25,LA\n"),
-            ("report.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", b"Sample DOCX"),
-            ("image.png", "image/png", b"\x89PNG\r\n\x1a\n..."),
-        ]
-
         created_files = []
-        for filename, content_type, content in file_data:
+        for filename, content_type, content in _FILE_DATA:
             uploaded_file = SimpleUploadedFile(filename, content, content_type=content_type)
             file_obj, created = File.objects.get_or_create(
                 team=team,
@@ -344,8 +363,9 @@ class Command(BaseCommand):
             )
             self._log_created("file", filename, created)
             created_files.append(file_obj)
+        return created_files
 
-        # Collection
+    def _seed_collection(self, team, files: list[File]) -> None:
         self.stdout.write("")
         self.stdout.write("--- Creating Collection ---")
         collection_name = "Sample Documents Collection"
@@ -354,22 +374,32 @@ class Command(BaseCommand):
             name=collection_name,
             defaults={"is_index": False},
         )
-
+        self._log_created("collection", collection_name, created)
+        if not files:
+            return
         if created:
-            self._log_created("collection", collection_name, created)
-            if created_files:
-                collection.files.set(created_files)
-                self.stdout.write(f"    Added {len(created_files)} file(s) to collection")
+            collection.files.set(files)
+            self.stdout.write(f"    Added {len(files)} file(s) to collection")
         else:
-            self._log_created("collection", collection_name, created)
-            if created_files:
-                collection.files.add(*created_files)
-                self.stdout.write(f"    Ensured {len(created_files)} file(s) in collection")
+            collection.files.add(*files)
+            self.stdout.write(f"    Ensured {len(files)} file(s) in collection")
 
-        # Evaluation (Evaluator + Dataset + Config)
+    def _seed_evaluation(self, team, llm_provider, llm_model) -> None:
         self.stdout.write("")
         self.stdout.write("--- Creating Evaluation ---")
-        evaluator_params = {
+        evaluator = self._seed_evaluator(team, llm_provider, llm_model)
+        dataset = self._seed_evaluation_dataset(team)
+        config, created = EvaluationConfig.objects.get_or_create(
+            team=team,
+            name="Sentiment Analysis Run",
+            defaults={"dataset": dataset},
+        )
+        if created:
+            config.evaluators.add(evaluator)
+        self._log_created("evaluation config", config.name, created)
+
+    def _seed_evaluator(self, team, llm_provider, llm_model) -> Evaluator:
+        params = {
             "llm_provider_id": llm_provider.id,
             "llm_temperature": 0.3,
             "prompt": (
@@ -392,7 +422,7 @@ class Command(BaseCommand):
             },
         }
         if llm_model:
-            evaluator_params["llm_provider_model_id"] = llm_model.id
+            params["llm_provider_model_id"] = llm_model.id
 
         evaluator, created = Evaluator.objects.get_or_create(
             team=team,
@@ -400,11 +430,13 @@ class Command(BaseCommand):
             defaults={
                 "type": "LlmEvaluator",
                 "evaluation_mode": EvaluationMode.MESSAGE,
-                "params": evaluator_params,
+                "params": params,
             },
         )
         self._log_created("evaluator", evaluator.name, created)
+        return evaluator
 
+    def _seed_evaluation_dataset(self, team) -> EvaluationDataset:
         dataset, created = EvaluationDataset.objects.get_or_create(
             team=team,
             name="Sample Customer Messages",
@@ -412,27 +444,14 @@ class Command(BaseCommand):
         )
         self._log_created("dataset", dataset.name, created)
         if created:
-            sample_msgs = [
-                ("My order arrived broken!", "I'm so sorry — let me get a replacement out today."),
-                ("Thanks for the fast shipping!", "Glad to hear it — enjoy!"),
-                ("This product doesn't match the description.", "I understand, let me help you with a return."),
-            ]
-            for input_text, output_text in sample_msgs:
+            for input_text, output_text in _EVALUATION_DATASET_MESSAGES:
                 msg = EvaluationMessage.objects.create(
                     input={"content": input_text, "role": "human"},
                     output={"content": output_text, "role": "ai"},
                 )
                 dataset.messages.add(msg)
-            self.stdout.write(f"    Added {len(sample_msgs)} sample messages to dataset")
-
-        config, created = EvaluationConfig.objects.get_or_create(
-            team=team,
-            name="Sentiment Analysis Run",
-            defaults={"dataset": dataset},
-        )
-        if created:
-            config.evaluators.add(evaluator)
-        self._log_created("evaluation config", config.name, created)
+            self.stdout.write(f"    Added {len(_EVALUATION_DATASET_MESSAGES)} sample messages to dataset")
+        return dataset
 
     def _log_created(self, entity_type: str, name: str, created: bool):
         """Helper to log entity creation status."""

--- a/apps/web/management/commands/bootstrap_data.py
+++ b/apps/web/management/commands/bootstrap_data.py
@@ -10,22 +10,32 @@ Usage:
     python manage.py bootstrap_data --skip-sample-data  # Only create user/team
 """
 
-import os
-
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management.base import BaseCommand
 
-from apps.assistants.models import OpenAiAssistant
+from apps.annotations.models import Tag
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.documents.models import Collection
+from apps.evaluations.models import (
+    EvaluationConfig,
+    EvaluationDataset,
+    EvaluationMessage,
+    EvaluationMode,
+    Evaluator,
+)
 from apps.experiments.models import Experiment, ExperimentSession, Participant
 from apps.files.models import File, FilePurpose
 from apps.pipelines.models import Pipeline
-from apps.service_providers.models import LlmProvider
+from apps.service_providers.llm_service.credentials import (
+    ProviderCredentials,
+    get_provider_credentials_from_env,
+)
+from apps.service_providers.models import LlmProvider, LlmProviderTypes
 from apps.service_providers.utils import get_first_llm_provider_model
 from apps.teams import backends
 from apps.teams.models import Membership, Team
+from apps.trace.models import Trace, TraceStatus
 
 
 class Command(BaseCommand):
@@ -146,17 +156,37 @@ class Command(BaseCommand):
     def _seed_sample_data(self, user, team):
         """Create sample pipelines, experiments, participants, files, etc."""
 
-        # LLM Provider and Model
+        # LLM Providers (one per configured env var set; falls back to a placeholder)
         self.stdout.write("")
-        self.stdout.write("--- Creating LLM Provider ---")
-        openai_api_key = os.environ.get("OPENAI_SECRET_KEY", "test-key")
-        llm_provider, created = LlmProvider.objects.get_or_create(
-            name="OpenAI", team=team, defaults={"type": "openai", "config": {"openai_api_key": openai_api_key}}
-        )
-        if created and openai_api_key != "test-key":
-            self.stdout.write(self.style.SUCCESS("  Using OPENAI_SECRET_KEY from environment"))
-        self._log_created("LLM provider", llm_provider.name, created)
+        self.stdout.write("--- Creating LLM Providers ---")
+        provider_credentials = get_provider_credentials_from_env()
+        if not provider_credentials:
+            self.stdout.write(
+                self.style.WARNING(
+                    "  No provider env vars set; creating a placeholder OpenAI provider with a dummy key."
+                    " Set OPENAI_API_KEY (or another supported key — see .env.example) to enable real LLM calls."
+                )
+            )
+            provider_credentials = [
+                ProviderCredentials(
+                    type=LlmProviderTypes.openai,
+                    name="OpenAI",
+                    config={"openai_api_key": "test-key"},
+                )
+            ]
 
+        llm_providers = []
+        for creds in provider_credentials:
+            provider, created = LlmProvider.objects.get_or_create(
+                team=team,
+                type=str(creds.type),
+                defaults={"name": creds.name, "config": creds.config},
+            )
+            self._log_created("LLM provider", f"{provider.name} ({creds.type})", created)
+            llm_providers.append(provider)
+
+        # Use the first provider as the default for chatbots and assistants
+        llm_provider = llm_providers[0]
         llm_model = get_first_llm_provider_model(llm_provider, team.id)
 
         # Pipelines
@@ -187,42 +217,37 @@ class Command(BaseCommand):
             "Programming Helper",
         ]
 
-        for i, name in enumerate(chatbot_names, 1):
-            _experiment, created = Experiment.objects.get_or_create(
+        experiments = []
+        for i, (name, pipeline) in enumerate(zip(chatbot_names, pipelines, strict=True), 1):
+            experiment, created = Experiment.objects.get_or_create(
                 team=team,
                 name=name,
                 defaults={
                     "owner": user,
                     "description": f"Test pipeline chatbot #{i} for development",
-                    "pipeline": pipelines[i - 1] if i <= len(pipelines) else None,
+                    "pipeline": pipeline,
                 },
             )
             self._log_created("experiment", name, created)
+            experiments.append(experiment)
 
-        # Assistants
+        # Tags
         self.stdout.write("")
-        self.stdout.write("--- Creating Assistants ---")
-        assistant_names = [
-            "Code Review Assistant",
-            "Documentation Writer",
-            "Bug Triage Assistant",
-        ]
-
-        for i, name in enumerate(assistant_names, 1):
-            assistant, created = OpenAiAssistant.objects.get_or_create(
+        self.stdout.write("--- Creating Tags ---")
+        tag_names = ["urgent", "resolved", "needs-review", "feedback"]
+        tags = []
+        for tag_name in tag_names:
+            tag, created = Tag.objects.get_or_create(
                 team=team,
-                name=name,
-                defaults={
-                    "assistant_id": f"test_asst_{i}",
-                    "instructions": f"You are a {name.lower()} that helps developers.",
-                    "llm_provider": llm_provider,
-                    "llm_provider_model": llm_model,
-                    "temperature": 0.8,
-                },
+                name=tag_name,
+                is_system_tag=False,
+                category="",
+                defaults={"created_by": user},
             )
-            self._log_created("assistant", name, created)
+            self._log_created("tag", tag_name, created)
+            tags.append(tag)
 
-        # Participants with Sessions
+        # Participants with Sessions (spread across experiments, tagged for variety)
         self.stdout.write("")
         self.stdout.write("--- Creating Participants with Sessions ---")
         participant_data = [
@@ -233,9 +258,8 @@ class Command(BaseCommand):
             {"name": "Eve Davis", "identifier": "eve.davis@example.com", "platform": "api"},
         ]
 
-        first_experiment = Experiment.objects.filter(team=team).first()
-
-        for data in participant_data:
+        seeded_sessions = []
+        for idx, data in enumerate(participant_data):
             participant, created = Participant.objects.get_or_create(
                 team=team,
                 platform=data["platform"],
@@ -243,31 +267,58 @@ class Command(BaseCommand):
                 defaults={"name": data["name"]},
             )
 
-            if created:
-                self._log_created("participant", f"{data['name']} ({data['identifier']})", created)
+            if not created:
+                self._log_created("participant", data["name"], created)
+                continue
 
-                if first_experiment:
-                    session = ExperimentSession.objects.create(
-                        team=team, experiment=first_experiment, participant=participant
-                    )
-                    ChatMessage.objects.create(
-                        chat=session.chat,
-                        message_type=ChatMessageType.HUMAN,
-                        content=f"Hello, I'm {data['name']}. Can you help me?",
-                    )
-                    ChatMessage.objects.create(
-                        chat=session.chat,
-                        message_type=ChatMessageType.AI,
-                        content=f"Hello {data['name']}! I'd be happy to help. What do you need?",
-                    )
-                    ChatMessage.objects.create(
-                        chat=session.chat,
-                        message_type=ChatMessageType.HUMAN,
-                        content="I have a question about your service.",
-                    )
-                    self.stdout.write(f"    Created session and messages for {data['name']}")
-            else:
-                self._log_created("participant", f"{data['name']}", created)
+            self._log_created("participant", f"{data['name']} ({data['identifier']})", created)
+            target_experiment = experiments[idx % len(experiments)]
+            session = ExperimentSession.objects.create(team=team, experiment=target_experiment, participant=participant)
+            ChatMessage.objects.create(
+                chat=session.chat,
+                message_type=ChatMessageType.HUMAN,
+                content=f"Hello, I'm {data['name']}. Can you help me?",
+            )
+            ChatMessage.objects.create(
+                chat=session.chat,
+                message_type=ChatMessageType.AI,
+                content=f"Hello {data['name']}! I'd be happy to help. What do you need?",
+            )
+            ChatMessage.objects.create(
+                chat=session.chat,
+                message_type=ChatMessageType.HUMAN,
+                content="I have a question about your service.",
+            )
+            session.chat.add_tag(tags[idx % len(tags)], team=team, added_by=user)
+            seeded_sessions.append(session)
+            self.stdout.write(
+                f"    Session for {data['name']} → {target_experiment.name} (tag: {tags[idx % len(tags)].name})"
+            )
+
+        # Traces (one per seeded session, with realistic-looking metrics)
+        if seeded_sessions:
+            self.stdout.write("")
+            self.stdout.write("--- Creating Traces ---")
+            for session in seeded_sessions:
+                messages = list(session.chat.messages.order_by("created_at"))
+                input_msg = next((m for m in messages if m.message_type == ChatMessageType.HUMAN), None)
+                output_msg = next((m for m in messages if m.message_type == ChatMessageType.AI), None)
+                Trace.objects.create(
+                    team=team,
+                    experiment=session.experiment,
+                    session=session,
+                    participant=session.participant,
+                    input_message=input_msg,
+                    output_message=output_msg,
+                    status=TraceStatus.SUCCESS,
+                    duration=1234,
+                    n_turns=1,
+                    n_toolcalls=0,
+                    n_total_tokens=250,
+                    n_prompt_tokens=200,
+                    n_completion_tokens=50,
+                )
+            self.stdout.write(self.style.SUCCESS(f"  Created {len(seeded_sessions)} trace(s)"))
 
         # Files
         self.stdout.write("")
@@ -314,6 +365,74 @@ class Command(BaseCommand):
             if created_files:
                 collection.files.add(*created_files)
                 self.stdout.write(f"    Ensured {len(created_files)} file(s) in collection")
+
+        # Evaluation (Evaluator + Dataset + Config)
+        self.stdout.write("")
+        self.stdout.write("--- Creating Evaluation ---")
+        evaluator_params = {
+            "llm_provider_id": llm_provider.id,
+            "llm_temperature": 0.3,
+            "prompt": (
+                "Analyse the sentiment of the user message.\n\nUser: {input.content}\nAssistant: {output.content}"
+            ),
+            "output_schema": {
+                "sentiment": {
+                    "type": "choice",
+                    "description": "Detected sentiment of the user's message",
+                    "choices": ["positive", "neutral", "negative"],
+                    "use_in_aggregations": True,
+                },
+                "score": {
+                    "type": "int",
+                    "description": "Sentiment score from 1 (very negative) to 10 (very positive)",
+                    "ge": 1,
+                    "le": 10,
+                    "use_in_aggregations": True,
+                },
+            },
+        }
+        if llm_model:
+            evaluator_params["llm_provider_model_id"] = llm_model.id
+
+        evaluator, created = Evaluator.objects.get_or_create(
+            team=team,
+            name="Sentiment Analyzer",
+            defaults={
+                "type": "LlmEvaluator",
+                "evaluation_mode": EvaluationMode.MESSAGE,
+                "params": evaluator_params,
+            },
+        )
+        self._log_created("evaluator", evaluator.name, created)
+
+        dataset, created = EvaluationDataset.objects.get_or_create(
+            team=team,
+            name="Sample Customer Messages",
+            defaults={"evaluation_mode": EvaluationMode.MESSAGE},
+        )
+        self._log_created("dataset", dataset.name, created)
+        if created:
+            sample_msgs = [
+                ("My order arrived broken!", "I'm so sorry — let me get a replacement out today."),
+                ("Thanks for the fast shipping!", "Glad to hear it — enjoy!"),
+                ("This product doesn't match the description.", "I understand, let me help you with a return."),
+            ]
+            for input_text, output_text in sample_msgs:
+                msg = EvaluationMessage.objects.create(
+                    input={"content": input_text, "role": "human"},
+                    output={"content": output_text, "role": "ai"},
+                )
+                dataset.messages.add(msg)
+            self.stdout.write(f"    Added {len(sample_msgs)} sample messages to dataset")
+
+        config, created = EvaluationConfig.objects.get_or_create(
+            team=team,
+            name="Sentiment Analysis Run",
+            defaults={"dataset": dataset},
+        )
+        if created:
+            config.evaluators.add(evaluator)
+        self._log_created("evaluation config", config.name, created)
 
     def _log_created(self, entity_type: str, name: str, created: bool):
         """Helper to log entity creation status."""


### PR DESCRIPTION
### Product Description
Developer-environment improvements: bring up a populated, working chatbot / evaluations surface from a fresh database with one command, and stop cached state from leaking across git worktrees.

### Technical Description
- New `apps/service_providers/llm_service/credentials.py` helper maps env vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_VERTEX_AI_CREDENTIALS_JSON`, `DEEPSEEK_API_KEY`, `AZURE_OPENAI_*`, `GROQ_API_KEY`, `PERPLEXITY_API_KEY`) to `LlmProvider.config` payloads. `bootstrap_data` and the LLM integration test fixtures both consume it, so the env→config mapping lives in one place. Unit-tested with `monkeypatch`-isolated env.
- `bootstrap_data` now creates one `LlmProvider` per configured provider env var (falls back to a placeholder OpenAI provider with a dummy key when nothing is set). It also seeds tags, spreads sessions across all chatbots instead of just the first one, creates one `Trace` per session with realistic-looking metrics, and adds a sentiment-analysis `Evaluator` + `EvaluationDataset` + `EvaluationConfig`. The fake-`assistant_id` `OpenAiAssistant` block was removed since it doesn't help browsing.
- `.config/wt.toml` now derives a unique Redis DB number per worktree (CRC32 of the sanitised branch name, mod 15, +1) and writes it into `.env`. `post-remove` runs `redis-cli FLUSHDB` for that DB. This was added to fix a real "click chatbot in test-team, get redirected to /a/team-0/... and 404" symptom caused by the 24h `team_slug:{id}` Django cache being shared between worktrees with overlapping team IDs.

### Migrations
- [x] The migrations are backwards compatible (no migrations in this PR)

### Demo
N/A — dev tooling only.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)