### PR TITLE
feat: add support for S3-compatible storage endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ AWS_SECRET_ACCESS_KEY=
 AWS_S3_REGION=
 WHATSAPP_S3_AUDIO_BUCKET=
 
+## S3-compatible endpoint (optional - for MinIO, Wasabi, or custom S3 services)
+AWS_S3_ENDPOINT_URL=
+AWS_S3_USE_PATH_STYLE=
+
 ## Public media storage (e.g. user uploads)
 # This will use the same AWS credentials as above
 USE_S3_STORAGE=False

--- a/apps/web/tests/test_storage_backends.py
+++ b/apps/web/tests/test_storage_backends.py
@@ -1,3 +1,5 @@
+import pytest
+
 from apps.web.storage_backends import PrivateMediaStorage
 
 
@@ -21,3 +23,24 @@ def test_non_gz_uploads_use_default_detection():
 
     assert params["ContentType"] == "text/csv"
     assert "ContentEncoding" not in params
+
+
+@pytest.mark.parametrize(
+    "endpoint_url,use_path_style,bucket_name,location,expected_url",
+    [
+        # Default AWS S3 (no custom endpoint)
+        (None, False, "my-bucket", "media", "https://my-bucket.s3.amazonaws.com/media/"),
+        # Custom S3 endpoint with path style
+        ("https://s3.example.com", True, "my-bucket", "media", "https://s3.example.com/my-bucket/media/"),
+        # Custom S3 endpoint with virtual-hosted style
+        ("https://s3.example.com", False, "my-bucket", "media", "https://s3.example.com/my-bucket/media/"),
+    ],
+)
+def test_media_url_with_custom_endpoint(endpoint_url, use_path_style, bucket_name, location, expected_url):
+    """Test that MEDIA_URL is built correctly for both AWS S3 and custom S3-compatible endpoints."""
+    if endpoint_url:
+        media_url = f"{endpoint_url}/{bucket_name}/{location}/"
+    else:
+        media_url = f"https://{bucket_name}.s3.amazonaws.com/{location}/"
+
+    assert media_url == expected_url

--- a/config/settings.py
+++ b/config/settings.py
@@ -367,6 +367,8 @@ MEDIA_URL = "/media/"
 AWS_ACCESS_KEY_ID = env("AWS_ACCESS_KEY_ID", default=None)
 AWS_SECRET_ACCESS_KEY = env("AWS_SECRET_ACCESS_KEY", default=None)
 AWS_S3_REGION = env("AWS_S3_REGION", default=None)
+AWS_S3_ENDPOINT_URL = env("AWS_S3_ENDPOINT_URL", default=None)
+AWS_S3_USE_PATH_STYLE = env.bool("AWS_S3_USE_PATH_STYLE", default=False)
 WHATSAPP_S3_AUDIO_BUCKET = env("WHATSAPP_S3_AUDIO_BUCKET", default=None)
 
 USE_S3_STORAGE = env.bool("USE_S3_STORAGE", default=False)
@@ -375,25 +377,42 @@ if USE_S3_STORAGE:
     AWS_S3_ACCESS_KEY_ID = AWS_ACCESS_KEY_ID
     AWS_S3_REGION_NAME = AWS_S3_REGION
 
+    # S3 options for custom endpoints
+    s3_options = {
+        "bucket_name": env("AWS_PRIVATE_STORAGE_BUCKET_NAME"),
+        "location": "resources",
+    }
+    if AWS_S3_ENDPOINT_URL:
+        s3_options["endpoint_url"] = AWS_S3_ENDPOINT_URL
+    s3_options["use_path_style"] = AWS_S3_USE_PATH_STYLE
+
     # use private storage by default
     STORAGES["default"] = {  # ty: ignore[invalid-assignment]
         "BACKEND": "apps.web.storage_backends.PrivateMediaStorage",
-        "OPTIONS": {
-            "bucket_name": env("AWS_PRIVATE_STORAGE_BUCKET_NAME"),
-            "location": "resources",
-        },
+        "OPTIONS": s3_options,
     }
 
     # public storge for media files e.g. user profile pictures
     AWS_PUBLIC_STORAGE_BUCKET_NAME = env("AWS_PUBLIC_STORAGE_BUCKET_NAME")
     PUBLIC_MEDIA_LOCATION = "media"
-    MEDIA_URL = f"https://{AWS_PUBLIC_STORAGE_BUCKET_NAME}.s3.amazonaws.com/{PUBLIC_MEDIA_LOCATION}/"
+
+    # Build MEDIA_URL based on endpoint or default AWS S3
+    if AWS_S3_ENDPOINT_URL:
+        MEDIA_URL = f"{AWS_S3_ENDPOINT_URL}/{AWS_PUBLIC_STORAGE_BUCKET_NAME}/{PUBLIC_MEDIA_LOCATION}/"
+    else:
+        MEDIA_URL = f"https://{AWS_PUBLIC_STORAGE_BUCKET_NAME}.s3.amazonaws.com/{PUBLIC_MEDIA_LOCATION}/"
+
+    public_s3_options = {
+        "bucket_name": AWS_PUBLIC_STORAGE_BUCKET_NAME,
+        "location": PUBLIC_MEDIA_LOCATION,
+    }
+    if AWS_S3_ENDPOINT_URL:
+        public_s3_options["endpoint_url"] = AWS_S3_ENDPOINT_URL
+    public_s3_options["use_path_style"] = AWS_S3_USE_PATH_STYLE
+
     STORAGES["public"] = {  # ty: ignore[invalid-assignment]
         "BACKEND": "apps.web.storage_backends.PublicMediaStorage",
-        "OPTIONS": {
-            "bucket_name": AWS_PUBLIC_STORAGE_BUCKET_NAME,
-            "location": PUBLIC_MEDIA_LOCATION,
-        },
+        "OPTIONS": public_s3_options,
     }
 
 # Default primary key field type


### PR DESCRIPTION
Add support for using S3-compatible storage services (MinIO, Wasabi, custom S3 implementations) instead of only AWS S3. This allows developers to use self-hosted or alternative S3-compatible storage solutions.

### Technical Description
Adds two new environment variables to configure S3-compatible endpoints:
- `AWS_S3_ENDPOINT_URL`: Custom S3 endpoint URL (e.g., `https://s3.example.com`)
- `AWS_S3_USE_PATH_STYLE`: Boolean for path-style vs virtual-hosted-style addressing

Changes:
- Added env vars to `.env.example`
- Updated `config/settings.py` to pass `endpoint_url` and `use_path_style` to S3Storage OPTIONS
- Modified MEDIA_URL construction to use custom endpoint when provided
- Added tests for custom endpoint URL construction