### PR TITLE
refactor: remove unused use_processor_bot_voice field from Experiment

### DIFF
--- a/apps/channels/tests/test_base_channel_behavior.py
+++ b/apps/channels/tests/test_base_channel_behavior.py
@@ -732,28 +732,24 @@ def test_voice_tag_created_on_message(
 
 @pytest.mark.django_db()
 @pytest.mark.parametrize(
-    ("expected_message_type", "response_behaviour", "use_processor_bot_voice"),
+    ("expected_message_type", "response_behaviour"),
     [
-        ("text", VoiceResponseBehaviours.NEVER, True),
-        ("text", VoiceResponseBehaviours.RECIPROCAL, True),
-        ("voice", VoiceResponseBehaviours.ALWAYS, True),
-        ("text", VoiceResponseBehaviours.NEVER, False),
-        ("text", VoiceResponseBehaviours.RECIPROCAL, False),
-        ("voice", VoiceResponseBehaviours.ALWAYS, False),
+        ("text", VoiceResponseBehaviours.NEVER),
+        ("text", VoiceResponseBehaviours.RECIPROCAL),
+        ("voice", VoiceResponseBehaviours.ALWAYS),
     ],
 )
 @patch("apps.channels.tests.test_base_channel_behavior.TestChannel.send_voice_to_user")
 @patch("apps.channels.tests.test_base_channel_behavior.TestChannel.send_text_to_user")
 @patch("apps.service_providers.speech_service.SpeechService.synthesize_voice", Mock())
 def test_send_message_to_user_with_single_bot(
-    send_text_to_user, send_voice_to_user, expected_message_type, response_behaviour, use_processor_bot_voice
+    send_text_to_user, send_voice_to_user, expected_message_type, response_behaviour
 ):
     """A simple test to make sure that when we call `channel_instance.send_message_to_user`, the correct message format
     will be used
     """
 
     session = ExperimentSessionFactory.create(
-        experiment__use_processor_bot_voice=use_processor_bot_voice,
         experiment__voice_response_behaviour=response_behaviour,
     )
     session.experiment_channel = ExperimentChannelFactory.create(experiment=session.experiment)

--- a/apps/experiments/migrations/0142_remove_experiment_use_processor_bot_voice.py
+++ b/apps/experiments/migrations/0142_remove_experiment_use_processor_bot_voice.py
@@ -2,14 +2,30 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
+    """State-only removal of the unused Experiment.use_processor_bot_voice field.
+
+    The DB column is kept in place so the previous code revision can keep
+    running during the rolling deploy. The column is dropped in a follow-up
+    migration. Adds a DB-level default so INSERTs from the new code (which no
+    longer references the column) satisfy the existing NOT NULL constraint.
+    """
 
     dependencies = [
         ("experiments", "0141_experimentsession_session_token_required"),
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name="experiment",
-            name="use_processor_bot_voice",
+        migrations.RunSQL(
+            sql="ALTER TABLE experiments_experiment ALTER COLUMN use_processor_bot_voice SET DEFAULT false;",
+            reverse_sql="ALTER TABLE experiments_experiment ALTER COLUMN use_processor_bot_voice DROP DEFAULT;",
+        ),
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name="experiment",
+                    name="use_processor_bot_voice",
+                ),
+            ],
+            database_operations=[],
         ),
     ]

--- a/apps/experiments/migrations/0142_remove_experiment_use_processor_bot_voice.py
+++ b/apps/experiments/migrations/0142_remove_experiment_use_processor_bot_voice.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("experiments", "0141_experimentsession_session_token_required"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="experiment",
+            name="use_processor_bot_voice",
+        ),
+    ]

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -603,7 +603,6 @@ class Experiment(BaseTeamModel, VersionsMixin):
     trace_provider = models.ForeignKey(
         "service_providers.TraceProvider", on_delete=models.SET_NULL, null=True, blank=True
     )
-    use_processor_bot_voice = models.BooleanField(default=False)
     participant_allowlist = ArrayField(models.CharField(max_length=128), default=list, blank=True)
 
     # Versioning fields
@@ -1023,12 +1022,6 @@ class Experiment(BaseTeamModel, VersionsMixin):
                 group_name="Voice",
                 name="echo_transcript",
                 raw_value=self.echo_transcript,
-                to_display=VersionFieldDisplayFormatters.yes_no,
-            ),
-            VersionField(
-                group_name="Voice",
-                name="use_processor_bot_voice",
-                raw_value=self.use_processor_bot_voice,
                 to_display=VersionFieldDisplayFormatters.yes_no,
             ),
             VersionField(group_name="Tracing", name="tracing_provider", raw_value=self.trace_provider),

--- a/docs/design/read-only-chatbot-inspection-api.md
+++ b/docs/design/read-only-chatbot-inspection-api.md
@@ -497,7 +497,6 @@ shape, one parser.
     "conversational_consent_enabled": false,
     "voice_response_behaviour": "reciprocal",
     "echo_transcript": false,
-    "use_processor_bot_voice": false,
     "debug_mode_enabled": false,
     "file_uploads_enabled": false,
     "participant_allowlist": []


### PR DESCRIPTION
### Product Description
No user-facing change.

### Technical Description
`use_processor_bot_voice` (added in migration 0088) is never read by any live business logic. This PR removes it entirely:

- Field declaration dropped from `Experiment`
- `VersionField` entry removed from `_get_version_details()`
- Migration 0142 drops the DB column
- `test_send_message_to_user_with_single_bot` collapsed from 6 parametrized cases to 3 — the field was set in the factory but outcomes were identical regardless of its value
- Stale reference removed from design doc example payload

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Closes #3575