### PR TITLE
bump widget to 0.8.0

### DIFF
--- a/components/chat_widget/package-lock.json
+++ b/components/chat_widget/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-chat-studio-widget",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-chat-studio-widget",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.27.0",

--- a/components/chat_widget/package.json
+++ b/components/chat_widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-chat-studio-widget",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Chat component for Open Chat Studio",
   "main": "dist/index.cjs.js",
   "exports": "./dist/esm/open-chat-studio-widget.js",


### PR DESCRIPTION
### Technical Description
Bump widget version to 0.8.0


### Docs and Changelog
- [x] This PR requires docs/changelog update

* Internal release to add 'session_id' parameter from https://github.com/dimagi/open-chat-studio/pull/3533 (for usage directly within OCS platform)