### PR TITLE
ci: fix ty-check pre-commit hook in code-style job

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -82,10 +82,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24.x
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
       - name: Install dependencies
         run: |
           npm ci
           sudo apt-get install -y ripgrep
+          uv venv
+          uv sync --locked --dev
       - id: file_changes
         uses: trilom/file-changes-action@v1.2.4
       - id: changed_files


### PR DESCRIPTION
### Product Description
No change.

### Technical Description
The `ty` pre-commit hook was bumped `v0.0.40 → v0.0.44` in 1c4d3d2c1 (2026-06-08). The newer version hard-errors (exit 2) when `[tool.ty.environment].python = ".venv"` in `pyproject.toml` points to a path that doesn't exist on disk. The `code-style` CI job runs the hook but never creates a `.venv`, so it now fails on every PR that touches a Python file (`code-style` is skipped on `main`, so it went unnoticed there).

Fix mirrors the other jobs: set up `uv` and run `uv venv && uv sync` before pre-commit so the hook resolves the project environment as it does locally.

### Docs and Changelog
- [ ] This PR requires docs/changelog update