### PR TITLE
include deleted channels in export + rename Experiment -> Chatbot

### DIFF
--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -63,12 +63,13 @@ def get_usage_data(start: datetime, end: datetime):
 
 def get_whatsapp_numbers():
     return _write_data_to_csv(
-        ["Team", "Experiment", "Messaging Provider", "Account", "Number"], get_whatsapp_number_data()
+        ["Team", "Chatbot", "Messaging Provider", "Account", "Number", "Channel Active"], get_whatsapp_number_data()
     )
 
 
 def get_whatsapp_number_data():
-    channels = ExperimentChannel.objects.filter(deleted=False, platform=ChannelPlatform.WHATSAPP).values(
+    channels = ExperimentChannel.objects.filter(platform=ChannelPlatform.WHATSAPP).values(
+        "deleted",
         "extra_data",
         "team__name",
         "experiment__name",
@@ -99,6 +100,7 @@ def get_whatsapp_number_data():
             provider_name,
             account,
             channel["extra_data"].get("number", "---"),
+            not channel["deleted"],
         )
 
 
@@ -110,13 +112,13 @@ def get_whatsapp_message_stats(start: datetime, end: datetime):
             chat__experiment_session__experiment_channel__platform=ChannelPlatform.WHATSAPP,
             message_type__in=["human", "ai"],
         )
-        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
         .values(
             "chat__team__name",
             "chat__team__slug",
             "chat__experiment_session__experiment__id",
             "chat__experiment_session__experiment__name",
             "chat__experiment_session__experiment_channel__extra_data",
+            "chat__experiment_session__experiment_channel__deleted",
             "message_type",
         )
         .annotate(count=Count("id"))
@@ -130,12 +132,14 @@ def get_whatsapp_message_stats(start: datetime, end: datetime):
         team_slug = row["chat__team__slug"]
         experiment_id = row["chat__experiment_session__experiment__id"]
         extra_data = row["chat__experiment_session__experiment_channel__extra_data"] or {}
+        deleted = row["chat__experiment_session__experiment_channel__deleted"]
         number = extra_data.get("number", "---")
         key = (team_slug, experiment_id, number)
         pivot[key][row["message_type"]] += row["count"]
         key_metadata[key] = {
             "team_name": row["chat__team__name"],
             "experiment_name": row["chat__experiment_session__experiment__name"],
+            "channel_active": not deleted,
         }
 
     results = [
@@ -144,6 +148,7 @@ def get_whatsapp_message_stats(start: datetime, end: datetime):
             "team_slug": team_slug,
             "experiment": key_metadata[key]["experiment_name"],
             "experiment_id": experiment_id,
+            "channel_active": key_metadata[key]["channel_active"],
             "number": number,
             "human_count": counts["human"],
             "ai_count": counts["ai"],
@@ -294,13 +299,17 @@ def top_teams_to_csv(start: datetime, end: datetime):
 def top_experiments_to_csv(start: datetime, end: datetime):
     data = get_top_experiments(start, end)
     rows = ((d["team"], d["experiment"], d["msg_count"], d["session_count"]) for d in data)
-    return _write_data_to_csv(["Team", "Experiment", "Messages", "Sessions"], rows)
+    return _write_data_to_csv(["Team", "Chatbot", "Messages", "Sessions"], rows)
 
 
 def whatsapp_message_stats_to_csv(start: datetime, end: datetime):
     stats = get_whatsapp_message_stats(start, end)
-    rows = ((s["team"], s["experiment"], s["number"], s["human_count"], s["ai_count"]) for s in stats)
-    return _write_data_to_csv(["Team", "Experiment", "Channel Number", "Human Messages", "AI Messages"], rows)
+    rows = (
+        (s["team"], s["experiment"], s["number"], s["human_count"], s["ai_count"], s["channel_active"]) for s in stats
+    )
+    return _write_data_to_csv(
+        ["Team", "Chatbot", "Channel Number", "Human Messages", "AI Messages", "Channel Active"], rows
+    )
 
 
 def _write_data_to_csv(headers, rows):

--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -68,14 +68,20 @@ def get_whatsapp_numbers():
 
 
 def get_whatsapp_number_data():
-    channels = ExperimentChannel.objects.filter(platform=ChannelPlatform.WHATSAPP).values(
-        "deleted",
-        "extra_data",
-        "team__name",
-        "experiment__name",
-        "messaging_provider__name",
-        "messaging_provider__type",
-        "messaging_provider__config",
+    # Use unfiltered queryset so deleted channels are included; the default manager
+    # hides them, which would make the "Channel Active" column always True.
+    channels = (
+        ExperimentChannel.objects.get_unfiltered_queryset()
+        .filter(platform=ChannelPlatform.WHATSAPP)
+        .values(
+            "deleted",
+            "extra_data",
+            "team__name",
+            "experiment__name",
+            "messaging_provider__name",
+            "messaging_provider__type",
+            "messaging_provider__config",
+        )
     )
     for channel in channels:
         account = "---"

--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -136,10 +136,14 @@ def get_whatsapp_message_stats(start: datetime, end: datetime):
         number = extra_data.get("number", "---")
         key = (team_slug, experiment_id, number)
         pivot[key][row["message_type"]] += row["count"]
+        # If a channel was deleted and recreated for the same (team, experiment, number),
+        # the query returns separate rows per deleted status. Treat the pivot as active
+        # if any underlying channel is active.
+        existing = key_metadata.get(key)
         key_metadata[key] = {
             "team_name": row["chat__team__name"],
             "experiment_name": row["chat__experiment_session__experiment__name"],
-            "channel_active": not deleted,
+            "channel_active": (existing["channel_active"] if existing else False) or not deleted,
         }
 
     results = [

--- a/apps/admin/tests/test_queries.py
+++ b/apps/admin/tests/test_queries.py
@@ -9,6 +9,7 @@ from apps.admin.queries import (
     get_team_activity_summary,
     get_top_experiments,
     get_top_teams,
+    get_whatsapp_message_stats,
 )
 from apps.admin.views import _compute_growth
 from apps.channels.models import ChannelPlatform
@@ -152,6 +153,80 @@ class TestGetTopExperiments:
         result = get_top_experiments(start, end, limit=2)
         assert len(result) == 2
         assert result[0]["msg_count"] >= result[1]["msg_count"]
+
+
+@pytest.mark.django_db()
+class TestGetWhatsappMessageStats:
+    def test_pivot_marks_channel_active_when_any_channel_active(self, date_range):
+        # When a WhatsApp channel for a number is deleted and recreated, the query returns
+        # separate rows per deleted status. The pivoted result should report the channel
+        # as active if any underlying channel is active.
+        start, end = date_range
+        team = TeamFactory.create(name="WA Team")
+        number = "+15550001111"
+
+        deleted_channel = ExperimentChannelFactory.create(
+            team=team,
+            platform=ChannelPlatform.WHATSAPP,
+            extra_data={"number": number},
+        )
+        active_channel = ExperimentChannelFactory.create(
+            team=team,
+            experiment=deleted_channel.experiment,
+            platform=ChannelPlatform.WHATSAPP,
+            extra_data={"number": number},
+        )
+        deleted_channel.deleted = True
+        deleted_channel.save()
+
+        deleted_session = ExperimentSessionFactory.create(
+            team=team,
+            experiment=deleted_channel.experiment,
+            experiment_channel=deleted_channel,
+            platform=ChannelPlatform.WHATSAPP,
+        )
+        active_session = ExperimentSessionFactory.create(
+            team=team,
+            experiment=active_channel.experiment,
+            experiment_channel=active_channel,
+            platform=ChannelPlatform.WHATSAPP,
+        )
+        ChatMessageFactory.create(chat=deleted_session.chat, message_type="human", content="old")
+        ChatMessageFactory.create(chat=active_session.chat, message_type="human", content="new")
+        ChatMessageFactory.create(chat=active_session.chat, message_type="ai", content="reply")
+
+        results = get_whatsapp_message_stats(start, end)
+        rows = [r for r in results if r["number"] == number]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["channel_active"] is True
+        assert row["human_count"] == 2
+        assert row["ai_count"] == 1
+
+    def test_pivot_marks_channel_inactive_when_all_channels_deleted(self, date_range):
+        start, end = date_range
+        team = TeamFactory.create(name="WA Team 2")
+        number = "+15550002222"
+
+        channel = ExperimentChannelFactory.create(
+            team=team,
+            platform=ChannelPlatform.WHATSAPP,
+            extra_data={"number": number},
+        )
+        session = ExperimentSessionFactory.create(
+            team=team,
+            experiment=channel.experiment,
+            experiment_channel=channel,
+            platform=ChannelPlatform.WHATSAPP,
+        )
+        ChatMessageFactory.create(chat=session.chat, message_type="human", content="hi")
+        channel.deleted = True
+        channel.save()
+
+        results = get_whatsapp_message_stats(start, end)
+        rows = [r for r in results if r["number"] == number]
+        assert len(rows) == 1
+        assert rows[0]["channel_active"] is False
 
 
 class TestComputeGrowth:

--- a/apps/admin/tests/test_queries.py
+++ b/apps/admin/tests/test_queries.py
@@ -10,6 +10,7 @@ from apps.admin.queries import (
     get_top_experiments,
     get_top_teams,
     get_whatsapp_message_stats,
+    get_whatsapp_number_data,
 )
 from apps.admin.views import _compute_growth
 from apps.channels.models import ChannelPlatform
@@ -227,6 +228,35 @@ class TestGetWhatsappMessageStats:
         rows = [r for r in results if r["number"] == number]
         assert len(rows) == 1
         assert rows[0]["channel_active"] is False
+
+
+@pytest.mark.django_db()
+class TestGetWhatsappNumberData:
+    def test_includes_deleted_channels_with_correct_active_flag(self):
+        # The default ExperimentChannel manager filters out deleted rows, so the export
+        # must bypass it to show both active and deleted channels accurately.
+        team = TeamFactory.create(name="WA Numbers")
+
+        active_channel = ExperimentChannelFactory.create(
+            team=team,
+            platform=ChannelPlatform.WHATSAPP,
+            extra_data={"number": "+15550003333"},
+        )
+        deleted_channel = ExperimentChannelFactory.create(
+            team=team,
+            platform=ChannelPlatform.WHATSAPP,
+            extra_data={"number": "+15550004444"},
+        )
+        deleted_channel.deleted = True
+        deleted_channel.save()
+
+        rows_by_number = {row[4]: row for row in get_whatsapp_number_data()}
+        assert "+15550003333" in rows_by_number
+        assert "+15550004444" in rows_by_number
+        assert rows_by_number["+15550003333"][5] is True  # active channel
+        assert rows_by_number["+15550004444"][5] is False  # deleted channel
+        assert rows_by_number["+15550003333"][1] == active_channel.experiment.name
+        assert rows_by_number["+15550004444"][1] == deleted_channel.experiment.name
 
 
 class TestComputeGrowth:


### PR DESCRIPTION
### Product Description
Small tweak to admin exports to include deleted channels and delete status.

Also rename 'Experiment' to 'Chatbot' in the CSV outputs.
