### PR TITLE
feat(evaluations): auto-pop rule CRUD + auto-run form (chunk B)

### DIFF
--- a/apps/evaluations/forms.py
+++ b/apps/evaluations/forms.py
@@ -13,6 +13,7 @@ from apps.annotations.models import Tag
 from apps.evaluations.exceptions import HistoryParseException
 from apps.evaluations.models import (
     ConditionType,
+    DatasetAutoPopulationRule,
     DatasetCreationStatus,
     EvaluationConfig,
     EvaluationDataset,
@@ -130,9 +131,17 @@ class EvaluationConfigForm(forms.ModelForm):
             "experiment_version",
             "run_generation",
             "base_experiment",
+            "auto_run_on_append",
         ]
         widgets = {
             "evaluators": EvaluatorCheckboxWidget(),
+        }
+        help_texts = {
+            "auto_run_on_append": (
+                "When enabled, an evaluation run is automatically enqueued for newly appended "
+                "dataset messages. Each auto-run only evaluates the new rows, but still incurs "
+                "LLM costs proportional to the number of evaluators and new messages."
+            ),
         }
 
     def __init__(self, team, *args, **kwargs):
@@ -1004,3 +1013,77 @@ class EvaluationDatasetEditForm(EvaluationDatasetBaseForm):
                     self._save_session_messages_clone(dataset)
 
         return dataset
+
+
+class DatasetAutoPopulationRuleForm(forms.ModelForm):
+    """Form for creating/editing an auto-population rule on a dataset.
+
+    The rule's evaluation_mode is always inherited from the parent dataset, so it is not
+    rendered as a user-editable field.
+    """
+
+    class Meta:
+        model = DatasetAutoPopulationRule
+        fields = [
+            "source_experiment",
+            "filter_query",
+            "is_enabled",
+        ]
+        widgets = {
+            "filter_query": forms.Textarea(
+                attrs={
+                    "rows": 3,
+                    "class": "textarea w-full font-mono text-sm",
+                    "placeholder": "filter_0_column=tags&filter_0_operator=contains&filter_0_value=...",
+                },
+            ),
+        }
+        help_texts = {
+            "source_experiment": (
+                "The chatbot whose new sessions/messages should be considered for ingestion. "
+                "Only the working version is shown; the ingestion task evaluates against the latest data."
+            ),
+            "filter_query": (
+                "Optional URL-encoded filter (same format used by the manual filter import on this page). "
+                "Leave empty to ingest every new session/message from the source experiment."
+            ),
+            "is_enabled": "When unchecked, the periodic ingestion task skips this rule.",
+        }
+
+    def __init__(self, *args, dataset: EvaluationDataset, team, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dataset = dataset
+        self.team = team
+        self.fields["source_experiment"].queryset = (
+            Experiment.objects.working_versions_queryset().filter(team=team).order_by("name")
+        )
+
+    def clean_filter_query(self):
+        raw = (self.cleaned_data.get("filter_query") or "").strip()
+        if not raw:
+            return ""
+        try:
+            from django.http import QueryDict  # noqa: PLC0415
+
+            from apps.web.dynamic_filters.datastructures import FilterParams  # noqa: PLC0415
+
+            FilterParams(QueryDict(raw))
+        except Exception as exc:
+            raise DjangoValidationError(f"Filter query did not parse: {exc}") from exc
+        return raw
+
+    def clean(self):
+        cleaned = super().clean()
+        source_experiment = cleaned.get("source_experiment")
+        if source_experiment and source_experiment.team_id != self.team.id:
+            self.add_error("source_experiment", "Source chatbot must belong to the current team.")
+        return cleaned
+
+    def save(self, commit=True):
+        instance: DatasetAutoPopulationRule = super().save(commit=False)
+        instance.team = self.team
+        instance.dataset = self.dataset
+        instance.evaluation_mode = self.dataset.evaluation_mode
+        if commit:
+            instance.save()
+        return instance

--- a/apps/evaluations/urls.py
+++ b/apps/evaluations/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from apps.generics.urls import make_crud_urls
 
-from .views import dataset_views, evaluation_config_views, evaluator_views
+from .views import auto_population_views, dataset_views, evaluation_config_views, evaluator_views
 
 app_name = "evaluations"
 
@@ -116,6 +116,21 @@ urlpatterns = [
         "dataset/<int:pk>/upload/",
         dataset_views.upload_dataset_csv,
         name="dataset_upload",
+    ),
+    path(
+        "dataset/<int:dataset_id>/auto_population_rule/new/",
+        auto_population_views.CreateAutoPopulationRule.as_view(),
+        name="auto_population_rule_new",
+    ),
+    path(
+        "dataset/<int:dataset_id>/auto_population_rule/<int:pk>/",
+        auto_population_views.EditAutoPopulationRule.as_view(),
+        name="auto_population_rule_edit",
+    ),
+    path(
+        "dataset/<int:dataset_id>/auto_population_rule/<int:pk>/delete/",
+        auto_population_views.DeleteAutoPopulationRule.as_view(),
+        name="auto_population_rule_delete",
     ),
 ]
 

--- a/apps/evaluations/views/auto_population_views.py
+++ b/apps/evaluations/views/auto_population_views.py
@@ -1,0 +1,141 @@
+from django.contrib import messages
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.http import Http404, HttpResponse
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.views.generic import CreateView, DeleteView, UpdateView
+from waffle import flag_is_active
+
+from apps.evaluations.forms import DatasetAutoPopulationRuleForm
+from apps.evaluations.models import DatasetAutoPopulationRule, EvaluationDataset
+from apps.teams.flags import Flags
+from apps.teams.mixins import LoginAndTeamRequiredMixin
+
+
+class FlagGatedMixin:
+    """Raise 404 unless the auto-populate flag is active for the request's team."""
+
+    def dispatch(self, request, *args, **kwargs):
+        if not flag_is_active(request, Flags.AUTO_POPULATE_EVAL_DATASETS.slug):
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
+
+
+class _DatasetScopedMixin:
+    """Resolve the parent dataset from the URL and enforce team scoping."""
+
+    def get_dataset(self) -> EvaluationDataset:
+        return get_object_or_404(
+            EvaluationDataset,
+            pk=self.kwargs["dataset_id"],
+            team=self.request.team,
+        )
+
+
+class CreateAutoPopulationRule(
+    FlagGatedMixin,
+    LoginAndTeamRequiredMixin,
+    PermissionRequiredMixin,
+    _DatasetScopedMixin,
+    CreateView,
+):
+    permission_required = "evaluations.add_datasetautopopulationrule"
+    model = DatasetAutoPopulationRule
+    form_class = DatasetAutoPopulationRuleForm
+    template_name = "evaluations/auto_population_rule_form.html"
+
+    def get_form_kwargs(self):
+        return {
+            **super().get_form_kwargs(),
+            "team": self.request.team,
+            "dataset": self.get_dataset(),
+        }
+
+    def get_context_data(self, **kwargs):
+        return {
+            **super().get_context_data(**kwargs),
+            "dataset": self.get_dataset(),
+            "title": "Create Auto-Population Rule",
+            "page_title": "Create Auto-Population Rule",
+            "button_text": "Create Rule",
+            "active_tab": "evaluation_datasets",
+        }
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        messages.success(self.request, "Auto-population rule created.")
+        return response
+
+    def get_success_url(self):
+        return reverse(
+            "evaluations:dataset_edit",
+            args=[self.request.team.slug, self.kwargs["dataset_id"]],
+        )
+
+
+class EditAutoPopulationRule(
+    FlagGatedMixin,
+    LoginAndTeamRequiredMixin,
+    PermissionRequiredMixin,
+    _DatasetScopedMixin,
+    UpdateView,
+):
+    permission_required = "evaluations.change_datasetautopopulationrule"
+    model = DatasetAutoPopulationRule
+    form_class = DatasetAutoPopulationRuleForm
+    template_name = "evaluations/auto_population_rule_form.html"
+
+    def get_queryset(self):
+        return DatasetAutoPopulationRule.objects.filter(
+            team=self.request.team,
+            dataset_id=self.kwargs["dataset_id"],
+        )
+
+    def get_form_kwargs(self):
+        return {
+            **super().get_form_kwargs(),
+            "team": self.request.team,
+            "dataset": self.get_dataset(),
+        }
+
+    def get_context_data(self, **kwargs):
+        return {
+            **super().get_context_data(**kwargs),
+            "dataset": self.get_dataset(),
+            "title": "Edit Auto-Population Rule",
+            "page_title": "Edit Auto-Population Rule",
+            "button_text": "Update Rule",
+            "active_tab": "evaluation_datasets",
+        }
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        messages.success(self.request, "Auto-population rule updated.")
+        return response
+
+    def get_success_url(self):
+        return reverse(
+            "evaluations:dataset_edit",
+            args=[self.request.team.slug, self.kwargs["dataset_id"]],
+        )
+
+
+class DeleteAutoPopulationRule(
+    FlagGatedMixin,
+    LoginAndTeamRequiredMixin,
+    PermissionRequiredMixin,
+    DeleteView,
+):
+    permission_required = "evaluations.delete_datasetautopopulationrule"
+    model = DatasetAutoPopulationRule
+
+    def get_queryset(self):
+        return DatasetAutoPopulationRule.objects.filter(
+            team=self.request.team,
+            dataset_id=self.kwargs["dataset_id"],
+        )
+
+    def delete(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        self.object.delete()
+        return HttpResponse(status=200)

--- a/apps/evaluations/views/dataset_views.py
+++ b/apps/evaluations/views/dataset_views.py
@@ -20,6 +20,7 @@ from django.views.decorators.http import require_http_methods, require_POST
 from django.views.generic import CreateView, DeleteView, TemplateView, UpdateView
 from django_htmx.http import reswap, retarget
 from django_tables2 import LazyPaginator, SingleTableView
+from waffle import flag_is_active
 
 from apps.chat.models import ChatMessage
 from apps.evaluations.forms import EvaluationDatasetEditForm, EvaluationDatasetForm
@@ -49,6 +50,7 @@ from apps.experiments.models import ExperimentSession
 from apps.files.models import File, FilePurpose
 from apps.filters.models import FilterSet
 from apps.teams.decorators import login_and_team_required
+from apps.teams.flags import Flags
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 from apps.utils.tables import render_first_table_row
 from apps.web.dynamic_filters.datastructures import FilterParams
@@ -122,6 +124,12 @@ class EditDataset(LoginAndTeamRequiredMixin, PermissionRequiredMixin, UpdateView
         context = super().get_context_data(**kwargs)
         context.update(self._get_filter_context_data())
         context["celery_job_id"] = self.object.job_id
+        context["auto_population_rules"] = (
+            self.object.auto_population_rules.select_related("source_experiment")
+            .annotate(contributed_message_count=Count("ingestion_entries"))
+            .order_by("-created_at")
+        )
+        context["auto_population_flag_active"] = flag_is_active(self.request, Flags.AUTO_POPULATE_EVAL_DATASETS.slug)
         return context
 
     def form_valid(self, form):

--- a/openspec/changes/auto-populate-eval-datasets/tasks.md
+++ b/openspec/changes/auto-populate-eval-datasets/tasks.md
@@ -4,17 +4,17 @@
 - [x] 1.2 Add `DatasetIngestionEntry` model (FK to `DatasetAutoPopulationRule`, `source_session_id`, `source_message_id`, FK to `EvaluationMessage`, `created_at`); add unique constraints on `(rule, source_message_id)` for message-mode and `(rule, source_session_id)` for session-mode (use partial unique indexes or two indexes).
 - [x] 1.3 Add `EvaluationConfig.auto_run_on_append` boolean field (default `False`).
 - [x] 1.4 Add `EvaluationRunType.DELTA = "delta"` choice and an `EvaluationRun.scoped_messages` M2M to `EvaluationMessage`.
-- [ ] 1.5 Add Waffle flag `evaluations.auto_populate_datasets` and gate rule create/update views and beat-task processing behind it. (Flag registered as `flag_auto_populate_eval_datasets` in chunk A; view/task gating lands with chunks B and C.)
+- [ ] 1.5 Add Waffle flag `evaluations.auto_populate_datasets` and gate rule create/update views and beat-task processing behind it. (Flag registered in chunk A; view-level gating added in chunk B; beat-task gating lands with chunk C.)
 - [x] 1.6 Generate Django migration via `uv run python manage.py makemigrations evaluations`; verify backwards-compatibility (no defaults that require backfill, all new fields nullable or with sane defaults).
 - [x] 1.7 Add admin registrations for `DatasetAutoPopulationRule` and `DatasetIngestionEntry`.
 
 ## 2. Forms, views, and URLs
 
-- [ ] 2.1 Add `DatasetAutoPopulationRuleForm` in `apps/evaluations/forms.py` with validation: source experiment in same team, `evaluation_mode` matches dataset's mode, filter query parses cleanly via `FilterParams(QueryDict(...))`.
-- [ ] 2.2 Add list/create/edit/delete views in `apps/evaluations/views/dataset_views.py` (or a new `auto_population_views.py`) following existing CBV patterns and team scoping.
-- [ ] 2.3 Wire URL patterns in `apps/evaluations/urls.py`; ensure `get_absolute_url` on the rule returns to its dataset.
-- [ ] 2.4 Update dataset detail template to list rules with status fields (last run, status, error, contributed-message count via `DatasetIngestionEntry` count).
-- [ ] 2.5 Add `auto_run_on_append` checkbox to the existing `EvaluationConfig` form with help text describing cost implications.
+- [x] 2.1 Add `DatasetAutoPopulationRuleForm` in `apps/evaluations/forms.py` with validation: source experiment in same team, `evaluation_mode` matches dataset's mode, filter query parses cleanly via `FilterParams(QueryDict(...))`.
+- [x] 2.2 Add list/create/edit/delete views in `apps/evaluations/views/dataset_views.py` (or a new `auto_population_views.py`) following existing CBV patterns and team scoping.
+- [x] 2.3 Wire URL patterns in `apps/evaluations/urls.py`; ensure `get_absolute_url` on the rule returns to its dataset.
+- [x] 2.4 Update dataset detail template to list rules with status fields (last run, status, error, contributed-message count via `DatasetIngestionEntry` count).
+- [x] 2.5 Add `auto_run_on_append` checkbox to the existing `EvaluationConfig` form with help text describing cost implications.
 
 ## 3. Ingestion task
 

--- a/templates/evaluations/auto_population_rule_form.html
+++ b/templates/evaluations/auto_population_rule_form.html
@@ -1,0 +1,26 @@
+{% extends "generic/object_form.html" %}
+{% load form_tags i18n %}
+
+{% block pre_form %}
+  <div class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+    {% blocktranslate trimmed with name=dataset.name mode=dataset.evaluation_mode %}
+      Configuring auto-population for dataset <strong>{{ name }}</strong> ({{ mode }} mode).
+      The periodic ingestion task will append matching {{ mode }}s from the source chatbot
+      to this dataset, skipping any that have already been ingested.
+    {% endblocktranslate %}
+  </div>
+{% endblock pre_form %}
+
+{% block form %}
+  {{ form.non_field_errors }}
+  {% render_form_fields form %}
+{% endblock form %}
+
+{% block form_actions %}
+  <div class="flex gap-2 mt-4">
+    <input type="submit" class="btn btn-primary" value="{{ button_text }}" :disabled="submitted">
+    <a class="btn btn-ghost" href="{% url 'evaluations:dataset_edit' request.team.slug dataset.id %}">
+      {% translate "Cancel" %}
+    </a>
+  </div>
+{% endblock form_actions %}

--- a/templates/evaluations/auto_population_rules_section.html
+++ b/templates/evaluations/auto_population_rules_section.html
@@ -1,0 +1,90 @@
+{% load i18n %}
+
+<div class="mt-8">
+  <div class="flex items-center justify-between mb-4">
+    <h2 class="pg-subtitle">{% translate "Auto-Population Rules" %}</h2>
+    <a class="btn btn-sm btn-primary"
+       href="{% url 'evaluations:auto_population_rule_new' request.team.slug object.id %}">
+      <i class="fa-solid fa-plus mr-1"></i> {% translate "New Rule" %}
+    </a>
+  </div>
+
+  <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+    {% translate "Rules append matching sessions/messages from a source chatbot to this dataset on a periodic schedule. Sources already ingested by a rule are skipped." %}
+  </p>
+
+  {% if auto_population_rules %}
+    <div class="overflow-x-auto">
+      <table class="table table-sm">
+        <thead>
+          <tr>
+            <th>{% translate "Source chatbot" %}</th>
+            <th>{% translate "Enabled" %}</th>
+            <th>{% translate "Last run" %}</th>
+            <th>{% translate "Status" %}</th>
+            <th>{% translate "Contributed" %}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for rule in auto_population_rules %}
+            <tr id="rule-row-{{ rule.id }}">
+              <td>{{ rule.source_experiment.name }}</td>
+              <td>
+                {% if rule.is_enabled %}
+                  <span class="badge badge-success">{% translate "Enabled" %}</span>
+                {% else %}
+                  <span class="badge badge-ghost">{% translate "Disabled" %}</span>
+                {% endif %}
+              </td>
+              <td>
+                {% if rule.last_run_at %}
+                  {{ rule.last_run_at|date:"Y-m-d H:i" }}
+                {% else %}
+                  <span class="text-gray-500">{% translate "Never" %}</span>
+                {% endif %}
+              </td>
+              <td>
+                {% if rule.last_run_status == 'success' %}
+                  <span class="badge badge-success">{% translate "Success" %}</span>
+                {% elif rule.last_run_status == 'error' %}
+                  <span class="badge badge-error" title="{{ rule.last_error }}">{% translate "Error" %}</span>
+                {% elif rule.last_run_status == 'no_op' %}
+                  <span class="badge badge-ghost">{% translate "No-op" %}</span>
+                {% else %}
+                  <span class="text-gray-500">—</span>
+                {% endif %}
+              </td>
+              <td>{{ rule.contributed_message_count }}</td>
+              <td class="text-right">
+                <a class="btn btn-xs btn-ghost"
+                   href="{% url 'evaluations:auto_population_rule_edit' request.team.slug object.id rule.id %}">
+                  {% translate "Edit" %}
+                </a>
+                <button class="btn btn-xs btn-ghost text-error"
+                        hx-delete="{% url 'evaluations:auto_population_rule_delete' request.team.slug object.id rule.id %}"
+                        hx-confirm='{% translate "Delete this rule? Already-ingested messages stay in the dataset." %}'
+                        hx-target="#rule-row-{{ rule.id }}"
+                        hx-swap="outerHTML"
+                        hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+                  {% translate "Delete" %}
+                </button>
+              </td>
+            </tr>
+            {% if rule.last_error and rule.last_run_status == 'error' %}
+              <tr>
+                <td colspan="6" class="text-xs text-error">
+                  <code>{{ rule.last_error|truncatechars:240 }}</code>
+                </td>
+              </tr>
+            {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <div class="text-sm text-gray-500 italic">
+      {% translate "No rules yet. Create one to start auto-populating this dataset." %}
+    </div>
+  {% endif %}
+</div>

--- a/templates/evaluations/dataset_edit.html
+++ b/templates/evaluations/dataset_edit.html
@@ -201,6 +201,10 @@
 
   {% endif %}
 
+  {% if auto_population_flag_active %}
+    {% include "evaluations/auto_population_rules_section.html" %}
+  {% endif %}
+
   <dialog id="editMessageModal" class="modal"></dialog>
 {% endblock post_form %}
 

--- a/templates/evaluations/evaluation_config_form.html
+++ b/templates/evaluations/evaluation_config_form.html
@@ -122,6 +122,8 @@
       </div>
     </div>
 
+    {% render_form_fields form "auto_run_on_append" %}
+
   </div>
 
 {% endblock form %}


### PR DESCRIPTION
> **Stacked PR:** depends on #3299. Review-base is \`sk/auto-pop-eval-datasets-schema\` so this diff shows only chunk B's changes.

### Product Description

When the new \`flag_auto_populate_eval_datasets\` flag is enabled for a team, an evaluation dataset gains an **Auto-Population Rules** section letting users configure rules that periodically append matching sessions/messages from a chosen source chatbot to that dataset. The evaluation config form gains an opt-in **auto-run on dataset append** checkbox.

No runtime ingestion happens yet — the periodic task and the auto-trigger plumbing land in chunks C and D respectively.

### Technical Description

This is **Chunk B** of openspec change [auto-populate-eval-datasets](./openspec/changes/auto-populate-eval-datasets/proposal.md). It adds:

- \`DatasetAutoPopulationRuleForm\` (apps/evaluations/forms.py)
  - Validates: source experiment team match, FilterParams parses cleanly.
  - \`evaluation_mode\` is inherited from the parent dataset (not user-editable) so the spec's mode-match invariant cannot be violated.
- \`apps/evaluations/views/auto_population_views.py\` — \`Create / Edit / Delete\` CBVs scoped to \`(team, dataset_id)\`. \`FlagGatedMixin\` raises 404 unless \`flag_auto_populate_eval_datasets\` is active. Permissions: standard \`evaluations.add/change/delete_datasetautopopulationrule\` (auto-generated by Django for the model added in chunk A).
- Nested URL patterns under \`dataset/<int:dataset_id>/auto_population_rule/\` for new, edit, delete.
- \`templates/evaluations/auto_population_rule_form.html\` — extends \`generic/object_form.html\`, contextualises the form with the parent dataset's name and mode.
- \`templates/evaluations/auto_population_rules_section.html\` — dataset-edit partial that lists rules with source chatbot, enabled badge, last-run timestamp, status badge, contributed-message count (via \`Count(\"ingestion_entries\")\` annotation), and edit/delete actions. Inline error banner on \`error\` rules.
- \`templates/evaluations/dataset_edit.html\` — includes the partial when \`auto_population_flag_active\` is true.
- \`EditDataset.get_context_data\` (apps/evaluations/views/dataset_views.py) — annotates rules with contributed count and exposes \`auto_population_flag_active\`.
- \`EvaluationConfigForm\` (apps/evaluations/forms.py) — adds \`auto_run_on_append\` to fields with help text describing the cost implications.
- \`templates/evaluations/evaluation_config_form.html\` — renders the new checkbox.

**Out of scope (chunks C–E):** the periodic ingestion task that actually exercises rules, the dataset-append → delta-run trigger, the run-history UI for delta runs, integration tests, docs.

**Validation:**

- \`uv run python manage.py check\` — clean.
- \`uv run ruff check apps/evaluations apps/teams/flags.py\` — clean.
- \`uv run ty check apps/evaluations\` — clean.
- \`uv run pytest apps/evaluations/tests/\` — 194 passed, no regressions.

### Migrations

- [x] The migrations are backwards compatible

(No new migrations in this PR — schema landed in chunk A.)

### Demo

n/a yet — flag is not enabled by default and the views render UI that does nothing at runtime until chunk C ships the ingestion task. A combined demo will accompany chunks C/D when the feature performs work.

### Docs and Changelog

- [ ] This PR requires docs/changelog update

User-facing docs land alongside the chunk that activates the feature (C/D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)