### PR TITLE
refactor(export): use ChatMessage as primary export unit instead of Trace

### DIFF
--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -132,10 +132,8 @@ def _build_session_cache_entry(session) -> dict:
     }
 
 
-def _build_message_row(message, participant_data, sc, experiment, trace_id, translation_language) -> list | None:
-    """Return an export row list for *message*, or None if the message is absent."""
-    if message is None:
-        return None
+def _build_message_row(message, participant_data, sc, experiment, trace_id, translation_language) -> list:
+    """Return an export row list for *message*."""
     content = get_message_content(message, translation_language) if translation_language else message.content
     row = [
         message.id,
@@ -163,7 +161,7 @@ def _build_message_row(message, participant_data, sc, experiment, trace_id, tran
     return row
 
 
-def _yield_row_for_message(message, session_cache, experiment, translation_language) -> list | None:
+def _yield_row_for_message(message, session_cache, experiment, translation_language) -> list:
     """Return an export row for a single message."""
     session = message.chat.experiment_session
     if session.id not in session_cache:
@@ -181,7 +179,8 @@ def generate_export_rows(experiment, sessions_queryset, translation_language=Non
     that memory usage stays bounded regardless of dataset size.  Session-level values
     (platform name, state JSON, participant fields, chat tags/comments) are cached the
     first time each session is encountered so they are serialised only once no matter
-    how many messages belong to that session.
+    how many messages belong to that session.  The cache stores plain strings/dicts
+    (not ORM objects) so its footprint is small even for experiments with many sessions.
     """
     yield _get_export_header(translation_language)
 
@@ -195,9 +194,7 @@ def generate_export_rows(experiment, sessions_queryset, translation_language=Non
             break
 
         for message in chunk:
-            row = _yield_row_for_message(message, session_cache, experiment, translation_language)
-            if row is not None:
-                yield row
+            yield _yield_row_for_message(message, session_cache, experiment, translation_language)
 
         last_pk = chunk[-1].pk
         if len(chunk) < EXPORT_CHUNK_SIZE:

--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -9,10 +9,10 @@ import dictdiffer
 
 from apps.analysis.translation import get_message_content
 from apps.annotations.models import Tag, UserComment
+from apps.chat.models import ChatMessage
 from apps.experiments.filters import ExperimentSessionFilter
 from apps.experiments.models import ExperimentSession
 from apps.service_providers.tracing import OCS_TRACE_PROVIDER
-from apps.trace.models import Trace
 from apps.web.dynamic_filters.datastructures import FilterParams
 
 _SPOOLED_MAX_BYTES = 10 * 1024 * 1024  # 10 MB threshold before spilling to disk
@@ -44,46 +44,48 @@ def get_filtered_sessions(experiment, query_params, timezone):
     return sessions_queryset
 
 
-def _get_participant_data_for_trace(trace):
-    """Returns (start_data, end_data) for a trace.
+def _get_participant_data_for_message(message) -> dict:
+    """Return participant data for a message by looking up its associated trace.
 
-    start_data is the participant_data snapshot at the beginning of the trace.
-    end_data is computed by applying participant_data_diff to start_data.
-    If the diff is empty, end_data equals start_data.
+    For human (input) messages: returns the snapshot at the start of the trace.
+    For AI (output) messages: applies the trace diff to get the end snapshot.
     """
-    start_data = trace.participant_data or {}
-    if trace.participant_data_diff:
-        end_data = dictdiffer.patch(trace.participant_data_diff, start_data)
-    else:
-        end_data = start_data
-    return start_data, end_data
+    if message.is_human_message:
+        traces = list(message.input_message_trace.all())
+        if traces:
+            return traces[0].participant_data or {}
+    elif message.is_ai_message:
+        traces = list(message.output_message_trace.all())
+        if traces:
+            trace = traces[0]
+            start_data = trace.participant_data or {}
+            if trace.participant_data_diff:
+                return dictdiffer.patch(trace.participant_data_diff, start_data)
+            return start_data
+    return {}
 
 
-def _build_trace_queryset(sessions_queryset):
-    """Return the base Trace queryset for export, ordered by pk for keyset pagination."""
+def _build_message_queryset(sessions_queryset):
+    """Return the base ChatMessage queryset for export, ordered by pk for keyset pagination."""
     return (
-        Trace.objects.filter(
-            session__in=sessions_queryset,
-            input_message__isnull=False,
+        ChatMessage.objects.filter(
+            chat__experiment_session__in=sessions_queryset,
         )
         .select_related(
-            "input_message",
-            "output_message",
-            "session",
-            "session__participant",
-            "session__experiment_channel",
-            "session__chat",  # OneToOneField: explicit JOIN beats implicit prefetch
+            "chat",
+            "chat__experiment_session",
+            "chat__experiment_session__participant",
+            "chat__experiment_session__experiment_channel",
         )
         .prefetch_related(
-            "input_message__tags",
-            "input_message__comments",
-            "input_message__comments__user",
-            "output_message__tags",
-            "output_message__comments",
-            "output_message__comments__user",
-            "session__chat__tags",
-            "session__chat__comments",
-            "session__chat__comments__user",
+            "tags",
+            "comments",
+            "comments__user",
+            "chat__tags",
+            "chat__comments",
+            "chat__comments__user",
+            "input_message_trace",
+            "output_message_trace",
         )
         .order_by("pk")
     )
@@ -161,37 +163,30 @@ def _build_message_row(message, participant_data, sc, experiment, trace_id, tran
     return row
 
 
-def _yield_rows_for_trace(trace, session_cache, experiment, translation_language) -> Generator[list]:
-    """Yield one export row per message (input + output) for a single trace."""
-    start_data, end_data = _get_participant_data_for_trace(trace)
-    trace_id = _get_trace_id_for_export(trace.input_message)
-    session = trace.session
-
+def _yield_row_for_message(message, session_cache, experiment, translation_language) -> list | None:
+    """Return an export row for a single message."""
+    session = message.chat.experiment_session
     if session.id not in session_cache:
         session_cache[session.id] = _build_session_cache_entry(session)
     sc = session_cache[session.id]
-
-    for message, participant_data in [(trace.input_message, start_data), (trace.output_message, end_data)]:
-        row = _build_message_row(message, participant_data, sc, experiment, trace_id, translation_language)
-        if row is not None:
-            yield row
+    participant_data = _get_participant_data_for_message(message)
+    trace_id = _get_trace_id_for_export(message)
+    return _build_message_row(message, participant_data, sc, experiment, trace_id, translation_language)
 
 
 def generate_export_rows(experiment, sessions_queryset, translation_language=None) -> Generator[list]:
-    """Yield the header row, then one data row per message across all matching traces.
+    """Yield the header row, then one data row per message across all matching sessions.
 
-    Traces are processed in chunks of EXPORT_CHUNK_SIZE using keyset pagination so
+    Messages are processed in chunks of EXPORT_CHUNK_SIZE using keyset pagination so
     that memory usage stays bounded regardless of dataset size.  Session-level values
     (platform name, state JSON, participant fields, chat tags/comments) are cached the
     first time each session is encountered so they are serialised only once no matter
-    how many traces belong to that session.
+    how many messages belong to that session.
     """
     yield _get_export_header(translation_language)
 
-    base_qs = _build_trace_queryset(sessions_queryset)
+    base_qs = _build_message_queryset(sessions_queryset)
     last_pk = 0
-    # Cache stores plain strings/dicts (not ORM objects) so its footprint is small
-    # even for experiments with many sessions.
     session_cache: dict[int, dict] = {}
 
     while True:
@@ -199,12 +194,13 @@ def generate_export_rows(experiment, sessions_queryset, translation_language=Non
         if not chunk:
             break
 
-        for trace in chunk:
-            yield from _yield_rows_for_trace(trace, session_cache, experiment, translation_language)
+        for message in chunk:
+            row = _yield_row_for_message(message, session_cache, experiment, translation_language)
+            if row is not None:
+                yield row
 
         last_pk = chunk[-1].pk
         if len(chunk) < EXPORT_CHUNK_SIZE:
-            # Partial chunk means we've reached the end; skip the extra query.
             break
 
 
@@ -293,6 +289,9 @@ def _get_trace_id_for_export(message):
     """Returns the trace info from the message.
     This will return the first non-OCS trace info if it exists.
     """
+    if not message:
+        return ""
+
     if trace_infos := message.trace_info:
         non_ocs_trace = [
             info

--- a/apps/experiments/tests/test_export.py
+++ b/apps/experiments/tests/test_export.py
@@ -228,96 +228,82 @@ def test_participant_data_export_empty_data():
     assert json.loads(rows[2][pd_index]) == {}
 
 
-def test_trace_id_export():
-    input_msg_legacy = Mock(
-        id="msg1",
-        message_type="human",
-        content="Hello",
-        created_at="2024-01-01",
-        trace_info=[{"trace_id": "trace123"}],
-        tags=Mock(all=Mock(return_value=[])),
-        comments=Mock(all=Mock(return_value=[])),
-    )
-    output_msg_legacy = Mock(
-        id="msg2",
-        message_type="ai",
-        content="Hi",
-        created_at="2024-01-01",
-        trace_info=[],
-        tags=Mock(all=Mock(return_value=[])),
-        comments=Mock(all=Mock(return_value=[])),
-    )
+def test_trace_id_resolved_per_message_trace_info():
+    """Each message's Trace ID column comes from its own trace_info, not from a paired message.
 
-    input_msg_langfuse = Mock(
-        id="msg3",
-        message_type="human",
-        content="Hello again",
-        created_at="2024-01-01",
-        trace_info=[
-            {"trace_id": "traceABC", "trace_provider": OCS_TRACE_PROVIDER},
-            {"trace_id": "trace456", "trace_provider": "langfuse"},
-        ],
-        tags=Mock(all=Mock(return_value=[])),
-        comments=Mock(all=Mock(return_value=[])),
-    )
-    output_msg_langfuse = Mock(
-        id="msg4",
-        message_type="ai",
-        content="Hi again",
-        created_at="2024-01-01",
-        trace_info=[],
-        tags=Mock(all=Mock(return_value=[])),
-        comments=Mock(all=Mock(return_value=[])),
-    )
-
+    Verifies three cases:
+    - Legacy trace_info (no trace_provider): trace_id is used as-is.
+    - Multiple providers: OCS entries are excluded; the first non-OCS entry wins.
+    - Messages with no trace_info (e.g. AI responses): Trace ID column is empty.
+    """
     session = Mock(
+        id=1,
         external_id="session123",
         state={},
         get_platform_name=Mock(return_value="TestPlatform"),
         participant=Mock(name="Test Participant", identifier="participant123", public_id="public123"),
         chat=Mock(tags=Mock(all=Mock(return_value=[])), comments=Mock(all=Mock(return_value=[]))),
     )
+    empty_trace = Mock(participant_data={}, participant_data_diff=[])
 
-    trace1 = Mock(
-        input_message=input_msg_legacy,
-        output_message=output_msg_legacy,
-        session=session,
-        participant_data={},
-        participant_data_diff=[],
-        timestamp="2024-01-01T00:00:00",
-    )
-    trace2 = Mock(
-        input_message=input_msg_langfuse,
-        output_message=output_msg_langfuse,
-        session=session,
-        participant_data={},
-        participant_data_diff=[],
-        timestamp="2024-01-01T00:01:00",
-    )
+    def make_message(msg_id, is_human, content, trace_info):
+        msg = Mock(
+            id=msg_id,
+            message_type="human" if is_human else "ai",
+            content=content,
+            created_at="2024-01-01",
+            trace_info=trace_info,
+            is_human_message=is_human,
+            is_ai_message=not is_human,
+            tags=Mock(all=Mock(return_value=[])),
+            comments=Mock(all=Mock(return_value=[])),
+        )
+        msg.chat.experiment_session = session
+        if is_human:
+            msg.input_message_trace.all.return_value = [empty_trace]
+        else:
+            msg.output_message_trace.all.return_value = [empty_trace]
+        return msg
+
+    messages = [
+        make_message("msg1", True, "Hello", [{"trace_id": "trace123"}]),
+        make_message("msg2", False, "Hi", []),
+        make_message(
+            "msg3",
+            True,
+            "Hello again",
+            [
+                {"trace_id": "traceABC", "trace_provider": OCS_TRACE_PROVIDER},
+                {"trace_id": "trace456", "trace_provider": "langfuse"},
+            ],
+        ),
+        make_message("msg4", False, "Hi again", []),
+    ]
 
     experiment = Mock(public_id="exp123", name="Test Experiment")
 
     # Build a chainable mock queryset that supports the keyset-pagination pattern:
-    # Trace.objects.filter(...).select_related(...).prefetch_related(...).order_by("pk")
-    # then base_qs.filter(pk__gt=last_pk)[:CHUNK_SIZE] → [trace1, trace2]
-    mock_traces_qs = MagicMock()
-    mock_traces_qs.select_related.return_value = mock_traces_qs
-    mock_traces_qs.prefetch_related.return_value = mock_traces_qs
-    mock_traces_qs.order_by.return_value = mock_traces_qs
-    # .filter(pk__gt=...) returns a sliceable mock; [:chunk_size] yields the two traces
-    mock_traces_qs.filter.return_value.__getitem__ = Mock(return_value=[trace1, trace2])
+    # ChatMessage.objects.filter(...).select_related(...).prefetch_related(...).order_by("pk")
+    # then base_qs.filter(pk__gt=last_pk)[:CHUNK_SIZE] → messages
+    mock_messages_qs = MagicMock()
+    mock_messages_qs.select_related.return_value = mock_messages_qs
+    mock_messages_qs.prefetch_related.return_value = mock_messages_qs
+    mock_messages_qs.order_by.return_value = mock_messages_qs
+    mock_messages_qs.filter.return_value.__getitem__ = Mock(return_value=messages)
 
-    with patch("apps.experiments.export.Trace.objects.filter", return_value=mock_traces_qs):
+    with patch("apps.experiments.export.ChatMessage.objects.filter", return_value=mock_messages_qs):
         csv_in_memory = filtered_export_to_csv(experiment, Mock())
         rows = list(csv.reader(io.StringIO(csv_in_memory.getvalue()), delimiter=","))
 
     header = rows[0]
     trace_id_index = header.index("Trace ID")
 
-    assert rows[1][trace_id_index] == "trace123"  # human msg from trace1 (legacy)
-    assert rows[2][trace_id_index] == "trace123"  # ai msg from trace1 (same trace_id)
-    assert rows[3][trace_id_index] == "trace456"  # human msg from trace2 (langfuse)
-    assert rows[4][trace_id_index] == "trace456"  # ai msg from trace2 (same trace_id)
+    # Each message's trace_id comes from its own trace_info; AI messages with no
+    # trace_info get an empty string.
+    assert rows[1][trace_id_index] == "trace123"  # human msg (legacy trace_info)
+    assert rows[2][trace_id_index] == ""  # ai msg has no trace_info
+    assert rows[3][trace_id_index] == "trace456"  # human msg (langfuse, OCS excluded)
+    assert rows[4][trace_id_index] == ""  # ai msg has no trace_info
 
 
 @pytest.mark.django_db()

--- a/apps/experiments/tests/test_export.py
+++ b/apps/experiments/tests/test_export.py
@@ -85,7 +85,7 @@ def test_filtered_export_with_mocked_filter(mock_get_filtered_sessions, session_
     csv_in_memory = filtered_export_to_csv(experiment, filtered_queryset)
     csv_content = csv_in_memory.getvalue()
     csv_lines = csv_content.strip().split("\n") if csv_content.strip() else []
-    # Each trace produces 2 rows (human + AI), plus 1 header
+    # Each session produces 2 rows (human + AI message), plus 1 header
     expected_rows = len(filtered_indices) * 2 + 1
     assert len(csv_lines) == expected_rows
 


### PR DESCRIPTION
### Product Description
Fixes an issue where AI messages without human responses were not being exported.

### Technical Description
The export pipeline previously iterated over `Trace` objects to find messages to export. Traces were only used as the join between input/output messages and participant data snapshots — the messages themselves, session info, tags, and comments all came from related objects.

This refactor makes `ChatMessage` the primary iteration unit (again). The associated `Trace` is now only consulted when resolving participant data (via the `input_message_trace` / `output_message_trace` reverse relations, which are prefetched). This has two benefits:

- Messages that exist without a corresponding trace (e.g. pre-tracing data) are now included in exports.
- The query path is simpler: start from messages, go up to session, rather than starting from traces and walking through both messages and session.

One minor behavioural change: the "Trace ID" column now comes from each message's own `trace_info`. Previously both the human and AI rows for a given trace shared the trace ID sourced from the input message. AI response messages typically have no `trace_info`, so their Trace ID column will now be empty where it was previously propagated from the input message.

### Docs and Changelog
- [x] This PR requires docs/changelog update