### PR TITLE
Enable Anthropic prompt caching for pipeline LLM and router agents

### DIFF
--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -49,3 +49,15 @@ def get_system_message(prompt_template: str, prompt_context: PromptTemplateConte
         return SystemMessage(content=system_message)
     except KeyError as e:
         raise PipelineNodeRunError(str(e)) from e
+
+
+def get_agent_middleware(node, system_message: SystemMessage) -> list:
+    """Returns the common agent middleware for nodes that build LLM agents:
+    history compression and provider prompt caching.
+    """
+    middleware = []
+    if history_middleware := node.build_history_middleware(system_message=system_message):
+        middleware.append(history_middleware)
+    if caching_middleware := node.get_llm_service().get_prompt_caching_middleware():
+        middleware.append(caching_middleware)
+    return middleware

--- a/apps/pipelines/nodes/llm_node.py
+++ b/apps/pipelines/nodes/llm_node.py
@@ -14,7 +14,7 @@ from apps.chat.models import ChatMessageMetadataKeys
 from apps.experiments.models import ExperimentSession
 from apps.files.models import File
 from apps.pipelines.nodes.base import PipelineNode, PipelineState
-from apps.pipelines.nodes.helpers import get_system_message
+from apps.pipelines.nodes.helpers import get_agent_middleware, get_system_message
 from apps.pipelines.nodes.history_middleware import MessageSizeValidationMiddleware
 from apps.pipelines.nodes.tool_callbacks import ToolCallbacks
 from apps.service_providers.llm_service.datamodels import LlmChatResponse
@@ -103,11 +103,7 @@ def build_node_agent(
     tools = _get_configured_tools(node, session=session, tool_callbacks=tool_callbacks)
     system_message = get_system_message(prompt_template=node.prompt, prompt_context=prompt_context)
 
-    middleware = []
-    if history_middleware := node.build_history_middleware(system_message=system_message):
-        middleware.append(history_middleware)
-    if caching_middleware := node.get_llm_service().get_prompt_caching_middleware():
-        middleware.append(caching_middleware)
+    middleware = get_agent_middleware(node, system_message)
     # MessageSizeValidationMiddleware temporarily disabled — over-counts tool outputs and blocks
     # legitimate conversations. Re-enable after switching to a tool-aware token check.
 

--- a/apps/pipelines/nodes/llm_node.py
+++ b/apps/pipelines/nodes/llm_node.py
@@ -106,6 +106,8 @@ def build_node_agent(
     middleware = []
     if history_middleware := node.build_history_middleware(system_message=system_message):
         middleware.append(history_middleware)
+    if caching_middleware := node.get_llm_service().get_prompt_caching_middleware():
+        middleware.append(caching_middleware)
     # MessageSizeValidationMiddleware temporarily disabled — over-counts tool outputs and blocks
     # legitimate conversations. Re-enable after switching to a tool-aware token check.
 

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -54,7 +54,7 @@ from apps.pipelines.nodes.base import (
     deprecated_node,
 )
 from apps.pipelines.nodes.context import PipelineAccessor
-from apps.pipelines.nodes.helpers import get_system_message
+from apps.pipelines.nodes.helpers import get_agent_middleware, get_system_message
 from apps.pipelines.nodes.llm_node import execute_sub_agent
 from apps.pipelines.repository import ORMRepository, RepositoryLookupError
 from apps.pipelines.tasks import send_email_from_pipeline
@@ -681,11 +681,7 @@ class RouterNode(RouterMixin, PipelineRouterNode, HistoryMixin):
         )
 
         # Build the agent
-        middleware = []
-        if history_middleware := self.build_history_middleware(system_message=system_message):
-            middleware.append(history_middleware)
-        if caching_middleware := self.get_llm_service().get_prompt_caching_middleware():
-            middleware.append(caching_middleware)
+        middleware = get_agent_middleware(self, system_message)
 
         agent = create_agent(
             model=self.get_chat_model(),

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -684,6 +684,8 @@ class RouterNode(RouterMixin, PipelineRouterNode, HistoryMixin):
         middleware = []
         if history_middleware := self.build_history_middleware(system_message=system_message):
             middleware.append(history_middleware)
+        if caching_middleware := self.get_llm_service().get_prompt_caching_middleware():
+            middleware.append(caching_middleware)
 
         agent = create_agent(
             model=self.get_chat_model(),

--- a/apps/pipelines/tests/test_llm_node.py
+++ b/apps/pipelines/tests/test_llm_node.py
@@ -34,19 +34,22 @@ class TestBuildNodeAgentPromptCaching:
         build_node_agent(node, context=Mock(), session=Mock(), tool_callbacks=Mock())
         return captured["middleware"]
 
-    def test_anthropic_node_gets_caching_middleware(self, monkeypatch):
+    @pytest.mark.parametrize(
+        ("service", "expected"),
+        [
+            pytest.param(
+                AnthropicLlmService(anthropic_api_key="test", anthropic_api_base="https://api.anthropic.com"),
+                True,
+                id="anthropic_gets_caching_middleware",
+            ),
+            pytest.param(OpenAILlmService(openai_api_key="test"), False, id="openai_no_caching_middleware"),
+        ],
+    )
+    def test_node_caching_middleware(self, monkeypatch, service, expected):
         from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 
-        service = AnthropicLlmService(anthropic_api_key="test", anthropic_api_base="https://api.anthropic.com")
         middleware = self._build_agent_middleware(monkeypatch, service)
-        assert any(isinstance(m, AnthropicPromptCachingMiddleware) for m in middleware)
-
-    def test_openai_node_does_not_get_caching_middleware(self, monkeypatch):
-        from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
-
-        service = OpenAILlmService(openai_api_key="test")
-        middleware = self._build_agent_middleware(monkeypatch, service)
-        assert not any(isinstance(m, AnthropicPromptCachingMiddleware) for m in middleware)
+        assert any(isinstance(m, AnthropicPromptCachingMiddleware) for m in middleware) == expected
 
 
 class TestMessageSizeValidationMiddleware:

--- a/apps/pipelines/tests/test_llm_node.py
+++ b/apps/pipelines/tests/test_llm_node.py
@@ -5,8 +5,48 @@ from langchain_core.messages import HumanMessage, SystemMessage
 
 from apps.pipelines.exceptions import PipelineNodeRunError
 from apps.pipelines.nodes.history_middleware import MessageSizeValidationMiddleware
-from apps.pipelines.nodes.llm_node import _build_size_validation_middleware
+from apps.pipelines.nodes.llm_node import _build_size_validation_middleware, build_node_agent
 from apps.pipelines.repository import RepositoryLookupError
+from apps.service_providers.llm_service.main import AnthropicLlmService, OpenAILlmService
+
+
+class TestBuildNodeAgentPromptCaching:
+    """The node agent should include the LLM service's prompt caching middleware when one is provided."""
+
+    def _build_agent_middleware(self, monkeypatch, service):
+        captured = {}
+
+        def fake_create_agent(**kwargs):
+            captured.update(kwargs)
+            return Mock()
+
+        monkeypatch.setattr("apps.pipelines.nodes.llm_node.create_agent", fake_create_agent)
+        monkeypatch.setattr("apps.pipelines.nodes.llm_node._get_configured_tools", lambda *args, **kwargs: [])
+        monkeypatch.setattr("apps.pipelines.nodes.llm_node._get_prompt_context", lambda *args, **kwargs: Mock())
+        monkeypatch.setattr(
+            "apps.pipelines.nodes.llm_node.get_system_message",
+            lambda *args, **kwargs: SystemMessage(content="prompt"),
+        )
+
+        node = Mock()
+        node.get_llm_service.return_value = service
+        node.build_history_middleware.return_value = None
+        build_node_agent(node, context=Mock(), session=Mock(), tool_callbacks=Mock())
+        return captured["middleware"]
+
+    def test_anthropic_node_gets_caching_middleware(self, monkeypatch):
+        from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+
+        service = AnthropicLlmService(anthropic_api_key="test", anthropic_api_base="https://api.anthropic.com")
+        middleware = self._build_agent_middleware(monkeypatch, service)
+        assert any(isinstance(m, AnthropicPromptCachingMiddleware) for m in middleware)
+
+    def test_openai_node_does_not_get_caching_middleware(self, monkeypatch):
+        from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+
+        service = OpenAILlmService(openai_api_key="test")
+        middleware = self._build_agent_middleware(monkeypatch, service)
+        assert not any(isinstance(m, AnthropicPromptCachingMiddleware) for m in middleware)
 
 
 class TestMessageSizeValidationMiddleware:

--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -4,7 +4,7 @@ import logging
 import re
 from functools import cached_property
 from io import BytesIO
-from typing import ClassVar, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 import pydantic
 from django.db.models import Q
@@ -31,6 +31,9 @@ from apps.service_providers.llm_service.utils import (
     extract_file_ids_from_ocs_citations,
     get_openai_container_file_contents,
 )
+
+if TYPE_CHECKING:
+    from langchain.agents.middleware import AgentMiddleware
 
 logger = logging.getLogger("ocs.llm_service")
 
@@ -66,6 +69,13 @@ class LlmService(pydantic.BaseModel):
 
     def attach_built_in_tools(self, built_in_tools: list[str], config: dict[str, BaseModel] | None = None) -> list:
         raise NotImplementedError
+
+    def get_prompt_caching_middleware(self) -> AgentMiddleware | None:
+        """Agent middleware that enables prompt caching for this provider, if it requires opt-in.
+
+        Providers with automatic server-side caching (OpenAI, Azure, DeepSeek) return None.
+        """
+        return None
 
     def get_output_parser(self):
         return self._default_parser
@@ -377,6 +387,16 @@ class AnthropicLlmService(LlmService):
             kwargs["model_kwargs"] = {"output_config": {"effort": effort}}
 
         return kwargs
+
+    def get_prompt_caching_middleware(self) -> AgentMiddleware | None:
+        from langchain_anthropic.middleware import (  # noqa: PLC0415 - TID253: heavy lib, slow startup
+            AnthropicPromptCachingMiddleware,
+        )
+
+        # Adds a cache breakpoint to the last message of each model request, caching the
+        # tools + system prompt + history prefix. Anthropic ignores breakpoints on prompts
+        # below the model's cacheable minimum, so this is safe for small prompts.
+        return AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore")
 
     def attach_built_in_tools(self, built_in_tools: list[str], config: dict[str, BaseModel] | None = None) -> list:
         config = config or {}

--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -396,7 +396,7 @@ class AnthropicLlmService(LlmService):
         # Adds a cache breakpoint to the last message of each model request, caching the
         # tools + system prompt + history prefix. Anthropic ignores breakpoints on prompts
         # below the model's cacheable minimum, so this is safe for small prompts.
-        return AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore")
+        return AnthropicPromptCachingMiddleware(ttl="5m", unsupported_model_behavior="ignore")
 
     def attach_built_in_tools(self, built_in_tools: list[str], config: dict[str, BaseModel] | None = None) -> list:
         config = config or {}

--- a/apps/service_providers/tests/test_llm_service.py
+++ b/apps/service_providers/tests/test_llm_service.py
@@ -51,7 +51,7 @@ def test_openai_service_uses_responses_api():
 
 
 @pytest.mark.parametrize(
-    "provider_type,config",
+    ("provider_type", "config"),
     [
         (LlmProviderTypes.groq, {"openai_api_key": "test"}),
         (LlmProviderTypes.perplexity, {"openai_api_key": "test"}),

--- a/apps/service_providers/tests/test_llm_service.py
+++ b/apps/service_providers/tests/test_llm_service.py
@@ -78,3 +78,31 @@ def test_voyage_ai_service_returns_local_index_manager():
     service = LlmProviderTypes.voyage.get_llm_service({"voyage_api_key": "test"})
     manager = service.get_local_index_manager("voyage-4-large")
     assert isinstance(manager, VoyageAILocalIndexManager)
+
+
+def test_anthropic_service_returns_prompt_caching_middleware():
+    from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+
+    service = AnthropicLlmService(anthropic_api_key="test", anthropic_api_base="https://api.anthropic.com")
+    middleware = service.get_prompt_caching_middleware()
+    assert isinstance(middleware, AnthropicPromptCachingMiddleware)
+    assert middleware.ttl == "5m"
+    # The agent model is always ChatAnthropic for this service, but never surface
+    # warnings to end users if that assumption breaks.
+    assert middleware.unsupported_model_behavior == "ignore"
+
+
+@pytest.mark.parametrize(
+    "service",
+    [
+        pytest.param(OpenAILlmService(openai_api_key="test"), id="openai-automatic-caching"),
+        pytest.param(
+            AzureLlmService(
+                openai_api_key="test", openai_api_base="https://api.openai.com/v1", openai_api_version="v1"
+            ),
+            id="azure-automatic-caching",
+        ),
+    ],
+)
+def test_non_anthropic_services_have_no_prompt_caching_middleware(service):
+    assert service.get_prompt_caching_middleware() is None


### PR DESCRIPTION
### Product Description

Enables [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) for chatbot LLM and router nodes. For bots using Anthropic models, repeated prompt content (system prompt, tools, conversation history) is cached server-side by Anthropic, reducing latency and input-token cost — cache reads are billed at ~10% of the normal input rate. No user-facing configuration changes.

### Technical Description

Unlike OpenAI/Azure/DeepSeek (automatic server-side caching), Anthropic caching is opt-in via `cache_control` breakpoints. Per the audit in #3621 ([comment](https://github.com/dimagi/open-chat-studio/issues/3621#issuecomment-4691520689)), the `cache_prompt=True` constructor flag suggested in the issue does not exist in `langchain-anthropic`; the supported mechanism for `create_agent` is `AnthropicPromptCachingMiddleware`, which ships with the already-pinned `langchain-anthropic==1.0.4`.

- New `LlmService.get_prompt_caching_middleware()` hook returning `None` by default; `AnthropicLlmService` returns `AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore")` (default 5-minute TTL).
- Wired into both agent-building call sites: `build_node_agent` (LLM node) and `RouterNode._process_conditional`.
- The middleware sets a `cache_control` breakpoint on the last content block of each model request, caching the tools + system prompt + history prefix. The breakpoint advances each turn, so multi-turn conversations and intra-turn tool loops reuse the cached prefix.

**Caveats (from the audit):**
- Prompts below Anthropic's model-dependent cacheable minimum (1024–4096 tokens) are silently not cached — no premium, no benefit.
- Bots whose prompt template references `{current_datetime}` (second-level precision) get no *cross-turn* cache hits, and single-shot (no-tool) turns for those bots pay the 1.25× cache-write premium without reads. Tool-using turns still benefit from intra-turn prefix reuse. Reducing `{current_datetime}` granularity is recommendation 3 in the issue and is pending discussion.
- Validation in staging should watch `usage_metadata.input_token_details.cache_read`/`cache_creation` (visible in Langfuse; internal Trace metrics don't capture cached tokens yet — recommendation 1 in the issue).

### Migrations
- [x] The migrations are backwards compatible

No migrations.

### Demo

N/A — behavior change is server-side billing/latency; validate via cache token counts in traces.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Part of #3621

https://claude.ai/code/session_01NSpxBpCqavPGcJn9T5g3Hc

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSpxBpCqavPGcJn9T5g3Hc)_