### PR TITLE
Add `inv dev` honcho launcher; default celery to no-beat

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+web: uv run inv runserver
+worker: uv run inv celery
+assets: npm run dev-watch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ dev = [
     "prek>=0.3.2",
     "django-types",
     "ty==0.0.33",
+    "honcho>=2.0.0",
 ]
 docs = [
     "zensical>=0.0.40",

--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,6 @@
 import platform
 import re
+import sys
 import textwrap
 import time
 from pathlib import Path
@@ -164,6 +165,14 @@ def ngrok_url(c: Context):
     return public_url
 
 
+def _disable_stdin_forwarding(c: Context) -> None:
+    """Stop invoke from forwarding stdin to child processes. The long-running
+    dev tasks (runserver, celery worker) never read interactive input, and
+    forwarding fails with EINVAL when launched under a parent (honcho) whose
+    stdin is a foreign TTY whose process group we don't own."""
+    c.config.run.in_stream = False
+
+
 def _get_portless_name(c: Context) -> str:
     result = c.run("portless list", hide=True, warn=True)
     used_names = set(re.findall(r"http://(\w+)\.localhost", result.stdout)) if result.ok else set()
@@ -178,6 +187,7 @@ def _get_portless_name(c: Context) -> str:
 @task(aliases=["django"], help={"public": "Expose server publicly via ngrok tunnel"})
 def runserver(c: Context, public=False):
     """Start Django development server (alias: inv django)."""
+    _disable_stdin_forwarding(c)
     has_portless = c.run("which portless", hide=True, warn=True).ok
     if has_portless:
         portless_name = _get_portless_name(c)
@@ -197,9 +207,9 @@ def runserver(c: Context, public=False):
         else:
             env = " ".join(env_vars)
             runserver_command = f"{env} {runserver_command}"
-            pty = True
+            pty = sys.stdout.isatty()
     else:
-        pty = True
+        pty = sys.stdout.isatty()
 
     c.run(runserver_command, echo=True, pty=pty)
 
@@ -212,6 +222,7 @@ def runserver(c: Context, public=False):
 )
 def celery(c: Context, gevent=False, beat=False):
     """Start Celery worker with auto-reload on code changes."""
+    _disable_stdin_forwarding(c)
     cmd = "celery -A config worker -l INFO"
     if gevent:
         cmd += " --pool gevent --concurrency 10"
@@ -222,7 +233,7 @@ def celery(c: Context, gevent=False, beat=False):
 
     if gevent:
         cprint("Starting celery worker with gevent pool. This will not run celery beat.", "yellow")
-    c.run(f'watchfiles --filter python "{cmd}"', echo=True, pty=True)
+    c.run(f'watchfiles --filter python "{cmd}"', echo=True, pty=sys.stdout.isatty())
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -207,10 +207,10 @@ def runserver(c: Context, public=False):
 @task(
     help={
         "gevent": "Use gevent pool for async tasks (disables beat scheduler)",
-        "beat": "Include beat scheduler for periodic tasks (default: True)",
+        "beat": "Include beat scheduler for periodic tasks (default: False)",
     }
 )
-def celery(c: Context, gevent=False, beat=True):
+def celery(c: Context, gevent=False, beat=False):
     """Start Celery worker with auto-reload on code changes."""
     cmd = "celery -A config worker -l INFO"
     if gevent:

--- a/tasks.py
+++ b/tasks.py
@@ -175,7 +175,7 @@ def _get_portless_name(c: Context) -> str:
     return name
 
 
-@task(aliases=["django", "dev"], help={"public": "Expose server publicly via ngrok tunnel"})
+@task(aliases=["django"], help={"public": "Expose server publicly via ngrok tunnel"})
 def runserver(c: Context, public=False):
     """Start Django development server (alias: inv django)."""
     has_portless = c.run("which portless", hide=True, warn=True).ok
@@ -223,6 +223,12 @@ def celery(c: Context, gevent=False, beat=False):
     if gevent:
         cprint("Starting celery worker with gevent pool. This will not run celery beat.", "yellow")
     c.run(f'watchfiles --filter python "{cmd}"', echo=True, pty=True)
+
+
+@task
+def dev(c: Context):
+    """Run Django, Celery, and the webpack asset watcher together via honcho."""
+    c.run("uv run honcho -f Procfile.dev start", echo=True, pty=True)
 
 
 @task(

--- a/uv.lock
+++ b/uv.lock
@@ -1896,6 +1896,18 @@ wheels = [
 ]
 
 [[package]]
+name = "honcho"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/c8/d860888358bf5c8a6e7d78d1b508b59b0e255afd5655f243b8f65166dafd/honcho-2.0.0.tar.gz", hash = "sha256:af3815c03c634bf67d50f114253ea9fef72ecff26e4fd06b29234789ac5b8b2e", size = 45618, upload-time = "2024-10-06T14:26:53.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/1c/25631fc359955569e63f5446dbb7022c320edf9846cbe892ee5113433a7e/honcho-2.0.0-py3-none-any.whl", hash = "sha256:56dcd04fc72d362a4befb9303b1a1a812cba5da283526fbc6509be122918ddf3", size = 22093, upload-time = "2024-10-06T14:26:52.181Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -3089,6 +3101,7 @@ dev = [
     { name = "django-debug-toolbar" },
     { name = "django-types" },
     { name = "factory-boy" },
+    { name = "honcho" },
     { name = "invoke" },
     { name = "mock" },
     { name = "prek" },
@@ -3205,6 +3218,7 @@ dev = [
     { name = "django-debug-toolbar", specifier = ">=5.2.0" },
     { name = "django-types" },
     { name = "factory-boy" },
+    { name = "honcho", specifier = ">=2.0.0" },
     { name = "invoke" },
     { name = "mock" },
     { name = "prek", specifier = ">=0.3.2" },


### PR DESCRIPTION
### Product Description
No change. Developer tooling only.

### Technical Description
Bundles the three long-running dev processes (Django, Celery via watchfiles, webpack dev-watch) behind a single command so you no longer need three terminals.

- New `Procfile.dev` defines `web`, `worker`, `assets` — each delegates back to existing invoke tasks (`uv run inv runserver`, `uv run inv celery`) so portless detection and the celery command stay in one place.
- New `inv dev` task shells out to `uv run honcho -f Procfile.dev start`. Honcho added to the `dev` dependency group.
- Dropped the `dev` alias from `inv runserver` so the new task can take that name; `inv runserver` and `inv django` still work.
- `inv celery` now defaults `beat=False` (the previous default included `-B`). Run `inv celery --beat` if you need the beat scheduler. The Procfile-driven worker therefore runs without beat by default, matching how most contributors actually run things.

### Demo
N/A — dev-only change. To try: `uv sync --dev && uv run inv dev`.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Dev-tooling change only; no user-facing changelog entry needed.