### PR TITLE
Fix ClaudeSonnet46Parameters: remove temperature

### DIFF
--- a/apps/service_providers/llm_service/model_parameters.py
+++ b/apps/service_providers/llm_service/model_parameters.py
@@ -296,13 +296,34 @@ class ClaudeOpus46Parameters(BasicParameters):
         return value
 
 
-class ClaudeSonnet46Parameters(ClaudeOpus46Parameters):
+class ClaudeSonnet46Parameters(LLMModelParamBase):
+    """Parameters for Claude Sonnet 4.6.
+
+    Sonnet 4.6 was released after Claude Opus 4.6 and therefore does not support
+    setting temperature — only 1.0 is accepted for backwards compatibility, so
+    temperature is not exposed here.
+    """
+
     max_tokens: int = Field(
         title="Max Output Tokens",
         default=32000,
         description="The maximum number of tokens to generate in the completion.",
         ge=1,
         le=64000,
+    )
+    effort: Claude46EffortParameter = Field(
+        title="Reasoning Effort",
+        default=Claude46EffortParameter.HIGH,
+        description="Control intelligence, speed, and cost tradeoffs with adaptive thinking.",
+        json_schema_extra=UiSchema(widget=Widgets.select, enum_labels=Claude46EffortParameter.labels),
+    )
+    adaptive_thinking: bool = Field(
+        title="Enable Adaptive Thinking",
+        default=False,
+        description="Let Claude dynamically decide when and how much to think with adaptive thinking mode. "
+        "At the default effort level (high), Claude will almost always think. "
+        "At lower effort levels, Claude may skip thinking for simpler problems.",
+        json_schema_extra=UiSchema(widget=Widgets.toggle),
     )
 
 

--- a/apps/service_providers/tests/llm_service/test_model_parameters.py
+++ b/apps/service_providers/tests/llm_service/test_model_parameters.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from apps.service_providers.llm_service.model_parameters import GPT52Parameters, get_schema
+from apps.service_providers.llm_service.model_parameters import ClaudeSonnet46Parameters, GPT52Parameters, get_schema
 
 
 class TestGPT52ParametersNoneEffort:
@@ -48,3 +48,26 @@ class TestGPT52ParametersSchema:
     def test_top_p_has_default_on_show_in_schema(self):
         schema = get_schema(GPT52Parameters)
         assert schema["properties"]["top_p"]["ui:onShowDefault"] == 1.0
+
+
+class TestClaudeSonnet46Parameters:
+    """Claude Sonnet 4.6 was released after Opus 4.6 and does not support
+    temperature. Verify the parameter class omits it entirely."""
+
+    def test_temperature_not_in_fields(self):
+        assert "temperature" not in ClaudeSonnet46Parameters.model_fields
+
+    def test_temperature_not_in_model_dump(self):
+        params = ClaudeSonnet46Parameters()
+        assert "temperature" not in params.model_dump()
+
+    def test_defaults(self):
+        params = ClaudeSonnet46Parameters()
+        assert params.max_tokens == 32000
+        assert params.effort == "high"
+        assert params.adaptive_thinking is False
+
+    def test_effort_and_adaptive_thinking_configurable(self):
+        params = ClaudeSonnet46Parameters(effort="low", adaptive_thinking=True)
+        assert params.effort == "low"
+        assert params.adaptive_thinking is True


### PR DESCRIPTION
### Product Description
No change — this fixes a bug where users could set temperature on Claude Sonnet 4.6 to non-1.0 values, which would result in a 400 error from the Anthropic API. Temperature is no longer exposed for this model.

### Technical Description
Sonnet 4.6 was released on Feb 17, 2026 — 12 days after Claude Opus 4.6 (Feb 5, 2026), placing it in the group of models that no longer support temperature (only 1.0 is accepted for backwards compatibility; any other value returns a 400).

`ClaudeSonnet46Parameters` previously inherited from `ClaudeOpus46Parameters`, which exposes `temperature` as a 0.0–2.0 range slider. The fix restructures it to inherit directly from `LLMModelParamBase` — the same pattern already used by `ClaudeOpus47Parameters` — keeping `effort` and `adaptive_thinking` but dropping `temperature`.

`ClaudeOpus46Parameters` is unchanged: Opus 4.6 is the cutoff model itself and does still support temperature.

### Migrations
No migrations.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Fixes #3371