### PR TITLE
Add automated Claude code review workflow for PRs

### DIFF
--- a/.github/workflows/README-claude-workflows.md
+++ b/.github/workflows/README-claude-workflows.md
@@ -4,7 +4,7 @@ For engineers responsible for extending, debugging, or operating the Claude work
 
 ## Setup
 
-The `ANTHROPIC_API_KEY` secret must be set under **Settings > Secrets and variables > Actions** in the repository. All three Claude workflows require it.
+The `ANTHROPIC_API_KEY` secret must be set under **Settings > Secrets and variables > Actions** in the repository. All Claude workflows require it.
 
 ## Workflow files
 
@@ -13,6 +13,7 @@ The `ANTHROPIC_API_KEY` secret must be set under **Settings > Secrets and variab
 | `.github/workflows/claude.yml` | Claude Code | Issue labelled `claude`, `@claude` mention, daily schedule, manual dispatch |
 | `.github/workflows/claude-followup.yml` | Claude Followup | CI completes on any `claude/**` branch |
 | `.github/workflows/claude-dependabot.yml` | Claude Dependabot PR Review | Dependabot PR opened or updated, manual dispatch |
+| `.github/workflows/claude-code-review.yml` | Claude Code Review | PR opened, marked ready for review, or pushed to (non-Dependabot, non-draft) |
 
 ## Tool allowlist
 
@@ -23,6 +24,8 @@ For more information on `claude_args` see [GitHub for claude-code-action usage g
 ## Concurrency
 
 Runs on the same issue queue instead of cancelling each other (`cancel-in-progress: false`). If a second trigger fires while a run is in progress for the same issue, it waits. Runs for different issues execute in parallel.
+
+The code review workflow is the exception: a new push to a PR cancels any in-progress review of that PR (`cancel-in-progress: true`), since a review of stale code is wasted spend.
 
 ## Branch and label conventions
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,52 @@
+# Claude Code Review
+#
+# Automated code review on pull requests using the official Anthropic
+# code-review plugin. Findings are verified by the plugin's review agents
+# and posted as inline comments on the PR diff.
+#
+# Triggered on: PR opened, marked ready for review, or pushed to
+# Requirements: ANTHROPIC_API_KEY secret must be configured
+#
+# Notes:
+# - Dependabot PRs are excluded — they get their own review via
+#   claude-dependabot.yml
+# - Draft PRs are skipped; the review runs when the PR is marked ready
+# - A new push cancels any in-progress review of the same PR
+
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+
+jobs:
+  review:
+    if: github.actor != 'dependabot[bot]' && !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh api:*),Read,Grep,Glob,Task"


### PR DESCRIPTION
### Product Description
No change — CI/tooling only.

### Technical Description
Adds automated PR review using `anthropics/claude-code-action@v1` with Anthropic's official `code-review` plugin (per the [GitHub Actions docs](https://code.claude.com/docs/en/github-actions)). Findings are posted as inline comments on the diff.

Decisions worth noting:
- Reviews run on open, ready-for-review, and **every push** — chosen for coverage over cost. If spend becomes an issue, dropping `synchronize` or gating on a label is a one-line change.
- Unlike the other Claude workflows, concurrency uses `cancel-in-progress: true` (per PR) so a new push doesn't waste spend reviewing stale code.
- Dependabot PRs are excluded (covered by `claude-dependabot.yml`); drafts are skipped until marked ready.
- Tool allowlist is read-only git/gh plus the inline-comment MCP tool, matching repo convention; permissions are `contents: read` / `pull-requests: write` so the review can comment but never push.

Uses the existing `ANTHROPIC_API_KEY` secret — no new setup required. Note: Anthropic also offers a managed Code Review service (claude.ai admin settings) that would make this workflow redundant if we ever adopt it.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)