### PR TITLE
Allow WebFetch/WebSearch in dependabot review workflow

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -82,7 +82,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "dependabot[bot]"
           claude_args: |
-            --allowedTools "Bash(npm:*),Bash(uv:*),Bash(git:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Edit"
+            --allowedTools "Bash(npm:*),Bash(uv:*),Bash(git:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Edit,WebFetch,WebSearch"
           prompt: |
             You are reviewing PR #${{ steps.pr.outputs.pr_number }}.
 


### PR DESCRIPTION
### Product Description
no change

### Technical Description
The dependabot review prompt instructs Claude to use `WebFetch` for changelog research, but `WebFetch`/`WebSearch` were missing from the `--allowedTools` allowlist, so the action blocked them at runtime — surfacing as "Live changelog fetching was unavailable in this environment" in its PR comments. Added both to the allowlist. These are served via Anthropic's API-side web tools, so the existing `ANTHROPIC_API_KEY` covers them.

### Docs and Changelog
- [ ] This PR requires docs/changelog update