### PR TITLE
Make prelogin contact form and email configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,14 @@ ACCOUNT_EMAIL_VERIFICATION=mandatory
 # TERMS_URL=
 # PRIVACY_POLICY_URL=
 
+## Prelogin contact page (optional)
+## Contact email shown on the contact page (leave unset to hide it)
+# PRELOGIN_CONTACT_EMAIL=
+## HubSpot embedded form (leave portal/form IDs unset to hide the form)
+# HUBSPOT_FORM_REGION=na1
+# HUBSPOT_FORM_PORTAL_ID=
+# HUBSPOT_FORM_ID=
+
 ## Optional Slack integration
 SLACK_CLIENT_ID=
 SLACK_CLIENT_SECRET=

--- a/apps/prelogin/tests/test_views.py
+++ b/apps/prelogin/tests/test_views.py
@@ -46,7 +46,46 @@ def test_applications_page_renders(client):
 def test_contact_page_renders(client):
     response = client.get(reverse("prelogin:contact"))
     assert response.status_code == 200
-    assert b"hubspot-form" in response.content
+    assert b"collaborate" in response.content
+
+
+@pytest.mark.django_db()
+def test_contact_page_shows_hubspot_form_when_configured(client, settings):
+    settings.HUBSPOT_FORM_PORTAL_ID = "503070"
+    settings.HUBSPOT_FORM_ID = "ab84dc67-539d-40d3-b9ac-466d8b8348bf"
+    response = client.get(reverse("prelogin:contact"))
+    content = response.content.decode()
+    assert 'id="hubspot-form"' in content
+    assert "js.hsforms.net" in content
+    assert "503070" in content
+
+
+@pytest.mark.django_db()
+def test_contact_page_hides_hubspot_form_when_not_configured(client, settings):
+    settings.HUBSPOT_FORM_PORTAL_ID = ""
+    settings.HUBSPOT_FORM_ID = ""
+    response = client.get(reverse("prelogin:contact"))
+    content = response.content.decode()
+    assert 'id="hubspot-form"' not in content
+    assert "js.hsforms.net" not in content
+
+
+@pytest.mark.django_db()
+def test_contact_page_shows_contact_email_when_configured(client, settings):
+    settings.HUBSPOT_FORM_PORTAL_ID = ""
+    settings.HUBSPOT_FORM_ID = ""
+    settings.PRELOGIN_CONTACT_EMAIL = "hello@example.com"
+    response = client.get(reverse("prelogin:contact"))
+    assert b"mailto:hello@example.com" in response.content
+
+
+@pytest.mark.django_db()
+def test_contact_page_omits_email_when_not_configured(client, settings):
+    settings.HUBSPOT_FORM_PORTAL_ID = ""
+    settings.HUBSPOT_FORM_ID = ""
+    settings.PRELOGIN_CONTACT_EMAIL = ""
+    response = client.get(reverse("prelogin:contact"))
+    assert b"mailto:" not in response.content
 
 
 @pytest.mark.django_db()

--- a/apps/prelogin/urls.py
+++ b/apps/prelogin/urls.py
@@ -11,11 +11,7 @@ urlpatterns = [
         TemplateView.as_view(template_name="prelogin/about.html", extra_context={"active_nav": "about"}),
         name="about",
     ),
-    path(
-        "contact/",
-        TemplateView.as_view(template_name="prelogin/contact.html", extra_context={"active_nav": "contact"}),
-        name="contact",
-    ),
+    path("contact/", views.contact, name="contact"),
     path(
         "applications/",
         TemplateView.as_view(template_name="prelogin/applications.html", extra_context={"active_nav": "applications"}),

--- a/apps/prelogin/views.py
+++ b/apps/prelogin/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect, render
@@ -21,3 +22,22 @@ def home(request):
             return HttpResponseRedirect(reverse("teams:create_team"))
     else:
         return render(request, "prelogin/home.html", {"active_nav": "home"})
+
+
+def contact(request):
+    hubspot_form = None
+    if settings.HUBSPOT_FORM_PORTAL_ID and settings.HUBSPOT_FORM_ID:
+        hubspot_form = {
+            "region": settings.HUBSPOT_FORM_REGION,
+            "portal_id": settings.HUBSPOT_FORM_PORTAL_ID,
+            "form_id": settings.HUBSPOT_FORM_ID,
+        }
+    return render(
+        request,
+        "prelogin/contact.html",
+        {
+            "active_nav": "contact",
+            "contact_email": settings.PRELOGIN_CONTACT_EMAIL,
+            "hubspot_form": hubspot_form,
+        },
+    )

--- a/config/settings.py
+++ b/config/settings.py
@@ -591,6 +591,14 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 # Add your google analytics ID to the environment to connect to Google Analytics
 GOOGLE_ANALYTICS_ID = env("GOOGLE_ANALYTICS_ID", default="")
 
+# Prelogin marketing pages
+# Optional contact email shown on the contact page. Leave unset to hide the email.
+PRELOGIN_CONTACT_EMAIL = env("PRELOGIN_CONTACT_EMAIL", default="")
+# HubSpot contact form embed. Leave portal/form IDs unset to hide the form.
+HUBSPOT_FORM_REGION = env("HUBSPOT_FORM_REGION", default="na1")
+HUBSPOT_FORM_PORTAL_ID = env("HUBSPOT_FORM_PORTAL_ID", default="")
+HUBSPOT_FORM_ID = env("HUBSPOT_FORM_ID", default="")
+
 # Sentry setup
 
 # populate this to configure sentry. should take the form: 'https://****@sentry.io/12345'

--- a/templates/prelogin/contact.html
+++ b/templates/prelogin/contact.html
@@ -24,13 +24,13 @@
     "@type": "Organization",
     "name": "Open Chat Studio by Dimagi",
     "url": "{{ request.build_absolute_uri }}",
-    "contactPoint": {
+    {% if contact_email %}"contactPoint": {
       "@type": "ContactPoint",
       "contactType": "sales",
-      "email": "ocs-info@dimagi.com",
+      "email": "{{ contact_email }}",
       "availableLanguage": "English"
     },
-    "parentOrganization": {
+    {% endif %}"parentOrganization": {
       "@type": "Organization",
       "name": "Dimagi, Inc.",
       "url": "https://dimagi.com/"
@@ -220,9 +220,16 @@
       <div class="contact-intro">
         <h1>Let's <em>collaborate</em></h1>
         <p>Tell us what you'd like to build, deploy, or research with Open Chat Studio, and we'll be in touch to explore how we can work together.</p>
-        <p>Fill in the form below, or email us at <a href="mailto:ocs-info@dimagi.com">ocs-info@dimagi.com</a>.</p>
+        {% if hubspot_form and contact_email %}
+        <p>Fill in the form below, or email us at <a href="mailto:{{ contact_email }}">{{ contact_email }}</a>.</p>
+        {% elif hubspot_form %}
+        <p>Fill in the form below and we'll be in touch.</p>
+        {% elif contact_email %}
+        <p>Email us at <a href="mailto:{{ contact_email }}">{{ contact_email }}</a> and we'll be in touch.</p>
+        {% endif %}
       </div>
 
+      {% if hubspot_form %}
       <div class="form-card">
         <div id="hubspot-form">
           <div class="form-fallback" id="hubspot-form-fallback">
@@ -230,6 +237,14 @@
           </div>
         </div>
       </div>
+      {% elif contact_email %}
+      <div class="form-card">
+        <div class="form-fallback">
+          <strong>Email us</strong><br>
+          Drop us a line at <a href="mailto:{{ contact_email }}">{{ contact_email }}</a> and we'll be in touch.
+        </div>
+      </div>
+      {% endif %}
 
       <div class="support-card">
         <div class="support-card-content">
@@ -246,15 +261,16 @@
 {% endblock content %}
 
 {% block page_scripts %}
+{% if hubspot_form %}
 <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/embed/v2.js"></script>
 <script>
   (function () {
     function mountForm() {
       if (typeof hbspt === 'undefined' || !hbspt.forms) return false;
       hbspt.forms.create({
-        region: "na1",
-        portalId: "503070",
-        formId: "ab84dc67-539d-40d3-b9ac-466d8b8348bf",
+        region: "{{ hubspot_form.region }}",
+        portalId: "{{ hubspot_form.portal_id }}",
+        formId: "{{ hubspot_form.form_id }}",
         target: "#hubspot-form",
         onFormReady: function () {
           var fb = document.getElementById('hubspot-form-fallback');
@@ -269,4 +285,5 @@
     }
   })();
 </script>
+{% endif %}
 {% endblock page_scripts %}


### PR DESCRIPTION
### Product Description
Operators hosting their own Open Chat Studio instance can now show their own contact email and HubSpot form on the contact page, instead of Dimagi's hardcoded values. The form and email each render only when configured.

### Technical Description
The contact page previously hardcoded Dimagi's HubSpot portal/form IDs and `ocs-info@dimagi.com` in the template. These now come from settings (`PRELOGIN_CONTACT_EMAIL`, `HUBSPOT_FORM_REGION/PORTAL_ID/FORM_ID`), so the page degrades gracefully for other hosts.

The contact route moved from a plain `TemplateView` to a small `contact` view that builds a `hubspot_form` dict only when both portal + form IDs are set. The template branches on that: form + embed script render when configured, otherwise an "email us" CTA shows when an email is set; the JSON-LD `contactPoint` and intro line follow the same rule.

Note for the Dimagi deploy: the previously-hardcoded values now need to be set as env vars (`HUBSPOT_FORM_PORTAL_ID=503070`, `HUBSPOT_FORM_ID=ab84dc67-539d-40d3-b9ac-466d8b8348bf`, `PRELOGIN_CONTACT_EMAIL=ocs-info@dimagi.com`) or the page renders in its no-form/no-email state.

### Migrations
N/A — no migrations.

### Demo
Contact page with neither HubSpot nor email configured shows intro + builders card only; with email set, an "email us" card; with HubSpot configured, the embedded form as before.

### Docs and Changelog
- [ ] This PR requires docs/changelog update