### PR TITLE
Add concordance results CSV export

### DIFF
--- a/apps/assessments/tests/test_export.py
+++ b/apps/assessments/tests/test_export.py
@@ -2,10 +2,9 @@ import csv
 import io
 
 import pytest
-from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
+from waffle.models import Flag
 
-from apps.assessments.models import Score
 from apps.assessments.score_writers import write_scores_from_evaluation_result
 from apps.evaluations.models import EvaluationResult
 from apps.human_annotations.models import Annotation, AnnotationStatus
@@ -18,6 +17,22 @@ from apps.utils.factories.evaluations import (
 from apps.utils.factories.experiment import ExperimentSessionFactory
 from apps.utils.factories.human_annotations import AnnotationItemFactory, AnnotationQueueFactory
 from apps.utils.factories.team import TeamWithUsersFactory
+
+
+def _enable_flag(name):
+    flag, _ = Flag.objects.get_or_create(name=name)
+    flag.everyone = True
+    flag.save()
+    flag.flush()
+    return flag
+
+
+@pytest.fixture()
+def concordance_flags():
+    """Enable all three feature flags required by the concordance views."""
+    _enable_flag("flag_assessments_concordance")
+    _enable_flag("flag_evaluations")
+    _enable_flag("flag_human_annotations")
 
 
 def _make_concordance_data(team):
@@ -53,7 +68,7 @@ def _make_concordance_data(team):
 
 
 @pytest.mark.django_db()
-def test_export_concordance_csv(client, flag_assessments_concordance, flag_evaluations, flag_human_annotations):
+def test_export_concordance_csv(client, concordance_flags):
     team = TeamWithUsersFactory.create()
     user = team.members.first()
     client.force_login(user)
@@ -77,7 +92,7 @@ def test_export_concordance_csv(client, flag_assessments_concordance, flag_evalu
 
 
 @pytest.mark.django_db()
-def test_export_concordance_csv_missing_params(client, flag_assessments_concordance, flag_evaluations, flag_human_annotations):
+def test_export_concordance_csv_missing_params(client, concordance_flags):
     team = TeamWithUsersFactory.create()
     user = team.members.first()
     client.force_login(user)

--- a/apps/assessments/tests/test_export.py
+++ b/apps/assessments/tests/test_export.py
@@ -3,7 +3,7 @@ import io
 
 import pytest
 from django.urls import reverse
-from waffle.models import Flag
+from waffle.testutils import override_flag
 
 from apps.assessments.score_writers import write_scores_from_evaluation_result
 from apps.evaluations.models import EvaluationResult
@@ -19,20 +19,15 @@ from apps.utils.factories.human_annotations import AnnotationItemFactory, Annota
 from apps.utils.factories.team import TeamWithUsersFactory
 
 
-def _enable_flag(name):
-    flag, _ = Flag.objects.get_or_create(name=name)
-    flag.everyone = True
-    flag.save()
-    flag.flush()
-    return flag
-
-
 @pytest.fixture()
 def concordance_flags():
     """Enable all three feature flags required by the concordance views."""
-    _enable_flag("flag_assessments_concordance")
-    _enable_flag("flag_evaluations")
-    _enable_flag("flag_human_annotations")
+    with (
+        override_flag("flag_assessments_concordance", active=True),
+        override_flag("flag_evaluations", active=True),
+        override_flag("flag_human_annotations", active=True),
+    ):
+        yield
 
 
 def _make_concordance_data(team):

--- a/apps/assessments/tests/test_export.py
+++ b/apps/assessments/tests/test_export.py
@@ -1,0 +1,87 @@
+import csv
+import io
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from apps.assessments.models import Score
+from apps.assessments.score_writers import write_scores_from_evaluation_result
+from apps.evaluations.models import EvaluationResult
+from apps.human_annotations.models import Annotation, AnnotationStatus
+from apps.utils.factories.evaluations import (
+    EvaluationConfigFactory,
+    EvaluationMessageFactory,
+    EvaluationRunFactory,
+    EvaluatorFactory,
+)
+from apps.utils.factories.experiment import ExperimentSessionFactory
+from apps.utils.factories.human_annotations import AnnotationItemFactory, AnnotationQueueFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+
+
+def _make_concordance_data(team):
+    """Create minimal concordance-ready fixtures; return (eval_config, queue, session)."""
+    schema = {"verdict": {"type": "choice", "choices": ["yes", "no"], "description": "x"}}
+    session = ExperimentSessionFactory.create(team=team, experiment__team=team)
+
+    evaluator = EvaluatorFactory.create(team=team, params={"llm_prompt": "x", "output_schema": schema})
+    eval_config = EvaluationConfigFactory.create(team=team)
+    eval_config.evaluators.add(evaluator)
+    run = EvaluationRunFactory.create(team=team, config=eval_config)
+    message = EvaluationMessageFactory.create(session=session)
+    result = EvaluationResult.objects.create(
+        team=team,
+        evaluator=evaluator,
+        message=message,
+        run=run,
+        output={"result": {"verdict": "yes"}},
+    )
+    write_scores_from_evaluation_result(result)
+
+    queue = AnnotationQueueFactory.create(team=team, schema=schema)
+    item = AnnotationItemFactory.create(queue=queue, session=session, team=team)
+    Annotation.objects.create(
+        team=team,
+        item=item,
+        reviewer=team.members.first(),
+        data={"verdict": "yes"},
+        status=AnnotationStatus.SUBMITTED,
+    )
+
+    return eval_config, queue, session
+
+
+@pytest.mark.django_db()
+def test_export_concordance_csv(client, flag_assessments_concordance, flag_evaluations, flag_human_annotations):
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    client.force_login(user)
+
+    eval_config, queue, session = _make_concordance_data(team)
+
+    url = reverse("assessments:concordance_export", args=[team.slug])
+    response = client.get(url, {"eval": eval_config.id, "queue": queue.id, "field": "verdict", "show": "all"})
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/csv"
+    assert "attachment" in response["Content-Disposition"]
+
+    reader = csv.DictReader(io.StringIO(response.content.decode()))
+    rows = list(reader)
+    assert len(rows) >= 1
+    first = rows[0]
+    assert "kind" in first
+    assert "judge_verdict" in first
+    assert "human_verdict" in first
+
+
+@pytest.mark.django_db()
+def test_export_concordance_csv_missing_params(client, flag_assessments_concordance, flag_evaluations, flag_human_annotations):
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    client.force_login(user)
+
+    url = reverse("assessments:concordance_export", args=[team.slug])
+    response = client.get(url)
+    assert response.status_code == 404

--- a/apps/assessments/urls.py
+++ b/apps/assessments/urls.py
@@ -6,4 +6,5 @@ app_name = "assessments"
 
 urlpatterns = [
     path("", views.ConcordanceView.as_view(), name="concordance"),
+    path("export/", views.export_concordance_csv, name="concordance_export"),
 ]

--- a/apps/assessments/views.py
+++ b/apps/assessments/views.py
@@ -1,3 +1,4 @@
+import csv
 from dataclasses import dataclass
 from typing import Any
 
@@ -11,6 +12,7 @@ from apps.assessments.models import Score
 from apps.evaluations.models import EvaluationConfig, EvaluationMode
 from apps.experiments.models import ExperimentSession
 from apps.human_annotations.models import AnnotationItem, AnnotationQueue
+from apps.teams.decorators import login_and_team_required
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 
 _SESSION_MODE = EvaluationMode.SESSION
@@ -284,3 +286,85 @@ class ConcordanceView(LoginAndTeamRequiredMixin, TemplateView):
             }
         )
         return context
+
+
+@login_and_team_required
+def export_concordance_csv(request: HttpRequest, team_slug: str) -> HttpResponse:
+    """Export concordance results as CSV.
+
+    Accepts the same ``eval``, ``queue``, ``field``, and ``show`` query
+    parameters as ``ConcordanceView``.  Returns a 404 when the feature flags
+    are inactive or required parameters are missing.
+    """
+    if not (
+        flag_is_active(request, "flag_assessments_concordance")
+        and flag_is_active(request, "flag_evaluations")
+        and flag_is_active(request, "flag_human_annotations")
+    ):
+        raise Http404("Concordance is not enabled for this team.")
+
+    team = request.team
+    eval_id = request.GET.get("eval")
+    queue_id = request.GET.get("queue")
+    field_name = request.GET.get("field")
+    show = request.GET.get("show", "all")
+    if show not in _SHOW_CHOICES:
+        show = "all"
+
+    if not eval_id or not queue_id:
+        raise Http404("eval and queue parameters are required.")
+
+    eval_config = get_object_or_404(EvaluationConfig, id=eval_id, team=team)
+    queue = get_object_or_404(AnnotationQueue, id=queue_id, team=team)
+    candidates = _candidate_categorical_fields(eval_config, queue)
+
+    if not candidates:
+        raise Http404("No matching categorical fields found.")
+
+    field_name = _resolve_field_name(field_name, candidates)
+    if field_name is None:
+        raise Http404("field parameter is required when multiple fields exist.")
+
+    rows_by_kind = _build_concordance_rows(team=team, eval_config=eval_config, queue=queue, field_name=field_name)
+    rows_by_show = {
+        "matched": rows_by_kind["matched"],
+        "eval_only": rows_by_kind["eval_only"],
+        "human_only": rows_by_kind["human_only"],
+        "all": rows_by_kind["matched"] + rows_by_kind["eval_only"] + rows_by_kind["human_only"],
+    }
+    rows = rows_by_show[show]
+
+    filename = f"concordance_{eval_config.name}_{queue.name}_{field_name}.csv".replace(" ", "_")
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+
+    writer = csv.writer(response)
+    writer.writerow(
+        [
+            "kind",
+            "session_external_id",
+            "experiment_public_id",
+            f"judge_{field_name}",
+            f"human_{field_name}",
+            "agree",
+            "eval_run_id",
+            "eval_result_id",
+            "annotation_item_id",
+        ]
+    )
+    for row in rows:
+        writer.writerow(
+            [
+                row.kind,
+                row.session_external_id,
+                row.experiment_public_id,
+                row.judge_value,
+                row.human_value,
+                row.agree,
+                row.eval_run_id,
+                row.eval_result_id,
+                row.annotation_item_id,
+            ]
+        )
+
+    return response

--- a/templates/assessments/concordance.html
+++ b/templates/assessments/concordance.html
@@ -11,7 +11,15 @@
 {% endblock breadcrumbs %}
 
 {% block app %}
-  <h1 class="text-2xl font-bold mb-4">{% translate "Concordance" %}</h1>
+  <div class="flex items-center mb-4">
+    <h1 class="text-2xl font-bold flex-1">{% translate "Concordance" %}</h1>
+    {% if rows is not None %}
+      <a href="{% url 'assessments:concordance_export' request.team.slug %}?{{ request.GET.urlencode }}"
+         class="btn btn-secondary btn-sm">
+        <i class="fa-solid fa-download"></i> {% translate "Export CSV" %}
+      </a>
+    {% endif %}
+  </div>
 
   <form method="get" class="mb-6 flex gap-4 items-end flex-wrap">
     <label class="form-control">


### PR DESCRIPTION
### Product Description
Users can now export concordance results as CSV directly from the concordance page via an *Export CSV* button in the top-right.

### Technical Description
New `export_concordance_csv` view in `apps/assessments/views.py` reuses the existing `_build_concordance_rows` logic — no new data access. Accepts the same `eval`, `queue`, `field`, and `show` query params as the concordance page, so the button passes through the current filter state via `request.GET.urlencode()`.

The button only renders when results are loaded (i.e. `rows` is in the template context).

### Migrations
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update