### PR TITLE
feat: require at least one variable in LLM evaluator prompts

### DIFF
--- a/apps/evaluations/evaluators.py
+++ b/apps/evaluations/evaluators.py
@@ -1,5 +1,5 @@
 from langchain_core.language_models import BaseChatModel
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from pydantic.config import ConfigDict
 from pydantic_core import ValidationError
 
@@ -73,6 +73,18 @@ class LlmEvaluator(LLMResponseMixin, BaseEvaluator):
         ),
         json_schema_extra=UiSchema(widget=Widgets.text_editor),
     )
+    @field_validator("prompt")
+    @classmethod
+    def prompt_must_contain_variable(cls, v: str) -> str:
+        required_prefixes = ["{input", "{output", "{context.", "{full_history}", "{generated_response}"]
+        if not any(prefix in v for prefix in required_prefixes):
+            raise ValueError(
+                "The prompt must include at least one variable so the evaluator has context to work with. "
+                "Available variables: {input.content}, {output.content}, {context.[name]}, {full_history}, "
+                "{generated_response}"
+            )
+        return v
+
     output_schema: dict[str, FieldDefinition] = Field(
         description="The expected output schema for the evaluation",
         json_schema_extra=UiSchema(widget=Widgets.key_value_pairs),

--- a/apps/evaluations/tests/test_llm_evaluator.py
+++ b/apps/evaluations/tests/test_llm_evaluator.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 from langchain_core.messages import AIMessage
+from pydantic import ValidationError
 
 from apps.evaluations.evaluators import LlmEvaluator
 from apps.evaluations.field_definitions import ChoiceFieldDefinition, IntFieldDefinition, StringFieldDefinition
@@ -17,6 +18,40 @@ from apps.utils.factories.evaluations import (
 )
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 from apps.utils.langchain import build_fake_llm_service
+
+_VALID_PROMPTS = [
+    "Evaluate this: {input.content}",
+    "Check the output: {output.content}",
+    "Context value: {context.my_param}",
+    "Full history: {full_history}",
+    "Generated: {generated_response}",
+]
+
+_OUTPUT_SCHEMA = {"result": {"type": "string", "description": "result"}}
+
+
+@pytest.mark.parametrize("prompt", _VALID_PROMPTS)
+def test_llm_evaluator_prompt_valid_variables(prompt):
+    evaluator = LlmEvaluator(
+        llm_provider_id=1,
+        llm_provider_model_id=1,
+        prompt=prompt,
+        output_schema=_OUTPUT_SCHEMA,
+    )
+    assert evaluator.prompt == prompt
+
+
+def test_llm_evaluator_prompt_no_variables_raises():
+    with pytest.raises(ValidationError) as exc_info:
+        LlmEvaluator(
+            llm_provider_id=1,
+            llm_provider_model_id=1,
+            prompt="Evaluate this conversation please.",
+            output_schema=_OUTPUT_SCHEMA,
+        )
+    error_message = str(exc_info.value)
+    assert "at least one variable" in error_message
+    assert "{input.content}" in error_message
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Product Description
Prevents users from saving an `LlmEvaluator` prompt that contains no variable references. Without at least one variable the evaluator receives no context about the conversation being evaluated, making it produce meaningless results.

### Technical Description
Adds a `@field_validator("prompt")` (Pydantic v2) to `LlmEvaluator` that checks the prompt contains at least one of the recognised variable prefixes (`{input`, `{output`, `{context.`, `{full_history}`, `{generated_response}`). If none are found a `ValueError` is raised with a clear message listing the available variables.

Tests added:
- Parametrised test verifying each valid variable prefix is accepted
- Test verifying a no-variable prompt raises `ValidationError` with a helpful message

### Migrations
- [ ] The migrations are backwards compatible

### Demo
N/A – validation only, no UI change.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Closes #3283