### PR TITLE
Stop sending DisallowedHost errors to Sentry

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -618,6 +618,9 @@ if SENTRY_DSN:
     from sentry_sdk.integrations.logging import ignore_logger
 
     ignore_logger("ocs.request")
+    # Scanners/bots hit the server by raw IP or ELB/EC2 DNS name, none of which are in ALLOWED_HOSTS,
+    # so Django correctly rejects them with a 400. These are pure noise in Sentry.
+    ignore_logger("django.security.DisallowedHost")
 
     sentry_sdk.init(
         dsn=SENTRY_DSN,


### PR DESCRIPTION
### Product Description
no change

### Technical Description
~7K `DisallowedHost` errors over 90 days in Sentry, all of it automated vulnerability scanning — requests addressed to the raw IP, EC2 internal DNS, or the ELB DNS name rather than our domain, so prod's restricted `ALLOWED_HOSTS` correctly rejects them with a 400. No user impact; just noise. Suppressing the Sentry logger (same pattern as the existing `ocs.request` ignore right above it). Django still rejects the requests exactly as before.

### Docs and Changelog
- [ ] This PR requires docs/changelog update