### PR TITLE
Log widget deprecation/sunset response headers

### DIFF
--- a/components/chat_widget/src/services/chat-session-service.spec.ts
+++ b/components/chat_widget/src/services/chat-session-service.spec.ts
@@ -325,3 +325,111 @@ describe('ChatSessionService session tokens', () => {
     await expect(service.fetchMessages('s1')).rejects.toThrow('Failed to poll messages: Server Error');
   });
 });
+
+describe('ChatSessionService deprecation headers', () => {
+  const DOCS_URL = 'https://docs.openchatstudio.com/chat_widget/';
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function response(headers: Record<string, string>, body: unknown = { messages: [], has_more: false, session_status: 'active' }) {
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers(headers),
+      json: () => Promise.resolve(body),
+    } as Response;
+  }
+
+  function makeService() {
+    return new ChatSessionService({ apiBaseUrl: 'https://example.com', widgetVersion: '0.5.0' });
+  }
+
+  const sunsetHeaders = (sunset: string) => ({
+    Deprecation: 'true',
+    Sunset: sunset,
+    Link: `<${DOCS_URL}>; rel="successor-version"`,
+  });
+
+  it('does not log when the response carries no deprecation header', async () => {
+    const service = makeService();
+    jest.spyOn(global, 'fetch').mockResolvedValue(response({}));
+
+    await service.fetchMessages('s1');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns when deprecated and the sunset date is in the future', async () => {
+    const service = makeService();
+    jest.spyOn(global, 'fetch').mockResolvedValue(response(sunsetHeaders('Wed, 01 Jan 2099 00:00:00 GMT')));
+
+    await service.fetchMessages('s1');
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0][0] as string;
+    expect(message).toContain('0.5.0');
+    expect(message).toContain('deprecated');
+    expect(message).toContain(DOCS_URL);
+  });
+
+  it('errors when the sunset date has already passed', async () => {
+    const service = makeService();
+    jest.spyOn(global, 'fetch').mockResolvedValue(response(sunsetHeaders('Sat, 01 Jan 2000 00:00:00 GMT')));
+
+    await service.fetchMessages('s1');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const message = errorSpy.mock.calls[0][0] as string;
+    expect(message).toContain('0.5.0');
+    expect(message).toContain(DOCS_URL);
+  });
+
+  it('logs only once across repeated polls at the same level', async () => {
+    const service = makeService();
+    jest.spyOn(global, 'fetch').mockResolvedValue(response(sunsetHeaders('Wed, 01 Jan 2099 00:00:00 GMT')));
+
+    await service.fetchMessages('s1');
+    await service.fetchMessages('s1');
+    await service.fetchMessages('s1');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('escalates from warning to error when the sunset date passes mid-session', async () => {
+    const service = makeService();
+    const sunsetMs = Date.parse('Wed, 01 Jan 2025 00:00:00 GMT');
+    jest.spyOn(global, 'fetch').mockResolvedValue(response(sunsetHeaders('Wed, 01 Jan 2025 00:00:00 GMT')));
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    nowSpy.mockReturnValue(sunsetMs - 1000);
+    await service.fetchMessages('s1');
+
+    nowSpy.mockReturnValue(sunsetMs + 1000);
+    await service.fetchMessages('s1');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('detects the headers on the session-start response too', async () => {
+    const service = makeService();
+    jest.spyOn(global, 'fetch').mockResolvedValue(response(sunsetHeaders('Wed, 01 Jan 2099 00:00:00 GMT'), { session_id: 's1', chatbot: {}, participant: {} }));
+
+    await service.startSession({ chatbot_id: 'c1' });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/chat_widget/src/services/chat-session-service.ts
+++ b/components/chat_widget/src/services/chat-session-service.ts
@@ -95,6 +95,7 @@ export class ChatSessionService {
   private readonly taskPollingMaxAttempts: number;
   private readonly messagePollingIntervalMs: number;
   private messagePollingTimer?: ReturnType<typeof setInterval>;
+  private loggedSunsetLevel?: 'warn' | 'error';
   private static readonly MAX_HISTORY_PAGES = 40;
 
   constructor(options: ChatSessionServiceOptions) {
@@ -109,7 +110,7 @@ export class ChatSessionService {
   }
 
   async startSession(requestBody: Record<string, unknown>): Promise<ChatStartSessionResponse> {
-    const response = await fetch(`${this.apiBaseUrl}/api/chat/start/`, {
+    const response = await this.request(`${this.apiBaseUrl}/api/chat/start/`, {
       method: 'POST',
       headers: this.getJsonHeaders(),
       body: JSON.stringify(requestBody),
@@ -123,7 +124,7 @@ export class ChatSessionService {
   }
 
   async sendMessage(sessionId: string, payload: Record<string, unknown>): Promise<ChatSendMessageResponse> {
-    const response = await fetch(`${this.apiBaseUrl}/api/chat/${sessionId}/message/`, {
+    const response = await this.request(`${this.apiBaseUrl}/api/chat/${sessionId}/message/`, {
       method: 'POST',
       headers: this.getJsonHeaders(),
       body: JSON.stringify(payload),
@@ -137,7 +138,7 @@ export class ChatSessionService {
   }
 
   async pollTaskOnce(sessionId: string, taskId: string): Promise<ChatTaskPollResponse> {
-    const response = await fetch(`${this.apiBaseUrl}/api/chat/${sessionId}/${taskId}/poll/`, {
+    const response = await this.request(`${this.apiBaseUrl}/api/chat/${sessionId}/${taskId}/poll/`, {
       headers: this.getCommonHeaders(),
     });
 
@@ -214,7 +215,7 @@ export class ChatSessionService {
       url.searchParams.set('since', since);
     }
 
-    const response = await fetch(url.toString(), {
+    const response = await this.request(url.toString(), {
       headers: this.getCommonHeaders(),
     });
     if (!response.ok) {
@@ -286,6 +287,58 @@ export class ChatSessionService {
 
   setSessionToken(token?: string): void {
     this.sessionToken = token;
+  }
+
+  private async request(input: string, init?: RequestInit): Promise<Response> {
+    const response = await fetch(input, init);
+    this.checkSunsetHeaders(response);
+    return response;
+  }
+
+  /**
+   * Log a deprecation warning (RFC 8594 `Deprecation`/`Sunset`/`Link` headers)
+   * when the server reports that this widget version is deprecated. Warns
+   * during the deprecation window and errors once the sunset date has passed.
+   * Logs at most once per level so polling does not flood the console.
+   */
+  private checkSunsetHeaders(response: Response): void {
+    const headers = response?.headers;
+    if (!headers || typeof headers.get !== 'function') {
+      return;
+    }
+    if (headers.get('Deprecation') !== 'true') {
+      return;
+    }
+
+    const sunsetAt = this.parseSunsetDate(headers.get('Sunset'));
+    const pastSunset = sunsetAt !== null && Date.now() >= sunsetAt.getTime();
+    const level: 'warn' | 'error' = pastSunset ? 'error' : 'warn';
+    if (this.loggedSunsetLevel === level) {
+      return;
+    }
+    this.loggedSunsetLevel = level;
+
+    const upgradeUrl = this.parseSuccessorUrl(headers.get('Link'));
+    const upgradeSuffix = upgradeUrl ? ` Upgrade: ${upgradeUrl}` : '';
+    const sunsetText = sunsetAt ? sunsetAt.toUTCString() : 'an upcoming date';
+    if (level === 'error') {
+      console.error(`[open-chat-studio-widget] Widget version ${this.widgetVersion} is past its sunset date ` + `(${sunsetText}) and may stop working.${upgradeSuffix}`);
+    } else {
+      console.warn(`[open-chat-studio-widget] Widget version ${this.widgetVersion} is deprecated and will stop ` + `working after ${sunsetText}.${upgradeSuffix}`);
+    }
+  }
+
+  private parseSunsetDate(sunset: string | null): Date | null {
+    if (!sunset) {
+      return null;
+    }
+    const parsed = new Date(sunset);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  private parseSuccessorUrl(link: string | null): string | undefined {
+    const match = link?.match(/<([^>]+)>\s*;\s*rel="?successor-version"?/);
+    return match?.[1];
   }
 
   private async raiseForStatus(response: Response, fallbackPrefix: string): Promise<never> {


### PR DESCRIPTION
### Product Description
Old chat-widget versions get no signal that they're on a deprecation path. The server already emits RFC 8594 `Deprecation`/`Sunset`/`Link` headers (via `widget_sunset_headers`) when a deprecated widget version calls the chat API; this teaches the widget to surface them so integrators see it in their console.

### Technical Description
All `ChatSessionService` fetches now route through a single `request()` wrapper so headers are inspected on every response, not just errors (they ride on 200s). `console.warn` during the deprecation window, `console.error` once past the sunset date, de-duplicated to once per level so polling doesn't flood the console — a long-lived session that crosses the sunset date escalates warn→error exactly once.

Console-only by design; no user-facing UI. Header detection is guarded so a malformed response can never break a chat flow.

This ships in the published npm widget, so it needs a widget release + version bump to reach users. Current server-side rule only flags versions `< 0.6.0`; `LATEST_VERSION` is `0.8.0`, so a fresh widget won't warn against itself.

### Migrations
N/A — no migrations.

### Demo
### Docs and Changelog
- [ ] This PR requires docs/changelog update