### PR TITLE
Add RFC 8594 sunset headers to legacy embed chat endpoints

### DIFF
--- a/apps/chatbots/tests/test_chatbot_views.py
+++ b/apps/chatbots/tests/test_chatbot_views.py
@@ -10,6 +10,7 @@ from django.template.response import TemplateResponse
 from django.test import Client, RequestFactory
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
+from django.utils.http import http_date
 
 from apps.annotations.models import Tag
 from apps.chatbots.tables import ChatbotSessionsTable
@@ -22,6 +23,7 @@ from apps.chatbots.views import (
     home,
 )
 from apps.events.models import StaticTriggerType
+from apps.experiments.const import EMBED_FLOW_SUCCESSOR_URL, EMBED_FLOW_SUNSET_AT
 from apps.experiments.models import Experiment, ExperimentSession, Participant, SessionStatus
 from apps.pipelines.models import Pipeline
 from apps.teams.helpers import get_team_membership_for_request
@@ -663,3 +665,19 @@ def test_session_table_session_query_uses_limit(team_with_users):
         "Session list ran an unbounded SELECT on experiments_experimentsession (no LIMIT) — "
         "pagination is not being applied at the SQL level. Session selects captured:\n" + "\n\n".join(session_selects)
     )
+
+
+@pytest.mark.django_db()
+@patch("apps.chat.channels.enqueue_static_triggers", Mock())
+def test_start_chatbot_session_public_embed_returns_deprecation_headers(client):
+    """The legacy embed flow is sunset (see issue #3540); responses must carry RFC 8594 headers."""
+    chatbot = ExperimentFactory.create()
+    url = reverse(
+        "chatbots:start_session_public_embed",
+        kwargs={"team_slug": chatbot.team.slug, "experiment_id": chatbot.public_id},
+    )
+    response = client.get(url)
+    assert response.status_code == 302
+    assert response.headers["Deprecation"] == "true"
+    assert response.headers["Sunset"] == http_date(EMBED_FLOW_SUNSET_AT.timestamp())
+    assert response.headers["Link"] == f'<{EMBED_FLOW_SUCCESSOR_URL}>; rel="successor-version"'

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -31,6 +31,7 @@ from apps.chatbots.tasks import send_bot_message
 from apps.chatbots.version_resolver import resolve_published_or_working
 from apps.events.models import EventLogStatusChoices, StaticTrigger, StaticTriggerType, TimeoutTrigger
 from apps.events.tables import EventsTable
+from apps.experiments.const import EMBED_FLOW_SUCCESSOR_URL, EMBED_FLOW_SUNSET_AT
 from apps.experiments.decorators import experiment_session_view, verify_session_access_cookie
 from apps.experiments.email import send_experiment_invitation
 from apps.experiments.filters import (
@@ -62,6 +63,7 @@ from apps.teams.decorators import login_and_team_required, team_required
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 from apps.teams.models import Flag
 from apps.trace.models import Trace
+from apps.utils.decorators import sunset
 from apps.utils.search import similarity_search
 from apps.web.dynamic_filters.datastructures import FilterParams
 from apps.web.waf import WafRule, waf_allow
@@ -726,11 +728,16 @@ def chatbot_chat(request, team_slug: str, experiment_id: uuid.UUID, session_id: 
     return _chatbot_chat_ui(request)
 
 
+@sunset(EMBED_FLOW_SUNSET_AT, successor_url=EMBED_FLOW_SUCCESSOR_URL)
 @xframe_options_exempt
 @team_required
 def start_chatbot_session_public_embed(request, team_slug: str, experiment_id: uuid.UUID):
     """Special view for starting chatbot sessions from embedded widgets. This will ignore consent and pre-surveys and
-    will ALWAYS create anonymous participants."""
+    will ALWAYS create anonymous participants.
+
+    Deprecated: legacy embed flow, sunset 2026-08-03 — use the chat widget (`/api/chat/*`).
+    See https://github.com/dimagi/open-chat-studio/issues/3540
+    """
     try:
         chatbot = get_object_or_404(Experiment, public_id=experiment_id, team=request.team)
     except ValidationError:
@@ -751,6 +758,7 @@ def start_chatbot_session_public_embed(request, team_slug: str, experiment_id: u
     return redirect("chatbots:chatbot_chat_embed", team_slug, chatbot.public_id, session.external_id)
 
 
+@sunset(EMBED_FLOW_SUNSET_AT, successor_url=EMBED_FLOW_SUCCESSOR_URL)
 @experiment_session_view(allowed_states=[SessionStatus.ACTIVE, SessionStatus.SETUP])
 @xframe_options_exempt
 def chatbot_chat_embed(request, team_slug: str, experiment_id: uuid.UUID, session_id: str):

--- a/apps/experiments/const.py
+++ b/apps/experiments/const.py
@@ -1,5 +1,13 @@
+from datetime import UTC, datetime
+
+# Sunset details for the legacy embedded web chat flow (the `/embed/start/` endpoints
+# and the pages they serve). Replaced by the chat widget backed by `/api/chat/*`.
+# Tracking issue: https://github.com/dimagi/open-chat-studio/issues/3540
+EMBED_FLOW_SUNSET_AT = datetime(2026, 8, 3, tzinfo=UTC)
+EMBED_FLOW_SUCCESSOR_URL = "https://docs.openchatstudio.com/chat_widget/"
+
 DEFAULT_CONSENT_TEXT = """
-Welcome to this chatbot built on Open Chat Studio! 
+Welcome to this chatbot built on Open Chat Studio!
 
 The Chatbot is provided "as-is" and "as available." Open Chat Studio makes no warranties,
 express or implied, regarding the Chatbot's accuracy, completeness, or availability.
@@ -10,7 +18,7 @@ or damages that may result from your use of the chatbot.
 You understand and agree that any reliance on the Chatbot's responses is solely at your own
 discretion and risk.
 
-By selecting “I Agree” below, you indicate that: 
+By selecting “I Agree” below, you indicate that:
 
 * You have read and understood the above information.
 * You voluntarily agree to try out this chatbot.

--- a/apps/experiments/tests/test_views.py
+++ b/apps/experiments/tests/test_views.py
@@ -8,8 +8,10 @@ from django.core.exceptions import ValidationError
 from django.http import HttpResponse
 from django.test import override_settings
 from django.urls import reverse
+from django.utils.http import http_date
 
 from apps.chat.channels import WebChannel
+from apps.experiments.const import EMBED_FLOW_SUCCESSOR_URL, EMBED_FLOW_SUNSET_AT
 from apps.experiments.models import (
     Experiment,
     ExperimentSession,
@@ -275,6 +277,22 @@ def test_user_email_used_for_participant_identifier(_trigger_mock, client):
     )
     client.post(url, data=post_data)
     assert Participant.objects.filter(team=experiment.team, identifier=user.email).exists()
+
+
+@pytest.mark.django_db()
+@mock.patch("apps.chat.channels.enqueue_static_triggers", mock.Mock())
+def test_start_session_public_embed_returns_deprecation_headers(client):
+    """The legacy embed flow is sunset (see issue #3540); responses must carry RFC 8594 headers."""
+    experiment = ExperimentFactory.create(team=TeamWithUsersFactory.create())
+    url = reverse(
+        "experiments:start_session_public_embed",
+        kwargs={"team_slug": experiment.team.slug, "experiment_id": experiment.public_id},
+    )
+    response = client.get(url)
+    assert response.status_code == 302
+    assert response.headers["Deprecation"] == "true"
+    assert response.headers["Sunset"] == http_date(EMBED_FLOW_SUNSET_AT.timestamp())
+    assert response.headers["Link"] == f'<{EMBED_FLOW_SUCCESSOR_URL}>; rel="successor-version"'
 
 
 @pytest.mark.django_db()

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -52,6 +52,7 @@ from apps.chatbots.version_resolver import resolve_published_or_working
 from apps.events.models import (
     StaticTriggerType,
 )
+from apps.experiments.const import EMBED_FLOW_SUCCESSOR_URL, EMBED_FLOW_SUNSET_AT
 from apps.experiments.decorators import (
     experiment_session_view,
     get_chat_session_access_cookie_data,
@@ -87,6 +88,7 @@ from apps.service_providers.utils import get_models_by_team_grouped_by_provider
 from apps.teams.decorators import login_and_team_required, team_required
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 from apps.trace.models import Trace
+from apps.utils.decorators import sunset
 from apps.web.waf import WafRule, waf_allow
 
 
@@ -111,6 +113,7 @@ def experiment_session_message(request, team_slug: str, experiment_id: uuid.UUID
 
 
 @waf_allow(WafRule.SizeRestrictions_BODY)
+@sunset(EMBED_FLOW_SUNSET_AT, successor_url=EMBED_FLOW_SUCCESSOR_URL)
 @experiment_session_view()
 @require_POST
 @xframe_options_exempt
@@ -209,6 +212,7 @@ def get_message_response(request, team_slug: str, experiment_id: uuid.UUID, sess
     )
 
 
+@sunset(EMBED_FLOW_SUNSET_AT, successor_url=EMBED_FLOW_SUCCESSOR_URL)
 @experiment_session_view()
 @require_GET
 @xframe_options_exempt
@@ -342,11 +346,16 @@ def start_session_public(request, team_slug: str, experiment_id: uuid.UUID):
     )
 
 
+@sunset(EMBED_FLOW_SUNSET_AT, successor_url=EMBED_FLOW_SUCCESSOR_URL)
 @xframe_options_exempt
 @team_required
 def start_session_public_embed(request, team_slug: str, experiment_id: uuid.UUID):
     """Special view for starting sessions from embedded widgets. This will ignore consent and pre-surveys and
-    will ALWAYS create anonymous participants."""
+    will ALWAYS create anonymous participants.
+
+    Deprecated: legacy embed flow, sunset 2026-08-03 — use the chat widget (`/api/chat/*`).
+    See https://github.com/dimagi/open-chat-studio/issues/3540
+    """
     try:
         experiment = get_object_or_404(Experiment, public_id=experiment_id, team=request.team)
     except ValidationError:


### PR DESCRIPTION
### Product Description

Day-0 step of deprecating the legacy embedded web chat flow (`/embed/start/` and the pages it serves), replaced by the [chat widget](https://docs.openchatstudio.com/chat_widget/) backed by `/api/chat/*`. No behaviour change — responses now carry `Deprecation`/`Sunset` (2026-08-03) and successor `Link` headers per RFC 8594.

Tracking issue: #3540

### Technical Description

First real use of the `@sunset` decorator from the new [feature deprecation process](https://github.com/dimagi/open-chat-studio/blob/main/docs/developer_guides/feature_deprecation.md). All 5 endpoints of the flow are decorated (the two `embed/start` entry points, `chatbot_chat_embed`, and the embed HTMX message/poll views) — the latter three are only reachable via the entry points and are deprecated as one surface. Sunset date + successor URL live in `apps/experiments/const.py` so the views and tests share one definition.

On `experiment_session_message_embed`, `@sunset` sits *below* `@waf_allow` (pre-commit enforces waf_allow-first).

### Docs and Changelog
- [x] This PR requires docs/changelog update

Changelog note: the legacy embed endpoints are deprecated and will be removed on 2026-08-03; sites embedding via the old iframe flow should upgrade to the current chat widget (https://docs.openchatstudio.com/chat_widget/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)