### PR TITLE
upgrade chat-widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "js-cookie": "^3.0.7",
         "js-tiktoken": "^1.0.21",
         "lodash": "^4.17.23",
-        "open-chat-studio-widget": "^0.7.0",
+        "open-chat-studio-widget": "^0.8.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-error-boundary": "^6.0.1",
@@ -154,6 +154,7 @@
     "node_modules/@babel/core": {
       "version": "7.27.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1944,6 +1945,7 @@
     "node_modules/@codemirror/view": {
       "version": "6.35.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "style-mod": "^4.1.0",
@@ -3683,6 +3685,7 @@
     "node_modules/@types/react": {
       "version": "19.2.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3918,6 +3921,7 @@
       "version": "8.54.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4600,6 +4604,7 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5205,6 +5210,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5355,6 +5361,7 @@
     "node_modules/chart.js": {
       "version": "4.5.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -5837,6 +5844,7 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5953,6 +5961,7 @@
     "node_modules/date-fns": {
       "version": "4.1.0",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -6336,6 +6345,7 @@
       "version": "9.39.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7336,6 +7346,7 @@
     "node_modules/immer": {
       "version": "10.1.1",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -8915,7 +8926,9 @@
       }
     },
     "node_modules/open-chat-studio-widget": {
-      "version": "0.7.0",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/open-chat-studio-widget/-/open-chat-studio-widget-0.8.0.tgz",
+      "integrity": "sha512-be8IKtWKRs8Kd8bCBP8QiwpoPc+P0bK47UKM1pQ7ezN9dsfecT/Pz0uhBntFApQdKkSjUxFh9elg4TbWGjKqiQ==",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.27.0",
@@ -9141,6 +9154,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9445,6 +9459,7 @@
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9452,6 +9467,7 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9909,6 +9925,7 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.18.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10395,7 +10412,8 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.1.5",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -10502,6 +10520,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10721,6 +10740,7 @@
       "version": "5.7.2",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10783,6 +10803,7 @@
       "version": "8.46.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -11013,6 +11034,7 @@
     "node_modules/webpack": {
       "version": "5.105.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "js-cookie": "^3.0.7",
     "js-tiktoken": "^1.0.21",
     "lodash": "^4.17.23",
-    "open-chat-studio-widget": "^0.7.0",
+    "open-chat-studio-widget": "^0.8.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-error-boundary": "^6.0.1",


### PR DESCRIPTION
### Technical Description
This is part of https://github.com/dimagi/open-chat-studio/issues/2761

With this version of the widget we can load the session data for sessions based on the session ID instead of only relying on the data saved in the browser localstorage.

This does create an increased security risk if session IDs are exposed though that is related to the API and will be addressed separately
