### PR TITLE
feat(evaluations): periodic ingestion task for auto-pop rules (chunk C)

### DIFF
--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -980,3 +980,271 @@ def create_dataset_from_sessions_task(self, dataset_id, team_id, session_ids):
         message = "An error occurred while creating session-mode messages"
         _save_dataset_error(dataset, message)
         return {"success": False, "error": message}
+
+
+# ---------------------------------------------------------------------------
+# Auto-population (chunk C of auto-populate-eval-datasets)
+# ---------------------------------------------------------------------------
+
+AUTO_POP_SAFETY_MARGIN_SECONDS = 60
+
+
+@shared_task(base=TaskbadgerTask)
+def auto_populate_eval_datasets():
+    """Periodic task: ingest new sessions/messages for every enabled auto-population rule.
+
+    Each rule is processed in its own transaction with a row-level lock so concurrent
+    workers can't double-process. Failures are recorded per-rule without aborting the tick;
+    after AUTO_DISABLE_FAILURE_THRESHOLD consecutive failures the rule is auto-disabled
+    and the team is notified.
+    """
+    from django.db.models import F  # noqa: PLC0415
+
+    from apps.evaluations.models import DatasetAutoPopulationRule  # noqa: PLC0415
+
+    flag = _resolve_auto_populate_flag()
+    if flag is None:
+        logger.info("Skipping auto_populate_eval_datasets: flag has no row yet (no team has enabled it)")
+        return
+
+    rule_ids = list(
+        DatasetAutoPopulationRule.objects.filter(is_enabled=True, team__in=flag.teams.all())
+        .order_by(F("last_run_at").asc(nulls_first=True))
+        .values_list("id", flat=True)
+    )
+    for rule_id in rule_ids:
+        try:
+            _process_auto_population_rule(rule_id)
+        except Exception:
+            logger.exception("Unexpected error processing auto-population rule %s", rule_id)
+
+
+def _resolve_auto_populate_flag():
+    """Return the persisted Flag row for the auto-populate-eval-datasets feature, or None."""
+    from apps.teams.flags import Flags  # noqa: PLC0415
+    from apps.teams.models import Flag  # noqa: PLC0415
+
+    try:
+        return Flag.objects.prefetch_related("teams").get(name=Flags.AUTO_POPULATE_EVAL_DATASETS.slug)
+    except Flag.DoesNotExist:
+        return None
+
+
+def _process_auto_population_rule(rule_id: int) -> None:
+    """Lock and process a single rule. Caller catches unexpected errors; this fn handles per-rule failures."""
+    from apps.evaluations.models import DatasetAutoPopulationRule  # noqa: PLC0415
+
+    with transaction.atomic():
+        rule = (
+            DatasetAutoPopulationRule.objects.select_for_update(skip_locked=True)
+            .select_related("dataset", "source_experiment", "team")
+            .filter(id=rule_id, is_enabled=True)
+            .first()
+        )
+        if rule is None:
+            return  # locked by another worker, disabled, or deleted
+
+        try:
+            with current_team(rule.team):
+                appended_count = _ingest_auto_population_rule(rule)
+        except Exception as exc:
+            _record_auto_population_rule_failure(rule, exc)
+            return
+
+        from apps.evaluations.models import AutoPopulationRunStatus  # noqa: PLC0415
+
+        rule.last_run_at = timezone.now()
+        rule.last_run_status = AutoPopulationRunStatus.SUCCESS if appended_count > 0 else AutoPopulationRunStatus.NO_OP
+        rule.last_error = ""
+        rule.consecutive_failure_count = 0
+        rule.save(
+            update_fields=[
+                "last_run_at",
+                "last_run_status",
+                "last_error",
+                "consecutive_failure_count",
+                "last_ingested_at",
+                "updated_at",
+            ]
+        )
+
+
+def _ingest_auto_population_rule(rule) -> int:
+    """Build EvaluationMessage rows for new sources matching ``rule`` and append to its dataset.
+
+    Mutates ``rule.last_ingested_at`` to the new high-water mark. Returns the number of
+    EvaluationMessage rows appended (which is also the number of DatasetIngestionEntry
+    rows written).
+    """
+    from apps.evaluations.models import EvaluationMode  # noqa: PLC0415
+
+    cutoff = rule.last_ingested_at - timedelta(seconds=AUTO_POP_SAFETY_MARGIN_SECONDS)
+    if rule.evaluation_mode == EvaluationMode.MESSAGE:
+        return _ingest_message_mode_rule(rule, cutoff)
+    return _ingest_session_mode_rule(rule, cutoff)
+
+
+def _ingest_message_mode_rule(rule, cutoff) -> int:
+    from django.db.models import Q  # noqa: PLC0415
+
+    from apps.evaluations.models import DatasetIngestionEntry  # noqa: PLC0415
+    from apps.evaluations.utils import make_evaluation_messages_from_sessions  # noqa: PLC0415
+    from apps.experiments.filters import ChatMessageFilter  # noqa: PLC0415
+
+    base_qs = (
+        ChatMessage.objects.filter(
+            chat__experiment_session__team_id=rule.team_id,
+            created_at__gt=cutoff,
+        )
+        .filter(
+            Q(chat__experiment_session__experiment_id=rule.source_experiment_id)
+            | Q(chat__experiment_session__experiment__working_version_id=rule.source_experiment_id)
+        )
+        .select_related("chat__experiment_session")
+        .order_by("created_at", "id")
+    )
+
+    if rule.filter_query:
+        base_qs = ChatMessageFilter().apply(base_qs, FilterParams(QueryDict(rule.filter_query)), timezone=None)
+
+    candidates = list(base_qs)
+    if not candidates:
+        return 0
+
+    new_watermark = max(msg.created_at for msg in candidates)
+
+    already_ingested_ids = set(
+        DatasetIngestionEntry.objects.filter(rule=rule, source_message__isnull=False).values_list(
+            "source_message_id", flat=True
+        )
+    )
+    fresh_candidates = [msg for msg in candidates if msg.id not in already_ingested_ids]
+    if not fresh_candidates:
+        rule.last_ingested_at = new_watermark
+        return 0
+
+    message_ids_per_session = defaultdict(list)
+    for msg in fresh_candidates:
+        ext = str(msg.chat.experiment_session.external_id)
+        message_ids_per_session[ext].append(msg.id)
+
+    eval_messages = make_evaluation_messages_from_sessions(message_ids_per_session)
+    if not eval_messages:
+        rule.last_ingested_at = new_watermark
+        return 0
+
+    EvaluationMessage.objects.bulk_create(eval_messages)
+    rule.dataset.messages.add(*eval_messages)
+
+    entries = []
+    for em in eval_messages:
+        for source_message_id in (em.input_chat_message_id, em.expected_output_chat_message_id):
+            if source_message_id is None:
+                continue
+            entries.append(
+                DatasetIngestionEntry(
+                    rule=rule,
+                    evaluation_message=em,
+                    source_session_id=em.session_id,
+                    source_message_id=source_message_id,
+                )
+            )
+    DatasetIngestionEntry.objects.bulk_create(entries, ignore_conflicts=True)
+
+    rule.last_ingested_at = new_watermark
+    return len(eval_messages)
+
+
+def _ingest_session_mode_rule(rule, cutoff) -> int:
+    from django.db.models import Q  # noqa: PLC0415
+
+    from apps.evaluations.models import DatasetIngestionEntry  # noqa: PLC0415
+    from apps.evaluations.utils import make_session_evaluation_messages  # noqa: PLC0415
+    from apps.experiments.filters import ExperimentSessionFilter  # noqa: PLC0415
+
+    base_qs = (
+        ExperimentSession.objects.filter(team_id=rule.team_id, created_at__gt=cutoff)
+        .filter(
+            Q(experiment_id=rule.source_experiment_id) | Q(experiment__working_version_id=rule.source_experiment_id)
+        )
+        .order_by("created_at", "id")
+    )
+
+    if rule.filter_query:
+        base_qs = ExperimentSessionFilter().apply(base_qs, FilterParams(QueryDict(rule.filter_query)), timezone=None)
+
+    candidates = list(base_qs)
+    if not candidates:
+        return 0
+
+    new_watermark = max(s.created_at for s in candidates)
+
+    already_ingested_ids = set(
+        DatasetIngestionEntry.objects.filter(rule=rule, source_message__isnull=True).values_list(
+            "source_session_id", flat=True
+        )
+    )
+    fresh = [s for s in candidates if s.id not in already_ingested_ids]
+    if not fresh:
+        rule.last_ingested_at = new_watermark
+        return 0
+
+    session_ext_ids = [str(s.external_id) for s in fresh]
+    eval_messages = make_session_evaluation_messages(session_ext_ids, team=rule.team)
+    if not eval_messages:
+        rule.last_ingested_at = new_watermark
+        return 0
+
+    EvaluationMessage.objects.bulk_create(eval_messages)
+    rule.dataset.messages.add(*eval_messages)
+
+    entries = [
+        DatasetIngestionEntry(
+            rule=rule,
+            evaluation_message=em,
+            source_session_id=em.session_id,
+            source_message_id=None,
+        )
+        for em in eval_messages
+        if em.session_id is not None
+    ]
+    DatasetIngestionEntry.objects.bulk_create(entries, ignore_conflicts=True)
+
+    rule.last_ingested_at = new_watermark
+    return len(eval_messages)
+
+
+def _record_auto_population_rule_failure(rule, exc: Exception) -> None:
+    from apps.evaluations.models import DatasetAutoPopulationRule  # noqa: PLC0415
+    from apps.ocs_notifications.notifications import (  # noqa: PLC0415
+        dataset_auto_population_rule_auto_disabled_notification,
+    )
+
+    error_message = str(exc) or exc.__class__.__name__
+    from apps.evaluations.models import AutoPopulationRunStatus  # noqa: PLC0415
+
+    rule.last_run_at = timezone.now()
+    rule.last_run_status = AutoPopulationRunStatus.ERROR
+    rule.last_error = error_message[:1000]
+    rule.consecutive_failure_count = (rule.consecutive_failure_count or 0) + 1
+    auto_disable = rule.consecutive_failure_count >= DatasetAutoPopulationRule.AUTO_DISABLE_FAILURE_THRESHOLD
+    update_fields = [
+        "last_run_at",
+        "last_run_status",
+        "last_error",
+        "consecutive_failure_count",
+        "updated_at",
+    ]
+    if auto_disable:
+        rule.is_enabled = False
+        update_fields.append("is_enabled")
+    rule.save(update_fields=update_fields)
+    logger.warning(
+        "Auto-population rule %s failed (%s consecutive)%s: %s",
+        rule.id,
+        rule.consecutive_failure_count,
+        " — auto-disabled" if auto_disable else "",
+        error_message,
+    )
+    if auto_disable:
+        dataset_auto_population_rule_auto_disabled_notification(rule, error_message)

--- a/apps/ocs_notifications/notifications.py
+++ b/apps/ocs_notifications/notifications.py
@@ -207,6 +207,24 @@ def tool_error_notification(team, tool_name: str, error_message: str, session=No
     )
 
 
+@silence_exceptions(logger, log_message="Failed to create dataset auto-population auto-disabled notification")
+def dataset_auto_population_rule_auto_disabled_notification(rule, last_error: str) -> None:
+    """Notify a team that an auto-population rule was auto-disabled after repeated failures."""
+    create_notification(
+        title="Auto-population rule disabled",
+        message=(
+            f"The auto-population rule for dataset '{rule.dataset.name}' has been disabled "
+            f"after repeated ingestion failures. Last error: {last_error[:200]}"
+        ),
+        level=LevelChoices.ERROR,
+        team=rule.team,
+        slug="auto-population-rule-auto-disabled",
+        event_data={"rule_id": rule.id, "dataset_id": rule.dataset_id},
+        permissions=["evaluations.change_datasetautopopulationrule"],
+        links={"View Dataset": rule.dataset.get_absolute_url()},
+    )
+
+
 @silence_exceptions(logger, log_message="Failed to create deprecated model notification")
 def deprecated_model_notification(
     team,

--- a/config/settings.py
+++ b/config/settings.py
@@ -519,6 +519,10 @@ SCHEDULED_TASKS = {
         "task": "apps.ocs_notifications.tasks.cleanup_old_notification_events",
         "schedule": timedelta(days=1),
     },
+    "evaluations.tasks.auto_populate_eval_datasets": {
+        "task": "apps.evaluations.tasks.auto_populate_eval_datasets",
+        "schedule": timedelta(minutes=5),
+    },
 }
 
 CACHES = {

--- a/openspec/changes/auto-populate-eval-datasets/tasks.md
+++ b/openspec/changes/auto-populate-eval-datasets/tasks.md
@@ -4,7 +4,7 @@
 - [x] 1.2 Add `DatasetIngestionEntry` model (FK to `DatasetAutoPopulationRule`, `source_session_id`, `source_message_id`, FK to `EvaluationMessage`, `created_at`); add unique constraints on `(rule, source_message_id)` for message-mode and `(rule, source_session_id)` for session-mode (use partial unique indexes or two indexes).
 - [x] 1.3 Add `EvaluationConfig.auto_run_on_append` boolean field (default `False`).
 - [x] 1.4 Add `EvaluationRunType.DELTA = "delta"` choice and an `EvaluationRun.scoped_messages` M2M to `EvaluationMessage`.
-- [ ] 1.5 Add Waffle flag `evaluations.auto_populate_datasets` and gate rule create/update views and beat-task processing behind it. (Flag registered in chunk A; view-level gating added in chunk B; beat-task gating lands with chunk C.)
+- [x] 1.5 Add Waffle flag `evaluations.auto_populate_datasets` and gate rule create/update views and beat-task processing behind it. (Flag registered in chunk A; view-level gating added in chunk B; beat-task gating done in chunk C — only rules belonging to teams in `flag.teams` are processed.)
 - [x] 1.6 Generate Django migration via `uv run python manage.py makemigrations evaluations`; verify backwards-compatibility (no defaults that require backfill, all new fields nullable or with sane defaults).
 - [x] 1.7 Add admin registrations for `DatasetAutoPopulationRule` and `DatasetIngestionEntry`.
 
@@ -18,11 +18,11 @@
 
 ## 3. Ingestion task
 
-- [ ] 3.1 Add `auto_populate_eval_datasets` periodic task in `apps/evaluations/tasks.py`: iterate enabled rules ordered by `last_run_at` ascending, lock each via `select_for_update(skip_locked=True)`, and dispatch to a per-rule helper.
-- [ ] 3.2 Implement `_ingest_rule(rule)` helper: build the appropriate filter (`ChatMessageFilter` for message mode, `ExperimentSessionFilter` for session mode), apply the rule's `filter_query`, restrict to source experiment + team, restrict to `created_at > last_ingested_at - safety_margin`, exclude sources already in `DatasetIngestionEntry` for this rule, batch the matches, and reuse `make_evaluation_messages_from_sessions` to build `EvaluationMessage` rows.
-- [ ] 3.3 In a single transaction per rule: append new `EvaluationMessage` rows to the dataset's M2M, write `DatasetIngestionEntry` rows, bump `last_ingested_at` to `max(source.created_at)` of the batch, set `last_run_status="success"`, reset `consecutive_failure_count`.
-- [ ] 3.4 On exception: set `last_run_status="error"`, store `last_error`, increment `consecutive_failure_count`; if it reaches 3, set `is_enabled=False` and emit a notification via `apps.ocs_notifications`. Catch per-rule so other rules in the tick are unaffected.
-- [ ] 3.5 Register the task in `CELERY_BEAT_SCHEDULE` (or via `django_celery_beat` periodic task fixture/data migration) at a 5-minute interval; gate registration behind the Waffle flag at task entry.
+- [x] 3.1 Add `auto_populate_eval_datasets` periodic task in `apps/evaluations/tasks.py`: iterate enabled rules ordered by `last_run_at` ascending, lock each via `select_for_update(skip_locked=True)`, and dispatch to a per-rule helper.
+- [x] 3.2 Implement `_ingest_rule(rule)` helper: build the appropriate filter (`ChatMessageFilter` for message mode, `ExperimentSessionFilter` for session mode), apply the rule's `filter_query`, restrict to source experiment + team, restrict to `created_at > last_ingested_at - safety_margin`, exclude sources already in `DatasetIngestionEntry` for this rule, batch the matches, and reuse `make_evaluation_messages_from_sessions` to build `EvaluationMessage` rows.
+- [x] 3.3 In a single transaction per rule: append new `EvaluationMessage` rows to the dataset's M2M, write `DatasetIngestionEntry` rows, bump `last_ingested_at` to `max(source.created_at)` of the batch, set `last_run_status="success"`, reset `consecutive_failure_count`.
+- [x] 3.4 On exception: set `last_run_status="error"`, store `last_error`, increment `consecutive_failure_count`; if it reaches 3, set `is_enabled=False` and emit a notification via `apps.ocs_notifications`. Catch per-rule so other rules in the tick are unaffected.
+- [x] 3.5 Register the task in `CELERY_BEAT_SCHEDULE` (or via `django_celery_beat` periodic task fixture/data migration) at a 5-minute interval; gate registration behind the Waffle flag at task entry.
 
 ## 4. Auto-trigger of delta evaluation runs
 


### PR DESCRIPTION
> **Stacked PR:** depends on #3299 (chunk A) and #3301 (chunk B). Review-base is \`sk/auto-pop-eval-datasets-views\` so this diff shows only chunk C's changes.

### Product Description

When a team enables \`flag_auto_populate_eval_datasets\` and creates an auto-population rule on a dataset (chunk B's UI), this PR is what makes the rule do work: every 5 minutes, the system walks each enabled rule, finds new sessions/messages from the source chatbot matching the rule's filter, and appends them to the dataset.

The dataset's run-history isn't touched yet — automatically running evaluators on the appended rows lands in chunk D.

### Technical Description

This is **Chunk C** of openspec change [auto-populate-eval-datasets](./openspec/changes/auto-populate-eval-datasets/proposal.md). It introduces:

- \`auto_populate_eval_datasets\` periodic Celery task in \`apps/evaluations/tasks.py\`. Orders rules by oldest \`last_run_at\` (nulls first) and processes each in its own \`select_for_update(skip_locked=True)\` transaction so concurrent workers can't double-process. Per-rule exceptions are caught so a single bad rule can't poison the tick.
- **Beat-task gating** completes the half of task 1.5 that wasn't covered by chunk B. The task resolves the persisted \`Flag\` row for \`flag_auto_populate_eval_datasets\` and only processes rules whose \`team\` is in \`flag.teams\`. If no team has the flag enabled, the task is a near-zero-cost no-op.
- **Message mode** (\`_ingest_message_mode_rule\`): applies \`ChatMessageFilter\` to the rule's stored \`FilterParams\` query string, scopes to source experiment + team + \`created_at > last_ingested_at - 60s\` safety margin, dedupes against existing \`DatasetIngestionEntry\` rows for this rule, then reuses the existing \`make_evaluation_messages_from_sessions\` helper to build EM rows. Writes one \`DatasetIngestionEntry\` per source \`ChatMessage\` that landed in a row (covering both \`input_chat_message\` and \`expected_output_chat_message\`).
- **Session mode** (\`_ingest_session_mode_rule\`): \`ExperimentSessionFilter\` + \`make_session_evaluation_messages\`, with one \`DatasetIngestionEntry\` per source \`ExperimentSession\`.
- **Forward-only watermark.** \`last_ingested_at\` advances to \`max(created_at)\` of every candidate considered, including ones that didn't become rows (e.g., orphan messages the helper couldn't pair). Combined with the \`(rule, source_*)\` partial unique constraints from chunk A, ingestion is strictly idempotent under retries, restarts, and concurrent workers.
- **Failure handling** (\`_record_auto_population_rule_failure\`): \`AutoPopulationRunStatus.{success,error,no_op}\` written per tick. Three consecutive errors auto-disable the rule and fire a notification via the new \`dataset_auto_population_rule_auto_disabled_notification\` in \`apps/ocs_notifications/notifications.py\`.
- \`CELERY_BEAT_SCHEDULE\` entry: \`evaluations.tasks.auto_populate_eval_datasets\`, every 5 minutes.

**Out of scope (chunks D–E):** the dataset-append → delta-run trigger, the \`scoped_messages\` runtime path in \`run_evaluation_task\`, the run-history UI for delta runs, integration tests, docs.

**Validation:**

- \`uv run python manage.py check\` — clean.
- \`uv run ruff check apps/evaluations apps/ocs_notifications\` — clean.
- \`uv run ty check apps/evaluations\` — clean.
- \`uv run pytest apps/evaluations/tests/\` — 194 passed, no regressions.

A failing rule will write its error to \`last_error\` and surface in the dataset edit page (added in chunk B). Auto-disable behaviour can be verified once Chunk E's integration tests land; manual testing is out of scope for a stacked-WIP PR.

### Migrations

- [x] The migrations are backwards compatible

(No migrations in this PR — the schema for these fields landed in chunk A.)

### Demo

n/a in isolation. The demo for the end-to-end flow (rule creation → ingestion → delta evaluation run) will accompany chunk D when the auto-trigger is wired up.

### Docs and Changelog

- [ ] This PR requires docs/changelog update

User-facing docs and the feature-flag entry in \`docs/developer_guides/feature_flags.md\` land with chunk E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)