### PR TITLE
Replace chatbots.dimagi.com with www.openchatstudio.com

### DIFF
--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -319,7 +319,7 @@ paths:
 
         client = OpenAI(
             api_key="your API key",
-            base_url=f"https://chatbots.dimagi.com/api/openai/{experiment_id}",
+            base_url=f"https://www.openchatstudio.com/api/openai/{experiment_id}",
         )
 
         completion = client.chat.completions.create(
@@ -378,7 +378,7 @@ paths:
 
         client = OpenAI(
             api_key="your API key",
-            base_url=f"https://chatbots.dimagi.com/api/openai/{experiment_id}/v{version}",
+            base_url=f"https://www.openchatstudio.com/api/openai/{experiment_id}/v{version}",
         )
 
         completion = client.chat.completions.create(

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -10,14 +10,14 @@ import requests
 headers = {"Accept": "application/json", "Content-Type": "application/json", "X-Api-Key": "<api-key>"}
 
 # List experiments
-response = requests.get("https://chatbots.dimagi.com/api/experiments", headers=headers)
+response = requests.get("https://www.openchatstudio.com/api/experiments", headers=headers)
 experiments = response.json()
 experiment_id = experiments[0]["id"]
 
 # Start a conversation with the experiment bot
 data = {"message": "Hi there"}
 response = requests.post(
-    f"https://chatbots.dimagi.com/channels/api/{experiment_id}/incoming_message",
+    f"https://www.openchatstudio.com/channels/api/{experiment_id}/incoming_message",
     data=data,
     headers=headers
 )
@@ -40,13 +40,13 @@ data = {
     ],
 }
 
-response = requests.post("https://chatbots.dimagi.com/api/sessions", data=data, headers=headers)
+response = requests.post("https://www.openchatstudio.com/api/sessions", data=data, headers=headers)
 session_id = response.json()["id"]
 
 # Update the session with a new message
 data = {"message": "Hi there", "session": session_id}
 response = requests.post(
-    f"https://chatbots.dimagi.com/channels/api/{experiment_id}/incoming_message",
+    f"https://www.openchatstudio.com/channels/api/{experiment_id}/incoming_message",
     data=data,
     headers=headers
 )

--- a/apps/api/openai.py
+++ b/apps/api/openai.py
@@ -45,7 +45,7 @@ create_chat_completion_response = inline_serializer(
 def chat_completions_schema(versioned: bool):
     operation_id = "openai_chat_completions"
     summary = "Chat Completions API for Experiments"
-    base_url = "https://chatbots.dimagi.com/api/openai/{experiment_id}"
+    base_url = "https://www.openchatstudio.com/api/openai/{experiment_id}"
 
     parameters = [
         OpenApiParameter(
@@ -59,7 +59,7 @@ def chat_completions_schema(versioned: bool):
     if versioned:
         operation_id = f"{operation_id}_versioned"
         summary = "Versioned Chat Completions API for Experiments"
-        base_url = "https://chatbots.dimagi.com/api/openai/{experiment_id}/v{version}"
+        base_url = "https://www.openchatstudio.com/api/openai/{experiment_id}/v{version}"
         parameters.append(
             OpenApiParameter(
                 name="version",

--- a/apps/channels/README.md
+++ b/apps/channels/README.md
@@ -14,7 +14,7 @@ and page access token (this is the token that was generated). You'll notice anot
 
 
 ### 3. Set up a webhook from the Meta App to OpenChatStudio
-1. In your Meta App's settings, under the Webhooks section, click on "Add Callback URL" and provide `https://chatbots.dimagi.com/channels/facebook/<your team slug>/incoming_message` as the callback URL. The Verify Token to use here is the one you saw when creating the Facebook channel in OpenChatStudio.
+1. In your Meta App's settings, under the Webhooks section, click on "Add Callback URL" and provide `https://www.openchatstudio.com/channels/facebook/<your team slug>/incoming_message` as the callback URL. The Verify Token to use here is the one you saw when creating the Facebook channel in OpenChatStudio.
 
 2. Once the webhook is set up, click on the `Add Subscriptions` button on the right hand side of the webhooks section and
 subscribe to the `messages` field. Currently only this field is supported.

--- a/apps/service_providers/llm_service/utils.py
+++ b/apps/service_providers/llm_service/utils.py
@@ -27,7 +27,7 @@ def detangle_file_ids(file_ids: list[str]) -> list[str]:
     return detangled_file_ids
 
 
-def extract_file_ids_from_ocs_citations(text: str) -> list[int]:
+def extract_file_ids_from_ocs_citations(text: str) -> list[str]:
     from apps.chat.agent.tools import OCS_CITATION_PATTERN  # noqa: PLC0415 - lazy: chat.agent.tools
 
     file_ids = []

--- a/apps/users/management/commands/migrate_2fa_data.py
+++ b/apps/users/management/commands/migrate_2fa_data.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
             row = cursor.fetchone()
             return row[0] if row else False
 
-    def _get_totp_devices(self):
+    def _get_totp_devices(self) -> list[dict]:
         """Get TOTP devices using raw SQL."""
         with connection.cursor() as cursor:
             cursor.execute("""

--- a/config/settings.py
+++ b/config/settings.py
@@ -578,7 +578,7 @@ PROJECT_METADATA = {
     "URL": "http://localhost:8000",
     "DESCRIPTION": gettext_lazy("Build Chatbots and deploy them to WhatsApp, Telegram, Slack and more"),
     "CONTACT_EMAIL": "devops+openchatstudio@dimagi.com",
-    "IMAGE": "https://chatbots.dimagi.com/static/images/logo.png",
+    "IMAGE": "https://www.openchatstudio.com/static/images/logo.png",
     "TERMS_URL": env("TERMS_URL", default=""),
     "PRIVACY_POLICY_URL": env("PRIVACY_POLICY_URL", default=""),
     "DOCS_URL": env("DOCS_URL", default="https://docs.openchatstudio.com"),

--- a/locust/README.md
+++ b/locust/README.md
@@ -30,7 +30,7 @@ python locust/get_chatbot_ids.py
 OCS_API_KEY=your-key python locust/get_chatbot_ids.py
 
 # Connect to a different instance
-OCS_API_KEY=your-key python locust/get_chatbot_ids.py --base-url https://chatbots.dimagi.com
+OCS_API_KEY=your-key python locust/get_chatbot_ids.py --base-url https://www.openchatstudio.com
 
 # Export as environment variable
 eval $(OCS_API_KEY=your-key python locust/get_chatbot_ids.py --format env)

--- a/locust/get_chatbot_ids.py
+++ b/locust/get_chatbot_ids.py
@@ -6,7 +6,7 @@ This script lists available chatbots (experiments) with their IDs.
 
 Usage:
     python locust/get_chatbot_ids.py
-    python locust/get_chatbot_ids.py --base-url https://chatbots.dimagi.com
+    python locust/get_chatbot_ids.py --base-url https://www.openchatstudio.com
     python locust/get_chatbot_ids.py --format env
     OCS_API_KEY=your-key python locust/get_chatbot_ids.py --format list
 """
@@ -127,7 +127,7 @@ Examples:
     OCS_API_KEY=your-key python locust/get_chatbot_ids.py
 
     # Specify a different base URL
-    python locust/get_chatbot_ids.py --base-url https://chatbots.dimagi.com
+    python locust/get_chatbot_ids.py --base-url https://www.openchatstudio.com
 
     # Export as environment variable
     OCS_API_KEY=your-key python locust/get_chatbot_ids.py --format env

--- a/templates/prelogin/applications.html
+++ b/templates/prelogin/applications.html
@@ -265,7 +265,7 @@
             <p class="uc-panel-desc">Chatbots for behavior change communication, health coaching, and personal wellbeing, reaching people in their own language on the platforms they already use.</p>
             <div style="margin-top:32px;">
               <div class="uc-bot-label">Example Bot: For Demonstration &amp; Research Purposes Only</div>
-              <a class="bot-card bot-card-h" href="https://chatbots.dimagi.com/a/dimagi/experiments/e/6d5abc50-167d-4e78-a2a1-6ff6d3cb229c/start/" target="_blank" rel="noopener">
+              <a class="bot-card bot-card-h" href="https://www.openchatstudio.com/a/dimagi/experiments/e/6d5abc50-167d-4e78-a2a1-6ff6d3cb229c/start/" target="_blank" rel="noopener">
                 <div class="bot-card-head" style="background:linear-gradient(135deg,#16006D 0%,#16006D 100%);">
                   <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
@@ -339,7 +339,7 @@
             <p class="uc-panel-desc">Personal coaches that help community health workers build capability through role-play, case-based learning, and structured feedback, deployed on the messaging apps they already use.</p>
             <div style="margin-top:32px;">
               <div class="uc-bot-label">Example Bot: For Demonstration &amp; Research Purposes Only</div>
-              <a class="bot-card bot-card-h" href="https://chatbots.dimagi.com/a/dimagi/experiments/e/d61f49c1-ebea-4d1e-98ec-d0b5cb111c10/start/" target="_blank" rel="noopener">
+              <a class="bot-card bot-card-h" href="https://www.openchatstudio.com/a/dimagi/experiments/e/d61f49c1-ebea-4d1e-98ec-d0b5cb111c10/start/" target="_blank" rel="noopener">
                 <div class="bot-card-head" style="background:linear-gradient(135deg,#16006D 0%,#16006D 100%);">
                   <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
@@ -414,7 +414,7 @@
             <p class="uc-panel-desc">Tools for multilateral agencies, funders, and implementing partners to improve knowledge navigation, data access, and program management at the systems level.</p>
             <div style="margin-top:32px;">
               <div class="uc-bot-label">Example Bot: For Demonstration &amp; Research Purposes Only</div>
-              <a class="bot-card bot-card-h" href="https://chatbots.dimagi.com/a/dimagi/experiments/e/f4219b24-3f35-45c3-91e8-60949439ce3a/start/" target="_blank" rel="noopener">
+              <a class="bot-card bot-card-h" href="https://www.openchatstudio.com/a/dimagi/experiments/e/f4219b24-3f35-45c3-91e8-60949439ce3a/start/" target="_blank" rel="noopener">
                 <div class="bot-card-head" style="background:linear-gradient(135deg,#16006D 0%,#16006D 100%);">
                   <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2"/>


### PR DESCRIPTION
### Product Description
Updates all references to the old `chatbots.dimagi.com` domain to the new `www.openchatstudio.com` domain.

### Technical Description
Direct URL/string replacements across API schema examples, docs, OpenAI service config, Facebook channel setup, project metadata, load-test helpers, and public templates. No logic, behavior, or data-structure changes.

### Migrations
- [x] The migrations are backwards compatible

No DB migrations.

### Docs and Changelog
- [ ] This PR requires docs/changelog update