### PR TITLE
fix: skip Claude review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,7 +31,12 @@ permissions:
 
 jobs:
   review:
-    if: github.actor != 'dependabot[bot]' && !github.event.pull_request.draft
+    # Fork PRs can't get an OIDC token (GitHub omits ACTIONS_ID_TOKEN_REQUEST_URL
+    # for fork-originated pull_request events), so the review is skipped for them.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
+      && !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
### Product Description
No change.

### Technical Description
The Claude Code Review action was failing on fork PRs with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL`. GitHub omits OIDC token capability for fork-originated `pull_request` events regardless of the `id-token: write` permission, so `claude-code-action`'s GitHub App token exchange fails.

Gating the job on `head.repo.full_name == github.repository` skips fork PRs (job is skipped, not errored). Internal/branch PRs are unaffected — they still get OIDC and full reviews.

Reviewing fork PRs would require `pull_request_target` (writable token + secrets exposure to untrusted PR code); deliberately not doing that here.

### Migrations
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update