### PR TITLE
feat: add gpt-5.4-mini model for OpenAI provider

### DIFF
--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -96,6 +96,7 @@ DEFAULT_LLM_PROVIDER_MODELS = {
         Model("gpt-5.3", k(400), parameters=GPT51Parameters),
         Model("gpt-5.3-instant", k(400), parameters=GPT51Parameters),
         Model("gpt-5.4", k(400), parameters=GPT52Parameters),
+        Model("gpt-5.4-mini", k(400), parameters=GPT52Parameters),
         Model("gpt-5.4-pro", k(400), parameters=GPT5ProParameters),
         Model("gpt-5.5", 1050000, parameters=GPT55Parameters),
         Model("gpt-5-mini", k(400), parameters=GPT5Parameters),

--- a/apps/service_providers/migrations/0054_add_gpt54mini.py
+++ b/apps/service_providers/migrations/0054_add_gpt54mini.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+from apps.service_providers.migration_utils import llm_model_migration
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("service_providers", "0053_add_gpt55_model"),
+    ]
+
+    operations = [
+        # Register gpt-5.4-mini (OpenAI) with 400K token context window.
+        llm_model_migration(),
+    ]


### PR DESCRIPTION
Adds `gpt-5.4-mini` to the OpenAI model list.

- Token limit: 400K (matching `gpt-5.4`)
- Parameters: `GPT52Parameters` (reasoning effort: none/low/medium/high/xhigh, matching `gpt-5.4`)
- Migration `0054` syncs the new model into the DB on next deploy