### PR TITLE
fix: retry CommCare Connect send on timeouts and surface span errors in Langfuse

### DIFF
--- a/apps/channels/clients/connect_client.py
+++ b/apps/channels/clients/connect_client.py
@@ -63,13 +63,6 @@ class CommCareConnectClient:
 
         return decrypted_messages
 
-    @retry(
-        wait=wait_exponential(multiplier=1, min=1, max=5),
-        reraise=True,
-        retry=retry_if_exception_type(httpx.ConnectError),
-        stop=stop_after_attempt(3),
-        before_sleep=before_sleep_log(logger, logging.INFO),
-    )
     def send_message_to_user(self, channel_id: str, message: str, encryption_key: bytes):
         ciphertext, tag, nonce = self._encrypt_message(key=encryption_key, message=message)
 
@@ -82,7 +75,16 @@ class CommCareConnectClient:
             },
             "message_id": str(uuid4()),
         }
+        self._send_fcm(payload)
 
+    @retry(
+        wait=wait_exponential(multiplier=1, min=1, max=5),
+        reraise=True,
+        retry=retry_if_exception_type((httpx.NetworkError, httpx.TimeoutException)),
+        stop=stop_after_attempt(3),
+        before_sleep=before_sleep_log(logger, logging.INFO),
+    )
+    def _send_fcm(self, payload: dict) -> None:
         url = f"{self._base_url}/messaging/send_fcm/"
         response = self.client.post(url, json=payload)
         response.raise_for_status()

--- a/apps/channels/tests/test_connect_client.py
+++ b/apps/channels/tests/test_connect_client.py
@@ -1,13 +1,53 @@
 import base64
 import json
 import os
+from unittest import mock
 from uuid import uuid4
 
+import httpx
+import pytest
 from Crypto.Cipher import AES
 from django.conf import settings
 from django.test import override_settings
 
 from apps.channels.clients.connect_client import CommCareConnectClient, Message
+
+
+@pytest.fixture()
+def disable_retry_wait():
+    """Tenacity sleeps between attempts. Skip the wait so timeout/retry tests stay fast."""
+    with mock.patch("apps.channels.clients.connect_client.wait_exponential", return_value=lambda _: 0):
+        yield
+
+
+class TestConnectClientSendRetry:
+    """send_message_to_user retries transient httpx errors and reuses the same message_id
+    across retries so the server can dedupe if a previous attempt actually arrived."""
+
+    _send_url = f"{settings.COMMCARE_CONNECT_SERVER_URL}/messaging/send_fcm/"
+
+    @override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
+    def test_retries_on_read_timeout(self, httpx_mock, disable_retry_wait):
+        httpx_mock.add_exception(httpx.ReadTimeout("read timed out"), url=self._send_url)
+        httpx_mock.add_response(method="POST", url=self._send_url, status_code=200)
+
+        client = CommCareConnectClient()
+        client.send_message_to_user(str(uuid4()), message="hello", encryption_key=os.urandom(32))
+
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 2
+
+    @override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
+    def test_message_id_stable_across_retries(self, httpx_mock, disable_retry_wait):
+        httpx_mock.add_exception(httpx.ReadTimeout("read timed out"), url=self._send_url)
+        httpx_mock.add_response(method="POST", url=self._send_url, status_code=200)
+
+        client = CommCareConnectClient()
+        client.send_message_to_user(str(uuid4()), message="hello", encryption_key=os.urandom(32))
+
+        requests = httpx_mock.get_requests()
+        ids = [json.loads(r.read())["message_id"] for r in requests]
+        assert ids[0] == ids[1], "message_id must be stable across retries for server-side dedupe"
 
 
 class TestConnectClient:

--- a/apps/channels/tests/test_connect_client.py
+++ b/apps/channels/tests/test_connect_client.py
@@ -9,14 +9,20 @@ import pytest
 from Crypto.Cipher import AES
 from django.conf import settings
 from django.test import override_settings
+from tenacity import wait_none
 
 from apps.channels.clients.connect_client import CommCareConnectClient, Message
 
 
 @pytest.fixture()
 def disable_retry_wait():
-    """Tenacity sleeps between attempts. Skip the wait so timeout/retry tests stay fast."""
-    with mock.patch("apps.channels.clients.connect_client.wait_exponential", return_value=lambda _: 0):
+    """Tenacity sleeps between attempts. Skip the wait so timeout/retry tests stay fast.
+
+    The @retry decorator binds the wait strategy at decoration time, so patching
+    `wait_exponential` in the module namespace has no effect — patch the bound
+    Retrying instance's `.wait` attribute directly instead.
+    """
+    with mock.patch.object(CommCareConnectClient._send_fcm.retry, "wait", wait_none()):
         yield
 
 

--- a/apps/service_providers/tests/test_langfuse_tracer.py
+++ b/apps/service_providers/tests/test_langfuse_tracer.py
@@ -146,3 +146,21 @@ def test_trace_marks_level_error_when_exception_propagates(patched_tracer, mock_
 
     mock_langfuse_client._test_span.update.assert_any_call(level="ERROR", status_message=mock.ANY)
     assert trace_context.exception is not None
+
+
+def test_span_update_failure_does_not_mask_application_error(
+    patched_tracer, mock_langfuse_client, mock_session, caplog
+):
+    """If span.update() itself raises while syncing state in finally, the original application
+    exception must still propagate — Langfuse update failures are best-effort and logged.
+    """
+    mock_langfuse_client._test_span.update.side_effect = RuntimeError("langfuse blew up")
+    trace_context = TraceContext(id=mock.sentinel.trace_id, name="test-trace")
+    span_context = TraceContext(id=mock.sentinel.span_id, name="failing-span")
+
+    with patched_tracer.trace(trace_context=trace_context, session=mock_session):
+        with pytest.raises(ValueError, match="real error"):
+            with patched_tracer.span(span_context=span_context, inputs={}):
+                raise ValueError("real error")
+
+    assert "Failed to update Langfuse span state" in caplog.text

--- a/apps/service_providers/tests/test_langfuse_tracer.py
+++ b/apps/service_providers/tests/test_langfuse_tracer.py
@@ -22,6 +22,8 @@ def mock_langfuse_client():
     client.start_as_current_observation.side_effect = start_observation
     client.get_current_trace_id.return_value = "trace-abc-123"
     client.get_trace_url.return_value = "https://langfuse.example/trace/trace-abc-123"
+    # Stash the span mock so tests can introspect calls made on it.
+    client._test_span = span
     return client
 
 
@@ -115,3 +117,32 @@ def test_trace_state_resets_on_exit(patched_tracer, mock_langfuse_client, mock_s
     assert patched_tracer.trace_record is None
     assert patched_tracer.client is None
     assert patched_tracer.session is None
+
+
+def test_span_marks_level_error_when_exception_propagates(patched_tracer, mock_langfuse_client, mock_session):
+    """If user code under `with span(...)` raises, the span must surface as ERROR in Langfuse
+    instead of looking like a successful span — otherwise failures are invisible in the trace UI.
+    """
+    trace_context = TraceContext(id=mock.sentinel.trace_id, name="test-trace")
+    span_context = TraceContext(id=mock.sentinel.span_id, name="failing-span")
+
+    with patched_tracer.trace(trace_context=trace_context, session=mock_session):
+        with pytest.raises(RuntimeError, match="boom"):
+            with patched_tracer.span(span_context=span_context, inputs={}):
+                raise RuntimeError("boom")
+
+    mock_langfuse_client._test_span.update.assert_any_call(level="ERROR", status_message=mock.ANY)
+    assert span_context.exception is not None
+    assert span_context.error is not None
+
+
+def test_trace_marks_level_error_when_exception_propagates(patched_tracer, mock_langfuse_client, mock_session):
+    """Same guarantee at the trace level: a propagating exception must mark the trace as ERROR."""
+    trace_context = TraceContext(id=mock.sentinel.trace_id, name="test-trace")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with patched_tracer.trace(trace_context=trace_context, session=mock_session):
+            raise RuntimeError("boom")
+
+    mock_langfuse_client._test_span.update.assert_any_call(level="ERROR", status_message=mock.ANY)
+    assert trace_context.exception is not None

--- a/apps/service_providers/tracing/langfuse.py
+++ b/apps/service_providers/tracing/langfuse.py
@@ -92,8 +92,14 @@ class LangFuseTracer(Tracer):
                 ) as trace:
                     self.trace_record = trace
                     self._langfuse_trace_id = self.client.get_current_trace_id()
-                    yield trace_context
-                    self._update_span_from_context(trace, trace_context)
+                    try:
+                        yield trace_context
+                    except Exception as exc:
+                        if not trace_context.has_error():
+                            trace_context.mark_span_as_error(str(exc), exception=exc)
+                        raise
+                    finally:
+                        self._update_span_from_context(trace, trace_context)
         finally:
             if self.trace_record:
                 self.client.flush()
@@ -126,8 +132,14 @@ class LangFuseTracer(Tracer):
             metadata=metadata,
             level=level,
         ) as span:
-            yield span_context
-            self._update_span_from_context(span, span_context)
+            try:
+                yield span_context
+            except Exception as exc:
+                if not span_context.has_error():
+                    span_context.mark_span_as_error(str(exc), exception=exc)
+                raise
+            finally:
+                self._update_span_from_context(span, span_context)
 
     def _update_span_from_context(self, span, context: TraceContext):
         if output := context.outputs:

--- a/apps/service_providers/tracing/langfuse.py
+++ b/apps/service_providers/tracing/langfuse.py
@@ -47,6 +47,13 @@ class LangFuseTracer(Tracer):
 
     The API is designed to be used with a single set of credentials whereas we need to provide
     different credentials per call. This is why we don't use the standard 'observe' decorator.
+
+    Error propagation: Langfuse's UI surfaces span failures via its own ``level`` field, which
+    is independent of OpenTelemetry status. The SDK only maps one direction (``level=ERROR``
+    sets OTel status), so a propagating exception leaves OTel status=ERROR but ``level``
+    unset — the span renders as successful. ``span()`` and ``trace()`` therefore catch the
+    exception, mark the ``TraceContext``, and run ``_update_span_from_context`` in a
+    ``finally`` so ``level=ERROR`` is set before the underlying observation closes.
     """
 
     def __init__(self, type_: str, config: dict):

--- a/apps/service_providers/tracing/langfuse.py
+++ b/apps/service_providers/tracing/langfuse.py
@@ -149,14 +149,19 @@ class LangFuseTracer(Tracer):
                 self._update_span_from_context(span, span_context)
 
     def _update_span_from_context(self, span, context: TraceContext):
-        if output := context.outputs:
-            span.update(output=output.copy())
+        # Best-effort: this is called from `finally` blocks, so a failure here would
+        # replace any in-flight application exception and hide the real failure.
+        try:
+            if output := context.outputs:
+                span.update(output=output.copy())
 
-        if exc := context.exception:
-            span.update(level="ERROR", status_message=str(exc))
+            if exc := context.exception:
+                span.update(level="ERROR", status_message=str(exc))
 
-        if error := context.error:
-            span.update(level="ERROR", status_message=error)
+            if error := context.error:
+                span.update(level="ERROR", status_message=error)
+        except Exception:
+            logger.exception("Failed to update Langfuse span state for span %s", context.name)
 
     def get_langchain_callback(self) -> BaseCallbackHandler | None:  # ty: ignore[invalid-method-override]
         if not self.ready:


### PR DESCRIPTION
### Product Description
Bots running on the CommCare Connect channel were intermittently sending users a generic "something went wrong" message instead of the bot's actual reply. The Langfuse trace UI also showed the affected spans as if they had succeeded, hiding the underlying failure from anyone trying to debug it.

### Technical Description
Two independent issues, found together while investigating one trace:

**1. `httpx.ReadTimeout` on `CommCareConnectClient.send_message_to_user` was not retried.**
The httpx client is configured with `timeout=10`, and `send_message_to_user` only retried on `httpx.ConnectError`. A 10s read timeout on `/messaging/send_fcm/` therefore propagated straight through to `_handle_supported_message`, which kicked the request into the `_inform_user_of_error` fallback path that sends "something went wrong while processing your message" instead of the bot's reply.

Fix:
- Retry on `httpx.NetworkError` and `httpx.TimeoutException` (matching the existing `create_channel` policy).
- Build the payload (including `message_id = uuid4()`) once, outside the retry loop, so retries reuse the same `message_id`. If a previous attempt actually arrived server-side before timing out, Connect can dedupe by `message_id` instead of delivering a duplicate message.

**2. Langfuse spans never showed `level=ERROR` when an exception propagated through them.**
`LangFuseTracer.span()` / `trace()` only called `_update_span_from_context` *after* `yield`, so a propagating exception skipped it. OpenTelemetry's `start_as_current_span` does record the exception and set OTel status to ERROR by default, but Langfuse's UI/export uses its own `level` field, and Langfuse only propagates one direction: `level=ERROR → OTel status=ERROR`, never the reverse. Result: the trace JSON exported the failing spans with no error indication, even though OTel had captured the exception internally.

Fix: wrap `yield` in `try/except/finally` in both `span()` and `trace()` — capture the exception onto the `TraceContext` via `mark_span_as_error()`, run `_update_span_from_context` in `finally` so it always reflects the (now-marked) context. Mirrors the pattern `OCSTracer` already uses.

### Migrations
- [x] The migrations are backwards compatible (no migrations)

### Demo
N/A — failure mode reproduces only when the upstream Connect endpoint is slow. The added unit tests exercise both the retry-on-timeout path and the Langfuse error-propagation path.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)