### PR TITLE
Improve OpenAPI schema metadata: title, description, and tag descriptions

### DIFF
--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -1,8 +1,8 @@
 openapi: 3.0.3
 info:
-  title: Dimagi Chatbots
+  title: Open Chat Studio
   version: '1'
-  description: Experiments with AI, GPT and LLMs
+  description: Build, deploy and monitor chatbots.
 paths:
   /api/chat/{session_id}/{task_id}/poll/:
     get:
@@ -1941,6 +1941,18 @@ components:
       type: http
       scheme: bearer
 tags:
+- name: Channels
+  description: Trigger bot messages or deliver messages directly to users on a channel.
 - name: Chat
   description: "\n                The Chat API is designed to be used for integrating
     chatbots into external systems.\n            "
+- name: Experiments
+  description: List and retrieve chatbots (formerly 'experiments').
+- name: Experiment Sessions
+  description: Manage chatbot sessions including session state, and session tags.
+- name: Files
+  description: Download the content of files associated with chat messages.
+- name: OpenAI
+  description: OpenAI-compatible endpoints for interacting with chatbots.
+- name: Participants
+  description: Manage participants, their data, and their schedules.

--- a/config/settings.py
+++ b/config/settings.py
@@ -447,8 +447,8 @@ REST_FRAMEWORK = {
 }
 
 SPECTACULAR_SETTINGS = {
-    "TITLE": "Dimagi Chatbots",
-    "DESCRIPTION": "Experiments with AI, GPT and LLMs",
+    "TITLE": "Open Chat Studio",
+    "DESCRIPTION": "Build, deploy and monitor chatbots.",
     "VERSION": "1",
     "SERVE_INCLUDE_SCHEMA": False,
     "SWAGGER_UI_SETTINGS": {

--- a/config/settings.py
+++ b/config/settings.py
@@ -456,10 +456,34 @@ SPECTACULAR_SETTINGS = {
     },
     "TAGS": [
         {
+            "name": "Channels",
+            "description": "Trigger bot messages or deliver messages directly to users on a channel.",
+        },
+        {
             "name": "Chat",
             "description": """
                 The Chat API is designed to be used for integrating chatbots into external systems.
             """,
+        },
+        {
+            "name": "Experiments",
+            "description": "List and retrieve chatbots (formerly 'experiments').",
+        },
+        {
+            "name": "Experiment Sessions",
+            "description": "Manage chatbot sessions including session state, and session tags.",
+        },
+        {
+            "name": "Files",
+            "description": "Download the content of files associated with chat messages.",
+        },
+        {
+            "name": "OpenAI",
+            "description": "OpenAI-compatible endpoints for interacting with chatbots.",
+        },
+        {
+            "name": "Participants",
+            "description": "Manage participants, their data, and their schedules.",
         },
     ],
 }


### PR DESCRIPTION
### Product Description
The generated API docs (Swagger UI / api-schemas/v1.yml) now show an accurate title ("Open Chat Studio" instead of "Dimagi Chatbots") and a short description for every API tag group, instead of only the Chat tag.

### Technical Description
Settings-only change to `SPECTACULAR_SETTINGS`: adds tag descriptions for all tags used in `extend_schema` across the codebase (Channels, Experiments, Experiment Sessions, Files, OpenAI, Participants). `api-schemas/v1.yml` was regenerated via `manage.py spectacular`; its diff also picks up the title/description change from the previous commit, where the snapshot had not been regenerated.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)