### PR TITLE
fix: read tokens from AIMessage.usage_metadata in MetricsCollector

### DIFF
--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -172,6 +172,7 @@ class OpenAIGenericService(LlmService):
             model_kwargs.pop("temperature")
 
         model = ChatOpenAI(model=llm_model, **model_kwargs, use_responses_api=self._use_responses_api)
+        print(":::", model.stream_usage)
         try:
             model.get_num_tokens_from_messages([HumanMessage("Hello")])
         except Exception:

--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -172,7 +172,6 @@ class OpenAIGenericService(LlmService):
             model_kwargs.pop("temperature")
 
         model = ChatOpenAI(model=llm_model, **model_kwargs, use_responses_api=self._use_responses_api)
-        print(":::", model.stream_usage)
         try:
             model.get_num_tokens_from_messages([HumanMessage("Hello")])
         except Exception:

--- a/apps/service_providers/tracing/metrics.py
+++ b/apps/service_providers/tracing/metrics.py
@@ -4,8 +4,7 @@ import threading
 from dataclasses import dataclass
 from typing import Any
 
-from langchain_core.callbacks.base import BaseCallbackHandler
-from langchain_core.outputs import LLMResult
+from langchain_core.callbacks import UsageMetadataCallbackHandler
 
 
 @dataclass
@@ -19,45 +18,31 @@ class TraceMetrics:
     n_completion_tokens: int | None = None
 
 
-class MetricsCollector(BaseCallbackHandler):
+class MetricsCollector(UsageMetadataCallbackHandler):
     """Thread-safe accumulator for pipeline execution metrics.
 
-    Registers as a LangChain callback handler to collect turn counts,
-    tool call counts, and token usage across all LLM calls
-    in a pipeline execution.
+    Collects turn counts, tool call counts, and token usage across all LLM
+    calls in a pipeline execution. Token usage is inherited from
+    UsageMetadataCallbackHandler, which reads AIMessage.usage_metadata — the
+    standard location populated by modern LangChain chat-model integrations
+    (including OpenAI's Responses API, where LLMResult.llm_output is None).
 
-    All counter access is protected by a threading lock because
-    LangGraph executes nodes in threads via DjangoSafeContextThreadPoolExecutor.
+    Counter access is protected by a threading lock because LangGraph
+    executes nodes in threads via DjangoSafeContextThreadPoolExecutor.
     """
 
     def __init__(self, start_time: float):
         super().__init__()
-        self._lock = threading.Lock()
+        self._counter_lock = threading.Lock()
         self._turns = 0
         self._toolcalls = 0
-        self._total_tokens = 0
-        self._prompt_tokens = 0
-        self._completion_tokens = 0
 
     def on_llm_start(self, serialized: dict[str, Any], prompts: list[str], **kwargs: Any) -> None:
-        with self._lock:
+        with self._counter_lock:
             self._turns += 1
 
-    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
-        token_usage = {}
-        if response.llm_output:
-            token_usage = response.llm_output.get("token_usage", {})
-
-        prompt_tokens = token_usage.get("prompt_tokens", 0) or 0
-        completion_tokens = token_usage.get("completion_tokens", 0) or 0
-
-        with self._lock:
-            self._total_tokens += prompt_tokens + completion_tokens
-            self._prompt_tokens += prompt_tokens
-            self._completion_tokens += completion_tokens
-
     def on_tool_start(self, serialized: dict[str, Any], input_str: str, **kwargs: Any) -> None:
-        with self._lock:
+        with self._counter_lock:
             self._toolcalls += 1
 
     def get_metrics(self) -> TraceMetrics:
@@ -66,11 +51,17 @@ class MetricsCollector(BaseCallbackHandler):
         Zero counts are converted to None to distinguish "no LLM calls happened"
         from "LLM calls happened but produced 0 tokens".
         """
+        with self._counter_lock:
+            turns = self._turns
+            toolcalls = self._toolcalls
         with self._lock:
-            return TraceMetrics(
-                n_turns=self._turns or None,
-                n_toolcalls=self._toolcalls or None,
-                n_total_tokens=self._total_tokens or None,
-                n_prompt_tokens=self._prompt_tokens or None,
-                n_completion_tokens=self._completion_tokens or None,
-            )
+            prompt_tokens = sum(u.get("input_tokens", 0) for u in self.usage_metadata.values())
+            completion_tokens = sum(u.get("output_tokens", 0) for u in self.usage_metadata.values())
+            total_tokens = sum(u.get("total_tokens", 0) for u in self.usage_metadata.values())
+        return TraceMetrics(
+            n_turns=turns or None,
+            n_toolcalls=toolcalls or None,
+            n_total_tokens=total_tokens or None,
+            n_prompt_tokens=prompt_tokens or None,
+            n_completion_tokens=completion_tokens or None,
+        )

--- a/apps/service_providers/tracing/tests/test_metrics_collector.py
+++ b/apps/service_providers/tracing/tests/test_metrics_collector.py
@@ -1,9 +1,35 @@
 import threading
 import time
 
-from langchain_core.outputs import LLMResult
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, LLMResult
 
 from apps.service_providers.tracing.metrics import MetricsCollector
+
+
+def _make_llm_result(
+    input_tokens: int,
+    output_tokens: int,
+    model_name: str = "gpt-4.1-mini",
+) -> LLMResult:
+    """Build an LLMResult shaped like a modern chat-model response.
+
+    Token usage lives on AIMessage.usage_metadata; llm_output is None,
+    matching what OpenAI's Responses API and Anthropic actually emit.
+    """
+    message = AIMessage(
+        content="response text",
+        usage_metadata={
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        },
+        response_metadata={"model_name": model_name},
+    )
+    return LLMResult(
+        generations=[[ChatGeneration(message=message)]],
+        llm_output=None,
+    )
 
 
 class TestMetricsCollectorTurns:
@@ -38,34 +64,34 @@ class TestMetricsCollectorToolCalls:
 
 
 class TestMetricsCollectorTokens:
-    def _make_llm_result(self, prompt_tokens: int, completion_tokens: int) -> LLMResult:
-        return LLMResult(
-            generations=[],
-            llm_output={"token_usage": {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens}},
-        )
-
     def test_accumulates_tokens_across_calls(self):
         collector = MetricsCollector(start_time=time.time())
-        collector.on_llm_end(self._make_llm_result(100, 50))
-        collector.on_llm_end(self._make_llm_result(200, 100))
+        collector.on_llm_end(_make_llm_result(100, 50))
+        collector.on_llm_end(_make_llm_result(200, 100))
 
         metrics = collector.get_metrics()
+        assert metrics.n_prompt_tokens == 300
+        assert metrics.n_completion_tokens == 150
         assert metrics.n_total_tokens == 450
 
-    def test_missing_llm_output_handled(self):
+    def test_accumulates_tokens_across_models(self):
+        collector = MetricsCollector(start_time=time.time())
+        collector.on_llm_end(_make_llm_result(100, 50, model_name="gpt-4.1-mini"))
+        collector.on_llm_end(_make_llm_result(80, 40, model_name="claude-haiku-4-5"))
+
+        metrics = collector.get_metrics()
+        assert metrics.n_prompt_tokens == 180
+        assert metrics.n_completion_tokens == 90
+        assert metrics.n_total_tokens == 270
+
+    def test_missing_usage_metadata_handled(self):
         collector = MetricsCollector(start_time=time.time())
         collector.on_llm_start({}, ["prompt"])
-        collector.on_llm_end(LLMResult(generations=[], llm_output=None))
+        message = AIMessage(content="response", response_metadata={"model_name": "gpt-4.1-mini"})
+        collector.on_llm_end(LLMResult(generations=[[ChatGeneration(message=message)]]))
 
         metrics = collector.get_metrics()
         assert metrics.n_turns == 1
-        assert metrics.n_total_tokens is None
-
-    def test_missing_token_usage_key_handled(self):
-        collector = MetricsCollector(start_time=time.time())
-        collector.on_llm_end(LLMResult(generations=[], llm_output={"model_name": "gpt-4"}))
-
-        metrics = collector.get_metrics()
         assert metrics.n_total_tokens is None
 
     def test_no_llm_calls_tokens_none(self):
@@ -110,10 +136,11 @@ class TestMetricsCollectorZeroToNone:
         assert metrics.n_total_tokens is None
 
     def test_turns_present_but_no_tokens(self):
-        """LLM called but no token_usage reported — n_turns is set, n_total_tokens is None."""
+        """LLM called but no usage_metadata reported — n_turns is set, n_total_tokens is None."""
         collector = MetricsCollector(start_time=time.time())
         collector.on_llm_start({}, ["prompt"])
-        collector.on_llm_end(LLMResult(generations=[], llm_output=None))
+        message = AIMessage(content="response", response_metadata={"model_name": "gpt-4.1-mini"})
+        collector.on_llm_end(LLMResult(generations=[[ChatGeneration(message=message)]]))
 
         metrics = collector.get_metrics()
         assert metrics.n_turns == 1

--- a/apps/service_providers/tracing/tests/test_ocs_tracer_metrics.py
+++ b/apps/service_providers/tracing/tests/test_ocs_tracer_metrics.py
@@ -2,13 +2,27 @@ from unittest.mock import Mock
 from uuid import uuid4
 
 import pytest
-from langchain_core.outputs import LLMResult
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, LLMResult
 
 from apps.service_providers.tracing.base import TraceContext
 from apps.service_providers.tracing.metrics import MetricsCollector
 from apps.service_providers.tracing.ocs_tracer import OCSCallbackHandler, OCSTracer
 from apps.trace.models import Trace
 from apps.utils.factories.experiment import ExperimentSessionFactory
+
+
+def _llm_result(input_tokens: int, output_tokens: int) -> LLMResult:
+    message = AIMessage(
+        content="response",
+        usage_metadata={
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        },
+        response_metadata={"model_name": "gpt-4.1-mini"},
+    )
+    return LLMResult(generations=[[ChatGeneration(message=message)]])
 
 
 @pytest.mark.django_db()
@@ -36,12 +50,7 @@ class TestOCSTracerMetrics:
             collector = tracer.metrics_collector
             # Simulate LLM calls
             collector.on_llm_start({}, ["prompt 1"])
-            collector.on_llm_end(
-                LLMResult(
-                    generations=[],
-                    llm_output={"token_usage": {"prompt_tokens": 100, "completion_tokens": 50}},
-                )
-            )
+            collector.on_llm_end(_llm_result(100, 50))
             collector.on_tool_start({"name": "search"}, "query")
 
         trace = Trace.objects.get(trace_id=trace_context.id)
@@ -71,12 +80,7 @@ class TestOCSTracerMetrics:
         def _run_trace_with_metrics_then_error():
             with tracer.trace(trace_context=trace_context, session=session):
                 tracer.metrics_collector.on_llm_start({}, ["prompt"])
-                tracer.metrics_collector.on_llm_end(
-                    LLMResult(
-                        generations=[],
-                        llm_output={"token_usage": {"prompt_tokens": 50, "completion_tokens": 20}},
-                    )
-                )
+                tracer.metrics_collector.on_llm_end(_llm_result(50, 20))
                 raise ValueError("boom")
 
         with pytest.raises(ValueError, match="boom"):
@@ -103,14 +107,9 @@ class TestOCSCallbackHandlerMetricsDelegation:
         tracer.metrics_collector = MetricsCollector(start_time=0.0)
 
         handler = OCSCallbackHandler(tracer=tracer)
-        handler.on_llm_end(
-            LLMResult(
-                generations=[],
-                llm_output={"token_usage": {"prompt_tokens": 10, "completion_tokens": 5}},
-            )
-        )
+        handler.on_llm_end(_llm_result(10, 5))
 
-        assert tracer.metrics_collector._total_tokens == 15
+        assert tracer.metrics_collector.get_metrics().n_total_tokens == 15
 
     def test_on_tool_start_delegates_to_collector(self):
         tracer = OCSTracer(Mock(id=1), team_id=1)


### PR DESCRIPTION
### Product Description
Token usage was not being recorded on traces for chats using OpenAI's Responses API or Anthropic, leaving `n_prompt_tokens` / `n_completion_tokens` / `n_total_tokens` always null on the trace record.

### Technical Description
`MetricsCollector` was reading token counts from `LLMResult.llm_output["token_usage"]`, which is populated by the legacy OpenAI Chat Completions endpoint but is `None` for OpenAI's Responses API and for Anthropic. Modern LangChain chat-model integrations standardize on `AIMessage.usage_metadata` (`input_tokens` / `output_tokens` / `total_tokens`).

`MetricsCollector` now inherits from `langchain_core.callbacks.UsageMetadataCallbackHandler` (available since langchain-core 0.3.49) and delegates token tracking to it. `get_metrics()` sums `input_tokens` / `output_tokens` / `total_tokens` across all models in `self.usage_metadata`. Counter access uses a separate `_counter_lock` so the turn/tool-call counters do not contend with the parent class's `_lock`. Tests updated to build `LLMResult` with `ChatGeneration` / `AIMessage(usage_metadata=...)` — the shape real chat-model integrations actually emit (the previous fixtures only covered the legacy `llm_output["token_usage"]` shape, which is why this regression slipped through).

### Migrations
- [x] The migrations are backwards compatible

(No migrations in this PR.)

### Demo
N/A — covered by unit tests.

### Docs and Changelog
- [ ] This PR requires docs/changelog update