### PR TITLE
Declarative registry for versioned node params

### DIFF
--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -1,13 +1,9 @@
-import logging
 from collections import defaultdict
 from collections.abc import Iterator
-from dataclasses import dataclass
 from functools import cached_property
-from typing import Self
 from uuid import uuid4
 
 import pydantic
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
 from django.urls import reverse
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
@@ -15,47 +11,16 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, System
 from apps.chat.models import ChatMessageType
 from apps.custom_actions.form_utils import set_custom_actions
 from apps.custom_actions.mixins import CustomActionOperationMixin
-from apps.documents.models import Collection
-from apps.experiments.models import ExperimentSession, SourceMaterial, VersionFieldDisplayFormatters
+from apps.experiments.models import ExperimentSession, VersionFieldDisplayFormatters
 from apps.experiments.versioning import VersionDetails, VersionField, VersionsMixin, VersionsObjectManagerMixin
 from apps.pipelines.exceptions import PipelineBuildError
 from apps.pipelines.flow import Flow, FlowNode, FlowNodeData
 from apps.pipelines.helper import create_pipeline_with_nodes, duplicate_pipeline_with_new_ids
+from apps.pipelines.versioning import get_versioned_param_specs
 from apps.teams.models import BaseTeamModel
 from apps.teams.utils import get_slug_for_team
 from apps.utils.fields import SanitizedJSONField
 from apps.utils.models import BaseModel
-
-versioning_logger = logging.getLogger("ocs.versioning")
-
-
-@dataclass
-class ModelParamSpec:
-    """A helper class to hold the parameter name and model of those that are database records"""
-
-    param_name: str
-    model_cls: VersionsMixin
-
-    def get_object(self, id: int):
-        return self.model_cls.objects.get(id=id)
-
-
-def _set_versioned_param_value(node_version: Self, param_name: str, param_cls):
-    """
-    Handles parameters referencing versioned models with the following logic:
-    - If the referenced model has changes compared to its latest version, a new version is created, and the
-        parameter is updated to point to this new version.
-    - If the referenced model matches the latest version, the parameter is simply updated to point to the existing
-        latest version.
-    """
-
-    if param_instance_id := node_version.params.get(param_name):
-        if param_instance := param_cls.objects.filter(id=param_instance_id).first():
-            if not param_instance.has_versions or param_instance.compare_with_latest():
-                new_instance_version = param_instance.create_new_version()
-                node_version.params[param_name] = str(new_instance_version.id)
-            else:
-                node_version.params[param_name] = str(param_instance.latest_version.id)
 
 
 class PipelineManager(VersionsObjectManagerMixin, models.Manager):
@@ -380,19 +345,13 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
 
     def create_new_version(self, is_copy=False, new_flow_id=None, pipeline=None):  # ty: ignore[invalid-method-override]
         """
-        Create a new version of the node and if the node is an assistant node, create a new version of the assistant
-        and update the `assistant_id` in the node params to the new assistant version id.
+        Create a new version of the node. Params that reference versioned records (see
+        `apps.pipelines.versioning`) are versioned along with the node and updated to point at the new version.
 
         Args:
             pipeline: If provided, the new version will be assigned to this pipeline before saving,
                 avoiding a transient state where the node temporarily belongs to the original pipeline.
         """
-        from apps.assistants.models import OpenAiAssistant  # noqa: PLC0415 - circular: assistants.models→models
-        from apps.pipelines.nodes.nodes import (  # noqa: PLC0415 - circular: nodes.nodes→models
-            AssistantNode,
-            LLMResponseWithPrompt,
-        )
-
         new_version = super().create_new_version(save=False, is_copy=is_copy)
         if is_copy and new_flow_id:
             old_flow_id = new_version.flow_id
@@ -400,15 +359,9 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
             if new_version.type not in ("StartNode", "EndNode") and new_version.params.get("name") == old_flow_id:
                 new_version.params["name"] = new_flow_id
 
-        if not is_copy and self.type == AssistantNode.__name__ and new_version.params.get("assistant_id"):
-            assistant = OpenAiAssistant.objects.get(id=new_version.params.get("assistant_id"))
-            if not assistant.is_a_version:
-                assistant_version = assistant.create_new_version()
-                # convert to string to be consistent with values from the UI
-                new_version.params["assistant_id"] = str(assistant_version.id)
-
-        if not is_copy and self.type == LLMResponseWithPrompt.__name__:
-            _set_versioned_param_value(new_version, "source_material_id", SourceMaterial)
+        if not is_copy:
+            for spec in get_versioned_param_specs(self.type):
+                spec.version_referenced_record(new_version.params)
 
         if pipeline is not None:
             new_version.pipeline = pipeline
@@ -443,42 +396,29 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
         self._archive_related_params()
 
     def _get_version_details(self) -> VersionDetails:
-        from apps.assistants.models import OpenAiAssistant  # noqa: PLC0415 - circular: assistants.models→models
         from apps.pipelines.nodes.nodes import LLMResponseWithPrompt  # noqa: PLC0415 - circular: nodes.nodes→models
 
         node_name = self.params.get("name", self.type)
         if node_name == self.flow_id:
             node_name = self.type
 
+        specs_by_param = {spec.param_name: spec for spec in get_versioned_param_specs(self.type)}
         param_versions = []
         for name, value in self.params.items():
             display_formatter = None
-            match name:
-                case "tools":
-                    display_formatter = VersionFieldDisplayFormatters.format_tools
-                case "custom_actions":
-                    # This is appended to the param_versions list separately
-                    continue
-                case "name":
-                    value = node_name
-                case "assistant_id":
-                    name = "assistant"
-                    # Load the assistant, since it is being versioned
-                    if value:
-                        value = OpenAiAssistant.objects.filter(id=value).first()
-                case "collection_id":
-                    name = "media"
-                    if value:
-                        value = Collection.objects.filter(id=value).first()
-                case "collection_index_ids":
-                    name = "Collection Indexes"
-                    if value:
-                        # Convert list of IDs to list of Collection objects
-                        value = list(Collection.objects.filter(id__in=value))
-                case "source_material_id":
-                    name = "source_material"
-                    if value:
-                        value = SourceMaterial.objects.filter(id=value).first()
+            if spec := specs_by_param.get(name):
+                # Load the referenced record(s) for display
+                name = spec.display_name
+                value = spec.resolve_for_display(value)
+            else:
+                match name:
+                    case "tools":
+                        display_formatter = VersionFieldDisplayFormatters.format_tools
+                    case "custom_actions":
+                        # This is appended to the param_versions list separately
+                        continue
+                    case "name":
+                        value = node_name
 
             param_versions.append(
                 VersionField(group_name=node_name, name=name, raw_value=value, to_display=display_formatter),
@@ -507,42 +447,8 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
         """
         Archive related params that were also versioned along with this node
         """
-        from apps.assistants.models import OpenAiAssistant  # noqa: PLC0415 - circular: assistants.models→models
-        from apps.pipelines.nodes import nodes  # noqa: PLC0415 - circular: nodes.nodes→models
-
-        # AssistantNode versions its assistant here. LLMResponseWithPrompt's collection params
-        # (media + index) are handled in the is_a_version-guarded block below; source_material is
-        # versioned in create_new_version but archival of its versions is still a TODO.
-        model_param_specs = {
-            nodes.AssistantNode.__name__: [ModelParamSpec(param_name="assistant_id", model_cls=OpenAiAssistant)],
-        }
-
-        for spec in model_param_specs.get(self.type, []):
-            if instance_id := self.params.get(spec.param_name):
-                try:
-                    obj = spec.get_object(instance_id)
-                    obj.archive()
-                except ObjectDoesNotExist:
-                    versioning_logger.exception(
-                        f"Failed to archive {spec.param_name} with id {instance_id}, since it could not be found"
-                    )
-
-        # ADR-0031: collections (single media + index list) are live shared resources. Only archive
-        # frozen per-bot versions (legacy data); never the live working collection.
-        if self.type == nodes.LLMResponseWithPrompt.__name__:
-            related_collection_ids = []
-            if media_collection_id := self.params.get("collection_id"):
-                related_collection_ids.append(media_collection_id)
-            related_collection_ids.extend(self.params.get("collection_index_ids") or [])
-            for related_collection_id in related_collection_ids:
-                try:
-                    collection = Collection.objects.get(id=related_collection_id)
-                    if collection.is_a_version:
-                        collection.archive()
-                except ObjectDoesNotExist:
-                    versioning_logger.exception(
-                        f"Failed to archive collection with id {related_collection_id}: not found"
-                    )
+        for spec in get_versioned_param_specs(self.type):
+            spec.archive_referenced_record(self.params)
 
 
 class PipelineEventInputs(models.TextChoices):

--- a/apps/pipelines/tests/test_versioning_registry.py
+++ b/apps/pipelines/tests/test_versioning_registry.py
@@ -1,0 +1,44 @@
+import pytest
+
+from apps.experiments.versioning import VersionsMixin
+from apps.pipelines.nodes import nodes as pipeline_nodes
+from apps.pipelines.versioning import (
+    _NODE_PARAM_SPECS,
+    ParamArchiving,
+    ParamVersioning,
+    VersionedParamSpec,
+)
+
+ALL_SPECS = [
+    pytest.param(node_type, spec, id=f"{node_type}.{spec.param_name}")
+    for node_type, specs in _NODE_PARAM_SPECS.items()
+    for spec in specs
+]
+
+
+@pytest.mark.parametrize(("node_type", "spec"), ALL_SPECS)
+def test_registry_node_types_and_params_exist(node_type, spec):
+    """Guards against registry drift: every spec must match a real param on a real node class."""
+    node_class = getattr(pipeline_nodes, node_type, None)
+    assert node_class is not None, f"Unknown node type '{node_type}' in versioned param registry"
+    assert spec.param_name in node_class.model_fields, (
+        f"'{spec.param_name}' is not a param of {node_type}; update the registry in apps.pipelines.versioning"
+    )
+
+
+@pytest.mark.parametrize(("node_type", "spec"), ALL_SPECS)
+def test_registry_models_are_versioned(node_type, spec):
+    model_cls = spec.model_cls
+    assert issubclass(model_cls, VersionsMixin), f"{spec.model_label} does not support versioning"
+
+
+def test_versioning_multi_id_params_is_unsupported():
+    with pytest.raises(ValueError, match="multi-ID"):
+        VersionedParamSpec(
+            param_name="some_ids",
+            model_label="documents.Collection",
+            display_name="some",
+            versioning=ParamVersioning.NEW_VERSION,
+            archiving=ParamArchiving.KEEP,
+            many=True,
+        )

--- a/apps/pipelines/tests/test_versioning_registry.py
+++ b/apps/pipelines/tests/test_versioning_registry.py
@@ -15,6 +15,8 @@ ALL_SPECS = [
     for spec in specs
 ]
 
+assert ALL_SPECS, "Versioned param registry must not be empty"
+
 
 @pytest.mark.parametrize(("node_type", "spec"), ALL_SPECS)
 def test_registry_node_types_and_params_exist(node_type, spec):

--- a/apps/pipelines/versioning.py
+++ b/apps/pipelines/versioning.py
@@ -1,0 +1,159 @@
+"""Registry of node params that reference database records.
+
+Each spec declares how a node param holding a model ID is handled when the node is
+versioned (publish), when a node version is archived, and how it is resolved for
+version-detail display. Adding a new param that references a versioned model only
+requires a new spec here; the code in ``apps.pipelines.models.Node`` is driven
+entirely by this registry.
+
+Custom actions are not included: they are linked through ``CustomActionOperation``
+records rather than an ID param, and are handled by ``CustomActionOperationMixin``.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+
+from django.apps import apps
+from django.core.exceptions import ObjectDoesNotExist
+
+versioning_logger = logging.getLogger("ocs.versioning")
+
+
+class ParamVersioning(StrEnum):
+    """How the referenced record is treated when the node is versioned."""
+
+    NEW_VERSION = "new_version"
+    """Always create a new version of the referenced record and point the param at it."""
+
+    REUSE_UNCHANGED = "reuse_unchanged"
+    """Create a new version only if the record changed since its latest version,
+    otherwise point the param at the existing latest version."""
+
+    LIVE_REFERENCE = "live_reference"
+    """The record is a live shared resource; the param keeps the working ID verbatim."""
+
+
+class ParamArchiving(StrEnum):
+    """How the referenced record is treated when the node version is archived."""
+
+    ARCHIVE = "archive"
+    """Archive the referenced record."""
+
+    ARCHIVE_VERSIONS_ONLY = "archive_versions_only"
+    """Archive the referenced record only if it is a version, never a live working record."""
+
+    KEEP = "keep"
+    """Leave the referenced record untouched."""
+
+
+@dataclass(frozen=True)
+class VersionedParamSpec:
+    param_name: str
+    model_label: str  # "app_label.ModelName"; resolved lazily to avoid circular imports
+    display_name: str
+    versioning: ParamVersioning
+    archiving: ParamArchiving
+    many: bool = False  # param holds a list of IDs
+
+    def __post_init__(self):
+        if self.many and self.versioning != ParamVersioning.LIVE_REFERENCE:
+            raise ValueError("Versioning of multi-ID params is not supported")
+
+    @property
+    def model_cls(self):
+        return apps.get_model(self.model_label)
+
+    def version_referenced_record(self, params: dict) -> None:
+        """Version the referenced record according to the spec's versioning strategy,
+        updating the param in ``params`` to point at the version."""
+        instance_id = params.get(self.param_name)
+        if not instance_id:
+            return
+
+        match self.versioning:
+            case ParamVersioning.LIVE_REFERENCE:
+                return
+            case ParamVersioning.NEW_VERSION:
+                instance = self.model_cls.objects.get(id=instance_id)
+                if not instance.is_a_version:
+                    params[self.param_name] = str(instance.create_new_version().id)
+            case ParamVersioning.REUSE_UNCHANGED:
+                instance = self.model_cls.objects.filter(id=instance_id).first()
+                if instance:
+                    if not instance.has_versions or instance.compare_with_latest():
+                        params[self.param_name] = str(instance.create_new_version().id)
+                    else:
+                        params[self.param_name] = str(instance.latest_version.id)
+
+    def archive_referenced_record(self, params: dict) -> None:
+        """Archive the record(s) referenced by the param according to the spec's
+        archiving strategy."""
+        if self.archiving == ParamArchiving.KEEP:
+            return
+
+        value = params.get(self.param_name)
+        instance_ids = (value if self.many else [value]) if value else []
+        for instance_id in instance_ids:
+            try:
+                instance = self.model_cls.objects.get(id=instance_id)
+            except ObjectDoesNotExist:
+                versioning_logger.exception(
+                    f"Failed to archive {self.param_name} with id {instance_id}, since it could not be found"
+                )
+                continue
+            if self.archiving == ParamArchiving.ARCHIVE_VERSIONS_ONLY and not instance.is_a_version:
+                continue
+            instance.archive()
+
+    def resolve_for_display(self, value):
+        """Resolve the raw param value to model instance(s) for version-detail display."""
+        if not value:
+            return value
+        if self.many:
+            return list(self.model_cls.objects.filter(id__in=value))
+        return self.model_cls.objects.filter(id=value).first()
+
+
+_NODE_PARAM_SPECS: dict[str, tuple[VersionedParamSpec, ...]] = {
+    "AssistantNode": (
+        VersionedParamSpec(
+            param_name="assistant_id",
+            model_label="assistants.OpenAiAssistant",
+            display_name="assistant",
+            versioning=ParamVersioning.NEW_VERSION,
+            archiving=ParamArchiving.ARCHIVE,
+        ),
+    ),
+    "LLMResponseWithPrompt": (
+        VersionedParamSpec(
+            param_name="source_material_id",
+            model_label="experiments.SourceMaterial",
+            display_name="source_material",
+            versioning=ParamVersioning.REUSE_UNCHANGED,
+            # Archiving source material versions when the node is archived is still a TODO
+            archiving=ParamArchiving.KEEP,
+        ),
+        # ADR-0031: collections (media + index) are live shared resources. Only frozen
+        # per-bot versions (legacy data) are ever archived; never the live working collection.
+        VersionedParamSpec(
+            param_name="collection_id",
+            model_label="documents.Collection",
+            display_name="media",
+            versioning=ParamVersioning.LIVE_REFERENCE,
+            archiving=ParamArchiving.ARCHIVE_VERSIONS_ONLY,
+        ),
+        VersionedParamSpec(
+            param_name="collection_index_ids",
+            model_label="documents.Collection",
+            display_name="Collection Indexes",
+            versioning=ParamVersioning.LIVE_REFERENCE,
+            archiving=ParamArchiving.ARCHIVE_VERSIONS_ONLY,
+            many=True,
+        ),
+    ),
+}
+
+
+def get_versioned_param_specs(node_type: str) -> tuple[VersionedParamSpec, ...]:
+    return _NODE_PARAM_SPECS.get(node_type, ())


### PR DESCRIPTION
Closes #3610. Pre-factor for #3398 (revert working version): the upcoming revert needs to invert the versioned-param rewriting, so the param→model knowledge has to live in one place first.

### Product Description
No change — pure refactor.

### Technical Description
Node params that reference DB records (`assistant_id`, `source_material_id`, collection params) were handled by per-type conditionals in three places in `apps/pipelines/models.py`: `Node.create_new_version`, `Node._archive_related_params`, and `Node._get_version_details`. These are now driven by a single registry in the new `apps/pipelines/versioning.py`, which also absorbs `ModelParamSpec` and `_set_versioned_param_value`.

The three existing strategies are preserved exactly, just named: `NEW_VERSION` (assistant: always version on publish), `REUSE_UNCHANGED` (source material: version only if changed), `LIVE_REFERENCE` (collections: working id kept verbatim, per ADR-0031) — with parallel archiving strategies. Existing versioning/archive tests pass unchanged and act as the no-behavior-change net; new tests guard against registry drift (every entry must name a real param on a real node class).

Custom actions stay out of the registry — they're linked via `CustomActionOperation` records, not an ID param.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)