### PR TITLE
Use email_subject from session state as email subject

### DIFF
--- a/apps/channels/channels_v2/email_channel.py
+++ b/apps/channels/channels_v2/email_channel.py
@@ -322,10 +322,21 @@ class EmailChannel(ChannelBase):
     def _get_sender(self) -> EmailSender:
         extra = self.experiment_channel.extra_data
         email_address = extra.get("email_address", "")
+
+        thread_context = self.thread_context
+        if not thread_context.subject and self.experiment_session:
+            custom_subject = self.experiment_session.state.get("email_subject")
+            if custom_subject:
+                thread_context = EmailThreadContext(
+                    subject=custom_subject,
+                    in_reply_to=thread_context.in_reply_to,
+                    references=thread_context.references,
+                )
+
         self._sender_instance = EmailSender(
             from_address=extra.get("from_address") or email_address,
             domain=_domain_from_address(email_address),
-            thread_context=self.thread_context,
+            thread_context=thread_context,
         )
         return self._sender_instance
 

--- a/apps/channels/channels_v2/email_channel.py
+++ b/apps/channels/channels_v2/email_channel.py
@@ -325,10 +325,11 @@ class EmailChannel(ChannelBase):
 
         thread_context = self.thread_context
         if not thread_context.subject and self.experiment_session:
-            custom_subject = self.experiment_session.state.get("email_subject")
-            if custom_subject:
+            state = self.experiment_session.state or {}
+            custom_subject = state.get("email_subject")
+            if isinstance(custom_subject, str) and custom_subject.strip():
                 thread_context = EmailThreadContext(
-                    subject=custom_subject,
+                    subject=custom_subject.strip(),
                     in_reply_to=thread_context.in_reply_to,
                     references=thread_context.references,
                 )

--- a/apps/channels/tests/test_email_channel.py
+++ b/apps/channels/tests/test_email_channel.py
@@ -546,6 +546,56 @@ class TestEmailChannel:
         callbacks = email_channel._get_callbacks()
         assert isinstance(callbacks, ChannelCallbacks)
 
+    def test_get_sender_uses_email_subject_from_session_state(self):
+        """email_subject in session.state is used as subject when no thread context subject exists."""
+        channel_mock = MagicMock()
+        channel_mock.extra_data = {"email_address": "bot@chat.openchatstudio.com"}
+        experiment_mock = MagicMock()
+        session_mock = MagicMock()
+        session_mock.state = {"email_subject": "Custom Subject"}
+
+        email_channel = EmailChannel(experiment_mock, channel_mock, session_mock)
+        sender = email_channel._get_sender()
+
+        assert isinstance(sender, EmailSender)
+        assert sender.thread_context.subject == "Custom Subject"
+
+    def test_get_sender_defaults_to_new_message_when_no_email_subject(self):
+        """When session.state has no email_subject, EmailSender defaults to 'New message' on flush."""
+        channel_mock = MagicMock()
+        channel_mock.extra_data = {"email_address": "bot@chat.openchatstudio.com"}
+        experiment_mock = MagicMock()
+        session_mock = MagicMock()
+        session_mock.state = {}
+
+        email_channel = EmailChannel(experiment_mock, channel_mock, session_mock)
+        sender = email_channel._get_sender()
+
+        assert isinstance(sender, EmailSender)
+        assert sender.thread_context.subject == ""
+        sender.send_text("Hello", "user@example.com")
+        sender.flush()
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].subject == "New message"
+
+    def test_get_sender_does_not_override_existing_thread_subject(self):
+        """Inbound reply threads (thread_context.subject already set) are unaffected by session state."""
+        channel_mock = MagicMock()
+        channel_mock.extra_data = {"email_address": "bot@chat.openchatstudio.com"}
+        experiment_mock = MagicMock()
+        session_mock = MagicMock()
+        session_mock.state = {"email_subject": "Custom Subject"}
+
+        inbound_ctx = EmailThreadContext(
+            subject="Re: Original Subject",
+            in_reply_to="<orig@example.com>",
+            references=["<orig@example.com>"],
+        )
+        email_channel = EmailChannel(experiment_mock, channel_mock, session_mock, thread_context=inbound_ctx)
+        sender = email_channel._get_sender()
+
+        assert sender.thread_context.subject == "Re: Original Subject"
+
 
 @pytest.mark.django_db()
 class TestEnsureSessionExistsForParticipant:

--- a/apps/channels/tests/test_email_channel.py
+++ b/apps/channels/tests/test_email_channel.py
@@ -596,6 +596,33 @@ class TestEmailChannel:
 
         assert sender.thread_context.subject == "Re: Original Subject"
 
+    @pytest.mark.parametrize("bad_value", [123, ["list"], {"dict": True}, "   ", None])
+    def test_get_sender_ignores_invalid_email_subject(self, bad_value):
+        """Non-string and whitespace-only email_subject values are ignored."""
+        channel_mock = MagicMock()
+        channel_mock.extra_data = {"email_address": "bot@chat.openchatstudio.com"}
+        experiment_mock = MagicMock()
+        session_mock = MagicMock()
+        session_mock.state = {"email_subject": bad_value}
+
+        email_channel = EmailChannel(experiment_mock, channel_mock, session_mock)
+        sender = email_channel._get_sender()
+
+        assert sender.thread_context.subject == ""
+
+    def test_get_sender_strips_whitespace_from_email_subject(self):
+        """Leading/trailing whitespace is stripped from email_subject."""
+        channel_mock = MagicMock()
+        channel_mock.extra_data = {"email_address": "bot@chat.openchatstudio.com"}
+        experiment_mock = MagicMock()
+        session_mock = MagicMock()
+        session_mock.state = {"email_subject": "  Hello World  "}
+
+        email_channel = EmailChannel(experiment_mock, channel_mock, session_mock)
+        sender = email_channel._get_sender()
+
+        assert sender.thread_context.subject == "Hello World"
+
 
 @pytest.mark.django_db()
 class TestEnsureSessionExistsForParticipant:


### PR DESCRIPTION
### Product Description
When sending outbound email messages (e.g. via the trigger_bot API), callers can now set `email_subject` in the session data to control the email subject line. Previously all outbound messages defaulted to `"New message"`.

### Technical Description
In `EmailChannel._get_sender()`, if `self.thread_context.subject` is empty (i.e. not an inbound reply thread) and the session state contains `email_subject`, a new `EmailThreadContext` is created with that subject. Inbound reply threads are unaffected since their `thread_context.subject` is already populated by `EmailThreadContext.from_inbound()`.

Three new tests added covering: custom subject used, default fallback when absent, inbound thread unaffected.

### Migrations
No migrations.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Fixes #3379