### PR TITLE
ci: enable dev-utils plugin for Claude workflows

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,17 @@
     ]
   },
   "enableAllProjectMcpServers": false,
+  "extraKnownMarketplaces": {
+    "dimagi-claude-workflows": {
+      "source": {
+        "source": "github",
+        "repo": "dimagi/dimagi-claude-workflows"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "dev-utils@dimagi-claude-workflows": true
+  },
   "env": {
     "MAX_THINKING_TOKENS": "32000"
   },

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -201,7 +201,7 @@ jobs:
             7. Add a comment to the issue summarizing what you did
 
             If all tasks are complete or blocked, comment on the issue explaining the status.
-          claude_args: '--allowedTools "Bash(npm run lint:*),Bash(npm run type-check:*),Bash(npm run build:*),Bash(ruff check:*),Bash(ruff format:*),Bash(pytest:*),Bash(uv run --no-project zensical build:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rm:*),Bash(gh pr create:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(ls:*),Bash(grep:*),Bash(sort:*),Bash(tail:*),Grep,Glob,Read,Write,Edit"'
+          claude_args: '--allowedTools "Bash(npm run lint:*),Bash(npm run type-check:*),Bash(npm run build:*),Bash(ruff check:*),Bash(ruff format:*),Bash(pytest:*),Bash(uv run --no-project zensical build:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rm:*),Bash(git checkout:*),Bash(git switch:*),Bash(git status:*),Bash(git diff:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh api:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(ls:*),Bash(grep:*),Bash(sort:*),Bash(tail:*),Grep,Glob,Read,Write,Edit"'
 
   # ── Event-driven: respond to @claude mentions, issue label ──
   claude:
@@ -282,4 +282,4 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           branch_prefix: "claude/"
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(npm run lint:*),Bash(npm run type-check:*),Bash(npm run build:*),Bash(ruff check:*),Bash(ruff format:*),Bash(pytest:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git checkout:*),Bash(git branch:*),Bash(gh pr create:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue comment:*),Bash(gh issue edit:*),Read,Write,Edit"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(npm run lint:*),Bash(npm run type-check:*),Bash(npm run build:*),Bash(ruff check:*),Bash(ruff format:*),Bash(pytest:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git checkout:*),Bash(git switch:*),Bash(git status:*),Bash(git diff:*),Bash(git branch:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(gh issue comment:*),Bash(gh issue edit:*),Read,Write,Edit"


### PR DESCRIPTION
### Product Description
No change — affects how Claude Code (CLI + the `claude.yml` GitHub Actions runs) is configured, not user-facing chatbot behavior.

### Technical Description
`.claude/settings.json` now registers the `dimagi/dimagi-claude-workflows` marketplace and enables the `dev-utils` plugin via `enabledPlugins`. `claude-code-action` auto-loads repo `.claude/settings.json` at startup, so this exposes `dev-utils:create-pr` and the rest of the plugin's skills/commands to Claude in CI as well as locally.

`claude.yml` `--allowedTools` is widened in both jobs (scheduled and event-driven) to cover the git/gh subcommands the `create-pr` skill declares: `git switch`, `git status`, `git diff`, `gh pr edit`, `gh api` (and `git checkout` for the scheduled job, which was missing it). Without these, the skill would hit permission prompts in CI and stall.

Worth a closer look: this is now the source of truth for the plugin in this repo — anyone cloning will auto-pick up the marketplace + plugin on next session start, which is the intended effect but worth being aware of.

The scheduled job's prompt still tells Claude to "create a PR" in prose rather than invoking `/dev-utils:create-pr` explicitly; left out of this PR so the wiring lands first and prompt tuning can follow separately.

### Migrations
N/A — config only.

### Docs and Changelog
- [ ] This PR requires docs/changelog update