### PR TITLE
Migrate EvaluationChannel to channels_v2 pipeline

### DIFF
--- a/apps/channels/channels_v2/evaluation_channel.py
+++ b/apps/channels/channels_v2/evaluation_channel.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from apps.channels.channels_v2.api_channel import NoOpSender
+from apps.channels.channels_v2.callbacks import ChannelCallbacks
+from apps.channels.channels_v2.capabilities import ChannelCapabilities
+from apps.channels.channels_v2.channel_base import ChannelBase
+from apps.channels.channels_v2.pipeline import MessageProcessingContext, MessageProcessingPipeline
+from apps.channels.channels_v2.sender import ChannelSender
+from apps.channels.channels_v2.stages.core import (
+    ChatMessageCreationStage,
+    EvalsBotInteractionStage,
+    MessageTypeValidationStage,
+    QueryExtractionStage,
+    ResponseFormattingStage,
+)
+from apps.channels.channels_v2.stages.terminal import ActivityTrackingStage, PersistenceStage
+from apps.chat.channels import MESSAGE_TYPES
+from apps.chat.exceptions import ChannelException
+from apps.service_providers.tracing import TracingService
+
+if TYPE_CHECKING:
+    from apps.channels.datamodels import BaseMessage
+    from apps.channels.models import ExperimentChannel
+    from apps.experiments.models import Experiment, ExperimentSession
+
+
+class EvaluationChannel(ChannelBase):
+    """Message handler for evaluation runs.
+
+    Internal channel — no message sending. Uses EvalsBot with in-memory
+    participant_data passed via ctx.channel_context (see
+    MessageProcessingContext.channel_context for the workaround note).
+    """
+
+    voice_replies_supported = False
+    supported_message_types = (MESSAGE_TYPES.TEXT,)
+
+    def __init__(
+        self,
+        experiment: Experiment,
+        experiment_channel: ExperimentChannel,
+        experiment_session: ExperimentSession,
+        participant_data: dict,
+    ):
+        super().__init__(experiment, experiment_channel, experiment_session)
+        if not self.experiment_session:
+            raise ChannelException("EvaluationChannel requires an existing session")
+        self._participant_data = participant_data
+
+    def _create_trace_service(self):
+        return TracingService.empty()
+
+    def _create_context(self, message: BaseMessage) -> MessageProcessingContext:
+        ctx = super()._create_context(message)
+        ctx.channel_context["participant_data"] = self._participant_data
+        return ctx
+
+    def _build_pipeline(self) -> MessageProcessingPipeline:
+        # ParticipantValidationStage omitted: the "evaluations" participant is internal,
+        # validating against participant_allowlist is meaningless (and would block private
+        # experiments). Nothing downstream in this pipeline reads ctx.participant_identifier.
+        # SessionActivationStage omitted: the eval bot does not gate on session status.
+        return MessageProcessingPipeline(
+            core_stages=[
+                MessageTypeValidationStage(),
+                QueryExtractionStage(),
+                ChatMessageCreationStage(),
+                EvalsBotInteractionStage(),
+                ResponseFormattingStage(),
+            ],
+            terminal_stages=[
+                PersistenceStage(),
+                ActivityTrackingStage(),
+            ],
+        )
+
+    def _get_callbacks(self) -> ChannelCallbacks:
+        return ChannelCallbacks()
+
+    def _get_sender(self) -> ChannelSender:
+        return NoOpSender()
+
+    def _get_capabilities(self) -> ChannelCapabilities:
+        return ChannelCapabilities(
+            supports_voice_replies=self.voice_replies_supported,
+            supports_files=False,
+            supports_conversational_consent=False,
+            supports_static_triggers=False,
+            supported_message_types=self.supported_message_types,
+        )

--- a/apps/channels/channels_v2/stages/core.py
+++ b/apps/channels/channels_v2/stages/core.py
@@ -9,7 +9,7 @@ from apps.channels.channels_v2.exceptions import EarlyExitResponse
 from apps.channels.channels_v2.pipeline import MessageProcessingContext
 from apps.channels.channels_v2.stages.base import ProcessingStage
 from apps.channels.datamodels import Attachment
-from apps.chat.bots import EventBot, get_bot
+from apps.chat.bots import EvalsBot, EventBot, get_bot
 from apps.chat.channels import MARKDOWN_REF_PATTERN, MESSAGE_TYPES, _start_experiment_session, strip_urls_and_emojis
 from apps.chat.const import STATUSES_FOR_COMPLETE_CHATS
 from apps.chat.exceptions import AudioSynthesizeException, UserReportableError
@@ -419,6 +419,36 @@ class BotInteractionStage(ProcessingStage):
         if not ctx.bot:
             ctx.bot = get_bot(ctx.experiment_session, ctx.experiment, ctx.trace_service)
 
+        ctx.bot_response = ctx.bot.process_input(
+            ctx.user_query,
+            attachments=ctx.message.attachments,
+            human_message=ctx.human_message,
+        )
+        ctx.files_to_send = ctx.bot_response.get_attached_files() or []
+
+
+# ---------------------------------------------------------------------------
+# EvalsBotInteractionStage
+# ---------------------------------------------------------------------------
+
+
+class EvalsBotInteractionStage(ProcessingStage):
+    """Bot interaction for evaluations -- uses EvalsBot with in-memory participant_data.
+
+    Reads participant_data from ctx.channel_context (set by EvaluationChannel),
+    bypassing the DB-backed ParticipantData model.
+    """
+
+    def should_run(self, ctx: MessageProcessingContext) -> bool:
+        return ctx.user_query is not None
+
+    def process(self, ctx: MessageProcessingContext) -> None:
+        ctx.bot = EvalsBot(
+            ctx.experiment_session,
+            ctx.experiment,
+            ctx.trace_service,
+            participant_data=ctx.channel_context["participant_data"],
+        )
         ctx.bot_response = ctx.bot.process_input(
             ctx.user_query,
             attachments=ctx.message.attachments,

--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -8,6 +8,7 @@ from telebot import types
 from twilio.request_validator import RequestValidator
 
 from apps.channels.channels_v2.api_channel import ApiChannel
+from apps.channels.channels_v2.evaluation_channel import EvaluationChannel
 from apps.channels.channels_v2.telegram_channel import TelegramChannel
 from apps.channels.clients.connect_client import CommCareConnectClient, Message
 from apps.channels.datamodels import (
@@ -21,7 +22,6 @@ from apps.channels.datamodels import (
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import (
     CommCareConnectChannel,
-    EvaluationChannel,
     FacebookMessengerChannel,
     SureAdhereChannel,
     WhatsappChannel,

--- a/apps/channels/tests/channels/concrete/test_evaluation_channel.py
+++ b/apps/channels/tests/channels/concrete/test_evaluation_channel.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.channels.channels_v2.evaluation_channel import EvaluationChannel
+from apps.channels.datamodels import BaseMessage
+from apps.channels.models import ExperimentChannel
+from apps.channels.tasks import handle_evaluation_message
+from apps.chat.exceptions import ChannelException
+from apps.chat.models import ChatMessage
+from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+
+
+def test_requires_existing_session():
+    with pytest.raises(ChannelException, match="requires an existing session"):
+        EvaluationChannel(
+            experiment=MagicMock(),
+            experiment_channel=MagicMock(),
+            experiment_session=None,
+            participant_data={},
+        )
+
+
+@pytest.fixture()
+def evals_experiment(db):
+    return ExperimentFactory.create(team=TeamWithUsersFactory.create())
+
+
+@pytest.fixture()
+def evals_channel(evals_experiment):
+    return ExperimentChannel.objects.get_team_evaluations_channel(evals_experiment.team)
+
+
+@pytest.mark.django_db()
+class TestEvaluationChannelEndToEnd:
+    @patch("apps.channels.channels_v2.stages.core.EvalsBot")
+    def test_processes_message_with_evals_bot(self, mock_evals_bot_cls, evals_experiment, evals_channel):
+        mock_bot = MagicMock()
+        mock_bot.process_input.return_value = ChatMessage(content="Bot response")
+        mock_evals_bot_cls.return_value = mock_bot
+        session = ExperimentSessionFactory.create(experiment=evals_experiment, experiment_channel=evals_channel)
+        participant_data = {"userid": "1234"}
+
+        channel = EvaluationChannel(
+            experiment=evals_experiment,
+            experiment_channel=evals_channel,
+            experiment_session=session,
+            participant_data=participant_data,
+        )
+        message = BaseMessage(participant_id=session.participant.identifier, message_text="Hi")
+
+        result = channel.new_user_message(message)
+
+        assert isinstance(result, ChatMessage)
+        assert result.content == "Bot response"
+        mock_evals_bot_cls.assert_called_once()
+        assert mock_evals_bot_cls.call_args.kwargs["participant_data"] == participant_data
+
+    @patch("apps.channels.channels_v2.stages.core.enqueue_static_triggers")
+    @patch("apps.chat.bots.PipelineBot.process_input")
+    def test_static_triggers_suppressed(self, mock_process, mock_triggers, evals_experiment, evals_channel):
+        mock_process.return_value = ChatMessage(content="Bot response")
+        session = ExperimentSessionFactory.create(experiment=evals_experiment, experiment_channel=evals_channel)
+
+        channel = EvaluationChannel(
+            experiment=evals_experiment,
+            experiment_channel=evals_channel,
+            experiment_session=session,
+            participant_data={},
+        )
+        channel.new_user_message(BaseMessage(participant_id=session.participant.identifier, message_text="Hi"))
+
+        mock_triggers.delay.assert_not_called()
+
+    @patch("apps.chat.bots.PipelineBot.process_input")
+    def test_handle_evaluation_message_task(self, mock_process, evals_experiment, evals_channel):
+        mock_process.return_value = ChatMessage(content="Bot response")
+        session = ExperimentSessionFactory.create(experiment=evals_experiment, experiment_channel=evals_channel)
+
+        result = handle_evaluation_message(
+            experiment_version=evals_experiment,
+            experiment_channel=evals_channel,
+            message_text="Test evaluation message",
+            session=session,
+            participant_data={},
+        )
+
+        assert isinstance(result, ChatMessage)
+        assert result.content == "Bot response"

--- a/apps/channels/tests/channels/stages/test_evals_bot_interaction.py
+++ b/apps/channels/tests/channels/stages/test_evals_bot_interaction.py
@@ -1,0 +1,57 @@
+from unittest.mock import MagicMock, patch
+
+from apps.channels.channels_v2.stages.core import EvalsBotInteractionStage
+from apps.channels.tests.channels.conftest import make_context
+
+
+class TestEvalsBotInteractionStage:
+    def setup_method(self):
+        self.stage = EvalsBotInteractionStage()
+
+    def test_should_not_run_without_query(self):
+        ctx = make_context(user_query=None)
+        assert self.stage.should_run(ctx) is False
+
+    @patch("apps.channels.channels_v2.stages.core.EvalsBot")
+    def test_constructs_evals_bot_with_participant_data(self, mock_evals_bot_cls):
+        mock_bot = MagicMock()
+        mock_bot.process_input.return_value = MagicMock(content="response", get_attached_files=lambda: [])
+        mock_evals_bot_cls.return_value = mock_bot
+
+        participant_data = {"userid": "1234"}
+        experiment = MagicMock()
+        session = MagicMock()
+        trace_service = MagicMock()
+        ctx = make_context(
+            user_query="Hello",
+            experiment=experiment,
+            experiment_session=session,
+            channel_context={"participant_data": participant_data},
+            trace_service=trace_service,
+        )
+
+        self.stage(ctx)
+
+        mock_evals_bot_cls.assert_called_once_with(
+            session,
+            experiment,
+            trace_service,
+            participant_data=participant_data,
+        )
+        assert ctx.bot is mock_bot
+
+    @patch("apps.channels.channels_v2.stages.core.EvalsBot")
+    def test_sets_bot_response_and_files(self, mock_evals_bot_cls):
+        files = [MagicMock(), MagicMock()]
+        bot_response = MagicMock(content="bot says hi")
+        bot_response.get_attached_files.return_value = files
+        mock_bot = MagicMock()
+        mock_bot.process_input.return_value = bot_response
+        mock_evals_bot_cls.return_value = mock_bot
+
+        ctx = make_context(user_query="Hello", channel_context={"participant_data": {}})
+
+        self.stage(ctx)
+
+        assert ctx.bot_response is bot_response
+        assert ctx.files_to_send == files

--- a/apps/channels/tests/test_evaluation_channel.py
+++ b/apps/channels/tests/test_evaluation_channel.py
@@ -1,3 +1,4 @@
+# TODO: remove after channels refactor
 from unittest.mock import patch
 
 import pytest

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -1508,6 +1508,7 @@ def _start_experiment_session(
     return session
 
 
+# TODO: remove after channels refactor
 class EvaluationChannel(ChannelBase):
     """Message Handler for Evaluations"""
 

--- a/docs/plans/channels_refactor.md
+++ b/docs/plans/channels_refactor.md
@@ -1436,11 +1436,16 @@ class EvaluationChannel(ChannelBase):
         return ctx
 
     def _build_pipeline(self) -> MessageProcessingPipeline:
+        # ParticipantValidationStage omitted: the "evaluations" participant
+        # is internal — validating it against participant_allowlist is
+        # meaningless and would block private experiments. Nothing
+        # downstream in this pipeline reads ctx.participant_identifier.
+        # SessionResolutionStage omitted: session is always pre-set.
+        # SessionActivationStage omitted: the eval bot does not gate on
+        # session status, and legacy EvaluationChannel never activated
+        # the session either.
         return MessageProcessingPipeline(
             core_stages=[
-                ParticipantValidationStage(),
-                # No SessionResolutionStage — session always pre-set
-                SessionActivationStage(),
                 MessageTypeValidationStage(),
                 QueryExtractionStage(),
                 ChatMessageCreationStage(),
@@ -2799,7 +2804,7 @@ All decisions below were made during the plan review and are reflected throughou
 | 25 | Architecture | No web channel `_inform_user_of_error` override | Web channel no longer needs a no-op override. Error message generation is separated from sending. The generated error message flows back to the web UI via `new_user_message`'s return value. |
 | 26 | Architecture | Voice synthesis fallback in `ResponseFormattingStage` | `AudioSynthesizeException` is caught in `ResponseFormattingStage` and gracefully degraded to text formatting. Not an unrecoverable error — does not propagate to the pipeline's catch-all. Creates `audio_synthesis_failure_notification`. |
 | 27 | Architecture | `WebChannel` pipeline | Overrides `_build_pipeline` to omit `ResponseSendingStage`, `SendingErrorHandlerStage`, `SessionResolutionStage`, and `ConsentFlowStage`. Sets `supports_conversational_consent: False`. Requires pre-existing session. `start_new_session` and `check_and_process_seed_message` class methods remain on the channel class (outside the pipeline). |
-| 28 | Architecture | `EvaluationChannel` + `channel_context` | Uses `ctx.channel_context` dict to pass `participant_data` to `EvalsBotInteractionStage`. This is a **workaround** scoped to `EvaluationChannel` only — it should NOT be used as a general-purpose extension mechanism. `EvalsBotInteractionStage` replaces `BotInteractionStage` and creates `EvalsBot` instead of calling `get_bot()`. |
+| 28 | Architecture | `EvaluationChannel` + `channel_context` | Uses `ctx.channel_context` dict to pass `participant_data` to `EvalsBotInteractionStage`. This is a **workaround** scoped to `EvaluationChannel` only — it should NOT be used as a general-purpose extension mechanism. `EvalsBotInteractionStage` replaces `BotInteractionStage` and creates `EvalsBot` instead of calling `get_bot()`. The `EvaluationChannel` pipeline also omits `ParticipantValidationStage` (the internal `"evaluations"` participant fails `is_participant_allowed` on private experiments; nothing downstream reads `ctx.participant_identifier` in this pipeline) and `SessionActivationStage` (legacy never activated the session, and the bot does not gate on session status). |
 | 29 | Architecture | `NEW_HUMAN_MESSAGE` trigger in `ChatMessageCreationStage` | `enqueue_static_triggers` for `NEW_HUMAN_MESSAGE` fires in `ChatMessageCreationStage` after the DB record is created. Gated by `capabilities.supports_static_triggers` (default `True`, `EvaluationChannel` sets `False`). Session creation triggers (`PARTICIPANT_JOINED_EXPERIMENT`, `CONVERSATION_START`) remain in `_start_experiment_session`. |
 | — | Update | `PersistenceStage` (terminal) | Renamed from `EarlyExitResponseStage`. Persists early exit responses to chat history AND saves voice attachments (tag + file). Runs after sending stages. |
 | 30 | Architecture | Voice attachment persistence | `PersistenceStage` tags the bot response as "voice" and saves synthesized audio as a file attachment. Moved from post-send logic in the old `_handle_supported_message`. |


### PR DESCRIPTION
### Product Description
No change. Internal refactor of how evaluation runs route through the channel layer.

### Technical Description
PR 3 of the channels refactor (see `docs/plans/channels_refactor.md`). Migrates `EvaluationChannel` from the legacy `apps/chat/channels.py` to the new context-based pipeline under `apps/channels/channels_v2/`, and adds a custom `EvalsBotInteractionStage` that constructs `EvalsBot` directly (bypassing `get_bot()`).

Notable decisions:
- **`channel_context` workaround** — `EvaluationChannel` writes `participant_data` into `ctx.channel_context` so `EvalsBotInteractionStage` can build `EvalsBot` without a DB lookup. The context field is documented as scoped to this channel only; it should not be used as a general extension mechanism.
- **Pipeline omissions**: `ParticipantValidationStage` (the internal `"evaluations"` participant fails `is_participant_allowed` on private experiments; nothing downstream in this pipeline reads `ctx.participant_identifier`), `SessionResolutionStage` (session always pre-set), `SessionActivationStage` (legacy never activated the session and the eval bot does not gate on status), `ConsentFlowStage`, and all sending stages.
- **Static triggers suppressed**: `ChannelCapabilities.supports_static_triggers=False` so `NEW_HUMAN_MESSAGE` does not fire during eval runs, matching legacy behavior.
- **Trace service**: overrides `_create_trace_service` to return `TracingService.empty()`.

Legacy `EvaluationChannel` in `apps/chat/channels.py` and the legacy test file are marked with `# TODO: remove after channels refactor` so they can be deleted in a follow-up PR once all v2 channels land.

Closes #3333.

### Demo
No user-facing change.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

This is an internal refactor with no behavior change for users — no changelog entry needed.