### PR TITLE
Return connect_channel_id from the update participant API

### DIFF
--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -495,6 +495,7 @@ paths:
                         data:
                           name: John
                           timezone: Africa/Johannesburg
+                        connect_channel_id: null
                   summary: A participant with their chatbot data
           description: ''
     post:
@@ -549,7 +550,26 @@ paths:
       - tokenAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParticipantDetail'
+              examples:
+                UpdateParticipantDataResponse:
+                  value:
+                    id: e172ff63-2469-419f-a828-783fc9291bc7
+                    identifier: part1
+                    name: John
+                    platform: commcare_connect
+                    remote_id: ''
+                    data:
+                    - chatbot: Support Bot
+                      chatbot_id: 815e7ef4-3479-4689-ae6c-29ca1a04ca8e
+                      data:
+                        name: John
+                      connect_channel_id: c64a1f7d-2f9b-4c3a-9e57-0f0c9a3a1b2d
+                  summary: Response including connect channel IDs
+          description: ''
   /api/participants/:
     get:
       operationId: list_participants_2
@@ -616,6 +636,7 @@ paths:
                         data:
                           name: John
                           timezone: Africa/Johannesburg
+                        connect_channel_id: null
                   summary: A participant with their chatbot data
           description: ''
     post:
@@ -670,7 +691,26 @@ paths:
       - tokenAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParticipantDetail'
+              examples:
+                UpdateParticipantDataResponse:
+                  value:
+                    id: e172ff63-2469-419f-a828-783fc9291bc7
+                    identifier: part1
+                    name: John
+                    platform: commcare_connect
+                    remote_id: ''
+                    data:
+                    - chatbot: Support Bot
+                      chatbot_id: 815e7ef4-3479-4689-ae6c-29ca1a04ca8e
+                      data:
+                        name: John
+                      connect_channel_id: c64a1f7d-2f9b-4c3a-9e57-0f0c9a3a1b2d
+                  summary: Response including connect channel IDs
+          description: ''
   /api/sessions/:
     get:
       operationId: session_list
@@ -1644,9 +1684,16 @@ components:
           format: uuid
           readOnly: true
         data: {}
+        connect_channel_id:
+          type: string
+          nullable: true
+          readOnly: true
+          description: CommCare Connect channel ID. Only set for commcare_connect
+            participants.
       required:
       - chatbot
       - chatbot_id
+      - connect_channel_id
     ParticipantDataUpdateRequest:
       type: object
       properties:

--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -1688,8 +1688,8 @@ components:
           type: string
           nullable: true
           readOnly: true
-          description: CommCare Connect channel ID. Only set for commcare_connect
-            participants.
+          description: CommCare Connect channel ID. Only set for the CommCare Connect
+            channel.
       required:
       - chatbot
       - chatbot_id

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -65,7 +65,7 @@ class ParticipantDetailSerializer(serializers.ModelSerializer):
         # queryset is pre-annotated via the view's get_queryset / prefetch
         qs = getattr(obj, "_prefetched_participant_data", None)
         if qs is None:
-            qs = obj.data_set.filter(team=obj.team)
+            qs = obj.data_set.filter(team=obj.team).select_related("experiment")
         return ParticipantDataEntrySerializer(qs, many=True).data
 
 

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -40,10 +40,16 @@ class ParticipantSerializer(serializers.ModelSerializer):
 class ParticipantDataEntrySerializer(serializers.ModelSerializer):
     chatbot = serializers.CharField(source="experiment.name", read_only=True)
     chatbot_id = serializers.UUIDField(source="experiment.public_id", read_only=True)
+    connect_channel_id = serializers.SerializerMethodField(
+        help_text="CommCare Connect channel ID. Only set for commcare_connect participants."
+    )
 
     class Meta:
         model = ParticipantData
-        fields = ["chatbot", "chatbot_id", "data"]
+        fields = ["chatbot", "chatbot_id", "data", "connect_channel_id"]
+
+    def get_connect_channel_id(self, obj) -> str | None:
+        return obj.system_metadata.get("commcare_connect_channel_id")
 
 
 class ParticipantDetailSerializer(serializers.ModelSerializer):

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -41,7 +41,7 @@ class ParticipantDataEntrySerializer(serializers.ModelSerializer):
     chatbot = serializers.CharField(source="experiment.name", read_only=True)
     chatbot_id = serializers.UUIDField(source="experiment.public_id", read_only=True)
     connect_channel_id = serializers.SerializerMethodField(
-        help_text="CommCare Connect channel ID. Only set for commcare_connect participants."
+        help_text="CommCare Connect channel ID. Only set for the CommCare Connect channel."
     )
 
     class Meta:

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -20,6 +20,9 @@ logger = get_task_logger("ocs.api")
 )
 def setup_connect_channels_for_bots(self, connect_id: str, experiment_data_map: dict):
     """
+    DEPRECATED: no longer queued; channels are created synchronously in the update-participant API
+    view. Kept so in-flight tasks survive deploy. Remove in a follow-up.
+
     Set up Connect channels for experiments that are using the ConnectMessaging channel
 
     experiment_data_map: {experiment_id: participant_data_id}

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -130,6 +130,13 @@ def test_create_and_update_participant_data(auth_method):
     url = reverse("api:participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
+    response_json = response.json()
+    assert response_json["identifier"] == identifier
+    assert response_json["platform"] == "api"
+    entries = {entry["chatbot_id"]: entry for entry in response_json["data"]}
+    assert entries[str(experiment.public_id)]["data"] == {"name": "John"}
+    assert entries[str(experiment.public_id)]["connect_channel_id"] is None
+    assert entries[str(experiment2.public_id)]["data"] == {"name": "Doe"}
 
     participant = Participant.objects.get(identifier=identifier)
     assert participant.name == ""

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -333,9 +333,7 @@ def _setup_channel_participant(experiment, identifier, channel_platform, system_
 
 
 @pytest.mark.django_db()
-@override_settings(
-    CELERY_TASK_ALWAYS_EAGER=True, COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123"
-)
+@override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
 def test_update_participant_data_and_setup_connect_channels(httpx_mock):
     """
     Test that a connect channel is created for a participant where
@@ -410,6 +408,15 @@ def test_update_participant_data_and_setup_connect_channels(httpx_mock):
     url = reverse("api:participant-data")
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 200
+
+    response_json = response.json()
+    assert response_json["identifier"] == "connectid_2"
+    channel_ids = {entry["chatbot_id"]: entry["connect_channel_id"] for entry in response_json["data"]}
+    assert channel_ids == {
+        str(experiment1.public_id): created_connect_channel_id,
+        str(experiment2.public_id): None,
+        str(experiment3.public_id): "7d6a-fdc93-4e9c",
+    }
 
     # Only one of the two experiments that the "ConnectID_2" participant belongs to has a connect messaging channel, so
     # we expect only one call to the Connect servers to have been made

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -296,6 +296,26 @@ def test_update_participant_schedules(experiment):
     assert updated_schedules[2].next_trigger_date == trigger_date3
 
 
+@pytest.mark.django_db()
+def test_list_participants_includes_connect_channel_id(experiment):
+    participant = ParticipantFactory(team=experiment.team, platform="commcare_connect")
+    ParticipantData.objects.create(
+        team=experiment.team,
+        participant=participant,
+        experiment=experiment,
+        system_metadata={"commcare_connect_channel_id": "abc-123", "consent": True},
+    )
+    user = experiment.team.members.first()
+    client = ApiTestClient(user, experiment.team)
+
+    response = client.get(reverse("api:participant-data"))
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    entry = next(p for p in results if p["identifier"] == participant.identifier)
+    assert entry["data"][0]["connect_channel_id"] == "abc-123"
+
+
 def _setup_channel_participant(experiment, identifier, channel_platform, system_metadata=None):
     participant, _ = Participant.objects.get_or_create(
         team=experiment.team, identifier=identifier, platform=channel_platform

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -430,6 +430,53 @@ def test_update_participant_data_and_setup_connect_channels(httpx_mock):
 
 
 @pytest.mark.django_db()
+@override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
+@pytest.mark.parametrize(
+    ("upstream", "expected_status"),
+    [
+        (500, 503),
+        (404, 404),
+        (400, 400),
+        ("network_error", 503),
+    ],
+)
+def test_update_participant_data_connect_channel_failure(httpx_mock, upstream, expected_status):
+    """A Connect API failure fails the request, but the participant data remains saved."""
+    url = f"{settings.COMMCARE_CONNECT_SERVER_URL}/messaging/create_channel/"
+    if upstream == "network_error":
+        # the client retries network errors up to 3 times
+        for _ in range(3):
+            httpx_mock.add_exception(httpx.ConnectError("connection failed"), method="POST", url=url)
+    else:
+        httpx_mock.add_response(method="POST", url=url, status_code=upstream)
+
+    team = TeamWithUsersFactory.create()
+    experiment = ExperimentFactory.create(team=team)
+    ExperimentChannelFactory.create(
+        team=team,
+        experiment=experiment,
+        platform=ChannelPlatform.COMMCARE_CONNECT,
+        extra_data={"commcare_connect_bot_name": "bot1"},
+    )
+    user = team.members.first()
+    client = ApiTestClient(user, team)
+
+    data = {
+        "identifier": "connectid_3",
+        "platform": "commcare_connect",
+        "data": [{"experiment": str(experiment.public_id), "data": {"name": "John"}}],
+    }
+    response = client.post(reverse("api:participant-data"), json.dumps(data), content_type="application/json")
+
+    assert response.status_code == expected_status
+    assert "Failed to create channel" in response.json()["detail"]
+    # the participant data was saved despite the channel-creation failure
+    participant_data = ParticipantData.objects.get(participant__identifier="connectid_3", experiment=experiment)
+    assert participant_data.data == {"name": "John"}
+    assert "commcare_connect_channel_id" not in participant_data.system_metadata
+
+
+@pytest.mark.django_db()
 def test_register_connect_participant(client, experiment):
     """
     Test registration of a participant with a connect ID. We want to ensure that if a participant already exists with

--- a/apps/api/views/participants.py
+++ b/apps/api/views/participants.py
@@ -2,12 +2,12 @@ import uuid
 
 from django.db import transaction
 from django.db.models import Prefetch
-from django.http import HttpResponse
 from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.api.pagination import CursorPagination
@@ -96,7 +96,7 @@ class ParticipantView(APIView):
         summary="Update Participant Data",
         tags=["Participants"],
         request=ParticipantDataUpdateRequest(),
-        responses={200: {}},
+        responses={200: ParticipantDetailSerializer},
         examples=[
             OpenApiExample(
                 name="CreateParticipantData",
@@ -199,7 +199,7 @@ def _update_participant_data(request):
     if platform == ChannelPlatform.COMMCARE_CONNECT:
         setup_connect_channels_for_bots.delay(connect_id=identifier, experiment_data_map=experiment_data_map)
 
-    return HttpResponse()
+    return Response(ParticipantDetailSerializer(participant).data)
 
 
 def _get_participant_experiments(team, experiment_data) -> dict[str, Experiment]:

--- a/apps/api/views/participants.py
+++ b/apps/api/views/participants.py
@@ -280,21 +280,28 @@ def _setup_connect_channels(identifier, participant_data_by_experiment_id):
     for channel, participant_data in pending:
         try:
             create_connect_channel_for_participant(channel, connect_client, identifier, participant_data)
-        except httpx.HTTPStatusError as e:
-            logger.error(
-                "Failed to create CommCare Connect channel for participant %s: HTTP %s - %s",
-                identifier,
-                e.response.status_code,
-                e.response.text,
-            )
-            if e.response.status_code == 404:
-                raise NotFound("Failed to create channel: Participant not found in CommCare Connect") from e
-            elif e.response.status_code >= 500:
-                raise ServiceUnavailable("Failed to create channel: CommCare Connect service error") from e
-            raise BadRequest(f"Failed to create channel: {e.response.text}") from e
         except httpx.HTTPError as e:
-            logger.error("Failed to create CommCare Connect channel for participant %s: %s", identifier, str(e))
-            raise ServiceUnavailable("Failed to create channel: Unable to connect to CommCare Connect service") from e
+            raise _connect_channel_error(e, identifier) from e
+
+
+def _connect_channel_error(error, identifier):
+    """Map a CommCare Connect client error to the DRF exception to return to the caller."""
+    if isinstance(error, httpx.HTTPStatusError):
+        status_code = error.response.status_code
+        logger.error(
+            "Failed to create CommCare Connect channel for participant %s: HTTP %s - %s",
+            identifier,
+            status_code,
+            error.response.text,
+        )
+        if status_code == 404:
+            return NotFound("Failed to create channel: Participant not found in CommCare Connect")
+        if status_code >= 500:
+            return ServiceUnavailable("Failed to create channel: CommCare Connect service error")
+        return BadRequest(f"Failed to create channel: {error.response.text}")
+
+    logger.error("Failed to create CommCare Connect channel for participant %s: %s", identifier, str(error))
+    return ServiceUnavailable("Failed to create channel: Unable to connect to CommCare Connect service")
 
 
 def _schedule_external_id(data, experiment, participant):

--- a/apps/api/views/participants.py
+++ b/apps/api/views/participants.py
@@ -1,11 +1,13 @@
+import logging
 import uuid
 
+import httpx
 from django.db import transaction
 from django.db.models import Prefetch
 from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema
-from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.exceptions import APIException, NotFound, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -19,6 +21,18 @@ from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.events.models import ScheduledMessage, TimePeriod
 from apps.experiments.models import Experiment, Participant, ParticipantData
 from apps.oauth.permissions import TokenHasOAuthResourceScope
+
+logger = logging.getLogger("ocs.api")
+
+
+class ServiceUnavailable(APIException):
+    status_code = 503
+    default_detail = "Service temporarily unavailable."
+
+
+class BadRequest(APIException):
+    status_code = 400
+    default_detail = "Bad request."
 
 
 class ParticipantView(APIView):
@@ -241,7 +255,23 @@ def _setup_connect_channels(identifier, participant_data_by_experiment_id):
 
     connect_client = CommCareConnectClient()
     for channel, participant_data in pending:
-        create_connect_channel_for_participant(channel, connect_client, identifier, participant_data)
+        try:
+            create_connect_channel_for_participant(channel, connect_client, identifier, participant_data)
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                "Failed to create CommCare Connect channel for participant %s: HTTP %s - %s",
+                identifier,
+                e.response.status_code,
+                e.response.text,
+            )
+            if e.response.status_code == 404:
+                raise NotFound("Failed to create channel: Participant not found in CommCare Connect") from e
+            elif e.response.status_code >= 500:
+                raise ServiceUnavailable("Failed to create channel: CommCare Connect service error") from e
+            raise BadRequest(f"Failed to create channel: {e.response.text}") from e
+        except httpx.HTTPError as e:
+            logger.error("Failed to create CommCare Connect channel for participant %s: %s", identifier, str(e))
+            raise ServiceUnavailable("Failed to create channel: Unable to connect to CommCare Connect service") from e
 
 
 def _schedule_external_id(data, experiment, participant):

--- a/apps/api/views/participants.py
+++ b/apps/api/views/participants.py
@@ -13,8 +13,9 @@ from rest_framework.views import APIView
 from apps.api.pagination import CursorPagination
 from apps.api.permissions import ReadOnlyAPIKeyPermission
 from apps.api.serializers import ParticipantDataUpdateRequest, ParticipantDetailSerializer
-from apps.api.tasks import setup_connect_channels_for_bots
-from apps.channels.models import ChannelPlatform
+from apps.api.tasks import create_connect_channel_for_participant
+from apps.channels.clients.connect_client import CommCareConnectClient
+from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.events.models import ScheduledMessage, TimePeriod
 from apps.experiments.models import Experiment, Participant, ParticipantData
 from apps.oauth.permissions import TokenHasOAuthResourceScope
@@ -179,7 +180,7 @@ def _update_participant_data(request):
     experiment_data = serializer.data["data"]
     experiment_map = _get_participant_experiments(team, experiment_data)
 
-    experiment_data_map = {}
+    connect_data_by_experiment_id = {}
     for data in experiment_data:
         experiment = experiment_map[data["experiment"]]
 
@@ -194,10 +195,10 @@ def _update_participant_data(request):
             _create_update_schedules(request, experiment, participant, schedule_data)
 
         if platform == ChannelPlatform.COMMCARE_CONNECT:
-            experiment_data_map[experiment.id] = participant_data.id
+            connect_data_by_experiment_id[experiment.id] = participant_data
 
-    if platform == ChannelPlatform.COMMCARE_CONNECT:
-        setup_connect_channels_for_bots.delay(connect_id=identifier, experiment_data_map=experiment_data_map)
+    if connect_data_by_experiment_id:
+        _setup_connect_channels(identifier, connect_data_by_experiment_id)
 
     return Response(ParticipantDetailSerializer(participant).data)
 
@@ -213,6 +214,34 @@ def _get_participant_experiments(team, experiment_data) -> dict[str, Experiment]
         raise NotFound(detail=response)
 
     return experiment_map
+
+
+def _setup_connect_channels(identifier, participant_data_by_experiment_id):
+    """
+    Synchronously create Connect channels for experiments that use the ConnectMessaging channel,
+    so the channel IDs can be returned in the response.
+
+    Persists each new channel ID to ``ParticipantData.system_metadata``. Participant data that
+    already has a channel ID is skipped, as are experiments without a Connect channel.
+    """
+    channels = ExperimentChannel.objects.filter(
+        platform=ChannelPlatform.COMMCARE_CONNECT,
+        experiment_id__in=participant_data_by_experiment_id.keys(),
+    )
+    # one channel per experiment, mirroring the previous task-based implementation
+    channel_by_experiment_id = {channel.experiment_id: channel for channel in channels}
+    pending = [
+        (channel, participant_data_by_experiment_id[experiment_id])
+        for experiment_id, channel in channel_by_experiment_id.items()
+        if "commcare_connect_channel_id" not in participant_data_by_experiment_id[experiment_id].system_metadata
+    ]
+    if not pending:
+        # Don't instantiate the client unnecessarily; it raises if Connect settings are missing.
+        return
+
+    connect_client = CommCareConnectClient()
+    for channel, participant_data in pending:
+        create_connect_channel_for_participant(channel, connect_client, identifier, participant_data)
 
 
 def _schedule_external_id(data, experiment, participant):

--- a/apps/api/views/participants.py
+++ b/apps/api/views/participants.py
@@ -84,6 +84,7 @@ class ParticipantView(APIView):
                             "chatbot": "Support Bot",
                             "chatbot_id": "815e7ef4-3479-4689-ae6c-29ca1a04ca8e",
                             "data": {"name": "John", "timezone": "Africa/Johannesburg"},
+                            "connect_channel_id": None,
                         },
                     ],
                 },
@@ -116,6 +117,7 @@ class ParticipantView(APIView):
             OpenApiExample(
                 name="CreateParticipantData",
                 summary="Create participant data for multiple experiments",
+                request_only=True,
                 value={
                     "identifier": "part1",
                     "platform": "api",
@@ -139,6 +141,7 @@ class ParticipantView(APIView):
             OpenApiExample(
                 name="UpdateParticipantSchedules",
                 summary="Update and delete participant schedules",
+                request_only=True,
                 value={
                     "identifier": "part1",
                     "platform": "api",
@@ -154,6 +157,26 @@ class ParticipantView(APIView):
                                 },
                                 {"id": "sched2", "delete": True},
                             ],
+                        },
+                    ],
+                },
+            ),
+            OpenApiExample(
+                name="UpdateParticipantDataResponse",
+                summary="Response including connect channel IDs",
+                response_only=True,
+                value={
+                    "id": "e172ff63-2469-419f-a828-783fc9291bc7",
+                    "identifier": "part1",
+                    "name": "John",
+                    "platform": "commcare_connect",
+                    "remote_id": "",
+                    "data": [
+                        {
+                            "chatbot": "Support Bot",
+                            "chatbot_id": "815e7ef4-3479-4689-ae6c-29ca1a04ca8e",
+                            "data": {"name": "John"},
+                            "connect_channel_id": "c64a1f7d-2f9b-4c3a-9e57-0f0c9a3a1b2d",
                         },
                     ],
                 },


### PR DESCRIPTION
### Product Description
`POST /api/participants` now returns the participant detail, including the CommCare Connect channel ID for each chatbot, so callers no longer need to poll for it.

### Technical Description
- Connect channels are created synchronously during the request (previously a Celery task), so the IDs are available in the response. Upstream failures map to 404/503/400; participant data stays saved and retries are idempotent.
- `connect_channel_id` added to the participant data serializer (also appears in GET).
- `setup_connect_channels_for_bots` is no longer queued; kept deprecated for in-flight tasks, removal to follow.

### Migrations
- [x] The migrations are backwards compatible

No migrations.

### Demo
N/A — see updated API schema examples.

### Docs and Changelog
- [x] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)