### PR TITLE
Add migration to register gpt-5.5 model

### DIFF
--- a/apps/service_providers/migrations/0053_add_gpt55_model.py
+++ b/apps/service_providers/migrations/0053_add_gpt55_model.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+from apps.service_providers.migration_utils import llm_model_migration
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("service_providers", "0052_seed_voyage_embedding_models"),
+    ]
+
+    operations = [
+        # Register gpt-5.5 (OpenAI) with 1,050,000 token context window.
+        llm_model_migration(),
+    ]


### PR DESCRIPTION
Follows up on #3308 which added `gpt-5.5` support but was missing the Django migration to run `llm_model_migration()` and actually register the model in the database.

## Changes

- `0053_add_gpt55_model.py` — runs `llm_model_migration()` to seed `gpt-5.5` into `LlmProviderModel` for all teams