### PR TITLE
fix: update django-template-partials deprecated inline=True syntax

### DIFF
--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -57,7 +57,7 @@
           <div class="form-control">
             <label class="label label-text">{% translate "Channels" %}</label>
             {% with field=filter_form.channels %}
-              {% partialdef "select_filter" inline=True %}
+              {% partialdef "select_filter" inline %}
                 <select x-cloak class="w-full h-10" id="{{ field.id_for_label }}" name="{{ field.name }}" multiple>
                   {% if not field.field.required %}
                     <option value="">---------</option>

--- a/templates/experiments/chat/input_bar.html
+++ b/templates/experiments/chat/input_bar.html
@@ -29,7 +29,7 @@
                 </li>
               </ul>
             </div>
-            {% partialdef code-interpreter-input inline=True %}
+            {% partialdef code-interpreter-input inline %}
           <!-- Supported file types for code interpreter: https://platform.openai.com/docs/assistants/tools/code-interpreter/supported-files -->
               <input
                 x-ref="codeInterpreter"
@@ -42,7 +42,7 @@
                 class="file-input file-input-sm w-full max-w-xs"
               />
             {% endpartialdef %}
-            {% partialdef file-search-input inline=True %}
+            {% partialdef file-search-input inline %}
           <!-- Supported file types for file search: https://platform.openai.com/docs/assistants/tools/file-search/supported-files -->
               <input
                 x-ref="fileSearch"


### PR DESCRIPTION
### Product Description
Updates deprecated `inline=True` syntax to bare `inline` keyword in django-template-partials `{% partialdef %}` tags.

This was deprecated in django-template-partials 25.1 and must be removed before a future release drops support entirely.

### Technical Description
- `templates/experiments/chat/input_bar.html` (2 occurrences)
- `templates/dashboard/index.html` (1 occurrence)

### Migrations
- [ ] The migrations are backwards compatible

### Demo
N/A — template syntax fix only, no behaviour change.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Closes #3281