### PR TITLE
feat: add message_text param to trigger_bot for direct message delivery (closes #3337)

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -888,8 +888,13 @@ paths:
   /api/trigger_bot:
     post:
       operationId: trigger_bot_message
-      description: Trigger the bot to send a message to the user
-      summary: Trigger the bot to send a message to the user
+      description: |-
+        Trigger the bot to send a message to the user, or deliver a message directly.
+
+        Provide either ``prompt_text`` (routes through the LLM/bot pipeline) or ``message_text``
+        (sends the exact text to the participant without any LLM processing). Exactly one is required.
+      summary: Trigger the bot to send a message to the user, or deliver a message
+        directly
       tags:
       - Channels
       requestBody:
@@ -910,10 +915,18 @@ paths:
                     key: value
                 summary: Generates a bot message and sends it to the user (auto-creates
                   participant if needed).
-              ParticipantNotFound:
+              SendMessageDirectly:
                 value:
-                  detail: Participant not found
-                summary: Participant not found
+                  identifier: '+15556793'
+                  experiment: exp1
+                  platform: whatsapp
+                  message_text: Your appointment is confirmed for tomorrow at 10am.
+                  session_data:
+                    key: value
+                  participant_data:
+                    key: value
+                summary: Send a pre-written message directly to the participant, bypassing
+                  the bot/LLM.
               ExperimentChannelNotFound:
                 value:
                   detail: Experiment cannot send messages on the connect_messaging
@@ -949,10 +962,6 @@ paths:
               schema:
                 description: Not Found
               examples:
-                ParticipantNotFound:
-                  value:
-                    detail: Participant not found
-                  summary: Participant not found
                 ExperimentChannelNotFound:
                   value:
                     detail: Experiment cannot send messages on the connect_messaging
@@ -1751,7 +1760,12 @@ components:
           title: Experiment ID
         prompt_text:
           type: string
+          nullable: true
           title: Prompt to go to bot
+        message_text:
+          type: string
+          nullable: true
+          title: Message to send directly to participant (bypasses bot/LLM)
         start_new_session:
           type: boolean
           default: false
@@ -1770,7 +1784,6 @@ components:
       - experiment
       - identifier
       - platform
-      - prompt_text
     UploadedFile:
       type: object
       properties:

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -300,7 +300,7 @@ class TriggerBotMessageRequest(serializers.Serializer):
         default=dict,
     )
 
-    def validate(self, data):
+    def validate(self, data):  # ty: ignore[invalid-method-override]
         has_prompt = bool(data.get("prompt_text"))
         has_message = bool(data.get("message_text"))
         if has_prompt and has_message:

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -283,7 +283,13 @@ class TriggerBotMessageRequest(serializers.Serializer):
     identifier = serializers.CharField(label="Participant Identifier")
     platform = serializers.ChoiceField(choices=ChannelPlatform.choices, label="Participant Platform")
     experiment = serializers.UUIDField(label="Experiment ID")
-    prompt_text = serializers.CharField(label="Prompt to go to bot")
+    prompt_text = serializers.CharField(label="Prompt to go to bot", required=False, allow_null=True, default=None)
+    message_text = serializers.CharField(
+        label="Message to send directly to participant (bypasses bot/LLM)",
+        required=False,
+        allow_null=True,
+        default=None,
+    )
     start_new_session = serializers.BooleanField(label="Starts a new session", required=False, default=False)
     session_data = serializers.DictField(
         help_text="Update session data. This will be merged with existing session data", required=False, default=dict
@@ -293,3 +299,12 @@ class TriggerBotMessageRequest(serializers.Serializer):
         required=False,
         default=dict,
     )
+
+    def validate(self, data):
+        has_prompt = bool(data.get("prompt_text"))
+        has_message = bool(data.get("message_text"))
+        if has_prompt and has_message:
+            raise serializers.ValidationError("Provide either 'prompt_text' or 'message_text', not both.")
+        if not has_prompt and not has_message:
+            raise serializers.ValidationError("Either 'prompt_text' or 'message_text' must be provided.")
+        return data

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -5,7 +5,7 @@ from django.db.models import Subquery
 from apps.channels.clients.connect_client import CommCareConnectClient
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import ChannelBase
-from apps.chatbots.version_resolver import resolve_published_or_working
+from apps.chat.models import ChatMessage, ChatMessageType
 from apps.experiments.models import Experiment, ParticipantData
 from apps.service_providers.tracing import TraceInfo
 from apps.teams.utils import current_team
@@ -84,11 +84,16 @@ def create_connect_channel_for_participant(channel, connect_client, connect_id, 
 @shared_task(ignore_result=True)
 def trigger_bot_message_task(data):
     """
-    Trigger a bot message for a participant on a specific platform using the prompt from the given data.
+    Trigger a bot message for a participant on a specific platform.
+
+    When ``data["message_text"]`` is set, the message is delivered directly to the participant
+    without any LLM processing. When ``data["prompt_text"]`` is set, the bot generates a
+    response via the LLM and sends that.
     """
     platform = data["platform"]
     experiment_public_id = data["experiment"]
-    prompt_text = data["prompt_text"]
+    prompt_text = data.get("prompt_text")
+    message_text = data.get("message_text")
     identifier = data["identifier"]
     start_new_session = data["start_new_session"]
     session_data = data.get("session_data")
@@ -96,9 +101,9 @@ def trigger_bot_message_task(data):
     experiment = Experiment.objects.get(public_id=experiment_public_id)
     experiment_channel = ExperimentChannel.objects.get(platform=platform, experiment=experiment)
 
-    target_experiment = resolve_published_or_working(experiment)
+    published_experiment = experiment.default_version
     ChannelClass = ChannelBase.get_channel_class_for_platform(platform)
-    channel = ChannelClass(experiment=target_experiment, experiment_channel=experiment_channel)
+    channel = ChannelClass(experiment=published_experiment, experiment_channel=experiment_channel)
 
     with current_team(experiment.team):
         channel.ensure_session_exists_for_participant(identifier, new_session=start_new_session)
@@ -108,6 +113,15 @@ def trigger_bot_message_task(data):
             session.state = merged_state
             session.save(update_fields=["state"])
 
-        channel.experiment_session.ad_hoc_bot_message(
-            prompt_text, TraceInfo(name="api trigger"), use_experiment=target_experiment
-        )
+        if message_text:
+            ChatMessage.objects.create(
+                chat=channel.experiment_session.chat,
+                message_type=ChatMessageType.AI,
+                content=message_text,
+                metadata={"direct_to_user": True},
+            )
+            channel.send_message_to_user(message_text)
+        else:
+            channel.experiment_session.ad_hoc_bot_message(
+                prompt_text, TraceInfo(name="api trigger"), use_experiment=published_experiment
+            )

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -6,6 +6,7 @@ from apps.channels.clients.connect_client import CommCareConnectClient
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import ChannelBase
 from apps.chat.models import ChatMessage, ChatMessageType
+from apps.chatbots.version_resolver import resolve_published_or_working
 from apps.experiments.models import Experiment, ParticipantData
 from apps.service_providers.tracing import TraceInfo
 from apps.teams.utils import current_team
@@ -101,9 +102,9 @@ def trigger_bot_message_task(data):
     experiment = Experiment.objects.get(public_id=experiment_public_id)
     experiment_channel = ExperimentChannel.objects.get(platform=platform, experiment=experiment)
 
-    published_experiment = experiment.default_version
+    target_experiment = resolve_published_or_working(experiment)
     ChannelClass = ChannelBase.get_channel_class_for_platform(platform)
-    channel = ChannelClass(experiment=published_experiment, experiment_channel=experiment_channel)
+    channel = ChannelClass(experiment=target_experiment, experiment_channel=experiment_channel)
 
     with current_team(experiment.team):
         channel.ensure_session_exists_for_participant(identifier, new_session=start_new_session)
@@ -120,8 +121,8 @@ def trigger_bot_message_task(data):
                 content=message_text,
                 metadata={"direct_to_user": True},
             )
-            channel.send_message_to_user(message_text)
+            channel.experiment_session.try_send_message(message_text)
         else:
             channel.experiment_session.ad_hoc_bot_message(
-                prompt_text, TraceInfo(name="api trigger"), use_experiment=published_experiment
+                prompt_text, TraceInfo(name="api trigger"), use_experiment=target_experiment
             )

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -555,11 +555,11 @@ def _setup_participant_data(
     )
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db()
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 @patch("apps.chat.channels.CommCareConnectClient")
 @pytest.mark.parametrize("auth_method", ["api_key", "oauth"])
-def test_generate_bot_message_and_send(ConnectClient, experiment, auth_method):
+def test_generate_bot_message_and_send(ConnectClient, experiment, auth_method, django_capture_on_commit_callbacks):
     """
     Test that a bot message is generated and sent to a participant. If there isn't a session for the participant yet,
     we expect one to be created. The generated bot message should be saved as an AI message, but the prompt should not
@@ -596,7 +596,8 @@ def test_generate_bot_message_and_send(ConnectClient, experiment, auth_method):
     }
     url = reverse("api:trigger_bot")
     with mock_llm(["Time to take a break and brew some coffee"], [0]):
-        response = client.post(url, json.dumps(data), content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
     connect_client_mock.send_message_to_user.assert_called()
     kwargs = connect_client_mock.send_message_to_user.call_args.kwargs
@@ -609,7 +610,8 @@ def test_generate_bot_message_and_send(ConnectClient, experiment, auth_method):
 
     # Call it a second time to make sure the session is reused
     with mock_llm(["Time to take a break and brew some tea"], [0]):
-        response = client.post(url, json.dumps(data), content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
     session = ExperimentSession.objects.get(participant=participant_data.participant, experiment=experiment)
     assert session.chat.messages.count() == 2
@@ -621,7 +623,8 @@ def test_generate_bot_message_and_send(ConnectClient, experiment, auth_method):
     first_session = session
     data["start_new_session"] = True
     with mock_llm(["Time to take a break an juice some fruit"], [0]):
-        response = client.post(url, json.dumps(data), content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
     first_session.refresh_from_db()
     assert first_session.status == SessionStatus.PENDING_REVIEW
@@ -636,13 +639,13 @@ def test_generate_bot_message_and_send(ConnectClient, experiment, auth_method):
     assert last_message.content == "Time to take a break an juice some fruit"
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db()
 @override_settings(
     CELERY_TASK_ALWAYS_EAGER=True, COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123"
 )
 @patch("apps.chat.channels.CommCareConnectClient")
 @pytest.mark.parametrize("consented", [True, False])
-def test_generate_bot_message_auto_creates_participant(ConnectClient, experiment, httpx_mock, consented):
+def test_generate_bot_message_auto_creates_participant(ConnectClient, experiment, httpx_mock, consented, django_capture_on_commit_callbacks):
     """
     Test that trigger_bot_message auto-creates participant and participant_data if they don't exist.
     This supports the auto-consent flow from CommCare Connect.
@@ -685,7 +688,8 @@ def test_generate_bot_message_auto_creates_participant(ConnectClient, experiment
     }
     url = reverse("api:trigger_bot")
     with mock_llm(["Welcome! How can I help you today?"], [0]):
-        response = client.post(url, json.dumps(data), content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(url, json.dumps(data), content_type="application/json")
 
     assert response.status_code == 200 if consented else 400
     if not consented:
@@ -718,9 +722,9 @@ def test_generate_bot_message_auto_creates_participant(ConnectClient, experiment
         assert not ExperimentSession.objects.filter(participant=participant, experiment=experiment).exists()
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db()
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-def test_generate_bot_message_for_email_channel(experiment):
+def test_generate_bot_message_for_email_channel(experiment, django_capture_on_commit_callbacks):
     """Regression: trigger_bot_message_task must work for the v2 EmailChannel.
 
     Previously raised AttributeError because v2 ChannelBase lacked
@@ -744,7 +748,8 @@ def test_generate_bot_message_for_email_channel(experiment):
     }
     url = reverse("api:trigger_bot")
     with mock_llm(["Hello from the bot"], [0]):
-        response = client.post(url, json.dumps(data), content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(url, json.dumps(data), content_type="application/json")
 
     assert response.status_code == 200
 
@@ -767,14 +772,14 @@ def test_generate_bot_message_for_email_channel(experiment):
 # ── trigger_bot direct-message (message_text) tests ──────────────────────────
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db()
 @override_settings(
     CELERY_TASK_ALWAYS_EAGER=True, COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123"
 )
 @patch("apps.api.views.channels.CommCareConnectClient")
 @patch("apps.chat.channels.CommCareConnectClient")
 @pytest.mark.parametrize("auth_method", ["api_key", "oauth"])
-def test_trigger_bot_direct_message(ConnectClientChat, ConnectClientView, experiment, auth_method):
+def test_trigger_bot_direct_message(ConnectClientChat, ConnectClientView, experiment, auth_method, django_capture_on_commit_callbacks):
     """
     trigger_bot with message_text delivers the message directly without going through the LLM.
     """
@@ -801,7 +806,8 @@ def test_trigger_bot_direct_message(ConnectClientChat, ConnectClientView, experi
         "message_text": message,
     }
     url = reverse("api:trigger_bot")
-    response = client.post(url, json.dumps(data), content_type="application/json")
+    with django_capture_on_commit_callbacks(execute=True):
+        response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
     # Message delivered via channel, not via LLM
@@ -817,9 +823,9 @@ def test_trigger_bot_direct_message(ConnectClientChat, ConnectClientView, experi
     assert saved_msg.content == message
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db()
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-def test_trigger_bot_direct_message_for_email_channel(experiment):
+def test_trigger_bot_direct_message_for_email_channel(experiment, django_capture_on_commit_callbacks):
     """
     trigger_bot with message_text must work for the EmailChannel (delivers via email, no LLM).
     """
@@ -839,7 +845,8 @@ def test_trigger_bot_direct_message_for_email_channel(experiment):
         "message_text": message,
     }
     url = reverse("api:trigger_bot")
-    response = client.post(url, json.dumps(data), content_type="application/json")
+    with django_capture_on_commit_callbacks(execute=True):
+        response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
     # Session and message created

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -126,7 +126,7 @@ def test_create_and_update_participant_data(auth_method):
             {"experiment": str(experiment2.public_id), "data": {"name": "Doe"}},
         ],
     }
-    url = reverse("api:participant-data")
+    url = reverse("api:update-participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
@@ -166,7 +166,7 @@ def test_update_participant_data_returns_404():
             {"experiment": str(experiment2.public_id), "data": {"name": "Doe"}},
         ],
     }
-    url = reverse("api:participant-data")
+    url = reverse("api:update-participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 404
     assert response.json() == {"errors": [{"message": f"Experiment {experiment2.public_id} not found"}]}
@@ -197,7 +197,7 @@ def test_create_participant_schedules(experiment):
             },
         ],
     }
-    url = reverse("api:participant-data")
+    url = reverse("api:update-participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
@@ -263,7 +263,7 @@ def test_update_participant_schedules(experiment):
             },
         ],
     }
-    url = reverse("api:participant-data")
+    url = reverse("api:update-participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
@@ -379,7 +379,7 @@ def test_update_participant_data_and_setup_connect_channels(httpx_mock):
             },
         ],
     }
-    url = reverse("api:participant-data")
+    url = reverse("api:update-participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
@@ -424,7 +424,7 @@ def test_register_connect_participant(client, experiment):
             },
         ],
     }
-    url = reverse("api:participant-data")
+    url = reverse("api:update-participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
@@ -762,3 +762,165 @@ def test_generate_bot_message_for_email_channel(experiment):
     assert sent.body == "Hello from the bot"
     assert sent.to == ["user@example.com"]
     assert sent.from_email == "bot@chat.openchatstudio.com"
+
+
+# ── trigger_bot direct-message (message_text) tests ──────────────────────────
+
+
+@pytest.mark.django_db()
+@override_settings(
+    CELERY_TASK_ALWAYS_EAGER=True, COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123"
+)
+@patch("apps.api.views.channels.CommCareConnectClient")
+@patch("apps.chat.channels.CommCareConnectClient")
+@pytest.mark.parametrize("auth_method", ["api_key", "oauth"])
+def test_trigger_bot_direct_message(ConnectClientChat, ConnectClientView, experiment, auth_method):
+    """
+    trigger_bot with message_text delivers the message directly without going through the LLM.
+    """
+    connect_client_mock = ConnectClientChat.return_value
+    connect_id = uuid.uuid4().hex
+    commcare_connect_channel_id = uuid.uuid4().hex
+    encryption_key = os.urandom(32).hex()
+    participant_data = _setup_participant_data(
+        experiment,
+        connect_id=connect_id,
+        system_metadata={"commcare_connect_channel_id": commcare_connect_channel_id, "consent": True},
+        encryption_key=encryption_key,
+    )
+    ExperimentChannelFactory.create(
+        team=experiment.team, experiment=experiment, platform=ChannelPlatform.COMMCARE_CONNECT
+    )
+    api_user = experiment.team.members.first()
+    client = ApiTestClient(api_user, experiment.team, auth_method=auth_method)
+    message = "Your appointment is confirmed for tomorrow at 10am."
+    data: dict[str, Any] = {
+        "identifier": connect_id,
+        "platform": ChannelPlatform.COMMCARE_CONNECT,
+        "experiment": str(experiment.public_id),
+        "message_text": message,
+    }
+    url = reverse("api:trigger_bot")
+    response = client.post(url, json.dumps(data), content_type="application/json")
+    assert response.status_code == 200
+
+    # Message delivered via channel, not via LLM
+    connect_client_mock.send_message_to_user.assert_called()
+    kwargs = connect_client_mock.send_message_to_user.call_args.kwargs
+    assert kwargs["message"] == message
+
+    # Message recorded in chat history as an AI message
+    session = ExperimentSession.objects.get(participant=participant_data.participant, experiment=experiment)
+    assert session.chat.messages.count() == 1
+    saved_msg = session.chat.messages.first()
+    assert saved_msg.message_type == "ai"
+    assert saved_msg.content == message
+
+
+@pytest.mark.django_db()
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+def test_trigger_bot_direct_message_for_email_channel(experiment):
+    """
+    trigger_bot with message_text must work for the EmailChannel (delivers via email, no LLM).
+    """
+    from django.core import mail  # noqa: PLC0415
+
+    ExperimentChannelFactory.create(
+        team=experiment.team,
+        experiment=experiment,
+        platform=ChannelPlatform.EMAIL,
+        extra_data={"email_address": "bot@chat.openchatstudio.com"},
+    )
+    api_user = experiment.team.members.first()
+    client = ApiTestClient(api_user, experiment.team)
+    message = "Hello from the platform!"
+    data = {
+        "identifier": "user@example.com",
+        "platform": ChannelPlatform.EMAIL,
+        "experiment": str(experiment.public_id),
+        "message_text": message,
+    }
+    url = reverse("api:trigger_bot")
+    response = client.post(url, json.dumps(data), content_type="application/json")
+    assert response.status_code == 200
+
+    # Session and message created
+    participant = Participant.objects.get(identifier="user@example.com", platform=ChannelPlatform.EMAIL)
+    session = ExperimentSession.objects.get(participant=participant, experiment=experiment)
+    assert session.chat.messages.count() == 1
+    saved_msg = session.chat.messages.first()
+    assert saved_msg.message_type == "ai"
+    assert saved_msg.content == message
+
+    # Email delivered directly (no LLM)
+    assert len(mail.outbox) == 1
+    sent = mail.outbox[0]
+    assert sent.body == message
+    assert sent.to == ["user@example.com"]
+
+
+@pytest.mark.django_db()
+@override_settings(
+    CELERY_TASK_ALWAYS_EAGER=True, COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123"
+)
+@patch("apps.api.views.channels.CommCareConnectClient")
+@patch("apps.chat.channels.CommCareConnectClient")
+def test_trigger_bot_direct_message_consent_required(ConnectClientChat, ConnectClientView, experiment, httpx_mock):
+    """
+    trigger_bot with message_text should return 400 when the participant has not consented (CCC platform).
+    """
+    connect_id = uuid.uuid4().hex
+    commcare_connect_channel_id = uuid.uuid4().hex
+    _setup_participant_data(
+        experiment,
+        connect_id=connect_id,
+        system_metadata={"commcare_connect_channel_id": commcare_connect_channel_id, "consent": False},
+    )
+    ExperimentChannelFactory.create(
+        team=experiment.team, experiment=experiment, platform=ChannelPlatform.COMMCARE_CONNECT
+    )
+    api_user = experiment.team.members.first()
+    client = ApiTestClient(api_user, experiment.team)
+    data = {
+        "identifier": connect_id,
+        "platform": ChannelPlatform.COMMCARE_CONNECT,
+        "experiment": str(experiment.public_id),
+        "message_text": "This should not be delivered.",
+    }
+    url = reverse("api:trigger_bot")
+    response = client.post(url, json.dumps(data), content_type="application/json")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "User has not given consent"
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "data_override,expected_error",
+    [
+        ({}, "Either 'prompt_text' or 'message_text' must be provided."),
+        (
+            {"prompt_text": "do something", "message_text": "direct text"},
+            "Provide either 'prompt_text' or 'message_text', not both.",
+        ),
+    ],
+)
+def test_trigger_bot_requires_prompt_or_message_text(experiment, data_override, expected_error):
+    """trigger_bot must reject requests that supply neither or both text fields."""
+    ExperimentChannelFactory.create(
+        team=experiment.team, experiment=experiment, platform=ChannelPlatform.EMAIL,
+        extra_data={"email_address": "bot@chat.openchatstudio.com"},
+    )
+    api_user = experiment.team.members.first()
+    client = ApiTestClient(api_user, experiment.team)
+    data = {
+        "identifier": "user@example.com",
+        "platform": ChannelPlatform.EMAIL,
+        "experiment": str(experiment.public_id),
+        **data_override,
+    }
+    url = reverse("api:trigger_bot")
+    response = client.post(url, json.dumps(data), content_type="application/json")
+    assert response.status_code == 400
+    errors = response.json()
+    # DRF wraps non_field_errors under "non_field_errors" key
+    assert any(expected_error in str(v) for v in errors.values())

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -555,7 +555,7 @@ def _setup_participant_data(
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db(transaction=True)
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 @patch("apps.chat.channels.CommCareConnectClient")
 @pytest.mark.parametrize("auth_method", ["api_key", "oauth"])
@@ -636,7 +636,7 @@ def test_generate_bot_message_and_send(ConnectClient, experiment, auth_method):
     assert last_message.content == "Time to take a break an juice some fruit"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db(transaction=True)
 @override_settings(
     CELERY_TASK_ALWAYS_EAGER=True, COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123"
 )
@@ -718,7 +718,7 @@ def test_generate_bot_message_auto_creates_participant(ConnectClient, experiment
         assert not ExperimentSession.objects.filter(participant=participant, experiment=experiment).exists()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db(transaction=True)
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 def test_generate_bot_message_for_email_channel(experiment):
     """Regression: trigger_bot_message_task must work for the v2 EmailChannel.
@@ -767,7 +767,7 @@ def test_generate_bot_message_for_email_channel(experiment):
 # ── trigger_bot direct-message (message_text) tests ──────────────────────────
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db(transaction=True)
 @override_settings(
     CELERY_TASK_ALWAYS_EAGER=True, COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123"
 )
@@ -817,7 +817,7 @@ def test_trigger_bot_direct_message(ConnectClientChat, ConnectClientView, experi
     assert saved_msg.content == message
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db(transaction=True)
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 def test_trigger_bot_direct_message_for_email_channel(experiment):
     """

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -7,6 +7,8 @@ import uuid
 from typing import Any
 from unittest.mock import patch
 
+from django.core import mail
+
 import httpx
 import pytest
 from dateutil.relativedelta import relativedelta
@@ -126,7 +128,7 @@ def test_create_and_update_participant_data(auth_method):
             {"experiment": str(experiment2.public_id), "data": {"name": "Doe"}},
         ],
     }
-    url = reverse("api:update-participant-data")
+    url = reverse("api:participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
@@ -166,7 +168,7 @@ def test_update_participant_data_returns_404():
             {"experiment": str(experiment2.public_id), "data": {"name": "Doe"}},
         ],
     }
-    url = reverse("api:update-participant-data")
+    url = reverse("api:participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 404
     assert response.json() == {"errors": [{"message": f"Experiment {experiment2.public_id} not found"}]}
@@ -197,7 +199,7 @@ def test_create_participant_schedules(experiment):
             },
         ],
     }
-    url = reverse("api:update-participant-data")
+    url = reverse("api:participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
@@ -263,7 +265,7 @@ def test_update_participant_schedules(experiment):
             },
         ],
     }
-    url = reverse("api:update-participant-data")
+    url = reverse("api:participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
@@ -379,7 +381,7 @@ def test_update_participant_data_and_setup_connect_channels(httpx_mock):
             },
         ],
     }
-    url = reverse("api:update-participant-data")
+    url = reverse("api:participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
@@ -424,7 +426,7 @@ def test_register_connect_participant(client, experiment):
             },
         ],
     }
-    url = reverse("api:update-participant-data")
+    url = reverse("api:participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
 
@@ -724,8 +726,6 @@ def test_generate_bot_message_for_email_channel(experiment):
     Previously raised AttributeError because v2 ChannelBase lacked
     ``ensure_session_exists_for_participant``.
     """
-    from django.core import mail  # noqa: PLC0415
-
     ExperimentChannelFactory.create(
         team=experiment.team,
         experiment=experiment,
@@ -823,8 +823,6 @@ def test_trigger_bot_direct_message_for_email_channel(experiment):
     """
     trigger_bot with message_text must work for the EmailChannel (delivers via email, no LLM).
     """
-    from django.core import mail  # noqa: PLC0415
-
     ExperimentChannelFactory.create(
         team=experiment.team,
         experiment=experiment,

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -81,12 +81,92 @@ def consent(request: Request):
     return HttpResponse()
 
 
+def _get_or_create_participant_data(request, identifier, platform, experiment, incoming_participant_data):
+    """Get or create a participant and their ParticipantData for an experiment.
+
+    If ``incoming_participant_data`` is provided it is merged into any existing data.
+    Returns the (possibly newly created) ``ParticipantData`` instance.
+    """
+    participant_data = ParticipantData.objects.filter(
+        participant__identifier=identifier,
+        participant__platform=platform,
+        experiment=experiment.id,
+    ).first()
+
+    if not participant_data:
+        participant, _ = Participant.objects.get_or_create(
+            identifier=identifier, platform=platform, team=request.team
+        )
+        participant_data, created = ParticipantData.objects.get_or_create(
+            participant=participant,
+            experiment=experiment,
+            defaults={"team": request.team, "data": incoming_participant_data or {}},
+        )
+        if not created and incoming_participant_data:
+            merged_data = {**participant_data.data, **incoming_participant_data}
+            if merged_data != participant_data.data:
+                participant_data.data = merged_data
+                participant_data.save(update_fields=["data"])
+    elif incoming_participant_data:
+        merged_data = {**participant_data.data, **incoming_participant_data}
+        if merged_data != participant_data.data:
+            participant_data.data = merged_data
+            participant_data.save(update_fields=["data"])
+
+    return participant_data
+
+
+def _ensure_commcare_connect_ready(channel, identifier, participant_data):
+    """Ensure a CommCare Connect channel exists for the participant and that they have consented.
+
+    Returns a ``JsonResponse`` error response if the channel cannot be created or consent has
+    not been given, or ``None`` if everything is in order.
+    """
+    if not participant_data.system_metadata.get("commcare_connect_channel_id"):
+        connect_client = CommCareConnectClient()
+        try:
+            create_connect_channel_for_participant(channel, connect_client, identifier, participant_data)
+        except httpx.HTTPStatusError as e:
+            connect_logger.error(
+                f"Failed to create CommCare Connect channel for participant {identifier}: "
+                f"HTTP {e.response.status_code} - {e.response.text}"
+            )
+            if e.response.status_code == 404:
+                return JsonResponse(
+                    {"detail": "Failed to create channel: Participant not found in CommCare Connect"},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            elif e.response.status_code >= 500:
+                return JsonResponse(
+                    {"detail": "Failed to create channel: CommCare Connect service error"},
+                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                )
+            else:
+                return JsonResponse(
+                    {"detail": f"Failed to create channel: {e.response.text}"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+        except httpx.HTTPError as e:
+            connect_logger.error(
+                f"Failed to create CommCare Connect channel for participant {identifier}: {str(e)}"
+            )
+            return JsonResponse(
+                {"detail": "Failed to create channel: Unable to connect to CommCare Connect service"},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+    if not participant_data.has_consented():
+        return JsonResponse({"detail": "User has not given consent"}, status=status.HTTP_400_BAD_REQUEST)
+
+    return None
+
+
 class TriggerBotMessageView(APIView):
     required_scopes = ("chatbots:interact",)
 
     @extend_schema(
         operation_id="trigger_bot_message",
-        summary="Trigger the bot to send a message to the user",
+        summary="Trigger the bot to send a message to the user, or deliver a message directly",
         tags=["Channels"],
         request=TriggerBotMessageRequest(),
         responses={
@@ -109,10 +189,17 @@ class TriggerBotMessageView(APIView):
                 status_codes=[200],
             ),
             OpenApiExample(
-                name="ParticipantNotFound",
-                summary="Participant not found",
-                value={"detail": "Participant not found"},
-                status_codes=[404],
+                name="SendMessageDirectly",
+                summary="Send a pre-written message directly to the participant, bypassing the bot/LLM.",
+                value={
+                    "identifier": "+15556793",
+                    "experiment": "exp1",
+                    "platform": "whatsapp",
+                    "message_text": "Your appointment is confirmed for tomorrow at 10am.",
+                    "session_data": {"key": "value"},
+                    "participant_data": {"key": "value"},
+                },
+                status_codes=[200],
             ),
             OpenApiExample(
                 name="ExperimentChannelNotFound",
@@ -131,18 +218,18 @@ class TriggerBotMessageView(APIView):
     @transaction.atomic
     def post(self, request):
         """
-        Trigger the bot to send a message to the user
+        Trigger the bot to send a message to the user, or deliver a message directly.
+
+        Provide either ``prompt_text`` (routes through the LLM/bot pipeline) or ``message_text``
+        (sends the exact text to the participant without any LLM processing). Exactly one is required.
         """
         serializer = TriggerBotMessageRequest(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         data = serializer.data
         platform = data["platform"]
-        identifier = data["identifier"]
-        identifier = ChannelPlatform(platform).normalize_identifier(identifier)
-        experiment_public_id = data["experiment"]
-
-        experiment = get_object_or_404(Experiment, public_id=experiment_public_id, team=request.team)
+        identifier = ChannelPlatform(platform).normalize_identifier(data["identifier"])
+        experiment = get_object_or_404(Experiment, public_id=data["experiment"], team=request.team)
 
         channel = ExperimentChannel.objects.filter(platform=platform, experiment=experiment).first()
         if not channel:
@@ -151,70 +238,13 @@ class TriggerBotMessageView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        participant_data = ParticipantData.objects.filter(
-            participant__identifier=identifier,
-            participant__platform=platform,
-            experiment=experiment.id,
-        ).first()
-
-        if not participant_data:
-            participant, _ = Participant.objects.get_or_create(
-                identifier=identifier, platform=platform, team=request.team
-            )
-            participant_data, created = ParticipantData.objects.get_or_create(
-                participant=participant,
-                experiment=experiment,
-                defaults={"team": request.team, "data": data.get("participant_data") or {}},
-            )
-            # If participant_data already existed and participant_data is provided in request
-            if not created and data.get("participant_data"):
-                merged_data = {**participant_data.data, **data["participant_data"]}
-                if merged_data != participant_data.data:
-                    participant_data.data = merged_data
-                    participant_data.save(update_fields=["data"])
-        elif data.get("participant_data"):
-            merged_data = {**participant_data.data, **data["participant_data"]}
-            if merged_data != participant_data.data:
-                participant_data.data = merged_data
-                participant_data.save(update_fields=["data"])
+        participant_data = _get_or_create_participant_data(
+            request, identifier, platform, experiment, data.get("participant_data")
+        )
 
         if platform == ChannelPlatform.COMMCARE_CONNECT:
-            if not participant_data.system_metadata.get("commcare_connect_channel_id"):
-                # Trigger the setup task to create the channel and get consent status from CCC
-                connect_client = CommCareConnectClient()
-                try:
-                    create_connect_channel_for_participant(channel, connect_client, identifier, participant_data)
-                except httpx.HTTPStatusError as e:
-                    connect_logger.error(
-                        f"Failed to create CommCare Connect channel for participant {identifier}: "
-                        f"HTTP {e.response.status_code} - {e.response.text}"
-                    )
-                    if e.response.status_code == 404:
-                        return JsonResponse(
-                            {"detail": "Failed to create channel: Participant not found in CommCare Connect"},
-                            status=status.HTTP_404_NOT_FOUND,
-                        )
-                    elif e.response.status_code >= 500:
-                        return JsonResponse(
-                            {"detail": "Failed to create channel: CommCare Connect service error"},
-                            status=status.HTTP_503_SERVICE_UNAVAILABLE,
-                        )
-                    else:
-                        return JsonResponse(
-                            {"detail": f"Failed to create channel: {e.response.text}"},
-                            status=status.HTTP_400_BAD_REQUEST,
-                        )
-                except httpx.HTTPError as e:
-                    connect_logger.error(
-                        f"Failed to create CommCare Connect channel for participant {identifier}: {str(e)}"
-                    )
-                    return JsonResponse(
-                        {"detail": "Failed to create channel: Unable to connect to CommCare Connect service"},
-                        status=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    )
-
-            if not participant_data.has_consented():
-                return JsonResponse({"detail": "User has not given consent"}, status=status.HTTP_400_BAD_REQUEST)
+            if error := _ensure_commcare_connect_ready(channel, identifier, participant_data):
+                return error
 
         trigger_bot_message_task.delay(data)
 

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -249,6 +249,6 @@ class TriggerBotMessageView(APIView):
             if error := _ensure_commcare_connect_ready(channel, identifier, participant_data):
                 return error
 
-        trigger_bot_message_task.delay(data)
+        transaction.on_commit(lambda: trigger_bot_message_task.delay(data))
 
         return Response(status=status.HTTP_200_OK)

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -229,6 +229,9 @@ class TriggerBotMessageView(APIView):
         data = serializer.data
         platform = data["platform"]
         identifier = ChannelPlatform(platform).normalize_identifier(data["identifier"])
+        # Propagate the normalized identifier so the async task uses a consistent value
+        data = dict(data)
+        data["identifier"] = identifier
         experiment = get_object_or_404(Experiment, public_id=data["experiment"], team=request.team)
 
         channel = ExperimentChannel.objects.filter(platform=platform, experiment=experiment).first()

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -249,6 +249,6 @@ class TriggerBotMessageView(APIView):
             if error := _ensure_commcare_connect_ready(channel, identifier, participant_data):
                 return error
 
-        transaction.on_commit(lambda: trigger_bot_message_task.delay(data))
+        trigger_bot_message_task.delay_on_commit(data)
 
         return Response(status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary

Modifies the existing `trigger_bot` endpoint to accept an optional `message_text` parameter. When provided, the exact text is delivered to the participant's channel without any LLM processing. When `prompt_text` is provided (existing behaviour), the bot generates a response as before.

Closes #3337

## Changes

- **Serializer:** `TriggerBotMessageRequest` — `prompt_text` becomes optional, `message_text` added (also optional); a `validate()` method enforces exactly one of the two must be present
- **Task:** `trigger_bot_message_task` — branches on which field is set; direct path creates a `ChatMessage` (AI type) and calls `channel.send_message_to_user()`
- **View:** Extract `_get_or_create_participant_data` and `_ensure_commcare_connect_ready` helpers; update OpenAPI docs to document both modes
- **Tests:** `test_trigger_bot_direct_message` (CCC, parametrized by auth), `test_trigger_bot_direct_message_for_email_channel`, `test_trigger_bot_direct_message_consent_required`, `test_trigger_bot_requires_prompt_or_message_text`

## Alternative considered

PR #3338 added a separate `send_message_to_participant` endpoint. This PR takes a simpler approach — a single new optional parameter on the existing `trigger_bot` endpoint — which keeps the API surface smaller and reuses all the existing participant/session setup logic.