### PR TITLE
Add session status to session API data

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -1358,6 +1358,8 @@ components:
           type: string
           format: date-time
           readOnly: true
+        status:
+          $ref: '#/components/schemas/StatusCb5Enum'
         tags:
           type: array
           items:
@@ -1424,6 +1426,8 @@ components:
           type: string
           format: date-time
           readOnly: true
+        status:
+          $ref: '#/components/schemas/StatusCb5Enum'
         messages:
           type: array
           items:
@@ -1731,6 +1735,24 @@ components:
       description: |-
         * `active` - Active
         * `ended` - Ended
+    StatusCb5Enum:
+      enum:
+      - setup
+      - pending
+      - pending-pre-survey
+      - active
+      - pending-review
+      - complete
+      - unknown
+      type: string
+      description: |-
+        * `setup` - Setting Up
+        * `pending` - Awaiting participant
+        * `pending-pre-survey` - Awaiting pre-survey
+        * `active` - Active
+        * `pending-review` - Awaiting final review.
+        * `complete` - Complete
+        * `unknown` - Unknown
     Team:
       type: object
       properties:

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -130,7 +130,7 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ExperimentSession
-        fields = ["url", "id", "team", "experiment", "participant", "created_at", "updated_at", "messages", "tags"]
+        fields = ["url", "id", "team", "experiment", "participant", "created_at", "updated_at", "status", "messages", "tags"]
 
     def __init__(self, *args, **kwargs):
         self._include_messages = kwargs.pop("include_messages", False)

--- a/apps/api/tests/test_session_api.py
+++ b/apps/api/tests/test_session_api.py
@@ -102,6 +102,7 @@ def get_session_json(session, expected_messages=None, expected_tags=None):
         },
         "created_at": DateTimeField().to_representation(session.created_at),
         "updated_at": DateTimeField().to_representation(session.updated_at),
+        "status": session.status,
         "tags": expected_tags if expected_tags is not None else [],
     }
     if expected_messages is not None:


### PR DESCRIPTION
### Product Description
Adds `status` to the session list and detail API responses, so API consumers can see the current state of a session (`setup`, `pending`, `active`, `complete`, etc.).

### Technical Description
Added `"status"` to `ExperimentSessionSerializer.Meta.fields`. No custom serializer field needed — DRF handles the `CharField` with choices natively. Updated the `get_session_json` test helper to include the expected `status` value.

### Migrations
No migrations.

### Docs and Changelog
- [x] This PR requires docs/changelog update