### PR TITLE
docs(assessments): UI design briefs for unified assessment

### DIFF
--- a/docs/design/ui/01-config-assessment-schema-scorers.md
+++ b/docs/design/ui/01-config-assessment-schema-scorers.md
@@ -1,0 +1,295 @@
+# 01 — Config: Assessment, Schema, and Scorers
+
+> The user-facing configuration surface for the unified assessment system. Covers everything a Bot Builder or Team Lead sets up *before* an Assessment starts producing Scores: the Assessment list and detail shell, the creation/edit flow, the AssessmentSchema catalogue and editor, and the AutomatedScorer / HumanScorer configuration forms.
+>
+> **Anchored to** [`../unified-assessment.md`](../unified-assessment.md): D-3 (bot_version moves to run), D-7 (two prior-score visibility knobs), D-8 (schema clone-and-repoint), D-10 (shared schema with per-scorer output_fields), D-11 (IRR sampling).
+>
+> **Out of scope** — covered by other briefs: Source configuration and RoutingRule builder (brief 02), review workflow (brief 03), runs/trends/concordance (brief 04).
+
+## User stories addressed
+
+This cluster of screens is the *configuration* entry point for every story. Specifically it lets a user express:
+
+- Story 1, 3, 4 — set up one or more `AutomatedScorer`s on an Assessment.
+- Story 5, 8, 9 — set up a `HumanScorer` with assignees, review count, and IRR sampling.
+- Story 2 — mix automated and human scorers on one Assessment (calibration).
+- Story 7 — point multiple scorers at the same `AssessmentSchema` so concordance has a real join key.
+
+The Source-driven population semantics for Stories 4–6 are configured here (the "Source" sub-row on Assessment) but the deep config of filters/sample-rate/routing lives in brief 02.
+
+## Information architecture
+
+```
+Assessments (list, list-of-lists)
+├── New Assessment                  (creation flow / wizard)
+└── /<assessment_id>/               (detail shell with tabs)
+    ├── Overview     ← THIS BRIEF (config summary, edit affordances)
+    ├── Source       ← brief 02
+    ├── Scorers      ← THIS BRIEF (per-scorer add/edit)
+    ├── Routing      ← brief 02
+    ├── Runs         ← brief 04
+    ├── Trends       ← brief 04
+    ├── Concordance  ← brief 04
+    └── Reviews      ← brief 03 (only when Assessment has a HumanScorer)
+
+Schemas (parallel top-level navigation entry — catalogue)
+├── New schema
+└── /<schema_id>/                   (detail / edit)
+```
+
+**Why a separate top-level "Schemas" entry**: a schema is reusable across Assessments (FR-1.5). Surfacing it only inside an Assessment's edit form hides the catalogue and makes reuse invisible. The detail page also needs to show "used by N Assessments" and the schema-version history chain (D-8).
+
+**Why the Assessment is one detail page with tabs, not a multi-page wizard after creation**: matches the pipeline-builder pattern already in the codebase (`templates/pipelines/`) and lets a user see config + activity for one Assessment without context-switching. Creation is a stepped flow; editing is per-tab.
+
+## Screens
+
+### S1 — Assessments list
+
+**Replaces**: `templates/evaluations/evaluation_runs_home.html` (evals home) **and** `templates/human_annotations/queue_detail.html` (queue list). One list, one mental model.
+
+**Purpose**: discover existing Assessments, see at-a-glance health, jump into the right one.
+
+**Primary user**: Bot Builder, Bot Owner, Team Lead.
+
+**Information shown per row**:
+- Name + description (truncated)
+- **Mode badge** — *Batch* (no `Source.filter_query_string`) or *Continuous* (filter set). Drives which other columns are meaningful.
+- **Source summary** — dataset name (batch) or filter summary (continuous). One-line; long values truncated with tooltip.
+- **Scorer mix chip** — small icons indicating which scorer kinds are present (LLM-judge, Python, Human). Tooltip shows count of each.
+- **Last activity** — for batch: last `AssessmentRun.finished_at` + status pill. For continuous: most-recent `Score.created_at` + per-24h score count.
+- **Schema name** — clickable; deep-link to schema detail.
+- **Archived** state (filtered out by default).
+
+**Primary actions**:
+- "New Assessment" button (top-right).
+- Row click → Assessment detail (Overview tab).
+- Row menu: archive, duplicate, delete (delete only if no Scores reference it — otherwise archive-only).
+
+**States**:
+- *Empty*: friendly call-to-action ("No Assessments yet — assess your first signal"), single CTA, link to docs.
+- *Loading*: standard table skeleton.
+- *Populated*: paginated table.
+- *Filter applied*: filter chips above the table.
+
+**Filters / sort**: by mode (batch / continuous / both), by scorer kind, by schema, by archived state. Default sort: most-recent activity.
+
+**Components**: `table`, `badge`, `btn`, `breadcrumbs`. Mode badge uses the same `badge-info` / `badge-accent` distinction as the trace-mode badge in existing experiment templates.
+
+### S2 — New Assessment (creation flow)
+
+**Replaces**: `templates/evaluations/evaluation_config_form.html` (eval config form) + `templates/human_annotations/queue_form.html` (queue form). Today these are two separate forms with overlapping concepts; the unified creation is one stepped flow.
+
+**Purpose**: walk a user through the smallest valid Assessment setup, with sensible defaults so simple cases stay one-form-deep.
+
+**Primary user**: Bot Builder, Team Lead.
+
+**Shape**: stepped form (DaisyUI `steps` component). Each step is a thin slice; the user can move forward only when the current step validates. "Back" preserves state.
+
+**Steps**:
+
+1. **Basics**
+   - Name (required), description (markdown allowed).
+   - Mode toggle: *Batch* (default) ⇄ *Continuous*. Tooltip on each describing the difference. Selection determines what step 2 looks like.
+
+2. **Source** *(thin; deep config in brief 02 lives on the detail page)*
+   - **Batch mode**: pick an existing dataset (autocomplete) **or** create one inline (CSV / sessions / manual).
+   - **Continuous mode**: minimal — granularity (`session` / `message`), filter string (with a "Copy from saved filter" affordance per D-12), optional sample rate.
+   - "Configure full source later" link → finish step 2 with defaults, jumps to detail-page Source tab after save.
+
+3. **Schema**
+   - Pick existing `AssessmentSchema` (autocomplete with preview), **or** create new schema inline (opens schema editor mini-form — S6).
+   - Show field summary once picked (name, count, types).
+
+4. **Scorers**
+   - "Add a scorer" — at least one required to save. Picker: `LLM Judge`, `Python`, `Human review`.
+   - Each scorer opens the scorer editor (S5/S5b) as a modal/drawer; saved scorers stack vertically below the picker.
+   - Each saved scorer shows: kind, name, `output_fields` chips, edit/remove.
+   - Validation: at least one scorer is required. Mixed scorer kinds allowed (per D-1).
+
+5. **Review & Save**
+   - One-page summary of all steps with edit-back links.
+   - "Save as draft" vs "Save and start" (batch only — continuous Assessments save and immediately begin listening).
+
+**States**:
+- *Draft persistence*: each step's state saved client-side as the user navigates; submit on final step.
+- *Validation*: per-step inline, summarised on review step.
+- *Schema-and-scorer interplay*: if user picks an existing schema and then adds a scorer with `output_fields` referencing fields not in the schema, block with inline error.
+
+**Components**: `steps`, `card`, `modal`, `drawer`, `form-control`, `select`, `radio`, `btn`, `alert`.
+
+### S3 — Assessment detail shell (Overview tab)
+
+**Purpose**: a stable home for one Assessment. Tabs along the top, breadcrumbs, primary metadata. Other tabs are owned by other briefs; this brief defines only the shell + Overview content.
+
+**Tabs** (left to right): Overview · Source · Scorers · Routing · Runs (batch only) · Trends (continuous only) · Concordance (≥2 scorer types) · Reviews (has HumanScorer). Tabs that don't apply to the Assessment are hidden, not greyed out.
+
+**Overview content**:
+- Header: name, description, mode badge, schema chip, archived state.
+- "What this Assessment does" panel — auto-generated one-liner: *"Continuously scores sessions matching `<filter summary>` with `<scorer mix>` against schema `<name>`."* Updates with config changes; helpful for non-technical reviewers.
+- **Scorer summary card** — each scorer as a row: kind icon + name + `output_fields` chips + status (active/disabled) + edit link.
+- **Routing summary card** — count of routing rules, top-level glance ("3 rules: 1 emit-tag, 2 escalate-to-human"). Detail in brief 02.
+- **Health/recency card** — for batch: latest 3 runs (status pill, started, finished, total scores). For continuous: latest score timestamp, 24h score count, count of `AppliedSourceFilter` failures in last 24h (per D-15 audit).
+- **Activity timeline** (collapsed by default) — last 10 events: run started/finished, scorer added, schema repointed (D-8), config edited.
+
+**Primary actions** (header right):
+- Edit (opens the relevant step of the creation flow for non-destructive edits, or directly the field for in-place edits).
+- "Run now" (batch only) — opens the run starter (brief 04).
+- Pause / resume (continuous only) — toggle whether lifecycle hooks fire for this Assessment.
+- Archive.
+- Duplicate.
+
+**Components**: `tabs`, `breadcrumbs`, `card`, `badge`, `stats`, `btn`, `dropdown` for the actions menu.
+
+### S4 — Schema catalogue (list) and detail
+
+**Replaces**: nothing — net new. Today schemas are inline JSON on `Evaluator.params["output_schema"]` and `AnnotationQueue.schema`. D-10 promotes them to a top-level catalogue.
+
+#### S4a — Schema list
+
+**Information per row**:
+- Name + description
+- Field count + type mix (e.g. "3 numeric, 2 categorical, 1 string")
+- Used-by count (Assessments referencing this schema)
+- Created date + author
+- "Has successors" indicator (chain of clone-and-repointed schemas per D-8)
+
+**Actions**: New schema · row click → detail · archive disabled (catalogue is append-only per D-8).
+
+#### S4b — Schema detail / editor
+
+**Two distinct modes**:
+
+1. **Read-only view** when the schema has any `Score` referencing it. This is the normal case (D-8 — schemas are logically immutable once Scores reference them).
+2. **Editable** when no Scores reference it yet (fresh schemas).
+
+**Read-only view shows**:
+- Field list with full definitions.
+- "Used by" list — Assessments + scorers, with deep links.
+- **Successor chain** (D-8) — if this schema has been cloned-and-repointed, show the chain visually:
+  ```
+  v1 (this) ─── v2 ─── v3 (current)
+  Show this when |chain| > 1.
+  ```
+- **"Edit" button → triggers clone-and-repoint** (S4c).
+
+**Field-level UI** (used in both modes):
+- Type-aware editor:
+  - `String`: max length, regex pattern.
+  - `Int` / `Float`: min, max, step.
+  - `Choice`: ordered list of options (drag-handle), allow-other toggle.
+- Flags: `required`.
+- Aggregation behaviour is **type-driven, not per-field-flagged**: `Numeric`, `Choice`, and `Boolean` fields always aggregate; `String` fields never do. No UI control needed (per FR-6.3).
+- Field name — kebab-case, validated against system-reserved names (D-4: `user_thumb`, `user_feedback_reason`, etc.).
+
+**Components**: `table`, `form-control`, `select`, `input`, `toggle`, `card`, `badge`. Field-list reordering uses the existing drag pattern from the pipeline builder.
+
+#### S4c — Schema edit (clone-and-repoint flow)
+
+**Trigger**: user clicks "Edit" on a schema with referencing Scores.
+
+**Modal/drawer copy**:
+> Editing this schema will create a new version. The current Assessments using it will be repointed; previous Scores keep referring to the old version. *Trend continuity is preserved for unchanged field names.*
+
+**Below the explainer, two action paths**:
+
+1. **Additive change** (add field / loosen constraint): show fields, let user add. Inline note: "Adding a field is a clone-and-repoint — old data unaffected."
+2. **Type change** (D-8 — UI **requires** picking a new name on type change): the field-type dropdown auto-disables and a "Rename field" affordance appears. Old name + value remain in old schema; new schema has new-name with new type.
+3. **Rename**: explicit checkbox "Treat as a rename" with warning copy: *"Renaming `accuracy` → `factuality` breaks trend continuity for this field. Old Scores will keep the old name. You own the consequence."*
+
+After save:
+- New `AssessmentSchema` row created.
+- Pop a toast listing which Assessments were repointed.
+- Surface the successor chain on the detail page.
+
+### S5 — AutomatedScorer editor (modal/drawer)
+
+**Replaces**: `templates/evaluations/evaluator_form.html`.
+
+**Two kinds**: `LLM_JUDGE` and `PYTHON`. Form shape differs.
+
+**Common fields**:
+- Display name (required, unique within Assessment).
+- `output_fields` — multi-select of fields from the Assessment's `AssessmentSchema`. Defaults to all fields. Per D-10: each scorer may cover a subset. Inline validation: at least one field selected; can't reference fields not in the schema.
+- "Show in concordance" — derived, not toggled (any scorer producing ≥1 field in common with another scorer auto-participates).
+
+#### S5a — LLM judge
+
+- Model picker (from team's `LlmProvider` rows).
+- Prompt — multiline editor with template-variable hint chips (`{{ input }}`, `{{ output }}`, `{{ history }}`, `{{ context }}`). The chip list should mirror what `schema_to_pydantic_model` expects to consume.
+- Temperature / top_p / structured-output toggle (advanced, collapsed).
+- **Preview run** — "Test on 10 sample items" button per FR-3.5. Returns inline result table; non-destructive (results not persisted to Score).
+
+#### S5b — Python evaluator
+
+- Code editor (monospace, syntax-highlighted).
+- "Inputs available" reference — same template variables as the LLM judge.
+- Test runner — same 10-item preview as S5a but executing the code.
+
+### S6 — HumanScorer editor (modal/drawer)
+
+**Replaces**: the per-queue fields on `templates/human_annotations/queue_form.html` (assignees, schema, review count) — but the schema is now picked at the Assessment level, not per-queue.
+
+**Fields**:
+- Display name (required).
+- `output_fields` — same semantics as automated scorer (D-10). Defaults to all schema fields. Lets one Assessment have, say, an LLM judge scoring `accuracy` + `tone` and a human reviewing only `tone`.
+- **Assignees** — M2M picker against team members who have the `ANNOTATION_REVIEWER` permission (see [`apps/teams/backends.py:229`](../../../apps/teams/backends.py)). Inline note: "Reviewers only see queues they're assigned to."
+- **`num_reviews_required`** — int 1–10. Inline helper: "How many independent reviews each item needs before it's complete."
+- **`irr_sample_rate`** — decimal 0.0–1.0 (default 0.0). Slider or percentage input. Helper: "Fraction of items that get one extra reviewer for inter-rater reliability measurement." Per D-11.
+- **Prior-score visibility (D-7)** — two toggles, side-by-side, with copy that explains the difference:
+  - `show_prior_automated_scores` — *"Show the LLM judge's score above the form."* Default off. Recommended for **calibration** workflows (Story 2).
+  - `show_prior_human_scores` — *"Show other reviewers' scores on the same item."* Default off. Keep off for **inter-rater reliability** (Story 9).
+- **Per-item assignment** (FR-4.4 / backlog #6) — toggle "Assign specific items to specific reviewers". When on, surfaces a "Assignments" sub-section in the Reviews tab (defined in brief 03).
+
+**Recommended-preset chips** (helpful but skippable): "Single review", "Consensus (3 reviewers)", "Calibration vs judge", "IRR 20% sample". Clicking a preset fills the form with the right combination per the [story-mapping table](../unified-assessment.md#how-the-user-stories-map-to-the-unified-design).
+
+## Cross-cutting concerns
+
+### Permissions
+
+- **Create/edit/delete Assessments, schemas, scorers** — team admins (per FR-10.1, FR-10.2).
+- **View Assessment list and detail** — anyone on the team (FR-10.5).
+- **Edit Reviews** — only the reviewer who submitted, plus team admins (brief 03).
+- **Cannot delete** an Assessment that has Scores referencing it — archive-only (existing OCS pattern, `archived_at`).
+
+### Feature flag
+
+The entire surface is gated behind a single team-managed Waffle flag (FR-10.6). Suggested name: `ASSESSMENTS`. The pre-unified routes (`/evaluations/`, `/human_annotations/queues/`) remain available behind their existing flags during transition.
+
+### Empty-team experience
+
+A team with the `ASSESSMENTS` flag on but no Assessments, no schemas, and no scorers should see a single "Create your first Assessment" landing screen with three example presets (Calibrate a judge · Continuously score with LLM judge · Set up a human review queue) that pre-fill the creation flow. Avoid an empty table; avoid showing the schemas-list and scorers list separately when there's nothing to show.
+
+### Archive vs delete
+
+- Schemas: no archive (catalogue is append-only per D-8).
+- Assessments: archive (set `archived_at`); hidden from default list, retrievable via "Show archived" filter.
+- Scorers, RoutingRules: belong to an Assessment — destroyed with the Assessment, edited otherwise.
+
+### Validation invariants the UI must enforce (or surface clearly)
+
+- Schema picked at step 3 must include every field referenced by any scorer's `output_fields` at step 4. If user removes a field from the schema that a scorer references, block.
+- A scorer's `output_fields` cannot be empty.
+- `num_reviews_required` ∈ [1, 10]; `irr_sample_rate` ∈ [0.0, 1.0].
+- Field name uniqueness within a schema; field names must not collide with system-reserved names (`user_thumb`, etc. — per D-4).
+- On schema type-change: forbid edit-in-place, force rename (per D-8 and S4c).
+
+## Open design questions
+
+1. **Wizard vs single-page form for creation (S2).** Stepped form is the draft recommendation because the source/schema/scorer choices interact (a poorly-chosen mode forces a rework later). But it's heavier than a single-page form. Decision pending — try wizard, fall back to single-page if usability testing surfaces friction.
+2. **Schema catalogue as top-level nav vs nested under Assessments.** Drafted as top-level (left rail) to make reuse visible. Alternative: under Assessments only, with a "browse all" link. Open.
+3. **Scorer naming convention surfaced to users.** Today's `Evaluator` rows have free-text names; the unified design doesn't change that. Should "name" of an automated scorer default to something like `LLM judge — accuracy, tone` to make scorer cards self-describing? Probably yes, but spec leaves to designer.
+4. **Per-Assessment authoritative-Review admin override (D-16).** Setting a Review authoritative manually requires a permission — where does this UI affordance live? Probably brief 03 (Reviews tab on the Assessment detail). Confirm during review of this brief.
+5. **Inline schema editor vs full-page (S2 step 3).** A user creating their first Assessment shouldn't have to leave the wizard to make a schema. Mini-form is drafted; if the full editor's complexity exceeds modal capacity (e.g. for `Choice` with many options), promote to full page with auto-save and return.
+
+## Cross-references
+
+| Topic | Where |
+|---|---|
+| Why two prior-score visibility knobs, not one | [D-7](../unified-assessment.md#d-7-two-prior-score-visibility-knobs-on-humanscorer-not-one) |
+| Why shared schema with per-scorer `output_fields` | [D-10](../unified-assessment.md#d-10-shared-schema-with-per-scorer-field-subsets-not-schema-per-scorer) |
+| Why schema editing is clone-and-repoint | [D-8](../unified-assessment.md#d-8-assessmentschema-is-a-real-catalogue-not-embedded-json) |
+| Why IRR is a separate sampling rate | [D-11](../unified-assessment.md#d-11-irr-sampling-is-a-separate-field-sampled-at-queue-entry) |
+| Why bot_version is a run parameter, not config | [D-3](../unified-assessment.md#d-3-bot_version-lives-on-assessmentrun-not-on-the-assessment) |
+| Existing concordance template as DaisyUI reference | [`templates/assessments/concordance.html`](../../../templates/assessments/concordance.html) |
+| Schema field type definitions | [`apps/evaluations/field_definitions.py`](../../../apps/evaluations/field_definitions.py) |
+| Reviewer permission group | [`apps/teams/backends.py:229`](../../../apps/teams/backends.py) |

--- a/docs/design/ui/02-source-and-routing-rules.md
+++ b/docs/design/ui/02-source-and-routing-rules.md
@@ -1,0 +1,281 @@
+# 02 — Source and Routing Rules
+
+> The data-plumbing tabs on an Assessment detail page: **Source** (where items come from — batch dataset or continuous filter) and **Routing** (the rules engine that fires actions on Scores, lifecycle events, flags, disagreement, or applied tags). These two tabs are paired because together they describe the *flow* of an Assessment — what flows in, what fires on the way through.
+>
+> **Anchored to** [`../unified-assessment.md`](../unified-assessment.md): D-5 (continuous Assessments produce no Runs), D-12 (reuse the filter language, not the `FilterSet` model), D-13 (Score targets), D-14 (`AppliedRoutingRule` audit), D-15 (lifecycle hooks, `AppliedSourceFilter`), D-16 (`HUMAN_DISAGREEMENT` + authoritative).
+>
+> **Out of scope** — covered by other briefs: Assessment/Schema/Scorer config (brief 01); the *act of reviewing* an escalated item (brief 03); the *results* of running (brief 04). The Routing tab here shows the rule definition + audit; consequences of rules firing belong to the action's target tab.
+
+## User stories addressed
+
+- Story 4 — *Continuous LLM-judge monitoring*: continuous `Source` with a filter expression.
+- Story 5 — *Human queue, judge-flagged*: `RoutingRule(SCORE_VALUE → ESCALATE_TO_HUMAN_SCORER)`.
+- Story 6 — *Human queue, user-feedback-flagged*: continuous `Source` with `filter_query_string` reading `USER_FEEDBACK` Scores.
+- Story 10 — *Second-pass review for uncertain items*: `RoutingRule(HUMAN_FLAG → ESCALATE_TO_HUMAN_SCORER)`.
+- Story 9 (adjudication side) — *Reviewer disagreement*: `RoutingRule(HUMAN_DISAGREEMENT → ESCALATE_TO_HUMAN_SCORER(mark_authoritative=True))` (D-16).
+- Backlog #4 (continued) — *Evals tag sessions for filtering*: `RoutingRule(SCORE_VALUE → EMIT_TAG)`.
+- Backlog #5 — *Cross-Assessment escalation*: `RoutingRule(LIFECYCLE_EVENT → ADD_TO_QUEUE)`.
+
+## Information architecture
+
+```
+Assessment detail
+├── Overview      (brief 01)
+├── Source        ← THIS BRIEF
+├── Scorers       (brief 01)
+├── Routing       ← THIS BRIEF
+├── Runs          (brief 04 — batch only)
+├── Trends        (brief 04 — continuous only)
+├── Concordance   (brief 04)
+└── Reviews       (brief 03)
+```
+
+The Source tab is **single-page**; mode determines the form. The Routing tab is a **list-with-modal-editor** — list of rules at the top, "Add rule" opens an editor that pivots on `trigger_kind` × `action_kind`.
+
+## Screens
+
+### S7 — Source tab
+
+**Purpose**: configure how items enter the Assessment. Mode is fixed at creation (S2 step 1, brief 01); this tab is for the rest of the configuration plus operational visibility.
+
+**Primary user**: Bot Builder, Team Lead.
+
+The tab pivots on the Assessment's mode (set at creation):
+
+#### S7a — Batch mode source
+
+For an Assessment with **no `Source.filter_query_string`** (D-5: items are added at config time; runs are explicit; no lifecycle hooks).
+
+**Sections** (top to bottom):
+
+1. **Dataset summary card**
+   - Dataset name, item count, granularity (`session` / `message` per D-13), CSV-import status if applicable.
+   - "Open dataset" link to the dataset editor (carried-forward from existing `templates/evaluations/dataset_edit.html` — out of scope for this brief).
+2. **Item population** (the three population mechanisms — UI affordances on the same underlying dataset, not separate sources):
+   - **Import sessions** — opens the sessions picker (replaces `add_items_from_sessions.html`). Filter sessions by experiment, date range, tag, participant. Bulk-select, "Add N sessions" button.
+   - **Import CSV** — replaces `dataset_create_form.html`. Column-mapping step matches `create_dataset_from_csv_task` shape; preserve the existing UX, just relabel "Evaluation dataset" → "Assessment dataset".
+   - **Add manual item** — minimal input/output/context form, append to dataset.
+   - **Import from another Assessment's results** — opens a picker for source Assessments with `≥1 HumanScorer` (carries forward FR-8.2 / today's `ImportFromAnnotationQueueForm`). One-shot copy; clearly labelled as such; explainer copy: *"This copies items at the moment of import. For live coupling, add a scorer to the source Assessment instead."*
+3. **Bot generation** (optional, per FR-3.6) — single toggle "Generate bot responses before scoring". When on: pick experiment (FK), version selection moves to `AssessmentRun` per D-3 (so no version field here).
+4. **Deduplication** — show counts of items already in *other* Assessments using the same dataset (per FR-2.7). Read-only awareness, no enforcement.
+
+**States**:
+- *Empty dataset*: three large CTAs side-by-side (Import sessions · Import CSV · Add manual item) — no awkward 0-row table.
+- *Mid-import*: progress chip on the affected section (CSV parse, bulk-add).
+
+#### S7b — Continuous mode source
+
+For an Assessment with **`Source.filter_query_string` set** (D-5: items stream in via lifecycle hooks; no `AssessmentRun` rows; aggregates are on-demand).
+
+**Sections**:
+
+1. **Granularity and target**
+   - Read-only chip showing `session` or `message` (set at creation; changing granularity requires creating a new Assessment).
+   - One-liner clarifying what gets scored: *"One Score row per `ExperimentSession`"* (session-granularity) or *"One Score row per `Trace` (LLM call / pipeline execution)"* (message-granularity, per D-13). Mention v1 latency caveat (D-15): *"Per-message scoring runs at session end."*
+2. **Filter editor**
+   - Filter-language editor (reuse the parser from [`apps/filters/`](../../../apps/filters/), per D-12). UI affordances:
+     - **"Copy from saved filter"** dropdown — pulls a saved `FilterSet`'s `filter_query_string` into the source as a starting point. After copy, the Source owns its own string; further edits to the originating `FilterSet` don't propagate.
+     - Visual filter builder fallback if free-text filter intimidates non-technical users — uses the same parser, just renders the predicates as chips with field/op/value selectors.
+   - **Live preview**: "Show 10 matching items from the last 24h" — read-only sample with deep links to the session/trace.
+3. **Sample rate** (FR-2.3 / FR-3.4) — decimal 0.0–1.0 (default 1.0). Slider + percentage display. Helper: *"Of items matching the filter, what fraction to score. Lower this to control cost on high-volume signals."*
+4. **Idempotency note** (read-only callout): *"Each target is scored at most once per Assessment (uniqueness on `(assessment, target, name, source)`)."* Per the Score unique index in the design doc.
+5. **Pause/resume** — toggle visible at the top of the section. When paused, lifecycle hooks no-op for this Assessment. State is reversible.
+6. **Operational health card** — three numbers per D-15:
+   - Latest `Score.created_at` (e.g. *"Latest score 4 min ago"*).
+   - 24h Score count grouped by source (small bar/sparkline).
+   - 24h `AppliedSourceFilter` failure count, broken down by `outcome` (`FILTER_NO_MATCH` / `DEDUP_SKIP` / `SAMPLE_ROLLED_OUT` / `SCORER_ERROR`). Each failure type links to a filtered audit view (S7c).
+   - "Why didn't this session get scored?" — small search box accepting a session id; runs a point query against `AppliedSourceFilter` to show the answer.
+
+**States**:
+- *Just configured, no traffic yet*: empty operational card with copy *"Waiting for first matching event."*
+- *Paused*: dimmed sections, banner *"This source is paused — no Scores are being written."*
+- *Many `SCORER_ERROR` rows*: alert at top of card with link to error breakdown.
+
+#### S7c — `AppliedSourceFilter` audit log (sub-view)
+
+Reachable from S7b's operational card. Read-only table.
+
+**Columns**: timestamp, event type, target (deep link), outcome, error message (if any).
+
+**Filters**: outcome type, date range, event type.
+
+**Empty state**: *"No skipped or failed dispatches in this window. Successful Scores are visible on the Scorers / Trends tabs."* (Per D-15 — successes are not audited.)
+
+### S8 — Routing tab
+
+**Purpose**: define the rules engine for an Assessment — what triggers what. Replaces the per-evaluator-only `EvaluatorTagRule` UI today; same general shape (rule list + per-rule editor) but with a richer trigger × action surface.
+
+**Primary user**: Team Lead (mostly), Bot Builder (for `EMIT_TAG` rules).
+
+#### S8a — Rule list
+
+**Information per row**:
+- Rule name (auto-generated default: `<trigger summary> → <action summary>`).
+- **Trigger chip** — colour-coded per kind:
+  - `SCORE_VALUE` — judge icon, e.g. *"score.accuracy < 0.5"*.
+  - `LIFECYCLE_EVENT` — event icon, e.g. *"SESSION_ENDED"*.
+  - `HUMAN_FLAG` — flag icon, e.g. *"reviewer flagged"*.
+  - `HUMAN_DISAGREEMENT` — split-arrow icon, e.g. *"disagreement on tone (stdev > 0.3)"* (D-16).
+  - `TAG_APPLIED` — tag icon, e.g. *"tag 'emergency' applied"*.
+- **Action chip** — colour-coded per kind:
+  - `EMIT_TAG` — *"tag 'low-quality'"*.
+  - `ESCALATE_TO_HUMAN_SCORER` — *"send to `<HumanScorer name>`"*, with `mark_authoritative=True` indicator if set.
+  - `NOTIFY` — *"notify `<channel>`"*.
+  - `ADD_TO_QUEUE` — *"queue in Assessment `<other>`"* (cross-Assessment per FR-11).
+- **Sample policy** — chip if not `EVERY` (`THRESHOLD` / `RANDOM_N_PERCENT(p)`).
+- **Status** — active / paused per rule.
+- **Last fired** — relative timestamp; click to jump into `AppliedRoutingRule` audit filtered to this rule (S8c).
+- **Fire count (last 24h / last 7d)** — sanity-check signal.
+
+**Actions**: "Add rule" (top-right) · per-row edit · per-row duplicate · per-row pause/resume · per-row delete.
+
+**Empty state**: *"No routing rules yet. Add a rule to react to scores, lifecycle events, or human flags."* with three "Common patterns" presets (see S8b below).
+
+#### S8b — Rule editor (modal/drawer)
+
+The editor pivots on `trigger_kind` × `action_kind`. To keep the UI tractable, present them as **two cascading selects + dynamically-rendered config blocks**, not a 5 × 4 grid.
+
+**Top of form**:
+- **Name** (auto-defaulted; editable).
+- **Preset chips** ("Common patterns") to pre-fill the form for the matrix the design doc enumerates:
+  - "Tag low-quality sessions" (SCORE_VALUE → EMIT_TAG)
+  - "Escalate to human review" (SCORE_VALUE → ESCALATE_TO_HUMAN_SCORER)
+  - "Random calibration sample" (SCORE_VALUE + RANDOM_N_PERCENT → ESCALATE_TO_HUMAN_SCORER)
+  - "Second-pass on reviewer flag" (HUMAN_FLAG → ESCALATE_TO_HUMAN_SCORER)
+  - "Adjudicate disagreement" (HUMAN_DISAGREEMENT → ESCALATE_TO_HUMAN_SCORER, `mark_authoritative=True`)
+  - "Alert on emergency tag" (TAG_APPLIED → NOTIFY)
+  - "Cross-Assessment escalation" (LIFECYCLE_EVENT → ADD_TO_QUEUE)
+
+##### Trigger block
+
+A `trigger_kind` select + a config sub-block per kind:
+
+- **`SCORE_VALUE`**:
+  - Field (dropdown from the Assessment's `AssessmentSchema` field names — already constrained to scorer `output_fields`).
+  - Operator (`<`, `≤`, `=`, `≥`, `>`, `∈` for categorical) — operator list pivots on the field's `data_type`.
+  - Value (input control pivots on `data_type` — number input for numeric, choice picker for categorical).
+  - Source filter (optional multi-select): *"Only trigger on scores from these sources"* — `LLM_JUDGE`, `PROGRAMMATIC`, `HUMAN_REVIEW`, `USER_FEEDBACK`, `SYSTEM`. Useful for Story-6-style "fire only on user feedback".
+- **`LIFECYCLE_EVENT`**:
+  - Event type select — `SESSION_ENDED` / `AUTOMATED_RUN_FINISHED` / `USER_FEEDBACK_RECEIVED` / `TAG_APPLIED`. (Per D-15: all four available to routing rules; only `SESSION_ENDED` drives continuous *scoring* in v1.)
+  - Optional payload filter (e.g. for `AUTOMATED_RUN_FINISHED`, restrict to a specific scorer).
+- **`HUMAN_FLAG`**:
+  - Optional flag-reason match (substring or choice — flag reasons are free-text today).
+  - Source `HumanScorer` (default: any in the same Assessment).
+- **`HUMAN_DISAGREEMENT`** (D-16):
+  - Field (dropdown).
+  - For numeric: stdev threshold (number input, default suggested per field).
+  - For categorical: behaviour fixed (non-unanimous) — read-only explainer.
+  - For string: disable trigger with inline note (*"Strings don't aggregate; disagreement isn't defined."* per FR-6.3).
+- **`TAG_APPLIED`**:
+  - Tag picker (multi-select against the team's `Tag` rows).
+  - Target type filter (optional: `Chat` / `ChatMessage`).
+
+##### Action block
+
+An `action_kind` select + a config sub-block per kind:
+
+- **`EMIT_TAG`**:
+  - Tag picker (or create new — inline against the team's `Tag` catalogue).
+  - Tag target — read-only chip showing what the tag attaches to based on Source granularity (session-granularity → `session.chat`; message-granularity → `ChatMessage`). Per the existing `EvaluatorTagRule` semantics.
+- **`ESCALATE_TO_HUMAN_SCORER`**:
+  - HumanScorer picker (only HumanScorers within the same Assessment listed — within-Assessment escalation is the default per FR-8.1).
+  - `mark_authoritative` toggle (D-16) — only enabled when the trigger is `HUMAN_DISAGREEMENT`; reset and hidden otherwise to prevent footguns.
+  - **Sample policy** — see below.
+  - Optional "Send to a different reviewer than the originator" toggle — relevant for `HUMAN_FLAG` (Story 10) and `HUMAN_DISAGREEMENT` (adjudicator role). Default on for those triggers.
+- **`NOTIFY`**:
+  - Channel — leverages existing OCS notification primitives (out-of-scope to specify the channel set here; reuse whatever `apps/events/EventAction` supports plus whatever explicit notification surfaces exist).
+  - Template — short text with template variables (rule name, trigger details).
+- **`ADD_TO_QUEUE`** (cross-Assessment, per FR-11):
+  - Target Assessment picker (only Assessments with ≥1 HumanScorer listed).
+  - Target HumanScorer picker (within the chosen Assessment).
+  - **Warning callout** (per FR-11.2): *"This is fire-and-forget. Scores produced by the receiving Assessment do not appear in this Assessment's concordance. Within-Assessment escalation is what you want for concordance."* Link to *"Use within-Assessment escalation instead"* which switches the action to `ESCALATE_TO_HUMAN_SCORER`.
+
+##### Sample policy block
+
+Always visible (FR-3.8 / D-doc rule semantics): `EVERY` (default) · `THRESHOLD` · `RANDOM_N_PERCENT(p)`.
+
+- For `RANDOM_N_PERCENT`: percentage input + helper *"Rolled deterministically per `(rule_id, triggered_by_id)` — re-firing the same trigger gets the same outcome."* (Matches the design doc's idempotency guarantee.)
+- For `THRESHOLD`: only meaningful when the trigger has a comparable axis (typically `SCORE_VALUE` numeric); UI hides or disables otherwise.
+
+##### Validation in the editor
+
+- `mark_authoritative=True` requires trigger = `HUMAN_DISAGREEMENT` (or admin manual override per D-16). UI enforces.
+- `ESCALATE_TO_HUMAN_SCORER` requires the target HumanScorer's `output_fields` to overlap with the triggering field for `SCORE_VALUE` / `HUMAN_DISAGREEMENT` triggers — block with inline error if not.
+- `SCORE_VALUE` triggers must reference a field actually produced by some scorer in this Assessment (i.e. is in some scorer's `output_fields` per D-10). Block otherwise with helper *"No scorer in this Assessment produces `<field>`."*
+- `RoutingRule(SCORE_VALUE)` on a field whose `data_type=STRING` is disabled (consistent with disagreement and aggregation).
+- Cross-Assessment `ADD_TO_QUEUE` is only available when the source has a granularity matching the target Assessment's first HumanScorer item type — block with helper otherwise.
+
+**Live preview panel** (right-side drawer if there's room): *"This rule would have fired N times in the last 24h."* Backed by a dry-run against historical Scores. Helps build confidence before turning a rule on.
+
+#### S8c — `AppliedRoutingRule` audit log
+
+Reachable from "Last fired" on any rule row in S8a, or from a per-Assessment top-level "Rule history" link.
+
+**Purpose**: answer "did this rule fire, and what did it produce?" Per D-14, every firing produces an `AppliedRoutingRule` row.
+
+**Columns**: timestamp, rule (chip), `triggered_by` (deep link — `AutomatedResult` / `Review` / `ExperimentSession` / `CustomTaggedItem` depending on trigger), `outcome` (deep link — `CustomTaggedItem` / `ReviewItem` / notification / etc.), context summary (the JSON `context` rendered as key-value chips: which field matched, what value, sample-roll outcome).
+
+**Filters**: rule, outcome type, date range, trigger kind.
+
+**Why this view exists**: when a routing rule misbehaves (e.g. fires too often, escalates the wrong items), the audit trail must be inspectable. The unique constraint on `(rule, triggered_by, outcome)` (D-14) means each firing is unambiguous.
+
+## Cross-cutting concerns
+
+### Permissions
+
+- **Create/edit/delete routing rules** — team admin.
+- **View routing rules and audit log** — anyone on the team with the `ASSESSMENTS` flag.
+- **Pause/resume a rule** — team admin.
+- **Pause/resume continuous Source** — team admin (this is the kill-switch for an Assessment writing Scores in production).
+
+### Idempotency and re-fires (operational copy that should appear in UI)
+
+The design doc commits to consumer-side idempotency, not at-most-once dispatch (D-15). The UI should surface this in two places:
+
+1. **On the SourceFilter editor (S7b)**, the dedup callout: *"Each target is scored at most once per Assessment."*
+2. **On the Routing rule editor (S8b) sample-policy helper**, the determinism callout: *"Same trigger + same rule = same outcome. Safe to re-fire."*
+
+This is the kind of guarantee users will lean on; the UI should be quiet about *how* it works (constraints + hashes) but loud about *that* it works.
+
+### "All matching rules fire" — no priority field
+
+Per the design doc's execution semantics: all matching rules fire; there is no priority/short-circuit. The Routing tab's rule list doesn't have a reorder handle. If a user expects ordering, surface a one-time tip on the rule editor: *"Rules don't have priority — all matching rules fire. Use overlapping trigger predicates if you want to encode 'low-priority shouldn't fire when high-priority does'."*
+
+### "No transitive cascade" — what artefacts can re-enter the dispatcher
+
+Per the design doc: artefacts created by a `RoutingRule` action (a tag from `EMIT_TAG`, a `ReviewItem` from `ESCALATE_TO_HUMAN_SCORER`) **do not** re-enter the lifecycle dispatcher. Scores produced by an escalated `Review` *do* fire `SCORE_VALUE` rules (because they're a real producing event).
+
+UI implication: on the rule editor for `TAG_APPLIED` triggers, surface a helper distinguishing the two: *"Triggers on tags applied by users in the UI or by `SESSION_ENDED`-driven system events. Does **not** trigger on tags emitted by other routing rules — those don't cascade."* This prevents a class of bug-report where someone expects an emit-tag rule's output to fire another tag-applied rule.
+
+### Lifecycle event types — quick reference table for the designer
+
+| Event | Fires when | Available as routing trigger | Drives continuous scoring? |
+|---|---|---|---|
+| `SESSION_ENDED` | Session reaches terminal state | yes | yes (v1) |
+| `AUTOMATED_RUN_FINISHED` | `AssessmentRun` reaches `COMPLETED` | yes | no |
+| `USER_FEEDBACK_RECEIVED` | A `Score(source=USER_FEEDBACK)` is written | yes | no (but `Source.filter_query_string` can read these scores) |
+| `TAG_APPLIED` | `CustomTaggedItem` created (human or system) | yes | no |
+
+`TRACE_FINISHED` does **not** exist in v1 (D-15). UI must not suggest it; per-message scoring runs at session end.
+
+## Open design questions
+
+1. **Filter editor — free-text vs visual builder.** Drafted as both (free-text primary, visual chips as a progressive disclosure). The visual builder might be too complex for v1; deferring may be the right call. Decision pending.
+2. **`NOTIFY` channel set.** The brief assumes existing notification primitives are reusable. If they're insufficient (e.g. no Slack/webhook for assessment-specific channels), specify what minimum surface is needed — defer to a separate, smaller brief if so.
+3. **Cross-Assessment `ADD_TO_QUEUE` discoverability.** Listed in S8b's preset chips but flagged as fire-and-forget; some users will reach for it expecting concordance. Should it be hidden behind a "show advanced actions" toggle? Worth user-testing.
+4. **Per-rule "dry-run last 24h" preview cost.** Useful but potentially expensive to compute on every editor open. If query cost is high, gate behind an explicit button rather than rendering on load.
+5. **Visual representation of `AppliedRoutingRule.context` JSON.** Drafted as "key-value chips"; if the JSON shape varies wildly by rule kind, may need per-trigger-kind formatters. Designer's call.
+
+## Cross-references
+
+| Topic | Where |
+|---|---|
+| Filter language to reuse (not the FilterSet model) | [D-12](../unified-assessment.md#d-12-reuse-the-filter-language-not-the-filterset-model) |
+| Why continuous Assessments don't have Runs | [D-5](../unified-assessment.md#d-5-continuous-assessments-do-not-produce-assessmentrun-rows) |
+| Score targets and message-granularity = Trace | [D-13](../unified-assessment.md#d-13-score-targets-are-measurement-units-trace-experimentsession-evaluationmessage-not-display-surfaces) |
+| `AppliedRoutingRule` audit shape | [D-14](../unified-assessment.md#d-14-audit-row-generalises-across-all-routing-rule-action-types) |
+| Lifecycle hooks, idempotency, `AppliedSourceFilter` | [D-15](../unified-assessment.md#d-15-lifecycle-hooks-dispatch-in-parallel-to-statictrigger-with-consumer-side-idempotency) |
+| `HUMAN_DISAGREEMENT` + authoritative Reviews | [D-16](../unified-assessment.md#d-16-reviewer-disagreement-is-resolved-by-authoritative-reviews-not-by-statistical-fiat) |
+| Cross-Assessment routing constraints (no concordance back) | [FR-11](../unified-assessment.md#fr-11-external-escalation-cross-assessment-routing-backlog-5) |
+| Today's `EvaluatorTagRule` (the shape being generalised) | [`apps/evaluations/models.py:555`](../../../apps/evaluations/models.py) |
+| Filter parser support for sessions + traces | [`apps/filters/`](../../../apps/filters/) |

--- a/docs/design/ui/03-review-workflow.md
+++ b/docs/design/ui/03-review-workflow.md
@@ -1,0 +1,249 @@
+# 03 — Review workflow (HumanScorer)
+
+> The screens reviewers see when they review an item. Two audiences: **reviewers** (working through an assigned queue, submitting Reviews) and **team leads / admins** (managing the queue, assigning items, overriding with authoritative Reviews). One Assessment with a `HumanScorer` powers all of this.
+>
+> **Anchored to** [`../unified-assessment.md`](../unified-assessment.md): D-7 (two prior-score visibility knobs), D-10 (per-scorer `output_fields`), D-11 (IRR sampling at queue entry), D-14 (`AppliedRoutingRule` provenance for escalated items), D-16 (authoritative Reviews resolve disagreement).
+>
+> **Out of scope** — covered by other briefs: HumanScorer configuration (brief 01); the rule that triggered an escalation (brief 02); aggregating reviews into concordance/trends (brief 04).
+
+## User stories addressed
+
+- Story 2 — *Manual calibration of LLM judges* (reviewer sees prior automated score per D-7).
+- Story 5 — *Human review queue, judge-flagged*.
+- Story 6 — *Human review queue, user-feedback-flagged*.
+- Story 9 — *Inter-rater reliability* (multi-review consensus + IRR sampling per D-11).
+- Story 10 — *Second-pass review* (HUMAN_FLAG → escalation showing flagging reviewer's score).
+- Adjudication side of D-16 — *Resolving disagreement* with authoritative Reviews.
+
+## Information architecture
+
+```
+Assessment detail
+├── Overview / Source / Scorers / Routing  (briefs 01, 02)
+├── Reviews          ← THIS BRIEF (admin / team-lead view; only when ≥1 HumanScorer)
+└── Runs / Trends / Concordance            (brief 04)
+
+Top-level Reviewer surface
+└── /my-reviews/     ← THIS BRIEF (reviewer's personal queue across all assigned HumanScorers)
+    └── /<review_item_id>/  ← THIS BRIEF (the actual review screen)
+```
+
+**Why two entry points to the same review screen**:
+- **Reviewer** lands at `/my-reviews/`, sees items across every Assessment they're assigned to, works through them. They don't think in terms of Assessments — they think *"I have 12 items to review."*
+- **Admin** lands at the Assessment detail's Reviews tab, sees the queue *for one Assessment*, manages assignments and flagged items, occasionally overrides with an authoritative Review.
+
+Both paths converge on the same per-item review screen (S10).
+
+## Screens
+
+### S9 — Reviewer's queue (`/my-reviews/`)
+
+**Replaces**: today's `templates/human_annotations/queue_detail.html` rendered for a reviewer. Conceptually a personal inbox across all assigned HumanScorers.
+
+**Purpose**: give a reviewer a single place to come back to and chip away at outstanding work without thinking about which Assessment owns what.
+
+**Primary user**: Reviewer (member of `ANNOTATION_REVIEWER_GROUP`, see [`apps/teams/backends.py:229`](../../../apps/teams/backends.py)).
+
+**Top section — summary stats**:
+- Open items count (across all assigned HumanScorers).
+- Today's submissions count.
+- Flagged items count (mine + items routed back to me for second-pass).
+- Items where `is_irr_sample = True` and the IRR slot is open (small chip per D-11).
+
+**Main list**:
+- Grouped by Assessment, collapsed-by-default cards. Each card shows: Assessment name, open count, "Review next" button.
+- Items list per card (when expanded): item identifier (target id / external session id), priority hint, status (pending / in-progress / awaiting-flag-review), age.
+- **IRR badge** on items where `is_irr_sample = True` (per D-11) — visually distinct but not loud; reviewers benefit from knowing, but should review the same way regardless.
+- **Escalation badge** on items routed to this reviewer via `HUMAN_FLAG` or `HUMAN_DISAGREEMENT` (per `AppliedRoutingRule.outcome` per D-14) — clarifies "why am I seeing this twice".
+
+**Primary actions**:
+- "Review next" (per Assessment) — opens the next-up `ReviewItem` (S10).
+- Click a specific item in the list → opens that item (S10).
+
+**Empty state**: *"All caught up. Nothing assigned to you right now."* Plus a small "Where do items come from?" link to a doc explaining sources, routing, and assignment.
+
+### S10 — Per-item review screen
+
+**Replaces**: `templates/human_annotations/annotate.html`. Same core shape — show the item, render the form, submit/flag — but with the D-7 visibility knobs, IRR awareness, escalation context, and authoritative flag affordances.
+
+**Primary user**: Reviewer (assignee of the HumanScorer).
+
+**Layout — three regions**:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Header: Assessment name · HumanScorer name · "Reviewing item   │
+│  N of M" · escalation badge (if any)                            │
+├─────────────────────────────────┬───────────────────────────────┤
+│                                 │                               │
+│  LEFT: the item under review    │  RIGHT: the review form       │
+│  (session transcript, trace,    │  (schema-driven inputs,       │
+│   dataset message — pivots on   │   prior-score panel,          │
+│   target type per D-13)         │   flag, submit, draft)        │
+│                                 │                               │
+└─────────────────────────────────┴───────────────────────────────┘
+```
+
+#### S10a — Item display (left pane)
+
+Pivots on Score target type (per D-13):
+
+- **`ExperimentSession` target** (session-granularity): full conversation transcript, with role chips, timestamps, and per-message metadata expandable. Reuse the existing chatbot session view shape (see [`templates/chatbots/manage/`](../../../templates/chatbots/manage/)).
+- **`Trace` target** (message-granularity): the specific LLM call — prompt, response, error, duration, participant. Use existing trace view shape (`templates/trace/`).
+- **`EvaluationMessage` target** (dataset-granularity, offline): input / output / context / history fields as the dataset edit view shows them today.
+
+**Common controls**: copy-id, jump-to-source (open the session/trace in its native page).
+
+#### S10b — Form (right pane)
+
+**Header strip**:
+- Item status (pending / in-progress / completed-by-others-but-i-still-need-to-review).
+- Reviews-needed badge: *"This item needs N reviews. M done."* Includes IRR `+1` if applicable per D-11.
+- **Escalation context block** (only if this item arrived via a `HUMAN_FLAG` or `HUMAN_DISAGREEMENT` routing rule, traced via `AppliedRoutingRule.triggered_by`):
+  - For `HUMAN_FLAG`: *"@alice flagged this item: '<flag reason>'. Her review was: …"* — flagging reviewer's score is **always shown on second-pass**, hardcoded per D-7's note on Story 10. Do *not* gate this on `show_prior_human_scores`.
+  - For `HUMAN_DISAGREEMENT`: *"Reviewers disagreed on `<field>`: @alice = 3, @bob = 1. You're the adjudicator — your submission will be marked authoritative."* (When the triggering rule has `mark_authoritative=True`.)
+
+**Prior-score panel** (rendered conditionally per D-7):
+- **Prior automated scores** — visible iff `HumanScorer.show_prior_automated_scores = True`. Render each automated scorer's value(s) for fields in the schema, with the scorer's name and timestamp. Subtle styling; don't dominate the form.
+- **Prior human scores** — visible iff `HumanScorer.show_prior_human_scores = True`. Render each other-reviewer's Review, with author name, timestamp, value(s).
+- **Escalation-provenance score** — visible regardless when escalated (Story 10's hardcoded behaviour). Override the `show_prior_human_scores=False` default in this one case.
+
+**Schema-driven form** (per FR-1, FR-4.1):
+- Only the fields in `HumanScorer.output_fields` (D-10) — reviewer doesn't see fields they're not asked to score.
+- Per-field input control by type:
+  - `String` — multiline.
+  - `Int` / `Float` — number with optional slider for bounded ranges.
+  - `Choice` — radio if ≤6 options, select if more.
+  - `Boolean` — segmented toggle (Yes / No).
+- Per-field optional comment ("Why?" subfield).
+- Field-level required-marker per the schema.
+
+**Action bar (bottom)**:
+- **Submit** — primary CTA. Validates required fields; creates one `Score` row per field per the design doc.
+- **Save draft** — secondary (FR-4.9 Could). Persists `Review.status = draft`. Reviewer can come back to it.
+- **Flag** — opens a small reason-input. Sets the item to `flagged` status; appends to flag history (`ReviewItem`).
+- **Unflag** — visible only for items currently flagged by this reviewer (FR-4.7).
+- **Skip** — *"I've already reviewed something equivalent / not my expertise."* Doesn't write a Review. Hides from this reviewer's queue. (FR-4.8 semantics.)
+
+**Mid-form helpers / footguns**:
+- If `Choice` field has an "allow-other" option, render the free-text "other" only when "Other" is selected (avoid noise).
+- Auto-save drafts every 30s (silent), so a closed tab doesn't lose work. Show a small "Draft saved 12s ago" footer.
+
+**States**:
+- *In-flight by another reviewer*: if `num_reviews_required > 1` and someone else has the form open, show a quiet *"@bob is reviewing too"* indicator (best-effort, not pessimistic locking).
+- *Skipping all items*: if every item left is the reviewer's own (FR-4.8 — skip items already reviewed by current user), surface the all-caught-up message (S9 empty state).
+- *Item was unflagged and reset*: if a reviewer comes back to find an item they previously flagged is now re-opened, banner *"This item was unflagged by an admin and needs a fresh review."*
+
+#### S10c — Adjudication mode
+
+A specialisation of S10 triggered when `AppliedRoutingRule.triggered_by` is a disagreement (D-16). Same screen, but:
+
+- Header shows *"Adjudication"* badge.
+- Prior-score panel shows **all** participating reviews side-by-side (override the visibility flags for this case).
+- Submit button label changes to **"Submit as authoritative"** when the routing rule had `mark_authoritative=True` — the submitted Review's `is_authoritative` is set on save.
+- A subtle explainer below the submit button: *"This review overrides the per-source consensus on the fields you submit."*
+
+### S11 — Reviews tab (Assessment detail; admin view)
+
+**Replaces**: today's `templates/human_annotations/queue_detail.html` rendered for admins. The admin view of the work-in-progress queue.
+
+**Primary user**: Team Lead, team admin.
+
+**Top section — queue health stats**:
+- Open / completed / flagged counts.
+- Average reviews-per-item vs `num_reviews_required` target.
+- IRR sample-rate actual vs configured target (per D-11).
+- Disagreement-rate per field (count of items where reviewers split, optionally with a stdev pill for numeric).
+
+**Main table — `ReviewItem`s**:
+
+**Columns**: item identifier · status pill · review-count badge (e.g. *2/3*) · IRR badge · flag indicator · most-recent reviewer · age · actions.
+
+**Per-row actions**:
+- View item (opens S10 read-only for admin if completed, editable if assigned to that admin).
+- **Assign reviewer** — only enabled when `HumanScorer.per_item_assignment = True` (FR-4.4 / backlog #6). Picker from the HumanScorer's assignees. Per-item assignment is a property of `HumanScorer`; brief 01 owns the toggle.
+- **Manual override → submit authoritative Review** — D-16's manual path. Opens S10 in adjudication mode; submitted Review's `is_authoritative` is set on save.
+- **Re-open** — for items closed prematurely (rare; team-lead only).
+
+**Filters**: status, flagged, IRR sample, has-escalation-history, assigned to me, schema-field-with-disagreement, date range.
+
+**Bulk actions** (checkbox column): bulk re-assign · bulk close (only when their `num_reviews_required` is met).
+
+**Empty state**: *"No items in this queue yet. Items arrive from this Assessment's Source (continuous) or its Routing rules (escalations)."* with a link to the Source and Routing tabs.
+
+### S12 — Manage assignees (sub-modal off Scorers tab)
+
+**Replaces**: `templates/human_annotations/manage_assignees.html`. Same intent, simpler shape because the HumanScorer is one row inside an Assessment now (not its own page).
+
+**Reachable from**: Scorers tab (brief 01) — "Manage assignees" affordance on a HumanScorer row.
+
+**Purpose**: M2M-pick which team users can review this HumanScorer's queue.
+
+**Sections**:
+- **Eligible users** — list of team members with the `ANNOTATION_REVIEWER` permission. Inline note linking to the permission docs for users who don't have it.
+- **Currently assigned** — checkboxes; bulk-add and bulk-remove.
+
+**Edge cases**:
+- Removing an assignee with open in-progress reviews — confirm prompt; offer *"Reassign their open items to: …"* picker. Don't silently orphan.
+- Adding a non-reviewer (someone without the permission) — block with explanatory copy; offer a link to grant the permission if the current user is a team admin.
+
+## Cross-cutting concerns
+
+### Permissions matrix
+
+| Action | Required permission |
+|---|---|
+| See `/my-reviews/` and review assigned items | `ANNOTATION_REVIEWER` group membership |
+| Submit a Review (`is_authoritative=False`) | assigned to the HumanScorer |
+| Submit a Review (`is_authoritative=True`) via routing rule | assigned to the HumanScorer **and** the routing rule had `mark_authoritative=True` |
+| Submit a Review (`is_authoritative=True`) manually | team admin / team lead (D-16: *"explicit toggle in the UI on any Review"*) |
+| Reassign a `ReviewItem` to a different reviewer | team admin |
+| Unflag a `ReviewItem` (admin path) | team admin |
+| View Reviews tab (admin) | team admin |
+| Configure a HumanScorer | team admin (brief 01) |
+
+The reviewer-flag (FR-4.7) and adjudication path are distinct:
+- Reviewer flags item → `ReviewItem.status = flagged` → if a `HUMAN_FLAG` routing rule exists, escalates to a different reviewer.
+- Disagreement detected (D-16) → if a `HUMAN_DISAGREEMENT` routing rule exists with `mark_authoritative=True`, escalates to an adjudicator whose Review becomes authoritative.
+
+### Form generation from schema
+
+The form on the right pane (S10b) is generated from `AssessmentSchema.fields ∩ HumanScorer.output_fields`. The renderer can reuse the existing dynamic-form builder ([`apps/human_annotations/forms.py:build_annotation_form`](../../../apps/human_annotations/forms.py)) with adaptations for the new model shapes.
+
+### IRR sampling — visibility decisions
+
+Per D-11, the IRR flag is set at `ReviewItem` creation (`is_irr_sample`), not at review time. UI implications:
+
+- Show the IRR badge in S9 (reviewer queue) and S11 (admin table) — but **don't** show the flag inside the review form itself. Reviewers should review the item the same way regardless; surfacing it on the form invites bias.
+- Open question: should reviewers know an item is IRR-sampled at all? Drafted as yes-in-queue, no-in-form. Worth confirming.
+
+### Authoritative override — discoverability
+
+D-16 says authoritative Reviews can be set procedurally (routing rule action) or manually (admin override). The manual path needs to be discoverable but not casual — listed as a per-row action in S11 with a confirm dialog, not a glaring button.
+
+### Reviewer feedback loop
+
+When a reviewer skips items (FR-4.8), flags items (FR-4.6), or saves drafts (FR-4.9), the action should produce a quiet toast confirmation. Avoid full-page reloads — these actions are high-frequency.
+
+## Open design questions
+
+1. **Reviewer's `/my-reviews/` ordering.** Drafted as grouped-by-Assessment. Alternative: chronological (oldest-first) across Assessments. Decision pending — depends on which signal the reviewer prioritises ("clear oldest backlog" vs "focus on one Assessment at a time").
+2. **IRR badge in the review form (S10b).** Currently hidden to avoid bias; alternative is to surface it for transparency. Worth testing.
+3. **Real-time "in-flight by another reviewer" indicator (S10b).** Useful but requires a presence mechanism. Could be deferred to v2 if the infrastructure cost is high; designers should know the v1 baseline is no presence.
+4. **Read-only review for admins.** When an admin opens a completed item from S11, should they see exactly what the reviewer saw (including prior-score panels for that reviewer) or a god-view (all reviews, all scores)? Drafted as god-view; confirm.
+5. **Field-level partial authority** (D-16 final paragraph). The design doc notes that partial-field authoritative override is expressed by submitting a Review with only the disputed fields. UI: does S10c surface a "submit only `<disputed_field>`" affordance, or do we expect the adjudicator to leave other fields blank? Defer to a follow-up usability decision.
+6. **Skip semantics.** FR-4.8 says "skip items already reviewed by the current user." Today the system enforces this automatically. The Skip button in S10b is for the explicit *"not my expertise"* case — should the action be just *"return to queue"* (item stays open for someone else to grab) or *"never show me this again"* (item gets a per-user skip record)? Recommend the former for v1.
+
+## Cross-references
+
+| Topic | Where |
+|---|---|
+| Why two prior-score visibility knobs | [D-7](../unified-assessment.md#d-7-two-prior-score-visibility-knobs-on-humanscorer-not-one) |
+| Per-scorer `output_fields` (form generation) | [D-10](../unified-assessment.md#d-10-shared-schema-with-per-scorer-field-subsets-not-schema-per-scorer) |
+| IRR sampling at queue entry | [D-11](../unified-assessment.md#d-11-irr-sampling-is-a-separate-field-sampled-at-queue-entry) |
+| Authoritative Reviews — when + how | [D-16](../unified-assessment.md#d-16-reviewer-disagreement-is-resolved-by-authoritative-reviews-not-by-statistical-fiat) |
+| `AppliedRoutingRule` provenance for escalations | [D-14](../unified-assessment.md#d-14-audit-row-generalises-across-all-routing-rule-action-types) |
+| Score targets (Trace / Session / EvaluationMessage) | [D-13](../unified-assessment.md#d-13-score-targets-are-measurement-units-trace-experimentsession-evaluationmessage-not-display-surfaces) |
+| Existing dynamic-form builder | [`apps/human_annotations/forms.py:build_annotation_form`](../../../apps/human_annotations/forms.py) |
+| Existing annotate template (the shape S10 replaces) | [`templates/human_annotations/annotate.html`](../../../templates/human_annotations/annotate.html) |
+| Reviewer permission group | [`apps/teams/backends.py:229`](../../../apps/teams/backends.py) |

--- a/docs/design/ui/04-analytics-runs-trends-concordance.md
+++ b/docs/design/ui/04-analytics-runs-trends-concordance.md
@@ -1,0 +1,261 @@
+# 04 — Analytics: Runs, Trends, and Concordance v1
+
+> The three analytical tabs on an Assessment. **Runs** (batch only) for "did this run pass?" and "did v4 beat v3?". **Trends** (continuous only) for "is production drifting?". **Concordance v1** for "do humans and judges agree?". Three distinct views on top of the same `Score` table (D-6).
+>
+> **Anchored to** [`../unified-assessment.md`](../unified-assessment.md): D-3 (`bot_version` is a per-run parameter), D-5 (continuous has no Runs), D-6 (Runs and Trends are separate views), D-13 (Score targets), D-16 (authoritative Reviews override consensus).
+>
+> **Out of scope** — covered by other briefs: Source / Routing / Scorers config (briefs 01, 02); the act of reviewing (brief 03). The Concordance v0 prototype at [`templates/assessments/concordance.html`](../../../templates/assessments/concordance.html) is the starting point this brief evolves *from*.
+
+## User stories addressed
+
+- Story 3 — *Regression checks across versions* (Runs tab; per-`AssessmentRun` `bot_version` per D-3).
+- Story 7 — *Concordance* (Concordance tab).
+- Story 8 — *Trend monitoring* (Trends tab).
+- Story 9 — *Inter-rater reliability* (per-author breakdown inside Concordance — the design doc's "group by `Score.author`" path).
+
+## Information architecture
+
+```
+Assessment detail
+├── Overview / Source / Scorers / Routing / Reviews   (briefs 01–03)
+├── Runs          ← THIS BRIEF (batch only)
+│   ├── /<run_id>/                  (run detail)
+│   └── /compare/<run_a>/<run_b>/   (side-by-side comparison)
+├── Trends        ← THIS BRIEF (continuous only)
+└── Concordance   ← THIS BRIEF (any Assessment with ≥2 scorer types or ≥2 reviewers)
+```
+
+**Tabs that don't apply are hidden, not greyed.** A batch Assessment doesn't show Trends; a continuous Assessment doesn't show Runs (D-5). An Assessment with only one scorer doesn't show Concordance.
+
+## Screens
+
+### S13 — Runs tab (batch only)
+
+**Replaces**: `templates/evaluations/evaluation_runs_home.html`. Same intent — list of runs, drill into one. New: per-run `bot_version` selection (D-3) is a runtime parameter.
+
+#### S13a — Runs list
+
+**Top section — quick stats** (across all runs of this Assessment):
+- Latest run status pill.
+- Latest aggregate per scorer (chips).
+- "Compare two runs" button — opens the comparison picker (S13c).
+
+**Main table — `AssessmentRun`s**:
+
+**Columns**: started · finished · duration · status · **bot version chip** (per-run; D-3) · scorer breakdown (small icons + per-scorer aggregate) · total Scores · row actions.
+
+**Status pill values** (from `AssessmentRun.status`): pending / processing / completed / failed. Match the existing pattern in [`templates/evaluations/evaluation_run_status_column.html`](../../../templates/evaluations/evaluation_run_status_column.html).
+
+**Per-row actions**: view detail (S13b) · re-run with same config · download CSV · download JSONL (FR-5.6).
+
+**"Start a run" CTA** (top-right):
+- Opens a small modal — pick `bot_version` (per D-3: specific / latest-working / latest-published — three choices, defaults to latest-working), confirm dataset size, "Start".
+- Background note: continuous Assessments don't have this CTA — the Runs tab itself is hidden for them.
+
+**Empty state**: *"No runs yet. Start a run to evaluate this Assessment against its dataset."* Single CTA.
+
+#### S13b — Run detail
+
+**Header**: run name (auto = *"Run N — `<bot_version_chip>` — `<started_at>`"*), status, started/finished/duration, total Scores.
+
+**Sections**:
+
+1. **Per-scorer summary** — one card per scorer:
+   - Scorer name + kind icon.
+   - **Aggregate panel** — per field in `output_fields`: aggregate value (mean for numeric, mode + distribution for categorical, true% for boolean), N, stdev. Sourced from `AssessmentRunAggregate` (eager batch cache per D-5).
+   - "Drill into Scores" link — opens S13d (per-scorer score table).
+   - Error count chip (errors are on `AutomatedResult`, not on Score — surface them here as workflow signal).
+2. **Routing-rule firings card** — count of `AppliedRoutingRule` rows produced by this run (per D-14). Click → S8c filtered to this run.
+3. **CSV / JSONL download** (FR-5.6) — per-run, with all FR-5.5 columns (global session id included).
+4. **CSV upload to correct/override** (FR-5.7) — batch-only feature. Surface as a small "Override results" affordance with explainer copy about re-aggregation.
+
+#### S13c — Run comparison (Story 3)
+
+Reachable from S13a's "Compare two runs" button.
+
+**Picker step**: choose Run A (default: latest), choose Run B (default: previous). Both must be on the same Assessment.
+
+**Comparison page**:
+
+- **Header strip**: Run A `<chip>` ↔ Run B `<chip>`, total Scores per side, bot_version per side.
+- **Per-field side-by-side table**:
+  - Rows: each field in the Assessment's schema.
+  - Columns: aggregate A, aggregate B, delta (with arrow + colour for direction-of-improvement, agnostic to "better is up/down").
+  - For numeric: mean ± stdev (A), mean ± stdev (B), delta.
+  - For categorical: mode % (A), mode % (B), distribution chips collapsed by default.
+- **Per-target diff drilldown** — *"Show me items where A and B disagree most."* Sortable table of targets with both A and B values, sorted by abs(delta). Useful for surfacing regressions on specific dataset items.
+- **Export**: CSV per the per-field side-by-side table.
+
+#### S13d — Per-scorer score drilldown
+
+A drilldown from S13b. Sortable, filterable table of every `Score` row produced by one scorer in one run.
+
+**Columns**: target (deep link) · per-field values (one column per `output_field`) · `AutomatedResult` status (success / error) · created_at · view (opens raw `AutomatedResult` JSON in a modal).
+
+Carries forward the existing `templates/evaluations/evaluation_results_table.html` shape; the new piece is that the values are now from Score rows, not from a dict on `EvaluationResult.output`.
+
+### S14 — Trends tab (continuous only)
+
+**Purpose**: answer Story 8 ("is production drifting?") with a rolling time-window view over the Score table.
+
+**Primary user**: Bot Owner, Team Lead.
+
+**Top section — time-window + filter chrome**:
+- **Time window** — common ranges (last 24h / 7d / 30d / 90d / custom). Default: last 7 days.
+- **Granularity** — hour / day / week (auto-selected based on window).
+- **Source filter** (FR-6.7) — multi-select: any combination of `LLM_JUDGE`, `PROGRAMMATIC`, `HUMAN_REVIEW`, `USER_FEEDBACK`, `SYSTEM`. Default: all.
+- **Field filter** — multi-select of fields in the Assessment's `AssessmentSchema`.
+- **Authoritative-only toggle** (D-16) — for the human-side: optionally include only Scores from `Review.is_authoritative=True`. Helpful when adjudicated ground truth is the comparator.
+
+**Main section — one chart per selected field**:
+
+- **Numeric fields** — line chart with mean ± std-band per bucket, one line per source. Optional median overlay. Y-axis = field value range.
+- **Boolean / Choice fields** — stacked area (proportion per category over time). For boolean, simplifies to "% true".
+- **Score volume** — small line chart of Scores-per-bucket (sanity-check; sudden drops imply dispatch problems — link to `AppliedSourceFilter` audit in S7c).
+
+**Side panel — current snapshot card**:
+- Latest aggregate per field per source.
+- "Compared to 7 days ago" delta arrow.
+- Link to the underlying score query (for export / power users).
+
+**Health card** (re-used from S7b):
+- Latest Score timestamp, 24h Score count, 24h `AppliedSourceFilter` failure count.
+
+**Empty state**: *"No Scores in this window. Continuous scoring depends on lifecycle events — see the [Source](../source-tab) tab for dispatch health."*
+
+**No materialised continuous-trend aggregates** (per the "Out of scope" callout in the design doc): queries compute on demand from `Score` rows. If query cost becomes a problem, the optimisation is precomputed daily/weekly buckets — additive, no UI change needed.
+
+### S15 — Concordance v1
+
+**Replaces**: `templates/assessments/concordance.html` (the v0 live for testing). The v0 already nails the basic shape — eval/queue picker, single shared categorical field, agreement %, matched/eval-only/human-only stats, deep links. v1 evolves it from "first useful thing" to "first useful thing across the full design surface".
+
+**Primary user**: Bot Builder, Team Lead.
+
+#### What v0 already does well (carry forward unchanged)
+
+- Picker UX: pick A, pick B, pick field, pick `show` filter (matched / eval-only / human-only / all).
+- Headline agreement %.
+- Stats strip with matched/eval-only/human-only counts.
+- Per-row deep links to eval result and annotation item.
+- Empty-state messaging per `show` value.
+
+#### What v1 adds
+
+1. **Picker generalisation**:
+   - Instead of "Evaluation × Annotation queue", pick **Assessment** + **Source A** + **Source B**.
+   - Sources are *any* scorer-source combination producing Scores on overlapping targets: e.g. *"LLM judge: accuracy"* vs *"Human consensus: accuracy"*, or *"LLM judge A"* vs *"LLM judge B"*, or *"Reviewer alice"* vs *"Reviewer bob"* (the inter-rater path per Story 9).
+   - In effect: source dropdown enumerates `(scorer, source_enum)` combinations producing Scores in the chosen Assessment, plus optional `Score.author` for the human-vs-human path.
+2. **Multi-field at once**:
+   - Drop the single-field selector; show one panel per shared field. Within a panel, the agreement headline + per-row table are scoped to that field.
+   - Field-tabs at the top for navigation when there are many fields.
+3. **Field-type-aware agreement statistics** (FR-7.3–7.5):
+   - **Categorical** — % agreement (already in v0) **plus** Cohen's Kappa with N and CI. Confusion matrix below the headline (collapsible).
+   - **Numeric** — Pearson correlation, mean absolute error, bias (mean of A - B), N. Scatter plot below the headline (collapsible). Bland-Altman is a v2 nice-to-have, not required.
+   - **Boolean** — both (categorical with 2 levels + numeric-style agreement).
+4. **Disagreement triage** (FR-7.6):
+   - "Sort by disagreement (largest first)" — for numeric, by abs(delta); for categorical, by "is disagreement" + freshness.
+   - One-click "Send disagreements to adjudication" — opens a confirm that creates `ReviewItem`s under an adjudicator HumanScorer (or surfaces a "no adjudicator HumanScorer exists, configure one in Routing" affordance, linking to brief 02).
+5. **Pre-aggregation transparency** (per the design doc's "Concordance is not a raw join on Score rows" callout):
+   - One-liner per source explaining how the side was computed: *"Source A: LLM judge — latest Score per target."* *"Source B: Human consensus — mean across N reviewers per target."* *"Source B: Reviewer alice — raw Scores (IRR path)."*
+   - If `is_authoritative=True` Reviews exist on the field, the consensus uses those preferentially (D-16 / FR-6.8). Surface this as a chip: *"Includes 3 authoritative reviews on `<field>`"*.
+6. **Filter affordances** (FR-7.8): date range, experiment filter (when target = `ExperimentSession`), tag filter.
+7. **Export** (FR-7.7): CSV per field + an "all fields" combined export.
+
+#### Layout sketch (v1)
+
+```
+Header: Assessment ▾   ·   Source A ▾   ·   Source B ▾   ·   Date range ▾   ·   [Filter chips]
+
+Field tabs: [accuracy] [tone] [helpfulness] [safety]
+
+┌── accuracy ─────────────────────────────────────────────────────────────┐
+│ Stats strip:  Agreement 84%  ·  κ = 0.71 (N=312)  ·  matched 312        │
+│               eval-only 14  ·  human-only 9                             │
+│                                                                         │
+│ Confusion matrix (collapsible)         Disagreement triage (top 20)     │
+│   [confusion table]                    [sortable list of mismatches]    │
+│                                                                         │
+│ Pre-aggregation note: Source A = LLM judge latest per target;           │
+│                       Source B = Human mean across 3 reviewers          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+#### Cross-Assessment concordance (explicitly out of scope)
+
+Per FR-7 and the design doc: concordance is **within-Assessment only** in v1. The picker only lists sources from the chosen Assessment. If a user expects cross-Assessment concordance, surface a small disclaimer near the picker: *"Comparing across Assessments isn't supported — both sides must score the same items. See [docs](...)."*
+
+#### Inter-rater reliability path (Story 9)
+
+When Source A or B = a specific `Score.author` (a single reviewer) and the other side = consensus or another reviewer:
+
+- Pre-aggregation note clarifies: *"Source A = Reviewer alice (raw Scores, no aggregation)."*
+- Stats interpretation: this is IRR, not eval-vs-human. UI copy adjusts: *"Inter-rater reliability between alice and bob"*.
+- For the "everyone vs everyone" IRR view: a small *"Show pairwise IRR"* mode that renders an N × N kappa matrix for the HumanScorer's assignees. v1 nice-to-have; defer if scope-tight.
+
+#### Migration from v0
+
+- v0 URL `/assessments/concordance/?eval=<id>&queue=<id>&field=<name>&show=<...>` should redirect to the v1 equivalent under the Assessment detail tab.
+- v0 only handled categorical fields; v1's numeric path is net-new.
+- v0 always took the **latest** Score per target (`_latest_score_per_target`) — v1 should *default to* consensus when `num_reviews_required > 1` and surface the pre-aggregation note so users see why their numbers changed.
+
+## Cross-cutting concerns
+
+### Where the data comes from
+
+Both Trends and Concordance read directly from the `Score` table. Runs read from `Score` + the eager `AssessmentRunAggregate` cache. Per D-6: no unified "trend abstraction" — three views over one table, each tuned to its question.
+
+### Source filtering interplay (D-16 + FR-6.8)
+
+Aggregation everywhere respects authoritative overrides per D-16/FR-6.8:
+- For a `(target, name)` with any authoritative Score, that Score *is* the human-side consensus value for that field.
+- Otherwise compute mean/mode normally across the eligible Scores.
+
+UI exposure: a small "Authoritative-only" toggle on Trends and Concordance (where applicable). On Runs (batch), authoritative is rare and not surfaced by default.
+
+### What "consensus" means precisely
+
+The design doc commits to this:
+- **Per-source consensus** = mean (numeric) / mode (categorical) of Scores grouped by source within the source-pre-aggregation step. With authoritative override per D-16.
+- For IRR Story 9: skip pre-aggregation on the human side; group by `Score.author` instead.
+
+The UI should never silently make a different aggregation choice; if a user changes a filter that alters how a side is computed, the pre-aggregation note (S15 item 5) updates live.
+
+### Performance
+
+- **Runs** views are bounded by Run scope — fast, hits the eager aggregate cache.
+- **Trends** is the more expensive path (window scans). Add indexes per the design doc's hint (`(target_content_type, target_object_id, name, source)`, `(created_at)` — both already present per `apps/assessments/models.py`).
+- **Concordance** queries are bounded by `(assessment, name)`. Pre-aggregation is the expensive part; cache per (Assessment, source-A, source-B, field, window) is justifiable if the queries get slow — additive optimisation.
+
+### Permissions
+
+- All three tabs are read-by-default for any team member with the `ASSESSMENTS` flag (FR-10.5).
+- Starting a run, downloading exports, and "send disagreements to adjudication" require team-admin or appropriate elevated permission.
+
+### Feature-flag transition
+
+While the unified surface rolls out:
+- The v0 concordance page (`flag_assessments_concordance`) keeps working until v1 is ready in this tab.
+- When `ASSESSMENTS` is fully enabled for a team, the v0 page becomes a redirect to the v1 tab. The two flags coexist briefly.
+
+## Open design questions
+
+1. **Concordance picker UX when source enumeration is large.** Drafted as flat dropdowns; if an Assessment has 5+ scorers, this gets noisy. Worth grouping by source kind (LLM-judge / Programmatic / Human / User-feedback).
+2. **Inter-rater pairwise matrix in v1.** Drafted as nice-to-have. Decide: ship in v1 or defer to v2? Depends on Story 9's real urgency.
+3. **Cross-Assessment concordance disclaimer placement.** Inline near the picker as drafted, or a separate "Why can't I compare across Assessments?" docs page? Smaller is better.
+4. **Trends y-axis bounds.** Drafted as data-driven autoscale; for `Choice` fields with known ranges (0–10 scale, say), should the axis lock to the schema's min/max? Likely yes for legibility.
+5. **Run comparison — which side is "before"?** Drafted with A on the left as user-picked; consider a convention where the *older* run is always A so the delta arrow is always *"newer beat older?"*. Tradeoff: less flexible for power users.
+6. **CSV upload to override results (S13b section 4 / FR-5.7).** Continuous Assessments explicitly *don't* support this per FR-5.7. Surface clearly so users don't expect it. Where the affordance lives on the Runs detail page is fine; just make sure it disappears for continuous.
+
+## Cross-references
+
+| Topic | Where |
+|---|---|
+| Runs and Trends are separate views, shared plumbing only | [D-6](../unified-assessment.md#d-6-separate-runs-and-trends-views-shared-score-plumbing-only) |
+| `bot_version` on `AssessmentRun`, not config (Story 3) | [D-3](../unified-assessment.md#d-3-bot_version-lives-on-assessmentrun-not-on-the-assessment) |
+| Continuous Assessments produce no `AssessmentRun` | [D-5](../unified-assessment.md#d-5-continuous-assessments-do-not-produce-assessmentrun-rows) |
+| Concordance pre-aggregation and the inter-rater path | [Score model section](../unified-assessment.md#score-the-value-layer), [story-mapping table](../unified-assessment.md#how-the-user-stories-map-to-the-unified-design) |
+| Authoritative Reviews override consensus | [D-16](../unified-assessment.md#d-16-reviewer-disagreement-is-resolved-by-authoritative-reviews-not-by-statistical-fiat), [FR-6.8](../unified-assessment.md#fr-6-aggregation--trends) |
+| Existing concordance v0 view (the shape this brief evolves from) | [`templates/assessments/concordance.html`](../../../templates/assessments/concordance.html) |
+| Existing eval-runs home (the shape S13 replaces) | [`templates/evaluations/evaluation_runs_home.html`](../../../templates/evaluations/evaluation_runs_home.html) |
+| Existing eval-result table | [`templates/evaluations/evaluation_results_table.html`](../../../templates/evaluations/evaluation_results_table.html) |
+| Score model + unique constraints | [`apps/assessments/models.py`](../../../apps/assessments/models.py) |

--- a/docs/design/ui/README.md
+++ b/docs/design/ui/README.md
@@ -1,0 +1,41 @@
+# Unified Assessment — UI design briefs
+
+Reference documents for designing the UI of the unified assessment system. Each brief targets one cluster of screens and is intended to be self-contained enough that a designer can work from it directly, while remaining anchored to the canonical data-model and decision-record in [`../unified-assessment.md`](../unified-assessment.md).
+
+## Status
+
+- **Score table** — shipped. See [`apps/assessments/models.py`](../../../apps/assessments/models.py).
+- **Concordance v0** — live for testing behind `flag_assessments_concordance`. Eval ↔ queue picker, categorical agreement % on shared field. See [`apps/assessments/views.py`](../../../apps/assessments/views.py) and [`templates/assessments/concordance.html`](../../../templates/assessments/concordance.html).
+- **Everything else in these briefs** — not built yet. The pre-unified UIs (eval configs, evaluators, annotation queues, annotate flow) are what the unified screens replace.
+
+## Briefs
+
+| # | Brief | Status |
+|---|---|---|
+| 01 | [Config: Assessment + Schema + Scorers](./01-config-assessment-schema-scorers.md) | draft |
+| 02 | [Source + Routing rules](./02-source-and-routing-rules.md) | draft |
+| 03 | [Review workflow (HumanScorer)](./03-review-workflow.md) | draft |
+| 04 | [Analytics: Runs + Trends + Concordance v1](./04-analytics-runs-trends-concordance.md) | draft |
+
+## How to read a brief
+
+Each brief follows the same shape:
+
+1. **Purpose & scope** — what cluster of screens this covers, what it does *not*.
+2. **User stories addressed** — pointer back to the stories in [`unified-assessment.md`](../unified-assessment.md#user-stories) that drive these screens.
+3. **Information architecture** — the list of screens and how they nest under the Assessment.
+4. **Per-screen specs** — for each screen: purpose, primary user, information shown, primary actions, key states (empty / loading / error / populated), and the components / data references that drive layout decisions.
+5. **Cross-cutting concerns** — permissions, feature-flag gating, empty-team experience, archiving.
+6. **Open design questions** — explicitly-unresolved points that a designer should flag rather than guess.
+
+## Conventions
+
+- **DaisyUI + Tailwind** is the project's component library. Existing patterns to reuse (verified in the concordance template): `breadcrumbs`, `stats` / `stat`, `badge` (`badge-success`, `badge-error`, `badge-ghost`, `badge-warning`), `alert` (`alert-info`, `alert-warning`), `form-control` + `label-text`, `select select-bordered`, `btn` (`btn-primary`, `btn-xs`, `join` / `join-item`), `table`, `card`, `tabs` / `tab`, `drawer`, `modal`.
+- **HTMX + Alpine.js** for in-page interactions over Django templates. React/TypeScript for islands of richer interaction (the pipeline builder is the existing reference). Don't introduce a new SPA layer for these flows unless a brief explicitly calls for it.
+- **Icons** are FontAwesome 6 (`fa-solid`, `fa-fw`) — see the concordance template for examples.
+- **Generic snippets** to reuse: `generic/chip_button.html` (compact link chip — used in concordance for session links).
+- **Feature flag**: the unified assessment surface lives behind `ASSESSMENTS` (per FR-10.6), replacing today's separate `flag_evaluations` and `flag_human_annotations`. Briefs assume the flag is active.
+
+## Canonical references
+
+When in doubt, the canonical source is [`docs/design/unified-assessment.md`](../unified-assessment.md). Briefs link to specific decision records (D-1 through D-16) when a UI choice is driven by a back-end constraint.

--- a/docs/design/unified-assessment.md
+++ b/docs/design/unified-assessment.md
@@ -85,7 +85,7 @@ A schema defines the structured fields that scorers (automated or human) produce
 | FR-1.1 | Define schemas as named, reusable objects owned by a team | Must |
 | FR-1.2 | Support field types: string, int, float, choice | Must |
 | FR-1.3 | Support validation constraints per field type (min/max, pattern, choices) | Must |
-| FR-1.4 | Support `required` and `use_in_aggregations` flags per field | Must |
+| FR-1.4 | Support `required` flag per field | Must |
 | FR-1.5 | A schema is reusable across multiple Assessments and is shared by all scorers within an Assessment (both automated and human, with each scorer addressing a subset via `output_fields` — see D-10) | Must |
 | FR-1.6 | Schemas are logically immutable once `Score` rows reference them; edits create a new schema row and repoint the Assessment (clone-and-repoint, not in-place edit). See D-8. | Must |
 
@@ -198,8 +198,7 @@ Aggregation computes statistical summaries across results. Both systems already 
 |----|------------|----------|
 | FR-6.1 | Compute numeric aggregates: mean, median, min, max, stdev | Must |
 | FR-6.2 | Compute categorical aggregates: mode, distribution (percentage per category) | Must |
-| FR-6.3 | Exclude string fields from aggregation by default | Must |
-| FR-6.4 | Respect per-field `use_in_aggregations` flag | Should |
+| FR-6.3 | Exclude string fields from aggregation — `String` field type is never aggregated; all `Numeric`, `Choice`, and `Boolean` fields are always aggregated | Must |
 | FR-6.5 | For batch runs: recompute `AssessmentRunAggregate` when new results land. For continuous Assessments: no stored aggregates — queries compute on demand from `Score` rows over a time window (see D-5) | Must |
 | FR-6.6 | Support trend analysis across multiple runs/time periods | Should |
 | FR-6.7 | Aggregates should be filterable by source type (show automated-only, human-only, or combined) | Should |


### PR DESCRIPTION
### Product Description
No change — documentation only.

### Technical Description
Adds four UI design briefs under `docs/design/ui/` plus a README index. The briefs are reference documents for a designer (or design AI) working on the unified assessment UI now that the `Score` table is shipped and the v0 concordance UI is live for testing.

Each brief is self-contained but anchored to `docs/design/unified-assessment.md` via cross-references to the canonical decisions (D-1 through D-16):

- **01 — Config: Assessment + Schema + Scorers.** Assessments list, creation wizard, tabbed detail shell, Schema catalogue + clone-and-repoint editor (D-8), AutomatedScorer (LLM / Python) and HumanScorer editors with the two D-7 visibility knobs and IRR sampling rate (D-11).
- **02 — Source + Routing rules.** Batch vs continuous Source tab (D-5, D-12), `AppliedSourceFilter` health card (D-15), Routing rule list + cascading-select editor pivoting on the trigger × action matrix, `AppliedRoutingRule` audit log (D-14).
- **03 — Review workflow.** Reviewer's personal `/my-reviews/` queue, per-item review screen with prior-score panel (D-7), IRR badge (D-11), escalation context (D-14), adjudication mode and authoritative override (D-16). Admin Reviews tab and manage-assignees modal.
- **04 — Analytics: Runs + Trends + Concordance v1.** Three separate tabs per D-6: batch Runs with per-run `bot_version` (D-3) and side-by-side comparison (Story 3), continuous Trends, and Concordance v1 evolving the live v0 into multi-field, multi-source-kind with κ + confusion matrix (categorical) and correlation/MAE (numeric), plus the inter-rater path (Story 9).

Also drops the per-field `use_in_aggregations` flag from FR-1.4 / FR-6 in favour of type-driven aggregation: `Numeric`, `Choice`, `Boolean` always aggregate; `String` never does. Removes one configuration knob with no real use cases for the off-state.

The briefs intentionally leave open design questions explicit (5–6 per brief) rather than guessing them, so a designer can flag rather than invent.

### Demo
N/A — documentation only.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

These are internal design documents under `docs/design/`, not user-facing docs.