### PR TITLE
Filter traces by session

### DIFF
--- a/apps/trace/filters.py
+++ b/apps/trace/filters.py
@@ -18,6 +18,7 @@ from apps.web.dynamic_filters.column_filters import (
     ExperimentFilter,
     ParticipantFilter,
     RemoteIdFilter,
+    SessionIdFilter,
     TimestampFilter,
 )
 
@@ -100,6 +101,8 @@ class TraceFilter(MultiColumnFilter):
     date_range_column: ClassVar[str] = "timestamp"
     filters: ClassVar[Sequence[ColumnFilter]] = [
         ParticipantFilter(),
+        # Trace relates to Session via FK, so the path to the external ID is ``session__external_id``.
+        SessionIdFilter(columns=["session__external_id"]),
         TimestampFilter(label="Timestamp", column="timestamp", query_param="timestamp"),
         MessageTagsFilter(),
         RemoteIdFilter(),

--- a/apps/trace/tests/test_filters.py
+++ b/apps/trace/tests/test_filters.py
@@ -8,7 +8,12 @@ from apps.annotations.models import Tag
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.trace.filters import TraceFilter
 from apps.trace.models import Trace, TraceStatus
-from apps.utils.factories.experiment import ChatFactory, ExperimentFactory, ParticipantFactory
+from apps.utils.factories.experiment import (
+    ChatFactory,
+    ExperimentFactory,
+    ExperimentSessionFactory,
+    ParticipantFactory,
+)
 from apps.utils.factories.traces import TraceFactory
 from apps.web.dynamic_filters.base import Operators
 from apps.web.dynamic_filters.datastructures import FilterParams
@@ -96,6 +101,21 @@ class TestTraceFilter:
 
         value = json.dumps(["other1", "other2"])
         result = self._create_filter_and_apply(queryset, "participant", Operators.ANY_OF, value)
+        assert trace not in result
+
+    def test_session_id_filter_equals(self, team, experiment, participant):
+        session = ExperimentSessionFactory.create(team=team, experiment=experiment, participant=participant)
+        trace = TraceFactory.create(team=team, experiment=experiment, participant=participant, session=session)
+        queryset = Trace.objects.filter(team=team)
+
+        # Matching session external ID (case-insensitive)
+        result = self._create_filter_and_apply(queryset, "session_id", Operators.EQUALS, str(session.external_id))
+        assert trace in result
+
+        # Non-matching session external ID
+        result = self._create_filter_and_apply(
+            queryset, "session_id", Operators.EQUALS, "00000000-0000-0000-0000-000000000000"
+        )
         assert trace not in result
 
     def test_remote_id_filter_any_of(self, trace, team):

--- a/apps/trace/tests/test_views.py
+++ b/apps/trace/tests/test_views.py
@@ -1,3 +1,7 @@
+import re
+from html import unescape
+from urllib.parse import parse_qs, urlparse
+
 import pytest
 from django.urls import reverse
 
@@ -33,10 +37,24 @@ def test_trace_detail_view_renders_filter_links(client, team_with_users):
     assert response.status_code == 200
     content = response.content.decode()
     home_url = reverse("trace:home", args=[team.slug])
-    assert f"{home_url}?filter_0_column=session_id&filter_0_operator=equals" in content
-    assert str(trace.session.external_id) in content
-    assert "filter_0_column=experiment&filter_0_operator=any+of" in content
-    assert "filter_0_column=participant&filter_0_operator=equals" in content
+
+    # Collect the filter query params from each link pointing at the trace table home.
+    links = {}
+    for href in re.findall(rf'href="({re.escape(home_url)}\?[^"]+)"', content):
+        params = parse_qs(urlparse(unescape(href)).query)
+        links[params["filter_0_column"][0]] = params
+
+    session_link = links["session_id"]
+    assert session_link["filter_0_operator"] == ["equals"]
+    assert session_link["filter_0_value"] == [str(trace.session.external_id)]
+
+    experiment_link = links["experiment"]
+    assert experiment_link["filter_0_operator"] == ["any of"]
+    assert experiment_link["filter_0_value"] == [f"[{trace.experiment_id}]"]
+
+    participant_link = links["participant"]
+    assert participant_link["filter_0_operator"] == ["equals"]
+    assert participant_link["filter_0_value"] == [trace.participant.identifier]
 
 
 @pytest.mark.django_db()

--- a/apps/trace/tests/test_views.py
+++ b/apps/trace/tests/test_views.py
@@ -21,6 +21,25 @@ def _make_trace(team, **kwargs):
 
 
 @pytest.mark.django_db()
+def test_trace_detail_view_renders_filter_links(client, team_with_users):
+    """The trace detail page links to the trace table pre-filtered by session/chatbot/participant."""
+    team = team_with_users
+    user = team.members.first()
+    trace = _make_trace(team)
+
+    client.force_login(user)
+    response = client.get(reverse("trace:trace_detail", args=[team.slug, trace.pk]))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    home_url = reverse("trace:home", args=[team.slug])
+    assert f"{home_url}?filter_0_column=session_id&filter_0_operator=equals" in content
+    assert str(trace.session.external_id) in content
+    assert "filter_0_column=experiment&filter_0_operator=any+of" in content
+    assert "filter_0_column=participant&filter_0_operator=equals" in content
+
+
+@pytest.mark.django_db()
 def test_trace_table_view_filters_by_team(client, team_with_users):
     """The trace list view must return only traces belonging to the requesting team."""
     team = team_with_users

--- a/templates/chatbots/chatbot_session_view.html
+++ b/templates/chatbots/chatbot_session_view.html
@@ -23,11 +23,11 @@
         {% url 'chatbots:chatbot_session_pagination_view' team.slug experiment.public_id experiment_session.external_id as paginate_url %}
         <div class="flex flex-wrap items-center justify-end gap-2">
           <div class="join">
-            <a class="btn join-item"
+            <a class="btn btn-sm join-item"
                href="{{ paginate_url }}?dir=prev">
               <i class="fa-solid fa-backward-step"></i> Older
             </a>
-            <a class="btn join-item"
+            <a class="btn btn-sm join-item"
                href="{{ paginate_url }}?dir=next">
               Newer <i class="fa-solid fa-forward-step"></i>
             </a>

--- a/templates/chatbots/chatbot_session_view.html
+++ b/templates/chatbots/chatbot_session_view.html
@@ -34,7 +34,7 @@
           </div>
           {% if perms.trace.view_trace %}
             <a class="btn btn-sm"
-               href="{% url 'trace:home' team.slug %}?filter_0_column=session_id&filter_0_operator=equals&filter_0_value={{ experiment_session.external_id }}">
+               href="{% url 'trace:home' team.slug %}{% querystring filter_0_column='session_id' filter_0_operator='equals' filter_0_value=experiment_session.external_id %}">
               <i class="fa-solid fa-stream"></i> View Traces
             </a>
           {% endif %}

--- a/templates/chatbots/chatbot_session_view.html
+++ b/templates/chatbots/chatbot_session_view.html
@@ -32,6 +32,12 @@
               Newer <i class="fa-solid fa-forward-step"></i>
             </a>
           </div>
+          {% if perms.trace.view_trace %}
+            <a class="btn btn-sm"
+               href="{% url 'trace:home' team.slug %}?filter_0_column=session_id&filter_0_operator=equals&filter_0_value={{ experiment_session.external_id }}">
+              <i class="fa-solid fa-stream"></i> View Traces
+            </a>
+          {% endif %}
           {% if perms.experiments.change_experimentsession and not experiment_session.ended_at %}
 
             {% if experiment_session.platform != "web" %}

--- a/templates/trace/trace_detail.html
+++ b/templates/trace/trace_detail.html
@@ -27,9 +27,34 @@
   <div>
     <div class="container mx-auto px-4 py-6">
       {# Heading #}
-      <div class="mb-6">
-        <h1 class="text-3xl font-bold mb-1">{{ trace.experiment.name }}</h1>
-        <p class="text-sm text-base-content/60">Trace ID: {{ trace.trace_id }}</p>
+      <div class="flex flex-wrap items-start justify-between gap-2 mb-6">
+        <div>
+          <h1 class="text-3xl font-bold mb-1">{{ trace.experiment.name }}</h1>
+          <p class="text-sm text-base-content/60">Trace ID: {{ trace.trace_id }}</p>
+        </div>
+        {# Quick links to the trace table pre-filtered by this trace's session/chatbot/participant #}
+        {% if perms.trace.view_trace %}
+          <div class="flex flex-wrap gap-2">
+            {% if trace.session %}
+              <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=session_id&filter_0_operator=equals&filter_0_value={{ trace.session.external_id }}"
+                 class="btn btn-sm btn-ghost">
+                <i class="fas fa-stream"></i> View session traces
+              </a>
+            {% endif %}
+            {% if trace.experiment %}
+              <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=experiment&filter_0_operator=any+of&filter_0_value=%5B{{ trace.experiment.working_version_id|default:trace.experiment_id }}%5D"
+                 class="btn btn-sm btn-ghost">
+                <i class="fas fa-robot"></i> View chatbot traces
+              </a>
+            {% endif %}
+            {% if trace.participant %}
+              <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=participant&filter_0_operator=equals&filter_0_value={{ trace.participant.identifier|urlencode }}"
+                 class="btn btn-sm btn-ghost">
+                <i class="fas fa-user"></i> View participant traces
+              </a>
+            {% endif %}
+          </div>
+        {% endif %}
       </div>
 
       {# Summary cards #}
@@ -122,30 +147,6 @@
           </time>
         </div>
       </div>
-
-      {# Quick links to the trace table pre-filtered by this trace's session/chatbot/participant #}
-      {% if perms.trace.view_trace %}
-        <div class="flex flex-wrap gap-2 mt-4">
-          {% if trace.session %}
-            <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=session_id&filter_0_operator=equals&filter_0_value={{ trace.session.external_id }}"
-               class="btn btn-sm btn-ghost">
-              <i class="fas fa-stream"></i> View session traces
-            </a>
-          {% endif %}
-          {% if trace.experiment %}
-            <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=experiment&filter_0_operator=any+of&filter_0_value=%5B{{ trace.experiment.working_version_id|default:trace.experiment_id }}%5D"
-               class="btn btn-sm btn-ghost">
-              <i class="fas fa-robot"></i> View chatbot traces
-            </a>
-          {% endif %}
-          {% if trace.participant %}
-            <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=participant&filter_0_operator=equals&filter_0_value={{ trace.participant.identifier|urlencode }}"
-               class="btn btn-sm btn-ghost">
-              <i class="fas fa-user"></i> View participant traces
-            </a>
-          {% endif %}
-        </div>
-      {% endif %}
     </div>
     <div class="border-t border-base-200 mt-2 pt-4">
       {% if trace.error %}

--- a/templates/trace/trace_detail.html
+++ b/templates/trace/trace_detail.html
@@ -32,29 +32,31 @@
           <h1 class="text-3xl font-bold mb-1">{{ trace.experiment.name }}</h1>
           <p class="text-sm text-base-content/60">Trace ID: {{ trace.trace_id }}</p>
         </div>
-        {# Quick links to the trace table pre-filtered by this trace's session/chatbot/participant #}
-        {% if perms.trace.view_trace %}
-          <div class="flex flex-wrap gap-2">
-            {% if trace.session %}
-              <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=session_id&filter_0_operator=equals&filter_0_value={{ trace.session.external_id }}"
-                 class="btn btn-sm">
-                <i class="fas fa-stream"></i> View session traces
-              </a>
-            {% endif %}
-            {% if trace.experiment %}
-              <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=experiment&filter_0_operator=any+of&filter_0_value=%5B{{ trace.experiment.working_version_id|default:trace.experiment_id }}%5D"
+        {# Quick links to the trace table pre-filtered by this trace's session/chatbot/participant. #}
+        {# This view already requires trace.view_trace, so no extra permission check is needed here. #}
+        <div class="flex flex-wrap gap-2">
+          {% if trace.session %}
+            <a href="{% url 'trace:home' request.team.slug %}{% querystring filter_0_column='session_id' filter_0_operator='equals' filter_0_value=trace.session.external_id %}"
+               class="btn btn-sm">
+              <i class="fas fa-stream"></i> View session traces
+            </a>
+          {% endif %}
+          {% if trace.experiment %}
+            {# The experiment filter matches on the working version id and expects a JSON-array value. #}
+            {% with exp_id=trace.experiment.working_version_id|default:trace.experiment_id|stringformat:'s' %}
+              <a href="{% url 'trace:home' request.team.slug %}{% querystring filter_0_column='experiment' filter_0_operator='any of' filter_0_value='['|add:exp_id|add:']' %}"
                  class="btn btn-sm">
                 <i class="fas fa-robot"></i> View chatbot traces
               </a>
-            {% endif %}
-            {% if trace.participant %}
-              <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=participant&filter_0_operator=equals&filter_0_value={{ trace.participant.identifier|urlencode }}"
-                 class="btn btn-sm">
-                <i class="fas fa-user"></i> View participant traces
-              </a>
-            {% endif %}
-          </div>
-        {% endif %}
+            {% endwith %}
+          {% endif %}
+          {% if trace.participant %}
+            <a href="{% url 'trace:home' request.team.slug %}{% querystring filter_0_column='participant' filter_0_operator='equals' filter_0_value=trace.participant.identifier %}"
+               class="btn btn-sm">
+              <i class="fas fa-user"></i> View participant traces
+            </a>
+          {% endif %}
+        </div>
       </div>
 
       {# Summary cards #}

--- a/templates/trace/trace_detail.html
+++ b/templates/trace/trace_detail.html
@@ -122,6 +122,30 @@
           </time>
         </div>
       </div>
+
+      {# Quick links to the trace table pre-filtered by this trace's session/chatbot/participant #}
+      {% if perms.trace.view_trace %}
+        <div class="flex flex-wrap gap-2 mt-4">
+          {% if trace.session %}
+            <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=session_id&filter_0_operator=equals&filter_0_value={{ trace.session.external_id }}"
+               class="btn btn-sm btn-ghost">
+              <i class="fas fa-stream"></i> View session traces
+            </a>
+          {% endif %}
+          {% if trace.experiment %}
+            <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=experiment&filter_0_operator=any+of&filter_0_value=%5B{{ trace.experiment.working_version_id|default:trace.experiment_id }}%5D"
+               class="btn btn-sm btn-ghost">
+              <i class="fas fa-robot"></i> View chatbot traces
+            </a>
+          {% endif %}
+          {% if trace.participant %}
+            <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=participant&filter_0_operator=equals&filter_0_value={{ trace.participant.identifier|urlencode }}"
+               class="btn btn-sm btn-ghost">
+              <i class="fas fa-user"></i> View participant traces
+            </a>
+          {% endif %}
+        </div>
+      {% endif %}
     </div>
     <div class="border-t border-base-200 mt-2 pt-4">
       {% if trace.error %}

--- a/templates/trace/trace_detail.html
+++ b/templates/trace/trace_detail.html
@@ -37,19 +37,19 @@
           <div class="flex flex-wrap gap-2">
             {% if trace.session %}
               <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=session_id&filter_0_operator=equals&filter_0_value={{ trace.session.external_id }}"
-                 class="btn btn-sm btn-ghost">
+                 class="btn btn-sm">
                 <i class="fas fa-stream"></i> View session traces
               </a>
             {% endif %}
             {% if trace.experiment %}
               <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=experiment&filter_0_operator=any+of&filter_0_value=%5B{{ trace.experiment.working_version_id|default:trace.experiment_id }}%5D"
-                 class="btn btn-sm btn-ghost">
+                 class="btn btn-sm">
                 <i class="fas fa-robot"></i> View chatbot traces
               </a>
             {% endif %}
             {% if trace.participant %}
               <a href="{% url 'trace:home' request.team.slug %}?filter_0_column=participant&filter_0_operator=equals&filter_0_value={{ trace.participant.identifier|urlencode }}"
-                 class="btn btn-sm btn-ghost">
+                 class="btn btn-sm">
                 <i class="fas fa-user"></i> View participant traces
               </a>
             {% endif %}


### PR DESCRIPTION
### Product Description
Make it easier to find all traces for a given session, chatbot, or participant. The trace table gains a **Session ID** filter, and quick links are added so users can jump from a trace detail page or a chatbot session transcript straight to a pre-filtered trace table.

Closes #3060.

### Technical Description
- `SessionIdFilter` is registered on `TraceFilter` with `columns=["session__external_id"]` — the override is needed because `Trace` reaches the session via FK (the reusable filter defaults to a bare `external_id` path used when filtering sessions directly).
- The navigation links target `trace:home`, **not** `trace:table`. The CodeRabbit plan suggested `trace:table`, but that endpoint only returns the bare HTMX table partial — the Alpine filter UI that reads `filter_N_*` params from `window.location.search` lives on the home page.
- The "View chatbot traces" link uses `working_version_id|default:experiment_id`. The experiment filter's options only list working-version chatbots and its backend clause matches on the working version id, so passing a versioned trace's raw `experiment_id` would not select correctly. The `any of` operator is URL-encoded as `any+of` and the value as a JSON array (`%5B…%5D`), which is what both the JS parser and the backend normalizer expect.
- All links are gated by `trace.view_trace`.

### Migrations
N/A — no migrations.

### Demo

**Quick links on trace view**
<img width="1249" height="272" alt="Screenshot from 2026-06-02 17-13-04" src="https://github.com/user-attachments/assets/a3a00849-530b-4110-b078-5a23210835d6" />

**Quick link from session view**
<img width="1249" height="272" alt="Screenshot from 2026-06-02 17-13-14" src="https://github.com/user-attachments/assets/e50b0628-e027-426c-b762-a881d9387d4d" />

**Session filter on trace table**
<img width="665" height="220" alt="Screenshot from 2026-06-02 17-13-24" src="https://github.com/user-attachments/assets/e29f2360-e1b3-4ffa-8d67-56872a04a400" />


### Docs and Changelog
- [x] This PR requires docs/changelog update