### PR TITLE
docs(adr): add ADR-0018 for team FK scoping convention

### DIFF
--- a/docs/adr/0018-scope-team-querysets-by-fk-not-slug-join.md
+++ b/docs/adr/0018-scope-team-querysets-by-fk-not-slug-join.md
@@ -1,0 +1,27 @@
+# ADR-0018: Scope team querysets by FK identity, not slug join
+
+<span class="adr-status adr-status-accepted">ACCEPTED</span>
+
+<p class="adr-meta">Author: Simon Kelly · Created: 2026-05-29</p>
+
+## Context
+
+Most resources are team-scoped (`BaseTeamModel`). Authenticated views resolve `request.team` through middleware, lazily, from the `team_slug` URL kwarg, so the current team is already in scope before any view body runs (enforced by `@login_and_team_required` / `LoginAndTeamRequiredMixin`).
+
+Despite this, many querysets filtered with `team__slug=<slug>`. That lookup traverses the `team` FK into `teams_team` purely to match a slug — forcing a JOIN to resolve a team id the request already held. It read as the natural form because the slug is the URL kwarg, but the join is redundant wherever `request.team` exists.
+
+## Decision
+
+We will scope team-bound querysets in authenticated views by the `team` FK identity — `team=request.team` — rather than the slug traversal `team__slug=<slug>`, wherever `request.team` is in scope.
+
+## Consequences
+
+- Each converted lookup drops a JOIN to `teams_team` from the emitted SQL; the win is most visible on hot API list endpoints that run on every request.
+- New code has one idiomatic scoping form to copy, and a `team__slug=` filter in a request-scoped view becomes a reviewable regression signal.
+- No behaviour change — both forms resolve to the same team and return identical rows.
+- The convention applies only where `request.team` exists; code without a request in scope (models, management commands, and views working off a raw slug) continues to filter by `team__slug=`.
+
+## Alternatives considered
+
+- Keep `team__slug=` everywhere → rejected: pays for a redundant JOIN, and mixing two scoping idioms invites drift.
+- `team_id=request.team.id` → rejected: emits equivalent SQL but reads less clearly than passing the instance, with no offsetting benefit.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -37,3 +37,4 @@ Where {lowercase-status} is one of: draft, proposed, accepted, rejected, superse
 | [0015](0015-human-annotations-app-with-queue-item-annotation-aggregate-model.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Dedicated human_annotations app with queue/item/annotation/aggregate model |
 | [0016](0016-authoritative-annotation-for-multi-reviewer-consensus.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Authoritative annotation for multi-reviewer consensus |
 | [0017](0017-eager-aggregation-of-submitted-annotations.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Eager per-submission aggregation into a per-queue record |
+| [0018](0018-scope-team-querysets-by-fk-not-slug-join.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Scope team querysets by FK identity, not slug join |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - 0015 Dedicated human_annotations app with queue/item/annotation/aggregate model: adr/0015-human-annotations-app-with-queue-item-annotation-aggregate-model.md
       - 0016 Authoritative annotation for multi-reviewer consensus: adr/0016-authoritative-annotation-for-multi-reviewer-consensus.md
       - 0017 Eager per-submission aggregation into a per-queue record: adr/0017-eager-aggregation-of-submitted-annotations.md
+      - 0018 Scope team querysets by FK identity, not slug join: adr/0018-scope-team-querysets-by-fk-not-slug-join.md
   - Developer Guides:
     - Processes:
       - Igor (Incremental Worker): developer_guides/igor.md


### PR DESCRIPTION
### Product Description
No change — documentation only.

### Technical Description
Extracts one decision from the (now fully shipped) `list-view-performance-design.md` spec into an ADR: scope team-bound querysets by the `team` FK (`team=request.team`) rather than the `team__slug=` join. This is the convention that #3464 (issue #3278) applied across ~73 sites.

Scope was deliberately limited to that one decision — the spec's other shipped decisions (Trace/ExperimentSession indexes, EXISTS-over-DISTINCT filter machinery, slice-then-prefetch) are not extracted here, so the source spec is left unchanged rather than collapsed to a pointer.

Behavioral claims in the ADR were checked against the code: `request.team` is set lazily by `apps/teams/middleware.py` from the `team_slug` kwarg and required by `login_and_team_required`; the remaining `team__slug=` sites are the intentionally-skipped non-request cases.

### Migrations
N/A — docs only.

### Docs and Changelog
- [ ] This PR requires docs/changelog update