### PR TITLE
Add platform field to session API responses

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -1360,6 +1360,10 @@ components:
           readOnly: true
         status:
           $ref: '#/components/schemas/StatusCb5Enum'
+        platform:
+          type: string
+          nullable: true
+          maxLength: 128
         tags:
           type: array
           items:
@@ -1428,6 +1432,10 @@ components:
           readOnly: true
         status:
           $ref: '#/components/schemas/StatusCb5Enum'
+        platform:
+          type: string
+          nullable: true
+          maxLength: 128
         messages:
           type: array
           items:

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -130,7 +130,19 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ExperimentSession
-        fields = ["url", "id", "team", "experiment", "participant", "created_at", "updated_at", "status", "messages", "tags"]
+        fields = [
+            "url",
+            "id",
+            "team",
+            "experiment",
+            "participant",
+            "created_at",
+            "updated_at",
+            "status",
+            "platform",
+            "messages",
+            "tags",
+        ]
 
     def __init__(self, *args, **kwargs):
         self._include_messages = kwargs.pop("include_messages", False)

--- a/apps/api/tests/test_session_api.py
+++ b/apps/api/tests/test_session_api.py
@@ -103,6 +103,7 @@ def get_session_json(session, expected_messages=None, expected_tags=None):
         "created_at": DateTimeField().to_representation(session.created_at),
         "updated_at": DateTimeField().to_representation(session.updated_at),
         "status": session.status,
+        "platform": session.platform,
         "tags": expected_tags if expected_tags is not None else [],
     }
     if expected_messages is not None:


### PR DESCRIPTION
### Product Description
Adds `platform` to the session list and detail API responses.

### Technical Description
One-line addition to `ExperimentSessionSerializer.Meta.fields`. Uses `ExperimentSession.platform` directly (the same field used in `TriggerBotMessageResponse` in #3369). Test helper updated to include the expected value.

### Migrations
No migrations.

### Docs and Changelog
- [x] This PR requires docs/changelog update

Fixes #3374