### PR TITLE
Empirical inline-import verification + CI gate

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -113,6 +113,39 @@ jobs:
       - name: Run ty type checker
         run: uv run ty check apps/
 
+  inline-imports:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - id: file_changes
+        uses: trilom/file-changes-action@v1.2.4
+      - id: py_files
+        name: Filter changed Python files
+        run: |
+          files=$(echo '${{ steps.file_changes.outputs.files }}' | tr ' ' '\n' | grep -E '^apps/.*\.py$' | tr '\n' ' ' || true)
+          echo "files=$files" >> $GITHUB_OUTPUT
+      - name: Set up Python
+        if: steps.py_files.outputs.files != ''
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - uses: astral-sh/setup-uv@v7
+        if: steps.py_files.outputs.files != ''
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        if: steps.py_files.outputs.files != ''
+        run: |
+          uv venv
+          uv sync --locked --dev
+      - name: Check inline imports in changed files
+        if: steps.py_files.outputs.files != ''
+        env:
+          SECRET_KEY: secret-test-key
+        run: uv run python scripts/check_inline_imports.py apps --files ${{ steps.py_files.outputs.files }}
+
   check-uv-lock:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -123,9 +123,11 @@ jobs:
         uses: trilom/file-changes-action@v1.2.4
       - id: py_files
         name: Filter changed Python files
+        env:
+          CHANGED_FILES: ${{ steps.file_changes.outputs.files }}
         run: |
-          files=$(echo '${{ steps.file_changes.outputs.files }}' | tr ' ' '\n' | grep -E '^apps/.*\.py$' | tr '\n' ' ' || true)
-          echo "files=$files" >> $GITHUB_OUTPUT
+          files=$(printf '%s\n' "$CHANGED_FILES" | tr ' ' '\n' | grep -E '^apps/.*\.py$' | tr '\n' ' ' || true)
+          echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Set up Python
         if: steps.py_files.outputs.files != ''
         uses: actions/setup-python@v6
@@ -144,7 +146,10 @@ jobs:
         if: steps.py_files.outputs.files != ''
         env:
           SECRET_KEY: secret-test-key
-        run: uv run python scripts/check_inline_imports.py apps --files ${{ steps.py_files.outputs.files }}
+          CHANGED_FILES: ${{ steps.py_files.outputs.files }}
+        run: |
+          read -r -a files <<< "$CHANGED_FILES"
+          uv run python scripts/check_inline_imports.py apps --files "${files[@]}"
 
   check-uv-lock:
     runs-on: ubuntu-latest

--- a/apps/annotations/prefetch.py
+++ b/apps/annotations/prefetch.py
@@ -19,6 +19,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Prefetch
 
 from apps.annotations.models import CustomTaggedItem
+from apps.chat.models import Chat
 
 
 def chat_tagged_items_prefetch() -> Prefetch:
@@ -46,8 +47,6 @@ def attach_chat_tagged_items(rows):
     pre-populate ``row.chat``); this helper sets attributes on the related
     ``Chat`` instance, and a deferred FK would silently regress to N+1.
     """
-    from apps.chat.models import Chat  # noqa: PLC0415
-
     records = [getattr(r, "record", r) for r in rows]
     if not records:
         return records

--- a/apps/assistants/tasks.py
+++ b/apps/assistants/tasks.py
@@ -9,6 +9,7 @@ from openai import (
     UnprocessableEntityError,
 )
 
+from apps.assistants.models import OpenAiAssistant
 from apps.assistants.sync import OpenAiSyncError, delete_openai_assistant
 
 logger = get_task_logger("ocs.openai_sync")
@@ -21,8 +22,6 @@ logger = get_task_logger("ocs.openai_sync")
     bind=True,
 )
 def delete_openai_assistant_task(self, assistant_id: int):
-    from apps.assistants.models import OpenAiAssistant  # noqa: PLC0415 - circular: models.py imports this task
-
     try:
         assistant = OpenAiAssistant.all_objects.get(id=assistant_id, is_archived=True)
     except OpenAiAssistant.DoesNotExist:

--- a/apps/channels/apps.py
+++ b/apps/channels/apps.py
@@ -7,9 +7,9 @@ class BotChannelsAppConfig(AppConfig):
 
     def ready(self):
         # Register signal handlers
-        from anymail.signals import inbound  # noqa: PLC0415
+        from anymail.signals import inbound  # noqa: PLC0415 - lazy: signal hookup belongs in ready()
 
-        from . import signals  # noqa: F401, PLC0415
-        from .channels_v2.email_channel import email_inbound_handler  # noqa: PLC0415
+        from . import signals  # noqa: F401, PLC0415 - lazy: signal registration belongs in ready()
+        from .channels_v2.email_channel import email_inbound_handler  # noqa: PLC0415 - lazy: hookup in ready()
 
         inbound.connect(email_inbound_handler)

--- a/apps/channels/channels_v2/email_channel.py
+++ b/apps/channels/channels_v2/email_channel.py
@@ -16,6 +16,7 @@ from apps.channels.channels_v2.capabilities import ChannelCapabilities
 from apps.channels.channels_v2.channel_base import ChannelBase
 from apps.channels.channels_v2.sender import ChannelSender
 from apps.channels.datamodels import _MAX_REFERENCES, RawAttachment, SkippedAttachment
+from apps.channels.datamodels import EmailMessage as EmailMessageDatamodel
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.channels.utils import is_email_domain_allowed
 from apps.chat.channels import MESSAGE_TYPES
@@ -385,8 +386,9 @@ def email_inbound_handler(sender, event, **kwargs):
 
     Returns immediately so the ESP gets a fast 200 OK.
     """
-    from apps.channels.datamodels import EmailMessage as EmailMessageDatamodel  # noqa: PLC0415
-    from apps.channels.tasks import handle_email_message  # noqa: PLC0415
+    from apps.channels.tasks import (  # noqa: PLC0415 - tests patch handle_email_message on the tasks module
+        handle_email_message,
+    )
 
     message = event.message
 

--- a/apps/channels/channels_v2/whatsapp_channel.py
+++ b/apps/channels/channels_v2/whatsapp_channel.py
@@ -9,6 +9,7 @@ from apps.channels.channels_v2.capabilities import ChannelCapabilities
 from apps.channels.channels_v2.channel_base import ChannelBase
 from apps.channels.channels_v2.sender import ChannelSender
 from apps.channels.channels_v2.stages.core import AttachmentHydrationStage
+from apps.channels.datamodels import WhatsAppMessage
 from apps.channels.models import ChannelPlatform
 from apps.files.models import File, FilePurpose
 from apps.service_providers.models import MessagingProviderType
@@ -98,9 +99,6 @@ class WhatsappCallbacks(ChannelCallbacks):
         return self._service.get_message_audio(message)
 
     def on_submit_input_to_llm(self, recipient: str) -> None:
-        # noqa: PLC0415 - circular: datamodels imports chat.channels
-        from apps.channels.datamodels import WhatsAppMessage  # noqa: PLC0415
-
         if self._ctx is None:
             return
         message = self._ctx.message

--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -20,6 +20,7 @@ from apps.channels.datamodels import (
     TwilioMessage,
     WhatsAppMessage,
 )
+from apps.channels.datamodels import EmailMessage as EmailMessageDatamodel
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import (
     FacebookMessengerChannel,
@@ -228,12 +229,11 @@ def handle_meta_cloud_api_message(self, channel_id: int, team_slug: str, message
     retry_jitter=True,
 )
 def handle_email_message(self, email_data: dict, channel_id: int | None = None, session_id: int | None = None):
-    from apps.channels.channels_v2.email_channel import (  # noqa: PLC0415
+    from apps.channels.channels_v2.email_channel import (  # noqa: PLC0415 - tests patch EmailChannel at source module
         EmailChannel,
         EmailThreadContext,
         get_email_experiment_channel,
     )
-    from apps.channels.datamodels import EmailMessage as EmailMessageDatamodel  # noqa: PLC0415
 
     message = EmailMessageDatamodel(**email_data)
 

--- a/apps/channels/tests/channels/stages/test_attachment_hydration.py
+++ b/apps/channels/tests/channels/stages/test_attachment_hydration.py
@@ -8,6 +8,7 @@ from apps.channels.channels_v2.whatsapp_channel import WhatsappAttachmentHydrati
 from apps.channels.datamodels import Attachment, BaseMessage
 from apps.channels.tests.channels.conftest import make_context
 from apps.chat.models import ChatAttachment
+from apps.files.models import File
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.files import FileFactory
 
@@ -235,8 +236,6 @@ class TestWhatsappAttachmentHydrationStage:
 
         self.stage.process(ctx)
 
-        from apps.files.models import File  # noqa: PLC0415
-
         assert len(msg.attachments) == 1
         file_id = msg.attachments[0].file_id
         file_obj = File.objects.get(id=file_id)
@@ -263,8 +262,6 @@ class TestWhatsappAttachmentHydrationStage:
         )
 
         self.stage.process(ctx)
-
-        from apps.files.models import File  # noqa: PLC0415
 
         file_obj = File.objects.get(id=msg.attachments[0].file_id)
         # File.create appends a content-type-derived extension when none is provided.

--- a/apps/channels/tests/test_email_channel.py
+++ b/apps/channels/tests/test_email_channel.py
@@ -22,7 +22,7 @@ from apps.channels.datamodels import EmailMessage, RawAttachment
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.channels.tasks import handle_email_message
 from apps.chat.channels import MESSAGE_TYPES
-from apps.chat.models import Chat
+from apps.chat.models import Chat, ChatMessage, ChatMessageType
 from apps.chatbots.version_resolver import resolve_published_or_working
 from apps.experiments.models import ExperimentSession, Participant, SessionStatus
 from apps.files.models import File
@@ -1299,7 +1299,6 @@ class TestEmailAttachmentsEndToEnd:
         def fake_process_input(user_query, attachments=None, human_message=None):
             captured["attachments"] = attachments
             captured["query"] = user_query
-            from apps.chat.models import ChatMessage, ChatMessageType  # noqa: PLC0415
 
             return ChatMessage(content="ack: got the file", message_type=ChatMessageType.AI)
 

--- a/apps/documents/tasks.py
+++ b/apps/documents/tasks.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from io import BytesIO
 from itertools import groupby
 
+import openai
 from celery.app import shared_task
 from celery.utils.log import get_task_logger
 from celery_progress.backend import ProgressRecorder
@@ -19,6 +20,7 @@ from taskbadger.celery import Task as TaskbadgerTask
 
 from apps.assistants.models import OpenAiAssistant
 from apps.documents.datamodels import ChunkingStrategy, CollectionFileMetadata
+from apps.documents.document_source_service import sync_document_source
 from apps.documents.exceptions import ZipCreationError, ZipIntegrityError
 from apps.documents.models import (
     Collection,
@@ -96,8 +98,6 @@ def index_collection_files(collection_files_queryset: QuerySet[CollectionFile]) 
 
 
 def _cleanup_old_vector_store(llm_provider_id: int, vector_store_id: str, file_ids: list[str]):
-    import openai  # noqa: PLC0415 - lazy: avoid loading openai at startup (not in top-level imports)
-
     llm_provider = LlmProvider.objects.get(id=llm_provider_id)
     old_manager = llm_provider.get_remote_index_manager(vector_store_id)
     old_manager.delete_remote_index()
@@ -174,10 +174,6 @@ def create_collection_from_assistant_task(collection_id: int, assistant_id: int)
 @shared_task(ignore_result=True)
 def sync_document_source_task(document_source_id: int):
     """Sync a specific document source"""
-    from apps.documents.document_source_service import (  # noqa: PLC0415 - circular: document_source_service imports documents.tasks
-        sync_document_source,
-    )
-
     try:
         document_source = DocumentSource.objects.select_related("collection").get(id=document_source_id)
     except DocumentSource.DoesNotExist:

--- a/apps/events/actions.py
+++ b/apps/events/actions.py
@@ -1,7 +1,7 @@
 from django.db.models import Case, DateTimeField, F, When
 
 from apps.experiments.models import ExperimentSession
-from apps.pipelines.models import PipelineChatHistoryModes, PipelineEventInputs
+from apps.pipelines.models import Pipeline, PipelineChatHistoryModes, PipelineEventInputs
 from apps.pipelines.nodes.base import PipelineState
 from apps.service_providers.tracing import TraceInfo, TracingService
 from apps.utils.django_db import MakeInterval
@@ -99,10 +99,6 @@ class SendMessageToBotAction(EventActionHandlerBase):
 
 class PipelineStartAction(EventActionHandlerBase):
     def invoke(self, session: ExperimentSession, action) -> str:
-        from apps.pipelines.models import (  # noqa: PLC0415 - circular: pipelines.models → events.models → events.actions
-            Pipeline,
-        )
-
         try:
             pipeline: Pipeline = Pipeline.objects.get(id=action.params["pipeline_id"])
         except KeyError:

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -5,6 +5,7 @@ from celery.utils.log import get_task_logger
 from django.core.files.base import ContentFile
 from django.utils import timezone
 from field_audit.models import AuditAction
+from langchain_core.messages import AIMessage, HumanMessage
 from taskbadger.celery import Task as TaskbadgerTask
 
 from apps.channels.channels_v2.web_channel import WebChannel
@@ -169,11 +170,6 @@ def get_prompt_builder_response_task(team_id: int, user_id, data_dict: dict) -> 
 
 
 def _convert_prompt_builder_history(messages_history):
-    from langchain_core.messages import (  # noqa: PLC0415 - lazy: avoid langchain import on startup
-        AIMessage,
-        HumanMessage,
-    )
-
     history = []
     for message in messages_history:
         if "message" not in message:

--- a/apps/help/agents/filter.py
+++ b/apps/help/agents/filter.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 from typing import ClassVar, Literal
 
+from langchain_core.tools import tool
 from pydantic import BaseModel
 
 from apps.help.agent import build_system_agent
@@ -29,8 +30,6 @@ def make_get_options_tool(filter_class, team):
     The tool is closed over filter_class and team so it can call prepare(team)
     on the appropriate ColumnFilter instance without needing extra arguments.
     """
-    from langchain_core.tools import tool  # lazy-loaded to keep Django startup fast  # noqa: PLC0415
-
     _options_cache: dict[str, list[dict]] = {}  # param -> normalized options (cached per agent run)
 
     @tool

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -15,7 +15,8 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, System
 from apps.chat.models import ChatMessageType
 from apps.custom_actions.form_utils import set_custom_actions
 from apps.custom_actions.mixins import CustomActionOperationMixin
-from apps.experiments.models import ExperimentSession, SourceMaterial
+from apps.documents.models import Collection
+from apps.experiments.models import ExperimentSession, SourceMaterial, VersionFieldDisplayFormatters
 from apps.experiments.versioning import VersionDetails, VersionField, VersionsMixin, VersionsObjectManagerMixin
 from apps.pipelines.exceptions import PipelineBuildError
 from apps.pipelines.flow import Flow, FlowNode, FlowNodeData
@@ -436,10 +437,6 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
 
     def _get_version_details(self) -> VersionDetails:
         from apps.assistants.models import OpenAiAssistant  # noqa: PLC0415 - circular: assistants.models→models
-        from apps.documents.models import Collection  # noqa: PLC0415 - circular: documents.models→models
-        from apps.experiments.models import (  # noqa: PLC0415 - circular: experiments.models→models
-            VersionFieldDisplayFormatters,
-        )
         from apps.pipelines.nodes.nodes import LLMResponseWithPrompt  # noqa: PLC0415 - circular: nodes.nodes→models
 
         node_name = self.params.get("name", self.type)
@@ -504,7 +501,6 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
         Archive related params that were also versioned along with this node
         """
         from apps.assistants.models import OpenAiAssistant  # noqa: PLC0415 - circular: assistants.models→models
-        from apps.documents.models import Collection  # noqa: PLC0415 - circular: documents.models→models
         from apps.pipelines.nodes import nodes  # noqa: PLC0415 - circular: nodes.nodes→models
 
         # AssistantNode versions its assistant here. LLMResponseWithPrompt's collection params

--- a/apps/pipelines/nodes/llm_node.py
+++ b/apps/pipelines/nodes/llm_node.py
@@ -18,6 +18,7 @@ from apps.pipelines.nodes.helpers import get_system_message
 from apps.pipelines.nodes.history_middleware import MessageSizeValidationMiddleware
 from apps.pipelines.nodes.tool_callbacks import ToolCallbacks
 from apps.service_providers.llm_service.datamodels import LlmChatResponse
+from apps.service_providers.llm_service.main import OpenAIBuiltinTool
 from apps.service_providers.llm_service.prompt_context import PromptTemplateContext
 from apps.service_providers.llm_service.utils import (
     format_multimodal_input,
@@ -171,10 +172,6 @@ def _get_configured_tools(node, session: ExperimentSession, tool_callbacks: Tool
 
 
 def _get_search_tool(node):
-    from apps.service_providers.llm_service.main import (  # noqa: PLC0415 - lazy: llm_service.main loads heavy langchain deps
-        OpenAIBuiltinTool,
-    )
-
     if not node.collection_index_ids:
         return None
 

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -63,6 +63,7 @@ from apps.service_providers.llm_service.history_managers import AssistantPipelin
 from apps.service_providers.llm_service.prompt_context import (
     PipelineParticipantDataProxy,
     PromptTemplateContext,
+    SafeAccessWrapper,
 )
 from apps.service_providers.llm_service.retry import with_llm_retry
 from apps.service_providers.llm_service.runnables import (
@@ -742,10 +743,6 @@ class StaticRouterNode(RouterMixin, PipelineRouterNode):
     route_key: str = Field(..., description="The key in the data to use for routing")
 
     def _process_conditional(self, context: "NodeContext"):
-        from apps.service_providers.llm_service.prompt_context import (  # noqa: PLC0415 - lazy: avoids startup load
-            SafeAccessWrapper,
-        )
-
         match self.data_source:
             case self.DataSource.participant_data:
                 data = context.state.participant_data

--- a/apps/pipelines/utils.py
+++ b/apps/pipelines/utils.py
@@ -1,5 +1,7 @@
 from django.core.cache import cache
+from langchain_core.messages.utils import count_tokens_approximately
 
+from apps.pipelines.nodes.nodes import LLMResponseWithPrompt
 from apps.service_providers.models import LlmProviderModel
 
 
@@ -22,12 +24,6 @@ def compute_max_char_limit(pipeline) -> int | None:
 
 
 def _compute_max_char_limit(pipeline) -> int | None:
-    from langchain_core.messages.utils import count_tokens_approximately  # noqa: PLC0415
-
-    from apps.pipelines.nodes.nodes import (  # noqa: PLC0415 - lazy: nodes.py loads heavy langchain/pydantic deps
-        LLMResponseWithPrompt,
-    )
-
     llm_nodes = list(pipeline.node_set.filter(type=LLMResponseWithPrompt.__name__))
     if not llm_nodes:
         return None

--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -26,6 +26,7 @@ from apps.experiments.models import AgentTools, BuiltInTools, Experiment, Source
 from apps.pipelines.flow import FlowPipelineData
 from apps.pipelines.jinja_utils import djlint_check, parse_jinja_template
 from apps.pipelines.models import Pipeline
+from apps.pipelines.nodes import nodes as pipeline_nodes
 from apps.pipelines.nodes.base import OptionsSource
 from apps.pipelines.tables import PipelineTable
 from apps.pipelines.tasks import get_response_for_pipeline_test_message
@@ -339,8 +340,6 @@ def _pipeline_node_default_values(llm_providers: list[dict], llm_provider_models
 
 
 def _pipeline_node_schemas():
-    from apps.pipelines.nodes import nodes as pipeline_nodes  # noqa: PLC0415 - circular: nodes.nodes→views
-
     schemas = []
 
     node_classes = [

--- a/apps/service_providers/speech_service.py
+++ b/apps/service_providers/speech_service.py
@@ -5,18 +5,18 @@ import time
 from contextlib import closing
 from dataclasses import dataclass
 from io import BytesIO
-from typing import IO, TYPE_CHECKING, ClassVar
+from typing import IO, ClassVar
 
 import httpx
 import pydantic
+from elevenlabs.client import ElevenLabs as ElevenLabsClient
+from openai import OpenAI
+from pydub import AudioSegment
 
 from apps.channels.audio import convert_audio
 from apps.chat.exceptions import AudioSynthesizeException, AudioTranscriptionException, UserReportableError
 from apps.experiments.models import SyntheticVoice
 from apps.service_providers.intron import INTRON_BASE_URL
-
-if TYPE_CHECKING:
-    from openai import OpenAI
 
 log = logging.getLogger("ocs.speech")
 
@@ -83,7 +83,6 @@ class AWSSpeechService(SpeechService):
         Calls AWS Polly to convert the text to speech using the synthetic_voice
         """
         import boto3  # noqa: PLC0415 - TID253: heavy lib, slow startup
-        from pydub import AudioSegment  # noqa: PLC0415 - lazy: optional audio processing lib
 
         polly_client = boto3.Session(
             aws_access_key_id=self.aws_access_key_id,
@@ -118,7 +117,6 @@ class AzureSpeechService(SpeechService):
         """
         # keep heavy imports inline
         import azure.cognitiveservices.speech as speechsdk  # noqa: PLC0415 - lazy: optional provider dep (Azure speech SDK)
-        from pydub import AudioSegment  # noqa: PLC0415 - lazy: optional audio processing lib
 
         speech_config = speechsdk.SpeechConfig(subscription=self.azure_subscription_key, region=self.azure_region)
 
@@ -146,16 +144,17 @@ class AzureSpeechService(SpeechService):
                 file_size = os.path.getsize(temp_file_name)
                 if file_size < 4:
                     raise AudioSynthesizeException(
-                        f"Azure returned an empty audio file for voice '{synthetic_voice.language_code}-{synthetic_voice.name}'. "
-                        "This is likely caused by a mismatch between the text language and the configured voice language."
+                        f"Azure returned an empty audio file for voice "
+                        f"'{synthetic_voice.language_code}-{synthetic_voice.name}'. This is likely caused by a "
+                        "mismatch between the text language and the configured voice language."
                     )
                 with open(temp_file_name, "rb") as f:
                     header = f.read(4)
                 if header != b"RIFF":
                     raise AudioSynthesizeException(
                         f"Azure returned an invalid WAV file (bad RIFF header) for voice "
-                        f"'{synthetic_voice.language_code}-{synthetic_voice.name}'. "
-                        "This is likely caused by a mismatch between the text language and the configured voice language."
+                        f"'{synthetic_voice.language_code}-{synthetic_voice.name}'. This is likely caused by a "
+                        "mismatch between the text language and the configured voice language."
                     )
 
                 audio_segment = AudioSegment.from_file(
@@ -220,7 +219,6 @@ class OpenAISpeechService(SpeechService):
     @property
     def _client(self) -> "OpenAI":
         # keep heavy imports inline
-        from openai import OpenAI  # noqa: PLC0415 - lazy: optional provider dep (OpenAI speech)
 
         return OpenAI(api_key=self.openai_api_key, organization=self.openai_organization, base_url=self.openai_api_base)
 
@@ -229,7 +227,6 @@ class OpenAISpeechService(SpeechService):
         Calls OpenAI to convert the text to speech using the synthetic_voice
         """
         # keep heavy imports inline
-        from pydub import AudioSegment  # noqa: PLC0415 - lazy: optional audio processing lib
 
         response = self._client.audio.speech.create(model="gpt-4o-mini-tts", voice=synthetic_voice.name, input=text)
         audio_data = response.read()
@@ -256,13 +253,9 @@ class ElevenLabsSpeechService(SpeechService):
 
     @property
     def _client(self):
-        from elevenlabs.client import ElevenLabs as ElevenLabsClient  # noqa: PLC0415 - lazy: optional provider dep
-
         return ElevenLabsClient(api_key=self.elevenlabs_api_key)
 
     def _synthesize_voice(self, text: str, synthetic_voice: SyntheticVoice) -> SynthesizedAudio:
-        from pydub import AudioSegment  # noqa: PLC0415 - lazy: optional audio processing lib
-
         audio_iter = self._client.text_to_speech.convert(
             voice_id=synthetic_voice.external_id,
             model_id=self.elevenlabs_model,
@@ -291,8 +284,6 @@ class OpenAIVoiceEngineSpeechService(SpeechService):
 
     @property
     def _client(self) -> "OpenAI":
-        from openai import OpenAI  # noqa: PLC0415 - lazy: optional provider dep (OpenAI speech)
-
         return OpenAI(api_key=self.openai_api_key, organization=self.openai_organization, base_url=self.openai_api_base)
 
     def _synthesize_voice(self, text: str, synthetic_voice: SyntheticVoice) -> SynthesizedAudio:
@@ -300,7 +291,6 @@ class OpenAIVoiceEngineSpeechService(SpeechService):
         Uses the voice sample from `synthetic_voice` and calls OpenAI to synthesize audio with the sample voice
         """
         # keep heavy imports inline
-        from pydub import AudioSegment  # noqa: PLC0415 - lazy: optional audio processing lib
 
         sample_audio = synthetic_voice.file
 
@@ -345,8 +335,6 @@ class IntronSpeechService(SpeechService):
     _SUCCESS_STATUS: ClassVar[str] = "TTS_TEXT_AUDIO_GENERATED"
 
     def _synthesize_voice(self, text: str, synthetic_voice: SyntheticVoice) -> SynthesizedAudio:
-        from pydub import AudioSegment  # noqa: PLC0415 - lazy: optional audio processing lib
-
         # Pool the TCP/TLS connection across enqueue + (up to 120) status polls against the Intron API.
         # The S3 audio download is intentionally made outside this client because S3 rejects the Bearer
         # header with a 400, and mixing hosts in the same pool wouldn't improve reuse anyway.

--- a/apps/service_providers/tests/test_intron.py
+++ b/apps/service_providers/tests/test_intron.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from django.urls import reverse
 
@@ -54,8 +56,6 @@ def test_run_post_save_hook_seeds_intron_voices(team_with_users):
 @pytest.mark.django_db()
 def test_run_post_save_hook_returns_warning_on_seeding_failure(team_with_users):
     """If build_intron_synthetic_voices raises, the hook logs and returns a user-facing warning."""
-    from unittest import mock  # noqa: PLC0415 - only needed in this test
-
     provider = VoiceProvider.objects.create(
         team=team_with_users,
         name="Intron Test",

--- a/apps/service_providers/tests/test_voice_providers.py
+++ b/apps/service_providers/tests/test_voice_providers.py
@@ -299,10 +299,10 @@ def test_elevenlabs_synthesize_voice(team_with_users):
     fake_mp3_bytes = b"\xff\xfb\x90\x00" * 100
 
     speech_service = provider.get_speech_service()
-    with mock.patch("elevenlabs.client.ElevenLabs") as mock_client_cls:
+    with mock.patch("apps.service_providers.speech_service.ElevenLabsClient") as mock_client_cls:
         mock_client = mock_client_cls.return_value
         mock_client.text_to_speech.convert.return_value = iter([fake_mp3_bytes])
-        with mock.patch("pydub.AudioSegment") as mock_audio:
+        with mock.patch("apps.service_providers.speech_service.AudioSegment") as mock_audio:
             mock_segment = mock.Mock()
             mock_segment.__len__ = mock.Mock(return_value=2500)
             mock_audio.from_file.return_value = mock_segment
@@ -333,7 +333,7 @@ def test_elevenlabs_transcribe_audio(team_with_users):
     speech_service = provider.get_speech_service()
     mock_audio = BytesIO(b"fake audio data")
 
-    with mock.patch("elevenlabs.client.ElevenLabs") as mock_client_cls:
+    with mock.patch("apps.service_providers.speech_service.ElevenLabsClient") as mock_client_cls:
         mock_client = mock_client_cls.return_value
         mock_result = mock.Mock()
         mock_result.text = "Hello world"

--- a/apps/service_providers/tracing/langfuse.py
+++ b/apps/service_providers/tracing/langfuse.py
@@ -31,7 +31,7 @@ logger = logging.getLogger("ocs.tracing.langfuse")
 
 def get_langfuse_api_client(config: dict) -> LangfuseAPI:
     """Create a Langfuse management API client for reading trace data."""
-    from langfuse.api.client import LangfuseAPI  # noqa: PLC0415 - lazy: test mocks at source module level
+    from langfuse.api.client import LangfuseAPI  # noqa: PLC0415 - tests mock LangfuseAPI at source module
 
     return LangfuseAPI(
         base_url=config["host"],
@@ -228,7 +228,7 @@ class ClientManager:
         self._start_prune_thread()
 
     def get(self, config: dict) -> Langfuse:
-        from langfuse import Langfuse  # noqa: PLC0415 - lazy: test mocks langfuse.Langfuse at source module level
+        from langfuse import Langfuse  # noqa: PLC0415 - tests mock langfuse.Langfuse at source module
 
         public_key = config.get("public_key")
         with LangfuseResourceManager._lock:

--- a/apps/service_providers/tracing/ocs_tracer.py
+++ b/apps/service_providers/tracing/ocs_tracer.py
@@ -4,21 +4,19 @@ import logging
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from django.core.cache import cache
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.outputs import LLMResult
 
+from apps.experiments.models import Experiment, ExperimentSession
 from apps.ocs_notifications.notifications import trace_error_notification
 from apps.service_providers.tracing.const import OCS_TRACE_PROVIDER, SpanLevel
 from apps.service_providers.tracing.metrics import MetricsCollector
 from apps.trace.models import Trace, TraceStatus
 
 from .base import SpanNotificationConfig, TraceContext, Tracer
-
-if TYPE_CHECKING:
-    from apps.experiments.models import Experiment, ExperimentSession
 
 logger = logging.getLogger("ocs.tracing")
 
@@ -260,8 +258,6 @@ class OCSTracer(Tracer):
         """
         Bust any relevant caches when an error is detected in a span.
         """
-        from apps.experiments.models import Experiment  # noqa: PLC0415 - circular: experiments.models→tracing
-
         cache_key = Experiment.TREND_CACHE_KEY_TEMPLATE.format(experiment_id=self.experiment.id)
         cache.delete(cache_key)
 

--- a/apps/users/apps.py
+++ b/apps/users/apps.py
@@ -6,4 +6,4 @@ class UserConfig(AppConfig):
     label = "users"
 
     def ready(self):
-        from . import signals  # noqa  F401
+        from . import signals  # noqa: F401, PLC0415 - lazy: signal registration belongs in ready()

--- a/apps/utils/deletion.py
+++ b/apps/utils/deletion.py
@@ -23,7 +23,7 @@ def delete_object_with_auditing_of_related_objects(obj):
         obj: The object to delete.
     """
 
-    from field_audit.models import (  # noqa: PLC0415 - lazy: apps.py init before app registry ready
+    from field_audit.models import (  # noqa: PLC0415 - init-order: apps.py loads before app registry is ready
         AuditAction,
         AuditingManager,
     )
@@ -75,7 +75,7 @@ def _perform_updates_for_delete(updates_not_part_of_delete):
             combined_updates = reduce(or_, updates)
             _queryset_update_with_auditing(combined_updates, **{field.name: value})
         if objs:
-            from field_audit.models import AuditAction  # noqa: PLC0415 - lazy: apps.py init before app registry ready
+            from field_audit.models import AuditAction  # noqa: PLC0415 - init-order: loads before app registry
 
             model = objs[0].__class__
             objects_filter = model.objects.filter(list({obj.pk for obj in objs}))
@@ -87,8 +87,8 @@ def _queryset_update_with_auditing(queryset, **kw):
     Copied from `field_audit.models.AuditingQuerySet.update` so that it can be called with querysets
     that are not AuditingQuerySets.
     """
-    from field_audit import AuditService  # noqa: PLC0415 - lazy: apps.py init before app registry ready
-    from field_audit.models import AuditEvent  # noqa: PLC0415 - lazy: apps.py init before app registry ready
+    from field_audit import AuditService  # noqa: PLC0415 - init-order: apps.py loads before app registry is ready
+    from field_audit.models import AuditEvent  # noqa: PLC0415 - init-order: apps.py loads before app registry is ready
 
     audit_service = AuditService()
     fields_to_update = set(kw.keys())
@@ -267,7 +267,7 @@ def _get_related_pipeline_experiments_queryset(
 
 
 def get_admin_emails_with_delete_permission(team):
-    from apps.teams.models import Membership  # noqa: PLC0415 - lazy: apps.py init before app registry ready
+    from apps.teams.models import Membership  # noqa: PLC0415 - init-order: apps.py loads before app registry is ready
 
     return list(
         Membership.objects.filter(team__name=team.name, groups__permissions__codename="delete_team").values_list(

--- a/apps/utils/logging.py
+++ b/apps/utils/logging.py
@@ -11,8 +11,8 @@ class ContextVarFilter(logging.Filter):
     """Log filter that adds team and request_id from context vars."""
 
     def filter(self, record):
-        from apps.audit.transaction import get_audit_transaction_id  # noqa: PLC0415 - lazy: Django LOGGING startup
-        from apps.teams.utils import get_current_team  # noqa: PLC0415 - lazy: Django LOGGING startup
+        from apps.audit.transaction import get_audit_transaction_id  # noqa: PLC0415 - init-order: LOGGING setup
+        from apps.teams.utils import get_current_team  # noqa: PLC0415 - init-order: LOGGING setup
 
         team = get_current_team()
         record.team = team.slug if team else None

--- a/apps/web/admin.py
+++ b/apps/web/admin.py
@@ -28,7 +28,7 @@ class OcsAdminSite(admin.AdminSite):
 
                 # Inner import to prevent django.contrib.admin (app) from
                 # importing django.contrib.auth.models.User (unrelated model).
-                from django.contrib.auth.views import redirect_to_login  # noqa: PLC0415
+                from django.contrib.auth.views import redirect_to_login  # noqa: PLC0415 - lazy: avoid auth import
 
                 return redirect_to_login(
                     request.get_full_path(),

--- a/apps/web/dynamic_filters/base.py
+++ b/apps/web/dynamic_filters/base.py
@@ -275,10 +275,10 @@ def get_filter_registry() -> dict[str, type[MultiColumnFilter]]:
     Imports known filter modules to ensure subclasses are registered
     regardless of import order.
     """
-    import apps.experiments.filters  # noqa: F401, PLC0415
-    import apps.human_annotations.filters  # noqa: F401, PLC0415
-    import apps.ocs_notifications.filters  # noqa: F401, PLC0415
-    import apps.participants.filters  # noqa: F401, PLC0415
-    import apps.trace.filters  # noqa: F401, PLC0415
+    import apps.experiments.filters  # noqa: F401, PLC0415 - registration: load filter subclasses regardless of import order
+    import apps.human_annotations.filters  # noqa: F401, PLC0415 - registration: load filter subclasses regardless of import order
+    import apps.ocs_notifications.filters  # noqa: F401, PLC0415 - registration: load filter subclasses regardless of import order
+    import apps.participants.filters  # noqa: F401, PLC0415 - registration: load filter subclasses regardless of import order
+    import apps.trace.filters  # noqa: F401, PLC0415 - registration: load filter subclasses regardless of import order
 
     return {cls.slug: cls for cls in MultiColumnFilter.__subclasses__() if getattr(cls, "slug", "")}

--- a/scripts/check_inline_imports.py
+++ b/scripts/check_inline_imports.py
@@ -61,6 +61,25 @@ class InlineImport:
     justification: str | None = None
 
 
+def _read_justification(node: ast.AST, lines: list[str]) -> str | None:
+    """Return the lazy-import/noqa reason on an import statement, if any."""
+    for line in lines[node.lineno - 1 : node.end_lineno]:
+        if match := LAZY_MARKER.search(line) or NOQA_REASON.search(line):
+            return match.group("reason")
+    return None
+
+
+def _absolute_import_modules(node: ast.Import | ast.ImportFrom) -> tuple[str, ...]:
+    """Absolute module names an import targets (relative imports have none)."""
+    if isinstance(node, ast.Import):
+        return tuple(alias.name for alias in node.names)
+    return (node.module,) if node.level == 0 and node.module else ()
+
+
+def _is_function(node: ast.AST) -> bool:
+    return isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+
+
 def find_inline_imports(source: str) -> list[InlineImport]:
     """Return all import statements nested inside function or method bodies.
 
@@ -74,24 +93,15 @@ def find_inline_imports(source: str) -> list[InlineImport]:
     def visit(parent: ast.AST, in_function: bool) -> None:
         for node in ast.iter_child_nodes(parent):
             if in_function and isinstance(node, (ast.Import, ast.ImportFrom)):
-                justification = None
-                for line in lines[node.lineno - 1 : node.end_lineno]:
-                    if match := LAZY_MARKER.search(line) or NOQA_REASON.search(line):
-                        justification = match.group("reason")
-                        break
-                if isinstance(node, ast.Import):
-                    modules = tuple(alias.name for alias in node.names)
-                else:  # relative imports have no absolute module name
-                    modules = (node.module,) if node.level == 0 and node.module else ()
                 results.append(
                     InlineImport(
                         lineno=node.lineno,
                         statement=ast.unparse(node),
-                        modules=modules,
-                        justification=justification,
+                        modules=_absolute_import_modules(node),
+                        justification=_read_justification(node, lines),
                     )
                 )
-            visit(node, in_function or isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)))
+            visit(node, in_function or _is_function(node))
 
     visit(tree, False)
     return results
@@ -180,6 +190,22 @@ def _is_type_checking_test(test: ast.expr) -> bool:
     )
 
 
+def _imported_names(node: ast.AST, module_package: str) -> set[str]:
+    """Dotted names a single import node binds, resolving relative imports."""
+    if isinstance(node, ast.Import):
+        return {alias.name for alias in node.names}
+    if not isinstance(node, ast.ImportFrom):
+        return set()
+    if node.level == 0 and node.module:
+        return {node.module}
+    if node.level:
+        parts = module_package.split(".")[: len(module_package.split(".")) - (node.level - 1)]
+        base = ".".join(parts + ([node.module] if node.module else []))
+        # `from . import x` may import submodule x
+        return {base, *(f"{base}.{alias.name}" for alias in node.names)}
+    return set()
+
+
 def find_module_time_imports(source: str, module_package: str) -> set[str]:
     """Return dotted names imported at module-import time.
 
@@ -198,18 +224,8 @@ def find_module_time_imports(source: str, module_package: str) -> set[str]:
                 visit(ast.Module(body=node.orelse, type_ignores=[]), in_function)
                 continue
             if not in_function:
-                if isinstance(node, ast.Import):
-                    names.update(alias.name for alias in node.names)
-                elif isinstance(node, ast.ImportFrom):
-                    if node.level == 0 and node.module:
-                        names.add(node.module)
-                    elif node.level:
-                        parts = module_package.split(".")[: len(module_package.split(".")) - (node.level - 1)]
-                        base = ".".join(parts + ([node.module] if node.module else []))
-                        names.add(base)
-                        # `from . import x` may import submodule x
-                        names.update(f"{base}.{alias.name}" for alias in node.names)
-            visit(node, in_function or isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)))
+                names.update(_imported_names(node, module_package))
+            visit(node, in_function or _is_function(node))
 
     visit(tree, False)
     return names
@@ -443,6 +459,70 @@ def _scan_paths(package_dir: Path, files: tuple[Path, ...] | None) -> list[Path]
     return paths
 
 
+def _route_import(imp: InlineImport, ctx: "PackageContext") -> str:
+    """Decide how an inline import must be checked.
+
+    ``"justified"`` is decided immediately (config-blessed or a claim that
+    cannot be falsified). ``"empirical"`` needs a hoist test (unjustified or a
+    cycle claim). ``"lazy"`` needs the static module-time-import cross-check.
+    """
+    if is_banned_import(imp, ctx.banned_imports):
+        return "justified"  # config-blessed: ruff TID253 forces these inline
+    if imp.justification is None or claims_cycle(imp.justification):
+        return "empirical"
+    if claims_cost(imp.justification):
+        return "lazy"
+    return "justified"  # timing/patching constraints: not falsifiable, trusted
+
+
+def _classify_lazy_claims(candidates: list[Candidate], ctx: "PackageContext") -> list[Finding]:
+    """Fact-check ``lazy:`` claims: a module already imported at module-import
+    time elsewhere costs nothing extra to hoist, so the claim is dubious."""
+    if not candidates:
+        return []
+    index = module_time_import_index(ctx)
+    findings = []
+    for c in candidates:
+        hit = loaded_at_module_time(c.inline_import.modules, index)
+        if hit is None:
+            findings.append(Finding(c.path, c.inline_import, "justified"))
+            continue
+        module, importer = hit
+        rel_importer = importer.relative_to(ctx.import_root)
+        findings.append(
+            Finding(
+                c.path,
+                c.inline_import,
+                "dubious",
+                f"`{module}` is already imported at module level in {rel_importer}",
+            )
+        )
+    return findings
+
+
+def _empirical_verdict(imp: InlineImport, hoistable: bool) -> str:
+    """Verdict from a hoist test: a clean hoist means an unjustified import is
+    a ``violation`` and a (cycle-)justified one is ``stale``."""
+    if imp.justification is None:
+        return "violation" if hoistable else "legitimate"
+    return "stale" if hoistable else "justified"
+
+
+def _classify_empirical(candidates: list[Candidate], ctx: "PackageContext") -> list[Finding]:
+    """Hoist-test candidates. If the baseline import already fails, nothing is
+    proven and every candidate is inconclusive."""
+    if not candidates:
+        return []
+    baseline = _import_all_from_copy(ctx)
+    if not baseline.ok:
+        return [Finding(c.path, c.inline_import, "inconclusive", baseline.error) for c in candidates]
+    classified = classify_candidates(candidates, lambda cands: verify_hoists(ctx, cands))
+    return [
+        Finding(c.path, c.inline_import, _empirical_verdict(c.inline_import, hoistable), error)
+        for c, hoistable, error in classified
+    ]
+
+
 def check_package(
     package_dir: Path,
     exclude: tuple[str, ...] = (),
@@ -453,66 +533,55 @@ def check_package(
     ``files`` restricts which files are scanned for inline imports (e.g. the
     files changed in a PR); hoists are still verified against the whole
     top-level package, since import cycles span sub-packages.
-
-    The hoisted runs are compared against a baseline run of the unmodified
-    package in the same environment. If the baseline itself fails, the
-    empirical test proves nothing and findings are marked inconclusive.
     """
     ctx = PackageContext.resolve(package_dir, exclude)
     findings = []
-    empirical = []  # unjustified, or justified with a (testable) cycle claim
-    lazy_claimed = []
+    empirical: list[Candidate] = []  # unjustified, or a (testable) cycle claim
+    lazy_claimed: list[Candidate] = []
+    routes = {"empirical": empirical, "lazy": lazy_claimed}
     for path in _scan_paths(package_dir, files):
         if ctx.skip(path.resolve().relative_to(package_dir.resolve())):
             continue
         rel_path = str(path.resolve().relative_to(ctx.top_package))
         # utf-8-sig: tolerate files saved with a UTF-8 BOM
         for imp in find_inline_imports(path.read_text(encoding="utf-8-sig")):
-            if is_banned_import(imp, ctx.banned_imports):
-                # config-blessed: ruff TID253 forces these to stay inline
+            route = _route_import(imp, ctx)
+            if route == "justified":
                 findings.append(Finding(path, imp, "justified"))
-            elif imp.justification is None or claims_cycle(imp.justification):
-                empirical.append(Candidate(path, rel_path, imp))
-            elif claims_cost(imp.justification):
-                lazy_claimed.append(Candidate(path, rel_path, imp))
             else:
-                # timing/patching constraints: not falsifiable, trusted
-                findings.append(Finding(path, imp, "justified"))
+                routes[route].append(Candidate(path, rel_path, imp))
 
-    # Fact-check lazy/cost claims statically: a module already imported at
-    # module-import time elsewhere costs nothing extra to hoist.
-    if lazy_claimed:
-        index = module_time_import_index(ctx)
-        for c in lazy_claimed:
-            hit = loaded_at_module_time(c.inline_import.modules, index)
-            if hit is None:
-                findings.append(Finding(c.path, c.inline_import, "justified"))
-            else:
-                module, importer = hit
-                rel_importer = importer.relative_to(ctx.import_root)
-                findings.append(
-                    Finding(
-                        c.path,
-                        c.inline_import,
-                        "dubious",
-                        f"`{module}` is already imported at module level in {rel_importer}",
-                    )
-                )
-
-    # Empirically test the rest by hoisting: cycle claims must reproduce.
-    if empirical:
-        baseline = _import_all_from_copy(ctx)
-        if not baseline.ok:
-            findings += [Finding(c.path, c.inline_import, "inconclusive", baseline.error) for c in empirical]
-        else:
-            for c, hoistable, error in classify_candidates(empirical, lambda cands: verify_hoists(ctx, cands)):
-                if c.inline_import.justification is None:
-                    verdict = "violation" if hoistable else "legitimate"
-                else:
-                    verdict = "stale" if hoistable else "justified"
-                findings.append(Finding(c.path, c.inline_import, verdict, error))
+    findings += _classify_lazy_claims(lazy_claimed, ctx)
+    findings += _classify_empirical(empirical, ctx)
     findings.sort(key=lambda f: (str(f.path), f.inline_import.lineno))
     return findings
+
+
+def _format_finding(f: Finding) -> list[str]:
+    """Render a finding as output lines. Only failing/warning verdicts print;
+    legitimate and justified imports produce nothing."""
+    loc = f"{f.path}:{f.inline_import.lineno}"
+    stmt = f.inline_import.statement
+    reason = f.inline_import.justification
+    last_error = f.error.splitlines()[-1] if f.error else ""
+    if f.verdict == "violation":
+        return [
+            f"FAIL {loc}: `{stmt}` hoists cleanly",
+            "     Move it to module level, or justify it with `# noqa: PLC0415 - <reason>`.",
+        ]
+    if f.verdict == "stale":
+        return [
+            f'FAIL {loc}: `{stmt}` is justified as "{reason}" but hoists cleanly — stale justification',
+            "     Move it to module level, or correct the justification.",
+        ]
+    if f.verdict == "dubious":
+        return [f'WARN {loc}: `{stmt}` is justified as "{reason}" but {last_error}']
+    if f.verdict == "inconclusive":
+        return [
+            f"???  {loc}: `{stmt}` could not be verified; the package fails to import even without hoisting:",
+            f"     {last_error}",
+        ]
+    return []
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -545,28 +614,8 @@ def main(argv: list[str] | None = None) -> int:
     findings = check_package(args.package, exclude=tuple(args.exclude), files=files)
     counts = Counter(f.verdict for f in findings)
     for f in findings:
-        loc = f"{f.path}:{f.inline_import.lineno}"
-        last_error = f.error.splitlines()[-1] if f.error else ""
-        if f.verdict == "violation":
-            print(f"FAIL {loc}: `{f.inline_import.statement}` hoists cleanly")
-            print("     Move it to module level, or justify it with `# noqa: PLC0415 - <reason>`.")
-        elif f.verdict == "stale":
-            print(
-                f"FAIL {loc}: `{f.inline_import.statement}` is justified as"
-                f' "{f.inline_import.justification}" but hoists cleanly — stale justification'
-            )
-            print("     Move it to module level, or correct the justification.")
-        elif f.verdict == "dubious":
-            print(
-                f"WARN {loc}: `{f.inline_import.statement}` is justified as"
-                f' "{f.inline_import.justification}" but {last_error}'
-            )
-        elif f.verdict == "inconclusive":
-            print(
-                f"???  {loc}: `{f.inline_import.statement}` could not be"
-                " verified; the package fails to import even without hoisting:"
-            )
-            print(f"     {last_error}")
+        for line in _format_finding(f):
+            print(line)
     if findings:
         print(
             f"Checked {len(findings)} inline imports:"

--- a/scripts/check_inline_imports.py
+++ b/scripts/check_inline_imports.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+"""
+Verify whether inline (function-level) imports can safely move to module level.
+
+Finds imports nested inside functions/methods, hoists a copy of each to module
+level in a temporary copy of the package, and attempts to import every module
+in the package. If the imports all succeed, the inline import is unjustified
+(no real dependency cycle) and the check fails.
+
+The package may be a sub-package (e.g. ``apps/experiments``): the whole
+top-level package is copied and imported so intra-project absolute imports
+resolve. If a ``manage.py`` with ``DJANGO_SETTINGS_MODULE`` exists at the
+import root, ``django.setup()`` runs before importing and ``migrations/``
+directories are skipped.
+
+Justifications (`# noqa: PLC0415 - <reason>` or `# lazy-import: <reason>`)
+are verified, not trusted — claims rot and AI-generated code invents them:
+``circular:`` claims are hoist-tested (a clean hoist disproves the cycle →
+FAIL); other claims are cost claims, fact-checked statically (the module
+already imported at module-import time elsewhere → WARN). Only modules in
+ruff's ``banned-module-level-imports`` (TID253) are config-blessed and
+skipped. Only failing/warning imports are printed.
+
+Verification is batched: all candidate imports are hoisted in one run first;
+only if that fails does the script bisect to isolate the legitimate ones.
+Hoisting is monotone (a set of hoists that imports cleanly implies every
+subset does), so bisection is sound.
+
+Usage:
+    ./check_inline_imports.py ocs_deploy
+    uv run python scripts/check_inline_imports.py apps/experiments
+"""
+
+import argparse
+import ast
+import fnmatch
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+LAZY_MARKER = re.compile(r"#\s*lazy-import:\s*(?P<reason>.+?)\s*$")
+# The codebase's existing convention: `# noqa: PLC0415 - <reason>` (reason
+# text after a dash also counts as a deliberate-inline justification).
+NOQA_REASON = re.compile(r"#\s*noqa:?[A-Z0-9, ]*\bPLC0415\b[^#-]*-\s*(?P<reason>.+?)\s*$")
+DJANGO_SETTINGS_RE = re.compile(r"""DJANGO_SETTINGS_MODULE['"]\s*,\s*['"](?P<module>[\w.]+)['"]""")
+SUBPROCESS_TIMEOUT = 600
+
+
+@dataclass
+class InlineImport:
+    lineno: int
+    statement: str
+    modules: tuple[str, ...] = ()  # absolute module names the statement imports
+    justification: str | None = None
+
+
+def find_inline_imports(source: str) -> list[InlineImport]:
+    """Return all import statements nested inside function or method bodies.
+
+    Imports in top-level ``if``/``try`` blocks are ignored: they already
+    execute at module import time, so hoisting is moot.
+    """
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    results = []
+
+    def visit(parent: ast.AST, in_function: bool) -> None:
+        for node in ast.iter_child_nodes(parent):
+            if in_function and isinstance(node, (ast.Import, ast.ImportFrom)):
+                justification = None
+                for line in lines[node.lineno - 1 : node.end_lineno]:
+                    if match := LAZY_MARKER.search(line) or NOQA_REASON.search(line):
+                        justification = match.group("reason")
+                        break
+                if isinstance(node, ast.Import):
+                    modules = tuple(alias.name for alias in node.names)
+                else:  # relative imports have no absolute module name
+                    modules = (node.module,) if node.level == 0 and node.module else ()
+                results.append(
+                    InlineImport(
+                        lineno=node.lineno,
+                        statement=ast.unparse(node),
+                        modules=modules,
+                        justification=justification,
+                    )
+                )
+            visit(node, in_function or isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)))
+
+    visit(tree, False)
+    return results
+
+
+def hoist_import(source: str, statement: str) -> str:
+    """Return source with a copy of ``statement`` added at module level.
+
+    The original inline import is left in place (it becomes a no-op
+    re-import), so no other code needs to move. The statement is inserted
+    after the module docstring and any ``__future__`` imports.
+    """
+    tree = ast.parse(source)
+    insert_lineno = 0  # insert before this 0-based line
+    for node in tree.body:
+        is_docstring = isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant)
+        is_future = isinstance(node, ast.ImportFrom) and node.module == "__future__"
+        if is_docstring or is_future:
+            insert_lineno = node.end_lineno
+        else:
+            break
+    lines = source.splitlines(keepends=True)
+    lines.insert(insert_lineno, statement + "\n")
+    return "".join(lines)
+
+
+def find_import_root(package_dir: Path) -> Path:
+    """Return the nearest ancestor directory that is not itself a package.
+
+    Walking up past ``__init__.py`` files finds the directory that must be on
+    ``sys.path`` for the package's absolute imports to resolve (e.g. the repo
+    root for ``apps/experiments``).
+    """
+    root = package_dir.resolve()
+    while (root / "__init__.py").exists():
+        root = root.parent
+    return root
+
+
+def detect_django_settings(import_root: Path) -> str | None:
+    """Return the DJANGO_SETTINGS_MODULE declared in manage.py, if any."""
+    manage = import_root / "manage.py"
+    if not manage.exists():
+        return None
+    match = DJANGO_SETTINGS_RE.search(manage.read_text(encoding="utf-8-sig"))
+    return match.group("module") if match else None
+
+
+def load_banned_imports(import_root: Path) -> tuple[str, ...]:
+    """Return ruff's banned-module-level-imports from pyproject.toml, if any.
+
+    Modules listed there (TID253) are deliberately imported inside functions,
+    so inline imports of them need no verification.
+    """
+    pyproject = import_root / "pyproject.toml"
+    if not pyproject.exists():
+        return ()
+    config = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    for key in ("tool", "ruff", "lint", "flake8-tidy-imports"):
+        config = config.get(key, {}) if isinstance(config, dict) else {}
+    return tuple(config.get("banned-module-level-imports", ()))
+
+
+def is_banned_import(imp: InlineImport, banned: tuple[str, ...]) -> bool:
+    """Whether the import targets a banned module or one of its submodules."""
+    return any(module == ban or module.startswith(ban + ".") for module in imp.modules for ban in banned)
+
+
+def claims_cycle(justification: str) -> bool:
+    """Whether a justification claims a circular import (empirically testable)."""
+    return bool(re.match(r"circular\b", justification.strip(), re.IGNORECASE))
+
+
+def claims_cost(justification: str) -> bool:
+    """Whether a justification claims import cost (checkable via the index).
+
+    Other claims (timing constraints, test patching) are not falsifiable by
+    either method and are trusted as long as a reason is given.
+    """
+    return bool(re.match(r"lazy\b", justification.strip(), re.IGNORECASE))
+
+
+def _is_type_checking_test(test: ast.expr) -> bool:
+    return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
+        isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+    )
+
+
+def find_module_time_imports(source: str, module_package: str) -> set[str]:
+    """Return dotted names imported at module-import time.
+
+    Module, class, and top-level ``try``/``if`` scope all execute on import;
+    function bodies and ``if TYPE_CHECKING:`` blocks (never executed at
+    runtime) are excluded. Relative imports are resolved against
+    ``module_package`` (the importing module's package).
+    """
+    tree = ast.parse(source)
+    names: set[str] = set()
+
+    def visit(parent: ast.AST, in_function: bool) -> None:
+        for node in ast.iter_child_nodes(parent):
+            if isinstance(node, ast.If) and _is_type_checking_test(node.test):
+                # only the else branch runs at runtime
+                visit(ast.Module(body=node.orelse, type_ignores=[]), in_function)
+                continue
+            if not in_function:
+                if isinstance(node, ast.Import):
+                    names.update(alias.name for alias in node.names)
+                elif isinstance(node, ast.ImportFrom):
+                    if node.level == 0 and node.module:
+                        names.add(node.module)
+                    elif node.level:
+                        parts = module_package.split(".")[: len(module_package.split(".")) - (node.level - 1)]
+                        base = ".".join(parts + ([node.module] if node.module else []))
+                        names.add(base)
+                        # `from . import x` may import submodule x
+                        names.update(f"{base}.{alias.name}" for alias in node.names)
+            visit(node, in_function or isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)))
+
+    visit(tree, False)
+    return names
+
+
+def _is_startup_relevant(rel: Path) -> bool:
+    """Whether a file's module-time imports count as production startup cost.
+
+    Tests, factories, conftest, and management commands only load on demand,
+    so their imports cannot make a ``lazy:`` claim dubious.
+    """
+    if any(part in ("tests", "factories", "management", "migrations") for part in rel.parts):
+        return False
+    return not (rel.name.startswith("test_") or rel.name == "conftest.py")
+
+
+def module_time_import_index(ctx: "PackageContext") -> dict[str, Path]:
+    """Map every module-time-imported dotted name in the tree to one importer.
+
+    Used to fact-check ``lazy:`` justifications: a module already imported at
+    module level elsewhere costs nothing extra to import at module level here.
+    """
+    index: dict[str, Path] = {}
+    for path in sorted(ctx.top_package.rglob("*.py")):
+        rel = path.relative_to(ctx.top_package)
+        if not _is_startup_relevant(rel):
+            continue
+        parts = (ctx.top_package.name, *rel.with_suffix("").parts)
+        module_package = ".".join(parts[:-1])
+        # utf-8-sig: tolerate files saved with a UTF-8 BOM
+        for name in find_module_time_imports(path.read_text(encoding="utf-8-sig"), module_package):
+            index.setdefault(name, path)
+    return index
+
+
+def loaded_at_module_time(modules: tuple[str, ...], index: dict[str, Path]) -> tuple[str, Path] | None:
+    """Return (module, importer) if any of ``modules`` is provably loaded at
+    module-import time somewhere in the tree (itself or a submodule of it)."""
+    for module in modules:
+        for name, path in index.items():
+            if name == module or name.startswith(module + "."):
+                return module, path
+    return None
+
+
+@dataclass
+class PackageContext:
+    """Resolved layout of the package under test."""
+
+    package_dir: Path  # the scanned (sub-)package, as given on the CLI
+    import_root: Path  # directory that must be on sys.path
+    top_package: Path  # top-level package containing package_dir
+    django_settings: str | None
+    banned_imports: tuple[str, ...]  # ruff banned-module-level-imports
+    exclude: tuple[str, ...]  # globs relative to package_dir
+
+    @classmethod
+    def resolve(cls, package_dir: Path, exclude: tuple[str, ...]) -> "PackageContext":
+        resolved = package_dir.resolve()
+        import_root = find_import_root(resolved)
+        top_name = resolved.relative_to(import_root).parts[0]
+        return cls(
+            package_dir=package_dir,
+            import_root=import_root,
+            top_package=import_root / top_name,
+            django_settings=detect_django_settings(import_root),
+            banned_imports=load_banned_imports(import_root),
+            exclude=exclude,
+        )
+
+    def skip(self, rel_to_scan: Path) -> bool:
+        """Whether a file (relative to the scanned package) should be ignored."""
+        if self.django_settings and "migrations" in rel_to_scan.parts:
+            return True
+        rel = rel_to_scan.as_posix()
+        return any(fnmatch.fnmatch(rel, pattern) for pattern in self.exclude)
+
+
+@dataclass
+class HoistResult:
+    ok: bool
+    error: str
+
+
+@dataclass
+class Candidate:
+    path: Path  # original file path, for reporting
+    rel_path: str  # path relative to the top-level package
+    inline_import: InlineImport
+
+
+def discover_modules(pkg_copy: Path, ctx: PackageContext) -> list[str]:
+    """Return dotted module names for every importable .py file in the copy."""
+    scan_rel = ctx.package_dir.resolve().relative_to(ctx.top_package)
+    modules = []
+    for path in sorted(pkg_copy.rglob("*.py")):
+        rel = path.relative_to(pkg_copy)
+        if ctx.django_settings and "migrations" in rel.parts:
+            continue
+        try:
+            rel_to_scan = rel.relative_to(scan_rel)
+        except ValueError:
+            pass  # outside the scanned sub-package; excludes don't apply
+        else:
+            if ctx.skip(rel_to_scan):
+                continue
+        parts = (pkg_copy.name, *rel.with_suffix("").parts)
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        modules.append(".".join(parts))
+    return modules
+
+
+def _bootstrap_code(tmp: str, ctx: PackageContext, modules: list[str]) -> str:
+    """Build the subprocess code: shadow the real package, set up Django,
+    import everything."""
+    lines = ["import sys", f"sys.path.insert(0, {tmp!r})"]
+    if ctx.django_settings:
+        lines += [
+            "import os",
+            f"os.environ.setdefault('DJANGO_SETTINGS_MODULE', {ctx.django_settings!r})",
+            "import django",
+            "django.setup()",
+        ]
+    lines.append("import importlib")
+    lines += [f"importlib.import_module({m!r})" for m in modules]
+    return "\n".join(lines)
+
+
+def _import_all_from_copy(ctx: PackageContext, mutate=None) -> HoistResult:
+    """Copy the top-level package to a temp dir, optionally mutate it, import
+    everything.
+
+    Importing every module (not just an edited one) matters: an import cycle
+    can fail through one entry point and succeed through another. The temp
+    copy is placed first on ``sys.path`` so it shadows the real package, while
+    the import root (cwd) still provides sibling top-level modules such as
+    Django settings.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        pkg_copy = Path(tmp) / ctx.top_package.name
+        shutil.copytree(ctx.top_package, pkg_copy)
+        if mutate is not None:
+            mutate(pkg_copy)
+        code = _bootstrap_code(tmp, ctx, discover_modules(pkg_copy, ctx))
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", code],
+                cwd=ctx.import_root,
+                capture_output=True,
+                text=True,
+                timeout=SUBPROCESS_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            return HoistResult(ok=False, error="import run timed out")
+        if proc.returncode == 0:
+            return HoistResult(ok=True, error="")
+        return HoistResult(ok=False, error=proc.stderr.strip())
+
+
+def verify_hoists(ctx: PackageContext, candidates: list[Candidate]) -> HoistResult:
+    """Empirically test whether hoisting all ``candidates`` breaks any import."""
+
+    def apply_hoists(pkg_copy: Path) -> None:
+        by_file: dict[str, list[str]] = {}
+        for candidate in candidates:
+            by_file.setdefault(candidate.rel_path, []).append(candidate.inline_import.statement)
+        for rel_path, statements in by_file.items():
+            target = pkg_copy / rel_path
+            # utf-8-sig: tolerate files saved with a UTF-8 BOM
+            source = target.read_text(encoding="utf-8-sig")
+            for statement in statements:
+                source = hoist_import(source, statement)
+            target.write_text(source)
+
+    return _import_all_from_copy(ctx, mutate=apply_hoists)
+
+
+def classify_candidates(
+    candidates: list[Candidate],
+    verify: Callable[[list[Candidate]], HoistResult],
+) -> list[tuple[Candidate, bool, str]]:
+    """Return (candidate, hoistable, error) triples using batched bisection.
+
+    All candidates are hoisted together first; in the common case (everything
+    hoists cleanly) this costs a single run. On failure the set is bisected:
+    hoisting is monotone, so a set that imports cleanly proves every member
+    individually hoistable.
+    """
+    if not candidates:
+        return []
+    result = verify(candidates)
+    if result.ok:
+        return [(c, True, "") for c in candidates]
+    if len(candidates) == 1:
+        return [(candidates[0], False, result.error)]
+    mid = len(candidates) // 2
+    return classify_candidates(candidates[:mid], verify) + classify_candidates(candidates[mid:], verify)
+
+
+@dataclass
+class Finding:
+    path: Path
+    inline_import: InlineImport
+    # "violation"    unjustified and hoists cleanly                  -> fail
+    # "stale"        claims a cycle that empirically does not exist  -> fail
+    # "dubious"      claims lazy cost but module loads at startup    -> warn
+    # "legitimate"   unjustified but genuinely cannot be hoisted
+    # "justified"    claim checked (or config-blessed) and holds up
+    # "inconclusive" baseline import fails; nothing was proven       -> exit 2
+    verdict: str
+    error: str = ""
+
+
+def _scan_paths(package_dir: Path, files: tuple[Path, ...] | None) -> list[Path]:
+    """Return the files to scan: the whole package, or just ``files``.
+
+    Missing and non-Python files are skipped with a note (CI may pass deleted
+    or renamed paths); files outside the package are an error.
+    """
+    if files is None:
+        return sorted(package_dir.rglob("*.py"))
+    paths = []
+    for path in sorted(files):
+        if path.suffix != ".py" or not path.exists():
+            print(f"note: skipping {path} (missing or not a .py file)", file=sys.stderr)
+            continue
+        if not path.resolve().is_relative_to(package_dir.resolve()):
+            raise ValueError(f"{path} is not inside {package_dir}")
+        paths.append(path)
+    return paths
+
+
+def check_package(
+    package_dir: Path,
+    exclude: tuple[str, ...] = (),
+    files: tuple[Path, ...] | None = None,
+) -> list[Finding]:
+    """Find every inline import in the package and verify each one.
+
+    ``files`` restricts which files are scanned for inline imports (e.g. the
+    files changed in a PR); hoists are still verified against the whole
+    top-level package, since import cycles span sub-packages.
+
+    The hoisted runs are compared against a baseline run of the unmodified
+    package in the same environment. If the baseline itself fails, the
+    empirical test proves nothing and findings are marked inconclusive.
+    """
+    ctx = PackageContext.resolve(package_dir, exclude)
+    findings = []
+    empirical = []  # unjustified, or justified with a (testable) cycle claim
+    lazy_claimed = []
+    for path in _scan_paths(package_dir, files):
+        if ctx.skip(path.resolve().relative_to(package_dir.resolve())):
+            continue
+        rel_path = str(path.resolve().relative_to(ctx.top_package))
+        # utf-8-sig: tolerate files saved with a UTF-8 BOM
+        for imp in find_inline_imports(path.read_text(encoding="utf-8-sig")):
+            if is_banned_import(imp, ctx.banned_imports):
+                # config-blessed: ruff TID253 forces these to stay inline
+                findings.append(Finding(path, imp, "justified"))
+            elif imp.justification is None or claims_cycle(imp.justification):
+                empirical.append(Candidate(path, rel_path, imp))
+            elif claims_cost(imp.justification):
+                lazy_claimed.append(Candidate(path, rel_path, imp))
+            else:
+                # timing/patching constraints: not falsifiable, trusted
+                findings.append(Finding(path, imp, "justified"))
+
+    # Fact-check lazy/cost claims statically: a module already imported at
+    # module-import time elsewhere costs nothing extra to hoist.
+    if lazy_claimed:
+        index = module_time_import_index(ctx)
+        for c in lazy_claimed:
+            hit = loaded_at_module_time(c.inline_import.modules, index)
+            if hit is None:
+                findings.append(Finding(c.path, c.inline_import, "justified"))
+            else:
+                module, importer = hit
+                rel_importer = importer.relative_to(ctx.import_root)
+                findings.append(
+                    Finding(
+                        c.path,
+                        c.inline_import,
+                        "dubious",
+                        f"`{module}` is already imported at module level in {rel_importer}",
+                    )
+                )
+
+    # Empirically test the rest by hoisting: cycle claims must reproduce.
+    if empirical:
+        baseline = _import_all_from_copy(ctx)
+        if not baseline.ok:
+            findings += [Finding(c.path, c.inline_import, "inconclusive", baseline.error) for c in empirical]
+        else:
+            for c, hoistable, error in classify_candidates(empirical, lambda cands: verify_hoists(ctx, cands)):
+                if c.inline_import.justification is None:
+                    verdict = "violation" if hoistable else "legitimate"
+                else:
+                    verdict = "stale" if hoistable else "justified"
+                findings.append(Finding(c.path, c.inline_import, verdict, error))
+    findings.sort(key=lambda f: (str(f.path), f.inline_import.lineno))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("package", type=Path, help="Package directory to check")
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="GLOB",
+        help="Glob (relative to the package) of files to skip entirely,"
+        " e.g. 'lambdas/*' for standalone Lambda entry points. Repeatable.",
+    )
+    parser.add_argument(
+        "--files",
+        nargs="*",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help="Only scan these files for inline imports (e.g. the files changed"
+        " in a PR). Hoists are still verified against the whole package.",
+    )
+    args = parser.parse_args(argv)
+
+    django_settings = detect_django_settings(find_import_root(args.package.resolve()))
+    if django_settings:
+        print(f"Django project detected (settings: {django_settings})", file=sys.stderr)
+
+    files = tuple(args.files) if args.files is not None else None
+    findings = check_package(args.package, exclude=tuple(args.exclude), files=files)
+    counts = Counter(f.verdict for f in findings)
+    for f in findings:
+        loc = f"{f.path}:{f.inline_import.lineno}"
+        last_error = f.error.splitlines()[-1] if f.error else ""
+        if f.verdict == "violation":
+            print(f"FAIL {loc}: `{f.inline_import.statement}` hoists cleanly")
+            print("     Move it to module level, or justify it with `# noqa: PLC0415 - <reason>`.")
+        elif f.verdict == "stale":
+            print(
+                f"FAIL {loc}: `{f.inline_import.statement}` is justified as"
+                f' "{f.inline_import.justification}" but hoists cleanly — stale justification'
+            )
+            print("     Move it to module level, or correct the justification.")
+        elif f.verdict == "dubious":
+            print(
+                f"WARN {loc}: `{f.inline_import.statement}` is justified as"
+                f' "{f.inline_import.justification}" but {last_error}'
+            )
+        elif f.verdict == "inconclusive":
+            print(
+                f"???  {loc}: `{f.inline_import.statement}` could not be"
+                " verified; the package fails to import even without hoisting:"
+            )
+            print(f"     {last_error}")
+    if findings:
+        print(
+            f"Checked {len(findings)} inline imports:"
+            f" {counts['violation']} hoistable, {counts['stale']} stale,"
+            f" {counts['dubious']} dubious, {counts['legitimate']} legitimate,"
+            f" {counts['justified']} justified."
+        )
+    else:
+        print("No inline imports found.")
+    if counts["violation"] or counts["stale"]:
+        return 1
+    if counts["inconclusive"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_inline_imports.py
+++ b/scripts/test_check_inline_imports.py
@@ -1,0 +1,574 @@
+"""Tests for check_inline_imports.py.
+
+Run with: uv run pytest scripts/test_check_inline_imports.py -v
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from check_inline_imports import (  # noqa: E402
+    Candidate,
+    HoistResult,
+    InlineImport,
+    check_package,
+    claims_cycle,
+    classify_candidates,
+    detect_django_settings,
+    find_import_root,
+    find_inline_imports,
+    find_module_time_imports,
+    hoist_import,
+    is_banned_import,
+    load_banned_imports,
+    main,
+)
+
+
+def make_pkg(root: Path, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(content))
+
+
+class TestFindImportRoot:
+    def test_top_level_package(self, tmp_path):
+        make_pkg(tmp_path, {"pkg/__init__.py": ""})
+        assert find_import_root(tmp_path / "pkg") == tmp_path
+
+    def test_nested_package(self, tmp_path):
+        make_pkg(
+            tmp_path,
+            {"apps/__init__.py": "", "apps/experiments/__init__.py": ""},
+        )
+        assert find_import_root(tmp_path / "apps" / "experiments") == tmp_path
+
+
+class TestDetectDjangoSettings:
+    def test_no_manage_py(self, tmp_path):
+        assert detect_django_settings(tmp_path) is None
+
+    def test_manage_py_with_settings(self, tmp_path):
+        (tmp_path / "manage.py").write_text(
+            'import os\nos.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")\n'
+        )
+        assert detect_django_settings(tmp_path) == "config.settings"
+
+    def test_manage_py_single_quotes(self, tmp_path):
+        (tmp_path / "manage.py").write_text(
+            "import os\nos.environ.setdefault('DJANGO_SETTINGS_MODULE', 'proj.settings.dev')\n"
+        )
+        assert detect_django_settings(tmp_path) == "proj.settings.dev"
+
+    def test_manage_py_without_settings(self, tmp_path):
+        (tmp_path / "manage.py").write_text("print('hello')\n")
+        assert detect_django_settings(tmp_path) is None
+
+
+class TestHoistImport:
+    def test_multiple_statements_accumulate(self):
+        source = '"""Doc."""\nx = 1\n'
+        source = hoist_import(source, "import os")
+        source = hoist_import(source, "import sys")
+        lines = source.splitlines()
+        assert lines[0] == '"""Doc."""'
+        assert set(lines[1:3]) == {"import os", "import sys"}
+        assert lines[3] == "x = 1"
+
+
+def _candidate(name: str) -> Candidate:
+    return Candidate(
+        path=Path(f"{name}.py"),
+        rel_path=f"{name}.py",
+        inline_import=InlineImport(lineno=1, statement=f"import {name}"),
+    )
+
+
+class TestClassifyCandidates:
+    def test_all_pass_uses_single_run(self):
+        candidates = [_candidate("a"), _candidate("b"), _candidate("c")]
+        calls = []
+
+        def verify(cands):
+            calls.append(len(cands))
+            return HoistResult(ok=True, error="")
+
+        results = classify_candidates(candidates, verify)
+        assert calls == [3]
+        assert [hoistable for _, hoistable, _ in results] == [True] * 3
+
+    def test_single_failure_isolated(self):
+        candidates = [_candidate("a"), _candidate("bad"), _candidate("c")]
+
+        def verify(cands):
+            if any(c.rel_path == "bad.py" for c in cands):
+                return HoistResult(ok=False, error="ImportError: cycle")
+            return HoistResult(ok=True, error="")
+
+        results = dict(
+            (c.rel_path, (hoistable, error)) for c, hoistable, error in classify_candidates(candidates, verify)
+        )
+        assert results["a.py"] == (True, "")
+        assert results["c.py"] == (True, "")
+        assert results["bad.py"] == (False, "ImportError: cycle")
+
+    def test_empty(self):
+        assert classify_candidates([], lambda c: HoistResult(True, "")) == []
+
+
+class TestClaimsCycle:
+    def test_circular_prefix(self):
+        assert claims_cycle("circular: a imports b")
+
+    def test_circular_case_insensitive(self):
+        assert claims_cycle("Circular dependency with models")
+
+    def test_lazy_reason(self):
+        assert not claims_cycle("lazy: heavy lib, slow startup")
+
+    def test_timing_reason(self):
+        assert not claims_cycle("deferred until app registry is ready")
+
+
+class TestModuleTimeImports:
+    def test_collects_module_class_and_try_scope(self):
+        source = textwrap.dedent(
+            """
+            import os
+            try:
+                import fast_json
+            except ImportError:
+                import json
+            class C:
+                from collections import OrderedDict
+
+            def f():
+                import csv
+            """
+        )
+        names = find_module_time_imports(source, "pkg.sub")
+        assert {"os", "fast_json", "json", "collections"} <= names
+        assert "csv" not in names
+
+    def test_resolves_relative_imports(self):
+        names = find_module_time_imports("from . import audio\nfrom .speech import stt\n", "apps.channels")
+        assert "apps.channels.audio" in names
+        assert "apps.channels.speech" in names
+
+    def test_type_checking_blocks_excluded(self):
+        # TYPE_CHECKING imports never execute at runtime; the else branch does.
+        source = textwrap.dedent(
+            """
+            import typing
+            from typing import TYPE_CHECKING
+
+            if TYPE_CHECKING:
+                from twilio.rest import Client
+            if typing.TYPE_CHECKING:
+                import boto3
+            else:
+                import runtime_fallback
+            """
+        )
+        names = find_module_time_imports(source, "pkg")
+        assert "twilio.rest" not in names
+        assert "boto3" not in names
+        assert "runtime_fallback" in names
+
+
+class TestJustificationVerification:
+    """Justified imports are verified, not trusted (claims rot)."""
+
+    def test_stale_circular_claim_fails(self, tmp_path):
+        make_pkg(
+            tmp_path,
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": ("def f():\n    import json  # noqa: PLC0415 - circular: b imports a\n    return json\n"),
+            },
+        )
+        (finding,) = check_package(tmp_path / "pkg")
+        assert finding.verdict == "stale"
+
+    def test_confirmed_circular_claim_is_justified(self, tmp_path):
+        make_pkg(
+            tmp_path,
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": (
+                    "def f():\n    from pkg.b import g  # noqa: PLC0415 - circular: b imports a\n    return g\n"
+                ),
+                "pkg/b.py": "from pkg.a import f\ndef g():\n    return f\n",
+            },
+        )
+        findings = {f.path.name: f.verdict for f in check_package(tmp_path / "pkg")}
+        assert findings["a.py"] == "justified"
+
+    def test_dubious_lazy_claim_warns(self, tmp_path):
+        # json is claimed lazy in a.py but imported at module level in b.py.
+        make_pkg(
+            tmp_path,
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": ("def f():\n    import json  # noqa: PLC0415 - lazy: heavy lib\n    return json\n"),
+                "pkg/b.py": "import json\n",
+            },
+        )
+        (finding,) = check_package(tmp_path / "pkg")
+        assert finding.verdict == "dubious"
+        assert "b.py" in finding.error
+
+    def test_valid_lazy_claim_is_justified(self, tmp_path):
+        make_pkg(
+            tmp_path,
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": ("def f():\n    import json  # noqa: PLC0415 - lazy: heavy lib\n    return json\n"),
+            },
+        )
+        (finding,) = check_package(tmp_path / "pkg")
+        assert finding.verdict == "justified"
+
+    def test_non_cost_claims_are_not_cross_referenced(self, tmp_path):
+        # Timing/patching constraints are not falsifiable by the import index;
+        # only `lazy:`-prefixed (cost) claims are.
+        make_pkg(
+            tmp_path,
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": (
+                    "def f():\n"
+                    "    import json  # noqa: PLC0415 - deferred until app registry is ready\n"
+                    "    return json\n"
+                ),
+                "pkg/b.py": "import json\n",
+            },
+        )
+        (finding,) = check_package(tmp_path / "pkg")
+        assert finding.verdict == "justified"
+
+    def test_imports_in_test_files_do_not_indict_lazy_claims(self, tmp_path):
+        # Module-time imports in tests/factories/management commands are not
+        # production startup cost, so they cannot make a lazy claim dubious.
+        make_pkg(
+            tmp_path,
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": ("def f():\n    import json  # noqa: PLC0415 - lazy: heavy lib\n    return json\n"),
+                "pkg/tests/__init__.py": "",
+                "pkg/tests/test_a.py": "import json\n",
+                "pkg/tests/conftest.py": "import json\n",
+                "pkg/factories/__init__.py": "import json\n",
+                "pkg/management/commands/cmd.py": "import json\n",
+            },
+        )
+        findings = {f.path.name: f.verdict for f in check_package(tmp_path / "pkg")}
+        assert findings["a.py"] == "justified"
+
+    def test_stale_justification_fails_ci(self, tmp_path, capsys, monkeypatch):
+        make_pkg(
+            tmp_path,
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": ("def f():\n    import json  # noqa: PLC0415 - circular: b imports a\n    return json\n"),
+            },
+        )
+        monkeypatch.chdir(tmp_path)
+        exit_code = main(["pkg"])
+        out = capsys.readouterr().out
+        assert exit_code == 1
+        assert "stale" in out
+
+    def test_dubious_justification_warns_but_passes_ci(self, tmp_path, capsys, monkeypatch):
+        make_pkg(
+            tmp_path,
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": ("def f():\n    import json  # noqa: PLC0415 - lazy: heavy lib\n    return json\n"),
+                "pkg/b.py": "import json\n",
+            },
+        )
+        monkeypatch.chdir(tmp_path)
+        exit_code = main(["pkg"])
+        out = capsys.readouterr().out
+        assert exit_code == 0
+        assert "WARN" in out
+
+
+class TestLoadBannedImports:
+    def test_no_pyproject(self, tmp_path):
+        assert load_banned_imports(tmp_path) == ()
+
+    def test_pyproject_without_setting(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\nline-length = 100\n")
+        assert load_banned_imports(tmp_path) == ()
+
+    def test_pyproject_with_setting(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.ruff.lint.flake8-tidy-imports]\nbanned-module-level-imports = ["boto3", "langchain_openai"]\n'
+        )
+        assert load_banned_imports(tmp_path) == ("boto3", "langchain_openai")
+
+
+class TestIsBannedImport:
+    BANNED = ("boto3", "langchain_openai")
+
+    def _imp(self, source: str) -> InlineImport:
+        (imp,) = find_inline_imports(f"def f():\n    {source}\n")
+        return imp
+
+    def test_exact_module(self):
+        assert is_banned_import(self._imp("import boto3"), self.BANNED)
+
+    def test_from_import(self):
+        assert is_banned_import(self._imp("from langchain_openai import ChatOpenAI"), self.BANNED)
+
+    def test_submodule(self):
+        assert is_banned_import(self._imp("from boto3.s3.transfer import TransferConfig"), self.BANNED)
+
+    def test_prefix_is_not_submodule(self):
+        assert not is_banned_import(self._imp("import boto3_helpers"), self.BANNED)
+
+    def test_unrelated_module(self):
+        assert not is_banned_import(self._imp("import json"), self.BANNED)
+
+    def test_relative_import(self):
+        assert not is_banned_import(self._imp("from . import signals"), self.BANNED)
+
+
+class TestFindInlineImports:
+    def test_finds_function_imports(self):
+        source = textwrap.dedent(
+            """
+            import os
+
+            def f():
+                import json
+                return json
+            """
+        )
+        imports = find_inline_imports(source)
+        assert [i.statement for i in imports] == ["import json"]
+
+    def test_nested_function_import_reported_once(self):
+        source = textwrap.dedent(
+            """
+            def outer():
+                def inner():
+                    import json
+                    return json
+                return inner
+            """
+        )
+        imports = find_inline_imports(source)
+        assert [i.statement for i in imports] == ["import json"]
+
+    def test_lazy_marker_justifies(self):
+        source = textwrap.dedent(
+            """
+            def f():
+                import json  # lazy-import: heavy module
+            """
+        )
+        (imp,) = find_inline_imports(source)
+        assert imp.justification == "heavy module"
+
+    def test_noqa_dash_reason_justifies(self):
+        source = textwrap.dedent(
+            """
+            def f():
+                import json  # noqa: PLC0415 - lazy: heavy lib, slow startup
+            """
+        )
+        (imp,) = find_inline_imports(source)
+        assert imp.justification == "lazy: heavy lib, slow startup"
+
+    def test_noqa_multiple_codes_with_reason_justifies(self):
+        source = textwrap.dedent(
+            """
+            def f():
+                from . import signals  # noqa: F401, PLC0415 - circular: x imports y
+            """
+        )
+        (imp,) = find_inline_imports(source)
+        assert imp.justification == "circular: x imports y"
+
+    def test_bare_noqa_is_not_justified(self):
+        source = textwrap.dedent(
+            """
+            def f():
+                import json  # noqa: PLC0415
+            """
+        )
+        (imp,) = find_inline_imports(source)
+        assert imp.justification is None
+
+    def test_noqa_without_plc0415_reason_not_justified(self):
+        source = textwrap.dedent(
+            """
+            def f():
+                import json  # noqa: F401 - some reason
+            """
+        )
+        (imp,) = find_inline_imports(source)
+        assert imp.justification is None
+
+
+class TestCheckPackageEndToEnd:
+    """End-to-end on synthetic non-Django packages (real subprocesses)."""
+
+    def test_violation_and_legitimate(self, tmp_path):
+        # b->a at module level; a->b inline. Hoisting a->b creates a real
+        # cycle (legitimate). util's inline import hoists fine (violation).
+        make_pkg(
+            tmp_path,
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": ("def f():\n    from pkg.b import g\n    return g\n"),
+                "pkg/b.py": ("from pkg.a import f\ndef g():\n    return f\n"),
+                "pkg/util.py": ("def h():\n    import json\n    return json\n"),
+            },
+        )
+        findings = check_package(tmp_path / "pkg")
+        verdicts = {f"{f.path.name}:{f.inline_import.statement}": f.verdict for f in findings}
+        assert verdicts["a.py:from pkg.b import g"] == "legitimate"
+        assert verdicts["util.py:import json"] == "violation"
+
+    def test_subpackage_scan_imports_whole_tree(self, tmp_path):
+        # Scanning a sub-package must still resolve absolute imports through
+        # the top-level package (the original bug: No module named 'apps').
+        make_pkg(
+            tmp_path,
+            {
+                "apps/__init__.py": "",
+                "apps/exp/__init__.py": "",
+                "apps/exp/views.py": (
+                    "from apps.other.models import X\ndef f():\n    import json\n    return json, X\n"
+                ),
+                "apps/other/__init__.py": "",
+                "apps/other/models.py": "X = 1\n",
+            },
+        )
+        findings = check_package(tmp_path / "apps" / "exp")
+        (finding,) = findings
+        assert finding.verdict == "violation"
+
+    def test_migrations_skipped_for_django(self, tmp_path):
+        (tmp_path / "manage.py").write_text(
+            'import os\nos.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.missing")\n'
+        )
+        make_pkg(
+            tmp_path,
+            {
+                "pkg/__init__.py": "",
+                "pkg/migrations/__init__.py": "",
+                "pkg/migrations/0001_init.py": ("def forward(apps, schema_editor):\n    from pkg.models import X\n"),
+                "pkg/models.py": "X = 1\n",
+            },
+        )
+        findings = check_package(tmp_path / "pkg")
+        assert all("migrations" not in f.path.parts for f in findings)
+
+    def test_banned_imports_are_justified_without_verification(self, tmp_path):
+        # A banned-module-level import is deliberately inline; it must be
+        # skipped without spawning any verification subprocess.
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.ruff.lint.flake8-tidy-imports]\nbanned-module-level-imports = ["json"]\n'
+        )
+        make_pkg(
+            tmp_path,
+            {
+                "pkg/__init__.py": "",
+                "pkg/m.py": ("def f():\n    import json\n    return json\n"),
+            },
+        )
+        (finding,) = check_package(tmp_path / "pkg")
+        assert finding.verdict == "justified"
+
+
+def test_no_inline_imports(tmp_path):
+    make_pkg(tmp_path, {"pkg/__init__.py": "", "pkg/m.py": "import os\n"})
+    assert check_package(tmp_path / "pkg") == []
+
+
+class TestFilesMode:
+    """--files: scan only the given files, verify against the whole tree."""
+
+    def _make(self, tmp_path):
+        make_pkg(
+            tmp_path,
+            {
+                "pkg/__init__.py": "",
+                "pkg/one.py": ("def f():\n    import json\n    return json\n"),
+                "pkg/two.py": ("def g():\n    import csv\n    return csv\n"),
+            },
+        )
+        return tmp_path / "pkg"
+
+    def test_only_listed_files_scanned(self, tmp_path):
+        pkg = self._make(tmp_path)
+        findings = check_package(pkg, files=(pkg / "one.py",))
+        assert [f.path.name for f in findings] == ["one.py"]
+        assert findings[0].verdict == "violation"
+
+    def test_missing_file_skipped_with_note(self, tmp_path, capsys):
+        pkg = self._make(tmp_path)
+        findings = check_package(pkg, files=(pkg / "gone.py",))
+        assert findings == []
+        assert "gone.py" in capsys.readouterr().err
+
+    def test_non_python_file_skipped_with_note(self, tmp_path, capsys):
+        pkg = self._make(tmp_path)
+        (pkg / "data.txt").write_text("not python")
+        findings = check_package(pkg, files=(pkg / "data.txt",))
+        assert findings == []
+        assert "data.txt" in capsys.readouterr().err
+
+    def test_file_outside_package_rejected(self, tmp_path):
+        pkg = self._make(tmp_path)
+        (tmp_path / "outside.py").write_text("x = 1\n")
+        with pytest.raises(ValueError, match="outside.py"):
+            check_package(pkg, files=(tmp_path / "outside.py",))
+
+    def test_main_accepts_files_flag(self, tmp_path, capsys, monkeypatch):
+        self._make(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        exit_code = main(["pkg", "--files", "pkg/one.py"])
+        out = capsys.readouterr().out
+        assert exit_code == 1
+        assert "one.py:2: `import json` hoists cleanly" in out
+        assert "import csv" not in out
+
+    def test_main_with_no_files_is_noop(self, tmp_path, capsys, monkeypatch):
+        self._make(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        exit_code = main(["pkg", "--files"])
+        assert exit_code == 0
+        assert "No inline imports found." in capsys.readouterr().out
+
+
+class TestMainOutput:
+    def test_only_hoistable_imports_printed(self, tmp_path, capsys, monkeypatch):
+        # One legitimate cycle, one violation: only the violation is printed.
+        make_pkg(
+            tmp_path,
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": ("def f():\n    from pkg.b import g\n    return g\n"),
+                "pkg/b.py": ("from pkg.a import f\ndef g():\n    return f\n"),
+                "pkg/util.py": ("def h():\n    import json\n    return json\n"),
+            },
+        )
+        monkeypatch.chdir(tmp_path)
+        exit_code = main(["pkg"])
+        out = capsys.readouterr().out
+        assert exit_code == 1
+        assert "util.py:2: `import json` hoists cleanly" in out
+        assert "from pkg.b import g" not in out  # legitimate: not printed
+        assert "1 hoistable" in out
+        assert "1 legitimate" in out

--- a/scripts/test_check_inline_imports.py
+++ b/scripts/test_check_inline_imports.py
@@ -36,6 +36,15 @@ def make_pkg(root: Path, files: dict[str, str]) -> None:
         path.write_text(textwrap.dedent(content))
 
 
+def check_one_import(root: Path, import_line: str, extra_files: dict[str, str] | None = None) -> list:
+    """Build a package whose sole function makes ``import_line`` (plus any
+    ``extra_files``) and return the findings — the common single-import case."""
+    files = {"pkg/__init__.py": "", "pkg/a.py": f"def f():\n    {import_line}\n    return None\n"}
+    files.update(extra_files or {})
+    make_pkg(root, files)
+    return check_package(root / "pkg")
+
+
 class TestFindImportRoot:
     def test_top_level_package(self, tmp_path):
         make_pkg(tmp_path, {"pkg/__init__.py": ""})
@@ -185,81 +194,46 @@ class TestJustificationVerification:
     """Justified imports are verified, not trusted (claims rot)."""
 
     def test_stale_circular_claim_fails(self, tmp_path):
-        make_pkg(
-            tmp_path,
-            {
-                "pkg/__init__.py": "",
-                "pkg/a.py": ("def f():\n    import json  # noqa: PLC0415 - circular: b imports a\n    return json\n"),
-            },
-        )
-        (finding,) = check_package(tmp_path / "pkg")
+        (finding,) = check_one_import(tmp_path, "import json  # noqa: PLC0415 - circular: b imports a")
         assert finding.verdict == "stale"
 
     def test_confirmed_circular_claim_is_justified(self, tmp_path):
-        make_pkg(
+        findings = check_one_import(
             tmp_path,
-            {
-                "pkg/__init__.py": "",
-                "pkg/a.py": (
-                    "def f():\n    from pkg.b import g  # noqa: PLC0415 - circular: b imports a\n    return g\n"
-                ),
-                "pkg/b.py": "from pkg.a import f\ndef g():\n    return f\n",
-            },
+            "from pkg.b import g  # noqa: PLC0415 - circular: b imports a",
+            {"pkg/b.py": "from pkg.a import f\ndef g():\n    return f\n"},
         )
-        findings = {f.path.name: f.verdict for f in check_package(tmp_path / "pkg")}
-        assert findings["a.py"] == "justified"
+        assert {f.path.name: f.verdict for f in findings}["a.py"] == "justified"
 
     def test_dubious_lazy_claim_warns(self, tmp_path):
         # json is claimed lazy in a.py but imported at module level in b.py.
-        make_pkg(
-            tmp_path,
-            {
-                "pkg/__init__.py": "",
-                "pkg/a.py": ("def f():\n    import json  # noqa: PLC0415 - lazy: heavy lib\n    return json\n"),
-                "pkg/b.py": "import json\n",
-            },
+        (finding,) = check_one_import(
+            tmp_path, "import json  # noqa: PLC0415 - lazy: heavy lib", {"pkg/b.py": "import json\n"}
         )
-        (finding,) = check_package(tmp_path / "pkg")
         assert finding.verdict == "dubious"
         assert "b.py" in finding.error
 
     def test_valid_lazy_claim_is_justified(self, tmp_path):
-        make_pkg(
-            tmp_path,
-            {
-                "pkg/__init__.py": "",
-                "pkg/a.py": ("def f():\n    import json  # noqa: PLC0415 - lazy: heavy lib\n    return json\n"),
-            },
-        )
-        (finding,) = check_package(tmp_path / "pkg")
+        (finding,) = check_one_import(tmp_path, "import json  # noqa: PLC0415 - lazy: heavy lib")
         assert finding.verdict == "justified"
 
     def test_non_cost_claims_are_not_cross_referenced(self, tmp_path):
         # Timing/patching constraints are not falsifiable by the import index;
         # only `lazy:`-prefixed (cost) claims are.
-        make_pkg(
+        (finding,) = check_one_import(
             tmp_path,
-            {
-                "pkg/__init__.py": "",
-                "pkg/a.py": (
-                    "def f():\n"
-                    "    import json  # noqa: PLC0415 - deferred until app registry is ready\n"
-                    "    return json\n"
-                ),
-                "pkg/b.py": "import json\n",
-            },
+            "import json  # noqa: PLC0415 - deferred until app registry is ready",
+            {"pkg/b.py": "import json\n"},
         )
-        (finding,) = check_package(tmp_path / "pkg")
         assert finding.verdict == "justified"
 
     def test_imports_in_test_files_do_not_indict_lazy_claims(self, tmp_path):
         # Module-time imports in tests/factories/management commands are not
         # production startup cost, so they cannot make a lazy claim dubious.
-        make_pkg(
+        findings = check_one_import(
             tmp_path,
+            "import json  # noqa: PLC0415 - lazy: heavy lib",
             {
-                "pkg/__init__.py": "",
-                "pkg/a.py": ("def f():\n    import json  # noqa: PLC0415 - lazy: heavy lib\n    return json\n"),
                 "pkg/tests/__init__.py": "",
                 "pkg/tests/test_a.py": "import json\n",
                 "pkg/tests/conftest.py": "import json\n",
@@ -267,37 +241,21 @@ class TestJustificationVerification:
                 "pkg/management/commands/cmd.py": "import json\n",
             },
         )
-        findings = {f.path.name: f.verdict for f in check_package(tmp_path / "pkg")}
-        assert findings["a.py"] == "justified"
+        assert {f.path.name: f.verdict for f in findings}["a.py"] == "justified"
 
     def test_stale_justification_fails_ci(self, tmp_path, capsys, monkeypatch):
-        make_pkg(
-            tmp_path,
-            {
-                "pkg/__init__.py": "",
-                "pkg/a.py": ("def f():\n    import json  # noqa: PLC0415 - circular: b imports a\n    return json\n"),
-            },
-        )
+        check_one_import(tmp_path, "import json  # noqa: PLC0415 - circular: b imports a")
         monkeypatch.chdir(tmp_path)
         exit_code = main(["pkg"])
-        out = capsys.readouterr().out
         assert exit_code == 1
-        assert "stale" in out
+        assert "stale" in capsys.readouterr().out
 
     def test_dubious_justification_warns_but_passes_ci(self, tmp_path, capsys, monkeypatch):
-        make_pkg(
-            tmp_path,
-            {
-                "pkg/__init__.py": "",
-                "pkg/a.py": ("def f():\n    import json  # noqa: PLC0415 - lazy: heavy lib\n    return json\n"),
-                "pkg/b.py": "import json\n",
-            },
-        )
+        check_one_import(tmp_path, "import json  # noqa: PLC0415 - lazy: heavy lib", {"pkg/b.py": "import json\n"})
         monkeypatch.chdir(tmp_path)
         exit_code = main(["pkg"])
-        out = capsys.readouterr().out
         assert exit_code == 0
-        assert "WARN" in out
+        assert "WARN" in capsys.readouterr().out
 
 
 class TestLoadBannedImports:


### PR DESCRIPTION
### Product Description
No change — developer tooling and import cleanup.

### Technical Description
ruff already requires a `# noqa` comment on every import that lives inside a function (PLC0415). The problem is the *reason* in that comment can be wrong — it goes stale as code changes, and AI-generated code often makes one up. This PR found two imports justified as "circular" where the cycle no longer existed.

`scripts/check_inline_imports.py` checks those reasons instead of trusting them. It copies `apps/` to a temp dir, moves a candidate import up to module level, and tries to import the whole project under `django.setup()`:

- **No reason / "circular" reason** → move it up and see if imports still work. If they do, the reason is false → **FAIL**.
- **"lazy" (load cost) reason** → check whether that module is already imported at startup elsewhere. If it is, the reason is void → **WARN** (doesn't block CI; the heuristic can be wrong).
- **Timing / test-patching reasons** → trusted (can't be checked either way).
- **Modules in ruff's banned list** → skipped (ruff already forces those inline).

A new `inline-imports` CI job runs the checker on a PR's changed `apps/**.py` files only — about 1–2 minutes when Python files change, and it skips setup entirely otherwise.

The rest of the diff is the cleanup a full project sweep turned up: 65 imports either moved to module level or given an accurate reason. That's what lets the CI gate start from a clean slate.

**Worth a closer look during review:**
- `speech_service.py`: moving its imports up flipped the correct `mock.patch` target from the source module to the usage site — the two `test_voice_providers.py` changes are exactly that.
- `channels/tasks.py` ↔ `email_channel.py`, and the `documents` task ↔ service pair, are genuine import cycles. One side of each stays inline, with a corrected reason.
- 9 "dubious lazy" warnings remain (in `llm_service/main.py` and `llm_service/utils.py`). They don't fail CI and are tracked in #3560.

**Verification:**
- Full sweep after cleanup: 0 imports that should move, 0 false reasons.
- Affected-app tests (1,872) pass.
- Startup time is unchanged. Timing `django.setup()` 7× on each branch: main 5.885s median, this branch 5.983s — a 0.1s gap that's within normal run-to-run noise (the ranges overlap). The heavy libraries moved up in `speech_service.py` (pydub, openai, elevenlabs) are already loaded at startup on `main` anyway, so moving them costs nothing — which is the same thing the checker's "dubious lazy" warning is pointing at.

### Docs and Changelog
- [ ] This PR requires docs/changelog update
