### PR TITLE
Fill remaining chat widget gaps on the main chat page

### DIFF
--- a/apps/channels/widget_versions.py
+++ b/apps/channels/widget_versions.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.utils.http import http_date
 from packaging.version import InvalidVersion, Version
 
-LATEST_VERSION = "0.9.0"
+LATEST_VERSION = "0.9.1"
 
 # Widgets older than 0.5.1 (Sept 2025) do not send the x-ocs-widget-version
 # header, so a missing/unparseable version is treated as older than everything.

--- a/apps/channels/widget_versions.py
+++ b/apps/channels/widget_versions.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.utils.http import http_date
 from packaging.version import InvalidVersion, Version
 
-LATEST_VERSION = "0.8.0"
+LATEST_VERSION = "0.9.0"
 
 # Widgets older than 0.5.1 (Sept 2025) do not send the x-ocs-widget-version
 # header, so a missing/unparseable version is treated as older than everything.

--- a/apps/chatbots/tests/test_chatbot_views.py
+++ b/apps/chatbots/tests/test_chatbot_views.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, datetime
 from unittest.mock import Mock, patch
 
@@ -11,6 +12,7 @@ from django.test import Client, RequestFactory
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils.http import http_date
+from waffle.testutils import override_flag
 
 from apps.annotations.models import Tag
 from apps.api.session_tokens import validate_session_token
@@ -720,3 +722,66 @@ def test_chatbot_chat_ui_includes_valid_session_token():
     token = response.context_data["session_token"]
     assert token
     assert validate_session_token(token, session.external_id)
+
+
+@pytest.mark.django_db()
+def test_chatbot_chat_ui_widget_context():
+    """The public chat page configures the widget with a greeting but never pins a version:
+    anonymous participants may not request one through the chat API."""
+    experiment = ExperimentFactory()
+    session = ExperimentSessionFactory(experiment=experiment, team=experiment.team)
+
+    request = RequestFactory().get("/")
+    request.team = experiment.team
+    request.experiment = experiment
+    request.experiment_session = session
+
+    response = _chatbot_chat_ui(request)
+
+    assert "widget_version_number" not in response.context_data
+    assert json.loads(response.context_data["welcome_messages"]) == [
+        f"Hello, you can ask me anything you want about {experiment.name}."
+    ]
+
+
+@pytest.mark.django_db()
+def test_chatbot_chat_session_includes_widget_session_context(client, team_with_users):
+    user = team_with_users.members.first()
+    experiment = ExperimentFactory(team=team_with_users)
+    session = ExperimentSessionFactory(experiment=experiment, participant__user=user)
+    client.force_login(user)
+
+    url = reverse(
+        "chatbots:chatbot_chat_session",
+        args=[team_with_users.slug, experiment.id, experiment.version_number, session.id],
+    )
+    response = client.get(url)
+
+    assert response.status_code == 200
+    token = response.context["session_token"]
+    assert validate_session_token(token, session.external_id)
+    assert response.context["widget_version_number"] == experiment.version_number
+    assert json.loads(response.context["welcome_messages"]) == [
+        f"Hello, you can ask me anything you want about {experiment.name}."
+    ]
+
+
+@pytest.mark.django_db()
+@override_flag("flag_chat_widget", active=True)
+def test_web_chat_widget_rendering(client, team_with_users):
+    user = team_with_users.members.first()
+    experiment = ExperimentFactory(team=team_with_users, file_uploads_enabled=True)
+    session = ExperimentSessionFactory(experiment=experiment, participant__user=user)
+    client.force_login(user)
+
+    url = reverse(
+        "chatbots:chatbot_chat_session",
+        args=[team_with_users.slug, experiment.id, experiment.version_number, session.id],
+    )
+    content = client.get(url).content.decode()
+
+    assert f'version-number="{experiment.version_number}"' in content
+    assert 'allow-attachments="true"' in content
+    assert "welcome-messages=" in content
+    # consent-form experiments keep the end-chat-and-give-feedback flow alongside the widget
+    assert "end-experiment-modal" in content

--- a/apps/chatbots/tests/test_chatbot_views.py
+++ b/apps/chatbots/tests/test_chatbot_views.py
@@ -724,24 +724,7 @@ def test_chatbot_chat_ui_includes_valid_session_token():
 
 
 @pytest.mark.django_db()
-def test_chatbot_chat_ui_widget_context():
-    """The public chat page never pins a widget version: anonymous participants
-    may not request one through the chat API."""
-    experiment = ExperimentFactory()
-    session = ExperimentSessionFactory(experiment=experiment, team=experiment.team)
-
-    request = RequestFactory().get("/")
-    request.team = experiment.team
-    request.experiment = experiment
-    request.experiment_session = session
-
-    response = _chatbot_chat_ui(request)
-
-    assert "widget_version_number" not in response.context_data
-
-
-@pytest.mark.django_db()
-def test_chatbot_chat_session_includes_widget_session_context(client, team_with_users):
+def test_chatbot_chat_session_includes_valid_session_token(client, team_with_users):
     user = team_with_users.members.first()
     experiment = ExperimentFactory(team=team_with_users)
     session = ExperimentSessionFactory(experiment=experiment, participant__user=user)
@@ -756,7 +739,6 @@ def test_chatbot_chat_session_includes_widget_session_context(client, team_with_
     assert response.status_code == 200
     token = response.context["session_token"]
     assert validate_session_token(token, session.external_id)
-    assert response.context["widget_version_number"] == experiment.version_number
 
 
 @pytest.mark.django_db()
@@ -773,7 +755,6 @@ def test_web_chat_widget_rendering(client, team_with_users):
     )
     content = client.get(url).content.decode()
 
-    assert f'version-number="{experiment.version_number}"' in content
     assert 'allow-attachments="true"' in content
     # consent-form experiments keep the end-chat-and-give-feedback flow alongside the widget
     assert "end-experiment-modal" in content

--- a/apps/chatbots/tests/test_chatbot_views.py
+++ b/apps/chatbots/tests/test_chatbot_views.py
@@ -1,4 +1,3 @@
-import json
 from datetime import UTC, datetime
 from unittest.mock import Mock, patch
 
@@ -726,8 +725,8 @@ def test_chatbot_chat_ui_includes_valid_session_token():
 
 @pytest.mark.django_db()
 def test_chatbot_chat_ui_widget_context():
-    """The public chat page configures the widget with a greeting but never pins a version:
-    anonymous participants may not request one through the chat API."""
+    """The public chat page never pins a widget version: anonymous participants
+    may not request one through the chat API."""
     experiment = ExperimentFactory()
     session = ExperimentSessionFactory(experiment=experiment, team=experiment.team)
 
@@ -739,9 +738,6 @@ def test_chatbot_chat_ui_widget_context():
     response = _chatbot_chat_ui(request)
 
     assert "widget_version_number" not in response.context_data
-    assert json.loads(response.context_data["welcome_messages"]) == [
-        f"Hello, you can ask me anything you want about {experiment.name}."
-    ]
 
 
 @pytest.mark.django_db()
@@ -761,9 +757,6 @@ def test_chatbot_chat_session_includes_widget_session_context(client, team_with_
     token = response.context["session_token"]
     assert validate_session_token(token, session.external_id)
     assert response.context["widget_version_number"] == experiment.version_number
-    assert json.loads(response.context["welcome_messages"]) == [
-        f"Hello, you can ask me anything you want about {experiment.name}."
-    ]
 
 
 @pytest.mark.django_db()
@@ -782,6 +775,5 @@ def test_web_chat_widget_rendering(client, team_with_users):
 
     assert f'version-number="{experiment.version_number}"' in content
     assert 'allow-attachments="true"' in content
-    assert "welcome-messages=" in content
     # consent-form experiments keep the end-chat-and-give-feedback flow alongside the widget
     assert "end-experiment-modal" in content

--- a/apps/chatbots/tests/test_chatbot_views.py
+++ b/apps/chatbots/tests/test_chatbot_views.py
@@ -724,6 +724,27 @@ def test_chatbot_chat_ui_includes_valid_session_token():
 
 
 @pytest.mark.django_db()
+@patch("apps.chat.channels.enqueue_static_triggers", Mock())
+def test_start_authed_web_session_with_default_version_chats_with_published_version(client, team_with_users):
+    """The chatbots table chat button posts version 0 so sessions run against the published version."""
+    user = team_with_users.members.first()
+    experiment = ExperimentFactory(team=team_with_users)
+    experiment.create_new_version(make_default=True)
+    client.force_login(user)
+
+    url = reverse(
+        "chatbots:start_authed_web_session",
+        args=[team_with_users.slug, experiment.id, Experiment.DEFAULT_VERSION_NUMBER],
+    )
+    response = client.post(url)
+    assert response.status_code == 302
+
+    response = client.get(response.url)
+    assert response.status_code == 200
+    assert response.context["experiment_version"].is_default_version
+
+
+@pytest.mark.django_db()
 def test_chatbot_chat_session_includes_valid_session_token(client, team_with_users):
     user = team_with_users.members.first()
     experiment = ExperimentFactory(team=team_with_users)

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -1,3 +1,4 @@
+import json
 import unicodedata
 import uuid
 from functools import cached_property
@@ -647,7 +648,16 @@ def chatbot_chat_session(request, team_slug: str, experiment_id: int, version_nu
     return TemplateResponse(
         request,
         "chatbots/chat/web_chat.html",
-        {"experiment": experiment, "session": session, "active_tab": "chatbots", **version_specific_vars},
+        {
+            "experiment": experiment,
+            "session": session,
+            "session_token": issue_session_token(session),
+            # pin widget-started sessions to the version being tested rather than the published one
+            "widget_version_number": version_number,
+            "welcome_messages": _widget_welcome_messages(experiment_version.name),
+            "active_tab": "chatbots",
+            **version_specific_vars,
+        },
     )
 
 
@@ -795,11 +805,17 @@ def _chatbot_chat_ui(request, embedded=False):
             "experiment": request.experiment,
             "session": request.experiment_session,
             "session_token": issue_session_token(request.experiment_session),
+            "welcome_messages": _widget_welcome_messages(chatbot_version.name),
             "active_tab": "chatbots",
             "embedded": embedded,
             **version_specific_vars,
         },
     )
+
+
+def _widget_welcome_messages(experiment_name: str) -> str:
+    """JSON for the widget's `welcome-messages` attribute, mirroring the legacy chat UI greeting."""
+    return json.dumps([f"Hello, you can ask me anything you want about {experiment_name}."])
 
 
 @login_and_team_required

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -651,8 +651,6 @@ def chatbot_chat_session(request, team_slug: str, experiment_id: int, version_nu
             "experiment": experiment,
             "session": session,
             "session_token": issue_session_token(session),
-            # pin widget-started sessions to the version being tested rather than the published one
-            "widget_version_number": version_number,
             "active_tab": "chatbots",
             **version_specific_vars,
         },

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -1,4 +1,3 @@
-import json
 import unicodedata
 import uuid
 from functools import cached_property
@@ -654,7 +653,6 @@ def chatbot_chat_session(request, team_slug: str, experiment_id: int, version_nu
             "session_token": issue_session_token(session),
             # pin widget-started sessions to the version being tested rather than the published one
             "widget_version_number": version_number,
-            "welcome_messages": _widget_welcome_messages(experiment_version.name),
             "active_tab": "chatbots",
             **version_specific_vars,
         },
@@ -805,17 +803,11 @@ def _chatbot_chat_ui(request, embedded=False):
             "experiment": request.experiment,
             "session": request.experiment_session,
             "session_token": issue_session_token(request.experiment_session),
-            "welcome_messages": _widget_welcome_messages(chatbot_version.name),
             "active_tab": "chatbots",
             "embedded": embedded,
             **version_specific_vars,
         },
     )
-
-
-def _widget_welcome_messages(experiment_name: str) -> str:
-    """JSON for the widget's `welcome-messages` attribute, mirroring the legacy chat UI greeting."""
-    return json.dumps([f"Hello, you can ask me anything you want about {experiment_name}."])
 
 
 @login_and_team_required

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "js-cookie": "^3.0.7",
         "js-tiktoken": "^1.0.21",
         "lodash": "^4.17.23",
-        "open-chat-studio-widget": "^0.9.0",
+        "open-chat-studio-widget": "^0.9.1",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-error-boundary": "^6.0.1",
@@ -8926,9 +8926,9 @@
       }
     },
     "node_modules/open-chat-studio-widget": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/open-chat-studio-widget/-/open-chat-studio-widget-0.9.0.tgz",
-      "integrity": "sha512-xlddK4LzR0kpM1u0jroAPwcb7cEs4e7BHNNm8X6Me0Ezyp18Q1nOoAkVG5lrLPnSzEf1jLBgliieAqCQtfDNAg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/open-chat-studio-widget/-/open-chat-studio-widget-0.9.1.tgz",
+      "integrity": "sha512-pz2AWosTsYoJDVZdbbwnPedqIv/D0amRqDb8Y0KtEYUGpSxDz+NIr2IcntfxgvxuF9n9Md5VCudVMDLa9RJb0Q==",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.27.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "js-cookie": "^3.0.7",
         "js-tiktoken": "^1.0.21",
         "lodash": "^4.17.23",
-        "open-chat-studio-widget": "^0.8.0",
+        "open-chat-studio-widget": "^0.9.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-error-boundary": "^6.0.1",
@@ -8926,9 +8926,9 @@
       }
     },
     "node_modules/open-chat-studio-widget": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/open-chat-studio-widget/-/open-chat-studio-widget-0.8.0.tgz",
-      "integrity": "sha512-be8IKtWKRs8Kd8bCBP8QiwpoPc+P0bK47UKM1pQ7ezN9dsfecT/Pz0uhBntFApQdKkSjUxFh9elg4TbWGjKqiQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/open-chat-studio-widget/-/open-chat-studio-widget-0.9.0.tgz",
+      "integrity": "sha512-xlddK4LzR0kpM1u0jroAPwcb7cEs4e7BHNNm8X6Me0Ezyp18Q1nOoAkVG5lrLPnSzEf1jLBgliieAqCQtfDNAg==",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.27.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "js-cookie": "^3.0.7",
     "js-tiktoken": "^1.0.21",
     "lodash": "^4.17.23",
-    "open-chat-studio-widget": "^0.9.0",
+    "open-chat-studio-widget": "^0.9.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-error-boundary": "^6.0.1",

--- a/templates/chatbots/chat/web_chat.html
+++ b/templates/chatbots/chat/web_chat.html
@@ -32,7 +32,6 @@
             session-id="{{ session.external_id }}"
             session-token="{{ session_token }}"
             api-base-url="{{ request.scheme }}://{{ request.get_host }}"
-            welcome-messages="{{ welcome_messages }}"
             {% if widget_version_number is not None %}
               version-number="{{ widget_version_number }}"
             {% endif %}

--- a/templates/chatbots/chat/web_chat.html
+++ b/templates/chatbots/chat/web_chat.html
@@ -32,9 +32,6 @@
             session-id="{{ session.external_id }}"
             session-token="{{ session_token }}"
             api-base-url="{{ request.scheme }}://{{ request.get_host }}"
-            {% if widget_version_number is not None %}
-              version-number="{{ widget_version_number }}"
-            {% endif %}
             {% if experiment.file_uploads_enabled %}
               allow-attachments="true"
             {% endif %}

--- a/templates/chatbots/chat/web_chat.html
+++ b/templates/chatbots/chat/web_chat.html
@@ -32,12 +32,20 @@
             session-id="{{ session.external_id }}"
             session-token="{{ session_token }}"
             api-base-url="{{ request.scheme }}://{{ request.get_host }}"
+            welcome-messages="{{ welcome_messages }}"
+            {% if widget_version_number is not None %}
+              version-number="{{ widget_version_number }}"
+            {% endif %}
+            {% if experiment.file_uploads_enabled %}
+              allow-attachments="true"
+            {% endif %}
             {% if not request.user.is_anonymous %}
               user-id="{{ request.user.email }}"
               user-name="{{ request.user.get_full_name }}"
             {% endif %}
           ></open-chat-studio-widget>
         </div>
+        {% include "experiments/chat/end_chat_button.html" %}
       {% else %}
         {% include "experiments/chat/chat_ui.html" %}
       {% endflag %}

--- a/templates/experiments/chat/chat_ui.html
+++ b/templates/experiments/chat/chat_ui.html
@@ -31,14 +31,7 @@
   {% endfor %}
 </div>
 {% include "experiments/chat/input_bar.html" %}
-{% if not embedded %}
-  {% if experiment.consent_form %}
-    <div class="w-full text-center bg-base-300">
-      <label for="end-experiment-modal" class="btn btn-warning btn-xs">End chat and give feedback</label>
-    </div>
-    {% include "experiments/chat/end_experiment_modal.html" %}
-  {% endif %}
-{% endif %}
+{% include "experiments/chat/end_chat_button.html" %}
 <script>
   let refreshTimer = null;
   const pollInterval = 30000;

--- a/templates/experiments/chat/end_chat_button.html
+++ b/templates/experiments/chat/end_chat_button.html
@@ -1,0 +1,6 @@
+{% if not embedded and experiment.consent_form %}
+  <div class="w-full text-center bg-base-300">
+    <label for="end-experiment-modal" class="btn btn-warning btn-xs">End chat and give feedback</label>
+  </div>
+  {% include "experiments/chat/end_experiment_modal.html" %}
+{% endif %}

--- a/templates/experiments/components/experiment_actions_column.html
+++ b/templates/experiments/components/experiment_actions_column.html
@@ -1,5 +1,6 @@
 {% if record.is_editable %}
-  <form method="post" action="{% url type|add:':start_authed_web_session' record.team.slug record.id record.get_working_version.version_number %}" class="inline">
+  {# version 0 = the published version (falls back to the working version when nothing is published) #}
+  <form method="post" action="{% url type|add:':start_authed_web_session' record.team.slug record.id 0 %}" class="inline">
     {% csrf_token %}
     <button type="submit" class="btn btn-sm" title="New Session">
       <i class="fas fa-comment"></i>


### PR DESCRIPTION
Closes #3599.

### Product Description
When `flag_chat_widget` is on, the main chat page now keeps feature parity with the legacy chat UI: file attachments (when enabled on the bot) and the "End chat and give feedback" flow for consent-form bots. The chatbots table chat button now starts sessions against the published version instead of the working version.

### Technical Description
- The authed chat view now issues a session token like the public view does.
- The end-chat button/modal is extracted into a shared include used by both the widget branch and the legacy UI.
- The chatbots table chat button posts version 0 (published, falling back to working when nothing is published) — first step toward the web chat view only ever serving published versions.
- Also bumps the widget to 0.9.1 (includes the upload CSRF fix from #3605) and `widget_versions.py:LATEST_VERSION` to match, per the release policy.

Out of scope: version pinning and welcome greeting (dropped — see above), seed-message typing indicator (widget-side, tracked separately), and char-limit enforcement (dropped per #3599).

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)