### PR TITLE
Speed up Django startup by deferring heavy ML imports

### DIFF
--- a/apps/documents/readers.py
+++ b/apps/documents/readers.py
@@ -2,8 +2,6 @@ import logging
 from io import BytesIO
 
 from bs4 import UnicodeDammit
-from markitdown import MarkItDown
-from markitdown._exceptions import FileConversionException, UnsupportedFormatException
 from pydantic import BaseModel, Field
 
 from apps.files.models import File
@@ -58,6 +56,10 @@ def get_file_content_reader(content_type) -> callable:
 
 def markitdown_read(file_obj) -> Document:
     # markitdown supports text, pdf, docx, xlsx, xls, outlook, pptx which will be handled by the default text reader
+    # Imported lazily: markitdown is slow to import and is only needed when actually reading a document (startup time).
+    from markitdown import MarkItDown  # noqa: PLC0415
+    from markitdown._exceptions import FileConversionException, UnsupportedFormatException  # noqa: PLC0415
+
     md = MarkItDown(enable_plugins=False)
     try:
         result = md.convert(BytesIO(file_obj.read()))

--- a/apps/documents/readers.py
+++ b/apps/documents/readers.py
@@ -56,9 +56,11 @@ def get_file_content_reader(content_type) -> callable:
 
 def markitdown_read(file_obj) -> Document:
     # markitdown supports text, pdf, docx, xlsx, xls, outlook, pptx which will be handled by the default text reader
-    # Imported lazily: markitdown is slow to import and is only needed when actually reading a document (startup time).
-    from markitdown import MarkItDown  # noqa: PLC0415
-    from markitdown._exceptions import FileConversionException, UnsupportedFormatException  # noqa: PLC0415
+    from markitdown import MarkItDown  # noqa: PLC0415 - TID253: heavy lib, slow startup
+    from markitdown._exceptions import (  # noqa: PLC0415 - TID253: heavy lib, slow startup
+        FileConversionException,
+        UnsupportedFormatException,
+    )
 
     md = MarkItDown(enable_plugins=False)
     try:

--- a/apps/help/__init__.py
+++ b/apps/help/__init__.py
@@ -9,8 +9,7 @@ class SystemAgentModel(BaseModel):
     key: str
 
     def init_model(self):
-        # Imported lazily: langchain.chat_models pulls in transformers and is slow to import (startup time).
-        from langchain.chat_models import init_chat_model  # noqa: PLC0415
+        from langchain.chat_models import init_chat_model  # noqa: PLC0415 - TID253: heavy lib, slow startup
 
         return init_chat_model(self.model, model_provider=self.provider, **self.model_kwargs)
 

--- a/apps/help/__init__.py
+++ b/apps/help/__init__.py
@@ -1,6 +1,5 @@
 from typing import Literal
 
-from langchain.chat_models import init_chat_model
 from pydantic import BaseModel
 
 
@@ -10,6 +9,9 @@ class SystemAgentModel(BaseModel):
     key: str
 
     def init_model(self):
+        # Imported lazily: langchain.chat_models pulls in transformers and is slow to import (startup time).
+        from langchain.chat_models import init_chat_model  # noqa: PLC0415
+
         return init_chat_model(self.model, model_provider=self.provider, **self.model_kwargs)
 
     @property

--- a/docs/agents/django_performance.md
+++ b/docs/agents/django_performance.md
@@ -12,15 +12,32 @@ def get_model():
 
 # ✅ GOOD - lazy import inside method (fast startup)
 def get_model():
-    from langchain_google_vertexai import ChatVertexAI
+    from langchain_google_vertexai import ChatVertexAI  # noqa: PLC0415 - TID253: heavy lib, slow startup
     return ChatVertexAI(...)
 ```
 
 Heavy libraries that benefit from lazy loading:
 * `langchain_google_vertexai` (~45s import time)
 * `langchain_google_genai` (~9s import time)
+* `langchain.chat_models` (~5s; pulls in `transformers`)
+* `markitdown` (~5s; pulls in `pandas`)
 * `langchain_anthropic`, `langchain_openai` (~3s combined)
+* `transformers` (~3s)
 * `boto3`, `pandas`, `numpy` (when not always needed)
+
+## Enforcing lazy imports
+These libraries are listed under `[tool.ruff.lint.flake8-tidy-imports]
+banned-module-level-imports` (TID253) in `pyproject.toml`, so a module-level
+import of any of them is a lint error. Import them inside the function that
+needs them and justify the inline import with the codebase convention:
+
+```python
+from markitdown import MarkItDown  # noqa: PLC0415 - TID253: heavy lib, slow startup
+```
+
+`scripts/check_inline_imports.py` verifies inline-import justifications across a
+package: it treats anything in the TID253 list as config-blessed, and
+hoist-tests the rest to catch stale `circular:` claims and unjustified imports.
 
 Use `TYPE_CHECKING` for type hints only:
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,11 @@ banned-module-level-imports = [
     "langchain_anthropic",
     "langchain_openai",
     "langchain_voyageai",
+    "langchain.chat_models",
     "boto3",
+    "markitdown",
+    "transformers",
+    "pandas",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
### Product Description
No change — internal startup-time optimization.

### Technical Description
`django.setup()` had crept to ~14.5s (warm). Profiling with `python -X importtime` showed two heavy libraries being imported at module/package load and dragged into every boot: `langchain.chat_models` (~5.7s, pulls `transformers`) via `apps/help/__init__.py`, and `markitdown` (~4.6s, pulls `pandas`) via `apps/documents/readers.py`. Both are moved to lazy imports inside the functions that use them, dropping setup to ~12.5s (~14%); `markitdown`, `langchain.chat_models`, and `pandas` no longer load at boot.

To stop regressions, added all four (plus `transformers`) to the existing `TID253 banned-module-level-imports` list — verified by `scripts/check_inline_imports.py`, which now treats them as config-blessed. The inline imports carry the codebase's standard `# noqa: PLC0415 - TID253` justification.

Not addressed here: `transformers` (~1.7s) still loads because `langchain_core`/`langgraph.prebuilt` import it deep in the chat-agent stack — a deeper, riskier refactor left for follow-up.

### Migrations
N/A — no migrations.

### Demo
N/A.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Updated `docs/agents/django_performance.md` (agent-facing) to document the enforcement; no user-facing changelog needed.