### PR TITLE
feat: capture decision report from auto-update-models workflow

### DIFF
--- a/.github/workflows/auto-update-models.yml
+++ b/.github/workflows/auto-update-models.yml
@@ -354,4 +354,4 @@ jobs:
           name: decision-report
           path: decision_report.md
           if-no-files-found: warn
-          retention-days: 30
+          retention-days: 5

--- a/.github/workflows/auto-update-models.yml
+++ b/.github/workflows/auto-update-models.yml
@@ -346,12 +346,3 @@ jobs:
               echo "for what happened."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
-
-      - name: Upload decision report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: decision-report
-          path: decision_report.md
-          if-no-files-found: warn
-          retention-days: 5

--- a/.github/workflows/auto-update-models.yml
+++ b/.github/workflows/auto-update-models.yml
@@ -294,8 +294,64 @@ jobs:
             9. Apply the `claude` and `auto-models` labels to the PR if they exist.
             10. If after dedup there is nothing to add, comment-only outcome: do NOT
                 open an empty PR — instead print a short summary to stdout and exit.
+            11. ALWAYS write a decision report to `./decision_report.md` before
+                exiting, regardless of outcome (PR opened, nothing to add, or
+                partial). Use this exact structure:
+
+                ```markdown
+                # Auto Update Models — Decision Report
+
+                **Run date (UTC):** <YYYY-MM-DD HH:MM>
+                **Candidates considered:** <count>
+                **Outcome:** <PR opened | Nothing to add | Error>
+                **PR:** <PR URL if opened, else "n/a">
+
+                ## Per-model decisions
+
+                ### `<model-id>` (org: `<org>`)
+                - **Verdict:** Added | Skipped | Needs follow-up
+                - **Mapped providers:** <e.g. openai, azure>  (if added)
+                - **Reason:** <one-sentence rationale — why added/skipped, or
+                  what info was missing>
+                - **Source:** <llm-stats.com URL from payload>
+
+                <repeat for every candidate in matched_models.json>
+
+                ## Notes
+                <any other context worth surfacing — sources consulted, edge
+                cases, decisions deferred to follow-up, etc.>
+                ```
+
+                Every candidate from `matched_models.json` MUST appear in the
+                "Per-model decisions" section with an explicit verdict and
+                reason — including skips and dedup matches. This file is the
+                audit trail for the run.
 
             Branch: ${{ steps.branch.outputs.branch_name }} (already created and
             checked out).
           claude_args: |
             --allowedTools "Bash(uv run:*),Bash(uv sync:*),Bash(python manage.py:*),Bash(npm run lint:*),Bash(ls:*),Bash(cat:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git checkout:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh label:*),Read,Write,Edit,Glob,Grep,WebFetch"
+
+      - name: Append decision report to step summary
+        if: always()
+        run: |
+          if [ -f decision_report.md ]; then
+            cat decision_report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "# Auto Update Models — Decision Report"
+              echo ""
+              echo "**No decision report was produced.** Claude Code exited without"
+              echo "writing \`decision_report.md\`. Check the Claude step logs above"
+              echo "for what happened."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload decision report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: decision-report
+          path: decision_report.md
+          if-no-files-found: warn
+          retention-days: 30


### PR DESCRIPTION
Adds an audit trail for the daily auto-update-models run so we can see what Claude decided, even when no PR is opened. Claude now writes a structured decision_report.md (verdict + reason per candidate), which is appended to the workflow step summary so it's visible on the run page.

<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->


### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->


### Migrations
<!--
There may be a potentially long window during the deployment where migrations are applied, but the old code is still running. We need to ensure that migrations can be applied to the current running code without breaking it, to the extent possible.

Delete this section if there are no migration.
 -->
- [ ] The migrations are backwards compatible


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
