### PR TITLE
Consolidate content-type detection into a single utility

### DIFF
--- a/apps/channels/channels_v2/email_channel.py
+++ b/apps/channels/channels_v2/email_channel.py
@@ -20,7 +20,7 @@ from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.channels.utils import is_email_domain_allowed
 from apps.chat.channels import MESSAGE_TYPES
 from apps.experiments.models import ExperimentSession
-from apps.files.content_type import DEFAULT_CONTENT_TYPE, detect_content_type
+from apps.files.content_type import detect_content_type
 from apps.files.models import File, FilePurpose
 from apps.service_providers.file_limits import (
     EMAIL_BLOCKED_CONTENT_TYPES,
@@ -203,7 +203,7 @@ def _persist_inbound_attachments(raw: list[RawAttachment], team_id: int) -> tupl
     for att in raw:
         size = len(att.content_bytes)
         ext = pathlib.Path(att.filename or "").suffix.lstrip(".").lower()
-        detected = detect_content_type(att.content_bytes, fallback=att.content_type) or DEFAULT_CONTENT_TYPE
+        detected = detect_content_type(att.content_bytes, fallback=att.content_type)
 
         if reason := _is_blocked(ext, att.content_type, detected):
             skipped.append({"name": att.filename, "reason": reason, "size": size})

--- a/apps/channels/channels_v2/email_channel.py
+++ b/apps/channels/channels_v2/email_channel.py
@@ -8,7 +8,6 @@ from email.utils import make_msgid
 from io import BytesIO
 from typing import TYPE_CHECKING
 
-import magic
 from django.core.mail import EmailMessage as DjangoEmailMessage
 from django.db import IntegrityError
 
@@ -21,6 +20,7 @@ from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.channels.utils import is_email_domain_allowed
 from apps.chat.channels import MESSAGE_TYPES
 from apps.experiments.models import ExperimentSession
+from apps.files.content_type import DEFAULT_CONTENT_TYPE, detect_content_type
 from apps.files.models import File, FilePurpose
 from apps.service_providers.file_limits import (
     EMAIL_BLOCKED_CONTENT_TYPES,
@@ -167,16 +167,6 @@ def _domain_from_address(email_address: str) -> str:
     return email_address
 
 
-def _detect_content_type(content: bytes, fallback: str = "") -> str:
-    try:
-        detected = magic.from_buffer(content[:2048], mime=True)
-        if detected and detected != "application/octet-stream":
-            return detected
-    except Exception:
-        logger.exception("magic content-type detection failed")
-    return fallback or "application/octet-stream"
-
-
 def _category(content_type: str) -> str:
     """Top-level category for mismatch comparison.
     Maps known textual application/* types (JSON, XML, YAML, ...) to 'text'
@@ -213,7 +203,7 @@ def _persist_inbound_attachments(raw: list[RawAttachment], team_id: int) -> tupl
     for att in raw:
         size = len(att.content_bytes)
         ext = pathlib.Path(att.filename or "").suffix.lstrip(".").lower()
-        detected = _detect_content_type(att.content_bytes, fallback=att.content_type)
+        detected = detect_content_type(att.content_bytes, fallback=att.content_type) or DEFAULT_CONTENT_TYPE
 
         if reason := _is_blocked(ext, att.content_type, detected):
             skipped.append({"name": att.filename, "reason": reason, "size": size})

--- a/apps/channels/tests/test_email_channel.py
+++ b/apps/channels/tests/test_email_channel.py
@@ -986,7 +986,7 @@ class TestPersistInboundAttachments:
         # size check fires (magic sees b"x"*N as text/plain, causing a
         # spurious mismatch against application/pdf before the size check).
         with patch(
-            "apps.channels.channels_v2.email_channel._detect_content_type",
+            "apps.channels.channels_v2.email_channel.detect_content_type",
             return_value="application/pdf",
         ):
             accepted, skipped = _persist_inbound_attachments(raw, team_id=team.id)
@@ -1025,7 +1025,7 @@ class TestPersistInboundAttachments:
         # detection-based rejection branch without relying on real libmagic
         # signatures (which can vary by version/platform).
         with patch(
-            "apps.channels.channels_v2.email_channel._detect_content_type",
+            "apps.channels.channels_v2.email_channel.detect_content_type",
             return_value="application/x-msdownload",
         ):
             accepted, skipped = _persist_inbound_attachments(raw, team_id=team.id)
@@ -1130,10 +1130,10 @@ class TestEmailInboundHandlerWithAttachments:
             [oversized], to_email=channel.extra_data["email_address"], text="Please process"
         )
 
-        # Mock _detect_content_type so the oversized PDF doesn't trip the
+        # Mock detect_content_type so the oversized PDF doesn't trip the
         # mismatch check (libmagic sees a long string of "x" as text/plain).
         with (
-            patch("apps.channels.channels_v2.email_channel._detect_content_type", return_value="application/pdf"),
+            patch("apps.channels.channels_v2.email_channel.detect_content_type", return_value="application/pdf"),
             patch("apps.channels.tasks.handle_email_message.delay") as delay,
         ):
             email_inbound_handler(sender=None, event=MagicMock(message=inbound))

--- a/apps/files/content_type.py
+++ b/apps/files/content_type.py
@@ -1,0 +1,80 @@
+"""Content-type detection helpers built around python-magic with safe fallbacks."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import mimetypes
+import pathlib
+from typing import BinaryIO
+
+import magic
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONTENT_TYPE = "application/octet-stream"
+_MAGIC_SAMPLE_BYTES = 2048
+
+
+def _magic_detect(content: bytes) -> str | None:
+    """Run python-magic on up to the first 2048 bytes.
+
+    Returns the detected MIME type, or None when detection fails or returns
+    the generic ``application/octet-stream`` (treated as "no signal").
+    """
+    if not content:
+        return None
+    try:
+        detected = magic.from_buffer(content[:_MAGIC_SAMPLE_BYTES], mime=True)
+    except Exception:
+        logger.exception("magic content-type detection failed")
+        return None
+    if not detected or detected == DEFAULT_CONTENT_TYPE:
+        return None
+    return detected
+
+
+def detect_content_type(
+    content: bytes = b"",
+    *,
+    filename: str = "",
+    fallback: str = "",
+) -> str | None:
+    """Best-effort MIME detection from raw bytes with cascading fallbacks.
+
+    Detection precedence:
+        1. python-magic applied to the first 2048 bytes of ``content``
+        2. ``mimetypes.guess_type(filename)`` when ``filename`` is provided
+        3. ``fallback`` (e.g. a claimed Content-Type header from an external source)
+
+    Returns ``None`` if no source produces a value; callers that need a
+    non-empty result should coalesce with :data:`DEFAULT_CONTENT_TYPE`.
+    """
+    if detected := _magic_detect(content):
+        return detected
+    if filename:
+        guessed, _ = mimetypes.guess_type(filename)
+        if guessed:
+            return guessed
+    return fallback or None
+
+
+def detect_content_type_from_file(file_obj: BinaryIO) -> str:
+    """Detect MIME from a file-like object, always returning a non-empty string.
+
+    Reads up to 2048 bytes from ``file_obj`` (seeking back to 0 afterwards),
+    then runs the same cascade as :func:`detect_content_type` using the
+    object's ``name`` attribute as the filename fallback. Falls through to
+    :data:`DEFAULT_CONTENT_TYPE` if every step fails.
+    """
+    content = b""
+    with contextlib.suppress(Exception):
+        file_obj.seek(0)
+        content = file_obj.read(_MAGIC_SAMPLE_BYTES)
+        file_obj.seek(0)
+
+    name = getattr(file_obj, "name", "") or ""
+    with contextlib.suppress(Exception):
+        name = pathlib.Path(name).name
+
+    return detect_content_type(content, filename=name) or DEFAULT_CONTENT_TYPE

--- a/apps/files/content_type.py
+++ b/apps/files/content_type.py
@@ -39,16 +39,14 @@ def detect_content_type(
     *,
     filename: str = "",
     fallback: str = "",
-) -> str | None:
+) -> str:
     """Best-effort MIME detection from raw bytes with cascading fallbacks.
 
     Detection precedence:
         1. python-magic applied to the first 2048 bytes of ``content``
         2. ``mimetypes.guess_type(filename)`` when ``filename`` is provided
         3. ``fallback`` (e.g. a claimed Content-Type header from an external source)
-
-    Returns ``None`` if no source produces a value; callers that need a
-    non-empty result should coalesce with :data:`DEFAULT_CONTENT_TYPE`.
+        4. :data:`DEFAULT_CONTENT_TYPE` (``application/octet-stream``)
     """
     if detected := _magic_detect(content):
         return detected
@@ -56,16 +54,15 @@ def detect_content_type(
         guessed, _ = mimetypes.guess_type(filename)
         if guessed:
             return guessed
-    return fallback or None
+    return fallback or DEFAULT_CONTENT_TYPE
 
 
 def detect_content_type_from_file(file_obj: BinaryIO) -> str:
-    """Detect MIME from a file-like object, always returning a non-empty string.
+    """Detect MIME from a file-like object.
 
     Reads up to 2048 bytes from ``file_obj`` (seeking back to 0 afterwards),
     then runs the same cascade as :func:`detect_content_type` using the
-    object's ``name`` attribute as the filename fallback. Falls through to
-    :data:`DEFAULT_CONTENT_TYPE` if every step fails.
+    object's ``name`` attribute as the filename fallback.
     """
     content = b""
     with contextlib.suppress(Exception):
@@ -77,4 +74,4 @@ def detect_content_type_from_file(file_obj: BinaryIO) -> str:
     with contextlib.suppress(Exception):
         name = pathlib.Path(name).name
 
-    return detect_content_type(content, filename=name) or DEFAULT_CONTENT_TYPE
+    return detect_content_type(content, filename=name)

--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from pgvector.django import HalfVectorField
 
 from apps.experiments.versioning import VersionDetails, VersionField, VersionsMixin, VersionsObjectManagerMixin
-from apps.files.content_type import detect_content_type, detect_content_type_from_file
+from apps.files.content_type import DEFAULT_CONTENT_TYPE, detect_content_type, detect_content_type_from_file
 from apps.generics.chips import Chip
 from apps.service_providers.file_limits import FILE_SENDABILITY_CHECKERS
 from apps.teams.models import BaseTeamModel
@@ -89,7 +89,7 @@ class File(BaseTeamModel, VersionsMixin):
         content = file_obj.read() if file_obj else None
 
         if not content_type:
-            content_type = detect_content_type(content or b"", filename=filename)
+            content_type = detect_content_type(content or b"", filename=filename) or DEFAULT_CONTENT_TYPE
 
         if content_type and not pathlib.Path(filename).suffix:
             extension = mimetypes.guess_extension(content_type)

--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from pgvector.django import HalfVectorField
 
 from apps.experiments.versioning import VersionDetails, VersionField, VersionsMixin, VersionsObjectManagerMixin
-from apps.files.content_type import DEFAULT_CONTENT_TYPE, detect_content_type, detect_content_type_from_file
+from apps.files.content_type import detect_content_type, detect_content_type_from_file
 from apps.generics.chips import Chip
 from apps.service_providers.file_limits import FILE_SENDABILITY_CHECKERS
 from apps.teams.models import BaseTeamModel
@@ -89,7 +89,7 @@ class File(BaseTeamModel, VersionsMixin):
         content = file_obj.read() if file_obj else None
 
         if not content_type:
-            content_type = detect_content_type(content or b"", filename=filename) or DEFAULT_CONTENT_TYPE
+            content_type = detect_content_type(content or b"", filename=filename)
 
         if content_type and not pathlib.Path(filename).suffix:
             extension = mimetypes.guess_extension(content_type)

--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -1,9 +1,7 @@
-import contextlib
 import mimetypes
 import pathlib
 from datetime import datetime
 
-import magic
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.db import models
@@ -11,6 +9,7 @@ from django.urls import reverse
 from pgvector.django import HalfVectorField
 
 from apps.experiments.versioning import VersionDetails, VersionField, VersionsMixin, VersionsObjectManagerMixin
+from apps.files.content_type import detect_content_type, detect_content_type_from_file
 from apps.generics.chips import Chip
 from apps.service_providers.file_limits import FILE_SENDABILITY_CHECKERS
 from apps.teams.models import BaseTeamModel
@@ -89,13 +88,8 @@ class File(BaseTeamModel, VersionsMixin):
     ):
         content = file_obj.read() if file_obj else None
 
-        if not content_type and content:
-            with contextlib.suppress(Exception):
-                detected = magic.from_buffer(content[:2048], mime=True)
-                if detected and detected != "application/octet-stream":
-                    content_type = detected
-
-        content_type = content_type or mimetypes.guess_type(filename)[0]
+        if not content_type:
+            content_type = detect_content_type(content or b"", filename=filename)
 
         if content_type and not pathlib.Path(filename).suffix:
             extension = mimetypes.guess_extension(content_type)
@@ -126,22 +120,7 @@ class File(BaseTeamModel, VersionsMixin):
     @staticmethod
     def get_content_type(file):
         """Detect content type by inspecting file bytes first, falling back to filename."""
-        with contextlib.suppress(Exception):
-            file.seek(0)
-            header = file.read(2048)
-            file.seek(0)
-            if header:
-                detected = magic.from_buffer(header, mime=True)
-                if detected and detected != "application/octet-stream":
-                    return detected
-
-        filename = file.name
-        with contextlib.suppress(Exception):
-            filename = pathlib.Path(filename).name
-        try:
-            return mimetypes.guess_type(filename)[0] or "application/octet-stream"
-        except Exception:
-            return "application/octet-stream"
+        return detect_content_type_from_file(file)
 
     @property
     def is_image(self):

--- a/apps/files/tests/test_content_type.py
+++ b/apps/files/tests/test_content_type.py
@@ -1,0 +1,86 @@
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+
+from apps.files.content_type import (
+    DEFAULT_CONTENT_TYPE,
+    detect_content_type,
+    detect_content_type_from_file,
+)
+
+
+@pytest.fixture()
+def magic_returns():
+    """Patch python-magic to return a controlled MIME type for deterministic tests."""
+
+    def _patch(value):
+        return patch("apps.files.content_type.magic.from_buffer", return_value=value)
+
+    return _patch
+
+
+class TestDetectContentType:
+    def test_uses_magic_when_signature_recognised(self, magic_returns):
+        with magic_returns("image/png"):
+            assert detect_content_type(b"any-bytes") == "image/png"
+
+    def test_treats_octet_stream_as_no_signal(self, magic_returns):
+        with magic_returns(DEFAULT_CONTENT_TYPE):
+            assert detect_content_type(b"any-bytes", filename="notes.txt") == "text/plain"
+
+    def test_falls_back_to_filename_when_no_bytes(self):
+        assert detect_content_type(b"", filename="notes.txt") == "text/plain"
+
+    def test_falls_back_to_explicit_fallback_when_no_other_signal(self):
+        assert detect_content_type(b"", fallback="application/pdf") == "application/pdf"
+
+    def test_returns_none_when_no_signal_at_all(self):
+        assert detect_content_type(b"") is None
+
+    def test_magic_takes_priority_over_filename(self, magic_returns):
+        with magic_returns("image/png"):
+            assert detect_content_type(b"any-bytes", filename="lie.txt") == "image/png"
+
+    def test_magic_takes_priority_over_fallback(self, magic_returns):
+        with magic_returns("image/png"):
+            assert detect_content_type(b"any-bytes", fallback="application/pdf") == "image/png"
+
+    def test_filename_takes_priority_over_fallback(self):
+        assert detect_content_type(b"", filename="a.json", fallback="application/pdf") == "application/json"
+
+    def test_magic_exception_falls_through(self):
+        with patch("apps.files.content_type.magic.from_buffer", side_effect=RuntimeError("libmagic boom")):
+            assert detect_content_type(b"any-bytes", fallback="application/pdf") == "application/pdf"
+
+
+class TestDetectContentTypeFromFile:
+    def test_detects_from_file_bytes(self, magic_returns):
+        f = BytesIO(b"any-bytes")
+        f.name = "image.png"
+        with magic_returns("image/png"):
+            assert detect_content_type_from_file(f) == "image/png"
+        # File must be seeked back to start so callers can re-read it.
+        assert f.tell() == 0
+
+    def test_falls_back_to_filename_when_bytes_unknown(self):
+        f = BytesIO(b"\x00\x00")
+        f.name = "notes.txt"
+        assert detect_content_type_from_file(f) == "text/plain"
+
+    def test_returns_default_when_everything_fails(self):
+        f = BytesIO(b"\x00\x00")
+        f.name = "no_extension"
+        assert detect_content_type_from_file(f) == DEFAULT_CONTENT_TYPE
+
+    def test_handles_unreadable_file(self):
+        class Broken:
+            name = "broken.txt"
+
+            def seek(self, *_):
+                raise OSError("cannot seek")
+
+            def read(self, *_):
+                raise OSError("cannot read")
+
+        assert detect_content_type_from_file(Broken()) == "text/plain"

--- a/apps/files/tests/test_content_type.py
+++ b/apps/files/tests/test_content_type.py
@@ -35,8 +35,8 @@ class TestDetectContentType:
     def test_falls_back_to_explicit_fallback_when_no_other_signal(self):
         assert detect_content_type(b"", fallback="application/pdf") == "application/pdf"
 
-    def test_returns_none_when_no_signal_at_all(self):
-        assert detect_content_type(b"") is None
+    def test_returns_default_when_no_signal_at_all(self):
+        assert detect_content_type(b"") == DEFAULT_CONTENT_TYPE
 
     def test_magic_takes_priority_over_filename(self, magic_returns):
         with magic_returns("image/png"):


### PR DESCRIPTION
### Product Description
Internal refactor, no user-visible behaviour change.

### Technical Description
Three places were running their own `magic.from_buffer` + fallback cascade (`File.create`, `File.get_content_type`, `email_channel._detect_content_type`). This PR consolidates them into a new `apps/files/content_type.py` utility with two helpers: `detect_content_type(content, *, filename="", fallback="")` (bytes-based, returns `str | None`) and `detect_content_type_from_file(file_obj)` (file-object, always returns a string). All three call sites now delegate to it.

Follow-up to ##3256.

### Migrations
- [x] The migrations are backwards compatible

No schema changes.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Generated with [Claude Code](https://claude.ai/code)