### PR TITLE
feat: add "Clear all" action to un-apply eval tags and delete runs

### DIFF
--- a/apps/evaluations/tagging.py
+++ b/apps/evaluations/tagging.py
@@ -206,3 +206,43 @@ def reverse_stale_tags(run: EvaluationRun) -> None:
         filter_q |= Q(object_id=target_pk, tag_id__in=tag_ids)
 
     CustomTaggedItem.objects.filter(content_type=content_type).filter(filter_q).delete()
+
+
+def remove_applied_tags_for_runs(runs) -> None:
+    """Remove every eval-applied tag across the given runs from its target object.
+
+    The inverse of `apply_rules_to_result` over whole runs: walks each run's AppliedTag
+    audit, resolves the result's target (Chat/ChatMessage) per the evaluator's mode, and
+    deletes the matching CustomTaggedItem links. Only eval-created links (those with no
+    user) are removed — tags a person added by hand are preserved.
+
+    All evaluators in a config share one evaluation_mode (enforced by form validation), so
+    every target resolves to the same content type; it's resolved once from the first target.
+
+    Must run before the runs (and their AppliedTag rows) are deleted, since it reads the
+    audit to know which tags to un-apply.
+    """
+    applied_tags = AppliedTag.objects.filter(evaluation_result__run__in=runs).select_related(
+        "evaluation_result__evaluator",
+        "evaluation_result__message__session__chat",
+        "evaluation_result__message__expected_output_chat_message",
+    )
+
+    content_type: ContentType | None = None
+    pairs: set[tuple[int, int]] = set()
+    for applied_tag in applied_tags:
+        result = applied_tag.evaluation_result
+        target = resolve_target(result.evaluator, result.message)
+        if target is None:
+            continue
+        if content_type is None:
+            content_type = ContentType.objects.get_for_model(type(target))
+        pairs.add((target.pk, applied_tag.tag_id))
+
+    if content_type is None or not pairs:
+        return
+
+    filter_q = Q()
+    for object_id, tag_id in pairs:
+        filter_q |= Q(object_id=object_id, tag_id=tag_id)
+    CustomTaggedItem.objects.filter(content_type=content_type, user__isnull=True).filter(filter_q).delete()

--- a/apps/evaluations/tests/test_clear_eval_runs.py
+++ b/apps/evaluations/tests/test_clear_eval_runs.py
@@ -1,0 +1,288 @@
+"""Tests for the "Clear all" action: un-apply eval tags and delete all runs for a config."""
+
+import pytest
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from apps.annotations.models import CustomTaggedItem
+from apps.evaluations.models import (
+    AppliedTag,
+    ConditionType,
+    EvaluationMode,
+    EvaluationResult,
+    EvaluationRun,
+)
+from apps.evaluations.tagging import remove_applied_tags_for_runs
+from apps.utils.factories.evaluations import (
+    AppliedTagFactory,
+    EvaluationConfigFactory,
+    EvaluationDatasetFactory,
+    EvaluationMessageFactory,
+    EvaluationResultFactory,
+    EvaluationRunFactory,
+    EvaluationTagFactory,
+    EvaluatorFactory,
+    EvaluatorTagRuleFactory,
+)
+from apps.utils.factories.experiment import ExperimentSessionFactory
+from apps.utils.factories.team import MembershipFactory, TeamFactory
+from apps.utils.factories.user import GroupFactory, UserFactory
+
+
+@pytest.fixture()
+def team(db):
+    return TeamFactory.create()
+
+
+@pytest.fixture()
+def evaluator(team):
+    return EvaluatorFactory.create(team=team, evaluation_mode=EvaluationMode.MESSAGE)
+
+
+@pytest.fixture()
+def tag_a(team):
+    return EvaluationTagFactory.create(team=team, name="tag-a")
+
+
+@pytest.fixture()
+def tag_rule(team, evaluator, tag_a):
+    return EvaluatorTagRuleFactory.create(
+        team=team,
+        evaluator=evaluator,
+        tag=tag_a,
+        field_name="sentiment",
+        condition_type=ConditionType.EQUALS,
+        condition_value={"value": "negative"},
+    )
+
+
+def _build_run(team, evaluator, messages, evaluation_mode=EvaluationMode.MESSAGE):
+    dataset = EvaluationDatasetFactory.create(team=team, messages=messages, evaluation_mode=evaluation_mode)
+    config = EvaluationConfigFactory.create(team=team, dataset=dataset, evaluators=[evaluator])
+    return EvaluationRunFactory.create(team=team, config=config)
+
+
+class TestRemoveAppliedTagsForRuns:
+    def test_removes_eval_applied_tag_from_message_target(self, team, evaluator, tag_a, tag_rule):
+        """An eval-applied tag is removed from the message target."""
+        message = EvaluationMessageFactory.create(create_chat_messages=True)
+        chat_message = message.expected_output_chat_message
+        chat_message.tags.add(tag_a, through_defaults={"team": team})
+
+        run = _build_run(team, evaluator, [message])
+        result = EvaluationResultFactory.create(team=team, evaluator=evaluator, message=message, run=run, output={})
+        AppliedTagFactory.create(team=team, evaluation_result=result, rule=tag_rule, tag=tag_a)
+
+        remove_applied_tags_for_runs(EvaluationRun.objects.filter(pk=run.pk))
+
+        assert not chat_message.tags.filter(pk=tag_a.pk).exists()
+
+    def test_removes_eval_applied_tag_from_session_chat_target(self, team, tag_a):
+        """Session-mode evaluators target the Chat; the applied tag is removed from it."""
+        session_evaluator = EvaluatorFactory.create(team=team, evaluation_mode=EvaluationMode.SESSION)
+        rule = EvaluatorTagRuleFactory.create(
+            team=team,
+            evaluator=session_evaluator,
+            tag=tag_a,
+            field_name="sentiment",
+            condition_type=ConditionType.EQUALS,
+            condition_value={"value": "negative"},
+        )
+        session = ExperimentSessionFactory.create(team=team)
+        message = EvaluationMessageFactory.create(session=session)
+        chat = session.chat
+        chat.tags.add(tag_a, through_defaults={"team": team})
+
+        run = _build_run(team, session_evaluator, [message], evaluation_mode=EvaluationMode.SESSION)
+        result = EvaluationResultFactory.create(
+            team=team, evaluator=session_evaluator, message=message, run=run, output={}
+        )
+        AppliedTagFactory.create(team=team, evaluation_result=result, rule=rule, tag=tag_a)
+
+        remove_applied_tags_for_runs(EvaluationRun.objects.filter(pk=run.pk))
+
+        assert not chat.tags.filter(pk=tag_a.pk).exists()
+
+    def test_preserves_manually_added_tag(self, team, evaluator, tag_a, tag_rule):
+        """A tag added by a person (user set) is preserved even when in the eval audit."""
+        user = UserFactory.create()
+        message = EvaluationMessageFactory.create(create_chat_messages=True)
+        chat_message = message.expected_output_chat_message
+        chat_message.add_tag(tag_a, team=team, added_by=user)
+
+        run = _build_run(team, evaluator, [message])
+        result = EvaluationResultFactory.create(team=team, evaluator=evaluator, message=message, run=run, output={})
+        AppliedTagFactory.create(team=team, evaluation_result=result, rule=tag_rule, tag=tag_a)
+
+        remove_applied_tags_for_runs(EvaluationRun.objects.filter(pk=run.pk))
+
+        assert chat_message.tags.filter(pk=tag_a.pk).exists()
+
+    def test_aggregates_across_multiple_runs(self, team, evaluator, tag_a, tag_rule):
+        """Tags applied across several runs of the config are all removed."""
+        message_one = EvaluationMessageFactory.create(create_chat_messages=True)
+        message_two = EvaluationMessageFactory.create(create_chat_messages=True)
+        message_one.expected_output_chat_message.tags.add(tag_a, through_defaults={"team": team})
+        message_two.expected_output_chat_message.tags.add(tag_a, through_defaults={"team": team})
+
+        run = _build_run(team, evaluator, [message_one, message_two])
+        run_two = EvaluationRunFactory.create(team=team, config=run.config)
+        result_one = EvaluationResultFactory.create(
+            team=team, evaluator=evaluator, message=message_one, run=run, output={}
+        )
+        result_two = EvaluationResultFactory.create(
+            team=team, evaluator=evaluator, message=message_two, run=run_two, output={}
+        )
+        AppliedTagFactory.create(team=team, evaluation_result=result_one, rule=tag_rule, tag=tag_a)
+        AppliedTagFactory.create(team=team, evaluation_result=result_two, rule=tag_rule, tag=tag_a)
+
+        remove_applied_tags_for_runs(EvaluationRun.objects.filter(config=run.config))
+
+        assert not message_one.expected_output_chat_message.tags.filter(pk=tag_a.pk).exists()
+        assert not message_two.expected_output_chat_message.tags.filter(pk=tag_a.pk).exists()
+
+    def test_tag_without_audit_untouched(self, team, evaluator, tag_a, tag_rule):
+        """A tag on a target with no AppliedTag row is left in place."""
+        tag_b = EvaluationTagFactory.create(team=team, name="tag-b-no-audit")
+        message = EvaluationMessageFactory.create(create_chat_messages=True)
+        chat_message = message.expected_output_chat_message
+        chat_message.tags.add(tag_b, through_defaults={"team": team})
+
+        run = _build_run(team, evaluator, [message])
+        EvaluationResultFactory.create(team=team, evaluator=evaluator, message=message, run=run, output={})
+
+        remove_applied_tags_for_runs(EvaluationRun.objects.filter(pk=run.pk))
+
+        assert chat_message.tags.filter(pk=tag_b.pk).exists()
+
+    def test_none_target_skipped_gracefully(self, team, evaluator, tag_rule, tag_a):
+        """An AppliedTag whose result resolves to no target is skipped without error."""
+        message = EvaluationMessageFactory.create()  # no chat messages → target is None
+        run = _build_run(team, evaluator, [message])
+        result = EvaluationResultFactory.create(team=team, evaluator=evaluator, message=message, run=run, output={})
+        AppliedTagFactory.create(team=team, evaluation_result=result, rule=tag_rule, tag=tag_a)
+
+        remove_applied_tags_for_runs(EvaluationRun.objects.filter(pk=run.pk))  # must not raise
+
+        assert CustomTaggedItem.objects.count() == 0
+
+
+class TestClearEvaluationRunsView:
+    def _setup_config_with_applied_tag(self, team, user=None):
+        evaluator = EvaluatorFactory.create(team=team, evaluation_mode=EvaluationMode.MESSAGE)
+        tag = EvaluationTagFactory.create(team=team, name="applied")
+        rule = EvaluatorTagRuleFactory.create(
+            team=team,
+            evaluator=evaluator,
+            tag=tag,
+            field_name="sentiment",
+            condition_type=ConditionType.EQUALS,
+            condition_value={"value": "negative"},
+        )
+        message = EvaluationMessageFactory.create(create_chat_messages=True)
+        chat_message = message.expected_output_chat_message
+        if user is not None:
+            chat_message.add_tag(tag, team=team, added_by=user)
+        else:
+            chat_message.tags.add(tag, through_defaults={"team": team})
+
+        dataset = EvaluationDatasetFactory.create(team=team, messages=[message])
+        config = EvaluationConfigFactory.create(team=team, dataset=dataset, evaluators=[evaluator])
+        run = EvaluationRunFactory.create(team=team, config=config)
+        result = EvaluationResultFactory.create(team=team, evaluator=evaluator, message=message, run=run, output={})
+        AppliedTagFactory.create(team=team, evaluation_result=result, rule=rule, tag=tag)
+        return config, chat_message, tag
+
+    @pytest.mark.django_db()
+    def test_clear_all_removes_tags_and_deletes_runs(self, client, team_with_users):
+        user = team_with_users.members.first()
+        config, chat_message, tag = self._setup_config_with_applied_tag(team_with_users)
+
+        client.force_login(user)
+        url = reverse("evaluations:clear_evaluation_runs", args=[team_with_users.slug, config.id])
+        response = client.post(url)
+
+        assert response.status_code == 200
+        assert response.headers["HX-Redirect"] == reverse(
+            "evaluations:evaluation_runs_home", args=[team_with_users.slug, config.id]
+        )
+        assert not chat_message.tags.filter(pk=tag.pk).exists()
+        assert not EvaluationRun.objects.filter(config=config).exists()
+        assert not EvaluationResult.objects.filter(run__config=config).exists()
+        assert not AppliedTag.objects.filter(rule__evaluator__in=config.evaluators.all()).exists()
+
+    @pytest.mark.django_db()
+    def test_clear_all_preserves_manual_tags(self, client, team_with_users):
+        user = team_with_users.members.first()
+        config, chat_message, tag = self._setup_config_with_applied_tag(team_with_users, user=user)
+
+        client.force_login(user)
+        url = reverse("evaluations:clear_evaluation_runs", args=[team_with_users.slug, config.id])
+        response = client.post(url)
+
+        assert response.status_code == 200
+        assert chat_message.tags.filter(pk=tag.pk).exists()
+        assert not EvaluationRun.objects.filter(config=config).exists()
+
+    @pytest.mark.django_db()
+    def test_clear_all_leaves_other_config_untouched(self, client, team_with_users):
+        user = team_with_users.members.first()
+        config, _, _ = self._setup_config_with_applied_tag(team_with_users)
+        other_config, other_chat_message, other_tag = self._setup_config_with_applied_tag(team_with_users)
+
+        client.force_login(user)
+        url = reverse("evaluations:clear_evaluation_runs", args=[team_with_users.slug, config.id])
+        client.post(url)
+
+        assert other_chat_message.tags.filter(pk=other_tag.pk).exists()
+        assert EvaluationRun.objects.filter(config=other_config).exists()
+
+    @pytest.mark.django_db()
+    def test_clear_all_requires_delete_permission(self, client, team_with_users):
+        view_perm = Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(EvaluationRun),
+            codename="view_evaluationrun",
+        )
+        limited_group = GroupFactory.create(name="evaluations-view-only")
+        limited_group.permissions.add(view_perm)
+        membership = MembershipFactory.create(team=team_with_users, groups=[limited_group])
+        config, chat_message, tag = self._setup_config_with_applied_tag(team_with_users)
+
+        client.force_login(membership.user)
+        url = reverse("evaluations:clear_evaluation_runs", args=[team_with_users.slug, config.id])
+        response = client.post(url)
+
+        assert response.status_code == 403
+        assert chat_message.tags.filter(pk=tag.pk).exists()
+        assert EvaluationRun.objects.filter(config=config).exists()
+
+    @pytest.mark.django_db()
+    def test_runs_page_shows_clear_all_button_for_admin(self, client, team_with_users):
+        user = team_with_users.members.first()
+        config = EvaluationConfigFactory.create(team=team_with_users)
+
+        client.force_login(user)
+        url = reverse("evaluations:evaluation_runs_home", args=[team_with_users.slug, config.id])
+        response = client.get(url)
+
+        clear_url = reverse("evaluations:clear_evaluation_runs", args=[team_with_users.slug, config.id])
+        assert clear_url in response.content.decode()
+
+    @pytest.mark.django_db()
+    def test_runs_page_hides_clear_all_for_view_only(self, client, team_with_users):
+        view_perm = Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(EvaluationRun),
+            codename="view_evaluationrun",
+        )
+        limited_group = GroupFactory.create(name="evaluations-view-only")
+        limited_group.permissions.add(view_perm)
+        membership = MembershipFactory.create(team=team_with_users, groups=[limited_group])
+        config = EvaluationConfigFactory.create(team=team_with_users)
+
+        client.force_login(membership.user)
+        url = reverse("evaluations:evaluation_runs_home", args=[team_with_users.slug, config.id])
+        response = client.get(url)
+
+        clear_url = reverse("evaluations:clear_evaluation_runs", args=[team_with_users.slug, config.id])
+        assert clear_url not in response.content.decode()

--- a/apps/evaluations/urls.py
+++ b/apps/evaluations/urls.py
@@ -28,6 +28,11 @@ urlpatterns = [
         name="evaluation_runs_home",
     ),
     path(
+        "<int:evaluation_pk>/runs/clear/",
+        evaluation_config_views.ClearEvaluationRuns.as_view(),
+        name="clear_evaluation_runs",
+    ),
+    path(
         "<int:evaluation_pk>/evaluation_runs_table",
         evaluation_config_views.EvaluationRunTableView.as_view(),
         name="evaluation_runs_table",

--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -11,13 +11,14 @@ from celery_progress.backend import Progress
 from django.conf import settings
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.db import transaction
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_http_methods, require_POST
-from django.views.generic import CreateView, DeleteView, TemplateView, UpdateView
+from django.views.generic import CreateView, DeleteView, TemplateView, UpdateView, View
 from django_tables2 import SingleTableView, columns, tables
 
 from apps.evaluations.const import EVALUATION_RUN_FIXED_HEADERS
@@ -25,6 +26,7 @@ from apps.evaluations.export import write_evaluation_csv
 from apps.evaluations.forms import EvaluationConfigForm, get_experiment_version_choices
 from apps.evaluations.models import EvaluationConfig, EvaluationRun, EvaluationRunStatus, EvaluationRunType
 from apps.evaluations.tables import EvaluationConfigTable, EvaluationRunTable
+from apps.evaluations.tagging import remove_applied_tags_for_runs
 from apps.evaluations.tasks import (
     export_evaluation_bulk_results_task,
     upload_evaluation_run_results_task,
@@ -157,6 +159,22 @@ class EvaluationRunHome(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Temp
             "table_url": reverse("evaluations:evaluation_runs_table", args=[team_slug, kwargs["evaluation_pk"]]),
             "trends_url": reverse("evaluations:evaluation_trends", args=[team_slug, kwargs["evaluation_pk"]]),
         }
+
+
+class ClearEvaluationRuns(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
+    """Un-apply the tags this config's runs created, then delete all of its runs."""
+
+    permission_required = "evaluations.delete_evaluationrun"
+
+    def post(self, request, team_slug: str, evaluation_pk: int):
+        config = get_object_or_404(EvaluationConfig, id=evaluation_pk, team=request.team)
+        runs = EvaluationRun.objects.filter(config=config)
+        with transaction.atomic():
+            remove_applied_tags_for_runs(runs)
+            runs.delete()
+        response = HttpResponse(status=200)
+        response["HX-Redirect"] = reverse("evaluations:evaluation_runs_home", args=[team_slug, evaluation_pk])
+        return response
 
 
 class EvaluationTrendsView(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateView):

--- a/templates/evaluations/evaluation_runs_home.html
+++ b/templates/evaluations/evaluation_runs_home.html
@@ -44,13 +44,15 @@
                   type="button"
                   hx-post="{% url 'evaluations:clear_evaluation_runs' request.team.slug config.id %}"
                   hx-trigger="confirmed"
+                  hx-disabled-elt="this"
                   onclick="alertify.confirm().setting({
                     title: 'Confirm',
                     message: 'Clear all? This removes the tags these runs applied to their targets and deletes all run history and results. This cannot be undone.',
                     transition: 'fade',
                     onok: function() { htmx.trigger('#clear-all-runs-button', 'confirmed'); },
                   }).show();">
-            <i class="fa-solid fa-eraser"></i>
+            <i class="fa-solid fa-eraser htmx-hide"></i>
+            <span class="loading loading-spinner loading-sm htmx-show"></span>
             Clear all
           </button>
         {% endif %}

--- a/templates/evaluations/evaluation_runs_home.html
+++ b/templates/evaluations/evaluation_runs_home.html
@@ -38,6 +38,22 @@
           <i class="fa-solid fa-play"></i>
           Run Evaluation
         </a>
+        {% if perms.evaluations.delete_evaluationrun %}
+          <button id="clear-all-runs-button"
+                  class="btn btn-outline btn-error"
+                  type="button"
+                  hx-post="{% url 'evaluations:clear_evaluation_runs' request.team.slug config.id %}"
+                  hx-trigger="confirmed"
+                  onclick="alertify.confirm().setting({
+                    title: 'Confirm',
+                    message: 'Clear all? This removes the tags these runs applied to their targets and deletes all run history and results. This cannot be undone.',
+                    transition: 'fade',
+                    onok: function() { htmx.trigger('#clear-all-runs-button', 'confirmed'); },
+                  }).show();">
+            <i class="fa-solid fa-eraser"></i>
+            Clear all
+          </button>
+        {% endif %}
         {% if perms.evaluations.delete_evaluationconfig %}
           <button id="delete-evaluation-button"
                   class="btn btn-outline btn-error"


### PR DESCRIPTION
### Product Description
Adds a **Clear all** button to the evaluation runs page. It lets users with delete permission wipe a config's run history in one action — and, crucially, also removes the tags those runs applied to their targets (chats / chat messages), so the targets are returned to the state they were in before the evaluator ran. Tags a person added by hand are left untouched.

### Technical Description
- New `ClearEvaluationRuns` view (`POST .../runs/clear/`), gated on the `evaluations.delete_evaluationrun` permission. It runs in a single transaction: un-apply tags, then delete the runs.
- New `remove_applied_tags_for_runs` helper in `apps/evaluations/tagging.py`. It walks each run's `AppliedTag` audit, resolves each result's target per the evaluator's `evaluation_mode`, and deletes only the eval-created `CustomTaggedItem` links (`user__isnull=True`). It must run before the runs are deleted, since it reads the audit to know which tags to un-apply.
- Template: a "Clear all" button on the runs home page, shown only when the user has delete permission, with an `alertify` confirmation prompt.
- Tests covering the helper (message/session targets, manual-tag preservation, multi-run aggregation, no-audit and none-target edge cases) and the view (clears + deletes, preserves manual tags, scoped to the config, permission enforcement, button visibility).

### Migrations
- [x] The migrations are backwards compatible

(No migrations in this PR.)

### Demo
https://www.loom.com/share/0476a268c41d4cff870ac90003f79e24

### Docs and Changelog
- [x] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)