### PR TITLE
Style auth pages to match the pre-login site

### DIFF
--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,39 +1,33 @@
-{% extends "web/base.html" %}
+{% extends "prelogin/auth_base.html" %}
 {% load form_tags i18n static %}
+{% block title %}
+  {% translate "Sign In" %} | Open Chat Studio
+{% endblock title %}
 
-{% block body %}
-  <div class="flex justify-center my-8 ">
-    <div class="w-96 px-4 py-4 bg-white dark:bg-neutral-800">
-      <div>
-        <h2 class="mt-6 text-center text-2xl font-bold text-gray-900 dark:text-gray-200">
-          {% translate "Sign In" %}
-        </h2>
-        <form class="mt-6 space-y-6" method="post">
-          {% csrf_token %}
-          {{ form.non_field_errors }}
-          {% if form.login %}
-            {% render_field form.login %}
-          {% endif %}
-          {% if form.password %}
-            {% render_field form.password %}
-          {% endif %}
-          <div>
-            {% if form.password %}
-              {% translate "Sign In" as btn_text %}
-            {% else %}
-              {% translate "Continue" as btn_text %}
-            {% endif %}
-            <input class="btn btn-primary btn-block" type="submit" value="{{ btn_text }}">
-          </div>
-        </form>
-        {% if form.password %}
-          <div class="text-sm mt-4">
-            <a href="{% url 'account_reset_password' %}" class="font-medium text-blue-700 dark:text-blue-300 hover:text-blue-500">
-              {% translate "Forgot password?" %}
-            </a>
-          </div>
-        {% endif %}
-      </div>
+{% block card_eyebrow %}
+  <h1 class="card-eyebrow">{% translate "Sign In" %}</h1>
+{% endblock card_eyebrow %}
+
+{% block auth_body %}
+  <form method="post">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    {% if form.login %}
+      {% render_field form.login %}
+    {% endif %}
+    {% if form.password %}
+      {% render_field form.password %}
+    {% endif %}
+    {% if form.password %}
+      {% translate "Sign In" as btn_text %}
+    {% else %}
+      {% translate "Continue" as btn_text %}
+    {% endif %}
+    <input class="btn btn-indigo" type="submit" value="{{ btn_text }}">
+  </form>
+  {% if form.password %}
+    <div class="auth-foot">
+      <a class="auth-link" href="{% url 'account_reset_password' %}">{% translate "Forgot password?" %}</a>
     </div>
-  </div>
-{% endblock body %}
+  {% endif %}
+{% endblock auth_body %}

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -2,7 +2,7 @@
 {% load account form_tags i18n static %}
 {# Restore the nav "Sign In" CTA: someone who remembers their password can bail to login #}
 {% block nav_signin_cta %}
-  <a class="btn btn-primary" href="{% url 'sso:login' %}">Sign In</a>
+  <a class="btn btn-primary" href="{% url 'sso:login' %}">{% translate "Sign In" %}</a>
 {% endblock nav_signin_cta %}
 
 {% block auth_body %}
@@ -23,7 +23,7 @@
            type="submit"
            value="{% translate "Send Password Reset" %}">
     <div class="pg-help">
-      {% blocktranslate %}
+      {% blocktranslate trimmed %}
         Please contact us if you have any trouble resetting your password.
       {% endblocktranslate %}
     </div>

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -1,22 +1,31 @@
-{% extends "account/base.html" %}
+{% extends "prelogin/auth_base.html" %}
 {% load account form_tags i18n static %}
-{% block content %}
+{# Restore the nav "Sign In" CTA: someone who remembers their password can bail to login #}
+{% block nav_signin_cta %}
+  <a class="btn btn-primary" href="{% url 'sso:login' %}">Sign In</a>
+{% endblock nav_signin_cta %}
+
+{% block auth_body %}
   <h1 class="pg-title">{% translate "Password Reset" %}</h1>
   {% if user.is_authenticated %}
     {% include "account/snippets/already_logged_in.html" %}
   {% endif %}
-  <h2 class="pg-subtitle">{% translate "Forgot your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}</h2>
-  <form method="post" action="{% url 'account_reset_password' %}" class="password_reset">
+  <h2 class="pg-subtitle">
+    {% translate "Forgot your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}
+  </h2>
+  <form method="post"
+        action="{% url 'account_reset_password' %}"
+        class="password_reset">
     {% csrf_token %}
     {{ form.non_field_errors }}
     {% render_field form.email %}
-    <div class="mt-2">
-      <input class="btn btn-primary" type="submit" value="{% translate "Send Password Reset" %}">
-    </div>
-    <div class="mt-2 pg-help">
+    <input class="btn btn-indigo"
+           type="submit"
+           value="{% translate "Send Password Reset" %}">
+    <div class="pg-help">
       {% blocktranslate %}
         Please contact us if you have any trouble resetting your password.
       {% endblocktranslate %}
     </div>
   </form>
-{% endblock content %}
+{% endblock auth_body %}

--- a/templates/account/password_reset_done.html
+++ b/templates/account/password_reset_done.html
@@ -6,8 +6,8 @@
     {% include "account/snippets/already_logged_in.html" %}
   {% endif %}
   <h2 class="pg-subtitle">
-    {% blocktranslate %}
-            We've sent you an e-mail. Please get in touch if you do not receive it within a few minutes.
-        {% endblocktranslate %}
+    {% blocktranslate trimmed %}
+      We've sent you an e-mail. Please get in touch if you do not receive it within a few minutes.
+    {% endblocktranslate %}
   </h2>
 {% endblock auth_body %}

--- a/templates/account/password_reset_done.html
+++ b/templates/account/password_reset_done.html
@@ -1,13 +1,13 @@
-{% extends "account/base.html" %}
+{% extends "prelogin/auth_base.html" %}
 {% load account i18n %}
-{% block content %}
-    <h1 class="pg-title">{% translate "Password Reset" %}</h1>
-    {% if user.is_authenticated %}
-        {% include "account/snippets/already_logged_in.html" %}
-    {% endif %}
-    <h2 class="pg-subtitle">
-        {% blocktranslate %}
+{% block auth_body %}
+  <h1 class="pg-title">{% translate "Password Reset" %}</h1>
+  {% if user.is_authenticated %}
+    {% include "account/snippets/already_logged_in.html" %}
+  {% endif %}
+  <h2 class="pg-subtitle">
+    {% blocktranslate %}
             We've sent you an e-mail. Please get in touch if you do not receive it within a few minutes.
         {% endblocktranslate %}
-    </h2>
-{% endblock content %}
+  </h2>
+{% endblock auth_body %}

--- a/templates/account/password_reset_from_key.html
+++ b/templates/account/password_reset_from_key.html
@@ -1,7 +1,13 @@
-{% extends "account/base.html" %}
+{% extends "prelogin/auth_base.html" %}
 {% load form_tags i18n %}
-{% block content %}
-  <h1 class="pg-title">{% if token_fail %}{% translate "Bad Token" %}{% else %}{% translate "Change Password" %}{% endif %}</h1>
+{% block auth_body %}
+  <h1 class="pg-title">
+    {% if token_fail %}
+      {% translate "Bad Token" %}
+    {% else %}
+      {% translate "Change Password" %}
+    {% endif %}
+  </h1>
   {% if token_fail %}
     {% url 'account_reset_password' as passwd_reset_url %}
     <div class="pg-content">
@@ -23,12 +29,12 @@
         {{ form.non_field_errors }}
         {% render_field form.password1 %}
         {% render_field form.password2 %}
-        <div class="mt-2">
-          <input class="btn btn-primary" type="submit" value="{% translate "Change Password" %}">
-        </div>
+        <input class="btn btn-indigo"
+               type="submit"
+               value="{% translate "Change Password" %}">
       </form>
     {% else %}
-      <p>{% translate "Your password is now changed." %}</p>
+      <p class="pg-content">{% translate "Your password is now changed." %}</p>
     {% endif %}
   {% endif %}
-{% endblock content %}
+{% endblock auth_body %}

--- a/templates/account/password_reset_from_key.html
+++ b/templates/account/password_reset_from_key.html
@@ -12,12 +12,12 @@
     {% url 'account_reset_password' as passwd_reset_url %}
     <div class="pg-content">
       <p>
-        {% blocktranslate %}
+        {% blocktranslate trimmed %}
           The password reset link was invalid, possibly because it has already been used.
         {% endblocktranslate %}
       </p>
       <p>
-        {% blocktranslate %}
+        {% blocktranslate trimmed %}
           Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.
         {% endblocktranslate %}
       </p>

--- a/templates/account/password_reset_from_key_done.html
+++ b/templates/account/password_reset_from_key_done.html
@@ -4,15 +4,15 @@
   <h1 class="pg-title">{% translate "Change Password" %}</h1>
   <div class="pg-content">
     <p>
-      {% blocktranslate %}
-                Your password has been changed.
-            {% endblocktranslate %}
+      {% blocktranslate trimmed %}
+        Your password has been changed.
+      {% endblocktranslate %}
     </p>
     <p>
       {% url login_url_name|default:"account_login" as login_url %}
-      {% blocktranslate %}
-                You can now <a href="{{ login_url }}">login</a> with your new password.
-            {% endblocktranslate %}
+      {% blocktranslate trimmed %}
+        You can now <a href="{{ login_url }}">login</a> with your new password.
+      {% endblocktranslate %}
     </p>
   </div>
 {% endblock auth_body %}

--- a/templates/account/password_reset_from_key_done.html
+++ b/templates/account/password_reset_from_key_done.html
@@ -1,18 +1,18 @@
-{% extends "account/base.html" %}
+{% extends "prelogin/auth_base.html" %}
 {% load i18n %}
-{% block content %}
-    <h1 class="pg-title">{% translate "Change Password" %}</h1>
-    <div class="pg-content">
-        <p>
-            {% blocktranslate %}
+{% block auth_body %}
+  <h1 class="pg-title">{% translate "Change Password" %}</h1>
+  <div class="pg-content">
+    <p>
+      {% blocktranslate %}
                 Your password has been changed.
             {% endblocktranslate %}
-        </p>
-        <p>
-            {% url login_url_name|default:"account_login" as login_url %}
-            {% blocktranslate %}
+    </p>
+    <p>
+      {% url login_url_name|default:"account_login" as login_url %}
+      {% blocktranslate %}
                 You can now <a href="{{ login_url }}">login</a> with your new password.
             {% endblocktranslate %}
-        </p>
-    </div>
-{% endblock content %}
+    </p>
+  </div>
+{% endblock auth_body %}

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -1,41 +1,38 @@
-{% extends "web/base.html" %}
+{% extends "prelogin/auth_base.html" %}
 {% load form_tags i18n static %}
+{% block title %}
+  {% translate "Sign Up" %} | Open Chat Studio
+{% endblock title %}
 
-{% block body %}
-  <div class="flex justify-center my-8 ">
-    <div class="w-96 px-4 py-4 bg-white">
-      <div>
-        <h2 class="mt-6 text-center text-2xl font-bold text-gray-900">
-          Sign up
-        </h2>
-        <form class="mt-6 space-y-6" method="post">
-          {% csrf_token %}
-          {{ form.non_field_errors }}
-          {% render_field form.email %}
-          {% render_field form.password1 %}
-          {% if project_settings.ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE %}
-            {% render_field form.password2 %}
-          {% endif %}
-          {% if invitation %}
-            <input type="hidden" name="invitation_id" value="{{ invitation.id }}">
-            {{ form.invitation_id.errors }}
-          {% else %}
-            {% render_field form.team_name %}
-          {% endif %}
-          {% if project_meta.TERMS_URL %}
-            {% render_field form.terms_agreement %}
-          {% endif %}
-          <div>
-            <input class="btn btn-primary btn-block" type="submit" value="{% translate "Sign Up" %}">
-          </div>
-        </form>
-        <div class="text-sm mt-4">
-          {% translate "Already have account?" %}
-          <a href="{% url login_url_name|default:"account_login" %}" class="font-medium text-blue-700 hover:text-blue-500">
-            {% translate "Go to sign in." %}
-          </a>
-        </div>
-      </div>
-    </div>
+{% block card_eyebrow %}
+  <h1 class="card-eyebrow">{% translate "Create Account" %}</h1>
+{% endblock card_eyebrow %}
+
+{% block auth_body %}
+  <form method="post">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    {% render_field form.email %}
+    {% render_field form.password1 %}
+    {% if project_settings.ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE %}
+      {% render_field form.password2 %}
+    {% endif %}
+    {% if invitation %}
+      <input type="hidden" name="invitation_id" value="{{ invitation.id }}">
+      {{ form.invitation_id.errors }}
+    {% else %}
+      {% render_field form.team_name %}
+    {% endif %}
+    {% if project_meta.TERMS_URL %}
+      {% render_field form.terms_agreement %}
+    {% endif %}
+    <input class="btn btn-indigo"
+           type="submit"
+           value="{% translate "Sign Up" %}">
+  </form>
+  <div class="auth-foot">
+    {% translate "Already have account?" %}
+    <a class="auth-link"
+       href="{% url login_url_name|default:"account_login" %}">{% translate "Go to sign in." %}</a>
   </div>
-{% endblock body %}
+{% endblock auth_body %}

--- a/templates/account/signup_closed.html
+++ b/templates/account/signup_closed.html
@@ -1,18 +1,15 @@
-{% extends "web/base.html" %}
-{% load allauth i18n %}
-{% block page_title %}
-  {% translate "Sign Up Closed" %}
-{% endblock page_title %}
+{% extends "prelogin/auth_base.html" %}
+{% load i18n %}
+{% block title %}
+  {% translate "Sign Up Closed" %} | Open Chat Studio
+{% endblock title %}
 
-{% block body %}
-  <div class="flex justify-center my-8 ">
-    <div class="w-96 px-4 py-4 bg-base-100">
-      <div>
-        <h2 class="mt-6 text-center text-2xl font-bold">
-          {% translate "Sign Up Closed" %}
-        </h2>
-        <p>{% translate "We are sorry, but the sign up is currently closed." %}</p>
-      </div>
-    </div>
+{% block card_eyebrow %}
+  <h1 class="card-eyebrow">{% translate "Sign Up" %}</h1>
+{% endblock card_eyebrow %}
+
+{% block auth_body %}
+  <div class="pg-content" style="text-align:center;">
+    <p>{% translate "We are sorry, but the sign up is currently closed." %}</p>
   </div>
-{% endblock body %}
+{% endblock auth_body %}

--- a/templates/prelogin/auth_base.html
+++ b/templates/prelogin/auth_base.html
@@ -1,0 +1,214 @@
+{% extends "prelogin/base.html" %}
+{% load i18n %}
+{% comment %}
+  Shared frame for logged-out auth pages (login, signup, password reset).
+  Wraps page content in a centered card using the pre-login brand styling.
+  Child templates fill:
+    - card_eyebrow : the indigo header strip (optional)
+    - auth_title   : heading inside the card (optional)
+    - auth_body    : the form / page content
+{% endcomment %}
+{# Hide the "Sign In" CTAs in the nav and footer while on an auth page #}
+{% block nav_signin_cta %}{% endblock %}
+
+{% block footer_signin_link %}{% endblock %}
+
+{% block page_styles %}
+  <style>
+  .auth-section {
+    position: relative;
+    padding: 72px 0 88px;
+    background:
+      radial-gradient(800px 360px at 0% 0%, rgba(137,210,220,0.30), transparent 65%),
+      radial-gradient(700px 320px at 100% 100%, rgba(141,233,105,0.14), transparent 65%),
+      var(--ocs-turquoise-pale, #D6EEF2);
+    overflow: hidden;
+  }
+  @media (max-width: 600px) {
+    .auth-section { padding: 48px 0 64px; }
+  }
+
+  .auth-card {
+    position: relative;
+    max-width: 440px;
+    margin: 0 auto;
+    background: #FFFFFF;
+    border: none;
+    border-radius: 22px;
+    padding: 36px;
+    box-shadow: 0 24px 56px -22px rgba(22,0,109,0.22);
+    overflow: hidden;
+  }
+  @media (max-width: 600px) {
+    .auth-card { padding: 28px 22px; }
+  }
+
+  /* Indigo header strip, bled to the card edges (matches contact form-card) */
+  .auth-card .card-eyebrow {
+    display: block;
+    margin: -36px -36px 28px;
+    padding: 14px 36px;
+    background: var(--ocs-purple, #16006D);
+    color: #FFFFFF !important;  /* beat ocs-theme's `h1 { color: ink !important }` */
+    font-family: 'Work Sans', system-ui, sans-serif;
+    font-size: 0.82rem;
+    font-weight: 600;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    text-align: center;
+  }
+  @media (max-width: 600px) {
+    .auth-card .card-eyebrow { margin: -28px -22px 24px; padding: 12px 22px; }
+  }
+
+  /* Headings */
+  .auth-card .auth-title,
+  .auth-card .pg-title {
+    font-size: 1.6rem;
+    font-weight: 600;
+    letter-spacing: -0.015em;
+    line-height: 1.2;
+    color: var(--ocs-ink, #1A1A1A);
+    margin: 0 0 8px;
+    text-align: center;
+  }
+  .auth-card .auth-subtitle,
+  .auth-card .pg-subtitle {
+    font-size: 0.98rem;
+    font-weight: 300;
+    line-height: 1.6;
+    color: rgba(22,0,109,0.72);
+    margin: 0 0 24px;
+    text-align: center;
+  }
+  .auth-card .pg-content { color: rgba(26,26,26,0.78); line-height: 1.65; }
+  .auth-card .pg-content p + p { margin-top: 12px; }
+  .auth-card .pg-content a,
+  .auth-card .pg-help a,
+  .auth-card .auth-link {
+    color: var(--ocs-purple, #16006D);
+    font-weight: 500;
+    text-decoration: none;
+    border-bottom: 2px solid rgba(141,233,105,0.85);
+    padding-bottom: 1px;
+    transition: color 150ms ease, border-color 150ms ease;
+  }
+  .auth-card .pg-content a:hover,
+  .auth-card .pg-help a:hover,
+  .auth-card .auth-link:hover {
+    color: var(--ocs-purple-hover, #2A1090);
+    border-bottom-color: var(--ocs-green, #8DE969);
+  }
+
+  /* Form fields */
+  .auth-card form { margin: 0; }
+  .auth-card .fieldset { margin-bottom: 18px; }
+  .auth-card .label {
+    display: block;
+    margin-bottom: 6px;
+    font-family: 'Work Sans', system-ui, sans-serif;
+    font-size: 0.92rem;
+    font-weight: 600;
+    color: var(--ocs-ink, #1A1A1A);
+  }
+  /* The field help icon uses a FontAwesome + DaisyUI hover dropdown that the
+     pre-login frame doesn't load, so it can't render. Hide it here; auth forms
+     surface the same info via labels, errors, and the explicit links below. */
+  .auth-card .label .form-text { display: none; }
+  .auth-card input[type="text"],
+  .auth-card input[type="email"],
+  .auth-card input[type="password"],
+  .auth-card input[type="number"],
+  .auth-card select,
+  .auth-card textarea {
+    width: 100%;
+    padding: 11px 14px;
+    font-family: 'Work Sans', system-ui, sans-serif;
+    font-size: 0.98rem;
+    color: var(--ocs-ink, #1A1A1A);
+    background: #FFFFFF;
+    border: 1px solid rgba(22,0,109,0.18);
+    border-radius: 10px;
+    transition: border-color 150ms ease, box-shadow 150ms ease;
+    box-sizing: border-box;
+  }
+  .auth-card input:focus,
+  .auth-card select:focus,
+  .auth-card textarea:focus {
+    outline: none;
+    border-color: var(--ocs-purple, #16006D);
+    box-shadow: 0 0 0 3px rgba(141,233,105,0.35);
+  }
+
+  /* Checkbox rows (e.g. terms agreement) */
+  .auth-card .form-check .label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 400;
+    cursor: pointer;
+  }
+  .auth-card .form-check input[type="checkbox"] {
+    width: auto;
+    accent-color: var(--ocs-purple, #16006D);
+  }
+
+  /* Errors */
+  .auth-card .errorlist {
+    list-style: none;
+    margin: 6px 0 0;
+    padding: 0;
+    color: #C0392B;
+    font-size: 0.85rem;
+    line-height: 1.5;
+  }
+  .auth-card .errorlist li { margin: 0; }
+
+  /* Submit button: full-width primary CTA */
+  .auth-card .btn { width: 100%; justify-content: center; }
+  .auth-card .btn + .btn { margin-top: 12px; }
+
+  /* Footer text below the form (e.g. "Already have an account?") */
+  .auth-foot {
+    margin-top: 22px;
+    text-align: center;
+    font-size: 0.92rem;
+    color: rgba(22,0,109,0.72);
+  }
+  .auth-card .pg-help { margin-top: 16px; font-size: 0.88rem; color: rgba(22,0,109,0.62); }
+
+  /* Inline messages (alertify is not loaded on the pre-login frame) */
+  .auth-messages { max-width: 440px; margin: 0 auto 18px; }
+  .auth-message {
+    padding: 12px 16px;
+    border-radius: 12px;
+    font-size: 0.92rem;
+    line-height: 1.5;
+    margin-bottom: 10px;
+  }
+  .auth-message.is-success { background: rgba(141,233,105,0.18); color: #3F6B23; border: 1px solid rgba(141,233,105,0.55); }
+  .auth-message.is-error   { background: rgba(192,57,43,0.10);  color: #A93226; border: 1px solid rgba(192,57,43,0.30); }
+  .auth-message.is-info,
+  .auth-message.is-default { background: rgba(137,210,220,0.22); color: #155E6B; border: 1px solid rgba(137,210,220,0.55); }
+  .auth-message.is-warning { background: rgba(247,184,1,0.14);  color: #8A6400; border: 1px solid rgba(247,184,1,0.40); }
+  </style>
+{% endblock page_styles %}
+
+{% block content %}
+  <section id="main" class="auth-section">
+    <div class="container">
+      {% if messages %}
+        <div class="auth-messages">
+          {% for message in messages %}
+            <div class="auth-message is-{{ message.tags|default:'default' }}">{{ message }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+      <div class="auth-card">
+        {% block card_eyebrow %}{% endblock %}
+        {% block auth_title %}{% endblock %}
+        {% block auth_body %}{% endblock %}
+      </div>
+    </div>
+  </section>
+{% endblock content %}

--- a/templates/prelogin/base.html
+++ b/templates/prelogin/base.html
@@ -1,99 +1,156 @@
-{% load static %}<!doctype html>
+{% load static %}
+<!DOCTYPE html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<link rel="icon" type="image/png" href="{% static 'prelogin/images/ocs-favicon.png' %}">
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>{% block title %}Open Chat Studio by Dimagi{% endblock %}</title>
-{% block meta %}{% endblock %}
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@200;300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="{% static 'prelogin/styles.css' %}">
-{% block page_styles %}{% endblock %}
-<link rel="stylesheet" href="{% static 'prelogin/ocs-theme.css' %}">
-</head>
-<body>
-<a class="skip-link" href="#main">Skip to main content</a>
-
-<!-- ───── NAV ───── -->
-<div class="nav-wrap">
-  <div class="container">
-    <nav class="primary">
-      <a class="logo" href="{% url 'prelogin:home' %}">
-        <img src="{% static 'prelogin/images/ocs-logo.png' %}" width="175" height="78" alt="Open Chat Studio by Dimagi" style="height:36px;width:auto;filter:brightness(0) invert(1);opacity:0.95;">
-      </a>
-      <div class="nav-links">
-        <a href="{% url 'prelogin:home' %}" {% if active_nav == "home" %}class="nav-active" aria-current="page"{% endif %}>Open Chat Studio</a>
-        <a href="{% url 'prelogin:applications' %}" {% if active_nav == "applications" %}class="nav-active" aria-current="page"{% endif %}>Use Cases</a>
-        <a href="{% url 'prelogin:about' %}" {% if active_nav == "about" %}class="nav-active" aria-current="page"{% endif %}>Community</a>
-        <a href="{% url 'prelogin:contact' %}" {% if active_nav == "contact" %}class="nav-active" aria-current="page"{% endif %}>Contact</a>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon"
+          type="image/png"
+          href="{% static 'prelogin/images/ocs-favicon.png' %}">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      {% block title %}Open Chat Studio by Dimagi{% endblock %}
+    </title>
+    {% block meta %}{% endblock %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@200;300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+          rel="stylesheet">
+    <link rel="stylesheet" href="{% static 'prelogin/styles.css' %}">
+    {% block page_styles %}{% endblock %}
+    <link rel="stylesheet" href="{% static 'prelogin/ocs-theme.css' %}">
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to main content</a>
+    <!-- ───── NAV ───── -->
+    <div class="nav-wrap">
+      <div class="container">
+        <nav class="primary">
+          <a class="logo" href="{% url 'prelogin:home' %}">
+            <img src="{% static 'prelogin/images/ocs-logo.png' %}"
+                 width="175"
+                 height="78"
+                 alt="Open Chat Studio by Dimagi"
+                 style="height:36px;
+                        width:auto;
+                        filter:brightness(0) invert(1);
+                        opacity:0.95">
+          </a>
+          <div class="nav-links">
+            <a href="{% url 'prelogin:home' %}"
+               {% if active_nav == "home" %}class="nav-active" aria-current="page"{% endif %}>Open Chat Studio</a>
+            <a href="{% url 'prelogin:applications' %}"
+               {% if active_nav == "applications" %}class="nav-active" aria-current="page"{% endif %}>Use Cases</a>
+            <a href="{% url 'prelogin:about' %}"
+               {% if active_nav == "about" %}class="nav-active" aria-current="page"{% endif %}>Community</a>
+            <a href="{% url 'prelogin:contact' %}"
+               {% if active_nav == "contact" %}class="nav-active" aria-current="page"{% endif %}>Contact</a>
+          </div>
+          <div class="nav-cta">
+            <a class="btn btn-ghost"
+               href="https://github.com/dimagi/open-chat-studio"
+               target="_blank"
+               rel="noopener">GitHub</a>
+            {% block nav_signin_cta %}
+              <a class="btn btn-primary" href="{% url 'sso:login' %}">Sign In</a>
+            {% endblock nav_signin_cta %}
+          </div>
+          <button class="nav-hamburger" aria-label="Open menu" aria-expanded="false">
+            {# djlint:off H020 #}
+            <span></span><span></span><span></span>
+            {# djlint:on #}
+          </button>
+        </nav>
       </div>
-      <div class="nav-cta">
-        <a class="btn btn-ghost" href="https://github.com/dimagi/open-chat-studio" target="_blank" rel="noopener">GitHub</a>
-        <a class="btn btn-primary" href="{% url 'sso:login' %}">Sign In</a>
-      </div>
-      <button class="nav-hamburger" aria-label="Open menu" aria-expanded="false">
-        {# djlint:off H020 #}
-        <span></span><span></span><span></span>
-        {# djlint:on #}
-      </button>
-    </nav>
-  </div>
-</div>
-
-{% block content %}{% endblock %}
-
-<!-- ───── FOOTER ───── -->
-<footer>
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <div class="logo" style="gap:10px;">
-          <img src="{% static 'prelogin/images/ocs-logo.png' %}" width="175" height="78" alt="Open Chat Studio by Dimagi" style="height:28px;width:auto;filter:brightness(0) invert(1);opacity:0.85;">
+    </div>
+    {% block content %}{% endblock %}
+    <!-- ───── FOOTER ───── -->
+    <footer>
+      <div class="container">
+        <div class="footer-grid">
+          <div class="footer-brand">
+            <div class="logo" style="gap:10px;">
+              <img src="{% static 'prelogin/images/ocs-logo.png' %}"
+                   width="175"
+                   height="78"
+                   alt="Open Chat Studio by Dimagi"
+                   style="height:28px;
+                          width:auto;
+                          filter:brightness(0) invert(1);
+                          opacity:0.85">
+            </div>
+            <p>Open-source AI chatbots for global development.</p>
+          </div>
+          <div class="footer-col">
+            <h2>About</h2>
+            <ul>
+              <li>
+                <a href="{% url 'prelogin:home' %}">Open Chat Studio</a>
+              </li>
+              <li>
+                <a href="{% url 'prelogin:applications' %}">Use Cases</a>
+              </li>
+              <li>
+                <a href="{% url 'prelogin:about' %}">Community</a>
+              </li>
+              <li>
+                <a href="{% url 'prelogin:open_opportunities' %}">Open Opportunities</a>
+              </li>
+              <li>
+                <a href="{% url 'prelogin:contact' %}">Contact</a>
+              </li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h2>Resources</h2>
+            <ul>
+              {% block footer_signin_link %}
+                <li>
+                  <a href="{% url 'sso:login' %}">Sign In</a>
+                </li>
+              {% endblock footer_signin_link %}
+              <li>
+                <a href="https://github.com/dimagi/open-chat-studio"
+                   target="_blank"
+                   rel="noopener">GitHub</a>
+              </li>
+              <li>
+                <a href="https://docs.openchatstudio.com/"
+                   target="_blank"
+                   rel="noopener">Documentation</a>
+              </li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h2>Dimagi</h2>
+            <ul>
+              <li>
+                <a href="https://dimagi.com/" target="_blank" rel="noopener">About Dimagi</a>
+              </li>
+              <li>
+                <a href="https://dimagi.com/blog/" target="_blank" rel="noopener">Blog</a>
+              </li>
+              <li>
+                <a href="https://www.dimagi.com/podcast/" target="_blank" rel="noopener">Podcast</a>
+              </li>
+            </ul>
+          </div>
         </div>
-        <p>Open-source AI chatbots for global development.</p>
+        <div class="footer-bottom">
+          <span>© 2026 DIMAGI, INC.</span>
+          <span style="display:flex;gap:24px;flex-wrap:wrap;">
+            <a href="https://dimagi.com/terms-privacy/"
+               target="_blank"
+               rel="noopener">PRIVACY</a>
+            <a href="https://dimagi.com/terms-of-service/"
+               target="_blank"
+               rel="noopener">TERMS</a>
+            <a href="https://dimagi.com/terms-aup/" target="_blank" rel="noopener">ACCEPTABLE USE POLICY</a>
+          </span>
+        </div>
       </div>
-      <div class="footer-col">
-        <h2>About</h2>
-        <ul>
-          <li><a href="{% url 'prelogin:home' %}">Open Chat Studio</a></li>
-          <li><a href="{% url 'prelogin:applications' %}">Use Cases</a></li>
-          <li><a href="{% url 'prelogin:about' %}">Community</a></li>
-          <li><a href="{% url 'prelogin:open_opportunities' %}">Open Opportunities</a></li>
-          <li><a href="{% url 'prelogin:contact' %}">Contact</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h2>Resources</h2>
-        <ul>
-          <li><a href="{% url 'sso:login' %}">Sign In</a></li>
-          <li><a href="https://github.com/dimagi/open-chat-studio" target="_blank" rel="noopener">GitHub</a></li>
-          <li><a href="https://docs.openchatstudio.com/" target="_blank" rel="noopener">Documentation</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h2>Dimagi</h2>
-        <ul>
-          <li><a href="https://dimagi.com/" target="_blank" rel="noopener">About Dimagi</a></li>
-          <li><a href="https://dimagi.com/blog/" target="_blank" rel="noopener">Blog</a></li>
-          <li><a href="https://www.dimagi.com/podcast/" target="_blank" rel="noopener">Podcast</a></li>
-        </ul>
-      </div>
-    </div>
-    <div class="footer-bottom">
-      <span>© 2026 DIMAGI, INC.</span>
-      <span style="display:flex;gap:24px;flex-wrap:wrap;">
-        <a href="https://dimagi.com/terms-privacy/" target="_blank" rel="noopener">PRIVACY</a>
-        <a href="https://dimagi.com/terms-of-service/" target="_blank" rel="noopener">TERMS</a>
-        <a href="https://dimagi.com/terms-aup/" target="_blank" rel="noopener">ACCEPTABLE USE POLICY</a>
-      </span>
-    </div>
-  </div>
-</footer>
-
-<!-- Mobile nav toggle -->
-<script>
+    </footer>
+    <!-- Mobile nav toggle -->
+    <script>
 (function () {
   var ham = document.querySelector('.nav-hamburger');
   if (ham) {
@@ -116,7 +173,8 @@
     });
   });
 })();
-</script>
-{% block page_scripts %}{% endblock %}
-</body>
+    </script>
+    {% block page_scripts %}
+    {% endblock page_scripts %}
+  </body>
 </html>


### PR DESCRIPTION
### Product Description
The login, signup, and password-reset pages now match the look of the public pre-login site (turquoise nav, purple footer, brand palette and fonts) instead of the logged-in app shell.

### Technical Description
Adds `prelogin/auth_base.html`, a centered-card layout extending `prelogin/base.html`. In-scope auth templates extend it directly via `{% block auth_body %}` and keep using `{% render_field %}` — the new frame restyles fields via CSS scoped to `.auth-card`, so the field-rendering pipeline is untouched.

Notes for review:
- `account/base.html` is deliberately **not** repointed — it's shared by out-of-scope pages (`email`, `mfa`, `oauth2 authorize`, `verification_sent`, …), and `prelogin/base.html` already owns the `content` block name. The password-reset family switches to `auth_base` individually instead.
- The nav/footer "Sign In" CTA is wrapped in overridable blocks (`nav_signin_cta`, `footer_signin_link`) and hidden on auth pages — except the password-reset request page, which restores the nav button so a user who remembers their password can bail to login.
- The pre-login frame doesn't load alertify/FontAwesome/DaisyUI, so messages render as inline styled alerts and the field help-icon dropdown is hidden in-card.

### Migrations
N/A — template/CSS only.

### Demo
<img width="1394" height="1026" alt="image" src="https://github.com/user-attachments/assets/f8fcb67e-2813-4a16-9fc5-8678997c1c54" />

### Docs and Changelog
- [ ] This PR requires docs/changelog update