### PR TITLE
Allow large bodies on evaluator edit

### DIFF
--- a/apps/evaluations/views/evaluator_views.py
+++ b/apps/evaluations/views/evaluator_views.py
@@ -144,6 +144,7 @@ class CreateEvaluator(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Evalua
         return reverse("evaluations:evaluator_home", args=[self.request.team.slug])
 
 
+@waf_allow(WafRule.SizeRestrictions_BODY)
 class EditEvaluator(LoginAndTeamRequiredMixin, PermissionRequiredMixin, EvaluatorFormsetMixin, UpdateView):
     permission_required = "evaluations.change_evaluator"
     model = Evaluator


### PR DESCRIPTION
### Product Description
Editing an evaluator with a large configuration no longer fails with a WAF block.

### Technical Description
Surfaced from a WAF log review: `EditEvaluator` was missing `@waf_allow(WafRule.SizeRestrictions_BODY)` while its `CreateEvaluator` sibling had it, despite both posting the same large `params` payload. Adding the decorator brings the two into line.

After merge, re-run `export_waf_allow_list` and deploy the updated allow-list to `ocs-deploy` for this to take effect (also picks up `^/$` for the prelogin homepage, already decorated but not yet deployed).

### Docs and Changelog
- [ ] This PR requires docs/changelog update