### PR TITLE
Search providers by public identifier fields, not just secrets

### DIFF
--- a/apps/service_providers/forms.py
+++ b/apps/service_providers/forms.py
@@ -237,6 +237,7 @@ def obfuscate_value(value):
 
 class AWSVoiceConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
     obfuscate_fields = ["aws_secret_access_key"]
+    additional_searchable_fields = ["aws_access_key_id"]
 
     aws_access_key_id = forms.CharField(label=_("Access Key ID"))
     aws_secret_access_key = forms.CharField(label=_("Secret Access Key"))
@@ -252,6 +253,7 @@ class AzureVoiceConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
 
 class TwilioMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
     obfuscate_fields = ["auth_token"]
+    additional_searchable_fields = ["account_sid"]
 
     account_sid = forms.CharField(label=_("Account SID"))
     auth_token = forms.CharField(label=_("Auth Token"))
@@ -265,6 +267,7 @@ class TurnIOMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
 
 class SureAdhereMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
     obfuscate_fields = ["client_secret"]
+    additional_searchable_fields = ["client_id"]
 
     client_id = forms.CharField(
         label=_("Client ID"), help_text=_("Azure AD B2C Application ID used for authentication.")
@@ -289,6 +292,7 @@ class SureAdhereMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
 
 class MetaCloudAPIMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
     obfuscate_fields = ["access_token", "app_secret", "verify_token"]
+    additional_searchable_fields = ["business_id"]
 
     business_id = forms.CharField(label=_("WhatsApp Business Account ID"))
     access_token = forms.CharField(label=_("System User Access Token"))
@@ -321,6 +325,7 @@ class MetaCloudAPIMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
 
 class CommCareAuthConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
     obfuscate_fields = ["api_key"]
+    additional_searchable_fields = ["username"]
 
     username = forms.CharField(label=_("Username"))
     api_key = forms.CharField(label=_("API Key"))
@@ -328,6 +333,7 @@ class CommCareAuthConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
 
 class BasicAuthConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
     obfuscate_fields = ["password"]
+    additional_searchable_fields = ["username"]
 
     username = forms.CharField(label=_("Username"))
     password = forms.CharField(label=_("Password"))
@@ -359,6 +365,7 @@ class SlackMessagingConfigForm(ProviderTypeConfigForm):
 
 class LangfuseTraceProviderForm(ObfuscatingMixin, ProviderTypeConfigForm):
     obfuscate_fields = ["secret_key"]
+    additional_searchable_fields = ["public_key"]
 
     secret_key = forms.CharField(label=_("Secret Key"))
     public_key = forms.CharField(label=_("Public Key"))

--- a/apps/service_providers/tests/test_usages.py
+++ b/apps/service_providers/tests/test_usages.py
@@ -308,6 +308,44 @@ def test_search_trace_provider(team_with_users):
 
 
 @pytest.mark.django_db()
+def test_search_langfuse_by_public_key(team_with_users):
+    """Langfuse exposes ``public_key`` as a non-secret identifier; it should still be searchable."""
+    trace = TraceProviderFactory(
+        team=team_with_users,
+        type=TraceProviderType.langfuse,
+        config={"public_key": "pk-lf-public-123", "secret_key": "trace-secret", "host": "https://example.com"},
+    )
+    matches = search_providers_by_api_key(ServiceProvider.tracing, "pk-lf-public-123", match="exact")
+    assert trace in matches
+
+
+@pytest.mark.django_db()
+def test_search_aws_voice_by_access_key_id(team_with_users):
+    voice = VoiceProviderFactory(
+        team=team_with_users,
+        type=VoiceProviderType.aws,
+        config={
+            "aws_access_key_id": "AKIA-PUBLIC-ID",
+            "aws_secret_access_key": "voice-secret",
+            "aws_region": "us-east-1",
+        },
+    )
+    matches = search_providers_by_api_key(ServiceProvider.voice, "AKIA-PUBLIC-ID", match="exact")
+    assert voice in matches
+
+
+@pytest.mark.django_db()
+def test_search_twilio_by_account_sid(team_with_users):
+    msg = MessagingProviderFactory(
+        team=team_with_users,
+        type=MessagingProviderType.twilio,
+        config={"auth_token": "twilio-secret", "account_sid": "AC-public-sid"},
+    )
+    matches = search_providers_by_api_key(ServiceProvider.messaging, "AC-public-sid", match="exact")
+    assert msg in matches
+
+
+@pytest.mark.django_db()
 def test_search_invalid_match_mode_raises(anthropic_provider):
     with pytest.raises(ValueError, match="unknown match mode"):
         search_providers_by_api_key(ServiceProvider.llm, "key", match="fuzzy")  # type: ignore[arg-type]

--- a/apps/service_providers/usages.py
+++ b/apps/service_providers/usages.py
@@ -268,16 +268,21 @@ def search_providers_by_api_key(
 
     matches = []
     for provider in queryset.iterator():
-        secret_fields = _secret_field_names(provider)
-        if not secret_fields:
+        fields = _searchable_field_names(provider)
+        if not fields:
             continue
-        if any(_value_matches(provider.config.get(f, ""), key, match) for f in secret_fields):
+        if any(_value_matches(provider.config.get(f, ""), key, match) for f in fields):
             matches.append(provider)
     return matches
 
 
-def _secret_field_names(provider) -> Iterable[str]:
-    """The set of config keys that hold credentials for ``provider``'s subtype."""
+def _searchable_field_names(provider) -> Iterable[str]:
+    """Config keys that can be matched against a supplied key for ``provider``'s subtype.
+
+    Includes the obfuscated secret fields plus any non-secret public identifiers
+    that the form opts into via ``additional_searchable_fields`` (e.g. Langfuse's
+    ``public_key`` or AWS' ``aws_access_key_id``).
+    """
     try:
         type_enum = provider.type_enum
     except (KeyError, ValueError):
@@ -291,7 +296,9 @@ def _secret_field_names(provider) -> Iterable[str]:
     form_cls = getattr(type_enum, "form_cls", None)
     if form_cls is None:
         return ()
-    return getattr(form_cls, "obfuscate_fields", ()) or ()
+    obfuscated = getattr(form_cls, "obfuscate_fields", ()) or ()
+    public = getattr(form_cls, "additional_searchable_fields", ()) or ()
+    return [*obfuscated, *public]
 
 
 def _value_matches(stored: object, target: str, match: MatchMode) -> bool:


### PR DESCRIPTION
### Product Description
Staff "find provider by API key" tool can now match Langfuse providers by their `public_key` (and similar non-secret identifiers on AWS Voice, Twilio, Meta Cloud API, SureAdhere, CommCare/Basic auth). Previously only obfuscated secret fields were searched, so common support lookups by a customer-supplied public key returned nothing.

### Technical Description
Forms opt extra fields into search via a new `additional_searchable_fields` class attribute, paralleling the existing `obfuscate_fields`. `search_providers_by_api_key` unions both lists when picking which config keys to compare against.

Which providers got the opt-in is a judgment call worth a glance — kept it to fields that are clearly customer-visible identifiers paired with a secret (Langfuse `public_key`, AWS `aws_access_key_id`, Twilio `account_sid`, Meta `business_id`, SureAdhere `client_id`, Basic/CommCare `username`). URLs/regions/API bases were left out.

### Migrations
N/A — no schema change.

### Docs and Changelog
- [ ] This PR requires docs/changelog update