### PR TITLE
chore: use symlinks instead of copies for .env and .envrc in worktrees

### DIFF
--- a/.claude/hooks/setup-env.sh
+++ b/.claude/hooks/setup-env.sh
@@ -12,8 +12,8 @@ if [ "$CURRENT_PATH" != "$ROOT_WORKTREE_PATH" ]; then
     echo "[ocs] Setting up worktree at $CURRENT_PATH"
     export ROOT_WORKTREE_PATH
 
-    [ -f "$ROOT_WORKTREE_PATH/.env" ]   && [ ! -f ".env" ]   && cp "$ROOT_WORKTREE_PATH/.env"   .env
-    [ -f "$ROOT_WORKTREE_PATH/.envrc" ] && [ ! -f ".envrc" ] && cp "$ROOT_WORKTREE_PATH/.envrc" .envrc
+    [ -f "$ROOT_WORKTREE_PATH/.env" ]   && [ ! -e ".env" ]   && ln -s "$ROOT_WORKTREE_PATH/.env"   .env
+    [ -f "$ROOT_WORKTREE_PATH/.envrc" ] && [ ! -e ".envrc" ] && ln -s "$ROOT_WORKTREE_PATH/.envrc" .envrc
     if [ -f "$ROOT_WORKTREE_PATH/.python-version" ] && [ ! -f ".python-version" ]; then
         cp "$ROOT_WORKTREE_PATH/.python-version" .python-version
     fi


### PR DESCRIPTION
### Product Description
No user-facing change.

### Technical Description
In the worktree setup hook, \`.env\` and \`.envrc\` were being copied from the root worktree. This switches to symlinks so that any updates to those files in the root are automatically reflected in all worktrees without needing to re-run setup.

Uses \`[ ! -e ... ]\` (instead of \`[ ! -f ... ]\`) to correctly detect existing symlinks before creating new ones.

### Docs and Changelog
- [ ] This PR requires docs/changelog update