### PR TITLE
fix(evaluations): centralise dataset message dedup to prevent duplicate references

### DIFF
--- a/apps/evaluations/auto_population.py
+++ b/apps/evaluations/auto_population.py
@@ -77,9 +77,8 @@ def _scan_for_new_sessions(rule: DatasetAutoPopulationRule, created_floor) -> li
     eval_messages = make_session_evaluation_messages(session_external_ids, team=rule.team)
     if not eval_messages:
         return []
-    created = EvaluationMessage.objects.bulk_create(eval_messages)
-    rule.dataset.messages.add(*created)
-    return list(created)
+    created, _ = rule.dataset.add_messages(eval_messages)
+    return created
 
 
 def _ingest_rule(rule: DatasetAutoPopulationRule) -> list[EvaluationMessage]:

--- a/apps/evaluations/forms.py
+++ b/apps/evaluations/forms.py
@@ -934,8 +934,7 @@ class EvaluationDatasetForm(EvaluationDatasetBaseForm):
             for pair in message_pairs
         ]
 
-        created_messages = EvaluationMessage.objects.bulk_create(evaluation_messages)
-        dataset.messages.set(created_messages)
+        dataset.add_messages(evaluation_messages)
 
     def _save_csv(self, dataset):
         """Dispatch async task to create messages from CSV."""

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Literal
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.urls import reverse
 from django.utils import timezone
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
@@ -257,6 +257,62 @@ class EvaluationDataset(BaseTeamModel):
     @property
     def is_pending(self):
         return self.status == DatasetCreationStatus.PENDING
+
+    def add_messages(self, messages: list[EvaluationMessage]) -> tuple[list[EvaluationMessage], int]:
+        """Persist and link messages to this dataset, skipping duplicate references.
+
+        Deduplication is mode-aware:
+        - message mode: a message duplicates another when they share the same
+          (input_chat_message_id, expected_output_chat_message_id) pair.
+        - session mode: a message duplicates another when they share the same session_id.
+
+        Messages without the relevant references (e.g. manual or CSV rows with null
+        FKs) are never treated as duplicates. The dataset row is locked for the
+        duration to serialise concurrent adds. Returns (created_messages, skipped_count).
+        """
+        with transaction.atomic():
+            # Lock the dataset row so concurrent add_messages calls can't both
+            # read "not a duplicate" and each insert the same reference.
+            EvaluationDataset.objects.select_for_update().get(pk=self.pk)
+
+            seen = self._existing_dedup_keys()
+            to_create = []
+            skipped = 0
+            for message in messages:
+                key = self._dedup_key(message)
+                if key is not None and key in seen:
+                    skipped += 1
+                    continue
+                if key is not None:
+                    seen.add(key)
+                to_create.append(message)
+
+            created = []
+            if to_create:
+                created = EvaluationMessage.objects.bulk_create(to_create)
+                self.messages.add(*created)
+            return created, skipped
+
+    def _dedup_key(self, message: EvaluationMessage) -> tuple | None:
+        """Return the dedup key for a message, or None if it can't be a duplicate."""
+        if self.evaluation_mode == EvaluationMode.SESSION:
+            if message.session_id is None:
+                return None
+            return ("session", message.session_id)
+        if message.input_chat_message_id is None or message.expected_output_chat_message_id is None:
+            return None
+        return ("pair", message.input_chat_message_id, message.expected_output_chat_message_id)
+
+    def _existing_dedup_keys(self) -> set[tuple]:
+        """Build the set of dedup keys already present in this dataset."""
+        if self.evaluation_mode == EvaluationMode.SESSION:
+            session_ids = self.messages.filter(session__isnull=False).values_list("session_id", flat=True)
+            return {("session", session_id) for session_id in session_ids}
+        pairs = self.messages.filter(
+            input_chat_message_id__isnull=False,
+            expected_output_chat_message_id__isnull=False,
+        ).values_list("input_chat_message_id", "expected_output_chat_message_id")
+        return {("pair", input_id, output_id) for input_id, output_id in pairs}
 
     class Meta:
         unique_together = ("name", "team")

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -498,8 +498,7 @@ def create_dataset_from_csv_task(
 
             # Bulk create messages
             progress_recorder.set_progress(95, 100, "Creating messages...")
-            created_messages = EvaluationMessage.objects.bulk_create(evaluation_messages)
-            dataset.messages.add(*created_messages)
+            created_messages, _ = dataset.add_messages(evaluation_messages)
 
             # Mark as completed
             dataset.status = DatasetCreationStatus.COMPLETED
@@ -878,33 +877,7 @@ def create_dataset_from_session_messages_task(
                 40, 100, f"Found {len(evaluation_messages)} messages, checking for duplicates..."
             )
 
-            # Get existing chat message pairs to avoid duplicates
-            existing_chat_message_pairs = set(
-                dataset.messages.filter(
-                    input_chat_message_id__isnull=False,
-                    expected_output_chat_message_id__isnull=False,
-                ).values_list("input_chat_message_id", "expected_output_chat_message_id")
-            )
-
-            # Filter out duplicates based on ChatMessage IDs
-            messages_to_add = []
-            for msg in evaluation_messages:
-                chat_pair = (msg.input_chat_message_id, msg.expected_output_chat_message_id)
-                if chat_pair not in existing_chat_message_pairs:
-                    messages_to_add.append(msg)
-                    existing_chat_message_pairs.add(chat_pair)
-
-            if not messages_to_add:
-                dataset.status = DatasetCreationStatus.COMPLETED
-                dataset.job_id = ""
-                dataset.save(update_fields=["status", "job_id"])
-                progress_recorder.set_progress(100, 100, "Clone complete - no new messages to add")
-                return {"success": True, "created_count": 0, "duplicates_skipped": len(evaluation_messages)}
-
-            progress_recorder.set_progress(70, 100, f"Creating {len(messages_to_add)} new messages...")
-
-            created_messages = EvaluationMessage.objects.bulk_create(messages_to_add)
-            dataset.messages.add(*created_messages)
+            created_messages, duplicates_skipped = dataset.add_messages(evaluation_messages)
 
             dataset.status = DatasetCreationStatus.COMPLETED
             dataset.job_id = ""
@@ -912,8 +885,11 @@ def create_dataset_from_session_messages_task(
 
             progress_recorder.set_progress(100, 100, "Clone complete")
 
-            duplicates_skipped = len(evaluation_messages) - len(messages_to_add)
-            return {"success": True, "created_count": len(created_messages), "duplicates_skipped": duplicates_skipped}
+            return {
+                "success": True,
+                "created_count": len(created_messages),
+                "duplicates_skipped": duplicates_skipped,
+            }
 
     except Exception as e:
         logger.exception(f"Error in clone task for dataset {dataset_id}: {e}")
@@ -956,35 +932,19 @@ def create_dataset_from_sessions_task(self, dataset_id, team_id, session_ids):
                 40, 100, f"Found {len(evaluation_messages)} sessions, checking for duplicates..."
             )
 
-            with transaction.atomic():
-                # Re-read existing session PKs inside the transaction for consistency
-                existing_session_pks = set(
-                    dataset.messages.select_for_update()
-                    .filter(session__isnull=False)
-                    .values_list("session_id", flat=True)
-                )
+            created_messages, duplicates_skipped = dataset.add_messages(evaluation_messages)
 
-                messages_to_add = [msg for msg in evaluation_messages if msg.session_id not in existing_session_pks]
-
-                if not messages_to_add:
-                    dataset.status = DatasetCreationStatus.COMPLETED
-                    dataset.job_id = ""
-                    dataset.save(update_fields=["status", "job_id"])
-                    progress_recorder.set_progress(100, 100, "Clone complete - no new sessions to add")
-                    return {"success": True, "created_count": 0, "duplicates_skipped": len(evaluation_messages)}
-
-                progress_recorder.set_progress(70, 100, f"Creating {len(messages_to_add)} new session messages...")
-
-                created_messages = EvaluationMessage.objects.bulk_create(messages_to_add)
-                dataset.messages.add(*created_messages)
-                dataset.status = DatasetCreationStatus.COMPLETED
-                dataset.job_id = ""
-                dataset.save(update_fields=["status", "job_id"])
+            dataset.status = DatasetCreationStatus.COMPLETED
+            dataset.job_id = ""
+            dataset.save(update_fields=["status", "job_id"])
 
             progress_recorder.set_progress(100, 100, "Clone complete")
 
-            duplicates_skipped = len(evaluation_messages) - len(messages_to_add)
-            return {"success": True, "created_count": len(created_messages), "duplicates_skipped": duplicates_skipped}
+            return {
+                "success": True,
+                "created_count": len(created_messages),
+                "duplicates_skipped": duplicates_skipped,
+            }
 
     except Exception as e:
         logger.exception(f"Error in session-mode clone task for dataset {dataset_id}: {e}")

--- a/apps/evaluations/tests/test_dataset_add_messages.py
+++ b/apps/evaluations/tests/test_dataset_add_messages.py
@@ -1,0 +1,161 @@
+import pytest
+
+from apps.chat.models import ChatMessageType
+from apps.evaluations.models import EvaluationDataset, EvaluationMessage, EvaluationMode
+from apps.utils.factories.experiment import ChatMessageFactory, ExperimentSessionFactory
+from apps.utils.factories.team import TeamFactory
+
+
+def _chat_message_pair(session):
+    """Create a (human, ai) ChatMessage pair on the session's chat."""
+    human = ChatMessageFactory.create(message_type=ChatMessageType.HUMAN, content="human", chat=session.chat)
+    ai = ChatMessageFactory.create(message_type=ChatMessageType.AI, content="ai", chat=session.chat)
+    return human, ai
+
+
+@pytest.mark.django_db()
+def test_message_mode_skips_pair_already_in_dataset():
+    """A message whose (input, output) chat-message pair is already in the dataset is skipped."""
+    session = ExperimentSessionFactory.create()
+    dataset = EvaluationDataset.objects.create(team=session.team, name="ds", evaluation_mode=EvaluationMode.MESSAGE)
+    human, ai = _chat_message_pair(session)
+    existing = EvaluationMessage.objects.create(
+        input={"content": "human"},
+        output={"content": "ai"},
+        input_chat_message=human,
+        expected_output_chat_message=ai,
+        session=session,
+    )
+    dataset.messages.add(existing)
+
+    incoming = EvaluationMessage(
+        input={"content": "human"},
+        output={"content": "ai"},
+        input_chat_message=human,
+        expected_output_chat_message=ai,
+        session=session,
+    )
+    created, skipped = dataset.add_messages([incoming])
+
+    assert len(created) == 0
+    assert skipped == 1
+    assert dataset.messages.count() == 1
+
+
+@pytest.mark.django_db()
+def test_message_mode_skips_duplicate_pair_within_batch():
+    """Two incoming messages with the same chat-message pair only add one."""
+    session = ExperimentSessionFactory.create()
+    dataset = EvaluationDataset.objects.create(team=session.team, name="ds", evaluation_mode=EvaluationMode.MESSAGE)
+    human, ai = _chat_message_pair(session)
+
+    incoming = [
+        EvaluationMessage(
+            input={"content": "human"},
+            output={"content": "ai"},
+            input_chat_message=human,
+            expected_output_chat_message=ai,
+            session=session,
+        )
+        for _ in range(2)
+    ]
+    created, skipped = dataset.add_messages(incoming)
+
+    assert len(created) == 1
+    assert skipped == 1
+    assert dataset.messages.count() == 1
+
+
+@pytest.mark.django_db()
+def test_message_mode_allows_same_input_different_output():
+    """Pair-based dedup: same input chat message with a different output is a distinct eval."""
+    session = ExperimentSessionFactory.create()
+    dataset = EvaluationDataset.objects.create(team=session.team, name="ds", evaluation_mode=EvaluationMode.MESSAGE)
+    human, ai_1 = _chat_message_pair(session)
+    ai_2 = ChatMessageFactory.create(message_type=ChatMessageType.AI, content="ai2", chat=session.chat)
+
+    incoming = [
+        EvaluationMessage(
+            input={"content": "human"},
+            output={"content": "ai"},
+            input_chat_message=human,
+            expected_output_chat_message=ai_1,
+            session=session,
+        ),
+        EvaluationMessage(
+            input={"content": "human"},
+            output={"content": "ai2"},
+            input_chat_message=human,
+            expected_output_chat_message=ai_2,
+            session=session,
+        ),
+    ]
+    created, skipped = dataset.add_messages(incoming)
+
+    assert len(created) == 2
+    assert skipped == 0
+    assert dataset.messages.count() == 2
+
+
+@pytest.mark.django_db()
+def test_session_mode_skips_session_already_in_dataset():
+    """A session-mode message whose session is already in the dataset is skipped."""
+    session = ExperimentSessionFactory.create()
+    dataset = EvaluationDataset.objects.create(team=session.team, name="ds", evaluation_mode=EvaluationMode.SESSION)
+    existing = EvaluationMessage.objects.create(input={}, output={}, session=session)
+    dataset.messages.add(existing)
+
+    incoming = EvaluationMessage(input={}, output={}, session=session)
+    created, skipped = dataset.add_messages([incoming])
+
+    assert len(created) == 0
+    assert skipped == 1
+    assert dataset.messages.count() == 1
+
+
+@pytest.mark.django_db()
+def test_session_mode_skips_duplicate_session_within_batch():
+    session = ExperimentSessionFactory.create()
+    dataset = EvaluationDataset.objects.create(team=session.team, name="ds", evaluation_mode=EvaluationMode.SESSION)
+
+    incoming = [
+        EvaluationMessage(input={}, output={}, session=session),
+        EvaluationMessage(input={}, output={}, session=session),
+    ]
+    created, skipped = dataset.add_messages(incoming)
+
+    assert len(created) == 1
+    assert skipped == 1
+    assert dataset.messages.count() == 1
+
+
+@pytest.mark.django_db()
+def test_null_fk_messages_are_never_deduped():
+    """Manual/CSV messages have no FKs and must never be treated as duplicates."""
+    team = TeamFactory.create()
+    dataset = EvaluationDataset.objects.create(team=team, name="ds", evaluation_mode=EvaluationMode.MESSAGE)
+
+    incoming = [
+        EvaluationMessage(input={"content": "x"}, output={"content": "y"}),
+        EvaluationMessage(input={"content": "x"}, output={"content": "y"}),
+    ]
+    created, skipped = dataset.add_messages(incoming)
+
+    assert len(created) == 2
+    assert skipped == 0
+    assert dataset.messages.count() == 2
+
+
+@pytest.mark.django_db()
+def test_messages_are_persisted_and_linked():
+    """Incoming unsaved messages are persisted and linked to the dataset."""
+    team = TeamFactory.create()
+    dataset = EvaluationDataset.objects.create(team=team, name="ds", evaluation_mode=EvaluationMode.MESSAGE)
+
+    incoming = [EvaluationMessage(input={"content": "x"}, output={"content": "y"})]
+    created, skipped = dataset.add_messages(incoming)
+
+    assert len(created) == 1
+    message = dataset.messages.get()
+    assert message.pk is not None
+    assert message.input == {"content": "x"}


### PR DESCRIPTION
### Product Description
no change

### Technical Description
Datasets could end up with two `EvaluationMessage` rows referencing the same session or chat-message pair. Dedup logic was duplicated across the five population paths and applied inconsistently — and the message-mode clone path deduped in memory with **no transaction or row lock**, so two concurrent clones on the same dataset could each read "not a duplicate" and both insert the same pair. (A production scan turned up exactly one such duplicate.)

All paths now route through a single `EvaluationDataset.add_messages()`:
- Locks the dataset row (`select_for_update`) for the duration — this is the actual race fix.
- Dedups by mode: `(input_chat_message_id, expected_output_chat_message_id)` pair for message mode, `session_id` for session mode; against both existing rows and within the incoming batch.
- Messages with null FKs (manual / CSV) are never deduped, so those paths keep their current behaviour.

Worth a reviewer's eye: message-mode dedup stays **pair-based**, so the same input chat message paired with a *different* expected output is intentionally still allowed (distinct eval). The existing single duplicate in production is **not** cleaned up by this PR — it only prevents new ones.

### Migrations
N/A — no schema change.

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update