### PR TITLE
feat: allow editing num_reviews_required after annotations start

### DIFF
--- a/apps/human_annotations/forms.py
+++ b/apps/human_annotations/forms.py
@@ -33,10 +33,15 @@ class AnnotationQueueForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # Schema *structure* is locked once annotations exist (only the 'required'
+        # property may change), but num_reviews_required stays editable.
         self._schema_locked = self.instance.pk and self.instance.items.filter(review_count__gt=0).exists()
-        if self._schema_locked:
-            self.fields["num_reviews_required"].disabled = True
-            self.fields["num_reviews_required"].help_text = "Cannot change after annotations have started."
+
+    def save(self, commit=True):
+        instance = super().save(commit=commit)
+        if commit and "num_reviews_required" in self.changed_data:
+            instance.resync_items()
+        return instance
 
     def clean_schema(self):
         raw = self.cleaned_data["schema"]

--- a/apps/human_annotations/forms.py
+++ b/apps/human_annotations/forms.py
@@ -39,6 +39,9 @@ class AnnotationQueueForm(forms.ModelForm):
 
     def save(self, commit=True):
         instance = super().save(commit=commit)
+        # resync_items requires the new num_reviews_required to be persisted, so it only runs
+        # when committing. The queue edit views always save with commit=True; a commit=False
+        # caller would need to invoke instance.resync_items() itself after saving.
         if commit and "num_reviews_required" in self.changed_data:
             instance.resync_items()
         return instance

--- a/apps/human_annotations/models.py
+++ b/apps/human_annotations/models.py
@@ -2,7 +2,7 @@ import logging
 
 from django.conf import settings
 from django.db import models, transaction
-from django.db.models import Sum
+from django.db.models import Exists, OuterRef, Sum
 from django.urls import reverse
 from django.utils import timezone
 from pydantic import TypeAdapter
@@ -29,6 +29,24 @@ class AnnotationItemStatus(models.TextChoices):
     AWAITING_RESOLUTION = "awaiting_resolution", "Awaiting resolution"
     COMPLETED = "completed", "Completed"
     FLAGGED = "flagged", "Flagged"
+
+
+def _compute_item_status(review_count: int, required: int, has_authoritative: bool) -> str:
+    """Pure status rule shared by per-item updates and the bulk recompute.
+
+    An item is COMPLETED once it has an authoritative annotation, or when it only has a
+    single review (one reviewer can't disagree with anyone, so there is nothing to
+    resolve). With two or more reviews and no authoritative pick it is AWAITING_RESOLUTION
+    — including after ``num_reviews_required`` is lowered, since lowering the requirement
+    does not retroactively resolve a disagreement between existing reviews.
+    """
+    if review_count == 0:
+        return AnnotationItemStatus.PENDING
+    if review_count < required:
+        return AnnotationItemStatus.IN_PROGRESS
+    if has_authoritative or review_count == 1:
+        return AnnotationItemStatus.COMPLETED
+    return AnnotationItemStatus.AWAITING_RESOLUTION
 
 
 class AnnotationQueueQuerySet(models.QuerySet):
@@ -118,6 +136,53 @@ class AnnotationQueue(BaseTeamModel):
             "percent": review_percent,
         }
 
+    def resync_items(self):
+        """Re-sync items to the current ``num_reviews_required``.
+
+        Recomputes every (non-FLAGGED) item's status and, when the queue becomes
+        multi-review, clears auto-assigned authoritative flags (left over from
+        single-review submissions, identified by a null ``authoritative_set_by``)
+        so those items go through normal resolution; human-picked authoritative
+        flags are kept. If any flags were cleared, stored aggregates are
+        recomputed too, since clearing them changes aggregation. FLAGGED items are
+        left untouched, matching ``AnnotationItem.update_status``.
+        """
+        with transaction.atomic():
+            cleared = 0
+            if self.num_reviews_required > 1:
+                cleared = Annotation.objects.filter(
+                    item__queue=self,
+                    is_authoritative=True,
+                    authoritative_set_by__isnull=True,
+                ).update(is_authoritative=False, authoritative_set_at=None)
+
+            items = self.items.exclude(status=AnnotationItemStatus.FLAGGED).annotate(
+                has_authoritative=Exists(
+                    Annotation.objects.filter(
+                        item=OuterRef("pk"),
+                        status=AnnotationStatus.SUBMITTED,
+                        is_authoritative=True,
+                    )
+                )
+            )
+            to_update = []
+            for item in items:
+                new_status = _compute_item_status(item.review_count, self.num_reviews_required, item.has_authoritative)
+                if new_status != item.status:
+                    item.status = new_status
+                    to_update.append(item)
+            if to_update:
+                AnnotationItem.objects.bulk_update(to_update, ["status"])
+
+        # Clearing authoritative flags changes aggregation (authoritative vs all-submitted),
+        # so refresh stored aggregates. Run outside the transaction, like recompute_queue_aggregates.
+        if cleared:
+            from apps.human_annotations.aggregation import (  # noqa: PLC0415 - circular: aggregation imports human_annotations.models
+                compute_aggregates_for_queue,
+            )
+
+            compute_aggregates_for_queue(self)
+
 
 class AnnotationItemType(models.TextChoices):
     SESSION = "session", "Session"
@@ -194,16 +259,11 @@ class AnnotationItem(BaseTeamModel):
         if self.status == AnnotationItemStatus.FLAGGED:
             return
 
-        required = self.queue.num_reviews_required
-
-        if self.review_count == 0:
-            self.status = AnnotationItemStatus.PENDING
-        elif self.review_count < required:
-            self.status = AnnotationItemStatus.IN_PROGRESS
-        elif required == 1 or self._has_authoritative_annotation():
-            self.status = AnnotationItemStatus.COMPLETED
-        else:
-            self.status = AnnotationItemStatus.AWAITING_RESOLUTION
+        self.status = _compute_item_status(
+            self.review_count,
+            self.queue.num_reviews_required,
+            self._has_authoritative_annotation(),
+        )
 
         if save:
             self.save(update_fields=["status"])

--- a/apps/human_annotations/models.py
+++ b/apps/human_annotations/models.py
@@ -156,12 +156,16 @@ class AnnotationQueue(BaseTeamModel):
                     authoritative_set_by__isnull=True,
                 ).update(is_authoritative=False, authoritative_set_at=None)
 
-            items = self.items.exclude(status=AnnotationItemStatus.FLAGGED).annotate(
-                has_authoritative=Exists(
-                    Annotation.objects.filter(
-                        item=OuterRef("pk"),
-                        status=AnnotationStatus.SUBMITTED,
-                        is_authoritative=True,
+            items = (
+                self.items.exclude(status=AnnotationItemStatus.FLAGGED)
+                .select_for_update()
+                .annotate(
+                    has_authoritative=Exists(
+                        Annotation.objects.filter(
+                            item=OuterRef("pk"),
+                            status=AnnotationStatus.SUBMITTED,
+                            is_authoritative=True,
+                        )
                     )
                 )
             )
@@ -181,7 +185,10 @@ class AnnotationQueue(BaseTeamModel):
                 compute_aggregates_for_queue,
             )
 
-            compute_aggregates_for_queue(self)
+            try:
+                compute_aggregates_for_queue(self)
+            except Exception:
+                logger.exception("Failed to recompute aggregates for queue %s during resync", self.id)
 
 
 class AnnotationItemType(models.TextChoices):

--- a/apps/human_annotations/models.py
+++ b/apps/human_annotations/models.py
@@ -155,6 +155,19 @@ class AnnotationQueue(BaseTeamModel):
                     is_authoritative=True,
                     authoritative_set_by__isnull=True,
                 ).update(is_authoritative=False, authoritative_set_at=None)
+            elif self.num_reviews_required == 1:
+                # Mirror submission's auto-mark: a lone review on a single-review queue is the
+                # authoritative answer. Without this, lowering the requirement to 1 completes the
+                # item via the single-review rule but leaves it with no authoritative annotation.
+                # set_by stays null (auto-assigned) so a later raise above 1 clears it again.
+                Annotation.objects.filter(
+                    item__queue=self,
+                    item__review_count=1,
+                    status=AnnotationStatus.SUBMITTED,
+                    is_authoritative=False,
+                ).exclude(item__status=AnnotationItemStatus.FLAGGED).update(
+                    is_authoritative=True, authoritative_set_at=timezone.now()
+                )
 
             items = (
                 self.items.exclude(status=AnnotationItemStatus.FLAGGED)

--- a/apps/human_annotations/tests/test_models.py
+++ b/apps/human_annotations/tests/test_models.py
@@ -288,6 +288,115 @@ def test_resync_lowering_requirement_completes_resolved_item(team):
 
 
 @pytest.mark.django_db()
+def test_resync_lowering_requirement_completes_only_items_with_authoritative(team):
+    """Lowering the requirement completes an item only when it has an authoritative pick.
+
+    Both items sit at IN_PROGRESS below a high requirement. After lowering it so their two
+    reviews satisfy the requirement, only the item with a human-picked authoritative
+    annotation becomes COMPLETED; the one without an authoritative pick goes to
+    AWAITING_RESOLUTION. A transition into COMPLETED requires an authoritative annotation.
+    """
+    User = get_user_model()
+    user1 = team.members.first()
+    user2 = User.objects.create(username="r2", email="r2@e.com")
+    MembershipFactory.create(team=team, user=user2)
+    queue = AnnotationQueue.objects.create(team=team, name="Q", schema={}, created_by=user1, num_reviews_required=3)
+
+    resolved = _make_session_item(queue, team)
+    unresolved = _make_session_item(queue, team)
+
+    # Two reviews each; with 3 required both sit at IN_PROGRESS.
+    resolved_ann = Annotation.objects.create(
+        item=resolved, team=team, reviewer=user1, data={}, status=AnnotationStatus.SUBMITTED
+    )
+    Annotation.objects.create(item=resolved, team=team, reviewer=user2, data={}, status=AnnotationStatus.SUBMITTED)
+    Annotation.objects.create(item=unresolved, team=team, reviewer=user1, data={}, status=AnnotationStatus.SUBMITTED)
+    Annotation.objects.create(item=unresolved, team=team, reviewer=user2, data={}, status=AnnotationStatus.SUBMITTED)
+
+    # Admin resolves the first item by picking an authoritative annotation.
+    resolved_ann.is_authoritative = True
+    resolved_ann.authoritative_set_by = user1
+    resolved_ann.authoritative_set_at = timezone.now()
+    resolved_ann.save(update_fields=["is_authoritative", "authoritative_set_by", "authoritative_set_at"])
+
+    resolved.refresh_from_db()
+    unresolved.refresh_from_db()
+    assert resolved.status == AnnotationItemStatus.IN_PROGRESS  # 2 reviews < 3 required
+    assert unresolved.status == AnnotationItemStatus.IN_PROGRESS
+
+    # Lower so both items' two reviews now satisfy the requirement.
+    queue.num_reviews_required = 2
+    queue.save()
+    queue.resync_items()
+
+    resolved.refresh_from_db()
+    unresolved.refresh_from_db()
+    assert resolved.status == AnnotationItemStatus.COMPLETED  # authoritative pick -> completed
+    assert unresolved.status == AnnotationItemStatus.AWAITING_RESOLUTION  # no authoritative -> never completed
+
+
+@pytest.mark.django_db()
+def test_resync_lowering_to_single_review_auto_marks_sole_review_authoritative(team):
+    """Lowering to 1 review auto-marks an item's sole non-authoritative review as authoritative.
+
+    Mirrors a fresh single-review submission: with nothing to disagree with, the lone review is
+    the answer. The item completes *with* an authoritative annotation, never a bare
+    completed-without-authoritative state. The auto-assigned flag has no set_by, so raising the
+    requirement again would clear it.
+    """
+    user = team.members.first()
+    queue = AnnotationQueue.objects.create(team=team, name="Q", schema={}, created_by=user, num_reviews_required=2)
+    item = _make_session_item(queue, team)
+    ann = Annotation.objects.create(item=item, team=team, reviewer=user, data={}, status=AnnotationStatus.SUBMITTED)
+    item.refresh_from_db()
+    ann.refresh_from_db()
+    assert item.status == AnnotationItemStatus.IN_PROGRESS  # 1 review < 2 required
+    assert ann.is_authoritative is False  # multi-review queue: not auto-marked on submission
+
+    queue.num_reviews_required = 1
+    queue.save()
+    queue.resync_items()
+
+    ann.refresh_from_db()
+    item.refresh_from_db()
+    assert ann.is_authoritative is True  # auto-marked as the sole review
+    assert ann.authoritative_set_by is None  # auto-assigned, not human-picked
+    assert ann.authoritative_set_at is not None
+    assert item.status == AnnotationItemStatus.COMPLETED  # completed *with* an authoritative pick
+
+
+@pytest.mark.django_db()
+def test_resync_lowering_to_single_review_keeps_two_review_disagreement_awaiting(team):
+    """Lowering to 1 never guesses an authoritative pick for a two-review item.
+
+    Two submitted reviews are a potential disagreement. Dropping the requirement to 1 must not
+    auto-promote either review to authoritative — the item stays AWAITING_RESOLUTION until an
+    admin explicitly picks one.
+    """
+    User = get_user_model()
+    user1 = team.members.first()
+    user2 = User.objects.create(username="r2", email="r2@e.com")
+    MembershipFactory.create(team=team, user=user2)
+    queue = AnnotationQueue.objects.create(team=team, name="Q", schema={}, created_by=user1, num_reviews_required=2)
+    item = _make_session_item(queue, team)
+    ann1 = Annotation.objects.create(item=item, team=team, reviewer=user1, data={}, status=AnnotationStatus.SUBMITTED)
+    ann2 = Annotation.objects.create(item=item, team=team, reviewer=user2, data={}, status=AnnotationStatus.SUBMITTED)
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.AWAITING_RESOLUTION
+
+    queue.num_reviews_required = 1
+    queue.save()
+    queue.resync_items()
+
+    item.refresh_from_db()
+    ann1.refresh_from_db()
+    ann2.refresh_from_db()
+    assert item.status == AnnotationItemStatus.AWAITING_RESOLUTION  # disagreement left unresolved
+    assert ann1.is_authoritative is False  # no review auto-promoted
+    assert ann2.is_authoritative is False
+
+
+@pytest.mark.django_db()
 def test_resync_does_not_touch_flagged_items(team):
     """Flagged items are left untouched by resync, matching update_status."""
     user = team.members.first()

--- a/apps/human_annotations/tests/test_models.py
+++ b/apps/human_annotations/tests/test_models.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import django.db
 import pytest
 from django.contrib.auth import get_user_model
@@ -337,3 +339,27 @@ def test_resync_recomputes_aggregates_after_clearing_authoritative(team):
     queue.refresh_from_db()
     # Authoritative cleared -> aggregation falls back to all submitted (5, 1) -> mean 3.
     assert queue.aggregate.aggregates["score"]["mean"] == 3
+
+
+@pytest.mark.django_db()
+def test_resync_swallows_aggregate_recompute_failure(team):
+    """A failure recomputing aggregates is logged, not raised, and the status change still commits."""
+    user = team.members.first()
+    queue = AnnotationQueue.objects.create(team=team, name="Q", schema={}, created_by=user, num_reviews_required=1)
+    item = _make_session_item(queue, team)
+    Annotation.objects.create(item=item, team=team, reviewer=user, data={}, status=AnnotationStatus.SUBMITTED)
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.COMPLETED
+
+    # Raising above 1 clears the auto-assigned authoritative flag, which triggers the aggregate
+    # recompute — force that recompute to fail.
+    queue.num_reviews_required = 3
+    queue.save()
+    with mock.patch(
+        "apps.human_annotations.aggregation.compute_aggregates_for_queue",
+        side_effect=Exception("boom"),
+    ):
+        queue.resync_items()  # must not raise
+
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.IN_PROGRESS  # status recompute committed despite the failure

--- a/apps/human_annotations/tests/test_models.py
+++ b/apps/human_annotations/tests/test_models.py
@@ -1,6 +1,7 @@
 import django.db
 import pytest
 from django.contrib.auth import get_user_model
+from django.utils import timezone
 
 from apps.human_annotations.models import (
     Annotation,
@@ -145,3 +146,194 @@ def test_get_progress_includes_awaiting_resolution(team):
 
     assert progress["awaiting_resolution_items"] == 1
     assert progress["completed_items"] == 0
+
+
+# ===== num_reviews_required recompute (resync_items) =====
+
+
+def _make_session_item(queue, team):
+    session = ExperimentSessionFactory.create(team=team, chat__team=team)
+    return AnnotationItem.objects.create(queue=queue, team=team, item_type=AnnotationItemType.SESSION, session=session)
+
+
+@pytest.mark.django_db()
+def test_resync_raising_requirement_reopens_completed_item(team):
+    """Raising the requirement reverts a completed single-review item to in_progress."""
+    user = team.members.first()
+    queue = AnnotationQueue.objects.create(team=team, name="Q", schema={}, created_by=user, num_reviews_required=1)
+    item = _make_session_item(queue, team)
+    Annotation.objects.create(item=item, team=team, reviewer=user, data={}, status=AnnotationStatus.SUBMITTED)
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.COMPLETED
+
+    queue.num_reviews_required = 3
+    queue.save()
+    queue.resync_items()
+
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.IN_PROGRESS
+
+
+@pytest.mark.django_db()
+def test_resync_raising_requirement_clears_auto_assigned_authoritative(team):
+    """Going multi-review clears auto-assigned authoritative flags (set_by is null)."""
+    user = team.members.first()
+    queue = AnnotationQueue.objects.create(team=team, name="Q", schema={}, created_by=user, num_reviews_required=1)
+    item = _make_session_item(queue, team)
+    ann = Annotation.objects.create(item=item, team=team, reviewer=user, data={}, status=AnnotationStatus.SUBMITTED)
+    ann.refresh_from_db()
+    assert ann.is_authoritative is True
+    assert ann.authoritative_set_by is None
+
+    queue.num_reviews_required = 3
+    queue.save()
+    queue.resync_items()
+
+    ann.refresh_from_db()
+    assert ann.is_authoritative is False
+    assert ann.authoritative_set_at is None
+
+
+@pytest.mark.django_db()
+def test_resync_raising_requirement_preserves_human_set_authoritative(team):
+    """A human-picked authoritative flag (set_by populated) survives a raise above 1."""
+    User = get_user_model()
+    user1 = team.members.first()
+    user2 = User.objects.create(username="r2", email="r2@e.com")
+    MembershipFactory.create(team=team, user=user2)
+    queue = AnnotationQueue.objects.create(team=team, name="Q", schema={}, created_by=user1, num_reviews_required=2)
+    item = _make_session_item(queue, team)
+    ann1 = Annotation.objects.create(item=item, team=team, reviewer=user1, data={}, status=AnnotationStatus.SUBMITTED)
+    Annotation.objects.create(item=item, team=team, reviewer=user2, data={}, status=AnnotationStatus.SUBMITTED)
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.AWAITING_RESOLUTION
+
+    # Admin manually picks the authoritative annotation -> COMPLETED
+    ann1.is_authoritative = True
+    ann1.authoritative_set_by = user1
+    ann1.authoritative_set_at = timezone.now()
+    ann1.save(update_fields=["is_authoritative", "authoritative_set_by", "authoritative_set_at"])
+    item.update_status()
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.COMPLETED
+
+    queue.num_reviews_required = 3
+    queue.save()
+    queue.resync_items()
+
+    ann1.refresh_from_db()
+    assert ann1.is_authoritative is True  # human-picked flag preserved
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.IN_PROGRESS  # 2 reviews < 3 required
+
+
+@pytest.mark.django_db()
+def test_resync_lowering_requirement_keeps_unresolved_item_awaiting(team):
+    """Lowering to 1 keeps a multi-review item with no authoritative pick awaiting resolution.
+
+    The disagreement between the two reviews is unresolved, so completing it would be
+    dishonest — it stays AWAITING_RESOLUTION until an admin picks an authoritative one.
+    """
+    User = get_user_model()
+    user1 = team.members.first()
+    user2 = User.objects.create(username="r2", email="r2@e.com")
+    MembershipFactory.create(team=team, user=user2)
+    queue = AnnotationQueue.objects.create(team=team, name="Q", schema={}, created_by=user1, num_reviews_required=2)
+    item = _make_session_item(queue, team)
+    Annotation.objects.create(item=item, team=team, reviewer=user1, data={}, status=AnnotationStatus.SUBMITTED)
+    Annotation.objects.create(item=item, team=team, reviewer=user2, data={}, status=AnnotationStatus.SUBMITTED)
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.AWAITING_RESOLUTION
+
+    queue.num_reviews_required = 1
+    queue.save()
+    queue.resync_items()
+
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.AWAITING_RESOLUTION
+
+
+@pytest.mark.django_db()
+def test_resync_lowering_requirement_completes_resolved_item(team):
+    """Lowering to 1 completes a multi-review item that already has an authoritative pick."""
+    User = get_user_model()
+    user1 = team.members.first()
+    user2 = User.objects.create(username="r2", email="r2@e.com")
+    MembershipFactory.create(team=team, user=user2)
+    queue = AnnotationQueue.objects.create(team=team, name="Q", schema={}, created_by=user1, num_reviews_required=2)
+    item = _make_session_item(queue, team)
+    ann1 = Annotation.objects.create(item=item, team=team, reviewer=user1, data={}, status=AnnotationStatus.SUBMITTED)
+    Annotation.objects.create(item=item, team=team, reviewer=user2, data={}, status=AnnotationStatus.SUBMITTED)
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.AWAITING_RESOLUTION
+
+    ann1.is_authoritative = True
+    ann1.authoritative_set_by = user1
+    ann1.authoritative_set_at = timezone.now()
+    ann1.save(update_fields=["is_authoritative", "authoritative_set_by", "authoritative_set_at"])
+    item.update_status()
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.COMPLETED
+
+    queue.num_reviews_required = 1
+    queue.save()
+    queue.resync_items()
+
+    ann1.refresh_from_db()
+    item.refresh_from_db()
+    assert ann1.is_authoritative is True  # human-picked auth kept (clear only runs when raising)
+    assert item.status == AnnotationItemStatus.COMPLETED
+
+
+@pytest.mark.django_db()
+def test_resync_does_not_touch_flagged_items(team):
+    """Flagged items are left untouched by resync, matching update_status."""
+    user = team.members.first()
+    queue = AnnotationQueue.objects.create(team=team, name="Q", schema={}, created_by=user, num_reviews_required=1)
+    item = _make_session_item(queue, team)
+    Annotation.objects.create(item=item, team=team, reviewer=user, data={}, status=AnnotationStatus.SUBMITTED)
+    item.status = AnnotationItemStatus.FLAGGED
+    item.save(update_fields=["status"])
+
+    queue.num_reviews_required = 3
+    queue.save()
+    queue.resync_items()
+
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.FLAGGED
+
+
+@pytest.mark.django_db()
+def test_resync_recomputes_aggregates_after_clearing_authoritative(team):
+    """Clearing authoritative flags refreshes stored aggregates (authoritative -> all-submitted)."""
+    User = get_user_model()
+    user1 = team.members.first()
+    user2 = User.objects.create(username="r2", email="r2@e.com")
+    MembershipFactory.create(team=team, user=user2)
+    queue = AnnotationQueue.objects.create(
+        team=team,
+        name="Q",
+        schema={"score": {"type": "int", "description": "Score", "ge": 1, "le": 5}},
+        created_by=user1,
+        num_reviews_required=1,
+    )
+    item = _make_session_item(queue, team)
+    # First submission auto-marked authoritative (score=5).
+    Annotation.objects.create(
+        item=item, team=team, reviewer=user1, data={"score": 5}, status=AnnotationStatus.SUBMITTED
+    )
+    # Over-budget second submission stays non-authoritative (score=1).
+    Annotation.objects.create(
+        item=item, team=team, reviewer=user2, data={"score": 1}, status=AnnotationStatus.SUBMITTED
+    )
+    queue.refresh_from_db()
+    # Aggregation uses only the authoritative annotation -> mean 5.
+    assert queue.aggregate.aggregates["score"]["mean"] == 5
+
+    queue.num_reviews_required = 3
+    queue.save()
+    queue.resync_items()
+
+    queue.refresh_from_db()
+    # Authoritative cleared -> aggregation falls back to all submitted (5, 1) -> mean 3.
+    assert queue.aggregate.aggregates["score"]["mean"] == 3

--- a/apps/human_annotations/tests/test_views.py
+++ b/apps/human_annotations/tests/test_views.py
@@ -143,8 +143,8 @@ def test_edit_queue_saves_optional_field(client, team_with_users, queue):
 
 
 @pytest.mark.django_db()
-def test_edit_queue_locks_fields_after_annotations(client, team_with_users, queue, user):
-    """num_reviews_required should be disabled after annotations have started; schema stays editable for 'required'."""
+def test_edit_queue_schema_locked_but_num_reviews_editable_after_annotations(client, team_with_users, queue, user):
+    """After annotations start the schema builder is locked, but num_reviews_required stays editable."""
     item = AnnotationItemFactory.create(queue=queue, team=team_with_users)
     Annotation.objects.create(
         item=item,
@@ -159,8 +159,41 @@ def test_edit_queue_locks_fields_after_annotations(client, team_with_users, queu
     assert response.status_code == 200
     form = response.context["form"]
     assert form.fields["schema"].disabled is False
-    assert form.fields["num_reviews_required"].disabled is True
+    assert form.fields["num_reviews_required"].disabled is False
     assert response.context["schema_locked"] is True
+    assert response.context["annotations_started"] is True
+
+
+@pytest.mark.django_db()
+def test_edit_queue_change_num_reviews_recomputes_item_statuses(client, team_with_users, queue, user):
+    """Changing num_reviews_required via the edit view recomputes existing item statuses."""
+    item = AnnotationItemFactory.create(queue=queue, team=team_with_users)
+    Annotation.objects.create(
+        item=item,
+        team=team_with_users,
+        reviewer=user,
+        data={"quality_score": 4, "notes": "OK"},
+        status=AnnotationStatus.SUBMITTED,
+    )
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.COMPLETED  # queue default num_reviews_required == 1
+
+    url = reverse("human_annotations:queue_edit", args=[team_with_users.slug, queue.pk])
+    response = client.post(
+        url,
+        {
+            "name": queue.name,
+            "description": queue.description,
+            "schema": json.dumps(queue.schema),
+            "num_reviews_required": 3,
+        },
+    )
+    assert response.status_code == 302
+
+    queue.refresh_from_db()
+    assert queue.num_reviews_required == 3
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.IN_PROGRESS
 
 
 @pytest.mark.django_db()

--- a/apps/human_annotations/views/queue_views.py
+++ b/apps/human_annotations/views/queue_views.py
@@ -118,8 +118,10 @@ class EditAnnotationQueue(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Up
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        annotations_started = self.object.items.filter(review_count__gt=0).exists()
         context["existing_schema"] = self.object.schema
-        context["schema_locked"] = self.object.items.filter(review_count__gt=0).exists()
+        context["schema_locked"] = annotations_started
+        context["annotations_started"] = annotations_started
         return context
 
     def get_success_url(self):

--- a/templates/human_annotations/queue_form.html
+++ b/templates/human_annotations/queue_form.html
@@ -16,6 +16,13 @@
 
     {% render_form_fields form "name" "description" "num_reviews_required" %}
 
+    {% if annotations_started %}
+      <div class="alert alert-warning mt-1 mb-3 text-sm">
+        <i class="fa fa-triangle-exclamation"></i>
+        <span>{% translate "Items have already been annotated. Changing the number of reviews required recalculates the status of every item; some completed items may reopen." %}</span>
+      </div>
+    {% endif %}
+
     <div class="fieldset w-full mt-4">
       <label class="label font-bold">
         <div>{% translate "Schema Fields" %}</div>
@@ -183,11 +190,46 @@
   </div>
 {% endblock form %}
 
+{% block form_actions %}
+  <input type="submit" class="btn btn-primary mt-2" value="{{ button_text }}"
+         :disabled="submitted"
+         {% if annotations_started %}x-data="reviewChangeGuard()" @click="confirmReviewChange($event)"{% endif %}>
+{% endblock form_actions %}
+
 {% block page_js %}
   {{ block.super }}
   {% if existing_schema %}{{ existing_schema|json_script:"existing-schema" }}{% endif %}
+  {% translate "Items have already been annotated. Changing the number of reviews required recalculates the status of every item, and some completed items may reopen. Continue?" as review_change_confirm_message %}
   <script>
     document.addEventListener('alpine:init', () => {
+      Alpine.data('reviewChangeGuard', () => ({
+        originalNumReviews: null,
+
+        init() {
+          const el = document.querySelector('[name="num_reviews_required"]');
+          this.originalNumReviews = el ? el.value : null;
+        },
+
+        confirmReviewChange(event) {
+          const el = document.querySelector('[name="num_reviews_required"]');
+          if (!el || el.value === this.originalNumReviews) {
+            return;
+          }
+          event.preventDefault();
+          const button = event.currentTarget;
+          alertify.confirm().setting({
+            title: 'Confirm',
+            message: "{{ review_change_confirm_message|escapejs }}",
+            transition: 'fade',
+            onok: () => {
+              // Confirmed: re-submit. Sync originalNumReviews so the re-submit doesn't re-prompt.
+              this.originalNumReviews = el.value;
+              button.form.requestSubmit(button);
+            },
+          }).show();
+        },
+      }));
+
       Alpine.data('schemaFieldBuilder', () => ({
         locked: {{ schema_locked|yesno:"true,false" }},
         fields: [],


### PR DESCRIPTION
Make num_reviews_required editable on the queue edit form even after annotations exist, and recompute item statuses when it changes.

- AnnotationQueue.resync_items() recomputes every non-flagged item's status, clears auto-assigned authoritative flags when going multi-review (human-picked flags kept), and refreshes aggregates when flags were cleared.
- _compute_item_status keys completion off the actual review situation (an authoritative pick, or a single review) rather than the queue's current requirement, so lowering the requirement leaves unresolved multi-review items in awaiting_resolution instead of silently completing them.
- Confirmation dialog (alertify) warns before applying the change in the UI.

<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->


### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
<img width="1286" height="302" alt="image" src="https://github.com/user-attachments/assets/88e1317f-2c97-427b-aa35-1d20c3df70b4" />

### Docs and Changelog
- [x] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
