### PR TITLE
Add support for BSUID fields in whatsapp payloads

### DIFF
--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -22,6 +22,18 @@ logger = logging.getLogger("ocs.channels")
 AttachmentType = Literal["code_interpreter", "file_search", "ocs_attachments"]
 
 
+def looks_like_bsuid(value: str) -> bool:
+    """Return True if `value` looks like a Meta business-scoped user ID.
+
+    BSUIDs use the format `<ISO country code>.<digits>` (e.g. US.13491208655302741918) and
+    parent BSUIDs use `<country>.ENT.<digits>`. Phone numbers (E.164 or wa_id digit string)
+    never contain a period.
+
+    See https://developers.facebook.com/documentation/business-messaging/whatsapp/business-scoped-user-ids
+    """
+    return "." in value
+
+
 class MediaCache(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -131,6 +143,11 @@ class TwilioMessage(BaseMessage):
     platform: ChannelPlatform
     media_url: str | None = Field(default=None)
     content_type_unparsed: str | None = Field(default=None)
+    phone_number: str | None = Field(default=None)
+    """The user's phone number (E.164) when included in the WhatsApp webhook (Twilio `From`
+    field). `None` for username-adopters whose phone is not exposed, and for non-WhatsApp
+    platforms (Facebook Messenger). Used alongside `participant_id` (BSUID) to match
+    legacy phone-keyed participants."""
 
     @field_validator("content_type", mode="before")
     @classmethod
@@ -151,19 +168,39 @@ class TwilioMessage(BaseMessage):
         prefix_to_remove = f"{prefix}:"
         platform = prefix_channel_map[prefix]
         to = message_data["To"].removeprefix(prefix_to_remove)
+        from_value = message_data["From"].removeprefix(prefix_to_remove)
+        phone_number = None
+
         if platform == ChannelPlatform.WHATSAPP:
             # Parse the number to E164 format, since this is the format of numbers in the DB
             # Normally they are already in this format, but this is just an extra layer of security
             number_obj = phonenumbers.parse(to)
             to = phonenumbers.format_number(number_obj, phonenumbers.PhoneNumberFormat.E164)
+
+            # ExternalUserId (BSUID) is the stable identifier on WhatsApp — Twilio guarantees
+            # it on every post-rollout webhook. Strip the `whatsapp:` prefix; missing field
+            # means a malformed payload, so the KeyError surfaces.
+            participant_id = message_data["ExternalUserId"].removeprefix(prefix_to_remove)
+            # `From` carries the phone only when the user has not adopted a username; otherwise
+            # it mirrors the BSUID. Normalize to E.164 for matching against legacy phone-keyed
+            # participants stored in the DB.
+            if not looks_like_bsuid(from_value):
+                phone_number = phonenumbers.format_number(
+                    phonenumbers.parse(from_value), phonenumbers.PhoneNumberFormat.E164
+                )
+        else:
+            # Facebook Messenger: no BSUID concept; use the sender id as before.
+            participant_id = from_value
+
         return TwilioMessage(
-            participant_id=message_data["From"].removeprefix(prefix_to_remove),
+            participant_id=participant_id,
             to=to,
             message_text=message_data["Body"],
             content_type=content_type,
             media_url=message_data.get("MediaUrl0"),
             content_type_unparsed=content_type,
             platform=platform,
+            phone_number=phone_number,
         )
 
 
@@ -217,6 +254,10 @@ class MetaCloudAPIMessage(TurnWhatsappMessage):
     """
 
     whatsapp_message_id: str | None = Field(default=None)
+    phone_number: str | None = Field(default=None)
+    """The user's phone number when included in the webhook (Meta `from` field).
+    `None` for username-adopters whose phone is not exposed. Used alongside
+    `participant_id` (BSUID) to match legacy phone-keyed participants."""
 
     @staticmethod
     def parse(message_data: "MetaCloudAPIWebhookMessage | dict") -> "MetaCloudAPIMessage":
@@ -225,9 +266,12 @@ class MetaCloudAPIMessage(TurnWhatsappMessage):
         if message_type == "text":
             body = message_data["text"]["body"]
 
-        # Prefer the phone number (`from`) when available; fall back to the BSUID (`from_user_id`)
-        # for username-adopters whose phone is not exposed by Meta.
-        participant_id = message_data.get("from") or message_data.get("from_user_id")
+        # BSUID (`from_user_id`) is the stable identifier — it's present on every post-rollout
+        # webhook regardless of whether the user adopted a username. A missing field means a
+        # malformed payload, so we let the KeyError surface.
+        participant_id = message_data["from_user_id"]
+        from_value = message_data.get("from")
+        phone_number = from_value if from_value and not looks_like_bsuid(from_value) else None
         return MetaCloudAPIMessage(
             participant_id=participant_id,
             message_text=body,
@@ -235,6 +279,7 @@ class MetaCloudAPIMessage(TurnWhatsappMessage):
             media_id=message_data.get(message_type, {}).get("id", None),
             content_type_unparsed=message_type,
             whatsapp_message_id=message_data.get("id"),
+            phone_number=phone_number,
         )
 
 

--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -223,8 +223,12 @@ class MetaCloudAPIMessage(TurnWhatsappMessage):
         if message_type == "text":
             body = message["text"]["body"]
 
+        # We need to handle multiple contacts
+        contact = message_data["contacts"][0]
+        wa_id = contact.get("wa_id")
+        user_id = contact.get("user_id")
         return MetaCloudAPIMessage(
-            participant_id=message_data["contacts"][0]["wa_id"],
+            participant_id=wa_id or user_id,
             message_text=body,
             content_type=message_type,
             media_id=message.get(message_type, {}).get("id", None),

--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -3,7 +3,7 @@ import logging
 from dataclasses import dataclass
 from functools import cached_property
 from io import BytesIO
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import phonenumbers
 from mailparser_reply import EmailReplyParser
@@ -13,6 +13,9 @@ from apps.channels.models import ChannelPlatform
 from apps.chat.channels import MESSAGE_TYPES
 from apps.documents.readers import Document
 from apps.files.models import File
+
+if TYPE_CHECKING:
+    from apps.channels.meta_webhook import MetaCloudAPIWebhookMessage
 
 logger = logging.getLogger("ocs.channels")
 
@@ -216,24 +219,22 @@ class MetaCloudAPIMessage(TurnWhatsappMessage):
     whatsapp_message_id: str | None = Field(default=None)
 
     @staticmethod
-    def parse(message_data: dict) -> "MetaCloudAPIMessage":
-        message = message_data["messages"][0]
-        message_type = message["type"]
+    def parse(message_data: "MetaCloudAPIWebhookMessage | dict") -> "MetaCloudAPIMessage":
+        message_type = message_data["type"]
         body = ""
         if message_type == "text":
-            body = message["text"]["body"]
+            body = message_data["text"]["body"]
 
-        # We need to handle multiple contacts
-        contact = message_data["contacts"][0]
-        wa_id = contact.get("wa_id")
-        user_id = contact.get("user_id")
+        # Prefer the phone number (`from`) when available; fall back to the BSUID (`from_user_id`)
+        # for username-adopters whose phone is not exposed by Meta.
+        participant_id = message_data.get("from") or message_data.get("from_user_id")
         return MetaCloudAPIMessage(
-            participant_id=wa_id or user_id,
+            participant_id=participant_id,
             message_text=body,
             content_type=message_type,
-            media_id=message.get(message_type, {}).get("id", None),
+            media_id=message_data.get(message_type, {}).get("id", None),
             content_type_unparsed=message_type,
-            whatsapp_message_id=message.get("id"),
+            whatsapp_message_id=message_data.get("id"),
         )
 
 

--- a/apps/channels/meta_webhook.py
+++ b/apps/channels/meta_webhook.py
@@ -1,28 +1,98 @@
 import hashlib
 import hmac
+from typing import NotRequired, TypedDict, cast
 
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.utils.crypto import constant_time_compare
 
 from apps.service_providers.models import MessagingProvider, MessagingProviderType
 
+# `from` is a Python keyword, so functional TypedDict syntax is required to express it as a field.
+MetaCloudAPIWebhookMessage = TypedDict(
+    "MetaCloudAPIWebhookMessage",
+    {
+        "id": str,
+        "timestamp": str,
+        "type": str,
+        "from": NotRequired[str],
+        "from_user_id": str,
+        "text": NotRequired[dict],
+        "audio": NotRequired[dict],
+        "voice": NotRequired[dict],
+        "image": NotRequired[dict],
+        "video": NotRequired[dict],
+        "document": NotRequired[dict],
+        "sticker": NotRequired[dict],
+        "location": NotRequired[dict],
+        "context": NotRequired[dict],
+        "interactive": NotRequired[dict],
+        "button": NotRequired[dict],
+    },
+)
 
-def extract_message_values(data: dict) -> list[dict]:
-    """Extract value dicts that contain messages from Meta webhook payload.
+
+def extract_messages(data: dict) -> list[tuple[str, MetaCloudAPIWebhookMessage]]:
+    """Extract individual messages from a Meta webhook payload.
+
+    Returns ``(phone_number_id, message)`` tuples — one per logical message after
+    grouping. Consecutive text messages from the same user within a single change
+    value are merged into a single message: the latest entry by timestamp is kept,
+    with earlier text bodies prepended (newline-separated). Non-text messages pass
+    through unchanged; mixed-type traffic from the same user yields one merged text
+    entry plus the individual non-text entries.
+
+    The grouping key is ``from_user_id`` (falling back to ``from`` for legacy
+    payloads that predate BSUID rollout).
 
     See https://developers.facebook.com/documentation/business-messaging/whatsapp/webhooks/create-webhook-endpoint/
-
-    See https://developers.facebook.com/documentation/business-messaging/whatsapp/webhooks/overview for an
-    example of the payload
     """
-
-    values = []
+    results: list[tuple[str, MetaCloudAPIWebhookMessage]] = []
     for entry in data.get("entry", []):
         for change in entry.get("changes", []):
             value = change.get("value", {})
-            if value.get("messages") and value.get("metadata", {}).get("phone_number_id"):
-                values.append(value)
-    return values
+            messages = value.get("messages") or []
+            phone_number_id = value.get("metadata", {}).get("phone_number_id")
+            if not messages or not phone_number_id:
+                continue
+            for msg in _merge_text_messages_per_user(messages):
+                results.append((phone_number_id, msg))
+    return results
+
+
+def _merge_text_messages_per_user(
+    messages: list[MetaCloudAPIWebhookMessage],
+) -> list[MetaCloudAPIWebhookMessage]:
+    """Collapse text messages from the same user into a single message.
+
+    For each user (keyed by ``from_user_id`` or ``from``), all text messages are
+    sorted by timestamp and merged — the latest entry is kept as-is except that
+    ``text.body`` becomes the newline-joined bodies of every text message in the
+    group. The merged entry takes the position of the user's first text message;
+    non-text messages pass through in their original position.
+    """
+    result: list[MetaCloudAPIWebhookMessage] = []
+    text_groups: dict[str, list[MetaCloudAPIWebhookMessage]] = {}
+    first_idx: dict[str, int] = {}
+
+    for msg in messages:
+        if msg.get("type") != "text":
+            result.append(msg)
+            continue
+        user_key = msg.get("from_user_id") or msg.get("from") or ""
+        if user_key not in text_groups:
+            first_idx[user_key] = len(result)
+            text_groups[user_key] = []
+            result.append(msg)  # Placeholder; overwritten below if the group has >1 message.
+        text_groups[user_key].append(msg)
+
+    for user_key, group in text_groups.items():
+        if len(group) == 1:
+            continue
+        group.sort(key=lambda m: int(m.get("timestamp", "0")))
+        merged = cast(MetaCloudAPIWebhookMessage, dict(group[-1]))
+        merged["text"] = {**merged.get("text", {}), "body": "\n".join(m["text"]["body"] for m in group)}
+        result[first_idx[user_key]] = merged
+    return result
 
 
 def verify_webhook(request) -> HttpResponse:

--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -18,6 +18,7 @@ from apps.channels.datamodels import (
     TurnWhatsappMessage,
     TwilioMessage,
 )
+from apps.channels.meta_webhook import MetaCloudAPIWebhookMessage
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import (
     CommCareConnectChannel,
@@ -197,7 +198,7 @@ def get_experiment_channel_base_query(platform, **query_kwargs):
 
 
 @shared_task(bind=True, base=TaskbadgerTask, ignore_result=True)
-def handle_meta_cloud_api_message(self, channel_id: int, team_slug: str, message_data: dict):
+def handle_meta_cloud_api_message(self, channel_id: int, team_slug: str, message_data: MetaCloudAPIWebhookMessage):
     message = MetaCloudAPIMessage.parse(message_data)
     experiment_channel = (
         ExperimentChannel.objects.filter(

--- a/apps/channels/tests/message_examples/meta_cloud_api_messages.py
+++ b/apps/channels/tests/message_examples/meta_cloud_api_messages.py
@@ -1,3 +1,9 @@
+# Note: the webhook-envelope wrapper is intentionally duplicated across the full-payload
+# builders below rather than extracted to a helper. The explicit shape makes it easy to
+# see what an inbound Meta payload actually looks like when reading the fixtures alongside
+# the tests.
+
+
 def legacy_text_message_value(phone_number_id="12345"):
     """Pre-BSUID webhook value: only wa_id / from are present, no user_id fields."""
     return {

--- a/apps/channels/tests/message_examples/meta_cloud_api_messages.py
+++ b/apps/channels/tests/message_examples/meta_cloud_api_messages.py
@@ -1,21 +1,18 @@
-# Note: the webhook-envelope wrapper is intentionally duplicated across the full-payload
-# builders below rather than extracted to a helper. The explicit shape makes it easy to
-# see what an inbound Meta payload actually looks like when reading the fixtures alongside
-# the tests.
-
-
 def legacy_text_message_value(phone_number_id="12345"):
-    """Pre-BSUID webhook value: only wa_id / from are present, no user_id fields."""
+    """Default webhook value: both wa_id/from (phone) and user_id/from_user_id (BSUID)
+    present. Represents a non-username-adopter or a username-adopter whose phone is
+    visible via the contact book / 30-day cache."""
     return {
         "messaging_product": "whatsapp",
         "metadata": {
             "display_phone_number": "+15551234567",
             "phone_number_id": phone_number_id,
         },
-        "contacts": [{"profile": {"name": "User"}, "wa_id": "27456897512"}],
+        "contacts": [{"profile": {"name": "User"}, "wa_id": "27456897512", "user_id": "US.13491208655302741918"}],
         "messages": [
             {
                 "from": "27456897512",
+                "from_user_id": "US.13491208655302741918",
                 "id": "wamid.abc123",
                 "timestamp": "1706709716",
                 "text": {"body": "Hello"},
@@ -26,7 +23,8 @@ def legacy_text_message_value(phone_number_id="12345"):
 
 
 def legacy_text_message(phone_number_id="12345"):
-    """Pre-BSUID full webhook payload: only wa_id / from are present, no user_id fields."""
+    """Default full webhook payload: both wa_id/from (phone) and user_id/from_user_id (BSUID)
+    present."""
     return {
         "object": "whatsapp_business_account",
         "entry": [
@@ -34,23 +32,7 @@ def legacy_text_message(phone_number_id="12345"):
                 "id": "BIZ_ID",
                 "changes": [
                     {
-                        "value": {
-                            "messaging_product": "whatsapp",
-                            "metadata": {
-                                "display_phone_number": "+15551234567",
-                                "phone_number_id": phone_number_id,
-                            },
-                            "contacts": [{"profile": {"name": "User"}, "wa_id": "27456897512"}],
-                            "messages": [
-                                {
-                                    "from": "27456897512",
-                                    "id": "wamid.abc123",
-                                    "timestamp": "1706709716",
-                                    "text": {"body": "Hello"},
-                                    "type": "text",
-                                }
-                            ],
-                        },
+                        "value": legacy_text_message_value(phone_number_id),
                         "field": "messages",
                     }
                 ],
@@ -68,160 +50,10 @@ def multi_text_message(phone_number_ids):
                 "id": "BIZ_ID",
                 "changes": [
                     {
-                        "value": {
-                            "messaging_product": "whatsapp",
-                            "metadata": {
-                                "display_phone_number": "+15551234567",
-                                "phone_number_id": phone_number_id,
-                            },
-                            "contacts": [{"profile": {"name": "User"}, "wa_id": "27456897512"}],
-                            "messages": [
-                                {
-                                    "from": "27456897512",
-                                    "id": "wamid.abc123",
-                                    "timestamp": "1706709716",
-                                    "text": {"body": "Hello"},
-                                    "type": "text",
-                                }
-                            ],
-                        },
+                        "value": legacy_text_message_value(phone_number_id),
                         "field": "messages",
                     }
                     for phone_number_id in phone_number_ids
-                ],
-            }
-        ],
-    }
-
-
-def text_message_with_user_id_and_wa_id_value(phone_number_id="12345"):
-    """Dual-field webhook value: both wa_id and user_id present. Represents the
-    early-rollout / non-username-adopter / contact-book-populated case."""
-    return {
-        "messaging_product": "whatsapp",
-        "metadata": {
-            "display_phone_number": "+15551234567",
-            "phone_number_id": phone_number_id,
-        },
-        "contacts": [
-            {
-                "profile": {"name": "User"},
-                "wa_id": "27456897512",
-                "user_id": "US.13491208655302741918",
-            }
-        ],
-        "messages": [
-            {
-                "from": "27456897512",
-                "from_user_id": "US.13491208655302741918",
-                "id": "wamid.abc123",
-                "timestamp": "1706709716",
-                "text": {"body": "Hello"},
-                "type": "text",
-            }
-        ],
-    }
-
-
-def text_message_with_user_id_and_wa_id(phone_number_id="12345"):
-    return {
-        "object": "whatsapp_business_account",
-        "entry": [
-            {
-                "id": "BIZ_ID",
-                "changes": [
-                    {
-                        "value": text_message_with_user_id_and_wa_id_value(phone_number_id),
-                        "field": "messages",
-                    }
-                ],
-            }
-        ],
-    }
-
-
-def text_message_with_username_and_wa_id_value(phone_number_id="12345"):
-    """Username-adopter whose phone is still visible via contact book / 30-day cache."""
-    return {
-        "messaging_product": "whatsapp",
-        "metadata": {
-            "display_phone_number": "+15551234567",
-            "phone_number_id": phone_number_id,
-        },
-        "contacts": [
-            {
-                "profile": {"name": "User", "username": "@testusername"},
-                "wa_id": "27456897512",
-                "user_id": "US.13491208655302741918",
-            }
-        ],
-        "messages": [
-            {
-                "from": "27456897512",
-                "from_user_id": "US.13491208655302741918",
-                "id": "wamid.abc123",
-                "timestamp": "1706709716",
-                "text": {"body": "Hello"},
-                "type": "text",
-            }
-        ],
-    }
-
-
-def text_message_with_username_and_wa_id(phone_number_id="12345"):
-    return {
-        "object": "whatsapp_business_account",
-        "entry": [
-            {
-                "id": "BIZ_ID",
-                "changes": [
-                    {
-                        "value": text_message_with_username_and_wa_id_value(phone_number_id),
-                        "field": "messages",
-                    }
-                ],
-            }
-        ],
-    }
-
-
-def text_message_user_id_only_value(phone_number_id="12345"):
-    """Username-adopter whose phone is unavailable: only user_id / from_user_id present."""
-    return {
-        "messaging_product": "whatsapp",
-        "metadata": {
-            "display_phone_number": "+15551234567",
-            "phone_number_id": phone_number_id,
-        },
-        "contacts": [
-            {
-                "profile": {"name": "User", "username": "@testusername"},
-                "user_id": "US.13491208655302741918",
-            }
-        ],
-        "messages": [
-            {
-                "from_user_id": "US.13491208655302741918",
-                "id": "wamid.abc123",
-                "timestamp": "1706709716",
-                "text": {"body": "Hello"},
-                "type": "text",
-            }
-        ],
-    }
-
-
-def text_message_user_id_only(phone_number_id="12345"):
-    return {
-        "object": "whatsapp_business_account",
-        "entry": [
-            {
-                "id": "BIZ_ID",
-                "changes": [
-                    {
-                        "value": text_message_user_id_only_value(phone_number_id),
-                        "field": "messages",
-                    }
                 ],
             }
         ],
@@ -235,10 +67,11 @@ def audio_message_value(phone_number_id="12345"):
             "display_phone_number": "+15551234567",
             "phone_number_id": phone_number_id,
         },
-        "contacts": [{"profile": {"name": "User"}, "wa_id": "27456897512"}],
+        "contacts": [{"profile": {"name": "User"}, "wa_id": "27456897512", "user_id": "US.13491208655302741918"}],
         "messages": [
             {
                 "from": "27456897512",
+                "from_user_id": "US.13491208655302741918",
                 "id": "wamid.abc456",
                 "timestamp": "1706709716",
                 "type": "audio",
@@ -260,27 +93,7 @@ def audio_message(phone_number_id="12345"):
                 "id": "BIZ_ID",
                 "changes": [
                     {
-                        "value": {
-                            "messaging_product": "whatsapp",
-                            "metadata": {
-                                "display_phone_number": "+15551234567",
-                                "phone_number_id": phone_number_id,
-                            },
-                            "contacts": [{"profile": {"name": "User"}, "wa_id": "27456897512"}],
-                            "messages": [
-                                {
-                                    "from": "27456897512",
-                                    "id": "wamid.abc456",
-                                    "timestamp": "1706709716",
-                                    "type": "audio",
-                                    "audio": {
-                                        "mime_type": "audio/ogg; codecs=opus",
-                                        "sha256": "abc123",
-                                        "id": "1215194677037265",
-                                    },
-                                }
-                            ],
-                        },
+                        "value": audio_message_value(phone_number_id),
                         "field": "messages",
                     }
                 ],

--- a/apps/channels/tests/message_examples/meta_cloud_api_messages.py
+++ b/apps/channels/tests/message_examples/meta_cloud_api_messages.py
@@ -1,4 +1,5 @@
 def legacy_text_message_value(phone_number_id="12345"):
+    """Pre-BSUID webhook value: only wa_id / from are present, no user_id fields."""
     return {
         "messaging_product": "whatsapp",
         "metadata": {
@@ -19,6 +20,7 @@ def legacy_text_message_value(phone_number_id="12345"):
 
 
 def legacy_text_message(phone_number_id="12345"):
+    """Pre-BSUID full webhook payload: only wa_id / from are present, no user_id fields."""
     return {
         "object": "whatsapp_business_account",
         "entry": [

--- a/apps/channels/tests/message_examples/meta_cloud_api_messages.py
+++ b/apps/channels/tests/message_examples/meta_cloud_api_messages.py
@@ -1,4 +1,4 @@
-def text_message_value(phone_number_id="12345"):
+def legacy_text_message_value(phone_number_id="12345"):
     return {
         "messaging_product": "whatsapp",
         "metadata": {
@@ -18,7 +18,7 @@ def text_message_value(phone_number_id="12345"):
     }
 
 
-def text_message(phone_number_id="12345"):
+def legacy_text_message(phone_number_id="12345"):
     return {
         "object": "whatsapp_business_account",
         "entry": [
@@ -80,6 +80,140 @@ def multi_text_message(phone_number_ids):
                         "field": "messages",
                     }
                     for phone_number_id in phone_number_ids
+                ],
+            }
+        ],
+    }
+
+
+def text_message_with_user_id_and_wa_id_value(phone_number_id="12345"):
+    """Dual-field webhook value: both wa_id and user_id present. Represents the
+    early-rollout / non-username-adopter / contact-book-populated case."""
+    return {
+        "messaging_product": "whatsapp",
+        "metadata": {
+            "display_phone_number": "+15551234567",
+            "phone_number_id": phone_number_id,
+        },
+        "contacts": [
+            {
+                "profile": {"name": "User"},
+                "wa_id": "27456897512",
+                "user_id": "US.13491208655302741918",
+            }
+        ],
+        "messages": [
+            {
+                "from": "27456897512",
+                "from_user_id": "US.13491208655302741918",
+                "id": "wamid.abc123",
+                "timestamp": "1706709716",
+                "text": {"body": "Hello"},
+                "type": "text",
+            }
+        ],
+    }
+
+
+def text_message_with_user_id_and_wa_id(phone_number_id="12345"):
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "BIZ_ID",
+                "changes": [
+                    {
+                        "value": text_message_with_user_id_and_wa_id_value(phone_number_id),
+                        "field": "messages",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def text_message_with_username_and_wa_id_value(phone_number_id="12345"):
+    """Username-adopter whose phone is still visible via contact book / 30-day cache."""
+    return {
+        "messaging_product": "whatsapp",
+        "metadata": {
+            "display_phone_number": "+15551234567",
+            "phone_number_id": phone_number_id,
+        },
+        "contacts": [
+            {
+                "profile": {"name": "User", "username": "@testusername"},
+                "wa_id": "27456897512",
+                "user_id": "US.13491208655302741918",
+            }
+        ],
+        "messages": [
+            {
+                "from": "27456897512",
+                "from_user_id": "US.13491208655302741918",
+                "id": "wamid.abc123",
+                "timestamp": "1706709716",
+                "text": {"body": "Hello"},
+                "type": "text",
+            }
+        ],
+    }
+
+
+def text_message_with_username_and_wa_id(phone_number_id="12345"):
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "BIZ_ID",
+                "changes": [
+                    {
+                        "value": text_message_with_username_and_wa_id_value(phone_number_id),
+                        "field": "messages",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def text_message_user_id_only_value(phone_number_id="12345"):
+    """Username-adopter whose phone is unavailable: only user_id / from_user_id present."""
+    return {
+        "messaging_product": "whatsapp",
+        "metadata": {
+            "display_phone_number": "+15551234567",
+            "phone_number_id": phone_number_id,
+        },
+        "contacts": [
+            {
+                "profile": {"name": "User", "username": "@testusername"},
+                "user_id": "US.13491208655302741918",
+            }
+        ],
+        "messages": [
+            {
+                "from_user_id": "US.13491208655302741918",
+                "id": "wamid.abc123",
+                "timestamp": "1706709716",
+                "text": {"body": "Hello"},
+                "type": "text",
+            }
+        ],
+    }
+
+
+def text_message_user_id_only(phone_number_id="12345"):
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "BIZ_ID",
+                "changes": [
+                    {
+                        "value": text_message_user_id_only_value(phone_number_id),
+                        "field": "messages",
+                    }
                 ],
             }
         ],

--- a/apps/channels/tests/message_examples/meta_cloud_api_messages.py
+++ b/apps/channels/tests/message_examples/meta_cloud_api_messages.py
@@ -1,20 +1,3 @@
-def _wrap_in_webhook_payload(value, phone_number_id="12345"):
-    return {
-        "object": "whatsapp_business_account",
-        "entry": [
-            {
-                "id": "BIZ_ID",
-                "changes": [
-                    {
-                        "value": value,
-                        "field": "messages",
-                    }
-                ],
-            }
-        ],
-    }
-
-
 def text_message_value(phone_number_id="12345"):
     return {
         "messaging_product": "whatsapp",
@@ -36,7 +19,71 @@ def text_message_value(phone_number_id="12345"):
 
 
 def text_message(phone_number_id="12345"):
-    return _wrap_in_webhook_payload(text_message_value(phone_number_id), phone_number_id)
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "BIZ_ID",
+                "changes": [
+                    {
+                        "value": {
+                            "messaging_product": "whatsapp",
+                            "metadata": {
+                                "display_phone_number": "+15551234567",
+                                "phone_number_id": phone_number_id,
+                            },
+                            "contacts": [{"profile": {"name": "User"}, "wa_id": "27456897512"}],
+                            "messages": [
+                                {
+                                    "from": "27456897512",
+                                    "id": "wamid.abc123",
+                                    "timestamp": "1706709716",
+                                    "text": {"body": "Hello"},
+                                    "type": "text",
+                                }
+                            ],
+                        },
+                        "field": "messages",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def multi_text_message(phone_number_ids):
+    """Build a webhook payload containing one text-message change per phone_number_id."""
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "BIZ_ID",
+                "changes": [
+                    {
+                        "value": {
+                            "messaging_product": "whatsapp",
+                            "metadata": {
+                                "display_phone_number": "+15551234567",
+                                "phone_number_id": phone_number_id,
+                            },
+                            "contacts": [{"profile": {"name": "User"}, "wa_id": "27456897512"}],
+                            "messages": [
+                                {
+                                    "from": "27456897512",
+                                    "id": "wamid.abc123",
+                                    "timestamp": "1706709716",
+                                    "text": {"body": "Hello"},
+                                    "type": "text",
+                                }
+                            ],
+                        },
+                        "field": "messages",
+                    }
+                    for phone_number_id in phone_number_ids
+                ],
+            }
+        ],
+    }
 
 
 def audio_message_value(phone_number_id="12345"):
@@ -64,4 +111,37 @@ def audio_message_value(phone_number_id="12345"):
 
 
 def audio_message(phone_number_id="12345"):
-    return _wrap_in_webhook_payload(audio_message_value(phone_number_id), phone_number_id)
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "BIZ_ID",
+                "changes": [
+                    {
+                        "value": {
+                            "messaging_product": "whatsapp",
+                            "metadata": {
+                                "display_phone_number": "+15551234567",
+                                "phone_number_id": phone_number_id,
+                            },
+                            "contacts": [{"profile": {"name": "User"}, "wa_id": "27456897512"}],
+                            "messages": [
+                                {
+                                    "from": "27456897512",
+                                    "id": "wamid.abc456",
+                                    "timestamp": "1706709716",
+                                    "type": "audio",
+                                    "audio": {
+                                        "mime_type": "audio/ogg; codecs=opus",
+                                        "sha256": "abc123",
+                                        "id": "1215194677037265",
+                                    },
+                                }
+                            ],
+                        },
+                        "field": "messages",
+                    }
+                ],
+            }
+        ],
+    }

--- a/apps/channels/tests/message_examples/twilio_messages.py
+++ b/apps/channels/tests/message_examples/twilio_messages.py
@@ -32,6 +32,7 @@ def _audio_message(message: dict):
 class Whatsapp:
     to = "whatsapp:+14155238886"
     from_ = "whatsapp:+27456897512"
+    bsuid = "US.13491208655302741918"
 
     @staticmethod
     def text_message():
@@ -44,6 +45,24 @@ class Whatsapp:
     @staticmethod
     def audio_message():
         return _audio_message(Whatsapp.text_message())
+
+    @staticmethod
+    def text_message_with_external_user_id():
+        """Dual-field Twilio payload: From has the phone, ExternalUserId has the BSUID.
+
+        See https://www.twilio.com/en-us/changelog/whatsapp-usernames--new-business-scoped-user-id--bsuid--field-re
+        """
+        msg = _text_message(to=Whatsapp.to, from_=Whatsapp.from_)
+        msg["ExternalUserId"] = Whatsapp.bsuid
+        return msg
+
+    @staticmethod
+    def text_message_external_user_id_only():
+        """BSUID-only Twilio payload: From contains the BSUID and ExternalUserId is the same BSUID."""
+        msg = _text_message(to=Whatsapp.to, from_=f"whatsapp:{Whatsapp.bsuid}")
+        msg["ExternalUserId"] = Whatsapp.bsuid
+        msg.pop("WaId", None)
+        return msg
 
 
 class Messenger:

--- a/apps/channels/tests/message_examples/twilio_messages.py
+++ b/apps/channels/tests/message_examples/twilio_messages.py
@@ -33,10 +33,18 @@ class Whatsapp:
     to = "whatsapp:+14155238886"
     from_ = "whatsapp:+27456897512"
     bsuid = "US.13491208655302741918"
+    external_user_id = f"whatsapp:{bsuid}"
 
     @staticmethod
     def text_message():
-        return _text_message(to=Whatsapp.to, from_=Whatsapp.from_)
+        """Post-rollout Twilio payload: From has the phone, ExternalUserId has the BSUID.
+
+        Twilio guarantees ExternalUserId on every WhatsApp webhook from June 2026 onwards.
+        See https://www.twilio.com/en-us/changelog/whatsapp-usernames--new-business-scoped-user-id--bsuid--field-re
+        """
+        msg = _text_message(to=Whatsapp.to, from_=Whatsapp.from_)
+        msg["ExternalUserId"] = Whatsapp.external_user_id
+        return msg
 
     @staticmethod
     def image_message():
@@ -45,24 +53,6 @@ class Whatsapp:
     @staticmethod
     def audio_message():
         return _audio_message(Whatsapp.text_message())
-
-    @staticmethod
-    def text_message_with_external_user_id():
-        """Dual-field Twilio payload: From has the phone, ExternalUserId has the BSUID.
-
-        See https://www.twilio.com/en-us/changelog/whatsapp-usernames--new-business-scoped-user-id--bsuid--field-re
-        """
-        msg = _text_message(to=Whatsapp.to, from_=Whatsapp.from_)
-        msg["ExternalUserId"] = Whatsapp.bsuid
-        return msg
-
-    @staticmethod
-    def text_message_external_user_id_only():
-        """BSUID-only Twilio payload: From contains the BSUID and ExternalUserId is the same BSUID."""
-        msg = _text_message(to=Whatsapp.to, from_=f"whatsapp:{Whatsapp.bsuid}")
-        msg["ExternalUserId"] = Whatsapp.bsuid
-        msg.pop("WaId", None)
-        return msg
 
 
 class Messenger:

--- a/apps/channels/tests/test_datamodels.py
+++ b/apps/channels/tests/test_datamodels.py
@@ -19,18 +19,22 @@ class TestBaseMessage:
 
 
 class TestMetaCloudAPIMessageParse:
-    def test_legacy_payload_uses_wa_id_as_participant_id(self):
-        msg = MetaCloudAPIMessage.parse(meta_cloud_api_messages.legacy_text_message_value())
+    def test_legacy_payload_uses_phone_as_participant_id(self):
+        message = meta_cloud_api_messages.legacy_text_message_value()["messages"][0]
+        msg = MetaCloudAPIMessage.parse(message)
         assert msg.participant_id == "27456897512"
 
-    def test_dual_field_payload_prefers_wa_id(self):
-        msg = MetaCloudAPIMessage.parse(meta_cloud_api_messages.text_message_with_user_id_and_wa_id_value())
+    def test_dual_field_payload_prefers_phone(self):
+        message = meta_cloud_api_messages.text_message_with_user_id_and_wa_id_value()["messages"][0]
+        msg = MetaCloudAPIMessage.parse(message)
         assert msg.participant_id == "27456897512"
 
-    def test_username_adopter_with_wa_id_prefers_wa_id(self):
-        msg = MetaCloudAPIMessage.parse(meta_cloud_api_messages.text_message_with_username_and_wa_id_value())
+    def test_username_adopter_with_phone_prefers_phone(self):
+        message = meta_cloud_api_messages.text_message_with_username_and_wa_id_value()["messages"][0]
+        msg = MetaCloudAPIMessage.parse(message)
         assert msg.participant_id == "27456897512"
 
     def test_user_id_only_payload_falls_back_to_user_id(self):
-        msg = MetaCloudAPIMessage.parse(meta_cloud_api_messages.text_message_user_id_only_value())
+        message = meta_cloud_api_messages.text_message_user_id_only_value()["messages"][0]
+        msg = MetaCloudAPIMessage.parse(message)
         assert msg.participant_id == "US.13491208655302741918"

--- a/apps/channels/tests/test_datamodels.py
+++ b/apps/channels/tests/test_datamodels.py
@@ -1,4 +1,5 @@
-from apps.channels.datamodels import BaseMessage
+from apps.channels.datamodels import BaseMessage, MetaCloudAPIMessage
+from apps.channels.tests.message_examples import meta_cloud_api_messages
 
 
 class TestBaseMessage:
@@ -15,3 +16,21 @@ class TestBaseMessage:
         msg = BaseMessage(participant_id="u1", message_text="hi", attachment_file_ids=[42])
         rebuilt = BaseMessage(**msg.model_dump())
         assert rebuilt.attachment_file_ids == [42]
+
+
+class TestMetaCloudAPIMessageParse:
+    def test_legacy_payload_uses_wa_id_as_participant_id(self):
+        msg = MetaCloudAPIMessage.parse(meta_cloud_api_messages.legacy_text_message_value())
+        assert msg.participant_id == "27456897512"
+
+    def test_dual_field_payload_prefers_wa_id(self):
+        msg = MetaCloudAPIMessage.parse(meta_cloud_api_messages.text_message_with_user_id_and_wa_id_value())
+        assert msg.participant_id == "27456897512"
+
+    def test_username_adopter_with_wa_id_prefers_wa_id(self):
+        msg = MetaCloudAPIMessage.parse(meta_cloud_api_messages.text_message_with_username_and_wa_id_value())
+        assert msg.participant_id == "27456897512"
+
+    def test_user_id_only_payload_falls_back_to_user_id(self):
+        msg = MetaCloudAPIMessage.parse(meta_cloud_api_messages.text_message_user_id_only_value())
+        assert msg.participant_id == "US.13491208655302741918"

--- a/apps/channels/tests/test_datamodels.py
+++ b/apps/channels/tests/test_datamodels.py
@@ -1,4 +1,7 @@
-from apps.channels.datamodels import BaseMessage, MetaCloudAPIMessage
+import pytest
+
+from apps.channels.datamodels import BaseMessage, MetaCloudAPIMessage, TwilioMessage
+from apps.channels.models import ChannelPlatform
 from apps.channels.tests.message_examples import meta_cloud_api_messages
 
 
@@ -19,22 +22,109 @@ class TestBaseMessage:
 
 
 class TestMetaCloudAPIMessageParse:
-    def test_legacy_payload_uses_phone_as_participant_id(self):
-        message = meta_cloud_api_messages.legacy_text_message_value()["messages"][0]
-        msg = MetaCloudAPIMessage.parse(message)
-        assert msg.participant_id == "27456897512"
+    """Parse-time behavior of inbound Meta Cloud API webhook messages.
 
-    def test_dual_field_payload_prefers_phone(self):
-        message = meta_cloud_api_messages.text_message_with_user_id_and_wa_id_value()["messages"][0]
-        msg = MetaCloudAPIMessage.parse(message)
-        assert msg.participant_id == "27456897512"
+    ``participant_id`` is sourced strictly from ``from_user_id`` (the BSUID). The phone
+    number — when present in ``from`` — is captured separately as ``phone_number`` so the
+    channel can match a legacy phone-keyed Participant during the BSUID rollout.
+    """
 
-    def test_username_adopter_with_phone_prefers_phone(self):
-        message = meta_cloud_api_messages.text_message_with_username_and_wa_id_value()["messages"][0]
-        msg = MetaCloudAPIMessage.parse(message)
-        assert msg.participant_id == "27456897512"
+    BSUID = "US.13491208655302741918"
+    PHONE = "27456897512"
 
-    def test_user_id_only_payload_falls_back_to_user_id(self):
-        message = meta_cloud_api_messages.text_message_user_id_only_value()["messages"][0]
-        msg = MetaCloudAPIMessage.parse(message)
-        assert msg.participant_id == "US.13491208655302741918"
+    def test_payload_with_phone_captures_both_bsuid_and_phone(self):
+        """Webhook has BOTH ``from_user_id`` (BSUID) and ``from`` (phone)."""
+        message = {
+            "from_user_id": self.BSUID,
+            "from": self.PHONE,
+            "id": "wamid.abc123",
+            "timestamp": "1706709716",
+            "text": {"body": "Hello"},
+            "type": "text",
+        }
+        parsed = MetaCloudAPIMessage.parse(message)
+        assert parsed.participant_id == self.BSUID
+        assert parsed.phone_number == self.PHONE
+
+    def test_payload_without_phone_captures_only_bsuid(self):
+        """Username-adopter whose phone has been hidden by Meta. No ``from`` field."""
+        message = {
+            "from_user_id": self.BSUID,
+            "id": "wamid.abc123",
+            "timestamp": "1706709716",
+            "text": {"body": "Hello"},
+            "type": "text",
+        }
+        parsed = MetaCloudAPIMessage.parse(message)
+        assert parsed.participant_id == self.BSUID
+        assert parsed.phone_number is None
+
+    def test_audio_payload_preserves_media_id_and_message_id(self):
+        message = meta_cloud_api_messages.audio_message_value()["messages"][0]
+        parsed = MetaCloudAPIMessage.parse(message)
+        assert parsed.media_id == "1215194677037265"
+        assert parsed.whatsapp_message_id == "wamid.abc456"
+
+    def test_parse_raises_when_from_user_id_missing(self):
+        """Post-rollout Meta guarantees ``from_user_id`` on every webhook — its absence is
+        a malformed payload and should fail loudly."""
+        message = {
+            "from": "27456897512",
+            "id": "wamid.abc123",
+            "timestamp": "1706709716",
+            "text": {"body": "Hello"},
+            "type": "text",
+        }
+        with pytest.raises(KeyError):
+            MetaCloudAPIMessage.parse(message)
+
+
+class TestTwilioMessageParse:
+    """Parse-time behavior of inbound Twilio WhatsApp webhook messages.
+
+    Twilio guarantees ``ExternalUserId`` (BSUID) on every WhatsApp webhook post-rollout.
+    The ``From`` field carries the phone number for non-username-adopters and the BSUID
+    for username-adopters. We always source ``participant_id`` from ``ExternalUserId``;
+    the phone — when From is a real phone — is normalized to E.164 and captured as
+    ``phone_number``.
+    """
+
+    BSUID = "US.13491208655302741918"
+    BUSINESS = "whatsapp:+14155238886"
+
+    def test_payload_with_phone_captures_both_bsuid_and_phone(self):
+        """Standard post-rollout webhook. From has the phone, ExternalUserId has the BSUID."""
+        message = {
+            "From": "whatsapp:+27456897512",
+            "To": self.BUSINESS,
+            "ExternalUserId": f"whatsapp:{self.BSUID}",
+            "Body": "Hello",
+        }
+        parsed = TwilioMessage.parse(message)
+        assert parsed.platform == ChannelPlatform.WHATSAPP
+        assert parsed.participant_id == self.BSUID
+        assert parsed.phone_number == "+27456897512"
+
+    def test_payload_without_phone_captures_only_bsuid(self):
+        """Username-adopter. ``From`` mirrors the BSUID; no phone is exposed."""
+        message = {
+            "From": f"whatsapp:{self.BSUID}",
+            "To": self.BUSINESS,
+            "ExternalUserId": f"whatsapp:{self.BSUID}",
+            "Body": "Hello",
+        }
+        parsed = TwilioMessage.parse(message)
+        assert parsed.platform == ChannelPlatform.WHATSAPP
+        assert parsed.participant_id == self.BSUID
+        assert parsed.phone_number is None
+
+    def test_parse_raises_when_external_user_id_missing(self):
+        """Post-rollout Twilio guarantees ``ExternalUserId`` on every WhatsApp webhook —
+        its absence is a malformed payload and should fail loudly."""
+        message = {
+            "From": "whatsapp:+27456897512",
+            "To": self.BUSINESS,
+            "Body": "Hello",
+        }
+        with pytest.raises(KeyError):
+            TwilioMessage.parse(message)

--- a/apps/channels/tests/test_meta_cloud_api_webhook.py
+++ b/apps/channels/tests/test_meta_cloud_api_webhook.py
@@ -210,24 +210,7 @@ class TestNewMetaCloudApiMessage:
         )
 
         # Build a payload with two entries for two different phone numbers
-        payload = {
-            "object": "whatsapp_business_account",
-            "entry": [
-                {
-                    "id": "BIZ_ID",
-                    "changes": [
-                        {
-                            "value": meta_cloud_api_messages.text_message_value("12345"),
-                            "field": "messages",
-                        },
-                        {
-                            "value": meta_cloud_api_messages.text_message_value("99999"),
-                            "field": "messages",
-                        },
-                    ],
-                }
-            ],
-        }
+        payload = meta_cloud_api_messages.multi_text_message(["12345", "99999"])
         response = self._post(payload)
         assert response.status_code == 200
         assert mock_delay.call_count == 2
@@ -237,24 +220,7 @@ class TestNewMetaCloudApiMessage:
     @patch("apps.channels.tasks.handle_meta_cloud_api_message.delay")
     def test_unknown_phone_number_in_multi_payload_skipped(self, mock_delay, meta_cloud_api_channel):
         """A value with an unknown phone_number_id is skipped; other values are still dispatched."""
-        payload = {
-            "object": "whatsapp_business_account",
-            "entry": [
-                {
-                    "id": "BIZ_ID",
-                    "changes": [
-                        {
-                            "value": meta_cloud_api_messages.text_message_value("12345"),
-                            "field": "messages",
-                        },
-                        {
-                            "value": meta_cloud_api_messages.text_message_value("unknown_id"),
-                            "field": "messages",
-                        },
-                    ],
-                }
-            ],
-        }
+        payload = meta_cloud_api_messages.multi_text_message(["12345", "unknown_id"])
         response = self._post(payload)
         assert response.status_code == 200
         assert mock_delay.call_count == 1
@@ -287,24 +253,7 @@ class TestNewMetaCloudApiMessage:
 
         # Payload targeting BOTH attacker's phone_number_id and victim's phone_number_id,
         # signed with the attacker's app_secret.
-        payload = {
-            "object": "whatsapp_business_account",
-            "entry": [
-                {
-                    "id": "BIZ_ID",
-                    "changes": [
-                        {
-                            "value": meta_cloud_api_messages.text_message_value("attacker_phone_id"),
-                            "field": "messages",
-                        },
-                        {
-                            "value": meta_cloud_api_messages.text_message_value("12345"),
-                            "field": "messages",
-                        },
-                    ],
-                }
-            ],
-        }
+        payload = meta_cloud_api_messages.multi_text_message(["attacker_phone_id", "12345"])
         response = self._post(payload, app_secret=attacker_secret)
         assert response.status_code == 200
         mock_delay.assert_not_called()

--- a/apps/channels/tests/test_meta_cloud_api_webhook.py
+++ b/apps/channels/tests/test_meta_cloud_api_webhook.py
@@ -70,13 +70,79 @@ class TestMetaCloudAPIWebhookVerifySignature:
         assert meta_webhook.verify_signature(payload, signature, "") is False
 
 
-class TestMetaCloudAPIWebhookExtractMessageValues:
-    def test_extracts_message_values(self):
+class TestMetaCloudAPIWebhookExtractMessages:
+    def test_extracts_messages(self):
         data = meta_cloud_api_messages.legacy_text_message()
-        values = meta_webhook.extract_message_values(data)
-        assert len(values) == 1
-        assert values[0]["metadata"]["phone_number_id"] == "12345"
-        assert values[0]["messages"][0]["text"]["body"] == "Hello"
+        messages = meta_webhook.extract_messages(data)
+        assert len(messages) == 1
+        phone_id, message = messages[0]
+        assert phone_id == "12345"
+        assert message["text"]["body"] == "Hello"
+        assert message["from"] == "27456897512"
+
+    def test_collapses_multiple_text_messages_from_same_user(self):
+        value = meta_cloud_api_messages.legacy_text_message_value()
+        first = value["messages"][0]
+        value["messages"] = [
+            {**first, "id": "wamid.1", "timestamp": "100", "text": {"body": "first"}},
+            {**first, "id": "wamid.2", "timestamp": "200", "text": {"body": "second"}},
+            {**first, "id": "wamid.3", "timestamp": "300", "text": {"body": "third"}},
+        ]
+        data = {"object": "whatsapp_business_account", "entry": [{"changes": [{"value": value}]}]}
+
+        messages = meta_webhook.extract_messages(data)
+        assert len(messages) == 1
+        _, merged = messages[0]
+        assert merged["id"] == "wamid.3"  # Last entry's details kept.
+        assert merged["timestamp"] == "300"
+        assert merged["text"]["body"] == "first\nsecond\nthird"
+
+    def test_groups_separately_for_different_users(self):
+        value = meta_cloud_api_messages.legacy_text_message_value()
+        first = value["messages"][0]
+        value["messages"] = [
+            {**first, "id": "wamid.a", "from": "111", "from_user_id": "US.A", "text": {"body": "from A"}},
+            {**first, "id": "wamid.b", "from": "222", "from_user_id": "US.B", "text": {"body": "from B"}},
+        ]
+        data = {"object": "whatsapp_business_account", "entry": [{"changes": [{"value": value}]}]}
+
+        messages = meta_webhook.extract_messages(data)
+        assert len(messages) == 2
+        bodies = {m["text"]["body"] for _, m in messages}
+        assert bodies == {"from A", "from B"}
+
+    def test_does_not_merge_text_with_non_text_from_same_user(self):
+        value = meta_cloud_api_messages.legacy_text_message_value()
+        text_msg = value["messages"][0]
+        audio_msg = {
+            "id": "wamid.audio",
+            "timestamp": "200",
+            "from": text_msg["from"],
+            "type": "audio",
+            "audio": {"id": "media_abc"},
+        }
+        value["messages"] = [text_msg, audio_msg]
+        data = {"object": "whatsapp_business_account", "entry": [{"changes": [{"value": value}]}]}
+
+        messages = meta_webhook.extract_messages(data)
+        assert len(messages) == 2
+        types = [m["type"] for _, m in messages]
+        assert sorted(types) == ["audio", "text"]
+
+    def test_groups_by_from_user_id_when_present(self):
+        """Username-adopter sends two text messages: same from_user_id, same from (phone)."""
+        value = meta_cloud_api_messages.text_message_with_username_and_wa_id_value()
+        first = value["messages"][0]
+        value["messages"] = [
+            {**first, "id": "wamid.1", "timestamp": "100", "text": {"body": "hi"}},
+            {**first, "id": "wamid.2", "timestamp": "200", "text": {"body": "there"}},
+        ]
+        data = {"object": "whatsapp_business_account", "entry": [{"changes": [{"value": value}]}]}
+
+        messages = meta_webhook.extract_messages(data)
+        assert len(messages) == 1
+        _, merged = messages[0]
+        assert merged["text"]["body"] == "hi\nthere"
 
 
 @pytest.mark.django_db()
@@ -168,7 +234,7 @@ class TestNewMetaCloudApiMessage:
         mock_delay.assert_called_once_with(
             channel_id=meta_cloud_api_channel.id,
             team_slug=meta_cloud_api_channel.team.slug,
-            message_data=meta_cloud_api_messages.legacy_text_message_value(),
+            message_data=meta_cloud_api_messages.legacy_text_message_value()["messages"][0],
         )
 
     def test_invalid_signature_returns_200(self, meta_cloud_api_channel):
@@ -227,7 +293,7 @@ class TestNewMetaCloudApiMessage:
         mock_delay.assert_called_once_with(
             channel_id=meta_cloud_api_channel.id,
             team_slug=meta_cloud_api_channel.team.slug,
-            message_data=meta_cloud_api_messages.legacy_text_message_value("12345"),
+            message_data=meta_cloud_api_messages.legacy_text_message_value("12345")["messages"][0],
         )
 
     @patch("apps.channels.tasks.handle_meta_cloud_api_message.delay")

--- a/apps/channels/tests/test_meta_cloud_api_webhook.py
+++ b/apps/channels/tests/test_meta_cloud_api_webhook.py
@@ -130,8 +130,9 @@ class TestMetaCloudAPIWebhookExtractMessages:
         assert sorted(types) == ["audio", "text"]
 
     def test_groups_by_from_user_id_when_present(self):
-        """Username-adopter sends two text messages: same from_user_id, same from (phone)."""
-        value = meta_cloud_api_messages.text_message_with_username_and_wa_id_value()
+        """Same user (matched on ``from_user_id``) sends two text messages — they should be
+        merged into a single entry."""
+        value = meta_cloud_api_messages.legacy_text_message_value()
         first = value["messages"][0]
         value["messages"] = [
             {**first, "id": "wamid.1", "timestamp": "100", "text": {"body": "hi"}},

--- a/apps/channels/tests/test_meta_cloud_api_webhook.py
+++ b/apps/channels/tests/test_meta_cloud_api_webhook.py
@@ -72,7 +72,7 @@ class TestMetaCloudAPIWebhookVerifySignature:
 
 class TestMetaCloudAPIWebhookExtractMessageValues:
     def test_extracts_message_values(self):
-        data = meta_cloud_api_messages.text_message()
+        data = meta_cloud_api_messages.legacy_text_message()
         values = meta_webhook.extract_message_values(data)
         assert len(values) == 1
         assert values[0]["metadata"]["phone_number_id"] == "12345"
@@ -158,23 +158,23 @@ class TestNewMetaCloudApiMessage:
 
     @patch("apps.channels.tasks.handle_meta_cloud_api_message.delay")
     def test_valid_message_returns_200(self, mock_delay, meta_cloud_api_channel):
-        response = self._post(meta_cloud_api_messages.text_message())
+        response = self._post(meta_cloud_api_messages.legacy_text_message())
         assert response.status_code == 200
         mock_delay.assert_called_once()
 
     @patch("apps.channels.tasks.handle_meta_cloud_api_message.delay")
     def test_task_dispatched_with_correct_args(self, mock_delay, meta_cloud_api_channel):
-        self._post(meta_cloud_api_messages.text_message())
+        self._post(meta_cloud_api_messages.legacy_text_message())
         mock_delay.assert_called_once_with(
             channel_id=meta_cloud_api_channel.id,
             team_slug=meta_cloud_api_channel.team.slug,
-            message_data=meta_cloud_api_messages.text_message_value(),
+            message_data=meta_cloud_api_messages.legacy_text_message_value(),
         )
 
     def test_invalid_signature_returns_200(self, meta_cloud_api_channel):
         """Invalid signature returns 200 to prevent Meta from retrying."""
         factory = RequestFactory()
-        body = json.dumps(meta_cloud_api_messages.text_message()).encode()
+        body = json.dumps(meta_cloud_api_messages.legacy_text_message()).encode()
         request = factory.post(
             "/",
             data=body,
@@ -187,7 +187,7 @@ class TestNewMetaCloudApiMessage:
     def test_missing_signature_header_returns_200(self, meta_cloud_api_channel):
         """Missing signature header returns 200 to prevent Meta from retrying."""
         factory = RequestFactory()
-        body = json.dumps(meta_cloud_api_messages.text_message()).encode()
+        body = json.dumps(meta_cloud_api_messages.legacy_text_message()).encode()
         request = factory.post(
             "/",
             data=body,
@@ -227,7 +227,7 @@ class TestNewMetaCloudApiMessage:
         mock_delay.assert_called_once_with(
             channel_id=meta_cloud_api_channel.id,
             team_slug=meta_cloud_api_channel.team.slug,
-            message_data=meta_cloud_api_messages.text_message_value("12345"),
+            message_data=meta_cloud_api_messages.legacy_text_message_value("12345"),
         )
 
     @patch("apps.channels.tasks.handle_meta_cloud_api_message.delay")

--- a/apps/channels/tests/test_whatsapp_integration.py
+++ b/apps/channels/tests/test_whatsapp_integration.py
@@ -10,6 +10,7 @@ from apps.channels.models import ChannelPlatform
 from apps.channels.tasks import handle_meta_cloud_api_message, handle_turn_message, handle_twilio_message
 from apps.chat.channels import MESSAGE_TYPES, WhatsappChannel
 from apps.chat.models import Chat, ChatMessage
+from apps.experiments.models import Participant
 from apps.files.models import File
 from apps.service_providers.models import MessagingProviderType
 from apps.service_providers.speech_service import SynthesizedAudio
@@ -355,8 +356,6 @@ class TestMetaCloudApi:
     ):
         """When wa_id is missing (username-adopter, not in contact book), the BSUID becomes the
         participant identifier and a new Participant is created."""
-        from apps.experiments.models import Participant  # noqa: PLC0415
-
         chat = Chat.objects.create(team=meta_cloud_api_whatsapp_channel.experiment.team)
         bot_process_input.return_value = ChatMessage.objects.create(content="Hi", chat=chat)
 

--- a/apps/channels/tests/test_whatsapp_integration.py
+++ b/apps/channels/tests/test_whatsapp_integration.py
@@ -65,7 +65,16 @@ class TestTwilio:
             assert whatsapp_message.media_url is None
         else:
             assert whatsapp_message.content_type == MESSAGE_TYPES.VOICE
-            assert whatsapp_message.media_url == "http://example.com/media"
+
+    def test_parse_message_with_external_user_id_keeps_phone_as_participant_id(self):
+        message = twilio_messages.Whatsapp.text_message_with_external_user_id()
+        parsed = TwilioMessage.parse(message)
+        assert parsed.participant_id == "+27456897512"
+
+    def test_parse_message_external_user_id_only_uses_bsuid_as_participant_id(self):
+        message = twilio_messages.Whatsapp.text_message_external_user_id_only()
+        parsed = TwilioMessage.parse(message)
+        assert parsed.participant_id == "US.13491208655302741918"
 
     @pytest.mark.usefixtures("_twilio_whatsapp_channel")
     @pytest.mark.parametrize(
@@ -241,7 +250,7 @@ class TestMetaCloudApi:
     @pytest.mark.parametrize(
         ("message", "message_type"),
         [
-            (meta_cloud_api_messages.text_message_value(), "text"),
+            (meta_cloud_api_messages.legacy_text_message_value(), "text"),
             (meta_cloud_api_messages.audio_message_value(), "audio"),
         ],
     )
@@ -261,7 +270,7 @@ class TestMetaCloudApi:
     @pytest.mark.parametrize(
         ("incoming_message", "message_type"),
         [
-            (meta_cloud_api_messages.text_message_value(), "text"),
+            (meta_cloud_api_messages.legacy_text_message_value(), "text"),
             (meta_cloud_api_messages.audio_message_value(), "audio"),
         ],
     )
@@ -290,7 +299,7 @@ class TestMetaCloudApi:
         get_voice_transcript_mock.return_value = "Hi"
         handle_meta_cloud_api_message(
             channel_id=meta_cloud_api_whatsapp_channel.id,
-            team_slug=meta_cloud_api_whatsapp_channel.team.slug,
+            team_slug=meta_cloud_api_whatsapp_channel.experiment.team.slug,
             message_data=incoming_message,
         )
         if message_type == "text":
@@ -303,16 +312,62 @@ class TestMetaCloudApi:
     def test_unsupported_message_type_does_nothing(
         self, _handle_unsupported_message, _handle_supported_message, db, meta_cloud_api_whatsapp_channel
     ):
-        incoming_message = meta_cloud_api_messages.text_message_value()
+        incoming_message = meta_cloud_api_messages.legacy_text_message_value()
         incoming_message["messages"][0]["type"] = "video"
         incoming_message["messages"][0]["video"] = {}
         handle_meta_cloud_api_message(
             channel_id=meta_cloud_api_whatsapp_channel.id,
-            team_slug=meta_cloud_api_whatsapp_channel.team.slug,
+            team_slug=meta_cloud_api_whatsapp_channel.experiment.team.slug,
             message_data=incoming_message,
         )
         _handle_unsupported_message.assert_called()
         _handle_supported_message.assert_not_called()
+
+    @pytest.mark.django_db()
+    @pytest.mark.parametrize(
+        ("message", "message_type"),
+        [
+            (meta_cloud_api_messages.text_message_with_user_id_and_wa_id_value(), "text"),
+            (meta_cloud_api_messages.text_message_with_username_and_wa_id_value(), "text"),
+            (meta_cloud_api_messages.text_message_user_id_only_value(), "text"),
+        ],
+    )
+    def test_parse_bsuid_payload_shapes(self, message, message_type):
+        parsed = MetaCloudAPIMessage.parse(message)
+        if "wa_id" in message["contacts"][0]:
+            assert parsed.participant_id == "27456897512"
+        else:
+            assert parsed.participant_id == "US.13491208655302741918"
+
+    @pytest.mark.django_db()
+    @override_settings(WHATSAPP_S3_AUDIO_BUCKET="123")
+    @patch("apps.service_providers.messaging_service.MetaCloudAPIService.send_typing_indicator")
+    @patch("apps.service_providers.messaging_service.MetaCloudAPIService.send_text_message")
+    @patch("apps.chat.bots.PipelineBot.process_input")
+    def test_bsuid_only_payload_creates_participant_keyed_by_bsuid(
+        self,
+        bot_process_input,
+        send_text_message,
+        send_typing_indicator,
+        meta_cloud_api_whatsapp_channel,
+    ):
+        """When wa_id is missing (username-adopter, not in contact book), the BSUID becomes the
+        participant identifier and a new Participant is created."""
+        from apps.experiments.models import Participant  # noqa: PLC0415
+
+        chat = Chat.objects.create(team=meta_cloud_api_whatsapp_channel.experiment.team)
+        bot_process_input.return_value = ChatMessage.objects.create(content="Hi", chat=chat)
+
+        handle_meta_cloud_api_message(
+            channel_id=meta_cloud_api_whatsapp_channel.id,
+            team_slug=meta_cloud_api_whatsapp_channel.experiment.team.slug,
+            message_data=meta_cloud_api_messages.text_message_user_id_only_value(),
+        )
+
+        participant = Participant.objects.get(
+            team=meta_cloud_api_whatsapp_channel.experiment.team, platform=ChannelPlatform.WHATSAPP
+        )
+        assert participant.identifier == "US.13491208655302741918"
 
     @pytest.mark.django_db()
     @patch("apps.service_providers.messaging_service.MetaCloudAPIService.send_typing_indicator")
@@ -330,10 +385,10 @@ class TestMetaCloudApi:
         chat = Chat.objects.create(team=experiment.team)
         bot_process_input.return_value = ChatMessage.objects.create(content="Hi", chat=chat)
 
-        incoming_message = meta_cloud_api_messages.text_message_value()
+        incoming_message = meta_cloud_api_messages.legacy_text_message_value()
         handle_meta_cloud_api_message(
             channel_id=meta_cloud_api_whatsapp_channel.id,
-            team_slug=meta_cloud_api_whatsapp_channel.team.slug,
+            team_slug=meta_cloud_api_whatsapp_channel.experiment.team.slug,
             message_data=incoming_message,
         )
 

--- a/apps/channels/tests/test_whatsapp_integration.py
+++ b/apps/channels/tests/test_whatsapp_integration.py
@@ -248,14 +248,14 @@ class TestTurnio:
 
 class TestMetaCloudApi:
     @pytest.mark.parametrize(
-        ("message", "message_type"),
+        ("value", "message_type"),
         [
             (meta_cloud_api_messages.legacy_text_message_value(), "text"),
             (meta_cloud_api_messages.audio_message_value(), "audio"),
         ],
     )
-    def test_parse_messages(self, message, message_type):
-        parsed = MetaCloudAPIMessage.parse(message)
+    def test_parse_messages(self, value, message_type):
+        parsed = MetaCloudAPIMessage.parse(value["messages"][0])
         assert parsed.participant_id == "27456897512"
         if message_type == "text":
             assert parsed.message_text == "Hello"
@@ -268,7 +268,7 @@ class TestMetaCloudApi:
 
     @pytest.mark.django_db()
     @pytest.mark.parametrize(
-        ("incoming_message", "message_type"),
+        ("incoming_value", "message_type"),
         [
             (meta_cloud_api_messages.legacy_text_message_value(), "text"),
             (meta_cloud_api_messages.audio_message_value(), "audio"),
@@ -287,7 +287,7 @@ class TestMetaCloudApi:
         send_voice_message,
         get_voice_transcript_mock,
         synthesize_voice_mock,
-        incoming_message,
+        incoming_value,
         message_type,
         meta_cloud_api_whatsapp_channel,
     ):
@@ -300,7 +300,7 @@ class TestMetaCloudApi:
         handle_meta_cloud_api_message(
             channel_id=meta_cloud_api_whatsapp_channel.id,
             team_slug=meta_cloud_api_whatsapp_channel.experiment.team.slug,
-            message_data=incoming_message,
+            message_data=incoming_value["messages"][0],
         )
         if message_type == "text":
             send_text_message.assert_called()
@@ -312,29 +312,31 @@ class TestMetaCloudApi:
     def test_unsupported_message_type_does_nothing(
         self, _handle_unsupported_message, _handle_supported_message, db, meta_cloud_api_whatsapp_channel
     ):
-        incoming_message = meta_cloud_api_messages.legacy_text_message_value()
-        incoming_message["messages"][0]["type"] = "video"
-        incoming_message["messages"][0]["video"] = {}
+        incoming_value = meta_cloud_api_messages.legacy_text_message_value()
+        message = incoming_value["messages"][0]
+        message["type"] = "video"
+        message["video"] = {}
         handle_meta_cloud_api_message(
             channel_id=meta_cloud_api_whatsapp_channel.id,
             team_slug=meta_cloud_api_whatsapp_channel.experiment.team.slug,
-            message_data=incoming_message,
+            message_data=message,
         )
         _handle_unsupported_message.assert_called()
         _handle_supported_message.assert_not_called()
 
     @pytest.mark.django_db()
     @pytest.mark.parametrize(
-        ("message", "message_type"),
+        ("value", "message_type"),
         [
             (meta_cloud_api_messages.text_message_with_user_id_and_wa_id_value(), "text"),
             (meta_cloud_api_messages.text_message_with_username_and_wa_id_value(), "text"),
             (meta_cloud_api_messages.text_message_user_id_only_value(), "text"),
         ],
     )
-    def test_parse_bsuid_payload_shapes(self, message, message_type):
+    def test_parse_bsuid_payload_shapes(self, value, message_type):
+        message = value["messages"][0]
         parsed = MetaCloudAPIMessage.parse(message)
-        if "wa_id" in message["contacts"][0]:
+        if "from" in message:
             assert parsed.participant_id == "27456897512"
         else:
             assert parsed.participant_id == "US.13491208655302741918"
@@ -361,7 +363,7 @@ class TestMetaCloudApi:
         handle_meta_cloud_api_message(
             channel_id=meta_cloud_api_whatsapp_channel.id,
             team_slug=meta_cloud_api_whatsapp_channel.experiment.team.slug,
-            message_data=meta_cloud_api_messages.text_message_user_id_only_value(),
+            message_data=meta_cloud_api_messages.text_message_user_id_only_value()["messages"][0],
         )
 
         participant = Participant.objects.get(
@@ -385,7 +387,7 @@ class TestMetaCloudApi:
         chat = Chat.objects.create(team=experiment.team)
         bot_process_input.return_value = ChatMessage.objects.create(content="Hi", chat=chat)
 
-        incoming_message = meta_cloud_api_messages.legacy_text_message_value()
+        incoming_message = meta_cloud_api_messages.legacy_text_message_value()["messages"][0]
         handle_meta_cloud_api_message(
             channel_id=meta_cloud_api_whatsapp_channel.id,
             team_slug=meta_cloud_api_whatsapp_channel.experiment.team.slug,

--- a/apps/channels/tests/test_whatsapp_integration.py
+++ b/apps/channels/tests/test_whatsapp_integration.py
@@ -5,7 +5,7 @@ import pytest
 from django.test import override_settings
 from django.urls import reverse
 
-from apps.channels.datamodels import MetaCloudAPIMessage, TurnWhatsappMessage, TwilioMessage
+from apps.channels.datamodels import TurnWhatsappMessage
 from apps.channels.models import ChannelPlatform
 from apps.channels.tasks import handle_meta_cloud_api_message, handle_turn_message, handle_twilio_message
 from apps.chat.channels import MESSAGE_TYPES, WhatsappChannel
@@ -15,7 +15,7 @@ from apps.files.models import File
 from apps.service_providers.models import MessagingProviderType
 from apps.service_providers.speech_service import SynthesizedAudio
 from apps.utils.factories.channels import ExperimentChannelFactory
-from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
+from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory, ParticipantFactory
 from apps.utils.factories.files import FileFactory
 from apps.utils.factories.service_provider_factories import MessagingProviderFactory
 
@@ -53,30 +53,6 @@ def _twilio_whatsapp_channel(twilio_provider):
 
 
 class TestTwilio:
-    @pytest.mark.parametrize(
-        ("message", "message_type"),
-        [(twilio_messages.Whatsapp.text_message(), "text"), (twilio_messages.Whatsapp.audio_message(), "voice")],
-    )
-    def test_parse_messages(self, message, message_type):
-        whatsapp_message = TwilioMessage.parse(message)
-        assert whatsapp_message.platform == ChannelPlatform.WHATSAPP
-        assert whatsapp_message.participant_id == "+27456897512"
-        if message_type == "text":
-            assert whatsapp_message.content_type == MESSAGE_TYPES.TEXT
-            assert whatsapp_message.media_url is None
-        else:
-            assert whatsapp_message.content_type == MESSAGE_TYPES.VOICE
-
-    def test_parse_message_with_external_user_id_keeps_phone_as_participant_id(self):
-        message = twilio_messages.Whatsapp.text_message_with_external_user_id()
-        parsed = TwilioMessage.parse(message)
-        assert parsed.participant_id == "+27456897512"
-
-    def test_parse_message_external_user_id_only_uses_bsuid_as_participant_id(self):
-        message = twilio_messages.Whatsapp.text_message_external_user_id_only()
-        parsed = TwilioMessage.parse(message)
-        assert parsed.participant_id == "US.13491208655302741918"
-
     @pytest.mark.usefixtures("_twilio_whatsapp_channel")
     @pytest.mark.parametrize(
         ("incoming_message", "message_type"),
@@ -248,25 +224,6 @@ class TestTurnio:
 
 
 class TestMetaCloudApi:
-    @pytest.mark.parametrize(
-        ("value", "message_type"),
-        [
-            (meta_cloud_api_messages.legacy_text_message_value(), "text"),
-            (meta_cloud_api_messages.audio_message_value(), "audio"),
-        ],
-    )
-    def test_parse_messages(self, value, message_type):
-        parsed = MetaCloudAPIMessage.parse(value["messages"][0])
-        assert parsed.participant_id == "27456897512"
-        if message_type == "text":
-            assert parsed.message_text == "Hello"
-            assert parsed.content_type == MESSAGE_TYPES.TEXT
-            assert parsed.whatsapp_message_id == "wamid.abc123"
-        else:
-            assert parsed.media_id == "1215194677037265"
-            assert parsed.content_type == MESSAGE_TYPES.VOICE
-            assert parsed.whatsapp_message_id == "wamid.abc456"
-
     @pytest.mark.django_db()
     @pytest.mark.parametrize(
         ("incoming_value", "message_type"),
@@ -326,51 +283,6 @@ class TestMetaCloudApi:
         _handle_supported_message.assert_not_called()
 
     @pytest.mark.django_db()
-    @pytest.mark.parametrize(
-        ("value", "message_type"),
-        [
-            (meta_cloud_api_messages.text_message_with_user_id_and_wa_id_value(), "text"),
-            (meta_cloud_api_messages.text_message_with_username_and_wa_id_value(), "text"),
-            (meta_cloud_api_messages.text_message_user_id_only_value(), "text"),
-        ],
-    )
-    def test_parse_bsuid_payload_shapes(self, value, message_type):
-        message = value["messages"][0]
-        parsed = MetaCloudAPIMessage.parse(message)
-        if "from" in message:
-            assert parsed.participant_id == "27456897512"
-        else:
-            assert parsed.participant_id == "US.13491208655302741918"
-
-    @pytest.mark.django_db()
-    @override_settings(WHATSAPP_S3_AUDIO_BUCKET="123")
-    @patch("apps.service_providers.messaging_service.MetaCloudAPIService.send_typing_indicator")
-    @patch("apps.service_providers.messaging_service.MetaCloudAPIService.send_text_message")
-    @patch("apps.chat.bots.PipelineBot.process_input")
-    def test_bsuid_only_payload_creates_participant_keyed_by_bsuid(
-        self,
-        bot_process_input,
-        send_text_message,
-        send_typing_indicator,
-        meta_cloud_api_whatsapp_channel,
-    ):
-        """When wa_id is missing (username-adopter, not in contact book), the BSUID becomes the
-        participant identifier and a new Participant is created."""
-        chat = Chat.objects.create(team=meta_cloud_api_whatsapp_channel.experiment.team)
-        bot_process_input.return_value = ChatMessage.objects.create(content="Hi", chat=chat)
-
-        handle_meta_cloud_api_message(
-            channel_id=meta_cloud_api_whatsapp_channel.id,
-            team_slug=meta_cloud_api_whatsapp_channel.experiment.team.slug,
-            message_data=meta_cloud_api_messages.text_message_user_id_only_value()["messages"][0],
-        )
-
-        participant = Participant.objects.get(
-            team=meta_cloud_api_whatsapp_channel.experiment.team, platform=ChannelPlatform.WHATSAPP
-        )
-        assert participant.identifier == "US.13491208655302741918"
-
-    @pytest.mark.django_db()
     @patch("apps.service_providers.messaging_service.MetaCloudAPIService.send_typing_indicator")
     @patch("apps.service_providers.messaging_service.MetaCloudAPIService.send_text_message")
     @patch("apps.chat.bots.PipelineBot.process_input")
@@ -397,3 +309,160 @@ class TestMetaCloudApi:
             from_="12345",
             message_id="wamid.abc123",
         )
+
+
+BSUID = "US.13491208655302741918"
+PHONE = "27456897512"
+
+
+def _meta_message(*, bsuid: str, phone: str | None, msg_id: str = "wamid.abc", timestamp: str = "1") -> dict:
+    """Build a minimal inbound Meta Cloud API text-message payload.
+
+    ``phone=None`` means the user has adopted a username and Meta has hidden their phone
+    number — the webhook carries the BSUID only. ``phone="..."`` means the phone is still
+    visible (the user has not adopted a username, or is in the business's contact book).
+    """
+    message: dict = {
+        "from_user_id": bsuid,
+        "id": msg_id,
+        "timestamp": timestamp,
+        "text": {"body": "Hi"},
+        "type": "text",
+    }
+    if phone is not None:
+        message["from"] = phone
+    return message
+
+
+@pytest.mark.django_db()
+class TestWhatsappParticipantResolution:
+    """End-to-end participant-resolution scenarios for the WhatsApp BSUID rollout.
+
+    Five lifecycle scenarios are exercised through the Meta Cloud API webhook entry point.
+    The Twilio code path resolves through the same ``WhatsappChannel`` logic — its own
+    parser is covered by ``TestTwilioMessageParse`` in ``test_datamodels.py``.
+
+    Each scenario inlines the message it delivers; the presence or absence of ``from``
+    (the phone number) is visible at a glance via the ``phone=`` argument to
+    ``_meta_message``.
+    """
+
+    @patch("apps.service_providers.messaging_service.MetaCloudAPIService.send_typing_indicator")
+    @patch("apps.service_providers.messaging_service.MetaCloudAPIService.send_text_message")
+    @patch("apps.chat.bots.PipelineBot.process_input")
+    def _deliver(self, bot_process_input, send_text_message, send_typing_indicator, channel, message):
+        chat = Chat.objects.create(team=channel.experiment.team)
+        bot_process_input.return_value = ChatMessage.objects.create(content="ok", chat=chat)
+        handle_meta_cloud_api_message(
+            channel_id=channel.id,
+            team_slug=channel.experiment.team.slug,
+            message_data=message,
+        )
+
+    def _whatsapp_participants(self, team):
+        return Participant.objects.filter(team=team, platform=ChannelPlatform.WHATSAPP)
+
+    def test_scenario_1_new_username_adopter_creates_bsuid_keyed_participant(self, meta_cloud_api_whatsapp_channel):
+        """A brand-new user who has already adopted a WhatsApp username sends their first
+        message. The webhook carries ONLY the BSUID — no phone number.
+
+        Expected: a new Participant is created, keyed by the BSUID.
+        """
+        message = _meta_message(bsuid=BSUID, phone=None)
+
+        self._deliver(channel=meta_cloud_api_whatsapp_channel, message=message)
+
+        participants = self._whatsapp_participants(meta_cloud_api_whatsapp_channel.experiment.team)
+        assert participants.count() == 1
+        assert participants.get().identifier == BSUID
+
+    def test_scenario_2_username_adopter_later_reveals_phone_keeps_same_participant(
+        self, meta_cloud_api_whatsapp_channel
+    ):
+        """A username-adopter sends their first message (BSUID only). Later they share their
+        phone — via the contact-info button, or because Meta's contact-book / 30-day cache
+        starts including it — and subsequent webhooks now carry both BSUID and phone.
+
+        Expected: the second webhook resolves to the SAME participant created at T1. No
+        duplicate is created.
+        """
+        team = meta_cloud_api_whatsapp_channel.experiment.team
+
+        # T1: phone hidden — webhook has BSUID only.
+        self._deliver(
+            channel=meta_cloud_api_whatsapp_channel,
+            message=_meta_message(bsuid=BSUID, phone=None, msg_id="wamid.t1"),
+        )
+
+        # T2: phone now visible — webhook has BSUID + phone.
+        self._deliver(
+            channel=meta_cloud_api_whatsapp_channel,
+            message=_meta_message(bsuid=BSUID, phone=PHONE, msg_id="wamid.t2"),
+        )
+
+        participants = self._whatsapp_participants(team)
+        assert participants.count() == 1
+        assert participants.get().identifier == BSUID
+
+    def test_scenario_3_new_user_without_username_creates_bsuid_keyed_participant(
+        self, meta_cloud_api_whatsapp_channel
+    ):
+        """A brand-new user who has NOT adopted a username sends their first message. The
+        webhook carries both BSUID and phone.
+
+        Expected: a new Participant is created, keyed by the BSUID — not the phone. From
+        this point on, the participant is BSUID-keyed regardless of phone visibility.
+        """
+        message = _meta_message(bsuid=BSUID, phone=PHONE)
+
+        self._deliver(channel=meta_cloud_api_whatsapp_channel, message=message)
+
+        participants = self._whatsapp_participants(meta_cloud_api_whatsapp_channel.experiment.team)
+        assert participants.count() == 1
+        assert participants.get().identifier == BSUID
+
+    def test_scenario_4_pre_rollout_phone_keyed_participant_is_matched_via_phone(self, meta_cloud_api_whatsapp_channel):
+        """A participant from before the BSUID rollout already exists in the DB, keyed by
+        their phone number. After rollout, Meta starts including the BSUID in webhooks.
+
+        Expected: the post-rollout webhook (BSUID + phone) resolves to the existing
+        phone-keyed participant via the phone clause. No duplicate is created. The
+        identifier on the existing participant is NOT rewritten to the BSUID.
+        """
+        team = meta_cloud_api_whatsapp_channel.experiment.team
+        legacy = ParticipantFactory.create(team=team, identifier=PHONE, platform=ChannelPlatform.WHATSAPP)
+
+        self._deliver(
+            channel=meta_cloud_api_whatsapp_channel,
+            message=_meta_message(bsuid=BSUID, phone=PHONE),
+        )
+
+        participants = self._whatsapp_participants(team)
+        assert participants.count() == 1
+        assert participants.get().pk == legacy.pk
+        legacy.refresh_from_db()
+        assert legacy.identifier == PHONE
+
+    def test_scenario_5_pre_rollout_phone_keyed_participant_adopts_username_loses_continuity(
+        self, meta_cloud_api_whatsapp_channel
+    ):
+        """A pre-rollout participant (keyed by phone) adopts a username AFTER the rollout.
+        Their webhook now carries only the BSUID — no phone — and Meta's contact book and
+        30-day cache do not contain their phone number.
+
+        Expected: we have nothing to match against; a new BSUID-keyed participant is
+        created and the legacy phone-keyed participant is untouched. This is the one
+        accepted continuity loss in the rollout design.
+        """
+        team = meta_cloud_api_whatsapp_channel.experiment.team
+        legacy = ParticipantFactory.create(team=team, identifier=PHONE, platform=ChannelPlatform.WHATSAPP)
+
+        self._deliver(
+            channel=meta_cloud_api_whatsapp_channel,
+            message=_meta_message(bsuid=BSUID, phone=None),
+        )
+
+        participants = self._whatsapp_participants(team)
+        assert set(participants.values_list("identifier", flat=True)) == {PHONE, BSUID}
+        legacy.refresh_from_db()
+        assert legacy.identifier == PHONE

--- a/apps/channels/views.py
+++ b/apps/channels/views.py
@@ -451,8 +451,8 @@ class MetaCloudAPIWebhookView(View):
             return HttpResponse()
 
         try:
-            message_values = meta_webhook.extract_message_values(data)
-            if not message_values:
+            messages = meta_webhook.extract_messages(data)
+            if not messages:
                 log.debug("Meta Cloud API webhook received payload with no messages")
                 return HttpResponse()
 
@@ -460,9 +460,9 @@ class MetaCloudAPIWebhookView(View):
             log.debug("Meta Cloud API webhook payload missing expected fields")
             return HttpResponse()
 
-        # A payload may contain values for different phone numbers (e.g. a Business Account with multiple numbers),
-        # so each value must be routed to its own channel.
-        unique_phone_ids = {v["metadata"]["phone_number_id"] for v in message_values}
+        # A payload may contain messages for different phone numbers (e.g. a Business Account with
+        # multiple numbers), so each message must be routed to its own channel.
+        unique_phone_ids = {phone_id for phone_id, _ in messages}
         channel_map = {
             ch.extra_data["phone_number_id"]: ch
             for ch in ExperimentChannel.objects.filter(
@@ -482,8 +482,7 @@ class MetaCloudAPIWebhookView(View):
             log.warning("Meta Cloud API webhook signature verification failed for channel")
             return HttpResponse()
 
-        for value in message_values:
-            phone_number_id = value["metadata"]["phone_number_id"]
+        for phone_number_id, message in messages:
             ch = channel_map.get(phone_number_id)
             if not ch:
                 continue
@@ -491,7 +490,7 @@ class MetaCloudAPIWebhookView(View):
             tasks.handle_meta_cloud_api_message.delay(
                 channel_id=ch.id,
                 team_slug=ch.team.slug,
-                message_data=value,
+                message_data=message,
             )
 
         return HttpResponse()

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, ClassVar, cast
 import emoji
 import httpx
 from django.db import transaction
+from django.db.models import Q
 from django.http import Http404
 from telebot import TeleBot
 from telebot.apihelper import ApiTelegramException
@@ -171,6 +172,7 @@ class ChannelBase(ABC):
         timezone: str | None = None,
         session_external_id: str | None = None,
         metadata: dict | None = None,
+        participant_filter: Q | None = None,
     ):
         return _start_experiment_session(
             working_experiment,
@@ -181,6 +183,7 @@ class ChannelBase(ABC):
             timezone,
             session_external_id,
             metadata,
+            participant_filter=participant_filter,
         )
 
     @property
@@ -249,6 +252,16 @@ class ChannelBase(ABC):
         if self.experiment.is_a_version:
             experiment = self.experiment.working_version
         return experiment.participantdata_set.defer("data").get(participant__identifier=self.participant_identifier)
+
+    def get_participant_identifier_filter(self) -> Q:
+        """Filter clause used to find the existing ``Participant`` for this channel's message.
+
+        Override on subclasses that match a participant by more than just their identifier
+        (e.g. ``WhatsappChannel`` matches on BSUID OR phone to keep continuity across the
+        WhatsApp usernames rollout).
+        """
+        identifier = self.experiment_channel.platform_enum.normalize_identifier(self.participant_identifier)
+        return Q(identifier=identifier)
 
     @notify_on_delivery_failure(context="voice message")
     def _send_voice_to_user_with_notification(self, synthetic_voice: SynthesizedAudio):
@@ -870,13 +883,24 @@ class ChannelBase(ABC):
             self._ensure_sessions_exists()
 
     def _load_latest_session(self):
-        """Loads the latest experiment session on the channel"""
+        """Loads the latest experiment session on the channel.
+
+        Subclasses can match a participant by something other than just the identifier
+        (``WhatsappChannel`` matches by BSUID OR phone) via the
+        ``get_participant_identifier_filter`` hook.
+        """
+        participants = Participant.objects.filter(
+            self.get_participant_identifier_filter(),
+            team=self.experiment.team,
+            platform=self.experiment_channel.platform,
+        )
         self.experiment_session = (
             ExperimentSession.objects.filter(
                 experiment=self.experiment.get_working_version(),
-                participant__identifier=str(self.participant_identifier),
+                participant__in=participants,
             )
             .exclude(status__in=STATUSES_FOR_COMPLETE_CHATS)
+            .select_related("participant")
             .order_by("-created_at")
             .first()
         )
@@ -897,6 +921,7 @@ class ChannelBase(ABC):
             participant_identifier=self.participant_identifier,
             participant_user=self.participant_user,
             session_status=SessionStatus.SETUP,
+            participant_filter=self.get_participant_identifier_filter(),
         )
 
     def _is_reset_conversation_request(self):
@@ -1168,6 +1193,17 @@ class TelegramChannel(ChannelBase):
 
 
 class WhatsappChannel(ChannelBase):
+    def get_participant_identifier_filter(self) -> Q:
+        """Match an existing participant on either the BSUID (``message.participant_id``) or
+        the user's phone number (``message.phone_number``). Post-rollout, new WhatsApp
+        webhooks always carry a BSUID; some also carry a phone number, allowing continuity
+        with legacy phone-keyed participants from before the rollout.
+        """
+        phone = getattr(self.message, "phone_number", None) if self.message else None
+        if phone:
+            return Q(identifier=self.participant_identifier) | Q(identifier=phone)
+        return super().get_participant_identifier_filter()
+
     @property
     def voice_replies_supported(self) -> bool:
         # TODO: Update turn-python library to support this
@@ -1315,7 +1351,7 @@ class ApiChannel(ChannelBase):
             raise ChannelException("ApiChannel requires either an existing session or a user")
 
     @classmethod
-    def start_new_session(
+    def start_new_session(  # ty: ignore[invalid-method-override]
         cls,
         working_experiment: Experiment,
         experiment_channel: ExperimentChannel,
@@ -1453,6 +1489,7 @@ def _start_experiment_session(
     timezone: str | None = None,
     session_external_id: str | None = None,
     metadata: dict | None = None,
+    participant_filter: Q | None = None,
 ) -> ExperimentSession:
     if working_experiment.is_a_version:
         raise VersionedExperimentSessionsNotAllowedException(
@@ -1467,20 +1504,44 @@ def _start_experiment_session(
         # This should technically never happen, since we disable the input for logged in users
         raise Exception(f"User {participant_user.email} cannot impersonate participant {participant_identifier}")
 
+    normalized_identifier = experiment_channel.platform_enum.normalize_identifier(participant_identifier)
+    if participant_filter is None:
+        participant_filter = Q(identifier=normalized_identifier)
+
     with transaction.atomic():
-        participant, created = Participant.objects.get_or_create(
-            team=team,
-            identifier=experiment_channel.platform_enum.normalize_identifier(participant_identifier),
-            platform=experiment_channel.platform,
-            defaults={"user": participant_user},
-        )
-        if not created and participant_user and participant.user is None:
-            participant.user = participant_user
-            participant.save()
+        # When ``participant_filter`` is a simple equality (the common case), we can hand
+        # the whole lookup-or-create to ``get_or_create``. When it's a disjunction (e.g.
+        # ``WhatsappChannel`` matching BSUID OR legacy phone), we can't: ``get_or_create``
+        # requires the lookup kwargs and the create kwargs to be the same field set, but
+        # here we want to *look up* by either identifier and *create* with only the
+        # canonical (normalized) one. So in the disjunctive case we probe with
+        # ``.exists()`` first, fetching the existing participant only if one is there.
+        is_simple_filter = len(participant_filter.children) == 1
+        existing_participant = None
+        if not is_simple_filter:
+            matches = Participant.objects.filter(participant_filter, team=team, platform=experiment_channel.platform)
+            if matches.exists():
+                existing_participant = matches.order_by("created_at").first()
+
+        if existing_participant is None:
+            participant, created = Participant.objects.get_or_create(
+                team=team,
+                identifier=normalized_identifier,
+                platform=experiment_channel.platform,
+                defaults={"user": participant_user},
+            )
+            if not created and participant_user and participant.user is None:
+                participant.user = participant_user
+                participant.save()
+        else:
+            participant = existing_participant
+            if participant_user and participant.user is None:
+                participant.user = participant_user
+                participant.save()
 
         chat = Chat.objects.create(
             team=team,
-            name=f"{participant_identifier} - {experiment_channel.name}",
+            name=f"{participant.identifier} - {experiment_channel.name}",
             metadata=metadata or {},
         )
 

--- a/apps/service_providers/messaging_service.py
+++ b/apps/service_providers/messaging_service.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from twilio.rest.api.v2010.account.message import MessageInstance
 
 from apps.channels import audio
-from apps.channels.datamodels import MediaCache, TurnWhatsappMessage, TwilioMessage
+from apps.channels.datamodels import MediaCache, TurnWhatsappMessage, TwilioMessage, looks_like_bsuid
 from apps.channels.models import ChannelPlatform
 from apps.chat.channels import MESSAGE_TYPES
 from apps.chat.exceptions import ServiceWindowExpiredException
@@ -33,24 +33,12 @@ from apps.service_providers.speech_service import SynthesizedAudio
 logger = logging.getLogger("ocs.messaging")
 
 
-def _is_bsuid_recipient(recipient: str) -> bool:
-    """Return True if `recipient` looks like a Meta business-scoped user ID.
-
-    BSUIDs use the format `<ISO country code>.<digits>` (e.g. US.13491208655302741918) and
-    parent BSUIDs use `<country>.ENT.<digits>`. Phone numbers (E.164 or wa_id digit string)
-    never contain a period.
-
-    See https://developers.facebook.com/documentation/business-messaging/whatsapp/business-scoped-user-ids
-    """
-    return "." in recipient
-
-
 def _recipient_kwarg(recipient: str) -> dict:
     """Build the recipient half of a Meta Cloud API send payload.
 
     Routes BSUIDs to the new `recipient` field and phone numbers to the existing `to` field.
     """
-    if _is_bsuid_recipient(recipient):
+    if looks_like_bsuid(recipient):
         return {"recipient": recipient}
     return {"to": recipient}
 
@@ -524,6 +512,7 @@ class MetaCloudAPIService(MessagingService):
         for chunk in chunks:
             data = {
                 "messaging_product": "whatsapp",
+                "recipient_type": "individual",
                 **_recipient_kwarg(to),
                 "type": "text",
                 "text": {"body": chunk},
@@ -550,6 +539,7 @@ class MetaCloudAPIService(MessagingService):
         url = f"{self.META_API_BASE_URL}/{from_}/messages"
         data = {
             "messaging_product": "whatsapp",
+            "recipient_type": "individual",
             **_recipient_kwarg(to),
             "type": "audio",
             "audio": {"id": media_id},
@@ -619,6 +609,7 @@ class MetaCloudAPIService(MessagingService):
         url = f"{self.META_API_BASE_URL}/{from_}/messages"
         data = {
             "messaging_product": "whatsapp",
+            "recipient_type": "individual",
             **_recipient_kwarg(to),
             "type": media_type,
             media_type: {"id": media_id},

--- a/apps/service_providers/messaging_service.py
+++ b/apps/service_providers/messaging_service.py
@@ -33,6 +33,28 @@ from apps.service_providers.speech_service import SynthesizedAudio
 logger = logging.getLogger("ocs.messaging")
 
 
+def _is_bsuid_recipient(recipient: str) -> bool:
+    """Return True if `recipient` looks like a Meta business-scoped user ID.
+
+    BSUIDs use the format `<ISO country code>.<digits>` (e.g. US.13491208655302741918) and
+    parent BSUIDs use `<country>.ENT.<digits>`. Phone numbers (E.164 or wa_id digit string)
+    never contain a period.
+
+    See https://developers.facebook.com/documentation/business-messaging/whatsapp/business-scoped-user-ids
+    """
+    return "." in recipient
+
+
+def _recipient_kwarg(recipient: str) -> dict:
+    """Build the recipient half of a Meta Cloud API send payload.
+
+    Routes BSUIDs to the new `recipient` field and phone numbers to the existing `to` field.
+    """
+    if _is_bsuid_recipient(recipient):
+        return {"recipient": recipient}
+    return {"to": recipient}
+
+
 class MessagingService(pydantic.BaseModel):
     _type: ClassVar[str]
     _supported_platforms: ClassVar[list]
@@ -458,7 +480,7 @@ class MetaCloudAPIService(MessagingService):
             data = {
                 "messaging_product": "whatsapp",
                 "recipient_type": "individual",
-                "to": to,
+                **_recipient_kwarg(to),
                 "type": "template",
                 "template": {
                     "name": self.TEMPLATE_NAME,
@@ -502,7 +524,7 @@ class MetaCloudAPIService(MessagingService):
         for chunk in chunks:
             data = {
                 "messaging_product": "whatsapp",
-                "to": to,
+                **_recipient_kwarg(to),
                 "type": "text",
                 "text": {"body": chunk},
             }
@@ -528,7 +550,7 @@ class MetaCloudAPIService(MessagingService):
         url = f"{self.META_API_BASE_URL}/{from_}/messages"
         data = {
             "messaging_product": "whatsapp",
-            "to": to,
+            **_recipient_kwarg(to),
             "type": "audio",
             "audio": {"id": media_id},
         }
@@ -597,7 +619,7 @@ class MetaCloudAPIService(MessagingService):
         url = f"{self.META_API_BASE_URL}/{from_}/messages"
         data = {
             "messaging_product": "whatsapp",
-            "to": to,
+            **_recipient_kwarg(to),
             "type": media_type,
             media_type: {"id": media_id},
         }

--- a/apps/service_providers/tests/test_messaging_providers.py
+++ b/apps/service_providers/tests/test_messaging_providers.py
@@ -746,6 +746,139 @@ class TestMetaCloudAPIServiceWindow:
             )
 
 
+class TestMetaCloudAPIServiceBSUIDRecipient:
+    """Outbound send paths must use Meta's `recipient` field when targeting a BSUID,
+    and the `to` field when targeting a phone number.
+
+    See https://developers.facebook.com/documentation/business-messaging/whatsapp/business-scoped-user-ids
+    """
+
+    def _make_service(self):
+        return MetaCloudAPIService(access_token="test_token", business_id="123456")
+
+    @patch("apps.service_providers.messaging_service.httpx.post")
+    def test_send_text_message_to_bsuid_uses_recipient_field(self, mock_post):
+        mock_post.return_value = httpx.Response(
+            200,
+            json={"messages": [{"id": "wamid.test"}]},
+            request=httpx.Request("POST", "https://graph.facebook.com/v25.0/phone123/messages"),
+        )
+        self._make_service().send_text_message(
+            message="Hello",
+            from_="phone123",
+            to="US.13491208655302741918",
+            platform=ChannelPlatform.WHATSAPP,
+            last_activity_at=timezone.now() - timedelta(hours=1),
+        )
+        sent = mock_post.call_args.kwargs["json"]
+        assert sent == {
+            "messaging_product": "whatsapp",
+            "recipient": "US.13491208655302741918",
+            "type": "text",
+            "text": {"body": "Hello"},
+        }
+        assert "to" not in sent
+
+    @patch("apps.service_providers.messaging_service.httpx.post")
+    def test_send_text_message_to_phone_keeps_to_field(self, mock_post):
+        mock_post.return_value = httpx.Response(
+            200,
+            json={"messages": [{"id": "wamid.test"}]},
+            request=httpx.Request("POST", "https://graph.facebook.com/v25.0/phone123/messages"),
+        )
+        self._make_service().send_text_message(
+            message="Hello",
+            from_="phone123",
+            to="+27826419977",
+            platform=ChannelPlatform.WHATSAPP,
+            last_activity_at=timezone.now() - timedelta(hours=1),
+        )
+        sent = mock_post.call_args.kwargs["json"]
+        assert sent["to"] == "+27826419977"
+        assert "recipient" not in sent
+
+    @patch("apps.service_providers.messaging_service.httpx.post")
+    def test_send_template_message_to_bsuid_uses_recipient_field(self, mock_post):
+        mock_post.return_value = httpx.Response(
+            200,
+            json={"messages": [{"id": "wamid.test"}]},
+            request=httpx.Request("POST", "https://graph.facebook.com/v25.0/phone123/messages"),
+        )
+        self._make_service().send_template_message(
+            message="Hi",
+            from_="phone123",
+            to="US.13491208655302741918",
+            platform=ChannelPlatform.WHATSAPP,
+        )
+        sent = mock_post.call_args.kwargs["json"]
+        assert sent["recipient"] == "US.13491208655302741918"
+        assert "to" not in sent
+
+    @patch("apps.service_providers.messaging_service.httpx.post")
+    def test_send_voice_message_to_bsuid_uses_recipient_field(self, mock_post):
+        upload_response = httpx.Response(
+            200,
+            json={"id": "media_id_abc"},
+            request=httpx.Request("POST", "https://graph.facebook.com/v25.0/phone123/media"),
+        )
+        send_response = httpx.Response(
+            200,
+            json={"messages": [{"id": "wamid.test"}]},
+            request=httpx.Request("POST", "https://graph.facebook.com/v25.0/phone123/messages"),
+        )
+        mock_post.side_effect = [upload_response, send_response]
+        synthetic_voice = MagicMock(spec=SynthesizedAudio)
+        synthetic_voice.get_audio_bytes.return_value = b"fake-ogg"
+        self._make_service().send_voice_message(
+            synthetic_voice=synthetic_voice,
+            from_="phone123",
+            to="US.13491208655302741918",
+            platform=ChannelPlatform.WHATSAPP,
+            last_activity_at=timezone.now() - timedelta(hours=1),
+        )
+        sent = mock_post.call_args_list[1].kwargs["json"]
+        assert sent["recipient"] == "US.13491208655302741918"
+        assert "to" not in sent
+
+    @patch("apps.service_providers.messaging_service.httpx.post")
+    def test_send_file_to_user_bsuid_uses_recipient_field(self, mock_post):
+        upload_response = httpx.Response(
+            200,
+            json={"id": "media_id_abc"},
+            request=httpx.Request("POST", "https://graph.facebook.com/v25.0/phone123/media"),
+        )
+        send_response = httpx.Response(
+            200,
+            json={"messages": [{"id": "wamid.test"}]},
+            request=httpx.Request("POST", "https://graph.facebook.com/v25.0/phone123/messages"),
+        )
+        mock_post.side_effect = [upload_response, send_response]
+        file = MagicMock()
+        file.content_type = "image/jpeg"
+        file.name = "x.jpg"
+        file.file.open.return_value.__enter__.return_value = BytesIO(b"data")
+        self._make_service().send_file_to_user(
+            from_="phone123",
+            to="US.13491208655302741918",
+            platform=ChannelPlatform.WHATSAPP,
+            file=file,
+            download_link="https://example.com/x.jpg",
+            last_activity_at=timezone.now() - timedelta(hours=1),
+        )
+        sent = mock_post.call_args_list[1].kwargs["json"]
+        assert sent["recipient"] == "US.13491208655302741918"
+        assert "to" not in sent
+
+    def test_parent_bsuid_is_detected_as_bsuid(self):
+        """Parent BSUIDs use the ENT prefix between country and identifier (e.g. US.ENT.11815799212886844830)."""
+        from apps.service_providers.messaging_service import _is_bsuid_recipient  # noqa: PLC0415
+
+        assert _is_bsuid_recipient("US.ENT.11815799212886844830") is True
+        assert _is_bsuid_recipient("US.13491208655302741918") is True
+        assert _is_bsuid_recipient("+27826419977") is False
+        assert _is_bsuid_recipient("27826419977") is False
+
+
 def _test_messaging_provider(team, provider_type: MessagingProviderType, data):
     form = provider_type.form_cls(team, data=data)
     assert form.is_valid()

--- a/apps/service_providers/tests/test_messaging_providers.py
+++ b/apps/service_providers/tests/test_messaging_providers.py
@@ -624,6 +624,7 @@ class TestMetaCloudAPIServiceWindow:
         )
         assert mock_post.call_args.kwargs["json"] == {
             "messaging_product": "whatsapp",
+            "recipient_type": "individual",
             "to": "+27826419977",
             "type": "text",
             "text": {"body": "Hello"},
@@ -773,6 +774,7 @@ class TestMetaCloudAPIServiceBSUIDRecipient:
         sent = mock_post.call_args.kwargs["json"]
         assert sent == {
             "messaging_product": "whatsapp",
+            "recipient_type": "individual",
             "recipient": "US.13491208655302741918",
             "type": "text",
             "text": {"body": "Hello"},
@@ -871,12 +873,12 @@ class TestMetaCloudAPIServiceBSUIDRecipient:
 
     def test_parent_bsuid_is_detected_as_bsuid(self):
         """Parent BSUIDs use the ENT prefix between country and identifier (e.g. US.ENT.11815799212886844830)."""
-        from apps.service_providers.messaging_service import _is_bsuid_recipient  # noqa: PLC0415
+        from apps.channels.datamodels import looks_like_bsuid  # noqa: PLC0415
 
-        assert _is_bsuid_recipient("US.ENT.11815799212886844830") is True
-        assert _is_bsuid_recipient("US.13491208655302741918") is True
-        assert _is_bsuid_recipient("+27826419977") is False
-        assert _is_bsuid_recipient("27826419977") is False
+        assert looks_like_bsuid("US.ENT.11815799212886844830") is True
+        assert looks_like_bsuid("US.13491208655302741918") is True
+        assert looks_like_bsuid("+27826419977") is False
+        assert looks_like_bsuid("27826419977") is False
 
 
 def _test_messaging_provider(team, provider_type: MessagingProviderType, data):

--- a/docs/plans/channels_refactor.md
+++ b/docs/plans/channels_refactor.md
@@ -273,8 +273,29 @@ class ParticipantValidationStage(ProcessingStage):
 #### Stage 2: SessionResolutionStage
 
 ```py
+ParticipantIdentifierFilter = Callable[[MessageProcessingContext], Q]
+"""Channel-supplied resolver for the Participant lookup filter.
+
+Invoked at runtime by SessionResolutionStage with the live context, so the
+callable can read ctx.message and ctx.participant_identifier. Returns the Q
+clause used to match an existing Participant. Mirrors DeliveryErrorHandler:
+ChannelBase exposes an optional hook (default: None), and only channels
+with non-trivial matching rules (currently just WhatsappChannel) override.
+"""
+
+
 class SessionResolutionStage(ProcessingStage):
-    """Loads or creates experiment session. Also handles /reset command."""
+    """Loads or creates experiment session. Also handles /reset command.
+
+    Channels can inject a ``participant_identifier_filter`` callable via
+    ChannelBase._get_participant_identifier_filter() to customize how an
+    existing Participant is matched. The callable is invoked at runtime
+    with the live context. Default (callable is None) matches on the
+    normalized identifier alone.
+    """
+
+    def __init__(self, participant_identifier_filter: ParticipantIdentifierFilter | None = None) -> None:
+        self._participant_identifier_filter = participant_identifier_filter
 
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         return ctx.participant_allowed
@@ -284,15 +305,24 @@ class SessionResolutionStage(ProcessingStage):
         if ctx.experiment_session:
             return  # Already have session
 
-        # Try to load existing session (with select_related for performance)
+        filter_q = self._resolve_filter(ctx)
+
+        # Filter Participant first (so the channel-supplied Q can match on
+        # alternative identifiers like a legacy phone number), then look up
+        # sessions belonging to any of those participants.
+        participants = Participant.objects.filter(
+            filter_q,
+            team=ctx.experiment.team,
+            platform=ctx.experiment_channel.platform,
+        )
         ctx.experiment_session = (
             ExperimentSession.objects
-            .select_related("experiment", "participant")
             .filter(
                 experiment=ctx.experiment.get_working_version(),
-                participant__identifier=ctx.participant_identifier,
+                participant__in=participants,
             )
             .exclude(status__in=STATUSES_FOR_COMPLETE_CHATS)
+            .select_related("experiment", "participant")
             .first()
         )
 
@@ -304,6 +334,17 @@ class SessionResolutionStage(ProcessingStage):
         if not ctx.experiment_session:
             ctx.experiment_session = self._create_session(ctx)
 
+    def _resolve_filter(self, ctx: MessageProcessingContext) -> Q:
+        """Resolve the Participant lookup filter for this request.
+
+        Calls the channel-supplied callable if injected; otherwise falls
+        back to matching on the normalized identifier alone.
+        """
+        if self._participant_identifier_filter is not None:
+            return self._participant_identifier_filter(ctx)
+        identifier = ctx.experiment_channel.platform_enum.normalize_identifier(ctx.participant_identifier)
+        return Q(identifier=identifier)
+
     def _is_reset_command(self, ctx: MessageProcessingContext) -> bool:
         return ctx.message.message_text and ctx.message.message_text.strip() == "/reset"
 
@@ -313,14 +354,30 @@ class SessionResolutionStage(ProcessingStage):
             ctx.experiment_session.end(reason="reset by user")
 
         raise EarlyExitResponse("Session reset. Send a new message to start over.")
+
+    def _create_session(self, ctx: MessageProcessingContext):
+        """Delegates to _start_experiment_session.
+
+        The same channel-supplied filter is forwarded so that participant
+        lookup (before creation) honors the disjunctive match. The helper
+        retains its simple-vs-disjunctive Q branching unchanged.
+        """
+        return _start_experiment_session(
+            working_experiment=ctx.experiment.get_working_version(),
+            experiment_channel=ctx.experiment_channel,
+            participant_identifier=ctx.participant_identifier,
+            session_status=SessionStatus.SETUP,
+            participant_filter=self._resolve_filter(ctx),
+        )
 ```
 
-**Maps to**: `_ensure_sessions_exists()` (line 697-726) and `/reset` handling
+**Maps to**: `_ensure_sessions_exists()` (line 697-726), `/reset` handling, and `get_participant_identifier_filter()` (line 256-264 / line 1195-1205 in current code)
 
 > **Review decisions applied**:
 > - **`/reset` inside SessionResolutionStage** (Decision 7): The reset command is fundamentally about session lifecycle, so it belongs here rather than as a separate stage.
 > - **Pre-set session** (Decision 4): Web and Slack channels may pre-set `ctx.experiment_session` at creation time. This stage respects that and skips lookup.
 > - **`select_related`** (Decision 13): Session query uses `select_related("experiment", "participant")` to avoid N+1 queries downstream.
+> - **`participant_identifier_filter` injection (Fix 9)**: Channels override `ChannelBase._get_participant_identifier_filter()` to inject a callable that returns the `Q` clause used for Participant lookup. Invoked at runtime with the live context, so it can read per-message state. Default `None` → stage falls back to matching on normalized identifier alone. Currently only WhatsappChannel overrides (BSUID OR legacy phone). Mirrors the `DeliveryErrorHandler` pattern used by TelegramChannel for send-error side effects.
 
 #### Stage 3: MessageTypeValidationStage
 
@@ -1110,14 +1167,17 @@ class ChannelBase(ABC):
     def _build_pipeline(self) -> MessageProcessingPipeline:
         """Build standard processing pipeline.
 
-        All stages are zero-arg — they get dependencies from the context.
+        Stages are mostly zero-arg — they get dependencies from the context.
+        Two stages take channel-supplied callables at construction:
+          - SessionResolutionStage(participant_identifier_filter=...)
+          - SendingErrorHandlerStage(error_handlers=...)
         Core stages can be short-circuited by EarlyExitResponse.
         Terminal stages always run.
         """
         return MessageProcessingPipeline(
             core_stages=[
                 ParticipantValidationStage(),
-                SessionResolutionStage(),
+                SessionResolutionStage(participant_identifier_filter=self._get_participant_identifier_filter()),
                 SessionActivationStage(),
                 MessageTypeValidationStage(),
                 QueryExtractionStage(),
@@ -1133,6 +1193,20 @@ class ChannelBase(ABC):
                 ActivityTrackingStage(),
             ],
         )
+
+    def _get_participant_identifier_filter(self) -> ParticipantIdentifierFilter | None:
+        """Return a channel-supplied callable for resolving the Participant lookup filter.
+
+        Each callable returns the Q clause for Participant matching. Default: None —
+        SessionResolutionStage falls back to matching on the normalized identifier
+        alone. Override in subclasses to register platform-specific matching (e.g.
+        WhatsappChannel matches BSUID OR legacy phone number for continuity across
+        the BSUID rollout).
+
+        Mirrors `_get_delivery_error_handlers`: optional channel-side hook for
+        injecting a runtime callable into a generic stage.
+        """
+        return None
 
     def new_user_message(self, message: BaseMessage) -> ChatMessage:
         """Main entry point - runs message through pipeline"""
@@ -1310,7 +1384,39 @@ class TelegramChannel(ChannelBase):
         return [handle_telegram_block]
 ```
 
-**Much simpler\!** Channel-specific behavior is isolated to callbacks, sender, capabilities, and delivery-error handlers — not spread throughout the base class. Stages are zero-arg (with the exception of `SendingErrorHandlerStage`, which takes the channel-supplied handler chain), so `_build_pipeline()` rarely needs overriding.
+**Much simpler\!** Channel-specific behavior is isolated to callbacks, sender, capabilities, delivery-error handlers, and (when needed) a Participant filter — not spread throughout the base class. Stages are mostly zero-arg, with two opt-in channel injections at construction (`SendingErrorHandlerStage.error_handlers` and `SessionResolutionStage.participant_identifier_filter`).
+
+### 7b\. WhatsApp Example: Channel-Supplied Participant Filter
+
+WhatsappChannel is the sole channel that needs non-default Participant matching today. Same pattern as `handle_telegram_block`: a plain function colocated with the channel, plugged in via a `ChannelBase` hook.
+
+```py
+# apps/channels/channels_v2/whatsapp_channel.py
+
+def whatsapp_participant_filter(ctx: MessageProcessingContext) -> Q:
+    """Match BSUID OR legacy phone number for WhatsApp BSUID-rollout continuity.
+
+    Post-rollout, new webhooks always carry a BSUID (ctx.participant_identifier);
+    some also carry a legacy phone number (ctx.message.phone_number), allowing
+    continuity with phone-keyed participants from before the BSUID rollout.
+    """
+    identifier = ctx.experiment_channel.platform_enum.normalize_identifier(ctx.participant_identifier)
+    phone = getattr(ctx.message, "phone_number", None) if ctx.message else None
+    if phone:
+        return Q(identifier=identifier) | Q(identifier=phone)
+    return Q(identifier=identifier)
+
+
+class WhatsappChannel(ChannelBase):
+    # ... callbacks/sender/capabilities (provider-dependent — see Issue 3)
+
+    def _get_participant_identifier_filter(self) -> ParticipantIdentifierFilter:
+        return whatsapp_participant_filter
+```
+
+> **Why a closure, not a precomputed `Q`?** The filter depends on `ctx.message` and `ctx.participant_identifier`, neither of which exist when `_build_pipeline()` runs (pipeline is constructed once per channel instance, before any inbound message). Deferring evaluation to a callable invoked at runtime gives the filter per-message access to the live context — identical to how `DeliveryErrorHandler` callables receive `(ctx, exc)` at runtime.
+>
+> **No injection in other channels.** Every non-WhatsApp channel inherits the default `_get_participant_identifier_filter()` → `None`, and `SessionResolutionStage` falls back to its built-in `Q(identifier=normalize_identifier(...))`. No change to existing behavior for Telegram, Slack, Facebook, etc.
 
 ### 8\. Channel-Specific Pipeline Overrides
 
@@ -1324,7 +1430,7 @@ class ApiChannel(ChannelBase):
         return MessageProcessingPipeline(
             core_stages=[
                 ParticipantValidationStage(),
-                SessionResolutionStage(),
+                SessionResolutionStage(participant_identifier_filter=self._get_participant_identifier_filter()),
                 SessionActivationStage(),
                 MessageTypeValidationStage(),
                 QueryExtractionStage(),
@@ -1468,7 +1574,7 @@ class CommCareConnectChannel(ChannelBase):
         return MessageProcessingPipeline(
             core_stages=[
                 ParticipantValidationStage(),
-                SessionResolutionStage(),
+                SessionResolutionStage(participant_identifier_filter=self._get_participant_identifier_filter()),
                 SessionActivationStage(),
                 CommCareConsentCheckStage(),  # Platform-specific consent
                 MessageTypeValidationStage(),
@@ -2041,7 +2147,8 @@ def test_format_reference_section_with_citations():
 Each stage should have tests for these edge cases (where applicable):
 
 - **ParticipantValidationStage**: Public experiment, private+allowed, private+blocked, missing participant_id
-- **SessionResolutionStage**: Existing session found, no session (create new), pre-set session (Web/Slack), /reset with active session, /reset with no session, session in completed status
+- **SessionResolutionStage**: Existing session found, no session (create new), pre-set session (Web/Slack), /reset with active session, /reset with no session, session in completed status, default filter (no callable injected → normalized identifier match), channel-supplied filter callable invoked with live context, filter callable returning disjunctive Q (e.g. WhatsApp BSUID-or-phone), filter forwarded to `_start_experiment_session` on session create
+- **`whatsapp_participant_filter`** (channel-specific filter, colocated with `WhatsappChannel`): message has no phone_number → returns simple `Q(identifier=normalized)`, message has phone_number → returns disjunctive `Q(identifier=normalized) | Q(identifier=phone)`, `ctx.message is None` (ad hoc mini-pipeline) → falls back to identifier-only
 - **MessageTypeValidationStage**: Supported type, unsupported type, empty message
 - **SessionActivationStage**: Consent disabled (activates), no consent form (activates), consent enabled with form (skips), no session (skips)
 - **ConsentFlowStage**: Each status transition (SETUP→PENDING, PENDING→ACTIVE, PENDING→PENDING_PRE_SURVEY, PENDING_PRE_SURVEY→ACTIVE), consent denied, channel without consent support
@@ -2365,7 +2472,14 @@ def test_participant_validation_blocks_private_experiment():
 
 ```py
 class SessionResolutionStage(ProcessingStage):
-    """Loads or creates experiment session. Also handles /reset."""
+    """Loads or creates experiment session. Also handles /reset.
+
+    Accepts an optional channel-supplied ParticipantIdentifierFilter
+    callable for custom Participant matching (e.g. WhatsApp BSUID-or-phone).
+    """
+
+    def __init__(self, participant_identifier_filter: ParticipantIdentifierFilter | None = None):
+        self._participant_identifier_filter = participant_identifier_filter
 
     def should_run(self, ctx) -> bool:
         return ctx.participant_allowed
@@ -2379,17 +2493,26 @@ class SessionResolutionStage(ProcessingStage):
         if ctx.experiment_session:
             return
 
-        # Try to load existing (with select_related for performance)
-        ctx.experiment_session = self._load_latest_session(ctx)
+        # Resolve the channel-supplied filter (or fall back to default)
+        filter_q = self._resolve_filter(ctx)
 
-        # Create new if needed
+        # Try to load existing (with select_related for performance)
+        ctx.experiment_session = self._load_latest_session(ctx, filter_q)
+
+        # Create new if needed (forwards the same filter)
         if not ctx.experiment_session:
-            ctx.experiment_session = self._create_new_session(ctx)
+            ctx.experiment_session = self._create_new_session(ctx, filter_q)
+
+    def _resolve_filter(self, ctx) -> Q:
+        if self._participant_identifier_filter is not None:
+            return self._participant_identifier_filter(ctx)
+        identifier = ctx.experiment_channel.platform_enum.normalize_identifier(ctx.participant_identifier)
+        return Q(identifier=identifier)
 ```
 
-**Tests**: Test session loading, creation, /reset with active session, /reset with no session, pre-set session
+**Tests**: Test session loading, creation, /reset with active session, /reset with no session, pre-set session, default filter behavior, channel-supplied filter behavior (using a WhatsApp-like BSUID-or-phone matcher fixture)
 
-**Commit**: "Extract SessionResolutionStage with /reset handling"
+**Commit**: "Extract SessionResolutionStage with /reset handling and ParticipantIdentifierFilter hook"
 
 **3.2 MessageTypeValidationStage** (Week 4):
 
@@ -2657,7 +2780,7 @@ class ChannelBase(ABC):
         return MessageProcessingPipeline(
             core_stages=[
                 ParticipantValidationStage(),
-                SessionResolutionStage(),
+                SessionResolutionStage(participant_identifier_filter=self._get_participant_identifier_filter()),
                 SessionActivationStage(),
                 MessageTypeValidationStage(),
                 QueryExtractionStage(),
@@ -2830,6 +2953,7 @@ These fixes were identified during gap analysis comparing the new pipeline appro
 | G6 | Analytics | `ctx.human_message_tags` + PersistenceStage tagging | `MessageTypeValidationStage` appends `("unsupported_message_type", ERROR)` tag. `PersistenceStage` applies tags to the human ChatMessage. Preserves current analytics behavior. |
 | G7 | CommCare | Late-binding `CommCareConnectSender` (visitor pattern) | Sender holds a channel reference and resolves `connect_channel_id`/`encryption_key` lazily on first send via `@cached_property` on the channel. |
 | G8 | Stage ordering | SessionActivation immediately after SessionResolution | Groups session lifecycle stages together: resolve → activate → validate message type. |
+| G9 | WhatsApp | `ParticipantIdentifierFilter` injection (mirrors `DeliveryErrorHandler`) | `ChannelBase._get_participant_identifier_filter()` returns an optional `Callable[[ctx], Q]` that `SessionResolutionStage` invokes at runtime to resolve the Participant lookup filter. Default `None` → stage falls back to `Q(identifier=normalize_identifier(...))`. Only `WhatsappChannel` overrides, returning `whatsapp_participant_filter` (a closure colocated with the channel) which produces `Q(identifier=BSUID) \| Q(identifier=phone)` when `ctx.message.phone_number` is present. Replaces the `get_participant_identifier_filter` method that lived on `ChannelBase` and `WhatsappChannel` in the pre-refactor code. |
 
 ### Performance Notes (Deferred)
 
@@ -2908,11 +3032,11 @@ The rollout happens one channel at a time. Each PR adds the new channel implemen
 
 ### PR 5: WhatsappChannel — [ ] Not started
 
-- [ ] **Add:** `WhatsappChannel` + `WhatsappSender` + `WhatsappCallbacks` + `concrete/test_whatsapp_channel.py` + `senders/test_whatsapp_sender.py` + `callbacks/test_whatsapp_callbacks.py`
+- [ ] **Add:** `WhatsappChannel` + `WhatsappSender` + `WhatsappCallbacks` + `whatsapp_participant_filter` + `concrete/test_whatsapp_channel.py` + `senders/test_whatsapp_sender.py` + `callbacks/test_whatsapp_callbacks.py` + `filters/test_whatsapp_participant_filter.py`
 - [ ] **Mark for removal:** Add `# TODO: remove after channels refactor` to `WhatsappChannel` in `apps/chat/channels.py` + `apps/channels/tests/test_whatsapp_integration.py`
 - [ ] **Update:** `get_channel_class_for_platform()` + `apps/channels/tasks.py` imports to use new implementation
 
-**Why here:** First channel that delegates capabilities to `messaging_service` at runtime. Validates lazy messaging service resolution and capability delegation. Full pipeline with voice and files.
+**Why here:** First channel that delegates capabilities to `messaging_service` at runtime. Validates lazy messaging service resolution and capability delegation. Full pipeline with voice and files. **Also the first (and only) channel to override `_get_participant_identifier_filter()`** — uses `whatsapp_participant_filter` (colocated closure, mirrors `handle_telegram_block` from PR 4) to enable BSUID-or-phone Participant matching for legacy continuity across the BSUID rollout (G9).
 
 ### PR 6: SlackChannel — [ ] Not started
 

--- a/docs/plans/channels_refactor_example.py
+++ b/docs/plans/channels_refactor_example.py
@@ -50,6 +50,12 @@ Gap analysis fixes (post-review):
             MessageTypeValidationStage sets ("unsupported_message_type", ERROR) tag for analytics.
   - Fix 7:  CommCareConnectSender uses late-binding (visitor pattern) — holds channel reference,
             resolves connect_channel_id/encryption_key lazily on first send.
+  - Fix 8:  SessionResolutionStage accepts an optional ParticipantIdentifierFilter callable.
+            Channels override ChannelBase._get_participant_identifier_filter() to inject
+            custom Participant matching. The callable receives the live context and returns
+            a Q clause. Default: None — stage falls back to Q(identifier=normalized_identifier).
+            WhatsappChannel uses this to match on BSUID OR legacy phone number, mirroring the
+            DeliveryErrorHandler pattern used by TelegramChannel for send-error side effects.
 """
 
 from __future__ import annotations
@@ -62,6 +68,8 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from io import BytesIO
 from typing import TYPE_CHECKING, ClassVar
+
+from django.db.models import Q
 
 if TYPE_CHECKING:
     from apps.channels.datamodels import BaseMessage
@@ -342,15 +350,36 @@ class ParticipantValidationStage(ProcessingStage):
             raise EarlyExitResponse("Sorry, you are not allowed to chat to this bot")
 
 
+ParticipantIdentifierFilter = Callable[["MessageProcessingContext"], Q]
+"""Channel-supplied resolver for the Participant lookup filter.
+
+Invoked at runtime by SessionResolutionStage with the live context, so the
+callable can read ctx.message and ctx.participant_identifier. Returns the Q
+clause used to match an existing Participant. Mirrors the DeliveryErrorHandler
+pattern: ChannelBase exposes an optional hook (default: None), and only
+channels with non-trivial matching rules (currently just WhatsappChannel)
+override it.
+"""
+
+
 class SessionResolutionStage(ProcessingStage):
     """Loads or creates an experiment session.
 
     Also handles the /reset command (Issue 7).
     For Web/Slack channels the session is pre-set on the context, so this
     stage becomes a no-op (Issue 4).
+
+    Channels can inject a ``participant_identifier_filter`` callable to
+    customize how an existing Participant is matched. The callable is
+    invoked at runtime with the live context, so it has access to
+    ``ctx.message`` and ``ctx.participant_identifier``. Default behavior
+    (callable is ``None``) matches on the normalized identifier alone.
     """
 
     RESET_COMMAND = "/reset"
+
+    def __init__(self, participant_identifier_filter: ParticipantIdentifierFilter | None = None) -> None:
+        self._participant_identifier_filter = participant_identifier_filter
 
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         return ctx.participant_allowed
@@ -360,14 +389,24 @@ class SessionResolutionStage(ProcessingStage):
         if ctx.experiment_session is not None:
             return
 
-        # Try to load an existing active session (Issue 13: select_related)
-        from apps.chat.const import STATUSES_FOR_COMPLETE_CHATS
-        from apps.experiments.models import ExperimentSession
+        filter_q = self._resolve_filter(ctx)
 
+        # Try to load an existing active session (Issue 13: select_related).
+        # We filter Participant first (so the channel-supplied Q can match on
+        # alternative identifiers like a legacy phone number), then look up
+        # sessions belonging to any of those participants.
+        from apps.chat.const import STATUSES_FOR_COMPLETE_CHATS
+        from apps.experiments.models import ExperimentSession, Participant
+
+        participants = Participant.objects.filter(
+            filter_q,
+            team=ctx.experiment.team,
+            platform=ctx.experiment_channel.platform,
+        )
         ctx.experiment_session = (
             ExperimentSession.objects.filter(
                 experiment=ctx.experiment.get_working_version(),
-                participant__identifier=str(ctx.participant_identifier),
+                participant__in=participants,
             )
             .exclude(status__in=STATUSES_FOR_COMPLETE_CHATS)
             .select_related("participant", "chat", "experiment_channel")
@@ -384,6 +423,17 @@ class SessionResolutionStage(ProcessingStage):
         # Create a new session if none found
         if not ctx.experiment_session:
             ctx.experiment_session = self._create_session(ctx)
+
+    def _resolve_filter(self, ctx: MessageProcessingContext) -> Q:
+        """Resolve the Participant lookup filter for this request.
+
+        Calls the channel-supplied callable if one was injected; otherwise
+        falls back to matching on the normalized identifier alone.
+        """
+        if self._participant_identifier_filter is not None:
+            return self._participant_identifier_filter(ctx)
+        identifier = ctx.experiment_channel.platform_enum.normalize_identifier(ctx.participant_identifier)
+        return Q(identifier=identifier)
 
     def _is_reset_request(self, ctx: MessageProcessingContext) -> bool:
         from apps.chat.channels import MESSAGE_TYPES
@@ -402,7 +452,13 @@ class SessionResolutionStage(ProcessingStage):
         raise EarlyExitResponse("Conversation reset")
 
     def _create_session(self, ctx: MessageProcessingContext):
-        """Delegates to the existing _start_experiment_session helper."""
+        """Delegates to the existing _start_experiment_session helper.
+
+        The same channel-supplied filter is forwarded so that participant
+        lookup (before creation) honors the disjunctive match. The helper
+        itself still handles the simple-vs-disjunctive Q branching that
+        _start_experiment_session already implements.
+        """
         from apps.chat.channels import _start_experiment_session
         from apps.experiments.models import SessionStatus
 
@@ -411,6 +467,7 @@ class SessionResolutionStage(ProcessingStage):
             experiment_channel=ctx.experiment_channel,
             participant_identifier=ctx.participant_identifier,
             session_status=SessionStatus.SETUP,
+            participant_filter=self._resolve_filter(ctx),
         )
 
 
@@ -1276,7 +1333,7 @@ class ChannelBase(ABC):
         return MessageProcessingPipeline(
             core_stages=[
                 ParticipantValidationStage(),
-                SessionResolutionStage(),
+                SessionResolutionStage(participant_identifier_filter=self._get_participant_identifier_filter()),
                 SessionActivationStage(),
                 MessageTypeValidationStage(),
                 QueryExtractionStage(),
@@ -1321,6 +1378,19 @@ class ChannelBase(ABC):
         TelegramChannel registers a 403 "bot blocked" → consent revocation handler).
         """
         return []
+
+    def _get_participant_identifier_filter(self) -> ParticipantIdentifierFilter | None:
+        """Return a channel-supplied callable that resolves the Participant lookup filter.
+
+        Default: ``None`` — SessionResolutionStage falls back to matching on the
+        normalized identifier alone. Override to inject custom matching rules
+        (e.g. WhatsappChannel matches BSUID OR legacy phone number to keep
+        continuity across the BSUID rollout).
+
+        Mirrors ``_get_delivery_error_handlers``: only channels that need
+        non-default behavior override; everyone else inherits the no-op.
+        """
+        return None
 
     @abstractmethod
     def _get_callbacks(self) -> ChannelCallbacks:
@@ -1564,9 +1634,35 @@ class WhatsappCallbacks(ChannelCallbacks):
         self._sender.send_text(text=f"I heard: {transcript}", recipient=recipient)
 
 
+def whatsapp_participant_filter(ctx: MessageProcessingContext) -> Q:
+    """Match an existing WhatsApp participant on either BSUID or legacy phone number.
+
+    Post-rollout, new WhatsApp webhooks always carry a BSUID
+    (``ctx.participant_identifier``); some also carry a legacy phone number
+    (``ctx.message.phone_number``), allowing continuity with phone-keyed
+    participants from before the BSUID rollout. When the phone number is
+    present, the filter becomes disjunctive — _start_experiment_session
+    detects this and uses an ``.exists()`` probe instead of
+    ``get_or_create`` for participant lookup.
+
+    Mirrors ``handle_telegram_block`` (the Telegram delivery error handler):
+    a plain function colocated with the channel, plugged in via the
+    ``_get_participant_identifier_filter`` hook.
+    """
+    identifier = ctx.experiment_channel.platform_enum.normalize_identifier(ctx.participant_identifier)
+    phone = getattr(ctx.message, "phone_number", None) if ctx.message else None
+    if phone:
+        return Q(identifier=identifier) | Q(identifier=phone)
+    return Q(identifier=identifier)
+
+
 class WhatsappChannel(ChannelBase):
     """WhatsApp channel — capabilities are determined at runtime from the
-    messaging service (Twilio vs TurnIO). This is Issue 3 in action."""
+    messaging service (Twilio vs TurnIO). This is Issue 3 in action.
+
+    Also overrides ``_get_participant_identifier_filter`` to enable BSUID
+    OR phone-number Participant matching during the BSUID rollout (Fix 8).
+    """
 
     def __init__(self, experiment, experiment_channel, experiment_session=None):
         super().__init__(experiment, experiment_channel, experiment_session)
@@ -1595,6 +1691,11 @@ class WhatsappChannel(ChannelBase):
             supported_message_types=self.messaging_service.supported_message_types,
             can_send_file=self.messaging_service.can_send_file,
         )
+
+    def _get_participant_identifier_filter(self) -> ParticipantIdentifierFilter:
+        # BSUID-OR-phone matching is WhatsApp-specific and lives next to the
+        # channel, not in the generic SessionResolutionStage.
+        return whatsapp_participant_filter
 
 
 # ---------------------------------------------------------------------------
@@ -1865,7 +1966,7 @@ class ApiChannel(ChannelBase):
         return MessageProcessingPipeline(
             core_stages=[
                 ParticipantValidationStage(),
-                SessionResolutionStage(),
+                SessionResolutionStage(participant_identifier_filter=self._get_participant_identifier_filter()),
                 SessionActivationStage(),
                 MessageTypeValidationStage(),
                 QueryExtractionStage(),
@@ -2146,7 +2247,7 @@ class CommCareConnectChannel(ChannelBase):
         return MessageProcessingPipeline(
             core_stages=[
                 ParticipantValidationStage(),
-                SessionResolutionStage(),
+                SessionResolutionStage(participant_identifier_filter=self._get_participant_identifier_filter()),
                 SessionActivationStage(),
                 CommCareConsentCheckStage(),  # Platform-specific consent
                 MessageTypeValidationStage(),


### PR DESCRIPTION
Closes #3322
Closes #3025

### Product Description
WhatsApp users will be able to adopt usernames in 2026, after which their phone numbers (`wa_id` field) won't appear in webhook payloads — Meta replaces them with a Business-Scoped User ID (BSUID, more specifically, the `user_id` and `from_user_id` fields). This PR adds BSUID support so conversations from username-adopters continue to work on both inbound (webhook) and outbound (send-message) paths, on both the Meta Cloud API channel and the Twilio WhatsApp channel. Existing participants keyed by phone number keep continuity: a returning user whose webhook still includes their phone resolves to their original `Participant` record, so chat history is preserved across the rollout. The PR also fixes a bug where Meta webhook payloads containing multiple messages would silently drop everything after the first message.

### Technical Description

#### 1. BSUID as the participant identifier
(`apps/channels/datamodels.py`, `apps/channels/meta_webhook.py`)

- The BSUID is now the canonical `participant_id` on every post-rollout WhatsApp webhook — `from_user_id` for Meta Cloud API and `ExternalUserId` for Twilio. Both fields are guaranteed by their respective providers; a missing field is treated as a malformed payload (`KeyError` surfaces).
- `TwilioMessage` and `MetaCloudAPIMessage` gain an optional `phone_number` field, populated only when the webhook still exposes the user's phone (i.e. the user has not adopted a username, or Meta's contact-book / 30-day-window rules still apply). This is used for legacy-participant matching, not as an identifier.
- `looks_like_bsuid()` keys off the `.` separator (e.g. `US.13491208655302741918`) since phone numbers never contain one. Parent BSUIDs (`<country>.ENT.<digits>`) match the same rule.
- The Meta webhook message structure is now expressed as a `MetaCloudAPIWebhookMessage` `TypedDict`.

#### 2. Legacy-participant continuity
(`apps/chat/channels.py`)

- New `ChannelBase.get_participant_identifier_filter()` hook returns the `Q` clause used to find an existing `Participant` for the incoming message. Default is identifier equality; `WhatsappChannel` overrides it to match `Q(identifier=BSUID) | Q(identifier=phone)` when both are available.
- `_load_latest_session` uses this filter, so a returning user with a pre-rollout phone-keyed `Participant` record still resolves to the same row when their post-rollout webhook arrives.
- `start_new_session` / `_start_experiment_session` accept a `participant_filter` kwarg. For the simple equality case it still uses `get_or_create` on the normalized identifier. For the disjunctive WhatsApp case it does an `exists()` probe first; if a legacy phone-keyed participant matches, it's reused (oldest-first), otherwise a new participant is created keyed by the canonical BSUID.
- The new `Chat.name` is built from `participant.identifier` (post-resolution) rather than the raw inbound identifier, so legacy participants keep their phone-shaped label.

#### 3. Outbound (Meta Cloud API)
(`apps/service_providers/messaging_service.py`)

- The recipient passed to `send_text_message` / `send_voice_message` / `send_file_to_user` / `send_template_message` is `self.participant_identifier`, which for the webhook-triggered reply path resolves to `message.participant_id` — i.e. the BSUID — and is cached before the session is loaded. So replies to inbound messages always use Meta's new `recipient` field post-rollout, including for legacy participants matched by phone.
- `_recipient_kwarg(recipient)` dispatches on `looks_like_bsuid`: BSUID recipients go in `recipient`, phone recipients go in `to`. The `to` branch is only exercised on operator-initiated paths (UI / API / `ensure_session_exists_for_participant`) where the channel is constructed with a pre-loaded session whose `participant.identifier` is still a phone — i.e. legacy participants who haven't yet received a post-rollout webhook.
- All four send paths (template, text, audio, media) also set `recipient_type: "individual"` (template already had it), required by Meta when using `recipient`.

#### 4. Multi-message webhook handling (Meta Cloud API)
(`apps/channels/meta_webhook.py`, `apps/channels/views.py`, `apps/channels/tasks.py`)

- `extract_message_values` is replaced by `extract_messages`, which returns `(phone_number_id, message)` tuples — one per logical message rather than per value block. Each message is dispatched to its own Celery task. Previously only the first message per value was processed.
- Within a single change value, `_merge_text_messages_per_user` collapses all text messages from the same user (keyed by `from_user_id`, falling back to `from`) into one merged entry — sorted by timestamp, bodies newline-joined, latest entry's metadata retained, placed at the position of the user's first text. Non-text messages pass through individually. Avoids fanning out a flood of tasks when a user sends a burst of short texts.
- `handle_meta_cloud_api_message` now takes a single typed message dict (`MetaCloudAPIWebhookMessage`) rather than a value block.

#### BSUID rollout behavior

Three inbound scenarios once Meta's WhatsApp username rollout begins (BSUID is always the participant identifier; the difference is what's available for legacy matching):

1. **New participant who has adopted a username** — webhook contains only `user_id` / `from_user_id`; `wa_id` / `from` is omitted. A new `Participant` is created keyed by the BSUID.
2. **Participant who has not adopted a username** (new or returning) — webhook contains both phone and BSUID. Meta auto-adds the contact to our business contact book (enabled by default at the portfolio level), so if they later adopt a username, subsequent webhooks for that participant continue to include the phone number. Legacy phone-keyed `Participant` records are matched by the disjunctive filter.
3. **Existing participant who has adopted a username** — Meta still delivers the phone if the participant is in our contact book OR if they exchanged a message/call with the business number within the last 30 days. We only "lose" continuity (treat them as a new participant) when both conditions fail: they last interacted more than 30 days ago AND were never added to the contact book. This is an accepted risk.

In all three cases, replies to the incoming webhook use Meta's new `recipient` field with the BSUID.

### Migrations
- [x] The migrations are backwards compatible

No schema migrations. `Participant.identifier` semantics change for new WhatsApp records (BSUID rather than phone) but existing rows are unaffected and continue to resolve via the disjunctive filter.

### Demo
Server-side change with no UI. Inbound parsing, multi-message handling, legacy-participant continuity, and outbound recipient routing are covered in `test_datamodels.py`, `test_meta_cloud_api_webhook.py`, `test_whatsapp_integration.py`, and `test_messaging_providers.py`.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Changelog note: WhatsApp channels (Meta Cloud API and Twilio) now support business-scoped user IDs (BSUID) on both inbound webhooks and outbound sends, in preparation for Meta's WhatsApp usernames rollout in 2026. Existing phone-keyed participants keep continuity when their webhook still includes a phone number. Meta webhook payloads containing multiple messages are now all processed (previously only the first was handled).
