### PR TITLE
Fix CI changed-file parsing in inline-imports and code-style jobs

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -222,9 +222,9 @@ jobs:
         id: cov_flags
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "flags=--cov --cov-report=xml" >> $GITHUB_OUTPUT
+            echo "flags=--cov --cov-report=xml" >> "$GITHUB_OUTPUT"
           else
-            echo "flags=" >> $GITHUB_OUTPUT
+            echo "flags=" >> "$GITHUB_OUTPUT"
           fi
       - name: Run Tests
         env:

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -88,10 +88,17 @@ jobs:
           sudo apt-get install -y ripgrep
       - id: file_changes
         uses: trilom/file-changes-action@v1.2.4
+      - id: changed_files
+        name: Build space-separated file list
+        env:
+          CHANGED_FILES: ${{ steps.file_changes.outputs.files }}
+        run: |
+          files=$(printf '%s' "$CHANGED_FILES" | jq -r '.[]' | tr '\n' ' ')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run pre-commit hooks
         uses: j178/prek-action@v2
         with:
-          extra-args: --files ${{ steps.file_changes.outputs.files }}
+          extra-args: --files ${{ steps.changed_files.outputs.files }}
 
   type-check:
     if: github.ref != 'refs/heads/main'
@@ -126,7 +133,7 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.file_changes.outputs.files }}
         run: |
-          files=$(printf '%s\n' "$CHANGED_FILES" | tr ' ' '\n' | grep -E '^apps/.*\.py$' | tr '\n' ' ' || true)
+          files=$(printf '%s' "$CHANGED_FILES" | jq -r '.[]' | grep -E '^apps/.*\.py$' | tr '\n' ' ' || true)
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Set up Python
         if: steps.py_files.outputs.files != ''


### PR DESCRIPTION
### Product Description
N/A — CI infrastructure fix.

### Technical Description
`trilom/file-changes-action` outputs `files` as a JSON array (`["a.py","b.py"]`), but both the `inline-imports` and `code-style` jobs consumed it as a space-separated list, so neither was actually checking anything on PRs:

- **inline-imports**: the grep filter never matched, producing an empty list, so every guarded step was skipped and `check_inline_imports.py` never ran.
- **code-style**: prek received the whole JSON array as a single (missing) filename, so all file-filtered hooks (ruff, ruff format, eslint, prettier, djlint, ty, …) reported "(no files to check) Skipped".

Both now parse the array with `jq` (preinstalled on `ubuntu-latest`).

### Migrations
- [ ] The migrations are backwards compatible

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update