### PR TITLE
refactor: centralize ChatMessage.metadata keys in a StrEnum

### DIFF
--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import NotFound
 from taggit.serializers import TaggitSerializer, TagListSerializerField
 
 from apps.channels.models import ChannelPlatform, ExperimentChannel
-from apps.chat.models import ChatMessage, ChatMessageType
+from apps.chat.models import ChatMessage, ChatMessageMetadataKeys, ChatMessageType
 from apps.experiments.models import Experiment, ExperimentSession, Participant, ParticipantData
 from apps.files.models import File
 from apps.teams.models import Team
@@ -107,7 +107,7 @@ class MessageSerializer(TaggitSerializer, serializers.ModelSerializer):
             instance.tags = []
         data = super().to_representation(instance)
         data["role"] = ChatMessageType(data["role"]).role
-        for key in ChatMessage.INTERNAL_METADATA_KEYS:
+        for key in ChatMessageMetadataKeys.internal_keys():
             data["metadata"].pop(key, None)
         return data
 

--- a/apps/channels/channels_v2/stages/core.py
+++ b/apps/channels/channels_v2/stages/core.py
@@ -13,7 +13,7 @@ from apps.chat.bots import EventBot, get_bot
 from apps.chat.channels import MARKDOWN_REF_PATTERN, MESSAGE_TYPES, _start_experiment_session, strip_urls_and_emojis
 from apps.chat.const import STATUSES_FOR_COMPLETE_CHATS
 from apps.chat.exceptions import AudioSynthesizeException, UserReportableError
-from apps.chat.models import ChatMessage, ChatMessageType
+from apps.chat.models import ChatMessage, ChatMessageMetadataKeys, ChatMessageType
 from apps.events.models import StaticTriggerType
 from apps.events.tasks import enqueue_static_triggers
 from apps.experiments.models import ExperimentSession, SessionStatus, VoiceResponseBehaviours
@@ -348,7 +348,7 @@ class ChatMessageCreationStage(ProcessingStage):
         return ctx.user_query is not None
 
     def process(self, ctx: MessageProcessingContext) -> None:
-        attachments_key = ChatMessage.MetadataKeys.OCS_ATTACHMENT_FILE_IDS
+        attachments_key = ChatMessageMetadataKeys.OCS_ATTACHMENT_FILE_IDS
         metadata = {attachments_key: []}
         is_voice = ctx.message.content_type == MESSAGE_TYPES.VOICE
 

--- a/apps/channels/channels_v2/stages/core.py
+++ b/apps/channels/channels_v2/stages/core.py
@@ -348,7 +348,8 @@ class ChatMessageCreationStage(ProcessingStage):
         return ctx.user_query is not None
 
     def process(self, ctx: MessageProcessingContext) -> None:
-        metadata = {"ocs_attachment_file_ids": []}
+        attachments_key = ChatMessage.MetadataKeys.OCS_ATTACHMENT_FILE_IDS
+        metadata = {attachments_key: []}
         is_voice = ctx.message.content_type == MESSAGE_TYPES.VOICE
 
         # Save voice note as attachment
@@ -362,11 +363,11 @@ class ChatMessageCreationStage(ProcessingStage):
                 content_type=ctx.message.cached_media_data.content_type,
             )
             ctx.experiment_session.chat.attach_files("voice_message", [file])
-            metadata["ocs_attachment_file_ids"].append(file.id)
+            metadata[attachments_key].append(file.id)
 
         # Record attachment IDs
         if ctx.message.attachments:
-            metadata["ocs_attachment_file_ids"].extend([att.file_id for att in ctx.message.attachments])
+            metadata[attachments_key].extend([att.file_id for att in ctx.message.attachments])
 
         # Add trace metadata
         if ctx.trace_service:

--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -11,7 +11,7 @@ from pydantic import ValidationError
 from apps.annotations.models import TagCategories
 from apps.chat.conversation import BasicConversation
 from apps.chat.exceptions import ChatException
-from apps.chat.models import ChatMessage, ChatMessageType
+from apps.chat.models import ChatMessage, ChatMessageMetadataKeys, ChatMessageType
 from apps.events.models import StaticTriggerType
 from apps.experiments.models import AgentTools, Experiment, ExperimentSession, ParticipantData, SyntheticVoice
 from apps.pipelines.executor import CurrentThreadExecutor, DjangoLangGraphRunner, DjangoSafeContextThreadPoolExecutor
@@ -130,7 +130,7 @@ class PipelineBot:
         attachments = attachments or []
         state["input_message_metadata"] = {}
         if attachments:
-            state["input_message_metadata"][ChatMessage.MetadataKeys.OCS_ATTACHMENT_FILE_IDS] = [
+            state["input_message_metadata"][ChatMessageMetadataKeys.OCS_ATTACHMENT_FILE_IDS] = [
                 attachment.file_id for attachment in attachments
             ]
             state["attachments"] = [attachment.model_dump() for attachment in attachments]

--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -130,7 +130,7 @@ class PipelineBot:
         attachments = attachments or []
         state["input_message_metadata"] = {}
         if attachments:
-            state["input_message_metadata"]["ocs_attachment_file_ids"] = [
+            state["input_message_metadata"][ChatMessage.MetadataKeys.OCS_ATTACHMENT_FILE_IDS] = [
                 attachment.file_id for attachment in attachments
             ]
             state["attachments"] = [attachment.model_dump() for attachment in attachments]

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -765,17 +765,18 @@ class ChannelBase(ABC):
         return self._create_chat_message(message_text)
 
     def _create_chat_message(self, message_text):
-        metadata = {"ocs_attachment_file_ids": []}
+        attachments_key = ChatMessage.MetadataKeys.OCS_ATTACHMENT_FILE_IDS
+        metadata = {attachments_key: []}
         is_voice = self.message.content_type == MESSAGE_TYPES.VOICE
         if is_voice and self.message.cached_media_data:
             file = self._create_voice_note_attachment(
                 self.message.cached_media_data.data, self.message.cached_media_data.content_type
             )
-            metadata["ocs_attachment_file_ids"].append(file.id)
+            metadata[attachments_key].append(file.id)
 
         attachments = self.message.attachments
         if attachments:
-            metadata["ocs_attachment_file_ids"].extend([attachment.file_id for attachment in attachments])
+            metadata[attachments_key].extend([attachment.file_id for attachment in attachments])
         human_message = self._add_message_to_history(message_text, ChatMessageType.HUMAN, metadata=metadata)
         if is_voice:
             human_message.create_and_add_tag("voice", self.experiment.team, TagCategories.MEDIA_TYPE)

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -34,7 +34,7 @@ from apps.chat.exceptions import (
     UserReportableError,
     VersionedExperimentSessionsNotAllowedException,
 )
-from apps.chat.models import Chat, ChatMessage, ChatMessageType
+from apps.chat.models import Chat, ChatMessage, ChatMessageMetadataKeys, ChatMessageType
 from apps.events.models import StaticTriggerType
 from apps.events.tasks import enqueue_static_triggers
 from apps.experiments.models import (
@@ -765,7 +765,7 @@ class ChannelBase(ABC):
         return self._create_chat_message(message_text)
 
     def _create_chat_message(self, message_text):
-        attachments_key = ChatMessage.MetadataKeys.OCS_ATTACHMENT_FILE_IDS
+        attachments_key = ChatMessageMetadataKeys.OCS_ATTACHMENT_FILE_IDS
         metadata = {attachments_key: []}
         is_voice = self.message.content_type == MESSAGE_TYPES.VOICE
         if is_voice and self.message.cached_media_data:

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -121,14 +121,29 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
     A message in a chat. Analogous to the BaseMessage class in langchain.
     """
 
+    class MetadataKeys(StrEnum):
+        # OpenAI Assistant (internal)
+        OPENAI_RUN_ID = "openai_run_id"
+        OPENAI_FILE_IDS = "openai_file_ids"
+        OPENAI_THREAD_CHECKPOINT = "openai_thread_checkpoint"
+        # Files & attachments
+        OCS_ATTACHMENT_FILE_IDS = "ocs_attachment_file_ids"
+        CITED_FILES = "cited_files"
+        GENERATED_FILES = "generated_files"
+        # Tracing / observability
+        TRACE_INFO = "trace_info"
+        TRACE_PROVIDER = "trace_provider"  # legacy top-level; only read for migration in trace_info property
+        # History / compression
+        COMPRESSION_MARKER = "compression_marker"
+
     # Metadata keys that should be excluded from the API response
-    INTERNAL_METADATA_KEYS = {
-        # ID of the thread run
-        "openai_run_id",
-        "openai_file_ids",
-        # boolean indicating that this message has been synced to the thread
-        "openai_thread_checkpoint",
-    }
+    INTERNAL_METADATA_KEYS = frozenset(
+        {
+            MetadataKeys.OPENAI_RUN_ID,
+            MetadataKeys.OPENAI_FILE_IDS,
+            MetadataKeys.OPENAI_THREAD_CHECKPOINT,
+        }
+    )
     # override from BaseModel to allow setting created_at in evals
     created_at = models.DateTimeField(default=timezone.now)
 
@@ -162,18 +177,18 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
             created_at=message.created_at,
             message_type=ChatMessageType.SYSTEM,
             content=message.summary,
-            metadata={"compression_marker": PipelineChatHistoryModes.SUMMARIZE},
+            metadata={cls.MetadataKeys.COMPRESSION_MARKER: PipelineChatHistoryModes.SUMMARIZE},
         )
 
     @property
     def trace_info(self) -> list[dict]:
-        trace_info = self.metadata.get("trace_info")
+        trace_info = self.metadata.get(self.MetadataKeys.TRACE_INFO)
         if not trace_info:
             return []
 
         if isinstance(trace_info, dict):
             # migrate legacy format
-            trace_info["trace_provider"] = self.metadata.get("trace_provider")
+            trace_info["trace_provider"] = self.metadata.get(self.MetadataKeys.TRACE_PROVIDER)
             return [trace_info]
         return trace_info
 
@@ -204,11 +219,11 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
             PipelineChatHistoryModes,
         )
 
-        return self.metadata.get("compression_marker") == PipelineChatHistoryModes.SUMMARIZE
+        return self.metadata.get(self.MetadataKeys.COMPRESSION_MARKER) == PipelineChatHistoryModes.SUMMARIZE
 
     @property
     def compression_marker(self):
-        return self.metadata.get("compression_marker")
+        return self.metadata.get(self.MetadataKeys.COMPRESSION_MARKER)
 
     @property
     def created_at_datetime(self):
@@ -265,10 +280,15 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
         external_ids = []
         ids = []
 
-        metadata_key = ["openai_file_ids", "ocs_attachment_file_ids", "cited_files", "generated_files"]
-        for source in metadata_key:
+        metadata_keys = [
+            self.MetadataKeys.OPENAI_FILE_IDS,
+            self.MetadataKeys.OCS_ATTACHMENT_FILE_IDS,
+            self.MetadataKeys.CITED_FILES,
+            self.MetadataKeys.GENERATED_FILES,
+        ]
+        for source in metadata_keys:
             # openai_file_ids is a list of external ids
-            id_list = external_ids if source == "openai_file_ids" else ids
+            id_list = external_ids if source == self.MetadataKeys.OPENAI_FILE_IDS else ids
             if file_ids := self.metadata.get(source, []):
                 id_list.extend(file_ids)
 
@@ -279,7 +299,7 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
 
     def add_attachment_id(self, file_id: int):
         """Add a file ID to the message's attachment list."""
-        ids = self.metadata.setdefault("ocs_attachment_file_ids", [])
+        ids = self.metadata.setdefault(self.MetadataKeys.OCS_ATTACHMENT_FILE_IDS, [])
         if file_id not in ids:
             ids.append(file_id)
             self.save(update_fields=["metadata"])

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -136,6 +136,11 @@ class ChatMessageMetadataKeys(StrEnum):
         """Metadata keys that should be excluded from the API response."""
         return frozenset({cls.OPENAI_RUN_ID, cls.OPENAI_FILE_IDS, cls.OPENAI_THREAD_CHECKPOINT})
 
+    @classmethod
+    def attachment_keys(cls) -> frozenset["ChatMessageMetadataKeys"]:
+        """Metadata keys that hold file IDs referencing attachments on a message."""
+        return frozenset({cls.OPENAI_FILE_IDS, cls.OCS_ATTACHMENT_FILE_IDS, cls.CITED_FILES, cls.GENERATED_FILES})
+
 
 class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
     """
@@ -278,13 +283,7 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
         external_ids = []
         ids = []
 
-        metadata_keys = [
-            ChatMessageMetadataKeys.OPENAI_FILE_IDS,
-            ChatMessageMetadataKeys.OCS_ATTACHMENT_FILE_IDS,
-            ChatMessageMetadataKeys.CITED_FILES,
-            ChatMessageMetadataKeys.GENERATED_FILES,
-        ]
-        for source in metadata_keys:
+        for source in ChatMessageMetadataKeys.attachment_keys():
             # openai_file_ids is a list of external ids
             id_list = external_ids if source == ChatMessageMetadataKeys.OPENAI_FILE_IDS else ids
             if file_ids := self.metadata.get(source, []):

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -116,32 +116,33 @@ class ChatMessageType(models.TextChoices):
         }[self]
 
 
+class ChatMessageMetadataKeys(StrEnum):
+    # OpenAI Assistant (internal)
+    OPENAI_RUN_ID = "openai_run_id"
+    OPENAI_FILE_IDS = "openai_file_ids"
+    OPENAI_THREAD_CHECKPOINT = "openai_thread_checkpoint"
+    # Files & attachments
+    OCS_ATTACHMENT_FILE_IDS = "ocs_attachment_file_ids"
+    CITED_FILES = "cited_files"
+    GENERATED_FILES = "generated_files"
+    # Tracing / observability
+    TRACE_INFO = "trace_info"
+    TRACE_PROVIDER = "trace_provider"  # legacy top-level; only read for migration in trace_info property
+    # History / compression
+    COMPRESSION_MARKER = "compression_marker"
+
+
 class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
     """
     A message in a chat. Analogous to the BaseMessage class in langchain.
     """
 
-    class MetadataKeys(StrEnum):
-        # OpenAI Assistant (internal)
-        OPENAI_RUN_ID = "openai_run_id"
-        OPENAI_FILE_IDS = "openai_file_ids"
-        OPENAI_THREAD_CHECKPOINT = "openai_thread_checkpoint"
-        # Files & attachments
-        OCS_ATTACHMENT_FILE_IDS = "ocs_attachment_file_ids"
-        CITED_FILES = "cited_files"
-        GENERATED_FILES = "generated_files"
-        # Tracing / observability
-        TRACE_INFO = "trace_info"
-        TRACE_PROVIDER = "trace_provider"  # legacy top-level; only read for migration in trace_info property
-        # History / compression
-        COMPRESSION_MARKER = "compression_marker"
-
     # Metadata keys that should be excluded from the API response
     INTERNAL_METADATA_KEYS = frozenset(
         {
-            MetadataKeys.OPENAI_RUN_ID,
-            MetadataKeys.OPENAI_FILE_IDS,
-            MetadataKeys.OPENAI_THREAD_CHECKPOINT,
+            ChatMessageMetadataKeys.OPENAI_RUN_ID,
+            ChatMessageMetadataKeys.OPENAI_FILE_IDS,
+            ChatMessageMetadataKeys.OPENAI_THREAD_CHECKPOINT,
         }
     )
     # override from BaseModel to allow setting created_at in evals
@@ -177,18 +178,18 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
             created_at=message.created_at,
             message_type=ChatMessageType.SYSTEM,
             content=message.summary,
-            metadata={cls.MetadataKeys.COMPRESSION_MARKER: PipelineChatHistoryModes.SUMMARIZE},
+            metadata={ChatMessageMetadataKeys.COMPRESSION_MARKER: PipelineChatHistoryModes.SUMMARIZE},
         )
 
     @property
     def trace_info(self) -> list[dict]:
-        trace_info = self.metadata.get(self.MetadataKeys.TRACE_INFO)
+        trace_info = self.metadata.get(ChatMessageMetadataKeys.TRACE_INFO)
         if not trace_info:
             return []
 
         if isinstance(trace_info, dict):
             # migrate legacy format
-            trace_info["trace_provider"] = self.metadata.get(self.MetadataKeys.TRACE_PROVIDER)
+            trace_info["trace_provider"] = self.metadata.get(ChatMessageMetadataKeys.TRACE_PROVIDER)
             return [trace_info]
         return trace_info
 
@@ -219,11 +220,11 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
             PipelineChatHistoryModes,
         )
 
-        return self.metadata.get(self.MetadataKeys.COMPRESSION_MARKER) == PipelineChatHistoryModes.SUMMARIZE
+        return self.metadata.get(ChatMessageMetadataKeys.COMPRESSION_MARKER) == PipelineChatHistoryModes.SUMMARIZE
 
     @property
     def compression_marker(self):
-        return self.metadata.get(self.MetadataKeys.COMPRESSION_MARKER)
+        return self.metadata.get(ChatMessageMetadataKeys.COMPRESSION_MARKER)
 
     @property
     def created_at_datetime(self):
@@ -281,14 +282,14 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
         ids = []
 
         metadata_keys = [
-            self.MetadataKeys.OPENAI_FILE_IDS,
-            self.MetadataKeys.OCS_ATTACHMENT_FILE_IDS,
-            self.MetadataKeys.CITED_FILES,
-            self.MetadataKeys.GENERATED_FILES,
+            ChatMessageMetadataKeys.OPENAI_FILE_IDS,
+            ChatMessageMetadataKeys.OCS_ATTACHMENT_FILE_IDS,
+            ChatMessageMetadataKeys.CITED_FILES,
+            ChatMessageMetadataKeys.GENERATED_FILES,
         ]
         for source in metadata_keys:
             # openai_file_ids is a list of external ids
-            id_list = external_ids if source == self.MetadataKeys.OPENAI_FILE_IDS else ids
+            id_list = external_ids if source == ChatMessageMetadataKeys.OPENAI_FILE_IDS else ids
             if file_ids := self.metadata.get(source, []):
                 id_list.extend(file_ids)
 
@@ -299,7 +300,7 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
 
     def add_attachment_id(self, file_id: int):
         """Add a file ID to the message's attachment list."""
-        ids = self.metadata.setdefault(self.MetadataKeys.OCS_ATTACHMENT_FILE_IDS, [])
+        ids = self.metadata.setdefault(ChatMessageMetadataKeys.OCS_ATTACHMENT_FILE_IDS, [])
         if file_id not in ids:
             ids.append(file_id)
             self.save(update_fields=["metadata"])

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -131,20 +131,17 @@ class ChatMessageMetadataKeys(StrEnum):
     # History / compression
     COMPRESSION_MARKER = "compression_marker"
 
+    @classmethod
+    def internal_keys(cls) -> frozenset["ChatMessageMetadataKeys"]:
+        """Metadata keys that should be excluded from the API response."""
+        return frozenset({cls.OPENAI_RUN_ID, cls.OPENAI_FILE_IDS, cls.OPENAI_THREAD_CHECKPOINT})
+
 
 class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
     """
     A message in a chat. Analogous to the BaseMessage class in langchain.
     """
 
-    # Metadata keys that should be excluded from the API response
-    INTERNAL_METADATA_KEYS = frozenset(
-        {
-            ChatMessageMetadataKeys.OPENAI_RUN_ID,
-            ChatMessageMetadataKeys.OPENAI_FILE_IDS,
-            ChatMessageMetadataKeys.OPENAI_THREAD_CHECKPOINT,
-        }
-    )
     # override from BaseModel to allow setting created_at in evals
     created_at = models.DateTimeField(default=timezone.now)
 

--- a/apps/pipelines/nodes/llm_node.py
+++ b/apps/pipelines/nodes/llm_node.py
@@ -10,7 +10,7 @@ from langchain_core.messages.utils import count_tokens_approximately
 from langchain_core.tools import BaseTool
 
 from apps.chat.agent.tools import SearchCollectionByIdTool, SearchIndexTool, SearchToolConfig, get_node_tools
-from apps.chat.models import ChatMessage
+from apps.chat.models import ChatMessageMetadataKeys
 from apps.experiments.models import ExperimentSession
 from apps.files.models import File
 from apps.pipelines.nodes.base import PipelineNode, PipelineState
@@ -136,8 +136,8 @@ def _process_files(node: PipelineNode, cited_files: set[File], generated_files: 
     if generated_files:
         node.repo.attach_files_to_chat(attachment_type="code_interpreter", files=generated_files)
     return {
-        ChatMessage.MetadataKeys.CITED_FILES: [file.id for file in cited_files],
-        ChatMessage.MetadataKeys.GENERATED_FILES: [file.id for file in generated_files],
+        ChatMessageMetadataKeys.CITED_FILES: [file.id for file in cited_files],
+        ChatMessageMetadataKeys.GENERATED_FILES: [file.id for file in generated_files],
     }
 
 

--- a/apps/pipelines/nodes/llm_node.py
+++ b/apps/pipelines/nodes/llm_node.py
@@ -10,6 +10,7 @@ from langchain_core.messages.utils import count_tokens_approximately
 from langchain_core.tools import BaseTool
 
 from apps.chat.agent.tools import SearchCollectionByIdTool, SearchIndexTool, SearchToolConfig, get_node_tools
+from apps.chat.models import ChatMessage
 from apps.experiments.models import ExperimentSession
 from apps.files.models import File
 from apps.pipelines.nodes.base import PipelineNode, PipelineState
@@ -135,8 +136,8 @@ def _process_files(node: PipelineNode, cited_files: set[File], generated_files: 
     if generated_files:
         node.repo.attach_files_to_chat(attachment_type="code_interpreter", files=generated_files)
     return {
-        "cited_files": [file.id for file in cited_files],
-        "generated_files": [file.id for file in generated_files],
+        ChatMessage.MetadataKeys.CITED_FILES: [file.id for file in cited_files],
+        ChatMessage.MetadataKeys.GENERATED_FILES: [file.id for file in generated_files],
     }
 
 

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -27,7 +27,7 @@ from RestrictedPython.PrintCollector import PrintCollector
 
 from apps.annotations.models import TagCategories
 from apps.assistants.models import OpenAiAssistant
-from apps.chat.models import ChatMessage
+from apps.chat.models import ChatMessageMetadataKeys
 from apps.experiments.models import BuiltInTools, ExperimentSession
 from apps.files.models import FilePurpose
 from apps.pipelines.exceptions import (
@@ -1075,7 +1075,7 @@ class CodeNode(PipelineNode, OutputMessageTagMixin, RestrictedPythonExecutionMix
             self.repo.attach_files_to_chat(attachment_type="code_interpreter", files=[file])
 
             metadata = output_state.setdefault("output_message_metadata", {})
-            generated_files = metadata.setdefault(ChatMessage.MetadataKeys.GENERATED_FILES, [])
+            generated_files = metadata.setdefault(ChatMessageMetadataKeys.GENERATED_FILES, [])
             generated_files.append(file.id)
 
         return add_file_attachment

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -27,6 +27,7 @@ from RestrictedPython.PrintCollector import PrintCollector
 
 from apps.annotations.models import TagCategories
 from apps.assistants.models import OpenAiAssistant
+from apps.chat.models import ChatMessage
 from apps.experiments.models import BuiltInTools, ExperimentSession
 from apps.files.models import FilePurpose
 from apps.pipelines.exceptions import (
@@ -1074,7 +1075,7 @@ class CodeNode(PipelineNode, OutputMessageTagMixin, RestrictedPythonExecutionMix
             self.repo.attach_files_to_chat(attachment_type="code_interpreter", files=[file])
 
             metadata = output_state.setdefault("output_message_metadata", {})
-            generated_files = metadata.setdefault("generated_files", [])
+            generated_files = metadata.setdefault(ChatMessage.MetadataKeys.GENERATED_FILES, [])
             generated_files.append(file.id)
 
         return add_file_attachment

--- a/apps/pipelines/nodes/tool_callbacks.py
+++ b/apps/pipelines/nodes/tool_callbacks.py
@@ -1,4 +1,4 @@
-from apps.chat.models import ChatMessage
+from apps.chat.models import ChatMessageMetadataKeys
 from apps.pipelines.nodes.base import Intents
 
 
@@ -8,7 +8,7 @@ class ToolCallbacks:
         self.intents = []
 
     def attach_file(self, file_id: int):
-        key = ChatMessage.MetadataKeys.OCS_ATTACHMENT_FILE_IDS
+        key = ChatMessageMetadataKeys.OCS_ATTACHMENT_FILE_IDS
         if key not in self.output_message_metadata:
             self.output_message_metadata[key] = []
         self.output_message_metadata[key].append(file_id)

--- a/apps/pipelines/nodes/tool_callbacks.py
+++ b/apps/pipelines/nodes/tool_callbacks.py
@@ -1,3 +1,4 @@
+from apps.chat.models import ChatMessage
 from apps.pipelines.nodes.base import Intents
 
 
@@ -7,9 +8,10 @@ class ToolCallbacks:
         self.intents = []
 
     def attach_file(self, file_id: int):
-        if "ocs_attachment_file_ids" not in self.output_message_metadata:
-            self.output_message_metadata["ocs_attachment_file_ids"] = []
-        self.output_message_metadata["ocs_attachment_file_ids"].append(file_id)
+        key = ChatMessage.MetadataKeys.OCS_ATTACHMENT_FILE_IDS
+        if key not in self.output_message_metadata:
+            self.output_message_metadata[key] = []
+        self.output_message_metadata[key].append(file_id)
 
     def register_intent(self, intent: Intents):
         if intent not in self.intents:

--- a/apps/pipelines/repository.py
+++ b/apps/pipelines/repository.py
@@ -117,7 +117,7 @@ class ORMRepository:
         if history_type == "global":
             message = ChatMessage.objects.get(id=checkpoint_message_id)
             if compression_marker == COMPRESSION_MARKER:
-                message.metadata.update({"compression_marker": history_mode})
+                message.metadata.update({ChatMessage.MetadataKeys.COMPRESSION_MARKER: history_mode})
                 message.save(update_fields=["metadata"])
             else:
                 message.summary = compression_marker

--- a/apps/pipelines/repository.py
+++ b/apps/pipelines/repository.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from apps.chat.conversation import COMPRESSION_MARKER
-from apps.chat.models import ChatMessage
+from apps.chat.models import ChatMessage, ChatMessageMetadataKeys
 from apps.documents.models import Collection
 from apps.experiments.models import ExperimentSession, SourceMaterial
 from apps.files.models import File
@@ -117,7 +117,7 @@ class ORMRepository:
         if history_type == "global":
             message = ChatMessage.objects.get(id=checkpoint_message_id)
             if compression_marker == COMPRESSION_MARKER:
-                message.metadata.update({ChatMessage.MetadataKeys.COMPRESSION_MARKER: history_mode})
+                message.metadata.update({ChatMessageMetadataKeys.COMPRESSION_MARKER: history_mode})
                 message.save(update_fields=["metadata"])
             else:
                 message.summary = compression_marker

--- a/apps/service_providers/llm_service/adapters.py
+++ b/apps/service_providers/llm_service/adapters.py
@@ -16,7 +16,7 @@ from langchain_core.prompts import PromptTemplate, get_template_variables
 
 from apps.assistants.models import OpenAiAssistant, ToolResources
 from apps.chat.agent.tools import get_assistant_tools
-from apps.chat.models import Chat, ChatMessage
+from apps.chat.models import Chat, ChatMessageMetadataKeys
 from apps.experiments.models import ExperimentSession
 from apps.files.models import File
 from apps.pipelines.repository import ORMRepository
@@ -181,14 +181,14 @@ class AssistantAdapter(BaseAdapter):
 
     def _get_openai_metadata(self, annotation_file_ids: list):
         return {
-            ChatMessage.MetadataKeys.OPENAI_THREAD_CHECKPOINT: True,
-            ChatMessage.MetadataKeys.OPENAI_FILE_IDS: annotation_file_ids,
+            ChatMessageMetadataKeys.OPENAI_THREAD_CHECKPOINT: True,
+            ChatMessageMetadataKeys.OPENAI_FILE_IDS: annotation_file_ids,
         }
 
     def get_messages_to_sync_to_thread(self):
         to_sync = []
         for message in self.session.chat.message_iterator(with_summaries=False):
-            if message.get_metadata(ChatMessage.MetadataKeys.OPENAI_THREAD_CHECKPOINT):
+            if message.get_metadata(ChatMessageMetadataKeys.OPENAI_THREAD_CHECKPOINT):
                 break
             to_sync.append(message)
         return [

--- a/apps/service_providers/llm_service/adapters.py
+++ b/apps/service_providers/llm_service/adapters.py
@@ -16,7 +16,7 @@ from langchain_core.prompts import PromptTemplate, get_template_variables
 
 from apps.assistants.models import OpenAiAssistant, ToolResources
 from apps.chat.agent.tools import get_assistant_tools
-from apps.chat.models import Chat
+from apps.chat.models import Chat, ChatMessage
 from apps.experiments.models import ExperimentSession
 from apps.files.models import File
 from apps.pipelines.repository import ORMRepository
@@ -180,12 +180,15 @@ class AssistantAdapter(BaseAdapter):
         return self._get_openai_metadata(annotation_file_ids)
 
     def _get_openai_metadata(self, annotation_file_ids: list):
-        return {"openai_thread_checkpoint": True, "openai_file_ids": annotation_file_ids}
+        return {
+            ChatMessage.MetadataKeys.OPENAI_THREAD_CHECKPOINT: True,
+            ChatMessage.MetadataKeys.OPENAI_FILE_IDS: annotation_file_ids,
+        }
 
     def get_messages_to_sync_to_thread(self):
         to_sync = []
         for message in self.session.chat.message_iterator(with_summaries=False):
-            if message.get_metadata("openai_thread_checkpoint"):
+            if message.get_metadata(ChatMessage.MetadataKeys.OPENAI_THREAD_CHECKPOINT):
                 break
             to_sync.append(message)
         return [

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -27,7 +27,7 @@ from apps.assistants.sync import (
     get_and_store_openai_file,
 )
 from apps.chat.agent.openapi_tool import ToolArtifact
-from apps.chat.models import ChatMessage
+from apps.chat.models import ChatMessageMetadataKeys
 from apps.experiments.models import Experiment
 from apps.files.models import File
 from apps.service_providers.llm_service.adapters import AssistantAdapter
@@ -115,7 +115,7 @@ class AssistantChat(RunnableSerializable[dict, ChainOutput]):
             thread_id, run_id = self._get_response_with_retries(merged_config, input_dict, current_thread_id)
             ai_message, annotation_file_ids = self._get_output_with_annotations(thread_id, run_id)
             ai_message_metadata = self.adapter.get_output_message_metadata(annotation_file_ids)
-            ai_message_metadata[ChatMessage.MetadataKeys.OPENAI_RUN_ID] = run_id
+            ai_message_metadata[ChatMessageMetadataKeys.OPENAI_RUN_ID] = run_id
 
             if not current_thread_id:
                 self.adapter.update_thread_id(thread_id)

--- a/apps/service_providers/llm_service/runnables.py
+++ b/apps/service_providers/llm_service/runnables.py
@@ -27,6 +27,7 @@ from apps.assistants.sync import (
     get_and_store_openai_file,
 )
 from apps.chat.agent.openapi_tool import ToolArtifact
+from apps.chat.models import ChatMessage
 from apps.experiments.models import Experiment
 from apps.files.models import File
 from apps.service_providers.llm_service.adapters import AssistantAdapter
@@ -114,7 +115,7 @@ class AssistantChat(RunnableSerializable[dict, ChainOutput]):
             thread_id, run_id = self._get_response_with_retries(merged_config, input_dict, current_thread_id)
             ai_message, annotation_file_ids = self._get_output_with_annotations(thread_id, run_id)
             ai_message_metadata = self.adapter.get_output_message_metadata(annotation_file_ids)
-            ai_message_metadata["openai_run_id"] = run_id
+            ai_message_metadata[ChatMessage.MetadataKeys.OPENAI_RUN_ID] = run_id
 
             if not current_thread_id:
                 self.adapter.update_thread_id(thread_id)

--- a/apps/service_providers/tracing/service.py
+++ b/apps/service_providers/tracing/service.py
@@ -12,6 +12,8 @@ from uuid import UUID
 import sentry_sdk
 from langchain_core.runnables import RunnableConfig
 
+from apps.chat.models import ChatMessage
+
 from .base import TraceContext, Tracer
 from .callback import wrap_callback
 
@@ -242,7 +244,7 @@ class TracingService:
                 logger.exception("Error getting trace info")
                 continue
 
-        return {"trace_info": trace_info} if trace_info else {}
+        return {ChatMessage.MetadataKeys.TRACE_INFO: trace_info} if trace_info else {}
 
     @property
     def _active_tracers(self) -> list[Tracer]:

--- a/apps/service_providers/tracing/service.py
+++ b/apps/service_providers/tracing/service.py
@@ -12,7 +12,7 @@ from uuid import UUID
 import sentry_sdk
 from langchain_core.runnables import RunnableConfig
 
-from apps.chat.models import ChatMessage
+from apps.chat.models import ChatMessageMetadataKeys
 
 from .base import TraceContext, Tracer
 from .callback import wrap_callback
@@ -244,7 +244,7 @@ class TracingService:
                 logger.exception("Error getting trace info")
                 continue
 
-        return {ChatMessage.MetadataKeys.TRACE_INFO: trace_info} if trace_info else {}
+        return {ChatMessageMetadataKeys.TRACE_INFO: trace_info} if trace_info else {}
 
     @property
     def _active_tracers(self) -> list[Tracer]:


### PR DESCRIPTION
### Product Description
No user-facing changes. Internal refactor to make `ChatMessage.metadata` keys discoverable and typo-resistant.

### Technical Description
Introduces a `ChatMessage.MetadataKeys` `StrEnum` (mirroring the existing `Chat.MetadataKeys` pattern) that centralizes the 9 string keys previously sprinkled as literals across the codebase:

- **OpenAI Assistant (internal):** `openai_run_id`, `openai_file_ids`, `openai_thread_checkpoint`
- **Files & attachments:** `ocs_attachment_file_ids`, `cited_files`, `generated_files`
- **Tracing / observability:** `trace_info`, `trace_provider` (legacy top-level)
- **History / compression:** `compression_marker`

`INTERNAL_METADATA_KEYS` is rebuilt as a `frozenset` of enum members so the API-filter list and the source of truth can't drift.

All production call sites in `apps/chat/`, `apps/channels/`, `apps/pipelines/`, and `apps/service_providers/` have been migrated off raw literals. Tests left untouched — they still pass because `StrEnum` values compare and hash identically to the underlying string.

Out of scope (intentionally): `EvaluationMessage.metadata` keys, the `trace_provider` sub-field inside each `trace_info[]` item, and `Trace.trace_metadata` reads in `apps/trace/` / `apps/experiments/export.py` (different model).

### Migrations
- [x] The migrations are backwards compatible

No DB migration is required. `StrEnum` members stringify byte-identically to the existing literal keys, so existing rows are unchanged and all reads continue to match.

### Demo
N/A — internal refactor.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)