### PR TITLE
fix: bind task_id to session to prevent IDOR in chat poll endpoint

### DIFF
--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -39,6 +39,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ChatTaskPollUserError'
           description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatTaskPollNotFound'
+          description: ''
         '500':
           content:
             application/json:
@@ -1529,6 +1535,13 @@ components:
           type: string
       required:
       - status
+    ChatTaskPollNotFound:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
     ChatTaskPollStatusEnum:
       enum:
       - processing

--- a/apps/api/tests/test_chat_poll_api.py
+++ b/apps/api/tests/test_chat_poll_api.py
@@ -145,40 +145,27 @@ def test_chat_poll_generic_error_returns_500(api_client, mock_session, mock_task
 
 
 @pytest.mark.django_db()
-def test_chat_poll_task_bound_to_correct_session_succeeds(api_client, mock_session, mock_task_response):
-    """Polling with a task_id bound to the current session succeeds."""
-    task_id = "bound-task-ok"
-    cache.set(f"task_session:{task_id}", TEST_SESSION_ID, 60)
+@pytest.mark.parametrize(
+    ("cache_owner", "expected_status", "task_called"),
+    [
+        pytest.param(TEST_SESSION_ID, 200, True, id="bound-to-correct-session"),
+        pytest.param(str(uuid.uuid4()), 404, False, id="bound-to-different-session"),
+        pytest.param(None, 200, True, id="no-binding-backward-compat"),
+    ],
+)
+def test_chat_poll_task_session_binding(
+    api_client, mock_session, mock_task_response, cache_owner, expected_status, task_called
+):
+    """task_id is bound to its originating session; cross-session reads return 404 (IDOR prevention).
+    A missing binding is allowed for backward compatibility with tasks dispatched before this fix.
+    """
+    task_id = str(uuid.uuid4())  # unique per run to avoid inter-test cache pollution
+    if cache_owner is not None:
+        cache.set(f"task_session:{task_id}", cache_owner, 60)
     mock_task_response.return_value = {"complete": False, "error_msg": None, "message": None}
 
     url = reverse("api:chat:task-poll-response", kwargs={"session_id": TEST_SESSION_ID, "task_id": task_id})
     response = api_client.get(url)
 
-    assert response.status_code == 200
-
-
-@pytest.mark.django_db()
-def test_chat_poll_task_bound_to_different_session_returns_404(api_client, mock_session, mock_task_response):
-    """Polling session A's endpoint with a task_id bound to session B returns 404 (IDOR prevention)."""
-    other_session_id = str(uuid.uuid4())
-    task_id = "cross-session-task"
-    cache.set(f"task_session:{task_id}", other_session_id, 60)
-
-    url = reverse("api:chat:task-poll-response", kwargs={"session_id": TEST_SESSION_ID, "task_id": task_id})
-    response = api_client.get(url)
-
-    assert response.status_code == 404
-    mock_task_response.assert_not_called()
-
-
-@pytest.mark.django_db()
-def test_chat_poll_task_with_no_binding_succeeds(api_client, mock_session, mock_task_response):
-    """Tasks with no cache binding (dispatched before this fix) are allowed through for backward compatibility."""
-    task_id = "legacy-unbound-task"
-    # No cache.set — binding is absent
-    mock_task_response.return_value = {"complete": False, "error_msg": None, "message": None}
-
-    url = reverse("api:chat:task-poll-response", kwargs={"session_id": TEST_SESSION_ID, "task_id": task_id})
-    response = api_client.get(url)
-
-    assert response.status_code == 200
+    assert response.status_code == expected_status
+    assert mock_task_response.called == task_called

--- a/apps/api/tests/test_chat_poll_api.py
+++ b/apps/api/tests/test_chat_poll_api.py
@@ -2,6 +2,7 @@ import uuid
 from unittest import mock
 
 import pytest
+from django.core.cache import cache
 from django.urls import reverse
 from rest_framework.test import APIClient
 
@@ -141,3 +142,43 @@ def test_chat_poll_generic_error_returns_500(api_client, mock_session, mock_task
     assert response.status_code == 500
     data = response.json()
     assert data["status"] == "error"
+
+
+@pytest.mark.django_db()
+def test_chat_poll_task_bound_to_correct_session_succeeds(api_client, mock_session, mock_task_response):
+    """Polling with a task_id bound to the current session succeeds."""
+    task_id = "bound-task-ok"
+    cache.set(f"task_session:{task_id}", TEST_SESSION_ID, 60)
+    mock_task_response.return_value = {"complete": False, "error_msg": None, "message": None}
+
+    url = reverse("api:chat:task-poll-response", kwargs={"session_id": TEST_SESSION_ID, "task_id": task_id})
+    response = api_client.get(url)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db()
+def test_chat_poll_task_bound_to_different_session_returns_404(api_client, mock_session, mock_task_response):
+    """Polling session A's endpoint with a task_id bound to session B returns 404 (IDOR prevention)."""
+    other_session_id = str(uuid.uuid4())
+    task_id = "cross-session-task"
+    cache.set(f"task_session:{task_id}", other_session_id, 60)
+
+    url = reverse("api:chat:task-poll-response", kwargs={"session_id": TEST_SESSION_ID, "task_id": task_id})
+    response = api_client.get(url)
+
+    assert response.status_code == 404
+    mock_task_response.assert_not_called()
+
+
+@pytest.mark.django_db()
+def test_chat_poll_task_with_no_binding_succeeds(api_client, mock_session, mock_task_response):
+    """Tasks with no cache binding (dispatched before this fix) are allowed through for backward compatibility."""
+    task_id = "legacy-unbound-task"
+    # No cache.set — binding is absent
+    mock_task_response.return_value = {"complete": False, "error_msg": None, "message": None}
+
+    url = reverse("api:chat:task-poll-response", kwargs={"session_id": TEST_SESSION_ID, "task_id": task_id})
+    response = api_client.get(url)
+
+    assert response.status_code == 200

--- a/apps/api/tests/test_chat_poll_api.py
+++ b/apps/api/tests/test_chat_poll_api.py
@@ -144,6 +144,12 @@ def test_chat_poll_generic_error_returns_500(api_client, mock_session, mock_task
     assert data["status"] == "error"
 
 
+@pytest.fixture()
+def poll_setup(api_client, mock_session, mock_task_response):
+    """Bundle common fixtures for poll endpoint tests."""
+    return api_client, mock_session, mock_task_response
+
+
 @pytest.mark.django_db()
 @pytest.mark.parametrize(
     ("cache_owner", "expected_status", "task_called"),
@@ -153,12 +159,11 @@ def test_chat_poll_generic_error_returns_500(api_client, mock_session, mock_task
         pytest.param(None, 200, True, id="no-binding-backward-compat"),
     ],
 )
-def test_chat_poll_task_session_binding(
-    api_client, mock_session, mock_task_response, cache_owner, expected_status, task_called
-):
+def test_chat_poll_task_session_binding(poll_setup, cache_owner, expected_status, task_called):
     """task_id is bound to its originating session; cross-session reads return 404 (IDOR prevention).
     A missing binding is allowed for backward compatibility with tasks dispatched before this fix.
     """
+    api_client, _mock_session, mock_task_response = poll_setup
     task_id = str(uuid.uuid4())  # unique per run to avoid inter-test cache pollution
     if cache_owner is not None:
         cache.set(f"task_session:{task_id}", cache_owner, 60)

--- a/apps/api/tests/test_chat_session_token.py
+++ b/apps/api/tests/test_chat_session_token.py
@@ -76,7 +76,7 @@ def test_send_message_requires_token(api_client, session, token):
     url = reverse("api:chat:send-message", kwargs={"session_id": session.external_id})
     assert api_client.post(url, data={"message": "hi"}, format="json").status_code == 403
     with mock.patch("apps.api.views.chat.get_response_for_webchat_task") as task:
-        task.delay.return_value = mock.Mock(task_id="123")
+        task.delay.return_value = mock.Mock(task_id="send-msg-test-unique-456")
         response = api_client.post(url, data={"message": "hi"}, format="json", HTTP_X_SESSION_TOKEN=token)
     assert response.status_code == 202
 

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -465,13 +465,17 @@ def chat_send_message(request, session_id):
             attachment_data.append(attachment.model_dump())
 
     # Queue the response generation as a background task
-    task_id = get_response_for_webchat_task.delay(
+    task = get_response_for_webchat_task.delay(
         experiment_session_id=session.id,
         experiment_id=experiment_version.id,
         message_text=message_text,
         attachments=attachment_data if attachment_data else None,
         context=context,
-    ).task_id
+    )
+    task_id = task.task_id
+    # Bind the task to this session so the poll endpoint can reject cross-session reads (IDOR).
+    # TTL matches the Celery result backend's default expiry (24 h).
+    cache.set(f"task_session:{task_id}", str(session_id), 24 * 3600)
 
     response_data = ChatSendMessageResponse({"task_id": task_id, "status": "processing"}).data
     return Response(response_data, status=status.HTTP_202_ACCEPTED)
@@ -527,6 +531,13 @@ def chat_poll_task_response(request, session_id, task_id):
     session = get_experiment_session_cached(session_id)
     if not session:
         return NotFound()
+
+    # Verify the task belongs to this session to prevent cross-session result reads (IDOR).
+    # A missing binding (None) is allowed for backward compatibility with tasks dispatched
+    # before this check was introduced; a present but mismatched binding is rejected.
+    bound_session = cache.get(f"task_session:{task_id}")
+    if bound_session is not None and bound_session != str(session_id):
+        raise NotFound()
 
     experiment = session.experiment
     task_details = get_message_task_response(experiment, task_id)

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -481,6 +481,17 @@ def chat_send_message(request, session_id):
     return Response(response_data, status=status.HTTP_202_ACCEPTED)
 
 
+def _verify_task_belongs_to_session(task_id: str, session_id: str) -> None:
+    """Raise NotFound if task_id is bound to a different session (IDOR prevention).
+
+    A missing cache entry is allowed for backward compatibility with tasks
+    dispatched before this binding was introduced.
+    """
+    bound_session = cache.get(f"task_session:{task_id}")
+    if bound_session is not None and bound_session != str(session_id):
+        raise NotFound()
+
+
 @extend_schema(
     operation_id="chat_poll_task_response",
     summary="Poll for task updates",
@@ -533,21 +544,10 @@ def chat_send_message(request, session_id):
 @api_view(["GET"])
 @authentication_classes(AUTH_CLASSES)
 @permission_classes(SESSION_PERMISSION_CLASSES)
-def _verify_task_belongs_to_session(task_id: str, session_id: str) -> None:
-    """Raise NotFound if task_id is bound to a different session (IDOR prevention).
-
-    A missing cache entry is allowed for backward compatibility with tasks
-    dispatched before this binding was introduced.
-    """
-    bound_session = cache.get(f"task_session:{task_id}")
-    if bound_session is not None and bound_session != str(session_id):
-        raise NotFound()
-
-
 def chat_poll_task_response(request, session_id, task_id):
     session = get_experiment_session_cached(session_id)
     if not session:
-        return NotFound()
+        raise NotFound()
 
     _verify_task_belongs_to_session(task_id, str(session_id))
 

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -500,6 +500,12 @@ def chat_send_message(request, session_id):
                 "status": serializers.CharField(),
             },
         ),
+        404: inline_serializer(
+            "ChatTaskPollNotFound",
+            {
+                "detail": serializers.CharField(),
+            },
+        ),
         500: inline_serializer(
             "ChatTaskPollError",
             {
@@ -527,17 +533,23 @@ def chat_send_message(request, session_id):
 @api_view(["GET"])
 @authentication_classes(AUTH_CLASSES)
 @permission_classes(SESSION_PERMISSION_CLASSES)
+def _verify_task_belongs_to_session(task_id: str, session_id: str) -> None:
+    """Raise NotFound if task_id is bound to a different session (IDOR prevention).
+
+    A missing cache entry is allowed for backward compatibility with tasks
+    dispatched before this binding was introduced.
+    """
+    bound_session = cache.get(f"task_session:{task_id}")
+    if bound_session is not None and bound_session != str(session_id):
+        raise NotFound()
+
+
 def chat_poll_task_response(request, session_id, task_id):
     session = get_experiment_session_cached(session_id)
     if not session:
         return NotFound()
 
-    # Verify the task belongs to this session to prevent cross-session result reads (IDOR).
-    # A missing binding (None) is allowed for backward compatibility with tasks dispatched
-    # before this check was introduced; a present but mismatched binding is rejected.
-    bound_session = cache.get(f"task_session:{task_id}")
-    if bound_session is not None and bound_session != str(session_id):
-        raise NotFound()
+    _verify_task_belongs_to_session(task_id, str(session_id))
 
     experiment = session.experiment
     task_details = get_message_task_response(experiment, task_id)


### PR DESCRIPTION
### Product Description
No user-facing change. Security fix.

### Technical Description

`chat_poll_task_response` (`GET /api/chat/{session_id}/{task_id}/poll/`) fetched the Celery task result using only `task_id`, with no check that the task belonged to `{session_id}`. A caller holding a valid token for session A could read session B's assistant reply by supplying session B's `task_id`.

**Fix:**

In `chat_send_message`, after dispatching the task, write a cache binding:
```python
cache.set(f"task_session:{task_id}", str(session_id), 24 * 3600)
```

In `chat_poll_task_response`, verify the binding before hitting Celery:
```python
bound_session = cache.get(f"task_session:{task_id}")
if bound_session is not None and bound_session != str(session_id):
    raise NotFound()
```

A missing binding (`None`) is allowed through for backward compatibility with tasks dispatched before this fix was deployed. The TTL (24 h) matches the Celery result backend default.

**Regression tests added:**
- Task bound to correct session → 200
- Task bound to a different session → 404, Celery backend never queried
- No binding (legacy unbound task) → 200 (backward compatibility)

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Closes #3577