### PR TITLE
Add command to backfill Trace.output_message from message metadata

### DIFF
--- a/apps/trace/management/commands/backfill_trace_output_message.py
+++ b/apps/trace/management/commands/backfill_trace_output_message.py
@@ -68,18 +68,8 @@ class Command(BaseCommand):
                 break
 
             last_id = batch[-1][0]
-
-            traces_to_update = []
-            for trace_id, chat_id in batch:
-                processed += 1
-                message = self._find_output_message(trace_id, chat_id)
-                if message:
-                    traces_to_update.append(Trace(id=trace_id, output_message=message))
-
-            if traces_to_update:
-                if not dry_run:
-                    Trace.objects.bulk_update(traces_to_update, ["output_message"], batch_size=self.batch_size)
-                updated_count += len(traces_to_update)
+            processed += len(batch)
+            updated_count += self._update_batch(batch, dry_run)
 
             if processed % (self.batch_size * 5) == 0 or len(batch) < self.batch_size:
                 action = "Would update" if dry_run else "Updated"
@@ -87,19 +77,31 @@ class Command(BaseCommand):
 
         return updated_count
 
+    def _update_batch(self, batch, dry_run) -> int:
+        """Link each trace in the batch to its output message; returns the number linked."""
+        traces_to_update = []
+        for trace_id, chat_id in batch:
+            message = self._find_output_message(trace_id, chat_id)
+            if message:
+                traces_to_update.append(Trace(id=trace_id, output_message=message))
+
+        if traces_to_update and not dry_run:
+            Trace.objects.bulk_update(traces_to_update, ["output_message"], batch_size=self.batch_size)
+        return len(traces_to_update)
+
     def _find_output_message(self, trace_id, chat_id) -> ChatMessage | None:
         """Find the AI message in the trace's chat that references the trace in its metadata.
 
         ``trace_info`` is a list of per-provider entries; the OCS entry stores the Trace pk
         as an integer, so JSONB containment will not match external providers' string ids.
         Legacy messages stored ``trace_info`` as a single dict. If multiple messages match,
-        the latest one is taken as the final bot response of the trace.
+        the latest one (pk as tie-breaker) is taken as the final bot response of the trace.
         """
         return (
             ChatMessage.objects.filter(chat_id=chat_id, message_type=ChatMessageType.AI)
             .filter(
                 Q(metadata__trace_info__contains=[{"trace_id": trace_id}]) | Q(metadata__trace_info__trace_id=trace_id)
             )
-            .order_by("created_at")
+            .order_by("created_at", "id")
             .last()
         )

--- a/apps/trace/management/commands/backfill_trace_output_message.py
+++ b/apps/trace/management/commands/backfill_trace_output_message.py
@@ -1,0 +1,105 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from apps.chat.models import ChatMessage, ChatMessageType
+from apps.teams.models import Team
+from apps.trace.models import Trace
+
+
+class Command(BaseCommand):
+    # Traces created before the ad hoc bot message paths linked their AI message to the
+    # trace (see #3440) have output_message=NULL even though the message exists and
+    # carries the trace id in its metadata. This command restores the trace -> message
+    # link from the message metadata.
+    help = "Backfill Trace.output_message for traces whose AI message references them via metadata trace_info"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--team-slug",
+            type=str,
+            default=None,
+            help="Optional team slug to restrict the backfill to",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=500,
+            help="Number of traces to process per batch (default: 500)",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Preview changes without applying them",
+        )
+
+    def handle(self, *args, **options):
+        team_slug = options.get("team_slug")
+        self.batch_size = options.get("batch_size", 500)
+        dry_run = options.get("dry_run", False)
+
+        traces = Trace.objects.filter(output_message__isnull=True, session__isnull=False)
+        if team_slug:
+            try:
+                team = Team.objects.get(slug=team_slug)
+            except Team.DoesNotExist:
+                self.stderr.write(self.style.ERROR(f"Team with slug '{team_slug}' not found"))
+                return
+            traces = traces.filter(team=team)
+
+        total_count = traces.count()
+        self.stdout.write(f"Found {total_count} traces without an output message")
+
+        if dry_run:
+            self.stdout.write(self.style.NOTICE("DRY RUN MODE - No changes will be applied"))
+
+        updated_count = self._perform_backfill(traces.order_by("id"), total_count, dry_run)
+
+        action = "Would update" if dry_run else "Updated"
+        self.stdout.write(self.style.SUCCESS(f"{action} {updated_count} traces total"))
+
+    def _perform_backfill(self, qs, total_count, dry_run):
+        updated_count = 0
+        processed = 0
+        last_id = 0
+
+        while True:
+            batch = list(qs.filter(id__gt=last_id).values_list("id", "session__chat_id")[: self.batch_size])
+            if not batch:
+                break
+
+            last_id = batch[-1][0]
+
+            traces_to_update = []
+            for trace_id, chat_id in batch:
+                processed += 1
+                message = self._find_output_message(trace_id, chat_id)
+                if message:
+                    traces_to_update.append(Trace(id=trace_id, output_message=message))
+
+            if traces_to_update:
+                if not dry_run:
+                    Trace.objects.bulk_update(traces_to_update, ["output_message"], batch_size=self.batch_size)
+                updated_count += len(traces_to_update)
+
+            if processed % (self.batch_size * 5) == 0 or len(batch) < self.batch_size:
+                action = "Would update" if dry_run else "Updated"
+                self.stdout.write(f"  {action} {updated_count} so far (processed {processed}/{total_count})")
+
+        return updated_count
+
+    def _find_output_message(self, trace_id, chat_id) -> ChatMessage | None:
+        """Find the AI message in the trace's chat that references the trace in its metadata.
+
+        ``trace_info`` is a list of per-provider entries; the OCS entry stores the Trace pk
+        as an integer, so JSONB containment will not match external providers' string ids.
+        Legacy messages stored ``trace_info`` as a single dict. If multiple messages match,
+        the latest one is taken as the final bot response of the trace.
+        """
+        return (
+            ChatMessage.objects.filter(chat_id=chat_id, message_type=ChatMessageType.AI)
+            .filter(
+                Q(metadata__trace_info__contains=[{"trace_id": trace_id}]) | Q(metadata__trace_info__trace_id=trace_id)
+            )
+            .order_by("created_at")
+            .last()
+        )

--- a/apps/trace/tests/test_backfill_trace_output_message.py
+++ b/apps/trace/tests/test_backfill_trace_output_message.py
@@ -1,7 +1,8 @@
 import pytest
 from django.core.management import call_command
+from django.utils import timezone
 
-from apps.chat.models import ChatMessageType
+from apps.chat.models import ChatMessage, ChatMessageType
 from apps.utils.factories.experiment import ChatMessageFactory, ExperimentSessionFactory
 from apps.utils.factories.traces import TraceFactory
 
@@ -85,8 +86,11 @@ class TestBackfillTraceOutputMessage:
 
     def test_picks_latest_message_when_multiple_match(self, session):
         trace = _make_trace(session)
-        _make_message(session, trace.id)
+        first = _make_message(session, trace.id)
         latest = _make_message(session, trace.id)
+        # created_at is auto_now_add, so force identical timestamps to pin the
+        # tie-breaking behaviour: the higher pk (later insert) must win.
+        ChatMessage.objects.filter(id__in=[first.id, latest.id]).update(created_at=timezone.now())
 
         self._call_command()
 

--- a/apps/trace/tests/test_backfill_trace_output_message.py
+++ b/apps/trace/tests/test_backfill_trace_output_message.py
@@ -1,0 +1,145 @@
+import pytest
+from django.core.management import call_command
+
+from apps.chat.models import ChatMessageType
+from apps.utils.factories.experiment import ChatMessageFactory, ExperimentSessionFactory
+from apps.utils.factories.traces import TraceFactory
+
+
+def _make_trace(session, **kwargs):
+    return TraceFactory.create(
+        session=session,
+        experiment=session.experiment,
+        team=session.team,
+        participant=session.participant,
+        **kwargs,
+    )
+
+
+def _make_message(session, trace_id, message_type=ChatMessageType.AI, **kwargs):
+    metadata = kwargs.pop(
+        "metadata",
+        {"trace_info": [{"trace_id": trace_id, "trace_url": "http://example.com", "trace_provider": "ocs"}]},
+    )
+    return ChatMessageFactory.create(
+        chat=session.chat,
+        message_type=message_type,
+        content="a bot message",
+        metadata=metadata,
+        **kwargs,
+    )
+
+
+@pytest.fixture()
+def session():
+    return ExperimentSessionFactory.create()
+
+
+@pytest.mark.django_db()
+class TestBackfillTraceOutputMessage:
+    def _call_command(self, **kwargs):
+        call_command("backfill_trace_output_message", **kwargs)
+
+    def test_links_ai_message_to_trace(self, session):
+        trace = _make_trace(session)
+        message = _make_message(session, trace.id)
+
+        self._call_command()
+
+        trace.refresh_from_db()
+        assert trace.output_message == message
+
+    def test_ignores_human_messages(self, session):
+        trace = _make_trace(session)
+        _make_message(session, trace.id, message_type=ChatMessageType.HUMAN)
+
+        self._call_command()
+
+        trace.refresh_from_db()
+        assert trace.output_message is None
+
+    def test_ignores_messages_for_other_traces(self, session):
+        trace = _make_trace(session)
+        other_trace = _make_trace(session)
+        message = _make_message(session, other_trace.id)
+
+        self._call_command()
+
+        trace.refresh_from_db()
+        other_trace.refresh_from_db()
+        assert trace.output_message is None
+        assert other_trace.output_message == message
+
+    def test_does_not_change_traces_that_are_already_linked(self, session):
+        trace = _make_trace(session)
+        linked_message = _make_message(session, trace.id)
+        trace.output_message = linked_message
+        trace.save()
+        # a second message referencing the same trace should not steal the link
+        _make_message(session, trace.id)
+
+        self._call_command()
+
+        trace.refresh_from_db()
+        assert trace.output_message == linked_message
+
+    def test_picks_latest_message_when_multiple_match(self, session):
+        trace = _make_trace(session)
+        _make_message(session, trace.id)
+        latest = _make_message(session, trace.id)
+
+        self._call_command()
+
+        trace.refresh_from_db()
+        assert trace.output_message == latest
+
+    def test_supports_legacy_dict_trace_info_format(self, session):
+        trace = _make_trace(session)
+        message = _make_message(
+            session,
+            trace.id,
+            metadata={"trace_info": {"trace_id": trace.id}, "trace_provider": "ocs"},
+        )
+
+        self._call_command()
+
+        trace.refresh_from_db()
+        assert trace.output_message == message
+
+    def test_does_not_match_string_trace_ids_from_external_providers(self, session):
+        # Langfuse entries store their own trace id as a string; a string that happens
+        # to equal the OCS trace pk must not match.
+        trace = _make_trace(session)
+        _make_message(
+            session,
+            trace.id,
+            metadata={"trace_info": [{"trace_id": str(trace.id), "trace_provider": "langfuse"}]},
+        )
+
+        self._call_command()
+
+        trace.refresh_from_db()
+        assert trace.output_message is None
+
+    def test_dry_run_does_not_apply_changes(self, session):
+        trace = _make_trace(session)
+        _make_message(session, trace.id)
+
+        self._call_command(dry_run=True)
+
+        trace.refresh_from_db()
+        assert trace.output_message is None
+
+    def test_team_filter(self, session):
+        other_session = ExperimentSessionFactory.create()
+        trace = _make_trace(session)
+        other_trace = _make_trace(other_session)
+        message = _make_message(session, trace.id)
+        _make_message(other_session, other_trace.id)
+
+        self._call_command(team_slug=session.team.slug)
+
+        trace.refresh_from_db()
+        other_trace.refresh_from_db()
+        assert trace.output_message == message
+        assert other_trace.output_message is None


### PR DESCRIPTION
### Product Description

No change — data-repair management command only.

### Technical Description

Traces created via the ad hoc bot message path before #3440 was fixed (007c07895), and direct-send messages before c7458d006, have `output_message=NULL` even though the AI ChatMessage carries the trace pk in its `trace_info` metadata. `backfill_trace_output_message` restores the trace → message link from that metadata (the message → trace direction was always written).

Points worth a look:

- Matching relies on JSONB containment with an **integer** trace id, so Langfuse entries (string trace ids) can't false-match; there's a test pinning that.
- Legacy dict-shaped `trace_info` metadata is also handled.
- If multiple AI messages reference the same trace, the latest is taken as the final bot response.
- Supports `--dry-run`, `--batch-size`, and optional `--team-slug`; batching mirrors `backfill_participant_data_diff`.

Run with `--dry-run` first in prod to sanity-check the match count.

### Migrations

N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)