### PR TITLE
Add total count to first page of cursor-paginated API responses

### DIFF
--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -496,6 +496,7 @@ paths:
                           name: John
                           timezone: Africa/Johannesburg
                         connect_channel_id: null
+                    count: 123
                   summary: A participant with their chatbot data
           description: ''
     post:
@@ -637,6 +638,7 @@ paths:
                           name: John
                           timezone: Africa/Johannesburg
                         connect_channel_id: null
+                    count: 123
                   summary: A participant with their chatbot data
           description: ''
     post:
@@ -2675,6 +2677,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Chatbot'
+        count:
+          type: integer
+          description: Total number of items matching the query. Only present on the
+            first page (requests without a cursor).
+          example: 123
     PaginatedExperimentList:
       type: object
       required:
@@ -2694,6 +2701,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Experiment'
+        count:
+          type: integer
+          description: Total number of items matching the query. Only present on the
+            first page (requests without a cursor).
+          example: 123
     PaginatedExperimentSessionList:
       type: object
       required:
@@ -2713,6 +2725,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ExperimentSession'
+        count:
+          type: integer
+          description: Total number of items matching the query. Only present on the
+            first page (requests without a cursor).
+          example: 123
     PaginatedParticipantDetailList:
       type: object
       required:
@@ -2732,6 +2749,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ParticipantDetail'
+        count:
+          type: integer
+          description: Total number of items matching the query. Only present on the
+            first page (requests without a cursor).
+          example: 123
     Participant:
       type: object
       properties:

--- a/apps/api/pagination.py
+++ b/apps/api/pagination.py
@@ -5,3 +5,37 @@ class CursorPagination(RestCursorPagination):
     ordering = "-created_at"
     page_size_query_param = "page_size"
     max_page_size = 1500
+
+    def paginate_queryset(self, queryset, request, view=None):
+        # Compute the total count on the first page only (no cursor param).
+        # Consumers syncing data (e.g. Scout) need the total once up front to
+        # show real progress; skipping it on cursor-following requests keeps
+        # deep pagination as cheap as plain cursor pagination.
+        self.total_count = None
+        if request.query_params.get(self.cursor_query_param) is None:
+            self.total_count = self._get_count(queryset)
+        return super().paginate_queryset(queryset, request, view)
+
+    def get_paginated_response(self, data):
+        response = super().get_paginated_response(data)
+        if self.total_count is not None:
+            response.data["count"] = self.total_count
+        return response
+
+    def get_paginated_response_schema(self, schema):
+        schema = super().get_paginated_response_schema(schema)
+        schema["properties"]["count"] = {
+            "type": "integer",
+            "description": (
+                "Total number of items matching the query. Only present on the first page (requests without a cursor)."
+            ),
+            "example": 123,
+        }
+        return schema
+
+    @staticmethod
+    def _get_count(queryset):
+        try:
+            return queryset.count()
+        except (AttributeError, TypeError):
+            return len(queryset)

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -63,6 +63,7 @@ def test_list_experiments(auth_method, experiment):
         ],
         "next": None,
         "previous": None,
+        "count": 1,
     }
     assert response.json() == expected_json
 

--- a/apps/api/tests/test_participant_api.py
+++ b/apps/api/tests/test_participant_api.py
@@ -26,6 +26,7 @@ def test_list_participants(auth_method):
     client = ApiTestClient(user, team, auth_method=auth_method)
     response = client.get(reverse("api:participant-data"))
     assert response.status_code == 200
+    assert response.json()["count"] == 1
     results = response.json()["results"]
     assert len(results) == 1
     p = results[0]

--- a/apps/api/tests/test_session_api.py
+++ b/apps/api/tests/test_session_api.py
@@ -33,6 +33,7 @@ def test_list_sessions(auth_method, session):
         "next": None,
         "previous": None,
         "results": [get_session_json(session)],
+        "count": 1,
     }
 
 
@@ -67,6 +68,7 @@ def test_list_sessions_with_tag(experiment):
         "next": None,
         "previous": None,
         "results": expected_results,
+        "count": 2,
     }
 
     # Remove filters by tag
@@ -80,7 +82,30 @@ def test_list_sessions_with_tag(experiment):
         "next": None,
         "previous": None,
         "results": expected_results,
+        "count": 3,
     }
+
+
+@pytest.mark.django_db()
+def test_list_sessions_count_only_on_first_page(experiment):
+    """The total count is computed once, on the first page; cursor-following
+    requests skip the COUNT query and omit the field."""
+    user = experiment.team.members.first()
+    ExperimentSessionFactory.create_batch(3, experiment=experiment)
+
+    client = ApiTestClient(user, experiment.team)
+    response = client.get(reverse("api:session-list") + "?page_size=2")
+    assert response.status_code == 200
+    first_page = response.json()
+    assert first_page["count"] == 3
+    assert len(first_page["results"]) == 2
+    assert first_page["next"] is not None
+
+    response = client.get(first_page["next"])
+    assert response.status_code == 200
+    second_page = response.json()
+    assert "count" not in second_page
+    assert len(second_page["results"]) == 1
 
 
 def get_session_json(session, expected_messages=None, expected_tags=None):
@@ -236,6 +261,7 @@ def test_list_sessions_with_experiment_filter(experiment):
         "next": None,
         "previous": None,
         "results": expected_results,
+        "count": 2,
     }
 
     # Filter by second experiment
@@ -248,6 +274,7 @@ def test_list_sessions_with_experiment_filter(experiment):
         "next": None,
         "previous": None,
         "results": expected_results,
+        "count": 1,
     }
 
 


### PR DESCRIPTION
### Product Description

API consumers paging through `/api/sessions/`, `/api/participants/`, `/api/experiments/`, and `/api/v2/chatbots/` now receive a `count` field (total matching records) on the first page of results, so they can show real progress while syncing data. Built for Scout's materialization progress bars, which are currently indeterminate for OCS because cursor pagination exposes no totals.

### Technical Description

`apps/api/pagination.py` — the shared `CursorPagination` subclass now computes `queryset.count()` and includes it in the response envelope **only when the request has no `cursor` param** (i.e. the first page). Cursor-following requests skip the COUNT entirely, so deep pagination costs exactly what it does today; a full sync pays for one COUNT total.

Performance rationale: this is the same `COUNT(*)` the web UI's chatbot sessions table (`ChatbotSessionsTableView`, django-tables2 default paginator) already runs on every page render against the same team/experiment-filtered queryset, backed by the existing FK indexes (`experiment_id` on sessions, `participant_team_created_idx` on participants). The places where counting is genuinely too expensive (eval dataset pickers, annotation queues) use `LazyPaginator` and are unaffected.

Design notes for the reviewer:

- The field is **additive and optional** (not in the schema's `required` list), so existing consumers are unaffected. Scout already reads `count` opportunistically from first-page envelopes, so it needs no changes.
- The count reflects the fully filtered queryset, so optional filters (`tags`/`versions` on sessions) make the COUNT correspondingly more expensive — same as the web UI's filtered tables. If that's a concern, the count could be skipped when those params are present, but I kept the semantics uniform.
- `api-schemas/v1.yml` regenerated via `inv schema` (documents `count` on all four paginated response schemas).

### Demo

```
GET /api/sessions/?page_size=2
{"next": "...cursor=...", "previous": null, "results": [...], "count": 3}

GET /api/sessions/?page_size=2&cursor=...
{"next": null, "previous": "...", "results": [...]}        # no count, no COUNT query
```

### Docs and Changelog
- [x] This PR requires docs/changelog update

The API reference picks the field up from the regenerated OpenAPI schema. Changelog note: paginated list endpoints now return a total `count` on the first page of results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)