### PR TITLE
Add gpt-5.5 model support

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -1596,5 +1596,5 @@ components:
       scheme: bearer
 tags:
 - name: Chat
-  description: "\n                The Chat API is designed to be used for integrating\
-    \ chatbots into external systems.\n            "
+  description: "\n                The Chat API is designed to be used for integrating
+    chatbots into external systems.\n            "

--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -17,6 +17,7 @@ from apps.service_providers.llm_service.model_parameters import (
     GPT5ProParameters,
     GPT51Parameters,
     GPT52Parameters,
+    GPT55Parameters,
     OpenAIReasoningParameters,
 )
 from apps.service_providers.models import EmbeddingProviderModel, LlmProviderModel, LlmProviderTypes
@@ -96,6 +97,7 @@ DEFAULT_LLM_PROVIDER_MODELS = {
         Model("gpt-5.3-instant", k(400), parameters=GPT51Parameters),
         Model("gpt-5.4", k(400), parameters=GPT52Parameters),
         Model("gpt-5.4-pro", k(400), parameters=GPT5ProParameters),
+        Model("gpt-5.5", 1050000, parameters=GPT55Parameters),
         Model("gpt-5-mini", k(400), parameters=GPT5Parameters),
         Model("gpt-5-nano", k(400), parameters=GPT5Parameters),
         Model("gpt-5-pro", k(400), parameters=GPT5ProParameters),

--- a/apps/service_providers/llm_service/model_parameters.py
+++ b/apps/service_providers/llm_service/model_parameters.py
@@ -159,61 +159,10 @@ class GPT52Parameters(LLMModelParamBase):
         return value
 
 
-class GPT55Parameters(LLMModelParamBase):
-    # gpt-5.5: reasoning.effort supports none, low, medium (default), high, xhigh
-    effort: GPT52ReasoningEffortParameter = Field(
-        title="Reasoning Effort",
-        default=GPT52ReasoningEffortParameter.MEDIUM,
-        json_schema_extra=UiSchema(widget=Widgets.select, enum_labels=GPT52ReasoningEffortParameter.labels),
-    )
-
-    verbosity: OpenAIVerbosityParameter = Field(
-        title="Verbosity",
-        default=OpenAIVerbosityParameter.MEDIUM,
-        json_schema_extra=UiSchema(widget=Widgets.select, enum_labels=OpenAIVerbosityParameter.labels),
-    )
-
-    temperature: float | None = Field(
-        default=None,
-        ge=0.0,
-        le=2.0,
-        title="Temperature",
-        json_schema_extra=UiSchema(
-            widget=Widgets.range, visible_when=VisibleWhen(field="effort", value="none"), default_on_show=0.7
-        ),
-    )
-
-    top_p: float | None = Field(
-        default=None,
-        ge=0.0,
-        le=1.0,
-        title="Top P",
-        json_schema_extra=UiSchema(
-            widget=Widgets.range, visible_when=VisibleWhen(field="effort", value="none"), default_on_show=1.0
-        ),
-    )
-
-    @field_validator("temperature", mode="before")
-    def validate_temperature(cls, value: float, info):
-        if value is not None and info.data.get("effort") != "none":
-            raise PydanticCustomError(
-                "invalid_model_parameters",
-                "Temperature can only be set when reasoning effort is 'none'",
-            )
-        elif value is None and info.data.get("effort") == "none":
-            return 0.7
-        return value
-
-    @field_validator("top_p", mode="before")
-    def validate_top_p(cls, value: float, info):
-        if value is not None and info.data.get("effort") != "none":
-            raise PydanticCustomError(
-                "invalid_model_parameters",
-                "Top P can only be set when reasoning effort is 'none'",
-            )
-        elif value is None and info.data.get("effort") == "none":
-            return 1.0
-        return value
+class GPT55Parameters(GPT52Parameters):
+    # gpt-5.5 shares the same parameter schema as GPT52Parameters:
+    # reasoning.effort supports none, low, medium (default), high, xhigh
+    pass
 
 
 class GPT5ProParameters(LLMModelParamBase):

--- a/apps/service_providers/llm_service/model_parameters.py
+++ b/apps/service_providers/llm_service/model_parameters.py
@@ -159,6 +159,63 @@ class GPT52Parameters(LLMModelParamBase):
         return value
 
 
+class GPT55Parameters(LLMModelParamBase):
+    # gpt-5.5: reasoning.effort supports none, low, medium (default), high, xhigh
+    effort: GPT52ReasoningEffortParameter = Field(
+        title="Reasoning Effort",
+        default=GPT52ReasoningEffortParameter.MEDIUM,
+        json_schema_extra=UiSchema(widget=Widgets.select, enum_labels=GPT52ReasoningEffortParameter.labels),
+    )
+
+    verbosity: OpenAIVerbosityParameter = Field(
+        title="Verbosity",
+        default=OpenAIVerbosityParameter.MEDIUM,
+        json_schema_extra=UiSchema(widget=Widgets.select, enum_labels=OpenAIVerbosityParameter.labels),
+    )
+
+    temperature: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=2.0,
+        title="Temperature",
+        json_schema_extra=UiSchema(
+            widget=Widgets.range, visible_when=VisibleWhen(field="effort", value="none"), default_on_show=0.7
+        ),
+    )
+
+    top_p: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        title="Top P",
+        json_schema_extra=UiSchema(
+            widget=Widgets.range, visible_when=VisibleWhen(field="effort", value="none"), default_on_show=1.0
+        ),
+    )
+
+    @field_validator("temperature", mode="before")
+    def validate_temperature(cls, value: float, info):
+        if value is not None and info.data.get("effort") != "none":
+            raise PydanticCustomError(
+                "invalid_model_parameters",
+                "Temperature can only be set when reasoning effort is 'none'",
+            )
+        elif value is None and info.data.get("effort") == "none":
+            return 0.7
+        return value
+
+    @field_validator("top_p", mode="before")
+    def validate_top_p(cls, value: float, info):
+        if value is not None and info.data.get("effort") != "none":
+            raise PydanticCustomError(
+                "invalid_model_parameters",
+                "Top P can only be set when reasoning effort is 'none'",
+            )
+        elif value is None and info.data.get("effort") == "none":
+            return 1.0
+        return value
+
+
 class GPT5ProParameters(LLMModelParamBase):
     # gpt-5-pro only supports high effort, which is also its default
     verbosity: OpenAIVerbosityParameter = Field(


### PR DESCRIPTION
Adds **gpt-5.5** to the supported OpenAI models list.

Closes #3307

## Changes

- New `GPT55Parameters` class in `model_parameters.py`
  - Reasoning effort: `none`, `low`, `medium` (default), `high`, `xhigh`
  - Verbosity parameter (default: medium)
  - Temperature + Top P fields (visible only when effort is `none`)
- Registered `gpt-5.5` in `default_models.py` with 1,050,000 token context window

## Model specs (from OpenAI docs)

- Context window: 1,050,000 tokens
- Max output tokens: 128,000
- Pricing: $5.00 / $30.00 per 1M input/output tokens
- Knowledge cutoff: Dec 2025
- Supports streaming, function calling, structured outputs