### PR TITLE
[Docs] Add note re auto doc & changelog fails from PR from fork

### DIFF
--- a/docs/contributing/user_docs.md
+++ b/docs/contributing/user_docs.md
@@ -9,7 +9,8 @@ This guide explains how to make user docs changes that are clear, accurate, and 
 ## Before You Make a Change
 
 - Is this a user docs change, or should it go in [developer docs instead](#user-docs-vs-developer-docs)?
-- If you have user-facing code changes, use the AI-assisted docs/changelog automation [(i.e., the changelog process)](../developer_guides/user_docs.md#manual-trigger-in-docs-repo).
+- If you have user-facing code changes, use the AI-assisted docs/changelog automation [(i.e., the changelog process)](../developer_guides/user_docs.md).
+   - Note: If you are developing on a fork, the automated process to create user docs on a PR will fail, so you have to do this [manually](../developer_guides/user_docs.md#manual-option) or ask the Dimagi team to [run the GitHub action.](../developer_guides/user_docs.md#manual-trigger-in-docs-repo)
 - Are you updating an existing page, or should this be a new page?
 - Does the wording match the current product UI?
 - Will renaming or removing a page [break links](#if-you-move-or-rename-a-docs-page) pointing to that page?


### PR DESCRIPTION
### Product Description

Developer documentation


### Technical Description

- Added a note to the Contributing / user docs to clarify the impact of PRs from a fork causing the automatic user doc & changelog process to fail in the GitHub action workflows
- Noted the workaround


### Docs and Changelog
- [ ] This PR requires docs/changelog update
