### PR TITLE
Add email_verified field to /api/v2/me/ endpoint

### DIFF
--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -2647,11 +2647,15 @@ components:
         last_name:
           type: string
           maxLength: 150
+        email_verified:
+          type: boolean
+          readOnly: true
         team:
           allOf:
           - $ref: '#/components/schemas/Team'
           readOnly: true
       required:
+      - email_verified
       - id
       - team
       - username

--- a/apps/api/v2/serializers.py
+++ b/apps/api/v2/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 
 from apps.api.serializers import TeamSerializer
 from apps.experiments.models import Experiment
+from apps.users.helpers import user_has_confirmed_email_address
 from apps.users.models import CustomUser
 
 
@@ -32,12 +33,17 @@ class ChatbotSerializer(serializers.ModelSerializer):
 
 class MeSerializer(serializers.ModelSerializer):
     team = serializers.SerializerMethodField()
+    email_verified = serializers.SerializerMethodField()
 
     class Meta:
         model = CustomUser
-        fields = ["id", "username", "email", "first_name", "last_name", "team"]
+        fields = ["id", "username", "email", "first_name", "last_name", "email_verified", "team"]
 
     @extend_schema_field(TeamSerializer)
     def get_team(self, obj):
         team = self.context.get("team")
         return TeamSerializer(team).data if team else None
+
+    @extend_schema_field(serializers.BooleanField())
+    def get_email_verified(self, obj):
+        return user_has_confirmed_email_address(obj, obj.email)

--- a/apps/api/v2/tests/test_me_api.py
+++ b/apps/api/v2/tests/test_me_api.py
@@ -1,4 +1,5 @@
 import pytest
+from allauth.account.models import EmailAddress
 from django.urls import resolve, reverse
 from rest_framework.test import APIClient
 
@@ -41,9 +42,38 @@ def test_me_returns_user_and_team(auth_method):
     assert data["first_name"] == user.first_name
     assert data["last_name"] == user.last_name
 
+    # Email verified (no EmailAddress record → False)
+    assert data["email_verified"] is False
+
     # Team scoped to this token
     assert data["team"]["name"] == team.name
     assert data["team"]["slug"] == team.slug
+
+
+@pytest.mark.django_db()
+def test_me_email_verified_true():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    EmailAddress.objects.create(user=user, email=user.email, verified=True, primary=True)
+
+    client = ApiTestClient(user, team)
+    response = client.get(reverse("api:v2:me"))
+
+    assert response.status_code == 200
+    assert response.json()["email_verified"] is True
+
+
+@pytest.mark.django_db()
+def test_me_email_verified_false_when_unverified():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    EmailAddress.objects.create(user=user, email=user.email, verified=False, primary=True)
+
+    client = ApiTestClient(user, team)
+    response = client.get(reverse("api:v2:me"))
+
+    assert response.status_code == 200
+    assert response.json()["email_verified"] is False
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
## Summary

Adds `email_verified` to the response of the `/api/v2/me/` endpoint.

```json
"email_verified": user_has_confirmed_email_address(user, user.email)
```

Uses the existing `user_has_confirmed_email_address` helper from `apps.users.helpers`, which checks the allauth `EmailAddress` table for a verified record matching the user's current email.

This mirrors changes made to the oauth userinfo endpoint in https://github.com/dimagi/open-chat-studio/pull/3647

## Changes

- `apps/api/v2/serializers.py`: Added `email_verified` `SerializerMethodField` to `MeSerializer`
- `apps/api/v2/tests/test_me_api.py`: Added tests for verified, unverified, and no-record cases

### Docs and Changelog
- [x] This PR requires docs/changelog update