### PR TITLE
[DevOps] Upgrade repository-dispatch version to fix failing workflow dispatch docs/changelogs

### DIFF
--- a/.github/workflows/api-schema-dispatch.yml
+++ b/.github/workflows/api-schema-dispatch.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@v4.0.1
         with:
           token: ${{ secrets.OCS_DOCS_PAT }}
           repository: dimagi/open-chat-studio-docs

--- a/.github/workflows/docs-changelog-dispatch.yml
+++ b/.github/workflows/docs-changelog-dispatch.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Repository Dispatch
         if: steps.check_docs_needed.outputs.needs_docs_update == 'true'
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@v4.0.1
         with:
           token: ${{ secrets.OCS_DOCS_PAT }}
           repository: dimagi/open-chat-studio-docs


### PR DESCRIPTION
### Product Description

Fix for https://github.com/dimagi/open-chat-studio/issues/3441


### Technical Description

- Node.js 20 Deprecation. GitHub Actions rely on an underlying Node.js runtime environment to execute JavaScript-based actions. The Problem: actions/checkout@v4 and many older actions are built on top of Node.js 20. The Shift: GitHub officially deprecated the Node.js 20 runtime environment for actions. GitHub has mandated that actions must transition to a minimum requirement of Node.js 24
- The peter-evans/repository-dispatch must also be upgraded so that it can run on node.js 24
- The version to use is 4.0.1 https://github.com/peter-evans/repository-dispatch/releases/tag/v4.0.1


### Migrations
no migrations

### Docs and Changelog
- [ ] This PR requires docs/changelog update

