### PR TITLE
feat: Include session state in the retrieval endpoint

### DIFF
--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -1892,6 +1892,7 @@ components:
           type: array
           items:
             type: string
+        state: {}
       required:
       - created_at
       - experiment
@@ -1969,6 +1970,7 @@ components:
           type: array
           items:
             type: string
+        state: {}
       required:
       - created_at
       - experiment

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -148,6 +148,7 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
             "platform",
             "messages",
             "tags",
+            "state",
         ]
 
     def __init__(self, *args, **kwargs):

--- a/apps/api/tests/test_session_api.py
+++ b/apps/api/tests/test_session_api.py
@@ -130,6 +130,7 @@ def get_session_json(session, expected_messages=None, expected_tags=None):
         "status": session.status,
         "platform": session.platform,
         "tags": expected_tags if expected_tags is not None else [],
+        "state": session.state,
     }
     if expected_messages is not None:
         data["messages"] = expected_messages


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->


### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->
Include session state in the response payload for the session retrieval API

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
For what it's worth, here's a snippet:

<img width="479" height="227" alt="image" src="https://github.com/user-attachments/assets/3a35a4c4-2739-4349-be77-01114cd41717" />


### Docs and Changelog
- [x] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
