### PR TITLE
Link ad hoc bot AI message to the produced trace

### DIFF
--- a/apps/chat/bots.py
+++ b/apps/chat/bots.py
@@ -385,7 +385,9 @@ class EventBot:
             span.set_outputs({"response": message})
 
             if self.history_manager:
-                self.history_manager.save_message_to_history(message, type_=ChatMessageType.AI)
+                ai_message = self.history_manager.save_message_to_history(message, type_=ChatMessageType.AI)
+                if ai_message is not None:
+                    self.trace_service.set_output_message_id(ai_message.id)
         return message
 
     @property

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -38,9 +38,11 @@ from apps.utils.factories.experiment import (
 )
 from apps.utils.factories.pipelines import NodeFactory, PipelineFactory
 from apps.utils.factories.service_provider_factories import (
+    LlmProviderFactory,
     VoiceProviderFactory,
 )
 from apps.utils.factories.team import TeamFactory
+from apps.utils.langchain import build_fake_llm_service
 
 
 @pytest.fixture()
@@ -424,6 +426,24 @@ class TestExperimentSession:
         # Verify that the database changes were rolled back
         final_message_count = ChatMessage.objects.filter(chat=experiment_session.chat).count()
         assert final_message_count == initial_message_count, "Transaction should have rolled back the message creation"
+
+    @patch("apps.chat.channels.ChannelBase.from_experiment_session")
+    @patch("apps.service_providers.models.LlmProvider.get_llm_service")
+    def test_ad_hoc_message_links_ai_message_to_trace(
+        self, mock_get_llm_service, from_experiment_session, experiment_session
+    ):
+        """The Trace created during ad_hoc_bot_message should reference the AI ChatMessage it produced."""
+        mock_get_llm_service.return_value = build_fake_llm_service(responses=["Bot reply"])
+        LlmProviderFactory.create(team=experiment_session.experiment.team)
+        from_experiment_session.return_value = Mock()
+
+        experiment_session.ad_hoc_bot_message("Tell the user we're testing", TraceInfo(name="test"))
+
+        ai_message = ChatMessage.objects.get(chat=experiment_session.chat, message_type=ChatMessageType.AI)
+        assert ai_message.content == "Bot reply"
+
+        trace = Trace.objects.get(session=experiment_session)
+        assert trace.output_message_id == ai_message.id
 
     @pytest.mark.parametrize("participant_data_injected", [True, False])
     def test_requires_participant_data(self, participant_data_injected):


### PR DESCRIPTION
### Product Description
Fixes #3440 — when an ad hoc bot message was sent (e.g. from a scheduled message or event action), the resulting `Trace` record was not linked to the AI `ChatMessage` it produced.

### Technical Description
`EventBot.get_user_message` saved the AI `ChatMessage` via the history manager but never called `trace_service.set_output_message_id(ai_message.id)`, so `Trace.output_message` stayed `NULL` for ad hoc messages. The pipeline path (`PipelineBot._save_outputs`) already does this; this PR mirrors that behaviour in `EventBot`.

### Migrations
- [x] The migrations are backwards compatible (no migrations)

### Demo
Added `test_ad_hoc_message_links_ai_message_to_trace` which fails on `main` and passes with the fix.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Generated with [Claude Code](https://claude.ai/code)