### PR TITLE
Extend reviewer role permissions with chat viewer

### DIFF
--- a/apps/teams/backends.py
+++ b/apps/teams/backends.py
@@ -176,6 +176,12 @@ class GroupDef:
         return Permission.objects.filter(filters)
 
 
+CHAT_VIEWER_PERMS = [
+    AppPermSetDef("chat", [VIEW]),
+    AppPermSetDef("annotations", [VIEW]),
+    ModelPermSetDef("files", "file", [VIEW]),
+]
+
 GROUPS = [
     GroupDef(
         SUPER_ADMIN_GROUP,
@@ -207,11 +213,7 @@ GROUPS = [
     ),
     GroupDef(
         CHAT_VIEWER_GROUP,
-        [
-            AppPermSetDef("chat", [VIEW]),
-            AppPermSetDef("annotations", [VIEW]),
-            ModelPermSetDef("files", "file", [VIEW]),
-        ],
+        CHAT_VIEWER_PERMS,
     ),
     GroupDef(
         ASSISTANT_ADMIN_GROUP,
@@ -239,7 +241,8 @@ GROUPS = [
             ModelPermSetDef("human_annotations", "annotationitem", [VIEW, CHANGE]),
             ModelPermSetDef("human_annotations", "annotation", [ADD]),
             ModelPermSetDef("human_annotations", "annotationqueueaggregate", [VIEW]),
-        ],
+        ]
+        + CHAT_VIEWER_PERMS,
     ),
 ]
 

--- a/templates/experiments/chat/components/trace_icons.html
+++ b/templates/experiments/chat/components/trace_icons.html
@@ -1,19 +1,21 @@
 {% load static waffle_tags %}
 
-{% for trace_info in trace_infos %}
-  <div class="tooltip tooltip-right" data-tip="Open Trace on {{ trace_info.trace_provider|title }}">
-    {% if trace_info.trace_provider == "ocs" %}
-      <a class="btn btn-sm btn-square btn-ghost" href="{{ trace_info.trace_url }}" target="_blank">
-        <img class="rounded-md max-w-4 max-h-4" src="{% static 'images/favicons/favicon.svg' %}" alt="OCS Trace">
-      </a>
-    {% else %}
-      <a class="btn btn-sm btn-square btn-ghost" href="{{ trace_info.trace_url }}" target="_blank">
-        {% if trace_info.trace_provider == "langfuse" %}
-            {% include "svg/langfuse.svg" %}
-        {% else %}
-          <i class="fa-regular fa-chart-bar"></i>
-        {% endif %}
-      </a>
-    {% endif %}
-  </div>
-{% endfor %}
+{% if perms.trace.view_trace %}
+  {% for trace_info in trace_infos %}
+    <div class="tooltip tooltip-right" data-tip="Open Trace on {{ trace_info.trace_provider|title }}">
+      {% if trace_info.trace_provider == "ocs" %}
+        <a class="btn btn-sm btn-square btn-ghost" href="{{ trace_info.trace_url }}" target="_blank">
+          <img class="rounded-md max-w-4 max-h-4" src="{% static 'images/favicons/favicon.svg' %}" alt="OCS Trace">
+        </a>
+      {% else %}
+        <a class="btn btn-sm btn-square btn-ghost" href="{{ trace_info.trace_url }}" target="_blank">
+          {% if trace_info.trace_provider == "langfuse" %}
+              {% include "svg/langfuse.svg" %}
+          {% else %}
+            <i class="fa-regular fa-chart-bar"></i>
+          {% endif %}
+        </a>
+      {% endif %}
+    </div>
+  {% endfor %}
+{% endif %}


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->
Give chat view permissions to the annotation reviewer role by default.

### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->
Give chat view permissions to the annotation reviewer role by default. The other way to achieve this is to give the human reviewer the chat viewer role, but since this will probably always need to happen, it might be best to just absorb that role.

Also only render trace icons when the user has permission to view the trace

### Migrations
<!--
There may be a potentially long window during the deployment where migrations are applied, but the old code is still running. We need to ensure that migrations can be applied to the current running code without breaking it, to the extent possible.

Delete this section if there are no migration.
 -->
N/A

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
N/A

### Docs and Changelog
- [x] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
