### PR TITLE
Use channel external_id as Connect channel_source

### DIFF
--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -105,14 +105,19 @@ def setup_connect_channels_for_bots(self, connect_id: str, experiment_data_map: 
 
 
 def create_connect_channel_for_participant(channel, connect_client, connect_id, participant_data):
+    # channel_source is Connect's per-participant identity key, so it must be stable: the bot
+    # name is mutable and reusable, which previously caused distinct experiments to collide on
+    # the same Connect channel (https://github.com/dimagi/open-chat-studio/issues/3620). The
+    # bot name is sent separately as the display name.
     bot_name = channel.extra_data["commcare_connect_bot_name"]
-    response = connect_client.create_channel(connect_id=connect_id, channel_source=bot_name)
+    response = connect_client.create_channel(
+        connect_id=connect_id, channel_source=str(channel.external_id), channel_name=bot_name
+    )
     channel_id = response["channel_id"]
 
-    # Connect's create_channel is idempotent on (connect_user, channel_source), so a reused bot
-    # name returns a channel_id that may already be bound to another ParticipantData row. A
-    # channel_id can only route to one experiment, so never store it on a second row.
-    # See https://github.com/dimagi/open-chat-studio/issues/3620.
+    # Defense in depth: legacy Connect channels are keyed by bot name, so a returned channel_id
+    # may still be bound to another ParticipantData row. A channel_id can only route to one
+    # experiment, so never store it on a second row.
     existing = (
         ParticipantData.objects.filter(system_metadata__commcare_connect_channel_id=channel_id)
         .exclude(pk=participant_data.pk)

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -352,7 +352,7 @@ def test_update_participant_data_and_setup_connect_channels(httpx_mock):
     team = TeamWithUsersFactory.create()
     experiment1 = ExperimentFactory.create(team=team)
     ExperimentChannelFactory.create(team=team, experiment=experiment1, platform=ChannelPlatform.TELEGRAM)
-    ExperimentChannelFactory.create(
+    connect_channel = ExperimentChannelFactory.create(
         team=team,
         experiment=experiment1,
         platform=ChannelPlatform.COMMCARE_CONNECT,
@@ -425,7 +425,8 @@ def test_update_participant_data_and_setup_connect_channels(httpx_mock):
     request = httpx_mock.get_request()
     request_data = json.loads(request.read())
     assert request_data["connectid"] == "connectid_2"
-    assert request_data["channel_source"] == "bot1"
+    assert request_data["channel_source"] == str(connect_channel.external_id)
+    assert request_data["channel_name"] == "bot1"
     assert Participant.objects.filter(identifier="connectid_2").exists()
     data = ParticipantData.objects.get(participant__identifier="connectid_2", experiment_id=experiment1.id)
     assert data.system_metadata == {"commcare_connect_channel_id": created_connect_channel_id, "consent": True}
@@ -580,9 +581,14 @@ class TestCreateConnectChannelForParticipant:
         connect_id = uuid.uuid4().hex
         participant_data = _setup_participant_data(experiment, connect_id, system_metadata={})
         channel_id = str(uuid.uuid4())
+        connect_client = self._connect_client(channel_id)
 
-        create_connect_channel_for_participant(channel, self._connect_client(channel_id), connect_id, participant_data)
+        create_connect_channel_for_participant(channel, connect_client, connect_id, participant_data)
 
+        # the stable external_id is the identity key on Connect; the bot name is display-only
+        connect_client.create_channel.assert_called_once_with(
+            connect_id=connect_id, channel_source=str(channel.external_id), channel_name="bot1"
+        )
         participant_data.refresh_from_db()
         assert participant_data.system_metadata == {"commcare_connect_channel_id": channel_id, "consent": True}
         assert participant_data.encryption_key

--- a/apps/channels/clients/connect_client.py
+++ b/apps/channels/clients/connect_client.py
@@ -41,9 +41,17 @@ class CommCareConnectClient:
         stop=stop_after_attempt(3),
         before_sleep=before_sleep_log(logger, logging.INFO),
     )
-    def create_channel(self, connect_id: str, channel_source: str) -> dict:
+    def create_channel(self, connect_id: str, channel_source: str, channel_name: str | None = None) -> dict:
+        """Create (or fetch, idempotently) the Connect channel for a participant.
+
+        ``channel_source`` is Connect's identity key for the channel (per participant) and must be
+        a stable identifier; ``channel_name`` is the display name shown to the participant.
+        """
         url = f"{self._base_url}/messaging/create_channel/"
-        response = self.client.post(url, json={"connectid": str(connect_id), "channel_source": channel_source})
+        data = {"connectid": str(connect_id), "channel_source": channel_source}
+        if channel_name:
+            data["channel_name"] = channel_name
+        response = self.client.post(url, json=data)
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
Merge after https://github.com/dimagi/connect-id/pull/253

### Product Description
Bot renames and name reuse can no longer cause CommCare Connect channel collisions (#3620): the channel identity sent to Connect is now the channel's immutable `external_id` rather than the user-editable bot name.

### Technical Description
Connect's `create_channel` is idempotent on `(connect_user, channel_source)`, so identity must be a stable value. The bot name is still sent, as `channel_name`, which Connect stores for display (`visible_name`). The duplicate-binding guard from #3624 stays as defense in depth for legacy name-keyed Connect channels.

Existing channels switch over safely: rows that already hold a channel_id are never re-enrolled, so new-style `channel_source` values only apply to fresh enrollments, which get their own Connect channels either way.

**Deploy ordering**: requires the connect-id fix (FCM payload sending `visible_name` under the `channel_source` key: https://github.com/dimagi/connect-id/pull/253) to be deployed first, otherwise new-channel push notifications briefly display a UUID as the channel name. Verified the mobile app uses `channel_source` for display only — identity on the device is `channel_id` throughout.

Stacked on #3624; retarget to main once that merges.

### Docs and Changelog
- [ ] This PR requires docs/changelog update