### PR TITLE
Fix: renaming an evaluator output field blocked by stale tag rule validation

### DIFF
--- a/apps/evaluations/forms.py
+++ b/apps/evaluations/forms.py
@@ -283,8 +283,11 @@ class EvaluatorForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.team = team
         # Set by the view before is_valid() so the schema-drift check can
-        # ignore rules the user is deleting in the same submit.
+        # ignore rules the user is deleting in the same submit, and use the
+        # *submitted* field name (rather than the persisted one) for rules
+        # being edited in the same submit.
         self.pending_deleted_rule_pks: set[int] = set()
+        self.submitted_rule_field_names: dict[int, str] = {}
 
     def clean(self):
         cleaned_data = super().clean()
@@ -335,12 +338,18 @@ class EvaluatorForm(forms.ModelForm):
         rules = self.instance.tag_rules.exclude(pk__in=self.pending_deleted_rule_pks)
         errors = []
         for rule in rules:
+            # If the user is renaming this rule's field in the same submit, validate
+            # against the submitted field name rather than the persisted one so that
+            # a consistent rename (schema field + rule field changed together) is
+            # accepted, while an inconsistent rename (rule points to a non-existent
+            # field in the new schema) is still rejected.
+            field_name = self.submitted_rule_field_names.get(rule.pk, rule.field_name)
             try:
-                field_def = validate_field_in_schema(rule.field_name, output_schema)
+                field_def = validate_field_in_schema(field_name, output_schema)
                 validate_condition(rule.condition_type, rule.condition_value, field_def)
             except DjangoValidationError as err:
                 errors.append(
-                    f"Tag rule on field '{rule.field_name}' is incompatible with the updated "
+                    f"Tag rule on field '{field_name}' is incompatible with the updated "
                     f"output schema: {err.messages[0] if err.messages else err}"
                 )
         if errors:

--- a/apps/evaluations/forms.py
+++ b/apps/evaluations/forms.py
@@ -282,12 +282,6 @@ class EvaluatorForm(forms.ModelForm):
     def __init__(self, team, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.team = team
-        # Set by the view before is_valid() so the schema-drift check can
-        # ignore rules the user is deleting in the same submit, and use the
-        # *submitted* field name (rather than the persisted one) for rules
-        # being edited in the same submit.
-        self.pending_deleted_rule_pks: set[int] = set()
-        self.submitted_rule_field_names: dict[int, str] = {}
 
     def clean(self):
         cleaned_data = super().clean()
@@ -320,40 +314,7 @@ class EvaluatorForm(forms.ModelForm):
                 error_messages.append(f"{field_name.replace('_', ' ').title()}: {message}")
             raise forms.ValidationError(f"{', '.join(error_messages)}") from err
 
-        self._validate_existing_tag_rules_against_schema(params)
-
         return cleaned_data
-
-    def _validate_existing_tag_rules_against_schema(self, params):
-        """Block save when an existing tag rule no longer matches the new output_schema.
-
-        Skips rules the formset is deleting in the same submit so users aren't
-        stuck having to delete the rule and update the schema in two trips.
-        Surfaces all incompatible rules at once instead of stopping at the first.
-        """
-        if not (self.instance and self.instance.pk):
-            return
-
-        output_schema = (params or {}).get("output_schema") or {}
-        rules = self.instance.tag_rules.exclude(pk__in=self.pending_deleted_rule_pks)
-        errors = []
-        for rule in rules:
-            # If the user is renaming this rule's field in the same submit, validate
-            # against the submitted field name rather than the persisted one so that
-            # a consistent rename (schema field + rule field changed together) is
-            # accepted, while an inconsistent rename (rule points to a non-existent
-            # field in the new schema) is still rejected.
-            field_name = self.submitted_rule_field_names.get(rule.pk, rule.field_name)
-            try:
-                field_def = validate_field_in_schema(field_name, output_schema)
-                validate_condition(rule.condition_type, rule.condition_value, field_def)
-            except DjangoValidationError as err:
-                errors.append(
-                    f"Tag rule on field '{field_name}' is incompatible with the updated "
-                    f"output schema: {err.messages[0] if err.messages else err}"
-                )
-        if errors:
-            raise forms.ValidationError(errors)
 
 
 class EvaluatorTagRuleForm(forms.ModelForm):
@@ -513,6 +474,31 @@ class BaseEvaluatorTagRuleFormSet(forms.BaseInlineFormSet):
         kwargs["team"] = self.team
         kwargs["output_schema"] = self.output_schema
         return super()._construct_form(i, **kwargs)
+
+    def clean(self):
+        """Block save when a DB rule absent from this POST is incompatible with the schema.
+
+        Rows present in the POST are validated per-row against the output_schema
+        (including deletes and renames in the same submit). Rules missing from the
+        POST entirely (stale tab, concurrent edit) would otherwise silently survive
+        a schema change that breaks them, so check them here.
+        """
+        super().clean()
+        if not (self.instance and self.instance.pk):
+            return
+        submitted_pks = {form.instance.pk for form in self.forms if form.instance.pk}
+        errors = []
+        for rule in self.instance.tag_rules.exclude(pk__in=submitted_pks):
+            try:
+                field_def = validate_field_in_schema(rule.field_name, self.output_schema)
+                validate_condition(rule.condition_type, rule.condition_value, field_def)
+            except DjangoValidationError as err:
+                errors.append(
+                    f"Tag rule on field '{rule.field_name}' is incompatible with the updated "
+                    f"output schema: {err.messages[0] if err.messages else err}"
+                )
+        if errors:
+            raise forms.ValidationError(errors)
 
     @property
     def empty_form(self):

--- a/apps/evaluations/tests/test_evaluator_views.py
+++ b/apps/evaluations/tests/test_evaluator_views.py
@@ -1,0 +1,143 @@
+"""End-to-end tests for the evaluator create/edit views and the tag-rule formset wiring."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from apps.evaluations.models import ConditionType
+from apps.utils.factories.evaluations import EvaluatorFactory, EvaluatorTagRuleFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+
+
+@pytest.fixture()
+def team(db):
+    return TeamWithUsersFactory.create()
+
+
+@pytest.fixture()
+def client_with_user(team):
+    client = Client()
+    client.force_login(team.members.first())
+    return client
+
+
+@pytest.fixture()
+def evaluator(team):
+    return EvaluatorFactory.create(team=team)
+
+
+def _edit_url(team, evaluator):
+    return reverse("evaluations:evaluator_edit", args=[team.slug, evaluator.pk])
+
+
+def _params(output_schema):
+    return {
+        "llm_prompt": "prompt",
+        "llm_provider_id": 1,
+        "llm_provider_model_id": 1,
+        "output_schema": output_schema,
+    }
+
+
+def _post_data(evaluator, output_schema, rule_rows):
+    data = {
+        "name": evaluator.name,
+        "type": "LlmEvaluator",
+        "params": json.dumps(_params(output_schema)),
+        "evaluation_mode": evaluator.evaluation_mode,
+        "tag_rules-TOTAL_FORMS": str(len(rule_rows)),
+        "tag_rules-INITIAL_FORMS": str(len([r for r in rule_rows if r.get("id")])),
+        "tag_rules-MIN_NUM_FORMS": "0",
+        "tag_rules-MAX_NUM_FORMS": "1000",
+    }
+    for i, row in enumerate(rule_rows):
+        for key, value in row.items():
+            data[f"tag_rules-{i}-{key}"] = value
+    return data
+
+
+@pytest.mark.django_db()
+class TestEditEvaluatorSchemaDrift:
+    def test_renaming_field_and_updating_rule_in_same_submit_saves(self, client_with_user, team, evaluator):
+        """Renaming an output field and updating the tag rule to match, in one POST, succeeds."""
+        rule = EvaluatorTagRuleFactory.create(team=team, evaluator=evaluator, field_name="old_field")
+        new_schema = {"new_field": {"type": "choice", "description": "d", "choices": ["negative", "positive"]}}
+        data = _post_data(
+            evaluator,
+            new_schema,
+            [
+                {
+                    "id": str(rule.pk),
+                    "tag_name": rule.tag.name,
+                    "field_name": "new_field",
+                    "condition_type": ConditionType.EQUALS,
+                    "condition_value_single": "negative",
+                }
+            ],
+        )
+
+        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
+            response = client_with_user.post(_edit_url(team, evaluator), data)
+
+        assert response.status_code == 302, getattr(response, "context_data", None)
+        rule.refresh_from_db()
+        assert rule.field_name == "new_field"
+        evaluator.refresh_from_db()
+        assert evaluator.params["output_schema"] == new_schema
+
+    def test_schema_change_breaking_a_rule_is_blocked(self, client_with_user, team, evaluator):
+        """Removing a field that an existing rule references re-renders with errors and saves nothing."""
+        rule = EvaluatorTagRuleFactory.create(team=team, evaluator=evaluator, field_name="sentiment")
+        old_schema = evaluator.params["output_schema"]
+        data = _post_data(
+            evaluator,
+            {"score": {"type": "int", "description": "d"}},  # drops "sentiment"
+            [
+                {
+                    "id": str(rule.pk),
+                    "tag_name": rule.tag.name,
+                    "field_name": "sentiment",
+                    "condition_type": ConditionType.EQUALS,
+                    "condition_value_single": "negative",
+                }
+            ],
+        )
+
+        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
+            response = client_with_user.post(_edit_url(team, evaluator), data)
+
+        assert response.status_code == 200
+        evaluator.refresh_from_db()
+        assert evaluator.params["output_schema"] == old_schema
+        rule.refresh_from_db()
+        assert rule.field_name == "sentiment"
+
+    def test_deleting_stale_rule_with_schema_change_in_same_submit_saves(self, client_with_user, team, evaluator):
+        """Deleting the incompatible rule in the same POST as the schema change succeeds in one trip."""
+        rule = EvaluatorTagRuleFactory.create(team=team, evaluator=evaluator, field_name="sentiment")
+        new_schema = {"score": {"type": "int", "description": "d"}}
+        data = _post_data(
+            evaluator,
+            new_schema,
+            [
+                {
+                    "id": str(rule.pk),
+                    "tag_name": rule.tag.name,
+                    "field_name": "sentiment",
+                    "condition_type": ConditionType.EQUALS,
+                    "condition_value_single": "negative",
+                    "DELETE": "on",
+                }
+            ],
+        )
+
+        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
+            response = client_with_user.post(_edit_url(team, evaluator), data)
+
+        assert response.status_code == 302, getattr(response, "context_data", None)
+        evaluator.refresh_from_db()
+        assert evaluator.params["output_schema"] == new_schema
+        assert not evaluator.tag_rules.filter(pk=rule.pk).exists()

--- a/apps/evaluations/tests/test_tagging_integration.py
+++ b/apps/evaluations/tests/test_tagging_integration.py
@@ -375,6 +375,76 @@ class TestEvaluatorFormSchemaDrift:
             assert not form.is_valid()
         assert any("sentiment" in str(e) for e in form.errors.get("__all__", []))
 
+    def test_renaming_field_and_updating_rule_in_same_submit_succeeds(self, team, message_evaluator):
+        """Renaming an output field and updating the tag rule's field_name in the same POST
+        should not raise a false schema-drift validation error."""
+        rule = EvaluatorTagRuleFactory.create(
+            team=team,
+            evaluator=message_evaluator,
+            field_name="old_field",
+            condition_type=ConditionType.EQUALS,
+            condition_value={"value": "negative"},
+        )
+        # New schema renames "old_field" to "new_field"; the submitted formset
+        # updates the rule to reference "new_field" in the same request.
+        new_params = {
+            "llm_prompt": "prompt",
+            "llm_provider_id": 1,
+            "llm_provider_model_id": 1,
+            "output_schema": {
+                "new_field": {
+                    "type": "choice",
+                    "description": "d",
+                    "choices": ["negative", "positive"],
+                }
+            },
+        }
+        form_data = {
+            "name": message_evaluator.name,
+            "type": "LlmEvaluator",
+            "params": new_params,
+            "evaluation_mode": message_evaluator.evaluation_mode,
+        }
+        form = EvaluatorForm(team=team, data=form_data, instance=message_evaluator)
+        form.submitted_rule_field_names = {rule.pk: "new_field"}
+        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
+            assert form.is_valid(), form.errors
+
+    def test_renaming_rule_to_nonexistent_field_is_blocked(self, team, message_evaluator):
+        """If the submitted rule field name doesn't exist in the new schema, it should still
+        be rejected — we validate the submitted field name, not skip validation entirely."""
+        rule = EvaluatorTagRuleFactory.create(
+            team=team,
+            evaluator=message_evaluator,
+            field_name="old_field",
+            condition_type=ConditionType.EQUALS,
+            condition_value={"value": "negative"},
+        )
+        new_params = {
+            "llm_prompt": "prompt",
+            "llm_provider_id": 1,
+            "llm_provider_model_id": 1,
+            "output_schema": {
+                "new_field": {
+                    "type": "choice",
+                    "description": "d",
+                    "choices": ["negative", "positive"],
+                }
+            },
+        }
+        form_data = {
+            "name": message_evaluator.name,
+            "type": "LlmEvaluator",
+            "params": new_params,
+            "evaluation_mode": message_evaluator.evaluation_mode,
+        }
+        form = EvaluatorForm(team=team, data=form_data, instance=message_evaluator)
+        # Simulate the user submitting a rule that references a field not in the new schema
+        form.submitted_rule_field_names = {rule.pk: "completely_wrong_field"}
+        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
+            assert not form.is_valid()
+        assert any("completely_wrong_field" in str(e) for e in form.errors.get("__all__", []))
+
     def test_rule_with_incompatible_type_blocks_save(self, team, message_evaluator):
         EvaluatorTagRuleFactory.create(
             team=team,

--- a/apps/evaluations/tests/test_tagging_integration.py
+++ b/apps/evaluations/tests/test_tagging_integration.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 
 from apps.annotations.models import CustomTaggedItem, Tag
-from apps.evaluations.forms import EvaluatorForm, EvaluatorTagRuleFormSet
+from apps.evaluations.forms import EvaluatorTagRuleFormSet
 from apps.evaluations.models import (
     AppliedTag,
     ConditionType,
@@ -345,130 +345,134 @@ class TestTransactionRollback:
         assert AppliedTag.objects.count() == 0
 
 
-# ---- EvaluatorForm schema-drift validation --------------------------------
+# ---- Formset schema-drift validation ---------------------------------------
 
 
-class TestEvaluatorFormSchemaDrift:
-    def test_rule_with_removed_field_blocks_save(self, team, message_evaluator):
-        EvaluatorTagRuleFactory.create(
+def _formset_data(rows, initial=0):
+    data = {
+        "tag_rules-TOTAL_FORMS": str(len(rows)),
+        "tag_rules-INITIAL_FORMS": str(initial),
+        "tag_rules-MIN_NUM_FORMS": "0",
+        "tag_rules-MAX_NUM_FORMS": "1000",
+    }
+    for i, row in enumerate(rows):
+        for key, value in row.items():
+            data[f"tag_rules-{i}-{key}"] = value
+    return data
+
+
+NEW_FIELD_SCHEMA = {
+    "new_field": {
+        "type": "choice",
+        "description": "d",
+        "choices": ["negative", "positive"],
+    }
+}
+
+
+class TestFormsetSchemaDrift:
+    """Schema-drift validation lives on the tag-rule formset.
+
+    Rows present in the POST are validated per-row against the (new) output_schema;
+    DB rules absent from the POST entirely (stale tab, concurrent edit) are caught
+    by the formset-level clean().
+    """
+
+    def _rule_row(self, rule, **overrides):
+        row = {
+            "id": str(rule.pk),
+            "tag_name": rule.tag.name,
+            "field_name": rule.field_name,
+            "condition_type": rule.condition_type,
+            "condition_value_single": rule.condition_value.get("value", ""),
+        }
+        row.update(overrides)
+        return row
+
+    def test_row_referencing_removed_field_blocks(self, team, message_evaluator):
+        rule = EvaluatorTagRuleFactory.create(team=team, evaluator=message_evaluator, field_name="sentiment")
+        formset = EvaluatorTagRuleFormSet(
+            data=_formset_data([self._rule_row(rule)], initial=1),
+            instance=message_evaluator,
             team=team,
-            evaluator=message_evaluator,
-            field_name="sentiment",
-            condition_type=ConditionType.EQUALS,
-            condition_value={"value": "negative"},
+            # New schema drops "sentiment"
+            output_schema={"score": {"type": "int", "description": "d"}},
         )
-        # New output_schema drops "sentiment"
-        new_params = {
-            "llm_prompt": "prompt",
-            "llm_provider_id": 1,
-            "llm_provider_model_id": 1,
-            "output_schema": {"score": {"type": "int", "description": "d"}},
-        }
-        form_data = {
-            "name": message_evaluator.name,
-            "type": "LlmEvaluator",
-            "params": new_params,
-            "evaluation_mode": message_evaluator.evaluation_mode,
-        }
-        form = EvaluatorForm(team=team, data=form_data, instance=message_evaluator)
-        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
-            assert not form.is_valid()
-        assert any("sentiment" in str(e) for e in form.errors.get("__all__", []))
+        assert not formset.is_valid()
+        assert any("sentiment" in str(e) for e in formset.forms[0].errors.values())
+
+    def test_row_with_incompatible_condition_blocks(self, team, message_evaluator):
+        rule = EvaluatorTagRuleFactory.create(team=team, evaluator=message_evaluator, field_name="sentiment")
+        formset = EvaluatorTagRuleFormSet(
+            data=_formset_data([self._rule_row(rule)], initial=1),
+            instance=message_evaluator,
+            team=team,
+            # sentiment is now an int field; equals "negative" no longer applies
+            output_schema={"sentiment": {"type": "int", "description": "d"}},
+        )
+        assert not formset.is_valid()
 
     def test_renaming_field_and_updating_rule_in_same_submit_succeeds(self, team, message_evaluator):
         """Renaming an output field and updating the tag rule's field_name in the same POST
         should not raise a false schema-drift validation error."""
-        rule = EvaluatorTagRuleFactory.create(
+        rule = EvaluatorTagRuleFactory.create(team=team, evaluator=message_evaluator, field_name="old_field")
+        formset = EvaluatorTagRuleFormSet(
+            data=_formset_data([self._rule_row(rule, field_name="new_field")], initial=1),
+            instance=message_evaluator,
             team=team,
-            evaluator=message_evaluator,
-            field_name="old_field",
-            condition_type=ConditionType.EQUALS,
-            condition_value={"value": "negative"},
+            output_schema=NEW_FIELD_SCHEMA,
         )
-        # New schema renames "old_field" to "new_field"; the submitted formset
-        # updates the rule to reference "new_field" in the same request.
-        new_params = {
-            "llm_prompt": "prompt",
-            "llm_provider_id": 1,
-            "llm_provider_model_id": 1,
-            "output_schema": {
-                "new_field": {
+        assert formset.is_valid(), formset.errors
+
+    def test_renaming_rule_to_nonexistent_field_blocks(self, team, message_evaluator):
+        rule = EvaluatorTagRuleFactory.create(team=team, evaluator=message_evaluator, field_name="old_field")
+        formset = EvaluatorTagRuleFormSet(
+            data=_formset_data([self._rule_row(rule, field_name="completely_wrong_field")], initial=1),
+            instance=message_evaluator,
+            team=team,
+            output_schema=NEW_FIELD_SCHEMA,
+        )
+        assert not formset.is_valid()
+
+    def test_deleting_incompatible_rule_in_same_submit_succeeds(self, team, message_evaluator):
+        """Deleting a stale rule together with the schema change should work in one trip."""
+        rule = EvaluatorTagRuleFactory.create(team=team, evaluator=message_evaluator, field_name="old_field")
+        formset = EvaluatorTagRuleFormSet(
+            data=_formset_data([self._rule_row(rule, DELETE="on")], initial=1),
+            instance=message_evaluator,
+            team=team,
+            output_schema=NEW_FIELD_SCHEMA,
+        )
+        assert formset.is_valid(), formset.errors
+
+    def test_db_rule_absent_from_post_and_incompatible_blocks(self, team, message_evaluator):
+        """A rule that exists in the DB but isn't in the POST at all (stale tab,
+        concurrent edit) must still block an incompatible schema change."""
+        EvaluatorTagRuleFactory.create(team=team, evaluator=message_evaluator, field_name="sentiment")
+        formset = EvaluatorTagRuleFormSet(
+            data=_formset_data([]),
+            instance=message_evaluator,
+            team=team,
+            output_schema={"score": {"type": "int", "description": "d"}},
+        )
+        assert not formset.is_valid()
+        assert any("sentiment" in str(e) for e in formset.non_form_errors())
+
+    def test_db_rule_absent_from_post_but_compatible_passes(self, team, message_evaluator):
+        EvaluatorTagRuleFactory.create(team=team, evaluator=message_evaluator, field_name="sentiment")
+        formset = EvaluatorTagRuleFormSet(
+            data=_formset_data([]),
+            instance=message_evaluator,
+            team=team,
+            output_schema={
+                "sentiment": {
                     "type": "choice",
                     "description": "d",
                     "choices": ["negative", "positive"],
                 }
             },
-        }
-        form_data = {
-            "name": message_evaluator.name,
-            "type": "LlmEvaluator",
-            "params": new_params,
-            "evaluation_mode": message_evaluator.evaluation_mode,
-        }
-        form = EvaluatorForm(team=team, data=form_data, instance=message_evaluator)
-        form.submitted_rule_field_names = {rule.pk: "new_field"}
-        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
-            assert form.is_valid(), form.errors
-
-    def test_renaming_rule_to_nonexistent_field_is_blocked(self, team, message_evaluator):
-        """If the submitted rule field name doesn't exist in the new schema, it should still
-        be rejected — we validate the submitted field name, not skip validation entirely."""
-        rule = EvaluatorTagRuleFactory.create(
-            team=team,
-            evaluator=message_evaluator,
-            field_name="old_field",
-            condition_type=ConditionType.EQUALS,
-            condition_value={"value": "negative"},
         )
-        new_params = {
-            "llm_prompt": "prompt",
-            "llm_provider_id": 1,
-            "llm_provider_model_id": 1,
-            "output_schema": {
-                "new_field": {
-                    "type": "choice",
-                    "description": "d",
-                    "choices": ["negative", "positive"],
-                }
-            },
-        }
-        form_data = {
-            "name": message_evaluator.name,
-            "type": "LlmEvaluator",
-            "params": new_params,
-            "evaluation_mode": message_evaluator.evaluation_mode,
-        }
-        form = EvaluatorForm(team=team, data=form_data, instance=message_evaluator)
-        # Simulate the user submitting a rule that references a field not in the new schema
-        form.submitted_rule_field_names = {rule.pk: "completely_wrong_field"}
-        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
-            assert not form.is_valid()
-        assert any("completely_wrong_field" in str(e) for e in form.errors.get("__all__", []))
-
-    def test_rule_with_incompatible_type_blocks_save(self, team, message_evaluator):
-        EvaluatorTagRuleFactory.create(
-            team=team,
-            evaluator=message_evaluator,
-            field_name="sentiment",
-            condition_type=ConditionType.EQUALS,
-            condition_value={"value": "negative"},
-        )
-        # sentiment is now an int field; equals no longer applies
-        new_params = {
-            "llm_prompt": "prompt",
-            "llm_provider_id": 1,
-            "llm_provider_model_id": 1,
-            "output_schema": {"sentiment": {"type": "int", "description": "d"}},
-        }
-        form_data = {
-            "name": message_evaluator.name,
-            "type": "LlmEvaluator",
-            "params": new_params,
-            "evaluation_mode": message_evaluator.evaluation_mode,
-        }
-        form = EvaluatorForm(team=team, data=form_data, instance=message_evaluator)
-        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
-            assert not form.is_valid()
+        assert formset.is_valid(), formset.non_form_errors()
 
 
 # ---- Tag-rule formset --------------------------------------------------------

--- a/apps/evaluations/views/evaluator_views.py
+++ b/apps/evaluations/views/evaluator_views.py
@@ -75,13 +75,7 @@ class EvaluatorFormsetMixin:
         self.object = self.get_object_or_none()
 
         initial_instance = self.object or Evaluator(team=request.team)
-        initial_formset = self._build_tag_rule_formset(initial_instance, data=request.POST)
-        pending_deleted_pks = _extract_pending_deleted_rule_pks(request.POST, initial_formset.prefix)
-        submitted_rule_field_names = _extract_submitted_rule_field_names(request.POST, initial_formset.prefix)
-
         form = self.get_form()
-        form.pending_deleted_rule_pks = pending_deleted_pks
-        form.submitted_rule_field_names = submitted_rule_field_names
 
         if form.is_valid():
             evaluator = form.save(commit=False)
@@ -191,51 +185,6 @@ class DeleteEvaluator(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Delete
         self.object = self.get_object()
         self.object.delete()
         return HttpResponse(status=200)
-
-
-def _extract_pending_deleted_rule_pks(post_data, prefix: str) -> set[int]:
-    """Return existing-rule pks that the formset POST has marked DELETE."""
-    try:
-        total = int(post_data.get(f"{prefix}-TOTAL_FORMS", 0))
-    except (TypeError, ValueError):
-        return set()
-    pks: set[int] = set()
-    for i in range(total):
-        if not post_data.get(f"{prefix}-{i}-DELETE"):
-            continue
-        raw_pk = post_data.get(f"{prefix}-{i}-id")
-        if not raw_pk:
-            continue
-        try:
-            pks.add(int(raw_pk))
-        except (TypeError, ValueError):
-            continue
-    return pks
-
-
-def _extract_submitted_rule_field_names(post_data, prefix: str) -> dict[int, str]:
-    """Return a mapping of {rule_pk: submitted_field_name} for existing rules being edited
-    (not deleted) in this submit. Used so the schema-drift check can validate the *submitted*
-    field name instead of the persisted one when the user renames a field in the same request."""
-    total_str = post_data.get(f"{prefix}-TOTAL_FORMS", "0")
-    try:
-        total = int(total_str)
-    except (TypeError, ValueError):
-        return {}
-    result: dict[int, str] = {}
-    for i in range(total):
-        if post_data.get(f"{prefix}-{i}-DELETE"):
-            continue  # being deleted — handled by pending_deleted_rule_pks
-        raw_pk = post_data.get(f"{prefix}-{i}-id")
-        if not raw_pk:
-            continue  # new rule, no existing DB row to check
-        try:
-            pk = int(raw_pk)
-        except (TypeError, ValueError):
-            continue
-        submitted_field = post_data.get(f"{prefix}-{i}-field_name", "")
-        result[pk] = submitted_field
-    return result
 
 
 def _submitted_output_schema(form, instance) -> dict:

--- a/apps/evaluations/views/evaluator_views.py
+++ b/apps/evaluations/views/evaluator_views.py
@@ -77,9 +77,11 @@ class EvaluatorFormsetMixin:
         initial_instance = self.object or Evaluator(team=request.team)
         initial_formset = self._build_tag_rule_formset(initial_instance, data=request.POST)
         pending_deleted_pks = _extract_pending_deleted_rule_pks(request.POST, initial_formset.prefix)
+        submitted_rule_field_names = _extract_submitted_rule_field_names(request.POST, initial_formset.prefix)
 
         form = self.get_form()
         form.pending_deleted_rule_pks = pending_deleted_pks
+        form.submitted_rule_field_names = submitted_rule_field_names
 
         if form.is_valid():
             evaluator = form.save(commit=False)
@@ -209,6 +211,31 @@ def _extract_pending_deleted_rule_pks(post_data, prefix: str) -> set[int]:
         except (TypeError, ValueError):
             continue
     return pks
+
+
+def _extract_submitted_rule_field_names(post_data, prefix: str) -> dict[int, str]:
+    """Return a mapping of {rule_pk: submitted_field_name} for existing rules being edited
+    (not deleted) in this submit. Used so the schema-drift check can validate the *submitted*
+    field name instead of the persisted one when the user renames a field in the same request."""
+    total_str = post_data.get(f"{prefix}-TOTAL_FORMS", "0")
+    try:
+        total = int(total_str)
+    except (TypeError, ValueError):
+        return {}
+    result: dict[int, str] = {}
+    for i in range(total):
+        if post_data.get(f"{prefix}-{i}-DELETE"):
+            continue  # being deleted — handled by pending_deleted_rule_pks
+        raw_pk = post_data.get(f"{prefix}-{i}-id")
+        if not raw_pk:
+            continue  # new rule, no existing DB row to check
+        try:
+            pk = int(raw_pk)
+        except (TypeError, ValueError):
+            continue
+        submitted_field = post_data.get(f"{prefix}-{i}-field_name", "")
+        result[pk] = submitted_field
+    return result
 
 
 def _submitted_output_schema(form, instance) -> dict:


### PR DESCRIPTION
### Product Description
Renaming an output field on an LLM evaluator (and updating its tag rule to match in the same save) was rejected with a "tag rule is incompatible with the updated output schema" error, forcing two trips. Renames, condition changes, and rule deletions submitted together with a schema change now save in one go; schema changes that would actually break a rule are still blocked.

### Technical Description
The schema-drift check lived on `EvaluatorForm.clean()` and validated **persisted** rules against the **submitted** schema, so the view had to scrape raw formset POST data (deleted pks, renamed field names) to suppress false rejections — and it still validated stale condition values, leaving the same bug one level down (rename a field *and* change its condition value in one submit → false rejection).

Moved the validation to the tag-rule formset, which runs after the main form validates and is already bound to the submitted schema + submitted row data, so all in-POST cases (edit/rename/delete) are handled by existing per-row validation. The only residual case — a DB rule absent from the POST entirely (stale tab, concurrent edit) silently surviving a breaking schema change — is covered by a new `BaseEvaluatorTagRuleFormSet.clean()`. Net: the view's POST-scraping helpers and the form-level check are deleted.

Note for review: the first commit is the original shim-based fix; the second supersedes it with the formset approach. Reviewing the combined diff is easier than commit-by-commit.

New end-to-end view tests (`test_evaluator_views.py`) lock the rename/block/delete-in-same-submit behaviours through the real Create/Edit POST flow; they were verified green against both the old and new implementations.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
