### PR TITLE
Add async bulk download of latest eval results from runs page

### DIFF
--- a/apps/evaluations/export.py
+++ b/apps/evaluations/export.py
@@ -1,0 +1,91 @@
+"""Shared helpers for building and writing evaluation result export data.
+
+Both the per-run results table/CSV (``EvaluationRun.get_table_data`` /
+``download_evaluation_run_csv``) and the async bulk export
+(``export_evaluation_bulk_results_task``) build the same per-message row shape and
+share the same CSV column ordering, so the logic lives here to avoid two diverging
+code paths.
+"""
+
+from collections import OrderedDict, defaultdict
+
+from apps.evaluations.const import EVALUATION_RUN_FIXED_HEADERS
+
+
+def _populate_message_row_fixed_fields(row_data: OrderedDict, result, include_ids: bool = False) -> None:
+    """Populate the fixed/shared fields for a new message row."""
+    source_session = result.message.session if result.message.session_id else None
+    row_data["session"] = result.session.external_id if result.session_id else ""
+    row_data["source_session"] = source_session.external_id if source_session else ""
+    row_data["source_experiment_id"] = (
+        str(source_session.experiment.public_id) if source_session and source_session.experiment_id else ""
+    )
+    row_data["message_id"] = result.message_id
+    row_data["Dataset Input"] = result.input_message
+    row_data["Dataset Output"] = result.output_message
+    row_data["Generated Response"] = result.output.get("generated_response", "")
+    if include_ids:
+        row_data["id"] = result.message_id
+
+
+def build_evaluation_table_data(results, include_ids: bool = False) -> list[dict]:
+    """Aggregate *results* (an iterable of ``EvaluationResult``) into a list of per-message
+    row dicts, combining evaluator columns, message context, and applied tags.
+
+    Errors are namespaced per evaluator (``error (EvaluatorName)``) so that failures from
+    different evaluators on the same message are preserved rather than overwritten.
+
+    When *include_ids* is True each row carries a hidden ``id`` field (the message id) used by
+    the results table for row highlighting.
+    """
+    table_by_message: dict[int, OrderedDict] = {}
+    tags_by_message: dict[int, set] = defaultdict(set)
+
+    for result in results:
+        row_data = table_by_message.get(result.message_id)
+        if row_data is None:
+            row_data = OrderedDict()
+            _populate_message_row_fixed_fields(row_data, result, include_ids=include_ids)
+            table_by_message[result.message_id] = row_data
+
+        for key, value in result.output.get("result", {}).items():
+            row_data[f"{key} ({result.evaluator.name})"] = value
+
+        # Context is the same for every result on a message; updating each time is idempotent.
+        for key, value in result.message_context.items():
+            if key != "current_datetime":
+                row_data[key] = value
+
+        if result.output.get("error"):
+            row_data[f"error ({result.evaluator.name})"] = result.output["error"]
+
+        for applied_tag in result.applied_tags.all():
+            tags_by_message[result.message_id].add(applied_tag.tag.name)
+
+    for message_id, row_data in table_by_message.items():
+        tags = tags_by_message.get(message_id)
+        row_data["Applied Tags"] = ", ".join(sorted(tags)) if tags else ""
+
+    return [{"#": index, **row} for index, row in enumerate(table_by_message.values())]
+
+
+def write_evaluation_csv(writer, table_data: list[dict]) -> None:
+    """Write *table_data* rows to *writer* using the standard evaluation column ordering.
+
+    Fixed headers come first, then alphabetically-sorted dynamic columns, then any
+    error columns last.  This is shared between the per-run and bulk-download exports.
+    """
+    if not table_data:
+        writer.writerow(["No results available yet"])
+        return
+
+    all_headers: set[str] = set()
+    for row in table_data:
+        all_headers.update(row.keys())
+
+    error_headers = sorted(h for h in all_headers if h == "error" or h.startswith("error ("))
+    other_headers = sorted(h for h in all_headers if h not in EVALUATION_RUN_FIXED_HEADERS and h not in error_headers)
+    headers = [h for h in EVALUATION_RUN_FIXED_HEADERS if h in all_headers] + other_headers + error_headers
+    writer.writerow(headers)
+    for row in table_data:
+        writer.writerow([row.get(header, "") for header in headers])

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import importlib
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from functools import cached_property
 from typing import TYPE_CHECKING, Literal
 
@@ -15,6 +15,7 @@ from pydantic import BaseModel as PydanticBaseModel
 
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.chatbots.version_resolver import VersionSelectionRule, resolve_chatbot_version
+from apps.evaluations.export import build_evaluation_table_data
 from apps.evaluations.rule_validation import (
     ConditionType,
     validate_condition,
@@ -517,51 +518,7 @@ class EvaluationRun(BaseTeamModel):
             scoped_ids = self.scoped_messages.values_list("id", flat=True)
             results_qs = results_qs.filter(message_id__in=scoped_ids)
 
-        results = results_qs.all()
-        table_by_message = defaultdict(dict)
-        tags_by_message = defaultdict(set)
-        for result in results:
-            context_columns = {
-                # exclude 'current_datetime'
-                f"{key}": value
-                for key, value in result.message_context.items()
-                if key != "current_datetime"
-            }
-            # Build row data in order
-            row_data = OrderedDict()
-            row_data["session"] = result.session.external_id if result.session_id else ""
-            source_session = result.message.session if result.message.session_id else None
-            row_data["source_session"] = source_session.external_id if source_session else ""
-            row_data["source_experiment_id"] = (
-                str(source_session.experiment.public_id) if source_session and source_session.experiment_id else ""
-            )
-            row_data["message_id"] = result.message.id
-            row_data["Dataset Input"] = result.input_message
-            row_data["Dataset Output"] = result.output_message
-            row_data["Generated Response"] = result.output.get("generated_response", "")
-
-            row_data.update(
-                {f"{key} ({result.evaluator.name})": value for key, value in result.output.get("result", {}).items()}
-            )
-
-            row_data.update(context_columns)
-
-            for applied_tag in result.applied_tags.all():
-                tags_by_message[result.message.id].add(applied_tag.tag.name)
-
-            if result.output.get("error"):
-                row_data["error"] = result.output.get("error")
-
-            if include_ids is True:
-                row_data["id"] = result.message.id
-
-            table_by_message[result.message.id] = row_data
-
-        for message_id, row_data in table_by_message.items():
-            tags = tags_by_message.get(message_id)
-            row_data["Applied Tags"] = ", ".join(sorted(tags)) if tags else ""
-
-        return [{"#": index, **row} for index, row in enumerate(table_by_message.values())]
+        return build_evaluation_table_data(results_qs, include_ids=include_ids)
 
 
 class EvaluationResult(BaseTeamModel):

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -1,7 +1,7 @@
 import contextlib
 import csv
 import math
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from collections.abc import Iterable
 from datetime import timedelta
 from io import StringIO
@@ -27,6 +27,7 @@ from apps.evaluations.auto_population import (
 )
 from apps.evaluations.const import PREVIEW_SAMPLE_SIZE
 from apps.evaluations.exceptions import HistoryParseException
+from apps.evaluations.export import build_evaluation_table_data, write_evaluation_csv
 from apps.evaluations.models import (
     DatasetCreationStatus,
     EvaluationConfig,
@@ -973,78 +974,6 @@ def _get_bulk_results_queryset(config, team):
     )
 
 
-def _populate_message_row_fixed_fields(row_data: OrderedDict, result) -> None:
-    """Populate the fixed/shared fields for a new message row."""
-    source_session = result.message.session if result.message.session_id else None
-    row_data["session"] = result.session.external_id if result.session_id else ""
-    row_data["source_session"] = source_session.external_id if source_session else ""
-    row_data["source_experiment_id"] = (
-        str(source_session.experiment.public_id) if source_session and source_session.experiment_id else ""
-    )
-    row_data["message_id"] = result.message.id
-    row_data["Dataset Input"] = result.input_message
-    row_data["Dataset Output"] = result.output_message
-    row_data["Generated Response"] = result.output.get("generated_response", "")
-    row_data.update({k: v for k, v in result.message_context.items() if k != "current_datetime"})
-
-
-def _build_evaluation_table_data(results) -> list[dict]:
-    """Aggregate *results* (an iterable of EvaluationResult) into a list of per-message
-    row dicts, combining evaluator columns and tags.
-
-    Errors are namespaced per evaluator (``error (EvaluatorName)``) so that failures
-    from different evaluators on the same message are preserved rather than overwritten.
-    """
-    table_by_message: dict[int, OrderedDict] = {}
-    tags_by_message: dict[int, set] = defaultdict(set)
-
-    for result in results:
-        row_data = table_by_message.setdefault(result.message_id, OrderedDict())
-        if not row_data:
-            _populate_message_row_fixed_fields(row_data, result)
-
-        for k, v in result.output.get("result", {}).items():
-            row_data[f"{k} ({result.evaluator.name})"] = v
-
-        if result.output.get("error"):
-            row_data[f"error ({result.evaluator.name})"] = result.output["error"]
-
-        for applied_tag in result.applied_tags.all():
-            tags_by_message[result.message_id].add(applied_tag.tag.name)
-
-    for message_id, row_data in table_by_message.items():
-        tags = tags_by_message.get(message_id)
-        row_data["Applied Tags"] = ", ".join(sorted(tags)) if tags else ""
-
-    return [{"#": index, **row} for index, row in enumerate(table_by_message.values())]
-
-
-def _write_evaluation_csv(writer, table_data: list[dict]) -> None:
-    """Write *table_data* rows to *writer* using the standard evaluation column ordering.
-
-    Fixed headers come first, then alphabetically-sorted dynamic columns, then any
-    error columns last.  This is shared between the per-run and bulk-download exports.
-    """
-    from apps.evaluations.const import EVALUATION_RUN_FIXED_HEADERS
-
-    if not table_data:
-        writer.writerow(["No results available yet"])
-        return
-
-    all_headers: set[str] = set()
-    for row in table_data:
-        all_headers.update(row.keys())
-
-    error_headers = sorted(h for h in all_headers if h == "error" or h.startswith("error ("))
-    other_headers = sorted(
-        h for h in all_headers if h not in EVALUATION_RUN_FIXED_HEADERS and h not in error_headers
-    )
-    headers = [h for h in EVALUATION_RUN_FIXED_HEADERS if h in all_headers] + other_headers + error_headers
-    writer.writerow(headers)
-    for row in table_data:
-        writer.writerow([row.get(header, "") for header in headers])
-
-
 @shared_task(bind=True, base=TaskbadgerTask)
 def export_evaluation_bulk_results_task(self, evaluation_config_id, team_id):
     """
@@ -1065,11 +994,11 @@ def export_evaluation_bulk_results_task(self, evaluation_config_id, team_id):
             results = _get_bulk_results_queryset(config, team)
 
             progress_recorder.set_progress(40, 100, "Processing results...")
-            table_data = _build_evaluation_table_data(results)
+            table_data = build_evaluation_table_data(results)
 
             progress_recorder.set_progress(80, 100, "Generating CSV...")
             csv_buffer = StringIO()
-            _write_evaluation_csv(csv.writer(csv_buffer), table_data)
+            write_evaluation_csv(csv.writer(csv_buffer), table_data)
 
             filename = f"{config.name}_latest_results_{timezone.now().strftime('%Y-%m-%d_%H-%M-%S')}.csv"
             file_obj = File.objects.create(

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -1,7 +1,7 @@
 import contextlib
 import csv
 import math
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from collections.abc import Iterable
 from datetime import timedelta
 from io import StringIO
@@ -10,6 +10,7 @@ from typing import cast
 from celery import chord, shared_task
 from celery.utils.log import get_task_logger
 from celery_progress.backend import ProgressRecorder
+from django.core.files.base import ContentFile
 from django.db import transaction
 from django.db.models import Prefetch
 from django.http import QueryDict
@@ -28,6 +29,7 @@ from apps.evaluations.const import PREVIEW_SAMPLE_SIZE
 from apps.evaluations.exceptions import HistoryParseException
 from apps.evaluations.models import (
     DatasetCreationStatus,
+    EvaluationConfig,
     EvaluationDataset,
     EvaluationMessage,
     EvaluationMessageContent,
@@ -951,3 +953,129 @@ def create_dataset_from_sessions_task(self, dataset_id, team_id, session_ids):
         message = "An error occurred while creating session-mode messages"
         _save_dataset_error(dataset, message)
         return {"success": False, "error": message}
+
+
+@shared_task(bind=True, base=TaskbadgerTask)
+def export_evaluation_bulk_results_task(self, evaluation_config_id, team_id):
+    """
+    Async export of the most recent evaluation result for each dataset item,
+    across all completed evaluation runs for the given config.
+
+    Returns {"file_id": <id>} on success.
+    """
+    from apps.evaluations.const import EVALUATION_RUN_FIXED_HEADERS
+
+    progress_recorder = ProgressRecorder(self)
+    progress_recorder.set_progress(0, 100, "Starting export...")
+
+    try:
+        config = EvaluationConfig.objects.select_related("team").get(id=evaluation_config_id, team_id=team_id)
+        team = config.team
+
+        with current_team(team):
+            progress_recorder.set_progress(10, 100, "Fetching results...")
+
+            completed_run_ids = list(
+                EvaluationRun.objects.filter(
+                    config=config,
+                    status=EvaluationRunStatus.COMPLETED,
+                    type__in=[EvaluationRunType.FULL, EvaluationRunType.DELTA],
+                ).values_list("id", flat=True)
+            )
+
+            # Fetch all results for completed runs, newest run first.
+            # We deduplicate on (message_id, evaluator_id) to keep only the most recent run's result.
+            results = list(
+                EvaluationResult.objects.filter(run_id__in=completed_run_ids, team=team)
+                .select_related("message__session__experiment", "evaluator", "session", "run")
+                .prefetch_related("applied_tags__tag")
+                .order_by("message_id", "evaluator_id", "-run__created_at")
+            )
+
+            progress_recorder.set_progress(40, 100, f"Processing {len(results)} results...")
+
+            table_by_message: dict[int, OrderedDict] = {}
+            tags_by_message: dict[int, set] = defaultdict(set)
+            seen_message_evaluator: set[tuple] = set()
+
+            for result in results:
+                key = (result.message_id, result.evaluator_id)
+                if key in seen_message_evaluator:
+                    # Already have a more-recent result for this (message, evaluator) pair
+                    continue
+                seen_message_evaluator.add(key)
+
+                row_data = table_by_message.setdefault(result.message_id, OrderedDict())
+
+                # Populate fixed fields on first encounter for this message
+                if not row_data:
+                    row_data["session"] = result.session.external_id if result.session_id else ""
+                    source_session = result.message.session if result.message.session_id else None
+                    row_data["source_session"] = source_session.external_id if source_session else ""
+                    row_data["source_experiment_id"] = (
+                        str(source_session.experiment.public_id)
+                        if source_session and source_session.experiment_id
+                        else ""
+                    )
+                    row_data["message_id"] = result.message.id
+                    row_data["Dataset Input"] = result.input_message
+                    row_data["Dataset Output"] = result.output_message
+                    row_data["Generated Response"] = result.output.get("generated_response", "")
+
+                    context_columns = {
+                        k: v for k, v in result.message_context.items() if k != "current_datetime"
+                    }
+                    row_data.update(context_columns)
+
+                # Add evaluator result columns
+                for k, v in result.output.get("result", {}).items():
+                    row_data[f"{k} ({result.evaluator.name})"] = v
+
+                if result.output.get("error"):
+                    row_data["error"] = result.output.get("error")
+
+                for applied_tag in result.applied_tags.all():
+                    tags_by_message[result.message_id].add(applied_tag.tag.name)
+
+            for message_id, row_data in table_by_message.items():
+                tags = tags_by_message.get(message_id)
+                row_data["Applied Tags"] = ", ".join(sorted(tags)) if tags else ""
+
+            table_data = [{"#": index, **row} for index, row in enumerate(table_by_message.values())]
+
+            progress_recorder.set_progress(80, 100, "Generating CSV...")
+
+            csv_buffer = StringIO()
+            writer = csv.writer(csv_buffer)
+
+            if not table_data:
+                writer.writerow(["No results available yet"])
+            else:
+                all_headers: set[str] = set()
+                for row in table_data:
+                    all_headers.update(row.keys())
+
+                other_headers = sorted(
+                    [h for h in all_headers if h not in EVALUATION_RUN_FIXED_HEADERS and h != "error"]
+                )
+                headers = (
+                    [h for h in EVALUATION_RUN_FIXED_HEADERS if h in all_headers] + other_headers + ["error"]
+                )
+                writer.writerow(headers)
+                for row in table_data:
+                    writer.writerow([row.get(header, "") for header in headers])
+
+            filename = f"{config.name}_latest_results_{timezone.now().strftime('%Y-%m-%d_%H-%M-%S')}.csv"
+            file_obj = File.objects.create(
+                name=filename,
+                team=team,
+                content_type="text/csv",
+                file=ContentFile(csv_buffer.getvalue().encode("utf-8"), name=filename),
+            )
+
+            progress_recorder.set_progress(100, 100, "Export complete")
+            return {"file_id": file_obj.id}
+
+    except Exception as e:
+        logger.exception(f"Error exporting bulk evaluation results for config {evaluation_config_id}: {e}")
+        return {"error": str(e)}

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -974,29 +974,22 @@ def _get_bulk_results_queryset(config, team):
     )
 
 
-@shared_task(bind=True, base=TaskbadgerTask)
-def export_evaluation_bulk_results_task(self, evaluation_config_id, team_id):
+@shared_task(base=TaskbadgerTask)
+def export_evaluation_bulk_results_task(evaluation_config_id, team_id):
     """
     Async export of the most recent evaluation result for each dataset item,
     across all completed evaluation runs for the given config.
 
     Returns {"file_id": <id>} on success.
     """
-    progress_recorder = ProgressRecorder(self)
-    progress_recorder.set_progress(0, 100, "Starting export...")
-
     try:
         config = EvaluationConfig.objects.select_related("team").get(id=evaluation_config_id, team_id=team_id)
         team = config.team
 
         with current_team(team):
-            progress_recorder.set_progress(10, 100, "Fetching results...")
             results = _get_bulk_results_queryset(config, team)
-
-            progress_recorder.set_progress(40, 100, "Processing results...")
             table_data = build_evaluation_table_data(results)
 
-            progress_recorder.set_progress(80, 100, "Generating CSV...")
             csv_buffer = StringIO()
             write_evaluation_csv(csv.writer(csv_buffer), table_data)
 
@@ -1008,7 +1001,6 @@ def export_evaluation_bulk_results_task(self, evaluation_config_id, team_id):
                 file=ContentFile(csv_buffer.getvalue().encode("utf-8"), name=filename),
             )
 
-            progress_recorder.set_progress(100, 100, "Export complete")
             return {"file_id": file_obj.id}
 
     except Exception as e:

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -955,6 +955,96 @@ def create_dataset_from_sessions_task(self, dataset_id, team_id, session_ids):
         return {"success": False, "error": message}
 
 
+def _get_bulk_results_queryset(config, team):
+    """Return the most recent EvaluationResult per (message, evaluator) across all
+    completed FULL/DELTA runs for *config*, pushing deduplication into the DB via
+    DISTINCT ON so only the latest-run row per pair is fetched."""
+    return (
+        EvaluationResult.objects.filter(
+            run__config=config,
+            run__status=EvaluationRunStatus.COMPLETED,
+            run__type__in=[EvaluationRunType.FULL, EvaluationRunType.DELTA],
+            team=team,
+        )
+        .select_related("message__session__experiment", "evaluator", "session", "run")
+        .prefetch_related("applied_tags__tag")
+        .order_by("message_id", "evaluator_id", "-run__created_at")
+        .distinct("message_id", "evaluator_id")
+    )
+
+
+def _populate_message_row_fixed_fields(row_data: OrderedDict, result) -> None:
+    """Populate the fixed/shared fields for a new message row."""
+    source_session = result.message.session if result.message.session_id else None
+    row_data["session"] = result.session.external_id if result.session_id else ""
+    row_data["source_session"] = source_session.external_id if source_session else ""
+    row_data["source_experiment_id"] = (
+        str(source_session.experiment.public_id) if source_session and source_session.experiment_id else ""
+    )
+    row_data["message_id"] = result.message.id
+    row_data["Dataset Input"] = result.input_message
+    row_data["Dataset Output"] = result.output_message
+    row_data["Generated Response"] = result.output.get("generated_response", "")
+    row_data.update({k: v for k, v in result.message_context.items() if k != "current_datetime"})
+
+
+def _build_evaluation_table_data(results) -> list[dict]:
+    """Aggregate *results* (an iterable of EvaluationResult) into a list of per-message
+    row dicts, combining evaluator columns and tags.
+
+    Errors are namespaced per evaluator (``error (EvaluatorName)``) so that failures
+    from different evaluators on the same message are preserved rather than overwritten.
+    """
+    table_by_message: dict[int, OrderedDict] = {}
+    tags_by_message: dict[int, set] = defaultdict(set)
+
+    for result in results:
+        row_data = table_by_message.setdefault(result.message_id, OrderedDict())
+        if not row_data:
+            _populate_message_row_fixed_fields(row_data, result)
+
+        for k, v in result.output.get("result", {}).items():
+            row_data[f"{k} ({result.evaluator.name})"] = v
+
+        if result.output.get("error"):
+            row_data[f"error ({result.evaluator.name})"] = result.output["error"]
+
+        for applied_tag in result.applied_tags.all():
+            tags_by_message[result.message_id].add(applied_tag.tag.name)
+
+    for message_id, row_data in table_by_message.items():
+        tags = tags_by_message.get(message_id)
+        row_data["Applied Tags"] = ", ".join(sorted(tags)) if tags else ""
+
+    return [{"#": index, **row} for index, row in enumerate(table_by_message.values())]
+
+
+def _write_evaluation_csv(writer, table_data: list[dict]) -> None:
+    """Write *table_data* rows to *writer* using the standard evaluation column ordering.
+
+    Fixed headers come first, then alphabetically-sorted dynamic columns, then any
+    error columns last.  This is shared between the per-run and bulk-download exports.
+    """
+    from apps.evaluations.const import EVALUATION_RUN_FIXED_HEADERS
+
+    if not table_data:
+        writer.writerow(["No results available yet"])
+        return
+
+    all_headers: set[str] = set()
+    for row in table_data:
+        all_headers.update(row.keys())
+
+    error_headers = sorted(h for h in all_headers if h == "error" or h.startswith("error ("))
+    other_headers = sorted(
+        h for h in all_headers if h not in EVALUATION_RUN_FIXED_HEADERS and h not in error_headers
+    )
+    headers = [h for h in EVALUATION_RUN_FIXED_HEADERS if h in all_headers] + other_headers + error_headers
+    writer.writerow(headers)
+    for row in table_data:
+        writer.writerow([row.get(header, "") for header in headers])
+
+
 @shared_task(bind=True, base=TaskbadgerTask)
 def export_evaluation_bulk_results_task(self, evaluation_config_id, team_id):
     """
@@ -963,8 +1053,6 @@ def export_evaluation_bulk_results_task(self, evaluation_config_id, team_id):
 
     Returns {"file_id": <id>} on success.
     """
-    from apps.evaluations.const import EVALUATION_RUN_FIXED_HEADERS
-
     progress_recorder = ProgressRecorder(self)
     progress_recorder.set_progress(0, 100, "Starting export...")
 
@@ -974,96 +1062,14 @@ def export_evaluation_bulk_results_task(self, evaluation_config_id, team_id):
 
         with current_team(team):
             progress_recorder.set_progress(10, 100, "Fetching results...")
+            results = _get_bulk_results_queryset(config, team)
 
-            completed_run_ids = list(
-                EvaluationRun.objects.filter(
-                    config=config,
-                    status=EvaluationRunStatus.COMPLETED,
-                    type__in=[EvaluationRunType.FULL, EvaluationRunType.DELTA],
-                ).values_list("id", flat=True)
-            )
-
-            # Fetch all results for completed runs, newest run first.
-            # We deduplicate on (message_id, evaluator_id) to keep only the most recent run's result.
-            results = list(
-                EvaluationResult.objects.filter(run_id__in=completed_run_ids, team=team)
-                .select_related("message__session__experiment", "evaluator", "session", "run")
-                .prefetch_related("applied_tags__tag")
-                .order_by("message_id", "evaluator_id", "-run__created_at")
-            )
-
-            progress_recorder.set_progress(40, 100, f"Processing {len(results)} results...")
-
-            table_by_message: dict[int, OrderedDict] = {}
-            tags_by_message: dict[int, set] = defaultdict(set)
-            seen_message_evaluator: set[tuple] = set()
-
-            for result in results:
-                key = (result.message_id, result.evaluator_id)
-                if key in seen_message_evaluator:
-                    # Already have a more-recent result for this (message, evaluator) pair
-                    continue
-                seen_message_evaluator.add(key)
-
-                row_data = table_by_message.setdefault(result.message_id, OrderedDict())
-
-                # Populate fixed fields on first encounter for this message
-                if not row_data:
-                    row_data["session"] = result.session.external_id if result.session_id else ""
-                    source_session = result.message.session if result.message.session_id else None
-                    row_data["source_session"] = source_session.external_id if source_session else ""
-                    row_data["source_experiment_id"] = (
-                        str(source_session.experiment.public_id)
-                        if source_session and source_session.experiment_id
-                        else ""
-                    )
-                    row_data["message_id"] = result.message.id
-                    row_data["Dataset Input"] = result.input_message
-                    row_data["Dataset Output"] = result.output_message
-                    row_data["Generated Response"] = result.output.get("generated_response", "")
-
-                    context_columns = {
-                        k: v for k, v in result.message_context.items() if k != "current_datetime"
-                    }
-                    row_data.update(context_columns)
-
-                # Add evaluator result columns
-                for k, v in result.output.get("result", {}).items():
-                    row_data[f"{k} ({result.evaluator.name})"] = v
-
-                if result.output.get("error"):
-                    row_data["error"] = result.output.get("error")
-
-                for applied_tag in result.applied_tags.all():
-                    tags_by_message[result.message_id].add(applied_tag.tag.name)
-
-            for message_id, row_data in table_by_message.items():
-                tags = tags_by_message.get(message_id)
-                row_data["Applied Tags"] = ", ".join(sorted(tags)) if tags else ""
-
-            table_data = [{"#": index, **row} for index, row in enumerate(table_by_message.values())]
+            progress_recorder.set_progress(40, 100, "Processing results...")
+            table_data = _build_evaluation_table_data(results)
 
             progress_recorder.set_progress(80, 100, "Generating CSV...")
-
             csv_buffer = StringIO()
-            writer = csv.writer(csv_buffer)
-
-            if not table_data:
-                writer.writerow(["No results available yet"])
-            else:
-                all_headers: set[str] = set()
-                for row in table_data:
-                    all_headers.update(row.keys())
-
-                other_headers = sorted(
-                    [h for h in all_headers if h not in EVALUATION_RUN_FIXED_HEADERS and h != "error"]
-                )
-                headers = (
-                    [h for h in EVALUATION_RUN_FIXED_HEADERS if h in all_headers] + other_headers + ["error"]
-                )
-                writer.writerow(headers)
-                for row in table_data:
-                    writer.writerow([row.get(header, "") for header in headers])
+            _write_evaluation_csv(csv.writer(csv_buffer), table_data)
 
             filename = f"{config.name}_latest_results_{timezone.now().strftime('%Y-%m-%d_%H-%M-%S')}.csv"
             file_obj = File.objects.create(

--- a/apps/evaluations/tests/test_bulk_export_task.py
+++ b/apps/evaluations/tests/test_bulk_export_task.py
@@ -1,0 +1,89 @@
+import csv
+import io
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from apps.evaluations.evaluators import EvaluatorResult
+from apps.evaluations.models import EvaluationRun, EvaluationRunStatus, EvaluationRunType
+from apps.evaluations.tasks import export_evaluation_bulk_results_task
+from apps.files.models import File
+from apps.utils.factories.evaluations import (
+    EvaluationConfigFactory,
+    EvaluationMessageFactory,
+    EvaluationResultFactory,
+    EvaluationRunFactory,
+    EvaluatorFactory,
+)
+
+
+def _evaluator_output(score: float, generated_response: str) -> dict:
+    return EvaluatorResult(
+        message={
+            "input": {"content": "What is AI?", "role": "human"},
+            "output": {"content": "Artificial Intelligence", "role": "ai"},
+            "context": {},
+            "history": [],
+            "metadata": {},
+        },
+        result={"score": score},
+        generated_response=generated_response,
+    ).model_dump()
+
+
+def _read_csv_rows(file_id: int) -> list[dict]:
+    content = File.objects.get(id=file_id).file.read().decode("utf-8")
+    return list(csv.DictReader(io.StringIO(content)))
+
+
+@pytest.mark.django_db()
+def test_export_evaluation_bulk_results_task_creates_csv_file():
+    config = EvaluationConfigFactory.create()
+    team = config.team
+    evaluator = EvaluatorFactory.create(team=team)
+    run = EvaluationRunFactory.create(
+        team=team, config=config, status=EvaluationRunStatus.COMPLETED, type=EvaluationRunType.FULL
+    )
+    EvaluationResultFactory.create(
+        team=team, run=run, evaluator=evaluator, output=_evaluator_output(8.5, "Generated response")
+    )
+
+    result = export_evaluation_bulk_results_task(config.id, team.id)
+
+    rows = _read_csv_rows(result["file_id"])
+    assert len(rows) == 1
+    assert rows[0][f"score ({evaluator.name})"] == "8.5"
+    assert rows[0]["Generated Response"] == "Generated response"
+
+
+@pytest.mark.django_db()
+def test_export_uses_latest_run_result_per_message():
+    """When a message has results across multiple completed runs, the latest run wins."""
+    config = EvaluationConfigFactory.create()
+    team = config.team
+    evaluator = EvaluatorFactory.create(team=team)
+    message = EvaluationMessageFactory.create()
+
+    old_run = EvaluationRunFactory.create(
+        team=team, config=config, status=EvaluationRunStatus.COMPLETED, type=EvaluationRunType.FULL
+    )
+    # created_at is auto_now_add, so force the ordering via an update that bypasses it.
+    EvaluationRun.objects.filter(id=old_run.id).update(created_at=timezone.now() - timedelta(days=1))
+    EvaluationResultFactory.create(
+        team=team, run=old_run, evaluator=evaluator, message=message, output=_evaluator_output(1.0, "old")
+    )
+
+    new_run = EvaluationRunFactory.create(
+        team=team, config=config, status=EvaluationRunStatus.COMPLETED, type=EvaluationRunType.FULL
+    )
+    EvaluationResultFactory.create(
+        team=team, run=new_run, evaluator=evaluator, message=message, output=_evaluator_output(9.0, "new")
+    )
+
+    result = export_evaluation_bulk_results_task(config.id, team.id)
+
+    rows = _read_csv_rows(result["file_id"])
+    assert len(rows) == 1
+    assert rows[0][f"score ({evaluator.name})"] == "9.0"
+    assert rows[0]["Generated Response"] == "new"

--- a/apps/evaluations/urls.py
+++ b/apps/evaluations/urls.py
@@ -58,6 +58,16 @@ urlpatterns = [
         name="evaluation_run_update",
     ),
     path(
+        "<int:evaluation_pk>/bulk_download/start/",
+        evaluation_config_views.start_bulk_download,
+        name="evaluation_bulk_download_start",
+    ),
+    path(
+        "<int:evaluation_pk>/bulk_download/<str:task_id>/",
+        evaluation_config_views.get_bulk_download_link,
+        name="evaluation_bulk_download_link",
+    ),
+    path(
         "sessions_selection_table",
         dataset_views.DatasetSessionsSelectionTableView.as_view(),
         name="dataset_sessions_selection_list",

--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -9,7 +9,11 @@ from typing import Any
 from django.conf import settings
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from celery.result import AsyncResult
+from celery_progress.backend import Progress
+
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.template.response import TemplateResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
@@ -21,7 +25,7 @@ from apps.evaluations.const import EVALUATION_RUN_FIXED_HEADERS
 from apps.evaluations.forms import EvaluationConfigForm, get_experiment_version_choices
 from apps.evaluations.models import EvaluationConfig, EvaluationRun, EvaluationRunStatus, EvaluationRunType
 from apps.evaluations.tables import EvaluationConfigTable, EvaluationRunTable
-from apps.evaluations.tasks import upload_evaluation_run_results_task
+from apps.evaluations.tasks import export_evaluation_bulk_results_task, upload_evaluation_run_results_task
 from apps.evaluations.utils import build_trend_data, filter_aggregates_for_display, get_evaluators_with_schema
 from apps.experiments.models import Experiment
 from apps.generics import actions
@@ -611,3 +615,42 @@ def generate_evaluation_results_column_suggestions(result_columns, evaluation_ru
         suggestions[column] = suggested_evaluator_id
 
     return suggestions
+
+
+@login_and_team_required
+@permission_required("evaluations.view_evaluationrun")
+@require_POST
+def start_bulk_download(request, team_slug: str, evaluation_pk: int):
+    """Start an async bulk export of the most recent results per dataset item."""
+    config = get_object_or_404(EvaluationConfig, id=evaluation_pk, team=request.team)
+    task = export_evaluation_bulk_results_task.delay(config.id, request.team.id)
+    return TemplateResponse(
+        request,
+        "evaluations/partials/bulk_download.html",
+        {"config": config, "task_id": task.id},
+    )
+
+
+@login_and_team_required
+@permission_required("evaluations.view_evaluationrun")
+def get_bulk_download_link(request, team_slug: str, evaluation_pk: int, task_id: str):
+    """Poll the bulk export task and return a download link when ready."""
+    config = get_object_or_404(EvaluationConfig, id=evaluation_pk, team=request.team)
+    info = Progress(AsyncResult(task_id)).get_info()
+    context: dict = {"config": config}
+    if info["complete"] and info["success"]:
+        file_id = info["result"].get("file_id")
+        if file_id:
+            download_url = reverse("files:base", kwargs={"team_slug": team_slug, "pk": file_id}) + "?allow_s3=1"
+            context["export_download_url"] = download_url
+        else:
+            context["export_error"] = info["result"].get("error", "Export failed.")
+    elif info["complete"]:
+        context["export_error"] = "Export failed."
+    else:
+        context["task_id"] = task_id
+    return TemplateResponse(
+        request,
+        "evaluations/partials/bulk_download.html",
+        context,
+    )

--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -6,15 +6,14 @@ from functools import cached_property
 from io import StringIO
 from typing import Any
 
+from celery.result import AsyncResult
+from celery_progress.backend import Progress
 from django.conf import settings
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
-from celery.result import AsyncResult
-from celery_progress.backend import Progress
-
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
-from django.template.response import TemplateResponse
 from django.shortcuts import get_object_or_404, render
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_http_methods, require_POST
@@ -22,11 +21,11 @@ from django.views.generic import CreateView, DeleteView, TemplateView, UpdateVie
 from django_tables2 import SingleTableView, columns, tables
 
 from apps.evaluations.const import EVALUATION_RUN_FIXED_HEADERS
+from apps.evaluations.export import write_evaluation_csv
 from apps.evaluations.forms import EvaluationConfigForm, get_experiment_version_choices
 from apps.evaluations.models import EvaluationConfig, EvaluationRun, EvaluationRunStatus, EvaluationRunType
 from apps.evaluations.tables import EvaluationConfigTable, EvaluationRunTable
 from apps.evaluations.tasks import (
-    _write_evaluation_csv,
     export_evaluation_bulk_results_task,
     upload_evaluation_run_results_task,
 )
@@ -469,14 +468,12 @@ def create_evaluation_preview(request, team_slug, evaluation_pk):
 
 @permission_required("evaluations.view_evaluationrun")
 def download_evaluation_run_csv(request, team_slug, evaluation_pk, evaluation_run_pk):
-    evaluation_run = get_object_or_404(
-        EvaluationRun, id=evaluation_run_pk, config_id=evaluation_pk, team=request.team
-    )
+    evaluation_run = get_object_or_404(EvaluationRun, id=evaluation_run_pk, config_id=evaluation_pk, team=request.team)
     filename = f"{evaluation_run.config.name}_results_{evaluation_run.id}.csv"
     table_data = list(evaluation_run.get_table_data(include_ids=True))
     response = HttpResponse(content_type="text/csv")
     response["Content-Disposition"] = f"attachment; filename={filename}"
-    _write_evaluation_csv(csv.writer(response), table_data)
+    write_evaluation_csv(csv.writer(response), table_data)
     return response
 
 
@@ -521,9 +518,7 @@ def load_experiment_versions(request, team_slug: str):
 @permission_required("evaluations.change_evaluationrun")
 def update_evaluation_run_results(request, team_slug: str, evaluation_pk: int, evaluation_run_pk: int):
     """Upload CSV to update evaluation run results"""
-    evaluation_run = get_object_or_404(
-        EvaluationRun, id=evaluation_run_pk, config_id=evaluation_pk, team=request.team
-    )
+    evaluation_run = get_object_or_404(EvaluationRun, id=evaluation_run_pk, config_id=evaluation_pk, team=request.team)
     if request.method == "GET":
         context = {
             "active_tab": "evaluations",
@@ -567,9 +562,9 @@ def parse_evaluation_results_csv_columns(request, team_slug: str, evaluation_pk:
         sample_rows = all_rows[:3]
         total_rows = len(all_rows)
 
-        protected_columns = set(EVALUATION_RUN_FIXED_HEADERS) | set(["error"])
+        protected_columns = set(EVALUATION_RUN_FIXED_HEADERS) | {"error"}
 
-        result_columns = [col for col in columns if col not in protected_columns]
+        result_columns = [col for col in columns if col not in protected_columns and not col.startswith("error (")]
         suggestions = generate_evaluation_results_column_suggestions(result_columns, evaluation_run)
         return JsonResponse(
             {

--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -25,7 +25,11 @@ from apps.evaluations.const import EVALUATION_RUN_FIXED_HEADERS
 from apps.evaluations.forms import EvaluationConfigForm, get_experiment_version_choices
 from apps.evaluations.models import EvaluationConfig, EvaluationRun, EvaluationRunStatus, EvaluationRunType
 from apps.evaluations.tables import EvaluationConfigTable, EvaluationRunTable
-from apps.evaluations.tasks import export_evaluation_bulk_results_task, upload_evaluation_run_results_task
+from apps.evaluations.tasks import (
+    _write_evaluation_csv,
+    export_evaluation_bulk_results_task,
+    upload_evaluation_run_results_task,
+)
 from apps.evaluations.utils import build_trend_data, filter_aggregates_for_display, get_evaluators_with_schema
 from apps.experiments.models import Experiment
 from apps.generics import actions
@@ -472,23 +476,7 @@ def download_evaluation_run_csv(request, team_slug, evaluation_pk, evaluation_ru
     table_data = list(evaluation_run.get_table_data(include_ids=True))
     response = HttpResponse(content_type="text/csv")
     response["Content-Disposition"] = f"attachment; filename={filename}"
-    writer = csv.writer(response)
-
-    if not table_data:
-        writer.writerow(["No results available yet"])
-        return response
-
-    all_headers = set()
-    for row in table_data:
-        all_headers.update(row.keys())
-
-    other_headers = sorted([h for h in all_headers if h not in EVALUATION_RUN_FIXED_HEADERS and h != "error"])
-    headers = [h for h in EVALUATION_RUN_FIXED_HEADERS if h in all_headers] + other_headers + ["error"]
-    writer.writerow(headers)
-
-    for row in table_data:
-        writer.writerow([row.get(header, "") for header in headers])
-
+    _write_evaluation_csv(csv.writer(response), table_data)
     return response
 
 

--- a/templates/evaluations/evaluation_runs_home.html
+++ b/templates/evaluations/evaluation_runs_home.html
@@ -32,6 +32,7 @@
           <i class="fa-solid fa-eye"></i>
           Preview
         </a>
+        {% include "evaluations/partials/bulk_download.html" with config=config %}
         <a href="{% url 'evaluations:create_evaluation_run' request.team.slug config.id %}"
            class="btn btn-primary">
           <i class="fa-solid fa-play"></i>

--- a/templates/evaluations/partials/bulk_download.html
+++ b/templates/evaluations/partials/bulk_download.html
@@ -1,5 +1,5 @@
-<div class="flex flex-row gap-1" id="eval-bulk-download">
-  <button class="btn btn-sm btn-outline"
+<div class="flex flex-row gap-2" id="eval-bulk-download">
+  <button class="btn btn-outline"
           hx-post="{% url 'evaluations:evaluation_bulk_download_start' request.team.slug config.id %}"
           hx-trigger="click"
           hx-swap="outerHTML"
@@ -22,7 +22,7 @@
   {% endif %}
 
   {% if export_download_url %}
-    <a class="btn btn-sm btn-outline btn-success" href="{{ export_download_url }}">
+    <a class="btn btn-outline btn-success" href="{{ export_download_url }}">
       <i class="fa-solid fa-download"></i>
       Download CSV
     </a>

--- a/templates/evaluations/partials/bulk_download.html
+++ b/templates/evaluations/partials/bulk_download.html
@@ -1,0 +1,37 @@
+<div class="flex flex-row gap-1" id="eval-bulk-download">
+  <button class="btn btn-sm btn-outline"
+          hx-post="{% url 'evaluations:evaluation_bulk_download_start' request.team.slug config.id %}"
+          hx-trigger="click"
+          hx-swap="outerHTML"
+          hx-target="#eval-bulk-download"
+          {% if task_id %}disabled{% endif %}>
+    <i class="fa-solid fa-file-csv"></i>
+    {% if task_id %}
+      <span class="loading loading-bars loading-xs"></span> Generating
+    {% else %}
+      Download Latest Results
+    {% endif %}
+  </button>
+
+  {% if task_id %}
+    <div hx-get="{% url 'evaluations:evaluation_bulk_download_link' request.team.slug config.id task_id %}"
+         hx-trigger="every 2s"
+         hx-swap="outerHTML"
+         hx-target="#eval-bulk-download">
+    </div>
+  {% endif %}
+
+  {% if export_download_url %}
+    <a class="btn btn-sm btn-outline btn-success" href="{{ export_download_url }}">
+      <i class="fa-solid fa-download"></i>
+      Download CSV
+    </a>
+  {% endif %}
+
+  {% if export_error %}
+    <span class="text-error text-sm flex items-center gap-1">
+      <i class="fa-solid fa-triangle-exclamation"></i>
+      {{ export_error }}
+    </span>
+  {% endif %}
+</div>

--- a/templates/evaluations/partials/bulk_download.html
+++ b/templates/evaluations/partials/bulk_download.html
@@ -22,7 +22,7 @@
   {% endif %}
 
   {% if export_download_url %}
-    <a class="btn btn-outline btn-success" href="{{ export_download_url }}">
+    <a class="btn btn-success" href="{{ export_download_url }}">
       <i class="fa-solid fa-download"></i>
       Download CSV
     </a>


### PR DESCRIPTION
## Summary

Implements #3497.

Adds a **Download Latest Results** button to the evaluation runs home page that generates a CSV asynchronously, showing download progress via `celery-progress`.

## What's in the export

- The **most recent result for each dataset item** (per message/evaluator pair), across all completed FULL and DELTA runs for the evaluation config
- CSV structure matches the existing per-run download (same `EVALUATION_RUN_FIXED_HEADERS` column ordering)

## Changes

- `apps/evaluations/tasks.py` — new `export_evaluation_bulk_results_task` (Celery, `ProgressRecorder`, saves to `File` model)
- `apps/evaluations/views/evaluation_config_views.py` — two new views: `start_bulk_download` (POST, triggers task) and `get_bulk_download_link` (GET, polls status + returns download link)
- `apps/evaluations/urls.py` — two new URL patterns
- `templates/evaluations/partials/bulk_download.html` — HTMX polling template (modelled on `experiments/components/exports.html`)
- `templates/evaluations/evaluation_runs_home.html` — includes the new partial in the button row