### PR TITLE
feat: add claude-opus-4-8 model

### DIFF
--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -52,6 +52,7 @@ DEFAULT_LLM_PROVIDER_MODELS = {
         Model("gpt-4o", 128000),
     ],
     "anthropic": [
+        Model("claude-opus-4-8", k(1000), parameters=ClaudeOpus47Parameters),
         Model("claude-opus-4-7", k(1000), parameters=ClaudeOpus47Parameters),
         Model("claude-opus-4-6", k(200), is_translation_default=True, parameters=ClaudeOpus46Parameters),
         Model("claude-sonnet-4-6", 1000000, is_default=True, parameters=ClaudeSonnet46Parameters),

--- a/apps/service_providers/migrations/0055_add_gemini_3_5_flash.py
+++ b/apps/service_providers/migrations/0055_add_gemini_3_5_flash.py
@@ -1,7 +1,5 @@
 from django.db import migrations
 
-from apps.service_providers.migration_utils import llm_model_migration
-
 
 class Migration(migrations.Migration):
     dependencies = [
@@ -10,5 +8,5 @@ class Migration(migrations.Migration):
 
     operations = [
         # Add gemini-3.5-flash for both `google` and `google_vertex_ai` providers (1M context)
-        llm_model_migration(),
+        # llm_model_migration() moved to 0056_add_claude_opus_4_8
     ]

--- a/apps/service_providers/migrations/0056_add_claude_opus_4_8.py
+++ b/apps/service_providers/migrations/0056_add_claude_opus_4_8.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+from apps.service_providers.migration_utils import llm_model_migration
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("service_providers", "0055_add_gemini_3_5_flash"),
+    ]
+
+    operations = [
+        # Add claude-opus-4-8 for the `anthropic` provider (1M context)
+        llm_model_migration(),
+    ]


### PR DESCRIPTION
## Summary

Adds [Claude Opus 4.8](https://www.anthropic.com/news/claude-opus-4-8) to Open Chat Studio's supported Anthropic models.

Closes #3476

## Changes

- Added `claude-opus-4-8` to `DEFAULT_LLM_PROVIDER_MODELS` in `default_models.py` (1M context, reusing `ClaudeOpus47Parameters` — same effort/adaptive-thinking controls, no temperature/top_p/top_k)
- Stripped `llm_model_migration()` from migration 0055 (as required by the managing_models guide — only runs once per deployment)
- Created migration `0056_add_claude_opus_4_8` with `llm_model_migration()`

## Notes

Pricing is unchanged from Opus 4.7: $5/M input tokens, $25/M output tokens. `ClaudeOpus47Parameters` is reused since 4.8 has the same parameter constraints (no temperature, supports `xhigh` effort, adaptive thinking).