### PR TITLE
Record traces for direct API-triggered bot messages

### DIFF
--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -103,6 +103,7 @@ def trigger_bot_message_task(session_external_id: str, prompt_text: str | None, 
         session.ad_hoc_bot_message(
             prompt_text,
             TraceInfo(name="api trigger"),
+            fail_silently=False,
             use_experiment=target_experiment,
             message_text=message_text,
         )

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -4,7 +4,6 @@ from django.db.models import Subquery
 
 from apps.channels.clients.connect_client import CommCareConnectClient
 from apps.channels.models import ChannelPlatform, ExperimentChannel
-from apps.chat.channels import ChannelBase
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.chatbots.version_resolver import resolve_published_or_working
 from apps.experiments.models import ExperimentSession, ParticipantData
@@ -100,23 +99,15 @@ def trigger_bot_message_task(session_external_id: str, prompt_text: str | None, 
 
     experiment = session.experiment
     target_experiment = resolve_published_or_working(experiment)
-    ChannelClass = ChannelBase.get_channel_class_for_platform(session.experiment_channel.platform)
-    channel = ChannelClass(
-        experiment=target_experiment,
-        experiment_channel=session.experiment_channel,
-        experiment_session=session,
-    )
 
     with current_team(experiment.team):
         if message_text:
             ChatMessage.objects.create(
-                chat=channel.experiment_session.chat,
+                chat=session.chat,
                 message_type=ChatMessageType.AI,
                 content=message_text,
                 metadata={"direct_to_user": True},
             )
-            channel.experiment_session.try_send_message(message_text)
+            session.try_send_message(message_text)
         else:
-            channel.experiment_session.ad_hoc_bot_message(
-                prompt_text, TraceInfo(name="api trigger"), use_experiment=target_experiment
-            )
+            session.ad_hoc_bot_message(prompt_text, TraceInfo(name="api trigger"), use_experiment=target_experiment)

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -4,7 +4,6 @@ from django.db.models import Subquery
 
 from apps.channels.clients.connect_client import CommCareConnectClient
 from apps.channels.models import ChannelPlatform, ExperimentChannel
-from apps.chat.models import ChatMessage, ChatMessageType
 from apps.chatbots.version_resolver import resolve_published_or_working
 from apps.experiments.models import ExperimentSession, ParticipantData
 from apps.service_providers.tracing import TraceInfo
@@ -101,13 +100,9 @@ def trigger_bot_message_task(session_external_id: str, prompt_text: str | None, 
     target_experiment = resolve_published_or_working(experiment)
 
     with current_team(experiment.team):
-        if message_text:
-            ChatMessage.objects.create(
-                chat=session.chat,
-                message_type=ChatMessageType.AI,
-                content=message_text,
-                metadata={"direct_to_user": True},
-            )
-            session.try_send_message(message_text)
-        else:
-            session.ad_hoc_bot_message(prompt_text, TraceInfo(name="api trigger"), use_experiment=target_experiment)
+        session.ad_hoc_bot_message(
+            prompt_text,
+            TraceInfo(name="api trigger"),
+            use_experiment=target_experiment,
+            message_text=message_text,
+        )

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1522,21 +1522,25 @@ class ExperimentSession(BaseTeamModel):
     @transaction.atomic()
     def ad_hoc_bot_message(
         self,
-        instruction_prompt: str,
+        instruction_prompt: str | None,
         trace_info: TraceInfo,
         fail_silently=True,
         use_experiment: Experiment | None = None,
+        message_text: str | None = None,
     ):
         """Sends a bot message to this session and returns the trace data.
-        The bot message will be crafted using `instruction_prompt` and
+
+        When ``message_text`` is provided, that text is delivered to the participant verbatim,
+        bypassing the LLM. Otherwise the bot message is crafted using ``instruction_prompt`` and
         this session's history.
 
         Parameters:
-            instruction_prompt: The instruction prompt for the LLM
+            instruction_prompt: The instruction prompt for the LLM (ignored when ``message_text`` is set)
             trace_info: Metadata for adding to the trace
             fail_silently: Exceptions will not be suppresed if this is True
             use_experiment: The experiment whose data to use. This is useful for multi-bot setups where we want a
             specific child bot to handle the check-in.
+            message_text: A message to deliver to the participant directly, bypassing the LLM.
         """
         trace_service = None
         try:
@@ -1546,13 +1550,16 @@ class ExperimentSession(BaseTeamModel):
                 with trace_service.trace_or_span(
                     name=f"{experiment.name} - {trace_info.name}",
                     session=self,
-                    inputs={"input": instruction_prompt},
+                    inputs={"input": message_text if message_text is not None else instruction_prompt},
                     metadata=trace_info.metadata,
                     notification_config=SpanNotificationConfig(permissions=["experiments.change_experiment"]),
                 ) as span:
-                    bot_message = self._bot_prompt_for_user(
-                        instruction_prompt, trace_info, use_experiment=use_experiment, trace_service=trace_service
-                    )
+                    if message_text is not None:
+                        bot_message = self._save_direct_bot_message(message_text, experiment, trace_service)
+                    else:
+                        bot_message = self._bot_prompt_for_user(
+                            instruction_prompt, trace_info, use_experiment=use_experiment, trace_service=trace_service
+                        )
                     self.try_send_message(message=bot_message)
                     span.set_outputs({"response": bot_message})
                     trace_metadata = trace_service.get_trace_metadata()
@@ -1564,6 +1571,23 @@ class ExperimentSession(BaseTeamModel):
                     trace_metadata = trace_service.get_trace_metadata()
                     e.trace_metadata = trace_metadata
                 raise e
+
+    def _save_direct_bot_message(self, message: str, experiment: Experiment, trace_service: TracingService) -> str:
+        """Records a direct (non-LLM) bot message in the chat history and returns it.
+
+        The message is delivered to the participant verbatim, so it is stored as an AI message
+        flagged with ``direct_to_user`` metadata and linked to the trace.
+        """
+        from apps.service_providers.llm_service.history_managers import (  # noqa: PLC0415 - circular: history_managers imports experiments.models
+            ExperimentHistoryManager,
+        )
+
+        history_manager = ExperimentHistoryManager(session=self, experiment=experiment, trace_service=trace_service)
+        ai_message = history_manager.save_message_to_history(
+            message, type_=ChatMessageType.AI, message_metadata={"direct_to_user": True}
+        )
+        trace_service.set_output_message_id(ai_message.id)
+        return message
 
     def _bot_prompt_for_user(
         self,

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1542,6 +1542,9 @@ class ExperimentSession(BaseTeamModel):
             specific child bot to handle the check-in.
             message_text: A message to deliver to the participant directly, bypassing the LLM.
         """
+        if (instruction_prompt is None) == (message_text is None):
+            raise ValueError("Exactly one of instruction_prompt or message_text must be provided")
+
         trace_service = None
         try:
             with current_team(self.team):

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -469,6 +469,15 @@ class TestExperimentSession:
         trace = Trace.objects.get(session=experiment_session)
         assert trace.output_message_id == ai_message.id
 
+    @pytest.mark.parametrize(
+        ("instruction_prompt", "message_text"),
+        [(None, None), ("prompt", "message")],
+    )
+    def test_ad_hoc_message_requires_exactly_one_input(self, instruction_prompt, message_text, experiment_session):
+        """Neither-or-both of instruction_prompt/message_text is a programming error."""
+        with pytest.raises(ValueError, match="Exactly one of instruction_prompt or message_text"):
+            experiment_session.ad_hoc_bot_message(instruction_prompt, TraceInfo(name="test"), message_text=message_text)
+
     @pytest.mark.parametrize("participant_data_injected", [True, False])
     def test_requires_participant_data(self, participant_data_injected):
         prompt = "data: {participant_data}" if participant_data_injected else "data"

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -445,6 +445,30 @@ class TestExperimentSession:
         trace = Trace.objects.get(session=experiment_session)
         assert trace.output_message_id == ai_message.id
 
+    @patch("apps.chat.channels.ChannelBase.from_experiment_session")
+    @patch.object(ExperimentSession, "_bot_prompt_for_user")
+    def test_ad_hoc_message_direct_delivery(self, mock_bot_prompt, from_experiment_session, experiment_session):
+        """When ``message_text`` is provided the message is delivered verbatim, bypassing the LLM,
+        but still recorded in chat history (flagged ``direct_to_user``) and linked to the trace."""
+        mock_channel = Mock()
+        from_experiment_session.return_value = mock_channel
+        message = "Your appointment is confirmed for tomorrow at 10am."
+
+        experiment_session.ad_hoc_bot_message(None, TraceInfo(name="test"), message_text=message)
+
+        # The LLM is never consulted
+        mock_bot_prompt.assert_not_called()
+        # The message is delivered to the participant verbatim
+        mock_channel.send_message_to_user.assert_called_once_with(message)
+
+        # Recorded as an AI message flagged direct_to_user and linked to the trace
+        ai_message = ChatMessage.objects.get(chat=experiment_session.chat, message_type=ChatMessageType.AI)
+        assert ai_message.content == message
+        assert ai_message.metadata.get("direct_to_user") is True
+
+        trace = Trace.objects.get(session=experiment_session)
+        assert trace.output_message_id == ai_message.id
+
     @pytest.mark.parametrize("participant_data_injected", [True, False])
     def test_requires_participant_data(self, participant_data_injected):
         prompt = "data: {participant_data}" if participant_data_injected else "data"


### PR DESCRIPTION
[OCSBUGS-28](https://dimagi.atlassian.net/browse/OCSBUGS-28)

### Product Description
Bot messages pushed directly through the trigger-bot API (`message_text`, no LLM) are now captured in tracing like LLM-generated messages, so they show up in the session trace/observability views.

### Technical Description
The `message_text` path in `trigger_bot_message_task` built a `ChannelBase` instance it never used, created the `ChatMessage` inline, and sent it via `try_send_message` — entirely outside any trace span, so direct messages left no trace. Both paths now go through `session.ad_hoc_bot_message`, which gained a `message_text` parameter: when set, the text is delivered verbatim *inside the existing trace span* and persisted via `ExperimentHistoryManager.save_message_to_history` (flagged `direct_to_user`, version-tagged, and linked to the trace through `set_output_message_id`) — the same machinery the LLM path already used.

Reviewer note: `ad_hoc_bot_message`'s first parameter `instruction_prompt` is now `str | None` and is ignored when `message_text` is provided. The task passes both through; exactly one is set per the API contract.

### Migrations
N/A — no schema changes.

### Docs and Changelog
- [x] This PR requires docs/changelog update

[OCSBUGS-28]: https://dimagi.atlassian.net/browse/OCSBUGS-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ