### PR TITLE
Answer participant's original message after conversational consent (v2)

### DIFF
--- a/apps/channels/channels_v2/stages/core.py
+++ b/apps/channels/channels_v2/stages/core.py
@@ -331,13 +331,6 @@ class ConsentFlowStage(ProcessingStage):
     def _start_conversation(self, ctx: MessageProcessingContext) -> str | None:
         ctx.experiment_session.update_status(SessionStatus.ACTIVE)
 
-        # The consent token (e.g. "1") was persisted as a HUMAN message by
-        # ChatMessageCreationStage, but it's a control token, not conversational
-        # content. Drop it before building the bot's history so it doesn't end
-        # up between the original message and the AI reply (which would feed the
-        # LLM two consecutive HUMAN messages and corrupt the context).
-        self._discard_consent_token_message(ctx)
-
         # Original message wins over the seed message: answer what the
         # participant actually asked before they were interrupted for consent.
         original_message = self._get_original_message(ctx)
@@ -347,21 +340,6 @@ class ConsentFlowStage(ProcessingStage):
         if ctx.experiment.seed_message:
             return self._process_message(ctx, ctx.experiment.seed_message)
         return None
-
-    def _discard_consent_token_message(self, ctx: MessageProcessingContext) -> None:
-        """Delete the consent-token HUMAN message created for this request.
-
-        ``_start_conversation`` only runs once consent has been given, so
-        ``ctx.human_message`` is the consent token itself. Removing it keeps the
-        token out of the persisted chat history and the LLM context. The trace's
-        input-message link is re-pointed when the original message is answered
-        (see ``_process_message``).
-        """
-        consent_message = ctx.human_message
-        if consent_message is None:
-            return
-        consent_message.delete()
-        ctx.human_message = None
 
     def _get_original_message(self, ctx: MessageProcessingContext) -> ChatMessage | None:
         """Return the participant's first substantive message -- the one that
@@ -387,10 +365,6 @@ class ConsentFlowStage(ProcessingStage):
     ) -> str:
         """Invokes the bot with the given input and returns the response text.
 
-        Mirrors BotInteractionStage: notifies the channel (e.g. typing
-        indicator) before invoking the bot and exposes any assistant files via
-        ``ctx.files_to_send`` so ResponseFormattingStage can deliver them.
-
         Note: bot.process_input() persists the AI response internally.
         PersistenceStage detects this (ctx.bot_response is not None) and
         skips creating a duplicate AI ChatMessage for the early exit response.
@@ -399,16 +373,9 @@ class ConsentFlowStage(ProcessingStage):
         already in chat history), it is passed through so the AI response is
         linked to it without creating a duplicate HUMAN record.
         """
-        ctx.callbacks.on_submit_input_to_llm(ctx.participant_identifier)
         if not ctx.bot:
             ctx.bot = get_bot(ctx.experiment_session, ctx.experiment, ctx.trace_service)
-        # Re-point the trace's input message: the consent token it originally
-        # referenced has been discarded, so link the trace to the message we're
-        # actually answering.
-        if human_message is not None and ctx.trace_service:
-            ctx.trace_service.set_input_message_id(human_message.id)
         ctx.bot_response = ctx.bot.process_input(user_input=user_input, human_message=human_message)
-        ctx.files_to_send = ctx.bot_response.get_attached_files() or []
         return ctx.bot_response.content
 
 

--- a/apps/channels/channels_v2/stages/core.py
+++ b/apps/channels/channels_v2/stages/core.py
@@ -331,6 +331,13 @@ class ConsentFlowStage(ProcessingStage):
     def _start_conversation(self, ctx: MessageProcessingContext) -> str | None:
         ctx.experiment_session.update_status(SessionStatus.ACTIVE)
 
+        # The consent token (e.g. "1") was persisted as a HUMAN message by
+        # ChatMessageCreationStage, but it's a control token, not conversational
+        # content. Drop it before building the bot's history so it doesn't end
+        # up between the original message and the AI reply (which would feed the
+        # LLM two consecutive HUMAN messages and corrupt the context).
+        self._discard_consent_token_message(ctx)
+
         # Original message wins over the seed message: answer what the
         # participant actually asked before they were interrupted for consent.
         original_message = self._get_original_message(ctx)
@@ -340,6 +347,21 @@ class ConsentFlowStage(ProcessingStage):
         if ctx.experiment.seed_message:
             return self._process_message(ctx, ctx.experiment.seed_message)
         return None
+
+    def _discard_consent_token_message(self, ctx: MessageProcessingContext) -> None:
+        """Delete the consent-token HUMAN message created for this request.
+
+        ``_start_conversation`` only runs once consent has been given, so
+        ``ctx.human_message`` is the consent token itself. Removing it keeps the
+        token out of the persisted chat history and the LLM context. The trace's
+        input-message link is re-pointed when the original message is answered
+        (see ``_process_message``).
+        """
+        consent_message = ctx.human_message
+        if consent_message is None:
+            return
+        consent_message.delete()
+        ctx.human_message = None
 
     def _get_original_message(self, ctx: MessageProcessingContext) -> ChatMessage | None:
         """Return the participant's first substantive message -- the one that
@@ -365,6 +387,10 @@ class ConsentFlowStage(ProcessingStage):
     ) -> str:
         """Invokes the bot with the given input and returns the response text.
 
+        Mirrors BotInteractionStage: notifies the channel (e.g. typing
+        indicator) before invoking the bot and exposes any assistant files via
+        ``ctx.files_to_send`` so ResponseFormattingStage can deliver them.
+
         Note: bot.process_input() persists the AI response internally.
         PersistenceStage detects this (ctx.bot_response is not None) and
         skips creating a duplicate AI ChatMessage for the early exit response.
@@ -373,9 +399,16 @@ class ConsentFlowStage(ProcessingStage):
         already in chat history), it is passed through so the AI response is
         linked to it without creating a duplicate HUMAN record.
         """
+        ctx.callbacks.on_submit_input_to_llm(ctx.participant_identifier)
         if not ctx.bot:
             ctx.bot = get_bot(ctx.experiment_session, ctx.experiment, ctx.trace_service)
+        # Re-point the trace's input message: the consent token it originally
+        # referenced has been discarded, so link the trace to the message we're
+        # actually answering.
+        if human_message is not None and ctx.trace_service:
+            ctx.trace_service.set_input_message_id(human_message.id)
         ctx.bot_response = ctx.bot.process_input(user_input=user_input, human_message=human_message)
+        ctx.files_to_send = ctx.bot_response.get_attached_files() or []
         return ctx.bot_response.content
 
 

--- a/apps/channels/channels_v2/stages/core.py
+++ b/apps/channels/channels_v2/stages/core.py
@@ -273,7 +273,9 @@ class ConsentFlowStage(ProcessingStage):
 
     Sub-behaviors:
       - Builds consent/survey prompt text and raises EarlyExitResponse
-      - Handles seed message after consent is given
+      - After consent, sends the participant's original (pre-consent) message
+        to the bot so their first question is answered. Falls back to the
+        seed message only when there was no substantive original message.
     """
 
     USER_CONSENT_TEXT = "1"
@@ -308,9 +310,10 @@ class ConsentFlowStage(ProcessingStage):
 
             response = self._start_conversation(ctx)
             if response is None:
-                # Consent accepted but no seed message: the session is now ACTIVE.
-                # Halt silently -- there's nothing to send, and the consent token
-                # must not be forwarded to the bot as the participant's first prompt.
+                # Consent accepted but there's nothing to send to the bot: no
+                # substantive original message and no seed message. The session
+                # is now ACTIVE. Halt silently -- the consent token must not be
+                # forwarded to the bot as the participant's first prompt.
                 # (EarlyExitResponse("") would make terminal stages persist/send an
                 # empty AI message; EarlyAbort skips them entirely.)
                 raise EarlyAbort()
@@ -327,20 +330,52 @@ class ConsentFlowStage(ProcessingStage):
 
     def _start_conversation(self, ctx: MessageProcessingContext) -> str | None:
         ctx.experiment_session.update_status(SessionStatus.ACTIVE)
+
+        # Original message wins over the seed message: answer what the
+        # participant actually asked before they were interrupted for consent.
+        original_message = self._get_original_message(ctx)
+        if original_message is not None:
+            return self._process_message(ctx, original_message.content, human_message=original_message)
+
         if ctx.experiment.seed_message:
-            return self._process_seed_message(ctx)
+            return self._process_message(ctx, ctx.experiment.seed_message)
         return None
 
-    def _process_seed_message(self, ctx: MessageProcessingContext) -> str:
-        """Invokes the bot with the seed message and returns the response text.
+    def _get_original_message(self, ctx: MessageProcessingContext) -> ChatMessage | None:
+        """Return the participant's first substantive message -- the one that
+        triggered SETUP -> PENDING -- so it can be answered after consent.
+
+        Returns None when the participant's first message was itself just the
+        consent token (no prior content), so the caller falls back to the seed
+        message / silent halt.
+        """
+        first_human_message = (
+            ctx.experiment_session.chat.messages.filter(message_type=ChatMessageType.HUMAN)
+            .order_by("created_at")
+            .first()
+        )
+        if first_human_message is None:
+            return None
+        if first_human_message.content.strip() == self.USER_CONSENT_TEXT:
+            return None
+        return first_human_message
+
+    def _process_message(
+        self, ctx: MessageProcessingContext, user_input: str, human_message: ChatMessage | None = None
+    ) -> str:
+        """Invokes the bot with the given input and returns the response text.
 
         Note: bot.process_input() persists the AI response internally.
         PersistenceStage detects this (ctx.bot_response is not None) and
         skips creating a duplicate AI ChatMessage for the early exit response.
+
+        When ``human_message`` is provided (the original pre-consent message,
+        already in chat history), it is passed through so the AI response is
+        linked to it without creating a duplicate HUMAN record.
         """
         if not ctx.bot:
             ctx.bot = get_bot(ctx.experiment_session, ctx.experiment, ctx.trace_service)
-        ctx.bot_response = ctx.bot.process_input(user_input=ctx.experiment.seed_message)
+        ctx.bot_response = ctx.bot.process_input(user_input=user_input, human_message=human_message)
         return ctx.bot_response.content
 
 

--- a/apps/channels/channels_v2/stages/core.py
+++ b/apps/channels/channels_v2/stages/core.py
@@ -266,16 +266,18 @@ class ConsentCheckStage(ProcessingStage):
 class ConsentFlowStage(ProcessingStage):
     """Handles the conversational consent state machine.
 
-    This stage only manages consent state transitions and raises
-    EarlyExitResponse. It does NOT:
+    This stage only manages consent state transitions. It does NOT:
       - Send messages (ResponseSendingStage handles that)
       - Persist to chat history (PersistenceStage handles that)
+      - Invoke the bot (BotInteractionStage handles that)
 
     Sub-behaviors:
-      - Builds consent/survey prompt text and raises EarlyExitResponse
-      - After consent, sends the participant's original (pre-consent) message
-        to the bot so their first question is answered. Falls back to the
-        seed message only when there was no substantive original message.
+      - Builds the consent prompt text and raises EarlyExitResponse
+      - Once consent is given, swaps the participant's original (pre-consent)
+        message into ctx.user_query and lets the pipeline continue, so the
+        normal bot-interaction path answers their first question. Falls back
+        to the seed message when there was no substantive original message,
+        and halts silently when there is neither.
     """
 
     USER_CONSENT_TEXT = "1"
@@ -308,16 +310,7 @@ class ConsentFlowStage(ProcessingStage):
             if not self._user_gave_consent(ctx):
                 raise EarlyExitResponse(self._build_consent_prompt(ctx))
 
-            response = self._start_conversation(ctx)
-            if response is None:
-                # Consent accepted but there's nothing to send to the bot: no
-                # substantive original message and no seed message. The session
-                # is now ACTIVE. Halt silently -- the consent token must not be
-                # forwarded to the bot as the participant's first prompt.
-                # (EarlyExitResponse("") would make terminal stages persist/send an
-                # empty AI message; EarlyAbort skips them entirely.)
-                raise EarlyAbort()
-            raise EarlyExitResponse(response)
+            self._start_conversation(ctx)
 
     def _user_gave_consent(self, ctx: MessageProcessingContext) -> bool:
         return ctx.user_query is not None and ctx.user_query.strip() == self.USER_CONSENT_TEXT
@@ -328,18 +321,34 @@ class ConsentFlowStage(ProcessingStage):
         confirmation_text = ctx.experiment.consent_form.confirmation_text
         return f"{consent_text}\n\n{confirmation_text}"
 
-    def _start_conversation(self, ctx: MessageProcessingContext) -> str | None:
+    def _start_conversation(self, ctx: MessageProcessingContext) -> None:
+        """Consent accepted: activate the session and hand off to the normal
+        bot-interaction path by swapping the bot input into ctx.user_query.
+
+        ctx.human_message stays as the consent-token message. The bot excludes
+        the input message from the LLM history it builds, so the token never
+        sits next to the swapped-in query in the LLM context, while remaining
+        in the persisted history as the record of the consent reply.
+        """
         ctx.experiment_session.update_status(SessionStatus.ACTIVE)
 
         # Original message wins over the seed message: answer what the
         # participant actually asked before they were interrupted for consent.
         original_message = self._get_original_message(ctx)
         if original_message is not None:
-            return self._process_message(ctx, original_message.content, human_message=original_message)
+            ctx.user_query = original_message.content
+            return
 
         if ctx.experiment.seed_message:
-            return self._process_message(ctx, ctx.experiment.seed_message)
-        return None
+            ctx.user_query = ctx.experiment.seed_message
+            return
+
+        # Nothing to answer: no substantive original message and no seed
+        # message. The session is now ACTIVE. Halt silently -- the consent
+        # token must not be forwarded to the bot as the participant's first
+        # prompt. (EarlyExitResponse("") would make terminal stages
+        # persist/send an empty AI message; EarlyAbort skips them entirely.)
+        raise EarlyAbort()
 
     def _get_original_message(self, ctx: MessageProcessingContext) -> ChatMessage | None:
         """Return the participant's first substantive message -- the one that
@@ -359,24 +368,6 @@ class ConsentFlowStage(ProcessingStage):
         if first_human_message.content.strip() == self.USER_CONSENT_TEXT:
             return None
         return first_human_message
-
-    def _process_message(
-        self, ctx: MessageProcessingContext, user_input: str, human_message: ChatMessage | None = None
-    ) -> str:
-        """Invokes the bot with the given input and returns the response text.
-
-        Note: bot.process_input() persists the AI response internally.
-        PersistenceStage detects this (ctx.bot_response is not None) and
-        skips creating a duplicate AI ChatMessage for the early exit response.
-
-        When ``human_message`` is provided (the original pre-consent message,
-        already in chat history), it is passed through so the AI response is
-        linked to it without creating a duplicate HUMAN record.
-        """
-        if not ctx.bot:
-            ctx.bot = get_bot(ctx.experiment_session, ctx.experiment, ctx.trace_service)
-        ctx.bot_response = ctx.bot.process_input(user_input=user_input, human_message=human_message)
-        return ctx.bot_response.content
 
 
 # ---------------------------------------------------------------------------
@@ -520,7 +511,7 @@ class BotInteractionStage(ProcessingStage):
     def process(self, ctx: MessageProcessingContext) -> None:
         ctx.callbacks.on_submit_input_to_llm(ctx.participant_identifier)
 
-        # Lazy bot creation -- reuse if already created (e.g. by ConsentFlowStage seed message)
+        # Lazy bot creation -- reuse if already set on the context
         if not ctx.bot:
             ctx.bot = get_bot(ctx.experiment_session, ctx.experiment, ctx.trace_service)
 

--- a/apps/channels/channels_v2/stages/terminal.py
+++ b/apps/channels/channels_v2/stages/terminal.py
@@ -251,7 +251,8 @@ class PersistenceStage(ProcessingStage):
 
         # 2. Persist early exit response to chat history.
         #    Skip when ctx.bot_response exists -- bot.process_input() already
-        #    persisted the AI message (e.g. seed message in ConsentFlowStage).
+        #    persisted the AI message (e.g. when the catch-all error handler
+        #    set early_exit_response after BotInteractionStage succeeded).
         if ctx.early_exit_response is not None and ctx.bot_response is None:
             ChatMessage.objects.create(
                 chat=ctx.experiment_session.chat,

--- a/apps/channels/tests/channels/stages/test_consent_flow.py
+++ b/apps/channels/tests/channels/stages/test_consent_flow.py
@@ -20,10 +20,9 @@ class TestConsentFlowStage:
         query.first.return_value = first_human_message
         return session
 
-    def _make_message(self, content, message_id=1):
+    def _make_message(self, content):
         message = MagicMock()
         message.content = content
-        message.id = message_id
         return message
 
     def _make_experiment(self, consent_enabled=True, consent_form_id=1, seed_message=None):
@@ -84,113 +83,72 @@ class TestConsentFlowStage:
 
         assert "Do you consent?" in exc_info.value.response
 
-    @pytest.mark.parametrize(
-        (
-            "first_human_message_content",
-            "seed_message",
-            "has_bot",
-            "expected_exception",
-            "expected_input",
-            "expected_human_message",
-            "expected_response",
-        ),
-        [
-            pytest.param(
-                "1",
-                None,
-                False,
-                EarlyAbort,
-                None,
-                None,
-                None,
-                id="no-original-or-seed-halts-silently",
-            ),
-            pytest.param(
-                "How do I reset my password?",
-                "Welcome!",
-                True,
-                EarlyExitResponse,
-                "How do I reset my password?",
-                "original",
-                "Here's how to reset your password",
-                id="original-message-wins-over-seed",
-            ),
-            pytest.param(
-                "1",
-                "Welcome!",
-                True,
-                EarlyExitResponse,
-                "Welcome!",
-                None,
-                "Hi there",
-                id="falls-back-to-seed-when-first-message-is-consent-token",
-            ),
-        ],
-    )
-    def test_pending_consent_activation(
-        self,
-        first_human_message_content,
-        seed_message,
-        has_bot,
-        expected_exception,
-        expected_input,
-        expected_human_message,
-        expected_response,
-    ):
-        original = self._make_message(first_human_message_content)
-        session = self._make_session(status=SessionStatus.PENDING, first_human_message=original)
-        experiment = self._make_experiment(seed_message=seed_message)
-        bot = None
-        if has_bot:
-            bot = MagicMock()
-            bot.process_input.return_value.content = expected_response
+    def test_pending_consent_activates_with_no_original_or_seed(self):
+        # First message was the consent token itself -> no substantive original
+        # message and no seed message.
+        session = self._make_session(
+            status=SessionStatus.PENDING,
+            first_human_message=self._make_message("1"),
+        )
+        experiment = self._make_experiment(seed_message=None)
         ctx = make_context(
             experiment=experiment,
             experiment_session=session,
             user_query="1",
-            bot=bot,
         )
 
-        with pytest.raises(expected_exception) as exc_info:
+        # Nothing to send: halt silently (EarlyAbort) so the consent token is
+        # consumed without sending/persisting an empty message or forwarding it
+        # to the bot. The session is still transitioned to ACTIVE.
+        with pytest.raises(EarlyAbort):
             self.stage(ctx)
 
-        # The session is always activated once consent is accepted.
         session.update_status.assert_called_with(SessionStatus.ACTIVE)
 
-        if expected_exception is EarlyAbort:
-            # Nothing to send: halt silently so the consent token is consumed
-            # without forwarding it to the bot or persisting an empty message.
-            return
-
-        # The original message (when present) is passed through as the existing
-        # human_message so no duplicate HUMAN record is created; otherwise the
-        # seed message is sent with no linked human_message.
-        expected_hm = original if expected_human_message == "original" else None
-        bot.process_input.assert_called_once_with(user_input=expected_input, human_message=expected_hm)
-        assert exc_info.value.response == expected_response
-        assert ctx.bot_response is bot.process_input.return_value
-
-    def test_pending_consent_discards_consent_token_message(self):
-        # The consent token persisted by ChatMessageCreationStage must be removed
-        # so it doesn't pollute the bot history with a stray HUMAN message.
-        consent_token_message = self._make_message("1", message_id=42)
-        original = self._make_message("How do I reset my password?", message_id=7)
+    def test_pending_consent_answers_original_message(self):
+        # The participant's first (pre-consent) message is sent to the bot after
+        # consent, so their actual question is answered.
+        original = self._make_message("How do I reset my password?")
         session = self._make_session(status=SessionStatus.PENDING, first_human_message=original)
         experiment = self._make_experiment(seed_message="Welcome!")
         bot = MagicMock()
-        bot.process_input.return_value.content = "answer"
+        bot.process_input.return_value.content = "Here's how to reset your password"
         ctx = make_context(
             experiment=experiment,
             experiment_session=session,
             user_query="1",
             bot=bot,
-            human_message=consent_token_message,
         )
 
-        with pytest.raises(EarlyExitResponse):
+        with pytest.raises(EarlyExitResponse) as exc_info:
             self.stage(ctx)
 
-        consent_token_message.delete.assert_called_once_with()
-        assert ctx.human_message is None
-        # The trace is re-pointed to the message actually being answered.
-        ctx.trace_service.set_input_message_id.assert_called_once_with(original.id)
+        session.update_status.assert_called_with(SessionStatus.ACTIVE)
+        # Original message wins over the seed message, and is passed through as
+        # the existing human_message so no duplicate HUMAN record is created.
+        bot.process_input.assert_called_once_with(user_input="How do I reset my password?", human_message=original)
+        assert exc_info.value.response == "Here's how to reset your password"
+        assert ctx.bot_response is ctx.bot.process_input.return_value
+
+    def test_pending_consent_falls_back_to_seed_when_first_message_is_consent_token(self):
+        # First message was the consent token itself -> fall back to the seed.
+        session = self._make_session(
+            status=SessionStatus.PENDING,
+            first_human_message=self._make_message("1"),
+        )
+        experiment = self._make_experiment(seed_message="Welcome!")
+        bot = MagicMock()
+        bot.process_input.return_value.content = "Hi there"
+        ctx = make_context(
+            experiment=experiment,
+            experiment_session=session,
+            user_query="1",
+            bot=bot,
+        )
+
+        with pytest.raises(EarlyExitResponse) as exc_info:
+            self.stage(ctx)
+
+        session.update_status.assert_called_with(SessionStatus.ACTIVE)
+        bot.process_input.assert_called_once_with(user_input="Welcome!", human_message=None)
+        assert exc_info.value.response == "Hi there"

--- a/apps/channels/tests/channels/stages/test_consent_flow.py
+++ b/apps/channels/tests/channels/stages/test_consent_flow.py
@@ -83,72 +83,59 @@ class TestConsentFlowStage:
 
         assert "Do you consent?" in exc_info.value.response
 
-    def test_pending_consent_activates_with_no_original_or_seed(self):
-        # First message was the consent token itself -> no substantive original
-        # message and no seed message.
+    @pytest.mark.parametrize(
+        ("first_human_message_content", "seed_message", "expected_query"),
+        [
+            pytest.param(
+                "How do I reset my password?",
+                "Welcome!",
+                "How do I reset my password?",
+                id="original-message-wins-over-seed",
+            ),
+            pytest.param(
+                "1",
+                "Welcome!",
+                "Welcome!",
+                id="falls-back-to-seed-when-first-message-is-consent-token",
+            ),
+            pytest.param(
+                "1",
+                None,
+                None,
+                id="no-original-or-seed-halts-silently",
+            ),
+        ],
+    )
+    def test_pending_consent_activation(self, first_human_message_content, seed_message, expected_query):
+        consent_token_message = self._make_message("1")
         session = self._make_session(
             status=SessionStatus.PENDING,
-            first_human_message=self._make_message("1"),
+            first_human_message=self._make_message(first_human_message_content),
         )
-        experiment = self._make_experiment(seed_message=None)
+        experiment = self._make_experiment(seed_message=seed_message)
         ctx = make_context(
             experiment=experiment,
             experiment_session=session,
             user_query="1",
+            human_message=consent_token_message,
         )
 
-        # Nothing to send: halt silently (EarlyAbort) so the consent token is
-        # consumed without sending/persisting an empty message or forwarding it
-        # to the bot. The session is still transitioned to ACTIVE.
-        with pytest.raises(EarlyAbort):
+        if expected_query is None:
+            # Nothing to answer: halt silently (EarlyAbort) so the consent token
+            # is consumed without forwarding it to the bot or sending/persisting
+            # an empty message.
+            with pytest.raises(EarlyAbort):
+                self.stage(ctx)
+        else:
+            # The stage returns normally so the pipeline continues into
+            # BotInteractionStage with the swapped-in query. The consent-token
+            # message stays as ctx.human_message: the bot excludes the input
+            # message from the LLM history, keeping the token out of the
+            # LLM context while preserving it in the persisted history.
             self.stage(ctx)
 
-        session.update_status.assert_called_with(SessionStatus.ACTIVE)
-
-    def test_pending_consent_answers_original_message(self):
-        # The participant's first (pre-consent) message is sent to the bot after
-        # consent, so their actual question is answered.
-        original = self._make_message("How do I reset my password?")
-        session = self._make_session(status=SessionStatus.PENDING, first_human_message=original)
-        experiment = self._make_experiment(seed_message="Welcome!")
-        bot = MagicMock()
-        bot.process_input.return_value.content = "Here's how to reset your password"
-        ctx = make_context(
-            experiment=experiment,
-            experiment_session=session,
-            user_query="1",
-            bot=bot,
-        )
-
-        with pytest.raises(EarlyExitResponse) as exc_info:
-            self.stage(ctx)
+            assert ctx.user_query == expected_query
+            assert ctx.human_message is consent_token_message
+            assert ctx.bot_response is None
 
         session.update_status.assert_called_with(SessionStatus.ACTIVE)
-        # Original message wins over the seed message, and is passed through as
-        # the existing human_message so no duplicate HUMAN record is created.
-        bot.process_input.assert_called_once_with(user_input="How do I reset my password?", human_message=original)
-        assert exc_info.value.response == "Here's how to reset your password"
-        assert ctx.bot_response is ctx.bot.process_input.return_value
-
-    def test_pending_consent_falls_back_to_seed_when_first_message_is_consent_token(self):
-        # First message was the consent token itself -> fall back to the seed.
-        session = self._make_session(
-            status=SessionStatus.PENDING,
-            first_human_message=self._make_message("1"),
-        )
-        experiment = self._make_experiment(seed_message="Welcome!")
-        bot = MagicMock()
-        bot.process_input.return_value.content = "Hi there"
-        ctx = make_context(
-            experiment=experiment,
-            experiment_session=session,
-            user_query="1",
-            bot=bot,
-        )
-
-        with pytest.raises(EarlyExitResponse) as exc_info:
-            self.stage(ctx)
-
-        session.update_status.assert_called_with(SessionStatus.ACTIVE)
-        bot.process_input.assert_called_once_with(user_input="Welcome!", human_message=None)
-        assert exc_info.value.response == "Hi there"

--- a/apps/channels/tests/channels/stages/test_consent_flow.py
+++ b/apps/channels/tests/channels/stages/test_consent_flow.py
@@ -20,9 +20,10 @@ class TestConsentFlowStage:
         query.first.return_value = first_human_message
         return session
 
-    def _make_message(self, content):
+    def _make_message(self, content, message_id=1):
         message = MagicMock()
         message.content = content
+        message.id = message_id
         return message
 
     def _make_experiment(self, consent_enabled=True, consent_form_id=1, seed_message=None):
@@ -83,72 +84,113 @@ class TestConsentFlowStage:
 
         assert "Do you consent?" in exc_info.value.response
 
-    def test_pending_consent_activates_with_no_original_or_seed(self):
-        # First message was the consent token itself -> no substantive original
-        # message and no seed message.
-        session = self._make_session(
-            status=SessionStatus.PENDING,
-            first_human_message=self._make_message("1"),
-        )
-        experiment = self._make_experiment(seed_message=None)
+    @pytest.mark.parametrize(
+        (
+            "first_human_message_content",
+            "seed_message",
+            "has_bot",
+            "expected_exception",
+            "expected_input",
+            "expected_human_message",
+            "expected_response",
+        ),
+        [
+            pytest.param(
+                "1",
+                None,
+                False,
+                EarlyAbort,
+                None,
+                None,
+                None,
+                id="no-original-or-seed-halts-silently",
+            ),
+            pytest.param(
+                "How do I reset my password?",
+                "Welcome!",
+                True,
+                EarlyExitResponse,
+                "How do I reset my password?",
+                "original",
+                "Here's how to reset your password",
+                id="original-message-wins-over-seed",
+            ),
+            pytest.param(
+                "1",
+                "Welcome!",
+                True,
+                EarlyExitResponse,
+                "Welcome!",
+                None,
+                "Hi there",
+                id="falls-back-to-seed-when-first-message-is-consent-token",
+            ),
+        ],
+    )
+    def test_pending_consent_activation(
+        self,
+        first_human_message_content,
+        seed_message,
+        has_bot,
+        expected_exception,
+        expected_input,
+        expected_human_message,
+        expected_response,
+    ):
+        original = self._make_message(first_human_message_content)
+        session = self._make_session(status=SessionStatus.PENDING, first_human_message=original)
+        experiment = self._make_experiment(seed_message=seed_message)
+        bot = None
+        if has_bot:
+            bot = MagicMock()
+            bot.process_input.return_value.content = expected_response
         ctx = make_context(
             experiment=experiment,
             experiment_session=session,
             user_query="1",
+            bot=bot,
         )
 
-        # Nothing to send: halt silently (EarlyAbort) so the consent token is
-        # consumed without sending/persisting an empty message or forwarding it
-        # to the bot. The session is still transitioned to ACTIVE.
-        with pytest.raises(EarlyAbort):
+        with pytest.raises(expected_exception) as exc_info:
             self.stage(ctx)
 
+        # The session is always activated once consent is accepted.
         session.update_status.assert_called_with(SessionStatus.ACTIVE)
 
-    def test_pending_consent_answers_original_message(self):
-        # The participant's first (pre-consent) message is sent to the bot after
-        # consent, so their actual question is answered.
-        original = self._make_message("How do I reset my password?")
+        if expected_exception is EarlyAbort:
+            # Nothing to send: halt silently so the consent token is consumed
+            # without forwarding it to the bot or persisting an empty message.
+            return
+
+        # The original message (when present) is passed through as the existing
+        # human_message so no duplicate HUMAN record is created; otherwise the
+        # seed message is sent with no linked human_message.
+        expected_hm = original if expected_human_message == "original" else None
+        bot.process_input.assert_called_once_with(user_input=expected_input, human_message=expected_hm)
+        assert exc_info.value.response == expected_response
+        assert ctx.bot_response is bot.process_input.return_value
+
+    def test_pending_consent_discards_consent_token_message(self):
+        # The consent token persisted by ChatMessageCreationStage must be removed
+        # so it doesn't pollute the bot history with a stray HUMAN message.
+        consent_token_message = self._make_message("1", message_id=42)
+        original = self._make_message("How do I reset my password?", message_id=7)
         session = self._make_session(status=SessionStatus.PENDING, first_human_message=original)
         experiment = self._make_experiment(seed_message="Welcome!")
         bot = MagicMock()
-        bot.process_input.return_value.content = "Here's how to reset your password"
+        bot.process_input.return_value.content = "answer"
         ctx = make_context(
             experiment=experiment,
             experiment_session=session,
             user_query="1",
             bot=bot,
+            human_message=consent_token_message,
         )
 
-        with pytest.raises(EarlyExitResponse) as exc_info:
+        with pytest.raises(EarlyExitResponse):
             self.stage(ctx)
 
-        session.update_status.assert_called_with(SessionStatus.ACTIVE)
-        # Original message wins over the seed message, and is passed through as
-        # the existing human_message so no duplicate HUMAN record is created.
-        bot.process_input.assert_called_once_with(user_input="How do I reset my password?", human_message=original)
-        assert exc_info.value.response == "Here's how to reset your password"
-        assert ctx.bot_response is ctx.bot.process_input.return_value
-
-    def test_pending_consent_falls_back_to_seed_when_first_message_is_consent_token(self):
-        # First message was the consent token itself -> fall back to the seed.
-        session = self._make_session(
-            status=SessionStatus.PENDING,
-            first_human_message=self._make_message("1"),
-        )
-        experiment = self._make_experiment(seed_message="Welcome!")
-        bot = MagicMock()
-        bot.process_input.return_value.content = "Hi there"
-        ctx = make_context(
-            experiment=experiment,
-            experiment_session=session,
-            user_query="1",
-            bot=bot,
-        )
-
-        with pytest.raises(EarlyExitResponse) as exc_info:
-            self.stage(ctx)
-
-        session.update_status.assert_called_with(SessionStatus.ACTIVE)
-        bot.process_input.assert_called_once_with(user_input="Welcome!", human_message=None)
-        assert exc_info.value.response == "Hi there"
+        consent_token_message.delete.assert_called_once_with()
+        assert ctx.human_message is None
+        # The trace is re-pointed to the message actually being answered.
+        ctx.trace_service.set_input_message_id.assert_called_once_with(original.id)

--- a/apps/channels/tests/channels/stages/test_consent_flow.py
+++ b/apps/channels/tests/channels/stages/test_consent_flow.py
@@ -12,10 +12,18 @@ class TestConsentFlowStage:
     def setup_method(self):
         self.stage = ConsentFlowStage()
 
-    def _make_session(self, status=SessionStatus.SETUP):
+    def _make_session(self, status=SessionStatus.SETUP, first_human_message=None):
         session = MagicMock()
         session.status = status
+        # Stub the chat-history lookup that _get_original_message performs.
+        query = session.chat.messages.filter.return_value.order_by.return_value
+        query.first.return_value = first_human_message
         return session
+
+    def _make_message(self, content):
+        message = MagicMock()
+        message.content = content
+        return message
 
     def _make_experiment(self, consent_enabled=True, consent_form_id=1, seed_message=None):
         experiment = MagicMock()
@@ -75,8 +83,13 @@ class TestConsentFlowStage:
 
         assert "Do you consent?" in exc_info.value.response
 
-    def test_pending_consent_activates(self):
-        session = self._make_session(status=SessionStatus.PENDING)
+    def test_pending_consent_activates_with_no_original_or_seed(self):
+        # First message was the consent token itself -> no substantive original
+        # message and no seed message.
+        session = self._make_session(
+            status=SessionStatus.PENDING,
+            first_human_message=self._make_message("1"),
+        )
         experiment = self._make_experiment(seed_message=None)
         ctx = make_context(
             experiment=experiment,
@@ -84,10 +97,58 @@ class TestConsentFlowStage:
             user_query="1",
         )
 
-        # No seed message: halt silently (EarlyAbort) so the consent token is
+        # Nothing to send: halt silently (EarlyAbort) so the consent token is
         # consumed without sending/persisting an empty message or forwarding it
         # to the bot. The session is still transitioned to ACTIVE.
         with pytest.raises(EarlyAbort):
             self.stage(ctx)
 
         session.update_status.assert_called_with(SessionStatus.ACTIVE)
+
+    def test_pending_consent_answers_original_message(self):
+        # The participant's first (pre-consent) message is sent to the bot after
+        # consent, so their actual question is answered.
+        original = self._make_message("How do I reset my password?")
+        session = self._make_session(status=SessionStatus.PENDING, first_human_message=original)
+        experiment = self._make_experiment(seed_message="Welcome!")
+        bot = MagicMock()
+        bot.process_input.return_value.content = "Here's how to reset your password"
+        ctx = make_context(
+            experiment=experiment,
+            experiment_session=session,
+            user_query="1",
+            bot=bot,
+        )
+
+        with pytest.raises(EarlyExitResponse) as exc_info:
+            self.stage(ctx)
+
+        session.update_status.assert_called_with(SessionStatus.ACTIVE)
+        # Original message wins over the seed message, and is passed through as
+        # the existing human_message so no duplicate HUMAN record is created.
+        bot.process_input.assert_called_once_with(user_input="How do I reset my password?", human_message=original)
+        assert exc_info.value.response == "Here's how to reset your password"
+        assert ctx.bot_response is ctx.bot.process_input.return_value
+
+    def test_pending_consent_falls_back_to_seed_when_first_message_is_consent_token(self):
+        # First message was the consent token itself -> fall back to the seed.
+        session = self._make_session(
+            status=SessionStatus.PENDING,
+            first_human_message=self._make_message("1"),
+        )
+        experiment = self._make_experiment(seed_message="Welcome!")
+        bot = MagicMock()
+        bot.process_input.return_value.content = "Hi there"
+        ctx = make_context(
+            experiment=experiment,
+            experiment_session=session,
+            user_query="1",
+            bot=bot,
+        )
+
+        with pytest.raises(EarlyExitResponse) as exc_info:
+            self.stage(ctx)
+
+        session.update_status.assert_called_with(SessionStatus.ACTIVE)
+        bot.process_input.assert_called_once_with(user_input="Welcome!", human_message=None)
+        assert exc_info.value.response == "Hi there"


### PR DESCRIPTION
### Product Description
When conversational consent is enabled, the participant's first message (the one that triggered the consent flow) was used only as a trigger and never answered. After consent, the bot sent a seed message or nothing, silently dropping the participant's actual question. Now the bot answers the participant's original message after consent.

### Technical Description
`ConsentFlowStage` (v2) now looks up the first substantive HUMAN message from chat history when consent is accepted and forwards it to the bot. Original message wins over the seed message; the seed is used only when there was no substantive first message. If the first message was itself just the consent token, the previous behaviour is preserved. The original message is passed through as the existing human_message so no duplicate HUMAN record is created.

Fixes #3597

### Migrations
- [x] The migrations are backwards compatible (no migrations)

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Generated with [Claude Code](https://claude.ai/code)