### PR TITLE
fix: handle session=None in tracers for inbound email routing

### DIFF
--- a/apps/channels/channels_v2/stages/core.py
+++ b/apps/channels/channels_v2/stages/core.py
@@ -93,6 +93,10 @@ class SessionResolutionStage(ProcessingStage):
         if not ctx.experiment_session:
             ctx.experiment_session = self._create_session(ctx)
 
+        # The trace was opened with session=None for channels that route
+        # to a session lazily (e.g. EmailChannel). Back-fill it now.
+        ctx.trace_service.set_session(ctx.experiment_session)
+
     def _is_reset_request(self, ctx: MessageProcessingContext) -> bool:
         return (
             ctx.message.content_type == MESSAGE_TYPES.TEXT and ctx.message.message_text.lower().strip() == RESET_COMMAND
@@ -116,6 +120,7 @@ class SessionResolutionStage(ProcessingStage):
                 existing.end(trigger_type=StaticTriggerType.CONVERSATION_ENDED_BY_USER)
 
         ctx.experiment_session = self._create_session(ctx)
+        ctx.trace_service.set_session(ctx.experiment_session)
         raise EarlyExitResponse("Conversation reset")
 
     def _create_session(self, ctx: MessageProcessingContext):

--- a/apps/service_providers/tests/test_ocs_tracer.py
+++ b/apps/service_providers/tests/test_ocs_tracer.py
@@ -274,3 +274,43 @@ class TestSetTraceMetadata:
 
         # Should not raise
         tracer.set_trace_metadata({"trace_info": [{"trace_id": "lf-123"}]})
+
+
+@pytest.mark.django_db()
+class TestTraceWithoutSession:
+    """Inbound emails with no thread continuity open the trace before the
+    session is resolved — the tracer must accept session=None and back-fill
+    via set_session() once SessionResolutionStage has run."""
+
+    def test_trace_with_none_session_creates_record(self, experiment):
+        tracer = OCSTracer(experiment, experiment.team_id)
+        trace_context = TraceContext(id=uuid4(), name="test_trace")
+
+        with tracer.trace(trace_context=trace_context, session=None):
+            pass
+
+        trace = Trace.objects.get(trace_id=trace_context.id)
+        assert trace.session is None
+        assert trace.participant is None
+        assert trace.participant_data == {}
+        assert trace.session_state == {}
+
+    def test_set_session_backfills_trace_record(self, experiment):
+        tracer = OCSTracer(experiment, experiment.team_id)
+        session = ExperimentSessionFactory.create()
+        trace_context = TraceContext(id=uuid4(), name="test_trace")
+
+        with tracer.trace(trace_context=trace_context, session=None):
+            tracer.set_session(session)
+
+        trace = Trace.objects.get(trace_id=trace_context.id)
+        assert trace.session_id == session.id
+        assert trace.participant_id == session.participant_id
+
+    def test_set_session_noop_without_trace_record(self, experiment):
+        tracer = OCSTracer(experiment, experiment.team_id)
+        session = ExperimentSessionFactory.create()
+
+        # Should not raise even though no trace is open
+        tracer.set_session(session)
+        assert tracer.session is session

--- a/apps/service_providers/tracing/base.py
+++ b/apps/service_providers/tracing/base.py
@@ -158,6 +158,15 @@ class Tracer(ABC):
     def set_participant_data_diff(self, diff: list[tuple[str, str | list, Any]]) -> None:
         pass
 
+    def set_session(self, session: ExperimentSession) -> None:
+        """Late-bind a session to an active trace.
+
+        Called when the trace was opened with ``session=None`` (e.g. inbound
+        email routing) and the session is resolved partway through the
+        pipeline. Default is a no-op for tracers that cannot back-fill.
+        """
+        return None
+
     def set_trace_metadata(self, metadata: dict[str, Any]) -> None:
         return None
 

--- a/apps/service_providers/tracing/langfuse.py
+++ b/apps/service_providers/tracing/langfuse.py
@@ -63,7 +63,7 @@ class LangFuseTracer(Tracer):
     def trace(
         self,
         trace_context: TraceContext,
-        session: ExperimentSession,
+        session: ExperimentSession | None,
         inputs: dict[str, Any] | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> Iterator[TraceContext]:
@@ -71,6 +71,11 @@ class LangFuseTracer(Tracer):
 
         Acquires a Langfuse client from ClientManager, creates a trace,
         and ensures the client is flushed on exit.
+
+        ``session`` may be None when the trace is opened before routing has
+        identified a session (e.g. inbound email). Langfuse cannot back-fill
+        ``session_id``/``user_id`` after the trace is sent, so they are
+        omitted in that case.
         """
         # Check for reentry
         if self.trace_record:
@@ -80,11 +85,12 @@ class LangFuseTracer(Tracer):
 
         # Get client and create trace
         self.client = client_manager.get(self.config)
+        propagate_kwargs: dict[str, str] = {}
+        if session is not None:
+            propagate_kwargs["session_id"] = str(session.external_id)
+            propagate_kwargs["user_id"] = session.participant.identifier
         try:
-            with propagate_attributes(
-                session_id=str(session.external_id),
-                user_id=session.participant.identifier,
-            ):
+            with propagate_attributes(**propagate_kwargs):
                 with self.client.start_as_current_observation(
                     name=trace_context.name,
                     input=inputs,

--- a/apps/service_providers/tracing/ocs_tracer.py
+++ b/apps/service_providers/tracing/ocs_tracer.py
@@ -50,7 +50,7 @@ class OCSTracer(Tracer):
     def trace(
         self,
         trace_context: TraceContext,
-        session: ExperimentSession,
+        session: ExperimentSession | None,
         inputs: dict[str, Any] | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> Iterator[TraceContext]:
@@ -58,6 +58,11 @@ class OCSTracer(Tracer):
 
         Creates a database Trace record on entry and updates it with
         duration and status on exit.
+
+        ``session`` may be None (e.g. an inbound email that has not yet been
+        routed to a session). In that case the record is created without
+        session/participant; callers should invoke ``set_session`` once
+        the session is known so the record can be back-filled.
         """
 
         # Set base class state from context
@@ -80,9 +85,9 @@ class OCSTracer(Tracer):
             team_id=self.team_id,
             session=session,
             duration=0,
-            participant=session.participant,
-            participant_data=session.participant.get_data_for_experiment(session.experiment_id),
-            session_state=session.state,
+            participant=session.participant if session else None,
+            participant_data=(session.participant.get_data_for_experiment(session.experiment_id) if session else {}),
+            session_state=session.state if session else {},
         )
 
         self.start_time = time.time()
@@ -119,17 +124,18 @@ class OCSTracer(Tracer):
             self._update_trace_metrics()
             self.trace_record.save()
 
+            session_id = self.session.id if self.session else None
             logger.debug(
                 "Created trace in DB | experiment_id=%s, session_id=%s, duration=%sms",
                 self.experiment.id,
-                self.session.id,
+                session_id,
                 duration_ms,
             )
         except Exception:
             logger.exception(
                 "Error saving trace in DB | experiment_id=%s, session_id=%s, output_message_id=%s",
                 self.experiment.id,
-                self.session.id,
+                self.session.id if self.session else None,
                 self.trace_record.output_message_id,
             )
 
@@ -221,6 +227,20 @@ class OCSTracer(Tracer):
     def set_participant_data_diff(self, diff: list[tuple[str, str | list, Any]]) -> None:
         if self.trace_record:
             self.trace_record.participant_data_diff = diff
+
+    def set_session(self, session: ExperimentSession) -> None:
+        """Late-bind a session to the trace record after it has been resolved.
+
+        Used when ``trace`` was opened with ``session=None`` (e.g. inbound
+        email routing) and the session was created mid-pipeline.
+        """
+        self.session = session
+        if not self.trace_record:
+            return
+        self.trace_record.session = session
+        self.trace_record.participant = session.participant
+        self.trace_record.participant_data = session.participant.get_data_for_experiment(session.experiment_id)
+        self.trace_record.session_state = session.state
 
     def set_trace_metadata(self, metadata: dict[str, Any]) -> None:
         if self.trace_record:

--- a/apps/service_providers/tracing/service.py
+++ b/apps/service_providers/tracing/service.py
@@ -287,3 +287,18 @@ class TracingService:
     def set_participant_data_diff(self, diff: list[tuple[str, str | list, Any]]) -> None:
         for tracer in self._active_tracers:
             tracer.set_participant_data_diff(diff)
+
+    def set_session(self, session: ExperimentSession) -> None:
+        """Late-bind a session to active tracers after it has been resolved.
+
+        ``trace`` may be opened with ``session=None`` (e.g. inbound email
+        before routing has identified a session). Once a stage creates or
+        loads the session, callers should invoke this so tracers can
+        back-fill the session/participant on their records.
+        """
+        self.session = session
+        for tracer in self._active_tracers:
+            try:
+                tracer.set_session(session)
+            except Exception:
+                logger.exception(f"Tracer {tracer.__class__.__name__} failed to set session.")


### PR DESCRIPTION
### Product Description
Inbound emails sent to a chatbot that don't match an existing session no longer trigger a tracer error. Trace records are still created and back-filled with session/participant info once routing resolves them.

### Technical Description
`ChannelBase.new_user_message` opens the trace *before* the pipeline runs `SessionResolutionStage`, so for v2 channels that allow `experiment_session=None` (currently `EmailChannel`, latently `ApiChannel`) the OCS tracer crashed dereferencing `session.participant`:

```
File "apps/service_providers/tracing/ocs_tracer.py", line 83, in trace
    participant=session.participant,
AttributeError: 'NoneType' object has no attribute 'participant'
```

Other v2 channels don't hit it: `WebChannel` raises in `__init__` if no session is supplied, and v1 channels (`apps/chat/channels.py`) call `_ensure_sessions_exists()` *before* opening the trace.

Fix:
- `OCSTracer.trace()` and `LangFuseTracer.trace()` accept `session=None`. The OCS trace record is created with null session/participant (those FKs are already nullable); Langfuse omits `session_id`/`user_id` from `propagate_attributes` when session is None.
- New `Tracer.set_session()` (default no-op) and `TracingService.set_session()` that delegates to active tracers. `OCSTracer.set_session()` back-fills `session`, `participant`, `participant_data` and `session_state` on the existing trace record.
- `SessionResolutionStage` calls `ctx.trace_service.set_session(...)` once it has resolved/created a session (normal path and the `/reset` early-exit).

This also covers the latent `ApiChannel` case without touching `ApiChannel` (it allows `session=None` when a `user` is passed and would have hit the same crash).

### Migrations
- [x] The migrations are backwards compatible

(No migrations in this PR.)

### Demo
N/A — backend tracing fix. Verified by new tests in `test_ocs_tracer.py::TestTraceWithoutSession`.

### Docs and Changelog
- [ ] This PR requires docs/changelog update