### PR TITLE
fix(pipelines): temporarily disable MessageSizeValidationMiddleware

### DIFF
--- a/apps/pipelines/nodes/llm_node.py
+++ b/apps/pipelines/nodes/llm_node.py
@@ -104,8 +104,8 @@ def build_node_agent(
     middleware = []
     if history_middleware := node.build_history_middleware(system_message=system_message):
         middleware.append(history_middleware)
-    if size_middleware := _build_size_validation_middleware(node, system_message):
-        middleware.append(size_middleware)
+    # MessageSizeValidationMiddleware temporarily disabled — over-counts tool outputs and blocks
+    # legitimate conversations. Re-enable after switching to a tool-aware token check.
 
     return create_agent(
         # TODO: I think this will fail with google builtin tools


### PR DESCRIPTION
### Product Description
Unblocks chatbots whose tools (Custom Actions, etc.) return large responses. Users were hitting "Your message is too large for this model. It uses approximately N tokens..." errors after legitimate tool calls, even when their own input was tiny.

### Technical Description
`MessageSizeValidationMiddleware` runs `count_tokens_approximately(state["messages"])` before every model call. After a tool call lands in state, the ToolMessage content is included in the count — and the char-based approximation (4 chars/token) overshoots significantly on JSON-heavy tool output. Combined with `SummarizeHistoryMiddleware`'s message-count `keep` policy (which can't compress a single oversized ToolMessage), this caused `MessageTooLargeError` on the second model iteration of agents that call data-returning tools.

This PR disables the middleware wiring in `build_node_agent`. The class, its builder, and existing unit tests are intentionally left in place — the proper fix (excluding ToolMessages from the count, and/or switching to the chat model's real tokenizer) will land in a follow-up.

### Migrations
- [x] The migrations are backwards compatible (no migrations)


### Demo
N/A — internal middleware wiring change.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)