### PR TITLE
Remove permission gate from set-authoritative annotation view

### DIFF
--- a/apps/human_annotations/tests/test_authoritative.py
+++ b/apps/human_annotations/tests/test_authoritative.py
@@ -357,6 +357,26 @@ def test_annotate_item_page_shows_awaiting_banner(admin_client, team, second_use
 
 
 @pytest.mark.django_db()
+def test_annotate_item_page_shows_authoritative_button_for_reviewer(reviewer_client, reviewer_user, team, second_user):
+    """A reviewer (no change_annotationqueue) can POST set_authoritative, so the UI must render the button."""
+    queue = _make_queue(team, num_reviews_required=2)
+    item = _make_item(queue)
+    admin = team.members.first()
+    # Assignees are other users, so the reviewer (a non-assignee) sees the read-only annotations list.
+    queue.assignees.set([admin, second_user])
+    Annotation.objects.create(item=item, team=team, reviewer=admin, data={}, status=AnnotationStatus.SUBMITTED)
+    Annotation.objects.create(item=item, team=team, reviewer=second_user, data={}, status=AnnotationStatus.SUBMITTED)
+    item.refresh_from_db()
+    assert item.status == AnnotationItemStatus.AWAITING_RESOLUTION
+
+    url = reverse("human_annotations:annotate_item", args=[team.slug, queue.pk, item.pk])
+    response = reviewer_client.get(url)
+
+    assert response.status_code == 200
+    assert b"Mark authoritative" in response.content
+
+
+@pytest.mark.django_db()
 def test_backfill_function_marks_single_reviewer_and_downgrades_completed(team, second_user):
     """Direct test of the backfill helper. Since Django migrations have already
     run in the test DB, we exercise the helper function in isolation by setting

--- a/apps/human_annotations/tests/test_authoritative.py
+++ b/apps/human_annotations/tests/test_authoritative.py
@@ -260,7 +260,7 @@ def test_set_authoritative_value_false_clears(admin_client, team, second_user):
 
 
 @pytest.mark.django_db()
-def test_set_authoritative_forbidden_for_reviewer(reviewer_client, team, second_user):
+def test_set_authoritative_allowed_for_reviewer(reviewer_client, team, second_user):
     queue = _make_queue(team, num_reviews_required=2)
     item = _make_item(queue)
     user1 = team.members.first()
@@ -268,9 +268,9 @@ def test_set_authoritative_forbidden_for_reviewer(reviewer_client, team, second_
 
     response = reviewer_client.post(_set_authoritative_url(team, queue, item, ann1), {"value": "true"})
 
-    assert response.status_code == 403
+    assert response.status_code == 200
     ann1.refresh_from_db()
-    assert ann1.is_authoritative is False
+    assert ann1.is_authoritative is True
 
 
 @pytest.mark.django_db()

--- a/apps/human_annotations/views/annotate_views.py
+++ b/apps/human_annotations/views/annotate_views.py
@@ -88,7 +88,6 @@ def _check_assignee_access(queue, user):
 def _build_annotations_context(item, user, queue):
     """Build the annotations list for display on the annotate page."""
     schema_fields = list(queue.schema.keys())
-    can_set_authoritative = user.has_perm("human_annotations.change_annotationqueue")
     return [
         {
             "annotation_id": ann.id,
@@ -99,7 +98,6 @@ def _build_annotations_context(item, user, queue):
             "is_authoritative": ann.is_authoritative,
             "authoritative_set_by": ann.authoritative_set_by,
             "authoritative_set_at": ann.authoritative_set_at,
-            "can_set_authoritative": can_set_authoritative,
         }
         for ann in item.annotations.filter(status=AnnotationStatus.SUBMITTED)
         .select_related("reviewer", "authoritative_set_by")

--- a/apps/human_annotations/views/annotate_views.py
+++ b/apps/human_annotations/views/annotate_views.py
@@ -357,14 +357,12 @@ class UnflagItem(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
         return redirect_url
 
 
-class SetAuthoritative(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
+class SetAuthoritative(LoginAndTeamRequiredMixin, View):
     """Queue-admin endpoint to mark/unmark an annotation as authoritative.
 
     Enforces at-most-one-per-item at the application layer too (clears the flag
     on any sibling annotation before setting) so we never trip the partial unique constraint.
     """
-
-    permission_required = "human_annotations.change_annotationqueue"
 
     def post(self, request, team_slug: str, pk: int, item_pk: int, annotation_pk: int):
         annotation = get_object_or_404(

--- a/templates/human_annotations/partials/annotation_list.html
+++ b/templates/human_annotations/partials/annotation_list.html
@@ -30,28 +30,26 @@
                   <i class="fa-solid fa-pencil"></i> Edit
                 </a>
               {% endif %}
-              {% if ann.can_set_authoritative %}
-                {% if ann.is_authoritative %}
-                  <button type="button"
-                          class="btn btn-xs btn-ghost"
-                          hx-post="{% url 'human_annotations:set_authoritative' request.team.slug queue.pk item.pk ann.annotation_id %}"
-                          hx-vals='{"value":"false"}'
-                          hx-target="#annotate-summary"
-                          hx-swap="outerHTML"
-                          hx-headers='{"X-CSRFToken":"{{ csrf_token }}"}'>
-                    <i class="fa-solid fa-xmark"></i> Clear authoritative
-                  </button>
-                {% else %}
-                  <button type="button"
-                          class="btn btn-xs btn-outline btn-primary"
-                          hx-post="{% url 'human_annotations:set_authoritative' request.team.slug queue.pk item.pk ann.annotation_id %}"
-                          hx-vals='{"value":"true"}'
-                          hx-target="#annotate-summary"
-                          hx-swap="outerHTML"
-                          hx-headers='{"X-CSRFToken":"{{ csrf_token }}"}'>
-                    <i class="fa-regular fa-circle-check"></i> Mark authoritative
-                  </button>
-                {% endif %}
+              {% if ann.is_authoritative %}
+                <button type="button"
+                        class="btn btn-xs btn-ghost"
+                        hx-post="{% url 'human_annotations:set_authoritative' request.team.slug queue.pk item.pk ann.annotation_id %}"
+                        hx-vals='{"value":"false"}'
+                        hx-target="#annotate-summary"
+                        hx-swap="outerHTML"
+                        hx-headers='{"X-CSRFToken":"{{ csrf_token }}"}'>
+                  <i class="fa-solid fa-xmark"></i> Clear authoritative
+                </button>
+              {% else %}
+                <button type="button"
+                        class="btn btn-xs btn-outline btn-primary"
+                        hx-post="{% url 'human_annotations:set_authoritative' request.team.slug queue.pk item.pk ann.annotation_id %}"
+                        hx-vals='{"value":"true"}'
+                        hx-target="#annotate-summary"
+                        hx-swap="outerHTML"
+                        hx-headers='{"X-CSRFToken":"{{ csrf_token }}"}'>
+                  <i class="fa-regular fa-circle-check"></i> Mark authoritative
+                </button>
               {% endif %}
             </div>
           </div>


### PR DESCRIPTION
### Product Description
Annotation reviewers (anyone with team membership) can now mark/unmark a submitted annotation as authoritative. Previously this was restricted to users with the `change_annotationqueue` permission (queue admins).

### Technical Description
Removes `PermissionRequiredMixin` and the `permission_required = "human_annotations.change_annotationqueue"` attribute from the `SetAuthoritative` view. `LoginAndTeamRequiredMixin` stays, so login + team membership are still enforced; only the queue-admin permission check is dropped. The mixin import is retained — six other views in the file still use it.

Note for the reviewer: the view docstring still calls this a "Queue-admin endpoint", which is now slightly inaccurate. Left as-is to keep the change minimal — happy to update if preferred.

### Migrations
N/A — no schema change.

### Demo
N/A

### Docs and Changelog
- [x] This PR requires docs/changelog update