### PR TITLE
[Docs] Dont hide getting started pg menu

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,7 +1,3 @@
----
-hide:
-  - navigation
----
 # Getting Started
 
 This section will help you set up your development environment and get started with Open Chat Studio.


### PR DESCRIPTION
### Product Description
Small documentation usability fix

See below for fix
<img width="1031" height="735" alt="get started doc" src="https://github.com/user-attachments/assets/0d2535ab-9ca2-469d-8813-aa830c5086c0" />

### Technical Description
On the index.md of Getting Started menu, the left menu was hidden. 

### Docs and Changelog
- [ ] This PR requires docs/changelog update