### PR TITLE
Return session data from trigger_bot_message endpoint

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -944,7 +944,36 @@ paths:
       - tokenAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TriggerBotMessageResponse'
+              examples:
+                GenerateBotMessageAndSend:
+                  value:
+                    identifier: '+15556793'
+                    experiment: exp1
+                    platform: whatsapp
+                    prompt_text: Tell the user to do something
+                    session_data:
+                      key: value
+                    participant_data:
+                      key: value
+                  summary: Generates a bot message and sends it to the user (auto-creates
+                    participant if needed).
+                SendMessageDirectly:
+                  value:
+                    identifier: '+15556793'
+                    experiment: exp1
+                    platform: whatsapp
+                    message_text: Your appointment is confirmed for tomorrow at 10am.
+                    session_data:
+                      key: value
+                    participant_data:
+                      key: value
+                  summary: Send a pre-written message directly to the participant,
+                    bypassing the bot/LLM.
+          description: ''
         '400':
           content:
             application/json:
@@ -1806,6 +1835,28 @@ components:
       - experiment
       - identifier
       - platform
+    TriggerBotMessageResponse:
+      type: object
+      properties:
+        session_id:
+          type: string
+          readOnly: true
+        url:
+          type: string
+          format: uri
+          readOnly: true
+        team:
+          allOf:
+          - $ref: '#/components/schemas/Team'
+          readOnly: true
+        channel:
+          type: string
+          readOnly: true
+      required:
+      - channel
+      - session_id
+      - team
+      - url
     UploadedFile:
       type: object
       properties:

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -130,7 +130,18 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ExperimentSession
-        fields = ["url", "id", "team", "experiment", "participant", "created_at", "updated_at", "status", "messages", "tags"]
+        fields = [
+            "url",
+            "id",
+            "team",
+            "experiment",
+            "participant",
+            "created_at",
+            "updated_at",
+            "status",
+            "messages",
+            "tags",
+        ]
 
     def __init__(self, *args, **kwargs):
         self._include_messages = kwargs.pop("include_messages", False)
@@ -308,3 +319,16 @@ class TriggerBotMessageRequest(serializers.Serializer):
         if not has_prompt and not has_message:
             raise serializers.ValidationError("Either 'prompt_text' or 'message_text' must be provided.")
         return data
+
+
+class TriggerBotMessageResponse(serializers.ModelSerializer):
+    session_id = serializers.ReadOnlyField(source="external_id")
+    url = serializers.HyperlinkedIdentityField(
+        view_name="api:session-detail", lookup_field="external_id", lookup_url_kwarg="id"
+    )
+    team = TeamSerializer(read_only=True)
+    channel = serializers.CharField(source="experiment_channel.platform", read_only=True)
+
+    class Meta:
+        model = ExperimentSession
+        fields = ["session_id", "url", "team", "channel"]

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -327,7 +327,7 @@ class TriggerBotMessageResponse(serializers.ModelSerializer):
         view_name="api:session-detail", lookup_field="external_id", lookup_url_kwarg="id"
     )
     team = TeamSerializer(read_only=True)
-    channel = serializers.CharField(source="participant.platform", read_only=True)
+    channel = serializers.CharField(source="platform", read_only=True)
 
     class Meta:
         model = ExperimentSession

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -327,7 +327,7 @@ class TriggerBotMessageResponse(serializers.ModelSerializer):
         view_name="api:session-detail", lookup_field="external_id", lookup_url_kwarg="id"
     )
     team = TeamSerializer(read_only=True)
-    channel = serializers.CharField(source="experiment_channel.platform", read_only=True)
+    channel = serializers.CharField(source="participant.platform", read_only=True)
 
     class Meta:
         model = ExperimentSession

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -7,7 +7,7 @@ from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import ChannelBase
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.chatbots.version_resolver import resolve_published_or_working
-from apps.experiments.models import ParticipantData
+from apps.experiments.models import ExperimentSession, ParticipantData
 from apps.service_providers.tracing import TraceInfo
 from apps.teams.utils import current_team
 
@@ -94,8 +94,6 @@ def trigger_bot_message_task(session_external_id: str, prompt_text: str | None, 
     without any LLM processing. When ``prompt_text`` is set, the bot generates a
     response via the LLM and sends that.
     """
-    from apps.experiments.models import ExperimentSession  # noqa: PLC0415
-
     session = ExperimentSession.objects.select_related("experiment", "experiment_channel", "participant").get(
         external_id=session_external_id
     )

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -7,7 +7,7 @@ from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import ChannelBase
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.chatbots.version_resolver import resolve_published_or_working
-from apps.experiments.models import Experiment, ParticipantData
+from apps.experiments.models import ParticipantData
 from apps.service_providers.tracing import TraceInfo
 from apps.teams.utils import current_team
 
@@ -83,37 +83,33 @@ def create_connect_channel_for_participant(channel, connect_client, connect_id, 
 
 
 @shared_task(ignore_result=True)
-def trigger_bot_message_task(data):
+def trigger_bot_message_task(session_external_id: str, prompt_text: str | None, message_text: str | None):
     """
     Trigger a bot message for a participant on a specific platform.
 
-    When ``data["message_text"]`` is set, the message is delivered directly to the participant
-    without any LLM processing. When ``data["prompt_text"]`` is set, the bot generates a
+    The session must already exist (created synchronously by the view so that its ID can be
+    returned to the caller before the task runs).
+
+    When ``message_text`` is set, the message is delivered directly to the participant
+    without any LLM processing. When ``prompt_text`` is set, the bot generates a
     response via the LLM and sends that.
     """
-    platform = data["platform"]
-    experiment_public_id = data["experiment"]
-    prompt_text = data.get("prompt_text")
-    message_text = data.get("message_text")
-    identifier = data["identifier"]
-    start_new_session = data["start_new_session"]
-    session_data = data.get("session_data")
+    from apps.experiments.models import ExperimentSession  # noqa: PLC0415
 
-    experiment = Experiment.objects.get(public_id=experiment_public_id)
-    experiment_channel = ExperimentChannel.objects.get(platform=platform, experiment=experiment)
+    session = ExperimentSession.objects.select_related("experiment", "experiment_channel", "participant").get(
+        external_id=session_external_id
+    )
 
+    experiment = session.experiment
     target_experiment = resolve_published_or_working(experiment)
-    ChannelClass = ChannelBase.get_channel_class_for_platform(platform)
-    channel = ChannelClass(experiment=target_experiment, experiment_channel=experiment_channel)
+    ChannelClass = ChannelBase.get_channel_class_for_platform(session.experiment_channel.platform)
+    channel = ChannelClass(
+        experiment=target_experiment,
+        experiment_channel=session.experiment_channel,
+        experiment_session=session,
+    )
 
     with current_team(experiment.team):
-        channel.ensure_session_exists_for_participant(identifier, new_session=start_new_session)
-        if session_data:
-            session = channel.experiment_session
-            merged_state = {**session.state, **session_data}
-            session.state = merged_state
-            session.save(update_fields=["state"])
-
         if message_text:
             ChatMessage.objects.create(
                 chat=channel.experiment_session.chat,

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -606,12 +606,18 @@ def test_generate_bot_message_and_send(ConnectClient, experiment, auth_method, d
     first_message = session.chat.messages.first()
     assert first_message.message_type == "ai"
     assert first_message.content == "Time to take a break and brew some coffee"
+    response_data = response.json()
+    assert response_data["session_id"] == str(session.external_id)
+    assert response_data["channel"] == ChannelPlatform.COMMCARE_CONNECT
+    assert response_data["team"] == {"name": experiment.team.name, "slug": experiment.team.slug}
+    assert f"/api/sessions/{session.external_id}/" in response_data["url"]
 
     # Call it a second time to make sure the session is reused
     with mock_llm(["Time to take a break and brew some tea"]):
         with django_capture_on_commit_callbacks(execute=True):
             response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
+    assert response.json()["session_id"] == str(session.external_id)  # same session reused
     session = ExperimentSession.objects.get(participant=participant_data.participant, experiment=experiment)
     assert session.chat.messages.count() == 2
     last_message = session.chat.messages.last()
@@ -632,6 +638,7 @@ def test_generate_bot_message_and_send(ConnectClient, experiment, auth_method, d
         .order_by("-created_at")
         .first()
     )
+    assert response.json()["session_id"] == str(new_session.external_id)  # new session ID returned
     assert new_session.chat.messages.count() == 1
     last_message = new_session.chat.messages.last()
     assert last_message.message_type == "ai"
@@ -761,6 +768,9 @@ def test_generate_bot_message_for_email_channel(experiment, django_capture_on_co
     bot_message = session.chat.messages.first()
     assert bot_message.message_type == "ai"
     assert bot_message.content == "Hello from the bot"
+    response_data = response.json()
+    assert response_data["session_id"] == str(session.external_id)
+    assert response_data["channel"] == ChannelPlatform.EMAIL
 
     # Email actually delivered through the EmailSender
     assert len(mail.outbox) == 1
@@ -824,6 +834,9 @@ def test_trigger_bot_direct_message(
     saved_msg = session.chat.messages.first()
     assert saved_msg.message_type == "ai"
     assert saved_msg.content == message
+    response_data = response.json()
+    assert response_data["session_id"] == str(session.external_id)
+    assert response_data["channel"] == ChannelPlatform.COMMCARE_CONNECT
 
 
 @pytest.mark.django_db()

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -14,11 +14,13 @@ from rest_framework.response import Response
 from rest_framework.views import APIView, Request
 
 from apps.api.permissions import verify_hmac
-from apps.api.serializers import TriggerBotMessageRequest
+from apps.api.serializers import TriggerBotMessageRequest, TriggerBotMessageResponse
 from apps.api.tasks import create_connect_channel_for_participant, trigger_bot_message_task
 from apps.channels.clients.connect_client import CommCareConnectClient
 from apps.channels.models import ChannelPlatform, ExperimentChannel
+from apps.chat.channels import ChannelBase
 from apps.experiments.models import Experiment, Participant, ParticipantData
+from apps.teams.utils import current_team
 
 connect_logger = logging.getLogger("api.connect_channel")
 
@@ -94,9 +96,7 @@ def _get_or_create_participant_data(request, identifier, platform, experiment, i
     ).first()
 
     if not participant_data:
-        participant, _ = Participant.objects.get_or_create(
-            identifier=identifier, platform=platform, team=request.team
-        )
+        participant, _ = Participant.objects.get_or_create(identifier=identifier, platform=platform, team=request.team)
         participant_data, created = ParticipantData.objects.get_or_create(
             participant=participant,
             experiment=experiment,
@@ -147,9 +147,7 @@ def _ensure_commcare_connect_ready(channel, identifier, participant_data):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
         except httpx.HTTPError as e:
-            connect_logger.error(
-                f"Failed to create CommCare Connect channel for participant {identifier}: {str(e)}"
-            )
+            connect_logger.error(f"Failed to create CommCare Connect channel for participant {identifier}: {str(e)}")
             return JsonResponse(
                 {"detail": "Failed to create channel: Unable to connect to CommCare Connect service"},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -170,7 +168,7 @@ class TriggerBotMessageView(APIView):
         tags=["Channels"],
         request=TriggerBotMessageRequest(),
         responses={
-            200: {},
+            200: TriggerBotMessageResponse,
             400: {"description": "Bad Request"},
             404: {"description": "Not Found"},
         },
@@ -249,6 +247,21 @@ class TriggerBotMessageView(APIView):
             if error := _ensure_commcare_connect_ready(channel, identifier, participant_data):
                 return error
 
-        trigger_bot_message_task.delay_on_commit(data)
+        from apps.chatbots.version_resolver import resolve_published_or_working  # noqa: PLC0415
 
-        return Response(status=status.HTTP_200_OK)
+        target_experiment = resolve_published_or_working(experiment)
+        ChannelClass = ChannelBase.get_channel_class_for_platform(platform)
+        bot_channel = ChannelClass(experiment=target_experiment, experiment_channel=channel)
+        with current_team(experiment.team):
+            bot_channel.ensure_session_exists_for_participant(identifier, new_session=data["start_new_session"])
+            session = bot_channel.experiment_session
+            if data.get("session_data"):
+                session.state = {**session.state, **data["session_data"]}
+                session.save(update_fields=["state"])
+
+        trigger_bot_message_task.delay_on_commit(
+            str(session.external_id), data.get("prompt_text"), data.get("message_text")
+        )
+
+        response_serializer = TriggerBotMessageResponse(instance=session, context={"request": request})
+        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -19,6 +19,7 @@ from apps.api.tasks import create_connect_channel_for_participant, trigger_bot_m
 from apps.channels.clients.connect_client import CommCareConnectClient
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import ChannelBase
+from apps.chatbots.version_resolver import resolve_published_or_working
 from apps.experiments.models import Experiment, Participant, ParticipantData
 from apps.teams.utils import current_team
 
@@ -246,8 +247,6 @@ class TriggerBotMessageView(APIView):
         if platform == ChannelPlatform.COMMCARE_CONNECT:
             if error := _ensure_commcare_connect_ready(channel, identifier, participant_data):
                 return error
-
-        from apps.chatbots.version_resolver import resolve_published_or_working  # noqa: PLC0415
 
         target_experiment = resolve_published_or_working(experiment)
         ChannelClass = ChannelBase.get_channel_class_for_platform(platform)


### PR DESCRIPTION
### Product Description
The `trigger_bot` endpoint previously returned an empty HTTP 200. It now returns session information so callers can reference the session immediately without a follow-up lookup:

```json
{
  "session_id": "<external_id>",
  "url": "https://.../api/sessions/<external_id>/",
  "team": {"name": "My Team", "slug": "my-team"},
  "channel": "whatsapp"
}
```

### Technical Description
Session creation was previously done inside `trigger_bot_message_task` (a Celery task), which meant the session ID wasn't available to return synchronously. The fix moves session creation into the view — where it was always needed anyway for the response — and the task now receives a `session_external_id` and focuses only on message delivery.

Key changes:
- New `TriggerBotMessageResponse` serializer (`ModelSerializer`) with `session_id`, `url`, `team`, `channel` fields
- `trigger_bot_message_task` signature changes from `(data: dict)` to `(session_external_id, prompt_text, message_text)`; it no longer calls `ensure_session_exists_for_participant`
- `@extend_schema` updated to document the 200 response body
- Existing tests updated with response body assertions

### Migrations
No migrations.

### Docs and Changelog
- [x] This PR requires docs/changelog update

Fixes #3369