### PR TITLE
Switch admin usage CSV from character counts to trace tokens

### DIFF
--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -53,12 +53,12 @@ def get_usage_data(start: datetime, end: datetime):
         Trace.objects.filter(timestamp__gte=start, timestamp__lt=end)
         .exclude(status=TraceStatus.PENDING)
         .exclude(session__platform=ChannelPlatform.EVALUATIONS)
-        .values("team__name")
+        .values("team_id", "team__name")
         .annotate(
             run_count=Count("id"),
             total_tokens=Coalesce(Sum("n_total_tokens"), Value(0)),
         )
-        .order_by("-run_count")
+        .order_by("-run_count", "team__name")
     )
     for data in usage_data:
         yield data["team__name"], data["run_count"], data["total_tokens"]

--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -5,12 +5,13 @@ from collections import defaultdict
 from datetime import datetime
 
 from django.db.models import Count, Q, Sum, Value
-from django.db.models.functions import Coalesce, Length, TruncDate
+from django.db.models.functions import Coalesce, TruncDate
 
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.models import ChatMessage
 from apps.experiments.models import ExperimentSession, Participant
 from apps.teams.models import Team
+from apps.trace.models import Trace, TraceStatus
 
 
 def get_message_stats(start: datetime, end: datetime):
@@ -38,27 +39,29 @@ def get_participant_stats(start: datetime, end: datetime):
 
 
 def usage_to_csv(start: datetime, end: datetime):
-    return _write_data_to_csv(["Team", "Message Count", "Total Characters"], get_usage_data(start, end))
+    return _write_data_to_csv(["Team", "Run Count", "Total Tokens"], get_usage_data(start, end))
 
 
 def get_usage_data(start: datetime, end: datetime):
-    """Usage approximation based on character counts."""
+    """Per-team usage from completed trace token counts.
+
+    Only includes traces with a settled status (excludes PENDING) and excludes the
+    evaluations platform. Pre-tracing periods will report lower totals than the
+    legacy character-based proxy.
+    """
     usage_data = (
-        ChatMessage.objects.filter(created_at__gte=start, created_at__lt=end)
-        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
-        .values("chat__team__name")
+        Trace.objects.filter(timestamp__gte=start, timestamp__lt=end)
+        .exclude(status=TraceStatus.PENDING)
+        .exclude(session__platform=ChannelPlatform.EVALUATIONS)
+        .values("team__name")
         .annotate(
-            msg_count=Count("id"),
-            total_chars=Sum(
-                Length("content")
-                + Length("chat__experiment_session__experiment__prompt_text")
-                + Length(Coalesce("chat__experiment_session__experiment__source_material__material", Value("")))
-            ),
+            run_count=Count("id"),
+            total_tokens=Coalesce(Sum("n_total_tokens"), Value(0)),
         )
-        .order_by("-msg_count")
+        .order_by("-run_count")
     )
     for data in usage_data:
-        yield data["chat__team__name"], data["msg_count"], data["total_chars"]
+        yield data["team__name"], data["run_count"], data["total_tokens"]
 
 
 def get_whatsapp_numbers():

--- a/apps/admin/tests/test_queries.py
+++ b/apps/admin/tests/test_queries.py
@@ -9,11 +9,13 @@ from apps.admin.queries import (
     get_team_activity_summary,
     get_top_experiments,
     get_top_teams,
+    get_usage_data,
     get_whatsapp_message_stats,
     get_whatsapp_number_data,
 )
 from apps.admin.views import _compute_growth
 from apps.channels.models import ChannelPlatform
+from apps.trace.models import Trace, TraceStatus
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import (
     ChatMessageFactory,
@@ -21,6 +23,7 @@ from apps.utils.factories.experiment import (
     ParticipantFactory,
 )
 from apps.utils.factories.team import TeamFactory
+from apps.utils.factories.traces import TraceFactory
 
 
 @pytest.fixture()
@@ -257,6 +260,110 @@ class TestGetWhatsappNumberData:
         assert rows_by_number["+15550004444"][5] is False  # deleted channel
         assert rows_by_number["+15550003333"][1] == active_channel.experiment.name
         assert rows_by_number["+15550004444"][1] == deleted_channel.experiment.name
+
+
+@pytest.mark.django_db()
+class TestGetUsageData:
+    def _make_trace(self, *, session, status=TraceStatus.SUCCESS, tokens=0):
+        return TraceFactory.create(
+            team=session.team,
+            experiment=session.experiment,
+            session=session,
+            participant=session.participant,
+            status=status,
+            n_total_tokens=tokens,
+        )
+
+    def test_sums_tokens_and_counts_runs_per_team(self, date_range):
+        start, end = date_range
+        team_a = TeamFactory.create(name="Team A")
+        team_b = TeamFactory.create(name="Team B")
+        session_a = ExperimentSessionFactory.create(team=team_a, experiment__team=team_a)
+        session_b = ExperimentSessionFactory.create(team=team_b, experiment__team=team_b)
+
+        self._make_trace(session=session_a, tokens=100)
+        self._make_trace(session=session_a, tokens=50)
+        self._make_trace(session=session_b, tokens=200)
+
+        rows = {team: (run_count, tokens) for team, run_count, tokens in get_usage_data(start, end)}
+        assert rows["Team A"] == (2, 150)
+        assert rows["Team B"] == (1, 200)
+
+    def test_orders_by_run_count_descending(self, date_range):
+        start, end = date_range
+        team_small = TeamFactory.create(name="Small")
+        team_big = TeamFactory.create(name="Big")
+        small_session = ExperimentSessionFactory.create(team=team_small, experiment__team=team_small)
+        big_session = ExperimentSessionFactory.create(team=team_big, experiment__team=team_big)
+
+        self._make_trace(session=small_session, tokens=10)
+        for _ in range(3):
+            self._make_trace(session=big_session, tokens=10)
+
+        result = list(get_usage_data(start, end))
+        assert [row[0] for row in result] == ["Big", "Small"]
+
+    def test_excludes_evaluations_platform(self, date_range):
+        start, end = date_range
+        team = TeamFactory.create(name="T")
+        web_channel = ExperimentChannelFactory.create(team=team, platform=ChannelPlatform.WEB)
+        eval_channel = ExperimentChannelFactory.create(team=team, platform=ChannelPlatform.EVALUATIONS)
+        web_session = ExperimentSessionFactory.create(
+            team=team,
+            experiment=web_channel.experiment,
+            experiment_channel=web_channel,
+            platform=ChannelPlatform.WEB,
+        )
+        eval_session = ExperimentSessionFactory.create(
+            team=team,
+            experiment=eval_channel.experiment,
+            experiment_channel=eval_channel,
+            platform=ChannelPlatform.EVALUATIONS,
+        )
+        self._make_trace(session=web_session, tokens=100)
+        self._make_trace(session=eval_session, tokens=99999)
+
+        rows = list(get_usage_data(start, end))
+        assert rows == [("T", 1, 100)]
+
+    def test_excludes_pending_traces_but_includes_errors(self, date_range):
+        start, end = date_range
+        team = TeamFactory.create(name="T")
+        session = ExperimentSessionFactory.create(team=team, experiment__team=team)
+        self._make_trace(session=session, status=TraceStatus.SUCCESS, tokens=10)
+        self._make_trace(session=session, status=TraceStatus.ERROR, tokens=5)
+        self._make_trace(session=session, status=TraceStatus.PENDING, tokens=99999)
+
+        rows = list(get_usage_data(start, end))
+        assert rows == [("T", 2, 15)]
+
+    def test_handles_null_token_counts(self, date_range):
+        start, end = date_range
+        team = TeamFactory.create(name="T")
+        session = ExperimentSessionFactory.create(team=team, experiment__team=team)
+        TraceFactory.create(
+            team=team,
+            experiment=session.experiment,
+            session=session,
+            status=TraceStatus.SUCCESS,
+            n_total_tokens=None,
+        )
+
+        rows = list(get_usage_data(start, end))
+        assert rows == [("T", 1, 0)]
+
+    def test_filters_by_date_range(self, date_range):
+        start, end = date_range
+        team = TeamFactory.create(name="T")
+        session = ExperimentSessionFactory.create(team=team, experiment__team=team)
+        in_window = self._make_trace(session=session, tokens=10)
+        out_of_window = self._make_trace(session=session, tokens=99999)
+        # Trace.timestamp uses auto_now_add; bypass via update()
+        Trace.objects.filter(id=out_of_window.id).update(timestamp=start - timedelta(seconds=1))
+        Trace.objects.filter(id=in_window.id).update(timestamp=start + timedelta(seconds=1))
+
+        rows = list(get_usage_data(start, end))
+        assert rows == [("T", 1, 10)]
 
 
 class TestComputeGrowth:

--- a/apps/admin/tests/test_queries.py
+++ b/apps/admin/tests/test_queries.py
@@ -352,6 +352,27 @@ class TestGetUsageData:
         rows = list(get_usage_data(start, end))
         assert rows == [("T", 1, 0)]
 
+    def test_does_not_merge_teams_sharing_a_display_name(self, date_range):
+        # Team.name has no uniqueness constraint, so grouping by name alone would
+        # incorrectly combine separate teams. Each team must aggregate independently.
+        start, end = date_range
+        team_one = TeamFactory.create(name="Duplicate")
+        team_two = TeamFactory.create(name="Duplicate")
+        session_one = ExperimentSessionFactory.create(team=team_one, experiment__team=team_one)
+        session_two = ExperimentSessionFactory.create(team=team_two, experiment__team=team_two)
+
+        self._make_trace(session=session_one, tokens=10)
+        self._make_trace(session=session_two, tokens=20)
+        self._make_trace(session=session_two, tokens=30)
+
+        rows = list(get_usage_data(start, end))
+        assert len(rows) == 2
+        token_totals = sorted(row[2] for row in rows)
+        run_counts = sorted(row[1] for row in rows)
+        assert token_totals == [10, 50]
+        assert run_counts == [1, 2]
+        assert all(row[0] == "Duplicate" for row in rows)
+
     def test_filters_by_date_range(self, date_range):
         start, end = date_range
         team = TeamFactory.create(name="T")


### PR DESCRIPTION
### Product Description

The internal admin usage CSV now reports per-team token consumption sourced from `Trace` records, replacing the old per-message character-length approximation. The CSV header changes from `Team, Message Count, Total Characters` to `Team, Run Count, Total Tokens`.

This is prerequisite work for #3468 (remove `Experiment.prompt_text`) and #3470 (remove `Experiment.source_material`) — the old expression read both deprecated fields. Switching to `Trace.n_total_tokens` decouples the admin report from those fields and gives a more accurate signal.

### Technical Description

- `apps/admin/queries.py:get_usage_data` rewritten to aggregate over `Trace` instead of `ChatMessage`. Filters out `TraceStatus.PENDING` (in-flight) and the evaluations platform. `Sum("n_total_tokens")` wrapped in `Coalesce(..., Value(0))` to handle null token counts.
- `usage_to_csv` headers updated to `["Team", "Run Count", "Total Tokens"]`.
- Unused imports cleaned up (`Length` removed).
- Six new tests in `apps/admin/tests/test_queries.py::TestGetUsageData` cover: token sums, run counts, ordering, evaluations exclusion, pending-trace exclusion, error-status inclusion, null token handling, and date-range filtering.

### Migrations

- [x] The migrations are backwards compatible

(No migrations.)

### Demo

The CSV is downloaded via the admin usage export. Sample headers/rows after this change:

```
Team,Run Count,Total Tokens
Team A,42,15823
Team B,7,2104
```

### Docs and Changelog

- [ ] This PR requires docs/changelog update

Resolves #3472

🤖 Generated with [Claude Code](https://claude.com/claude-code)