### PR TITLE
feat(api): add URL-path versioning, pin v1 against current URLs

### DIFF
--- a/apps/api/tests/test_versioning.py
+++ b/apps/api/tests/test_versioning.py
@@ -1,0 +1,76 @@
+import pytest
+from django.urls import resolve, reverse
+from rest_framework.exceptions import NotFound
+from rest_framework.test import APIRequestFactory
+
+from apps.api.versioning import URLPathVersioning
+from apps.utils.factories.experiment import ExperimentFactory
+from apps.utils.factories.service_provider_factories import LlmProviderFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+from apps.utils.tests.clients import ApiTestClient
+
+
+@pytest.fixture()
+def experiment(db):
+    exp = ExperimentFactory.create(team=TeamWithUsersFactory.create())
+    LlmProviderFactory.create(team=exp.team)
+    return exp
+
+
+class TestURLPathVersioning:
+    """The version is read from the request path, defaulting to v1 for the unversioned alias."""
+
+    def setup_method(self):
+        self.factory = APIRequestFactory()
+        self.versioning = URLPathVersioning()
+
+    def test_unversioned_path_defaults_to_v1(self):
+        request = self.factory.get("/api/experiments/")
+        assert self.versioning.determine_version(request) == "v1"
+
+    def test_explicit_v1_path(self):
+        request = self.factory.get("/api/v1/experiments/")
+        assert self.versioning.determine_version(request) == "v1"
+
+    def test_disallowed_version_raises_not_found(self):
+        request = self.factory.get("/api/v9/experiments/")
+        with pytest.raises(NotFound):
+            self.versioning.determine_version(request)
+
+
+def test_reverse_produces_unversioned_urls():
+    """reverse() must yield the canonical unversioned URLs so existing callers never break."""
+    assert reverse("api:experiment-list") == "/api/experiments/"
+    assert reverse("api:participant-data") == "/api/participants"
+
+
+def test_v1_prefix_and_alias_resolve_to_same_view():
+    """Both /api/v1/ and the unversioned alias forward-resolve to the same view."""
+    assert resolve("/api/experiments/").func.__name__ == resolve("/api/v1/experiments/").func.__name__
+
+
+@pytest.mark.django_db()
+def test_unversioned_alias_serves_v1(experiment):
+    user = experiment.team.members.first()
+    client = ApiTestClient(user, experiment.team)
+    response = client.get("/api/experiments/")
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db()
+def test_v1_prefix_serves_same_surface_as_alias(experiment):
+    user = experiment.team.members.first()
+    client = ApiTestClient(user, experiment.team)
+    versioned = client.get("/api/v1/experiments/")
+    alias = client.get("/api/experiments/")
+    assert versioned.status_code == 200
+    assert versioned.json() == alias.json()
+
+
+@pytest.mark.django_db()
+def test_v2_not_yet_available(experiment):
+    """v2 is allowed by settings but has no routes yet, so it 404s."""
+    user = experiment.team.members.first()
+    client = ApiTestClient(user, experiment.team)
+    response = client.get("/api/v2/experiments/")
+    assert response.status_code == 404

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path
+from django.urls import include, path, re_path
 from rest_framework import routers
 
 from . import openai, views
@@ -23,7 +23,9 @@ chat_patterns = [
     path("<uuid:session_id>/<str:task_id>/poll/", views.chat_poll_task_response, name="task-poll-response"),
 ]
 
-urlpatterns = [
+# The v1 API surface. v1 is frozen against today's URLs and serializers; new endpoints and the
+# experiment -> chatbot rename land under v2 (added in a later phase).
+v1_patterns = [
     # Keep participants/ lying around for backwards compatability
     path("participants/", views.ParticipantView.as_view(), name="update-participant-data-old"),
     # GET: list participants; POST: update participant data
@@ -43,4 +45,14 @@ urlpatterns = [
     path("trigger_bot", views.TriggerBotMessageView.as_view(), name="trigger_bot"),
     path("chat/", include((chat_patterns, "chat"))),
     path("", include(router.urls)),
+]
+
+# Serve the v1 surface under an optional, non-capturing ``v1/`` prefix. The version is detected
+# from the request path by apps.api.versioning.URLPathVersioning, so it is never passed to views.
+# Because the prefix is optional and non-capturing:
+#   * ``/api/v1/...`` and the unversioned ``/api/...`` alias both resolve to these views, and
+#   * reverse() always produces the unversioned URL, keeping existing callers and hyperlinked
+#     serializer fields stable.
+urlpatterns = [
+    re_path(r"^(?:v1/)?", include(v1_patterns)),
 ]

--- a/apps/api/versioning.py
+++ b/apps/api/versioning.py
@@ -1,0 +1,29 @@
+import re
+
+from rest_framework.exceptions import NotFound
+from rest_framework.versioning import BaseVersioning
+
+
+class URLPathVersioning(BaseVersioning):
+    """Determine the API version from the URL path (``/api/<version>/...``).
+
+    Unlike DRF's stock :class:`~rest_framework.versioning.URLPathVersioning`, the version is read
+    from the request path rather than a captured URL kwarg. This means:
+
+    * the version segment is never threaded through view signatures (many of our function-based
+      views take no ``version`` argument), and
+    * ``reverse()`` produces the canonical *unversioned* URLs — the permanent ``/api/...`` alias of
+      v1 — so existing callers and hyperlinked serializer fields keep working unchanged.
+
+    A request without a version segment (the unversioned alias) resolves to ``default_version``.
+    """
+
+    invalid_version_message = "Invalid API version."
+    _version_pattern = re.compile(r"^/api/(?P<version>v\d+)/")
+
+    def determine_version(self, request, *args, **kwargs):
+        match = self._version_pattern.match(request.path_info)
+        version = match.group("version") if match else self.default_version
+        if not self.is_allowed_version(version):
+            raise NotFound(self.invalid_version_message)
+        return version

--- a/config/settings.py
+++ b/config/settings.py
@@ -438,6 +438,12 @@ REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PAGINATION_CLASS": "apps.api.pagination.CursorPagination",
     "PAGE_SIZE": 100,
+    # URL-path API versioning. v1 is frozen against today's surface and is also served under the
+    # unversioned /api/ alias (the permanent default); v2 (renamed surface + new endpoints) lands
+    # in a later phase. See apps/api/versioning.py and docs/design/read-only-chatbot-inspection-api.md.
+    "DEFAULT_VERSIONING_CLASS": "apps.api.versioning.URLPathVersioning",
+    "DEFAULT_VERSION": "v1",
+    "ALLOWED_VERSIONS": ["v1", "v2"],
 }
 
 SPECTACULAR_SETTINGS = {


### PR DESCRIPTION
### Product Description
No change. Infrastructure only — sets up API versioning so the existing API can be frozen as `v1` while a renamed `v2` surface and new endpoints (the read-only chatbot `/inspect/` endpoint) are added later.

### Technical Description
Track A step 1 of the [read-only chatbot-inspection API design](docs/design/read-only-chatbot-inspection-api.md). `v1` freezes today's surface and is *also* served under the existing unversioned `/api/` alias, so current callers never break. `/api/v2/` is allowed by settings but has no routes yet (404s) — it's where the `experiment`→`chatbot` rename and new endpoints land in a follow-up.

The notable decision is **not** using DRF's stock `URLPathVersioning`:
- it captures `version` as a URL kwarg and passes it to the view, but many of our function-based views (`chat_start_session(request)`, `generate_key`, `consent`, …) take no such arg → `TypeError`;
- its `reverse()` injects `version` into every reverse call, which would break the ~101 `reverse("api:...")` callers and the `HyperlinkedRelatedField`s that must keep emitting unversioned `/api/experiments/{id}/` URLs.

Instead, `apps/api/versioning.py` reads the version from `request.path` (defaulting to `v1`) and leaves `reverse()` plain. The routes are mounted once under an optional, non-capturing prefix — `re_path(r"^(?:v1/)?", include(v1_patterns))` — so `/api/v1/...` and `/api/...` resolve to the same views, `reverse()` deterministically stays unversioned, and there's no view churn or OpenAPI schema duplication.

The pre-existing chatbot-version path segment (`/api/openai/<id>/v<int:version>/chat/completions`) is a different concept and does not collide.

### Migrations
N/A — no migrations.

### Demo
N/A.

Verified: full `apps/api/tests/` suite passes (incl. `test_schema.py`, so `api-schema.yml` is unchanged); all `api:` reverse names still produce unversioned URLs; `/api/v1/experiments/` resolves to the same view as `/api/experiments/`; `/api/v2/...` → 404. New tests in `apps/api/tests/test_versioning.py`.

### Docs and Changelog
- [ ] This PR requires docs/changelog update