### PR TITLE
Guard against nullable platform/experiment_channel on session

### DIFF
--- a/api-schema.yml
+++ b/api-schema.yml
@@ -1860,6 +1860,7 @@ components:
         channel:
           type: string
           readOnly: true
+          nullable: true
       required:
       - channel
       - session_id

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -328,7 +328,7 @@ class TriggerBotMessageResponse(serializers.ModelSerializer):
         view_name="api:session-detail", lookup_field="external_id", lookup_url_kwarg="id"
     )
     team = TeamSerializer(read_only=True)
-    channel = serializers.CharField(source="platform", read_only=True)
+    channel = serializers.CharField(source="platform", read_only=True, allow_null=True)
 
     class Meta:
         model = ExperimentSession

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -100,7 +100,7 @@ def trigger_bot_message_task(session_external_id: str, prompt_text: str | None, 
 
     experiment = session.experiment
     target_experiment = resolve_published_or_working(experiment)
-    ChannelClass = ChannelBase.get_channel_class_for_platform(session.experiment_channel.platform)
+    ChannelClass = ChannelBase.get_channel_class_for_platform(session.platform)
     channel = ChannelClass(
         experiment=target_experiment,
         experiment_channel=session.experiment_channel,


### PR DESCRIPTION
### Product Description
No user-facing change — defensive fixes for edge cases with older sessions.

### Technical Description
Two small follow-ups to #3373:

1. **`trigger_bot_message_task`**: was accessing `session.experiment_channel.platform` to determine the channel class, but `experiment_channel` is a nullable FK. Use `session.platform` directly instead (it holds the same value, set at session creation time, without the nullable traversal).

2. **`TriggerBotMessageResponse.channel`**: `ExperimentSession.platform` is `null=True` on the model. Added `allow_null=True` to the serializer field so older sessions without a platform set don't cause a serialization error.

### Migrations
No migrations.

### Docs and Changelog
- [ ] This PR requires docs/changelog update