### PR TITLE
Prevent duplicate CommCare Connect channel ids

### DIFF
--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -1,3 +1,4 @@
+import httpx
 from celery.app import shared_task
 from celery.utils.log import get_task_logger
 from django.db.models import Subquery
@@ -14,6 +15,30 @@ logger = get_task_logger("ocs.api")
 
 class DuplicateConnectChannelError(Exception):
     """The channel_id returned by Connect is already bound to another ParticipantData row."""
+
+
+def connect_channel_error_details(error: Exception, identifier: str) -> tuple[int, str]:
+    """Map a channel-creation failure to an HTTP status code and a user-safe detail message."""
+    if isinstance(error, DuplicateConnectChannelError):
+        return 409, (
+            "Failed to create channel: the CommCare Connect channel is already linked to "
+            "another chatbot for this participant"
+        )
+    if isinstance(error, httpx.HTTPStatusError):
+        status_code = error.response.status_code
+        logger.error(
+            "Failed to create CommCare Connect channel for participant %s: HTTP %s - %s",
+            identifier,
+            status_code,
+            error.response.text,
+        )
+        if status_code == 404:
+            return 404, "Failed to create channel: Participant not found in CommCare Connect"
+        if status_code >= 500:
+            return 503, "Failed to create channel: CommCare Connect service error"
+        return 400, f"Failed to create channel: {error.response.text}"
+    logger.error("Failed to create CommCare Connect channel for participant %s: %s", identifier, str(error))
+    return 503, "Failed to create channel: Unable to connect to CommCare Connect service"
 
 
 @shared_task(

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -73,14 +73,43 @@ def setup_connect_channels_for_bots(self, connect_id: str, experiment_data_map: 
 
 
 def create_connect_channel_for_participant(channel, connect_client, connect_id, participant_data):
-    response = connect_client.create_channel(
-        connect_id=connect_id, channel_source=channel.extra_data["commcare_connect_bot_name"]
+    bot_name = channel.extra_data["commcare_connect_bot_name"]
+    response = connect_client.create_channel(connect_id=connect_id, channel_source=bot_name)
+    channel_id = response["channel_id"]
+
+    # Connect's create_channel is idempotent on (connect_user, channel_source), so a reused bot
+    # name returns a channel_id that may already be bound to another ParticipantData row. A
+    # channel_id can only route to one experiment, so never store it on a second row.
+    # See https://github.com/dimagi/open-chat-studio/issues/3620.
+    existing = (
+        ParticipantData.objects.filter(system_metadata__commcare_connect_channel_id=channel_id)
+        .exclude(pk=participant_data.pk)
+        .only("id", "experiment_id")
+        .first()
     )
+    if existing is not None:
+        logger.error(
+            "Connect returned channel_id %s for participant '%s' and experiment %s, but it is "
+            "already bound to ParticipantData %s (experiment %s). Not storing it; the bot name "
+            "'%s' was likely reused.",
+            channel_id,
+            connect_id,
+            participant_data.experiment_id,
+            existing.pk,
+            existing.experiment_id,
+            bot_name,
+        )
+        return
+
     participant_data.system_metadata = {
-        "commcare_connect_channel_id": response["channel_id"],
+        "commcare_connect_channel_id": channel_id,
         "consent": response["consent"],
     }
     participant_data.save(update_fields=["system_metadata"])
+    # Generate the key eagerly so the device (via generate_key) and the outbound send path can
+    # never race to create different keys for the same channel.
+    if not participant_data.encryption_key:
+        participant_data.generate_encryption_key()
 
 
 @shared_task(ignore_result=True)

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -12,6 +12,10 @@ from apps.teams.utils import current_team
 logger = get_task_logger("ocs.api")
 
 
+class DuplicateConnectChannelError(Exception):
+    """The channel_id returned by Connect is already bound to another ParticipantData row."""
+
+
 @shared_task(
     bind=True,
     acks_late=True,
@@ -63,6 +67,9 @@ def setup_connect_channels_for_bots(self, connect_id: str, experiment_data_map: 
             channel = channels[experiment.id]
             create_connect_channel_for_participant(channel, connect_client, connect_id, participant_datum)
             successful_ids.add(experiment.id)
+        except DuplicateConnectChannelError:
+            # Deterministic conflict, already logged — retrying will not resolve it.
+            continue
         except Exception as e:
             if self.request.retries == self.max_retries:
                 failed_ids = set(experiment_ids) - successful_ids
@@ -99,7 +106,10 @@ def create_connect_channel_for_participant(channel, connect_client, connect_id, 
             existing.experiment_id,
             bot_name,
         )
-        return
+        raise DuplicateConnectChannelError(
+            f"The CommCare Connect channel for bot name '{bot_name}' is already linked to another "
+            "chatbot for this participant"
+        )
 
     participant_data.system_metadata = {
         "commcare_connect_channel_id": channel_id,

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -5,7 +5,7 @@ import json
 import os
 import uuid
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import httpx
 import pytest
@@ -16,6 +16,7 @@ from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
+from apps.api.tasks import create_connect_channel_for_participant
 from apps.channels.models import ChannelPlatform
 from apps.experiments.models import ExperimentSession, Participant, ParticipantData, SessionStatus
 from apps.teams.backends import CHATBOT_ADMIN_GROUP, add_user_to_team
@@ -516,6 +517,59 @@ def test_register_connect_participant(client, experiment):
 
 
 @pytest.mark.django_db()
+class TestCreateConnectChannelForParticipant:
+    def _connect_channel(self, experiment, bot_name):
+        return ExperimentChannelFactory.create(
+            team=experiment.team,
+            experiment=experiment,
+            platform=ChannelPlatform.COMMCARE_CONNECT,
+            extra_data={"commcare_connect_bot_name": bot_name},
+        )
+
+    def _connect_client(self, channel_id):
+        client = Mock()
+        client.create_channel.return_value = {"channel_id": channel_id, "consent": True}
+        return client
+
+    def test_stores_channel_id_and_generates_encryption_key(self, experiment):
+        channel = self._connect_channel(experiment, "bot1")
+        connect_id = uuid.uuid4().hex
+        participant_data = _setup_participant_data(experiment, connect_id, system_metadata={})
+        channel_id = str(uuid.uuid4())
+
+        create_connect_channel_for_participant(channel, self._connect_client(channel_id), connect_id, participant_data)
+
+        participant_data.refresh_from_db()
+        assert participant_data.system_metadata == {"commcare_connect_channel_id": channel_id, "consent": True}
+        assert participant_data.encryption_key
+
+    def test_does_not_store_channel_id_owned_by_another_row(self, experiment, caplog):
+        """Connect's create_channel is idempotent on (connect_user, channel_source), so a reused
+        bot name returns a channel_id that may already be bound to another ParticipantData row.
+        It must never be stored on a second row (issue #3620)."""
+        channel_id = str(uuid.uuid4())
+        connect_id = uuid.uuid4().hex
+        existing = _setup_participant_data(
+            experiment,
+            connect_id,
+            system_metadata={"commcare_connect_channel_id": channel_id, "consent": True},
+        )
+        other_experiment = ExperimentFactory.create(team=experiment.team)
+        channel = self._connect_channel(other_experiment, "reused-bot-name")
+        participant_data = ParticipantData.objects.create(
+            team=experiment.team,
+            participant=existing.participant,
+            experiment=other_experiment,
+        )
+
+        create_connect_channel_for_participant(channel, self._connect_client(channel_id), connect_id, participant_data)
+
+        participant_data.refresh_from_db()
+        assert "commcare_connect_channel_id" not in participant_data.system_metadata
+        assert "already bound" in caplog.text
+
+
+@pytest.mark.django_db()
 class TestConnectApis:
     def _make_key_request(self, client, data):
         token = uuid.uuid4()
@@ -541,6 +595,66 @@ class TestConnectApis:
         assert base64.b64decode(base64_key) is not None
         participant_data.refresh_from_db()
         assert participant_data.encryption_key == base64_key
+
+    def test_generate_key_duplicate_rows_returns_oldest_key(self, client, experiment, httpx_mock, caplog):
+        """If duplicate rows hold the same channel_id (issue #3620), serve the oldest row's key —
+        the one the device originally fetched — instead of raising MultipleObjectsReturned."""
+        connect_id = uuid.uuid4().hex
+        commcare_connect_channel_id = uuid.uuid4().hex
+        oldest_key = base64.b64encode(os.urandom(32)).decode("utf-8")
+        oldest = _setup_participant_data(
+            experiment,
+            connect_id=connect_id,
+            system_metadata={"commcare_connect_channel_id": commcare_connect_channel_id},
+            encryption_key=oldest_key,
+        )
+        other_experiment = ExperimentFactory.create(team=experiment.team)
+        ParticipantData.objects.create(
+            team=experiment.team,
+            participant=oldest.participant,
+            experiment=other_experiment,
+            system_metadata={"commcare_connect_channel_id": commcare_connect_channel_id},
+            encryption_key=base64.b64encode(os.urandom(32)).decode("utf-8"),
+        )
+
+        httpx_mock.add_response(
+            method="GET", url=settings.COMMCARE_CONNECT_GET_CONNECT_ID_URL, json={"sub": connect_id}
+        )
+        response = self._make_key_request(client=client, data={"channel_id": commcare_connect_channel_id})
+
+        assert response.status_code == 200
+        assert response.json()["key"] == oldest_key
+        assert "Multiple ParticipantData rows" in caplog.text
+
+    @override_settings(COMMCARE_CONNECT_SERVER_SECRET="123123")
+    def test_consent_with_duplicate_rows_updates_oldest(self, client, experiment, caplog):
+        connect_id = uuid.uuid4().hex
+        commcare_connect_channel_id = uuid.uuid4().hex
+        oldest = _setup_participant_data(
+            experiment,
+            connect_id=connect_id,
+            system_metadata={"commcare_connect_channel_id": commcare_connect_channel_id, "consent": False},
+        )
+        other_experiment = ExperimentFactory.create(team=experiment.team)
+        ParticipantData.objects.create(
+            team=experiment.team,
+            participant=oldest.participant,
+            experiment=other_experiment,
+            system_metadata={"commcare_connect_channel_id": commcare_connect_channel_id, "consent": False},
+        )
+
+        payload = {"channel_id": commcare_connect_channel_id, "consent": True}
+        response = client.post(
+            reverse("api:commcare-connect:consent"),
+            json.dumps(payload),
+            headers=self._get_request_headers(payload),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        oldest.refresh_from_db()
+        assert oldest.system_metadata["consent"] is True
+        assert "Multiple ParticipantData rows" in caplog.text
 
     def test_generate_key_cannot_the_find_user(self, client, experiment, httpx_mock):
         connect_id = uuid.uuid4().hex

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -16,7 +16,7 @@ from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
-from apps.api.tasks import create_connect_channel_for_participant
+from apps.api.tasks import DuplicateConnectChannelError, create_connect_channel_for_participant
 from apps.channels.models import ChannelPlatform
 from apps.experiments.models import ExperimentSession, Participant, ParticipantData, SessionStatus
 from apps.teams.backends import CHATBOT_ADMIN_GROUP, add_user_to_team
@@ -479,6 +479,50 @@ def test_update_participant_data_connect_channel_failure(httpx_mock, upstream, e
 
 
 @pytest.mark.django_db()
+@override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
+def test_update_participant_data_duplicate_channel_id_conflict(httpx_mock):
+    """If Connect returns a channel_id already bound to another row, the request fails with a
+    409 and the channel_id is not stored, but the participant data remains saved."""
+    duplicate_channel_id = str(uuid.uuid4())
+    team = TeamWithUsersFactory.create()
+    experiment_a = ExperimentFactory.create(team=team)
+    experiment_b = ExperimentFactory.create(team=team)
+    ExperimentChannelFactory.create(
+        team=team,
+        experiment=experiment_b,
+        platform=ChannelPlatform.COMMCARE_CONNECT,
+        extra_data={"commcare_connect_bot_name": "reused-bot-name"},
+    )
+    # the same participant already owns this channel_id via another experiment
+    _setup_channel_participant(
+        experiment_a,
+        identifier="connectid_9",
+        channel_platform=ChannelPlatform.COMMCARE_CONNECT,
+        system_metadata={"commcare_connect_channel_id": duplicate_channel_id, "consent": True},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{settings.COMMCARE_CONNECT_SERVER_URL}/messaging/create_channel/",
+        json={"channel_id": duplicate_channel_id, "consent": True},
+    )
+
+    user = team.members.first()
+    client = ApiTestClient(user, team)
+    data = {
+        "identifier": "connectid_9",
+        "platform": "commcare_connect",
+        "data": [{"experiment": str(experiment_b.public_id), "data": {"name": "John"}}],
+    }
+    response = client.post(reverse("api:participant-data"), json.dumps(data), content_type="application/json")
+
+    assert response.status_code == 409
+    assert "already linked to another chatbot" in response.json()["detail"]
+    participant_data = ParticipantData.objects.get(participant__identifier="connectid_9", experiment=experiment_b)
+    assert participant_data.data == {"name": "John"}
+    assert "commcare_connect_channel_id" not in participant_data.system_metadata
+
+
+@pytest.mark.django_db()
 def test_register_connect_participant(client, experiment):
     """
     Test registration of a participant with a connect ID. We want to ensure that if a participant already exists with
@@ -562,7 +606,10 @@ class TestCreateConnectChannelForParticipant:
             experiment=other_experiment,
         )
 
-        create_connect_channel_for_participant(channel, self._connect_client(channel_id), connect_id, participant_data)
+        with pytest.raises(DuplicateConnectChannelError):
+            create_connect_channel_for_participant(
+                channel, self._connect_client(channel_id), connect_id, participant_data
+            )
 
         participant_data.refresh_from_db()
         assert "commcare_connect_channel_id" not in participant_data.system_metadata
@@ -974,6 +1021,51 @@ def test_generate_bot_message_for_email_channel(experiment, django_capture_on_co
     assert sent.body == "Hello from the bot"
     assert sent.to == ["user@example.com"]
     assert sent.from_email == "bot@chat.openchatstudio.com"
+
+
+@pytest.mark.django_db()
+@override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
+@patch("apps.api.views.channels.CommCareConnectClient")
+def test_trigger_bot_duplicate_channel_id_conflict(ConnectClientView, experiment):
+    """A duplicate channel_id during enrollment surfaces as a 409, not a misleading consent error."""
+    duplicate_channel_id = uuid.uuid4().hex
+    connect_id = uuid.uuid4().hex
+    # the participant already owns this channel_id via another experiment
+    other_experiment = ExperimentFactory.create(team=experiment.team)
+    existing = _setup_participant_data(
+        other_experiment,
+        connect_id=connect_id,
+        system_metadata={"commcare_connect_channel_id": duplicate_channel_id, "consent": True},
+    )
+    # the row for the target experiment has no channel yet
+    ParticipantData.objects.create(
+        team=experiment.team,
+        participant=existing.participant,
+        experiment=experiment,
+    )
+    ExperimentChannelFactory.create(
+        team=experiment.team,
+        experiment=experiment,
+        platform=ChannelPlatform.COMMCARE_CONNECT,
+        extra_data={"commcare_connect_bot_name": "reused-bot-name"},
+    )
+    ConnectClientView.return_value.create_channel.return_value = {
+        "channel_id": duplicate_channel_id,
+        "consent": True,
+    }
+
+    api_user = experiment.team.members.first()
+    client = ApiTestClient(api_user, experiment.team)
+    data = {
+        "identifier": connect_id,
+        "platform": ChannelPlatform.COMMCARE_CONNECT,
+        "experiment": str(experiment.public_id),
+        "message_text": "hello",
+    }
+    response = client.post(reverse("api:trigger_bot"), json.dumps(data), content_type="application/json")
+
+    assert response.status_code == 409
+    assert "already linked to another chatbot" in response.json()["detail"]
 
 
 # ── trigger_bot direct-message (message_text) tests ──────────────────────────

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -15,7 +15,11 @@ from rest_framework.views import APIView, Request
 
 from apps.api.permissions import verify_hmac
 from apps.api.serializers import TriggerBotMessageRequest, TriggerBotMessageResponse
-from apps.api.tasks import create_connect_channel_for_participant, trigger_bot_message_task
+from apps.api.tasks import (
+    DuplicateConnectChannelError,
+    create_connect_channel_for_participant,
+    trigger_bot_message_task,
+)
 from apps.channels.clients.connect_client import CommCareConnectClient
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import ChannelBase
@@ -126,6 +130,8 @@ def _ensure_commcare_connect_ready(channel, identifier, participant_data):
         connect_client = CommCareConnectClient()
         try:
             create_connect_channel_for_participant(channel, connect_client, identifier, participant_data)
+        except DuplicateConnectChannelError as e:
+            return JsonResponse({"detail": f"Failed to create channel: {e}"}, status=status.HTTP_409_CONFLICT)
         except httpx.HTTPStatusError as e:
             connect_logger.error(
                 f"Failed to create CommCare Connect channel for participant {identifier}: "

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -40,15 +40,14 @@ def generate_key(request: Request):
     response.raise_for_status()
     connect_id = response.json().get("sub").lower()
 
-    try:
-        participant_data = ParticipantData.objects.defer("data").get(
-            participant__identifier=connect_id, system_metadata__commcare_connect_channel_id=commcare_connect_channel_id
-        )
-    except ParticipantData.DoesNotExist:
-        connect_logger.exception(
+    participant_data = ParticipantData.objects.for_connect_channel(
+        commcare_connect_channel_id, participant_identifier=connect_id
+    )
+    if participant_data is None:
+        connect_logger.error(
             f"ParticipantData with connect_id: {connect_id} and channel_id: {commcare_connect_channel_id} not found"
         )
-        raise Http404() from None
+        raise Http404()
 
     if not participant_data.encryption_key:
         participant_data.generate_encryption_key()
@@ -76,9 +75,9 @@ def consent(request: Request):
     if "consent" not in request_data or "channel_id" not in request_data:
         return HttpResponse("Missing consent or commcare_connect_channel_id", status=400)
 
-    participant_data = get_object_or_404(
-        ParticipantData, system_metadata__commcare_connect_channel_id=request_data["channel_id"]
-    )
+    participant_data = ParticipantData.objects.for_connect_channel(request_data["channel_id"])
+    if participant_data is None:
+        raise Http404()
     participant_data.update_consent(request_data["consent"])
 
     return HttpResponse()

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -17,6 +17,7 @@ from apps.api.permissions import verify_hmac
 from apps.api.serializers import TriggerBotMessageRequest, TriggerBotMessageResponse
 from apps.api.tasks import (
     DuplicateConnectChannelError,
+    connect_channel_error_details,
     create_connect_channel_for_participant,
     trigger_bot_message_task,
 )
@@ -130,34 +131,9 @@ def _ensure_commcare_connect_ready(channel, identifier, participant_data):
         connect_client = CommCareConnectClient()
         try:
             create_connect_channel_for_participant(channel, connect_client, identifier, participant_data)
-        except DuplicateConnectChannelError as e:
-            return JsonResponse({"detail": f"Failed to create channel: {e}"}, status=status.HTTP_409_CONFLICT)
-        except httpx.HTTPStatusError as e:
-            connect_logger.error(
-                f"Failed to create CommCare Connect channel for participant {identifier}: "
-                f"HTTP {e.response.status_code} - {e.response.text}"
-            )
-            if e.response.status_code == 404:
-                return JsonResponse(
-                    {"detail": "Failed to create channel: Participant not found in CommCare Connect"},
-                    status=status.HTTP_404_NOT_FOUND,
-                )
-            elif e.response.status_code >= 500:
-                return JsonResponse(
-                    {"detail": "Failed to create channel: CommCare Connect service error"},
-                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
-                )
-            else:
-                return JsonResponse(
-                    {"detail": f"Failed to create channel: {e.response.text}"},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-        except httpx.HTTPError as e:
-            connect_logger.error(f"Failed to create CommCare Connect channel for participant {identifier}: {str(e)}")
-            return JsonResponse(
-                {"detail": "Failed to create channel: Unable to connect to CommCare Connect service"},
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
-            )
+        except (DuplicateConnectChannelError, httpx.HTTPError) as e:
+            status_code, detail = connect_channel_error_details(e, identifier)
+            return JsonResponse({"detail": detail}, status=status_code)
 
     if not participant_data.has_consented():
         return JsonResponse({"detail": "User has not given consent"}, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/api/views/participants.py
+++ b/apps/api/views/participants.py
@@ -15,7 +15,11 @@ from rest_framework.views import APIView
 from apps.api.pagination import CursorPagination
 from apps.api.permissions import ReadOnlyAPIKeyPermission
 from apps.api.serializers import ParticipantDataUpdateRequest, ParticipantDetailSerializer
-from apps.api.tasks import DuplicateConnectChannelError, create_connect_channel_for_participant
+from apps.api.tasks import (
+    DuplicateConnectChannelError,
+    connect_channel_error_details,
+    create_connect_channel_for_participant,
+)
 from apps.channels.clients.connect_client import CommCareConnectClient
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.events.models import ScheduledMessage, TimePeriod
@@ -25,19 +29,12 @@ from apps.oauth.permissions import TokenHasOAuthResourceScope
 logger = logging.getLogger("ocs.api")
 
 
-class ServiceUnavailable(APIException):
-    status_code = 503
-    default_detail = "Service temporarily unavailable."
+class ChannelCreationError(APIException):
+    """Channel-creation failure carrying the status code mapped from the upstream error."""
 
-
-class BadRequest(APIException):
-    status_code = 400
-    default_detail = "Bad request."
-
-
-class Conflict(APIException):
-    status_code = 409
-    default_detail = "Conflict."
+    def __init__(self, detail, status_code):
+        self.status_code = status_code
+        super().__init__(detail)
 
 
 class ParticipantView(APIView):
@@ -285,30 +282,9 @@ def _setup_connect_channels(identifier, participant_data_by_experiment_id):
     for channel, participant_data in pending:
         try:
             create_connect_channel_for_participant(channel, connect_client, identifier, participant_data)
-        except DuplicateConnectChannelError as e:
-            raise Conflict(f"Failed to create channel: {e}") from e
-        except httpx.HTTPError as e:
-            raise _connect_channel_error(e, identifier) from e
-
-
-def _connect_channel_error(error, identifier):
-    """Map a CommCare Connect client error to the DRF exception to return to the caller."""
-    if isinstance(error, httpx.HTTPStatusError):
-        status_code = error.response.status_code
-        logger.error(
-            "Failed to create CommCare Connect channel for participant %s: HTTP %s - %s",
-            identifier,
-            status_code,
-            error.response.text,
-        )
-        if status_code == 404:
-            return NotFound("Failed to create channel: Participant not found in CommCare Connect")
-        if status_code >= 500:
-            return ServiceUnavailable("Failed to create channel: CommCare Connect service error")
-        return BadRequest(f"Failed to create channel: {error.response.text}")
-
-    logger.error("Failed to create CommCare Connect channel for participant %s: %s", identifier, str(error))
-    return ServiceUnavailable("Failed to create channel: Unable to connect to CommCare Connect service")
+        except (DuplicateConnectChannelError, httpx.HTTPError) as e:
+            status_code, detail = connect_channel_error_details(e, identifier)
+            raise ChannelCreationError(detail, status_code) from e
 
 
 def _schedule_external_id(data, experiment, participant):

--- a/apps/api/views/participants.py
+++ b/apps/api/views/participants.py
@@ -15,7 +15,7 @@ from rest_framework.views import APIView
 from apps.api.pagination import CursorPagination
 from apps.api.permissions import ReadOnlyAPIKeyPermission
 from apps.api.serializers import ParticipantDataUpdateRequest, ParticipantDetailSerializer
-from apps.api.tasks import create_connect_channel_for_participant
+from apps.api.tasks import DuplicateConnectChannelError, create_connect_channel_for_participant
 from apps.channels.clients.connect_client import CommCareConnectClient
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.events.models import ScheduledMessage, TimePeriod
@@ -33,6 +33,11 @@ class ServiceUnavailable(APIException):
 class BadRequest(APIException):
     status_code = 400
     default_detail = "Bad request."
+
+
+class Conflict(APIException):
+    status_code = 409
+    default_detail = "Conflict."
 
 
 class ParticipantView(APIView):
@@ -280,6 +285,8 @@ def _setup_connect_channels(identifier, participant_data_by_experiment_id):
     for channel, participant_data in pending:
         try:
             create_connect_channel_for_participant(channel, connect_client, identifier, participant_data)
+        except DuplicateConnectChannelError as e:
+            raise Conflict(f"Failed to create channel: {e}") from e
         except httpx.HTTPError as e:
             raise _connect_channel_error(e, identifier) from e
 

--- a/apps/channels/tests/test_connect_integration.py
+++ b/apps/channels/tests/test_connect_integration.py
@@ -17,7 +17,7 @@ from apps.channels.tasks import handle_commcare_connect_message
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.experiments.models import ParticipantData
 from apps.utils.factories.channels import ExperimentChannelFactory
-from apps.utils.factories.experiment import ParticipantFactory
+from apps.utils.factories.experiment import ExperimentFactory, ParticipantFactory
 
 
 def _setup_participant(experiment) -> tuple:
@@ -138,6 +138,32 @@ class TestApiEndpoint:
         )
         assert response.status_code == 400
         assert response.json() == {"messages": [{"timestamp": ["This field may not be null."]}]}
+
+    @patch("apps.channels.views.tasks.handle_commcare_connect_message")
+    @override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
+    def test_duplicate_rows_route_to_oldest(self, handle_message_mock, client, experiment, caplog):
+        """If duplicate rows hold the same channel_id (issue #3620), route the message to the
+        oldest row instead of raising MultipleObjectsReturned."""
+        commcare_connect_channel_id, encryption_key, _, oldest = _setup_participant(experiment)
+        other_experiment = ExperimentFactory.create(team=experiment.team)
+        ParticipantData.objects.create(
+            team=experiment.team,
+            participant=oldest.participant,
+            experiment=other_experiment,
+            system_metadata=oldest.system_metadata,
+        )
+        payload = _build_user_message(encryption_key, commcare_connect_channel_id)
+
+        response = client.post(
+            reverse("channels:new_connect_message"),
+            json.dumps(payload),
+            headers=self._get_request_headers(payload),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert handle_message_mock.delay.call_args.kwargs["participant_data_id"] == oldest.id
+        assert "Multiple ParticipantData rows" in caplog.text
 
     @pytest.mark.parametrize(
         ("missing_record", "expected_response"),

--- a/apps/channels/views.py
+++ b/apps/channels/views.py
@@ -259,11 +259,8 @@ def new_connect_message(request: HttpRequest):
         return JsonResponse(serializer.errors, status=400)
 
     connect_channel_id = serializer.data["channel_id"]
-    try:
-        participant_data = ParticipantData.objects.get(
-            system_metadata__commcare_connect_channel_id=connect_channel_id,
-        )
-    except ParticipantData.DoesNotExist:
+    participant_data = ParticipantData.objects.for_connect_channel(connect_channel_id)
+    if participant_data is None:
         return JsonResponse({"detail": "No participant data found"}, status=404)
 
     channel = tasks.get_experiment_channel(

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1264,6 +1264,26 @@ class ParticipantDataObjectManager(models.Manager):
             experiment_id = experiment.working_version_id
         return super().get_queryset().filter(experiment_id=experiment_id, team=experiment.team)
 
+    def for_connect_channel(self, channel_id: str, participant_identifier: str | None = None):
+        """Resolve the ParticipantData row that owns a CommCare Connect channel ID.
+
+        Exactly one row should hold a given channel_id; duplicates break key exchange and message
+        routing (see issue #3620). If duplicates exist anyway, return the oldest row — the one
+        whose encryption key the device originally fetched — and log an error.
+        Returns ``None`` when no row matches.
+        """
+        queryset = self.get_queryset().filter(system_metadata__commcare_connect_channel_id=channel_id)
+        if participant_identifier is not None:
+            queryset = queryset.filter(participant__identifier=participant_identifier)
+        rows = list(queryset.defer("data").order_by("id")[:2])
+        if len(rows) > 1:
+            log.error(
+                "Multiple ParticipantData rows hold CommCare Connect channel_id %s; using the oldest (pk=%s)",
+                channel_id,
+                rows[0].pk,
+            )
+        return rows[0] if rows else None
+
 
 def validate_json_dict(value):
     """Participant data must be a dict"""


### PR DESCRIPTION
### Product Description
Fixes key exchange and message delivery failing for participants whose `ParticipantData` rows share a CommCare Connect channel ID (Sentry OPEN-CHAT-STUDIO-14F). Addresses #3620; replaces #3601.

### Technical Description
Root cause (full detail in #3620): Connect's `create_channel` is idempotent on `(connect_user, channel_source)` and OCS bot-name renames don't propagate to Connect, so reusing a bot name returns a channel_id already bound to another row. One channel_id can only route to one experiment, so the enrollment path now refuses to store it on a second row and logs an error instead.

Points worth reviewer attention:

- The three endpoints that look rows up by channel_id (`generate_key`, `consent`, `new_connect_message`) now share one manager method that, on duplicates, deterministically picks the **oldest** row and logs an error. Oldest because that's the row whose key the device originally fetched — and key serving and message routing must agree on the same row or decryption breaks.
- The encryption key is now generated eagerly at enrollment, closing the race where the device's `generate_key` fetch and the outbound send path could mint different keys for the same channel. The lazy paths remain as fallbacks for pre-existing rows.

Out of scope: the one-off repair of the single affected production participant (run separately via Django shell), and propagating renames to Connect (#3620 step 5).

### Docs and Changelog
- [ ] This PR requires docs/changelog update