### PR TITLE
fix: widget file uploads fail CSRF check for logged-in users

### DIFF
--- a/components/chat_widget/package.json
+++ b/components/chat_widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-chat-studio-widget",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Chat component for Open Chat Studio",
   "main": "dist/index.cjs.js",
   "exports": "./dist/esm/open-chat-studio-widget.js",

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -572,7 +572,7 @@ export class OcsChat {
         sessionId: this.activeSessionId,
         participantId: this.getOrGenerateUserId(),
         participantName: this.userName,
-        sessionToken: this.currentSessionToken,
+        headers: this.getChatService().getUploadHeaders(),
       });
       this.selectedFiles = uploadResult.selectedFiles;
       if (uploadResult.tokenRejected) {

--- a/components/chat_widget/src/services/chat-session-service.spec.ts
+++ b/components/chat_widget/src/services/chat-session-service.spec.ts
@@ -25,6 +25,35 @@ function completeMessage(content: string) {
   };
 }
 
+describe('ChatSessionService.getUploadHeaders', () => {
+  it('includes the common headers and the CSRF token', () => {
+    const service = new ChatSessionService({
+      apiBaseUrl: 'https://example.com',
+      widgetVersion: '1.0.0',
+      embedKey: 'embed-1',
+      sessionToken: 'tok-123',
+      csrfTokenProvider: () => 'csrf-456',
+    });
+
+    expect(service.getUploadHeaders()).toEqual({
+      'x-ocs-widget-version': '1.0.0',
+      'X-Embed-Key': 'embed-1',
+      'X-Session-Token': 'tok-123',
+      'X-CSRFToken': 'csrf-456',
+    });
+  });
+
+  it('omits the CSRF header when no token is available', () => {
+    const service = new ChatSessionService({
+      apiBaseUrl: 'https://example.com',
+      widgetVersion: '1.0.0',
+      csrfTokenProvider: () => undefined,
+    });
+
+    expect(service.getUploadHeaders()).toEqual({ 'x-ocs-widget-version': '1.0.0' });
+  });
+});
+
 describe('ChatSessionService.pollTask', () => {
   let service: ChatSessionService;
 

--- a/components/chat_widget/src/services/chat-session-service.ts
+++ b/components/chat_widget/src/services/chat-session-service.ts
@@ -359,15 +359,21 @@ export class ChatSessionService {
     throw new Error(message);
   }
 
-  private getJsonHeaders(): Record<string, string> {
+  /** Headers for multipart requests (no Content-Type — fetch sets the boundary). */
+  getUploadHeaders(): Record<string, string> {
     const headers = this.getCommonHeaders();
-    headers['Content-Type'] = 'application/json';
 
     const csrfToken = this.csrfTokenProvider(this.apiBaseUrl);
     if (csrfToken) {
       headers['X-CSRFToken'] = csrfToken;
     }
 
+    return headers;
+  }
+
+  private getJsonHeaders(): Record<string, string> {
+    const headers = this.getUploadHeaders();
+    headers['Content-Type'] = 'application/json';
     return headers;
   }
 

--- a/components/chat_widget/src/services/file-attachment-manager.spec.ts
+++ b/components/chat_widget/src/services/file-attachment-manager.spec.ts
@@ -8,12 +8,12 @@ function makeFile(name = 'a.txt') {
   return new File(['hello'], name, { type: 'text/plain' });
 }
 
-describe('FileAttachmentManager session tokens', () => {
+describe('FileAttachmentManager request headers', () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  it('sends the X-Session-Token header on upload when provided', async () => {
+  it('forwards the provided headers on upload', async () => {
     const manager = makeManager();
     const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
@@ -25,11 +25,13 @@ describe('FileAttachmentManager session tokens', () => {
       apiBaseUrl: 'https://example.com',
       sessionId: 's1',
       participantId: 'p1',
-      sessionToken: 'tok-123',
+      headers: { 'X-Session-Token': 'tok-123', 'X-CSRFToken': 'csrf-456', 'x-ocs-widget-version': '1.0.0' },
     });
 
     const headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
     expect(headers['X-Session-Token']).toBe('tok-123');
+    expect(headers['X-CSRFToken']).toBe('csrf-456');
+    expect(headers['x-ocs-widget-version']).toBe('1.0.0');
   });
 
   it('flags tokenRejected on a 403 upload response', async () => {
@@ -44,14 +46,14 @@ describe('FileAttachmentManager session tokens', () => {
       apiBaseUrl: 'https://example.com',
       sessionId: 's1',
       participantId: 'p1',
-      sessionToken: 'tok-123',
+      headers: { 'X-Session-Token': 'tok-123' },
     });
 
     expect(result.tokenRejected).toBe(true);
     expect(result.errorMessage).toBe('Session token required');
   });
 
-  it('omits the X-Session-Token header when no token is provided', async () => {
+  it('sends no auth headers when none are provided', async () => {
     const manager = makeManager();
     const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
@@ -66,7 +68,7 @@ describe('FileAttachmentManager session tokens', () => {
     });
 
     const headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
-    expect(headers['X-Session-Token']).toBeUndefined();
+    expect(headers).toEqual({});
   });
 
   it('does not flag tokenRejected on a non-403 failure', async () => {

--- a/components/chat_widget/src/services/file-attachment-manager.ts
+++ b/components/chat_widget/src/services/file-attachment-manager.ts
@@ -22,7 +22,8 @@ export interface UploadContext {
   sessionId: string;
   participantId: string;
   participantName?: string;
-  sessionToken?: string;
+  /** Auth headers (session token, CSRF, widget version) — see ChatSessionService.getUploadHeaders. */
+  headers?: Record<string, string>;
 }
 
 export interface UploadResult {
@@ -110,13 +111,9 @@ export class FileAttachmentManager {
     }
 
     try {
-      const headers: Record<string, string> = {};
-      if (context.sessionToken) {
-        headers['X-Session-Token'] = context.sessionToken;
-      }
       const response = await fetch(`${context.apiBaseUrl}/api/chat/${context.sessionId}/upload/`, {
         method: 'POST',
-        headers,
+        headers: context.headers ?? {},
         body: formData,
       });
 


### PR DESCRIPTION
### Product Description
Uploading a chat attachment as a logged-in user failed with `403 CSRF Failed: CSRF token missing`.

### Technical Description
The upload request built its headers by hand and only set `X-Session-Token`, while every other chat endpoint goes through the session service which adds `X-CSRFToken`, `x-ocs-widget-version`, and `X-Embed-Key`. DRF only enforces CSRF for cookie-authenticated requests, so anonymous embeds were unaffected — only logged-in same-origin users hit it.

Uploads now take their headers from the service (`getUploadHeaders()`), which also fixes the upload path never reporting the widget version or embed key.

Widget-only change, version bumped to 0.9.1. After publishing, `LATEST_VERSION` and the root `package.json` bump follow in the release PR per `docs/developer_guides/widget_versioning.md`.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)