### PR TITLE
Groundwork for reverting a chatbot to a previous version

### DIFF
--- a/apps/chatbots/tests/test_chatbot_views.py
+++ b/apps/chatbots/tests/test_chatbot_views.py
@@ -779,3 +779,29 @@ def test_web_chat_widget_rendering(client, team_with_users):
     assert 'allow-attachments="true"' in content
     # consent-form experiments keep the end-chat-and-give-feedback flow alongside the widget
     assert "end-experiment-modal" in content
+
+
+@pytest.mark.django_db()
+def test_version_operation_status_polling(client, team_with_users):
+    """The status endpoint reports any in-flight version operation, not just publish."""
+    team = team_with_users
+    user = team.members.first()
+    user.user_permissions.add(Permission.objects.get(codename="view_experiment"))
+    client.force_login(user)
+    experiment = ExperimentFactory.create(team=team, owner=user)
+    url = reverse("chatbots:check_version_operation_status", args=[team.slug, experiment.id])
+
+    # lock held by some non-publish operation: response keeps polling
+    experiment.acquire_version_operation_lock("revert-task-id")
+    response = client.get(url)
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Creating Version" in content
+    assert url in content  # hx-get poll target
+
+    # operation finished: response renders the create button and triggers a refresh
+    Experiment.release_version_operation_lock(experiment.id)
+    response = client.get(url)
+    content = response.content.decode()
+    assert "Create Version" in content
+    assert "version-changed" in content

--- a/apps/chatbots/urls.py
+++ b/apps/chatbots/urls.py
@@ -20,8 +20,8 @@ urlpatterns = [
     path("<int:experiment_id>/events/", include("apps.events.urls")),
     path(
         "<int:experiment_id>/versions/status",
-        views.chatbot_version_create_status,
-        name="check_version_creation_status",
+        views.chatbot_version_operation_status,
+        name="check_version_operation_status",
     ),
     path("<int:experiment_id>/sessions-table/", views.ChatbotSessionsTableView.as_view(), name="sessions-list"),
     path(

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -42,7 +42,7 @@ from apps.experiments.filters import (
 from apps.experiments.forms import ExperimentInvitationForm, ExperimentVersionForm
 from apps.experiments.models import Experiment, ExperimentSession, Participant, SessionStatus, SyntheticVoice
 from apps.experiments.tables import ExperimentVersionsTable
-from apps.experiments.tasks import async_create_experiment_version
+from apps.experiments.tasks import start_version_creation
 from apps.experiments.views import ExperimentVersionsTableView
 from apps.experiments.views.experiment import (
     start_session_public,
@@ -288,11 +288,7 @@ class CreateChatbot(LoginAndTeamRequiredMixin, PermissionRequiredMixin, CreateVi
             form.instance.name = unicodedata.normalize("NFC", form.instance.name)
             self.object = form.save()
 
-        task_id = async_create_experiment_version.delay(
-            experiment_id=self.object.id, version_description="", make_default=True
-        )
-        self.object.create_version_task_id = task_id
-        self.object.save(update_fields=["create_version_task_id"])
+        start_version_creation(self.object, make_default=True)
 
         return HttpResponseRedirect(self.get_success_url())
 
@@ -441,7 +437,7 @@ class CreateChatbotVersion(LoginAndTeamRequiredMixin, PermissionRequiredMixin, F
         if working_version.is_archived:
             raise PermissionDenied("Unable to version an archived chatbot.")
 
-        if working_version.create_version_task_id:
+        if working_version.version_operation_in_progress:
             messages.error(self.request, "Version creation is already in progress.")
             return HttpResponseRedirect(self.get_success_url())
 
@@ -451,11 +447,9 @@ class CreateChatbotVersion(LoginAndTeamRequiredMixin, PermissionRequiredMixin, F
             messages.error(self.request, error_msg)
             return render(self.request, self.template_name, self.get_context_data(form=form))
 
-        task_id = async_create_experiment_version.delay(
-            experiment_id=working_version.id, version_description=description, make_default=is_default
-        )
-        working_version.create_version_task_id = task_id
-        working_version.save(update_fields=["create_version_task_id"])
+        if not start_version_creation(working_version, version_description=description, make_default=is_default):
+            messages.error(self.request, "Version creation is already in progress.")
+            return HttpResponseRedirect(self.get_success_url())
         messages.success(self.request, "Creating new version. This might take a few minutes.")
 
         return HttpResponseRedirect(self.get_success_url())
@@ -503,11 +497,12 @@ def chatbot_version_details(request, team_slug: str, experiment_id: int, version
 
 @login_and_team_required
 @permission_required("experiments.view_experiment", raise_exception=True)
-def chatbot_version_create_status(
+def chatbot_version_operation_status(
     request,
     team_slug: str,
     experiment_id: int,
 ):
+    """Poll target for any in-flight version operation (publish, revert, ...)."""
     experiment = Experiment.objects.get(id=experiment_id, team=request.team)
     return TemplateResponse(
         request,
@@ -515,7 +510,9 @@ def chatbot_version_create_status(
         {
             "active_tab": "chatbots",
             "experiment": experiment,
-            "trigger_refresh": experiment.create_version_task_id is not None,
+            # this endpoint is only polled while an operation is in flight, so the
+            # response that shows the operation has finished must trigger a refresh
+            "trigger_refresh": True,
         },
     )
 
@@ -818,11 +815,7 @@ def copy_chatbot(request, team_slug, *args, **kwargs):
             # copy chatbot
             new_experiment = experiment.create_new_version(make_default=False, is_copy=True, name=new_name)
             # create default version for copied chatbot
-            task_id = async_create_experiment_version.delay(
-                experiment_id=new_experiment.id, version_description="", make_default=True
-            )
-            new_experiment.create_version_task_id = task_id
-            new_experiment.save(update_fields=["create_version_task_id"])
+            start_version_creation(new_experiment, make_default=True)
             return redirect("chatbots:single_chatbot_home", team_slug=team_slug, experiment_id=new_experiment.id)
     experiment_id = kwargs["pk"]
     return single_chatbot_home(request, team_slug, experiment_id)

--- a/apps/events/tests/test_trigger_sync.py
+++ b/apps/events/tests/test_trigger_sync.py
@@ -1,0 +1,59 @@
+import pytest
+
+from apps.events.models import EventActionType, StaticTriggerType
+from apps.events.versioning import sync_triggers
+from apps.utils.factories.events import EventActionFactory, StaticTriggerFactory, TimeoutTriggerFactory
+from apps.utils.factories.experiment import ExperimentFactory
+
+
+@pytest.mark.django_db()
+class TestSyncTriggers:
+    def test_copies_triggers_and_actions_to_target(self):
+        source = ExperimentFactory()
+        target = ExperimentFactory(team=source.team)
+        static = StaticTriggerFactory(
+            experiment=source,
+            type=StaticTriggerType.CONVERSATION_END,
+            action=EventActionFactory(action_type=EventActionType.LOG, params={"key": "value"}),
+        )
+        timeout = TimeoutTriggerFactory(experiment=source, delay=60, total_num_triggers=3)
+
+        sync_triggers(source, target)
+
+        new_static = target.static_triggers.get()
+        assert new_static.type == static.type
+        assert new_static.working_version_id == static.id
+        assert new_static.action_id != static.action_id
+        assert new_static.action.action_type == static.action.action_type
+        assert new_static.action.params == static.action.params
+
+        new_timeout = target.timeout_triggers.get()
+        assert new_timeout.delay == timeout.delay
+        assert new_timeout.total_num_triggers == timeout.total_num_triggers
+        assert new_timeout.working_version_id == timeout.id
+        assert new_timeout.action_id != timeout.action_id
+
+    def test_archives_target_triggers_absent_from_source(self):
+        source = ExperimentFactory()
+        target = ExperimentFactory(team=source.team)
+        stale_static = StaticTriggerFactory(experiment=target)
+        stale_timeout = TimeoutTriggerFactory(experiment=target)
+        source_static = StaticTriggerFactory(experiment=source)
+
+        sync_triggers(source, target)
+
+        stale_static.refresh_from_db()
+        stale_timeout.refresh_from_db()
+        assert stale_static.is_archived
+        assert stale_timeout.is_archived
+        assert [t.working_version_id for t in target.static_triggers.all()] == [source_static.id]
+        assert not target.timeout_triggers.exists()
+
+    def test_sync_with_no_triggers_is_a_noop(self):
+        source = ExperimentFactory()
+        target = ExperimentFactory(team=source.team)
+
+        sync_triggers(source, target)
+
+        assert not target.static_triggers.exists()
+        assert not target.timeout_triggers.exists()

--- a/apps/events/versioning.py
+++ b/apps/events/versioning.py
@@ -1,0 +1,31 @@
+"""Synchronisation of event triggers between experiments in a version family.
+
+This module must not import ``apps.events.models`` at module level: it is imported
+by ``apps.experiments.models``, which ``apps.events.models`` itself imports.
+"""
+
+from typing import TYPE_CHECKING
+
+from django.db import transaction
+
+if TYPE_CHECKING:
+    from apps.experiments.models import Experiment
+
+TRIGGER_ACCESSORS = ("static_triggers", "timeout_triggers")
+
+
+@transaction.atomic()
+def sync_triggers(source: "Experiment", target: "Experiment", is_copy: bool = False) -> None:
+    """Make ``target``'s static and timeout triggers mirror ``source``'s.
+
+    Every trigger on ``source`` is copied onto ``target`` together with its
+    ``EventAction``; triggers already on ``target`` have no counterpart on ``source``
+    and are archived. Publish uses this working -> version (``target`` is a freshly
+    created version with no triggers); revert (#3398) uses it version -> working.
+    """
+    for accessor in TRIGGER_ACCESSORS:
+        stale_triggers = list(getattr(target, accessor).all())
+        for trigger in getattr(source, accessor).all():
+            trigger.create_new_version(new_experiment=target, is_copy=is_copy)
+        for trigger in stale_triggers:
+            trigger.archive()

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -886,6 +886,32 @@ class Experiment(BaseTeamModel, VersionsMixin):
     def api_url(self):
         return self.get_api_url()
 
+    # `create_version_task_id` doubles as a lock guarding all long-running version
+    # operations (publish, revert): non-empty means an operation is in flight.
+
+    @property
+    def version_operation_in_progress(self) -> bool:
+        return bool(self.create_version_task_id)
+
+    def acquire_version_operation_lock(self, task_id: str) -> bool:
+        """Atomically claim the version-operation lock for `task_id`.
+
+        Returns False when another version operation is already in flight.
+        """
+        acquired = (
+            Experiment.objects.get_all()
+            .filter(id=self.id, create_version_task_id="")
+            .update(create_version_task_id=task_id, audit_action=AuditAction.AUDIT)
+            == 1
+        )
+        if acquired:
+            self.create_version_task_id = task_id
+        return acquired
+
+    @classmethod
+    def release_version_operation_lock(cls, experiment_id: int):
+        cls.objects.get_all().filter(id=experiment_id).update(create_version_task_id="", audit_action=AuditAction.AUDIT)
+
     @transaction.atomic()
     def create_new_version(  # ty: ignore[invalid-method-override]
         self,

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -38,6 +38,7 @@ from field_audit.models import AuditAction, AuditingManager
 
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
 from apps.chatbots.version_resolver import resolve_published_or_working
+from apps.events.versioning import sync_triggers
 from apps.experiments import model_audit_fields
 from apps.experiments.versioning import VersionDetails, VersionField, VersionsMixin, VersionsObjectManagerMixin, differs
 from apps.generics.chips import Chip
@@ -927,12 +928,7 @@ class Experiment(BaseTeamModel, VersionsMixin):
             # nothing to do for copy - just reference the same object in the new copy
             self._copy_attr_to_new_version("consent_form", new_version)
 
-        self._copy_trigger_to_new_version(
-            trigger_queryset=self.static_triggers, new_version=new_version, is_copy=is_copy
-        )
-        self._copy_trigger_to_new_version(
-            trigger_queryset=self.timeout_triggers, new_version=new_version, is_copy=is_copy
-        )
+        sync_triggers(self, new_version, is_copy=is_copy)
         self._copy_pipeline_to_new_version(new_version, is_copy)
 
         return new_version
@@ -999,10 +995,6 @@ class Experiment(BaseTeamModel, VersionsMixin):
             setattr(new_version, attr_name, latest_attr_version)
         else:
             setattr(new_version, attr_name, attr_instance.create_new_version())
-
-    def _copy_trigger_to_new_version(self, trigger_queryset, new_version, is_copy: bool = False):
-        for trigger in trigger_queryset.all():
-            trigger.create_new_version(new_experiment=new_version, is_copy=is_copy)
 
     @property
     def is_public(self) -> bool:

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -535,6 +535,49 @@ class Experiment(BaseTeamModel, VersionsMixin):
     DEFAULT_VERSION_NUMBER = 0
     TREND_CACHE_KEY_TEMPLATE = "experiment_trend_data_{experiment_id}"
 
+    # Every concrete model field must appear in exactly one of the two sets below
+    # (enforced by a guard test). Version creation clones the whole row, so a new
+    # field is versioned content unless it is explicitly classified as identity/state.
+    VERSIONED_CONTENT_FIELDS = frozenset(
+        {
+            "name",
+            "description",
+            "pipeline",
+            "seed_message",
+            "consent_form",
+            "voice_provider",
+            "synthetic_voice",
+            "conversational_consent_enabled",
+            "voice_response_behaviour",
+            "echo_transcript",
+            "trace_provider",
+            "participant_allowlist",
+            "debug_mode_enabled",
+            "file_uploads_enabled",
+        }
+    )
+    """The versioned snapshot: fields cloned into a version on publish, and the
+    surface a revert copies from a version back onto the working row."""
+
+    VERSION_IDENTITY_FIELDS = frozenset(
+        {
+            "id",
+            "team",
+            "owner",
+            "public_id",
+            "created_at",
+            "updated_at",
+            "working_version",
+            "version_number",
+            "is_default_version",
+            "is_archived",
+            "version_description",
+            "create_version_task_id",
+        }
+    )
+    """Row identity, version bookkeeping, and lifecycle/admin state: fixed up after
+    cloning (or owned by a single row) and never copied between rows in a family."""
+
     owner = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     name = models.CharField(max_length=128)
     description = models.TextField(null=True, default="", verbose_name="A longer description of the experiment.")  # noqa DJ001

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -1,10 +1,10 @@
 import time
+from uuid import uuid4
 
 from celery.app import shared_task
 from celery.utils.log import get_task_logger
 from django.core.files.base import ContentFile
 from django.utils import timezone
-from field_audit.models import AuditAction
 from langchain_core.messages import AIMessage, HumanMessage
 from taskbadger.celery import Task as TaskbadgerTask
 
@@ -52,7 +52,31 @@ def async_create_experiment_version(
         with current_team(experiment.team):
             experiment.create_new_version(version_description, make_default)
     finally:
-        Experiment.objects.filter(id=experiment_id).update(create_version_task_id="", audit_action=AuditAction.AUDIT)
+        Experiment.release_version_operation_lock(experiment_id)
+
+
+def start_version_creation(experiment, version_description: str = "", make_default: bool = False) -> bool:
+    """Dispatch async version creation under the version-operation lock.
+
+    The lock is acquired before dispatch so a concurrent version operation is
+    rejected atomically. Returns False when another operation is already in flight.
+    """
+    task_id = str(uuid4())
+    if not experiment.acquire_version_operation_lock(task_id):
+        return False
+    try:
+        async_create_experiment_version.apply_async(
+            kwargs={
+                "experiment_id": experiment.id,
+                "version_description": version_description,
+                "make_default": make_default,
+            },
+            task_id=task_id,
+        )
+    except Exception:
+        Experiment.release_version_operation_lock(experiment.id)
+        raise
+    return True
 
 
 @shared_task(bind=True, base=TaskbadgerTask)

--- a/apps/experiments/tests/test_version_operation_lock.py
+++ b/apps/experiments/tests/test_version_operation_lock.py
@@ -1,0 +1,72 @@
+from unittest.mock import patch
+
+import pytest
+
+from apps.experiments.models import Experiment
+from apps.experiments.tasks import start_version_creation
+from apps.utils.factories.experiment import ExperimentFactory
+
+
+@pytest.mark.django_db()
+class TestVersionOperationLock:
+    def test_acquire_and_release(self):
+        experiment = ExperimentFactory.create()
+        assert not experiment.version_operation_in_progress
+
+        assert experiment.acquire_version_operation_lock("task-1") is True
+        assert experiment.version_operation_in_progress
+        assert experiment.create_version_task_id == "task-1"
+
+        Experiment.release_version_operation_lock(experiment.id)
+        experiment.refresh_from_db()
+        assert not experiment.version_operation_in_progress
+
+    def test_second_acquire_is_rejected_while_in_flight(self):
+        experiment = ExperimentFactory.create()
+        assert experiment.acquire_version_operation_lock("task-1") is True
+
+        contender = Experiment.objects.get(id=experiment.id)
+        assert contender.acquire_version_operation_lock("task-2") is False
+
+        experiment.refresh_from_db()
+        assert experiment.create_version_task_id == "task-1"
+
+
+@pytest.mark.django_db()
+class TestStartVersionCreation:
+    @patch("apps.experiments.tasks.async_create_experiment_version.apply_async")
+    def test_acquires_lock_before_dispatch(self, apply_async):
+        experiment = ExperimentFactory.create()
+
+        assert start_version_creation(experiment, version_description="desc", make_default=True) is True
+
+        experiment.refresh_from_db()
+        assert experiment.version_operation_in_progress
+        assert apply_async.call_count == 1
+        kwargs = apply_async.call_args.kwargs
+        assert kwargs["task_id"] == experiment.create_version_task_id
+        assert kwargs["kwargs"] == {
+            "experiment_id": experiment.id,
+            "version_description": "desc",
+            "make_default": True,
+        }
+
+    @patch("apps.experiments.tasks.async_create_experiment_version.apply_async")
+    def test_rejected_while_another_operation_in_flight(self, apply_async):
+        experiment = ExperimentFactory.create(create_version_task_id="other-operation")
+
+        assert start_version_creation(experiment) is False
+
+        apply_async.assert_not_called()
+        experiment.refresh_from_db()
+        assert experiment.create_version_task_id == "other-operation"
+
+    @patch("apps.experiments.tasks.async_create_experiment_version.apply_async", side_effect=RuntimeError("boom"))
+    def test_releases_lock_when_dispatch_fails(self, apply_async):
+        experiment = ExperimentFactory.create()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            start_version_creation(experiment)
+
+        experiment.refresh_from_db()
+        assert not experiment.version_operation_in_progress

--- a/apps/experiments/tests/test_versioning.py
+++ b/apps/experiments/tests/test_versioning.py
@@ -418,3 +418,36 @@ class TestCopyExperiment:
             "errors": {"test": "value"},
             "viewport": {"x": 235.23538305148782, "y": 365.64304629840245, "zoom": 0.5570968254096753},
         }
+
+
+class TestExperimentFieldClassification:
+    """Guards against drift in the Experiment field classification.
+
+    Version creation clones the whole row, so every new field is implicitly part of
+    the versioned content unless classified otherwise. These tests force that
+    decision to be made explicitly when a field is added, renamed, or removed.
+    """
+
+    def test_every_concrete_field_is_classified(self):
+        concrete_fields = {field.name for field in Experiment._meta.get_fields() if field.concrete}
+        classified = Experiment.VERSIONED_CONTENT_FIELDS | Experiment.VERSION_IDENTITY_FIELDS
+
+        unclassified = concrete_fields - classified
+        assert not unclassified, (
+            f"Unclassified Experiment fields: {sorted(unclassified)}. Add each one to either "
+            "Experiment.VERSIONED_CONTENT_FIELDS (cloned on publish, restored on revert) or "
+            "Experiment.VERSION_IDENTITY_FIELDS (per-row identity/state, never copied)."
+        )
+
+        stale = classified - concrete_fields
+        assert not stale, f"Classified names that are not Experiment fields: {sorted(stale)}"
+
+    def test_classifications_are_disjoint(self):
+        overlap = Experiment.VERSIONED_CONTENT_FIELDS & Experiment.VERSION_IDENTITY_FIELDS
+        assert not overlap, f"Fields classified as both content and identity: {sorted(overlap)}"
+
+    def test_comparison_exclusions_are_not_content_fields(self):
+        """Fields excluded from version comparison must not be versioned content."""
+        excluded = set(Experiment().get_fields_to_exclude())
+        overlap = excluded & Experiment.VERSIONED_CONTENT_FIELDS
+        assert not overlap, f"Versioned content fields excluded from comparison: {sorted(overlap)}"

--- a/apps/pipelines/tests/test_models.py
+++ b/apps/pipelines/tests/test_models.py
@@ -13,6 +13,7 @@ from apps.pipelines.nodes.nodes import AssistantNode, LLMResponseWithPrompt
 from apps.pipelines.repository import ORMRepository
 from apps.pipelines.tests.utils import (
     boolean_node,
+    create_pipeline_model,
     create_runnable,
     end_node,
     llm_response_with_prompt_node,
@@ -431,6 +432,57 @@ class TestPipeline:
         # Double check that the node didn't archive the assistant
         assistant.refresh_from_db()
         assert assistant.is_archived is False
+
+
+@pytest.mark.django_db()
+class TestUpdateNodesFromData:
+    def test_re_adding_archived_node_flow_id_creates_fresh_working_node(self):
+        """Removing a node that has versions archives it; revert re-introduces the same
+        flow_id, which must yield a fresh editable working node without colliding with
+        the archived row."""
+        start, template, end = start_node(), render_template_node(), end_node()
+        pipeline = create_pipeline_model([start, template, end])
+        pipeline.create_new_version()  # the template node now has a version
+
+        original = Node.objects.get(pipeline=pipeline, flow_id=template["id"])
+        node_version = original.versions.get()
+
+        def set_nodes(node_dicts):
+            pipeline.data = {"edges": [], "nodes": [{"id": n["id"], "data": n} for n in node_dicts]}
+            pipeline.update_nodes_from_data()
+
+        # remove the template node; it has a version so it is archived rather than deleted
+        set_nodes([start, end])
+        original.refresh_from_db()
+        assert original.is_archived
+
+        # re-add the same flow_id
+        set_nodes([start, template, end])
+
+        re_added = Node.objects.get(pipeline=pipeline, flow_id=template["id"])
+        assert re_added.id != original.id
+        assert re_added.is_working_version
+        assert not re_added.is_archived
+        assert re_added.params["template_string"] == template["params"]["template_string"]
+
+        # the archived node and its version history are untouched
+        original.refresh_from_db()
+        node_version.refresh_from_db()
+        assert original.is_archived
+        assert node_version.working_version_id == original.id
+        assert Node.objects.get_all().filter(pipeline=pipeline, flow_id=template["id"]).count() == 2
+
+        # the re-added node is editable in place; no duplicate row appears
+        template["params"]["template_string"] = "updated: {{ input }}"
+        set_nodes([start, template, end])
+        re_added.refresh_from_db()
+        assert re_added.params["template_string"] == "updated: {{ input }}"
+        assert Node.objects.filter(pipeline=pipeline, flow_id=template["id"]).count() == 1
+
+        # publishing again versions the re-added node, not the archived one
+        pipeline.create_new_version()
+        assert re_added.versions.count() == 1
+        assert original.versions.count() == 1
 
 
 @pytest.mark.django_db()

--- a/templates/experiments/create_version_button.html
+++ b/templates/experiments/create_version_button.html
@@ -1,7 +1,7 @@
-{% if experiment.create_version_task_id %}
+{% if experiment.version_operation_in_progress %}
   <div id="version_check">
     <div class="tooltip" data-tip="A new version is being created"
-         hx-get="{% url 'chatbots:check_version_creation_status' experiment.team.slug experiment.id %}"
+         hx-get="{% url 'chatbots:check_version_operation_status' experiment.team.slug experiment.id %}"
          hx-trigger="every 2s"
          hx-swap="outerHTML"
          hx-target="#version_check"

--- a/templates/experiments/create_version_form.html
+++ b/templates/experiments/create_version_form.html
@@ -24,7 +24,7 @@
 {% block app %}
   <div class="app-card">
     <h1 class="pg-title">Create New Version</h1>
-    {% if experiment.create_version_task_id %}
+    {% if experiment.version_operation_in_progress %}
       <h2 class="pg-subtitle pb-5">A new version being created. Please wait until it is complete before making another version.</h2>
     {% else %}
       {% if not has_versions or version_details.fields_changed %}


### PR DESCRIPTION
### Product Description
No change — internal groundwork for #3398 (revert working version to a previous version).

### Technical Description
Four prep pieces for revert, one commit each: #3611, #3612, #3613, #3614.

Decisions worth knowing while reviewing:

- **Field classification (#3611)**: two frozensets on `Experiment` partition all concrete fields; a guard test forces classification of any new field. `owner`/`team` are identity (revert must not reassign them); `debug_mode_enabled`/`file_uploads_enabled` are content (user-editable bot settings cloned into versions). Not wired into publish/compare — revert will consume it.
- **Trigger sync (#3612)**: `sync_triggers(source, target)` removes stale target triggers by **archiving**, matching how the UI deletes working triggers. A hard delete would cascade through the `working_version` FK and destroy version history.
- **Node re-add coverage (#3613)**: test-only; existing `update_nodes_from_data` behavior turned out correct (archived row coexists with the fresh working node — no unique constraint on `(pipeline, flow_id)`).
- **Version-operation lock (#3614)**: `create_version_task_id` is kept as the column (no migration) but is now an atomic lock behind a model API, acquired *before* task dispatch. The old dispatch-then-save flow had a stale-lock race if the task finished before the view saved the id. Status endpoint renamed to `check_version_operation_status`; polling UX unchanged.

### Docs and Changelog
- [ ] This PR requires docs/changelog update