### PR TITLE
Allow Chatbot Admin and Chat Viewer groups to download files

### DIFF
--- a/apps/files/tests/test_file_view_permissions.py
+++ b/apps/files/tests/test_file_view_permissions.py
@@ -1,0 +1,38 @@
+import pytest
+from django.urls import reverse
+
+from apps.teams.backends import (
+    CHAT_VIEWER_GROUP,
+    CHATBOT_ADMIN_GROUP,
+    add_user_to_team,
+    create_default_groups,
+)
+from apps.utils.factories.files import FileFactory
+from apps.utils.factories.team import TeamFactory
+from apps.utils.factories.user import UserFactory
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("group_name", [CHATBOT_ADMIN_GROUP, CHAT_VIEWER_GROUP])
+def test_file_view_accessible_to_group(client, group_name):
+    """Regression test for #925: members of these groups can download a team File.
+
+    FileView is gated by `files.view_file`. Without that permission a logged-in
+    member who can generate a chat export (Chatbot Admin) or view a session
+    attachment (Chat Viewer) is denied on download.
+
+    create_default_groups() is called explicitly so the DB-backed groups reflect
+    the current backends.py definition even though pytest runs with --reuse-db.
+    """
+    create_default_groups()
+    team = TeamFactory.create()
+    user = UserFactory.create()
+    add_user_to_team(team, user, groups=[group_name])
+    file = FileFactory.create(team=team)
+
+    client.force_login(user)
+    url = reverse("files:base", args=[team.slug, file.id])
+    response = client.get(url)
+
+    # 200 means FileView served the file; a missing files.view_file would 302-redirect to login.
+    assert response.status_code == 200

--- a/apps/teams/backends.py
+++ b/apps/teams/backends.py
@@ -201,6 +201,7 @@ GROUPS = [
             ModelPermSetDef("annotations", "usercomment", ALL),
             CustomPermissionSetDef("experiments", CUSTOM_PERMISSIONS["experiments"]),
             AppPermSetDef("documents", ALL),
+            ModelPermSetDef("files", "file", [VIEW]),
         ],
     ),
     GroupDef(
@@ -208,6 +209,7 @@ GROUPS = [
         [
             AppPermSetDef("chat", [VIEW]),
             AppPermSetDef("annotations", [VIEW]),
+            ModelPermSetDef("files", "file", [VIEW]),
         ],
     ),
     GroupDef(

--- a/apps/teams/tests/test_permissions.py
+++ b/apps/teams/tests/test_permissions.py
@@ -175,6 +175,41 @@ def test_chatbot_admin_documents_permissions_regression():
     assert "delete_collection" in codenames
 
 
+def _group_codenames(group_name):
+    """All permission codenames granted to the named group across its permission_defs."""
+    group = next(g for g in GROUPS if g.name == group_name)
+    return {codename for perm_def in group.permission_defs for codename in perm_def.codenames}
+
+
+def test_chatbot_admin_can_view_files_regression():
+    """Regression test for #925: Chatbot Admin must include files.view_file.
+
+    `generate_chat_export` produces a `File` and the rendered download link points at
+    `files:base` (FileView), which requires `files.view_file`. Without this perm the
+    Chatbot Admin user successfully generates the export and sees the link, but the
+    actual download is denied.
+    """
+    from apps.teams.backends import CHATBOT_ADMIN_GROUP  # noqa: PLC0415
+
+    assert "view_file" in _group_codenames(CHATBOT_ADMIN_GROUP), (
+        "Chatbot Admin must include files.view_file so users who can generate chat "
+        "exports can also download the resulting File object via FileView."
+    )
+
+
+def test_chat_viewer_can_view_files_regression():
+    """Regression test for #925: Chat Viewer must include files.view_file.
+
+    Chat Viewer users download session attachments via FileView, which requires
+    `files.view_file`. Without it the download is denied.
+    """
+    from apps.teams.backends import CHAT_VIEWER_GROUP  # noqa: PLC0415
+
+    assert "view_file" in _group_codenames(CHAT_VIEWER_GROUP), (
+        "Chat Viewer must include files.view_file so users can download session attachments via FileView."
+    )
+
+
 def test_custom_permissions():
     mapped_permissions = [
         permission

--- a/apps/teams/tests/test_permissions.py
+++ b/apps/teams/tests/test_permissions.py
@@ -5,6 +5,8 @@ from django.contrib.auth.models import Group
 from apps.teams.backends import (
     ALL,
     CHANGE,
+    CHAT_VIEWER_GROUP,
+    CHATBOT_ADMIN_GROUP,
     CONTENT_TYPES,
     CUSTOM_PERMISSIONS,
     GROUPS,
@@ -155,8 +157,6 @@ def test_chatbot_admin_documents_permissions_regression():
     Django's auto-generated permission codenames ("view_collection", etc.), resulting in zero
     permissions being granted for documents.
     """
-    from apps.teams.backends import CHATBOT_ADMIN_GROUP  # noqa: PLC0415
-
     chatbot_admin = next(g for g in GROUPS if g.name == CHATBOT_ADMIN_GROUP)
     documents_def = next(pd for pd in chatbot_admin.permission_defs if pd.app_label == "documents")
 
@@ -189,8 +189,6 @@ def test_chatbot_admin_can_view_files_regression():
     Chatbot Admin user successfully generates the export and sees the link, but the
     actual download is denied.
     """
-    from apps.teams.backends import CHATBOT_ADMIN_GROUP  # noqa: PLC0415
-
     assert "view_file" in _group_codenames(CHATBOT_ADMIN_GROUP), (
         "Chatbot Admin must include files.view_file so users who can generate chat "
         "exports can also download the resulting File object via FileView."
@@ -203,8 +201,6 @@ def test_chat_viewer_can_view_files_regression():
     Chat Viewer users download session attachments via FileView, which requires
     `files.view_file`. Without it the download is denied.
     """
-    from apps.teams.backends import CHAT_VIEWER_GROUP  # noqa: PLC0415
-
     assert "view_file" in _group_codenames(CHAT_VIEWER_GROUP), (
         "Chat Viewer must include files.view_file so users can download session attachments via FileView."
     )


### PR DESCRIPTION
### Product Description

Users assigned the **Chatbot Admin** or **Chat Viewer** group could not download
files. A Chatbot Admin could generate a chat export but hit a permission error
when clicking the download link; a Chat Viewer hit the same wall on session
attachment downloads. Members of both groups can now download these files as
expected.

### Technical Description

`FileView` (`apps/files/views.py`) is gated by the `files.view_file` permission,
but neither the `Chatbot Admin` nor `Chat Viewer` group held any `files`
permission — only `Assistant Admin` did. The export-download link (and session
attachment downloads) therefore returned a permission denial.

This adds `ModelPermSetDef("files", "file", [VIEW])` to both groups in
`apps/teams/backends.py`:

- **Chatbot Admin** — for chat-export downloads and collection (documents) file access.
- **Chat Viewer** — for session attachment downloads.

Scoped to `view_file` only, not the full `files` set: collection file add/delete
is already gated by `documents.change_collection`, so the read permission was the
only thing missing. No data migration is required — permission groups re-sync
from `GROUPS` on every `migrate` via the existing post-migrate signal.

Note: with the permission missing, `permission_required` redirects an
already-logged-in user back to the login page, which surfaces in the browser as a
redirect loop (`ERR_TOO_MANY_REDIRECTS`) rather than a clean 403. Granting the
permission resolves the reported bug; tightening that denial to a proper 403 would
be a separate follow-up.

Tests added:

- `apps/teams/tests/test_permissions.py` — regression tests asserting each group's
  definition includes `view_file`.
- `apps/files/tests/test_file_view_permissions.py` — view-level test that a user
  holding only `Chatbot Admin`, and one holding only `Chat Viewer`, can `GET`
  `FileView` and receive the file instead of a redirect.

### Migrations

- [x] The migrations are backwards compatible

_No migrations in this PR — permission groups re-sync from `apps/teams/backends.py`
on every `migrate` via the existing post-migrate signal._

### Demo

**Before** — a user in both the Chatbot Admin and Chat Viewer groups generates a
chat export, clicks "Download export", and the download fails (the `files.view_file`
denial bouncing through the login redirect → `ERR_TOO_MANY_REDIRECTS`):

<img width="400" alt="before-3-download-denied" src="https://github.com/user-attachments/assets/a19a1320-7988-45f8-8657-3232f0875f4d" />

**After** — the same user downloads the export successfully and opens it:
<img width="400" alt="after-1-download-dialog" src="https://github.com/user-attachments/assets/f1c5d962-92d5-4e4f-b8d2-a86d87c3d7f5" />
<img width="400" alt="after-2-csv-in-excel" src="https://github.com/user-attachments/assets/007c6799-afba-4673-ac0b-a1359f67e9c3" />

### Docs and Changelog

- [ ] This PR requires docs/changelog update

Fixes #925
