### PR TITLE
Keep current_datetime out of the cached prompt prefix

### DIFF
--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -38,12 +38,24 @@ def temporary_session(team: Team, user_id: int):
         transaction.set_rollback(True)
 
 
+def prompt_uses_current_datetime(prompt_template: str) -> bool:
+    """Whether ``{current_datetime}`` appears in the prompt template."""
+    return any(
+        field_name == "current_datetime" for _, field_name, _, _ in Formatter().parse(prompt_template) if field_name
+    )
+
+
 def get_system_message(prompt_template: str, prompt_context: PromptTemplateContext) -> SystemMessage:
     """
     Returns a populated SystemMessage based on the provided prompt template and context.
     """
     input_variables = {v for _, v, _, _ in Formatter().parse(prompt_template) if v is not None}
     context = prompt_context.get_context(input_variables)
+    if "current_datetime" in context:
+        # Render the volatile second-precision datetime at day precision so the cached system
+        # prompt prefix stays stable within a day. The precise time is injected into the latest
+        # message turn instead (see apps.pipelines.nodes.llm_node). See issue #3625.
+        context["current_datetime"] = prompt_context.get_current_date()
     try:
         system_message = prompt_template.format(**context)
         return SystemMessage(content=system_message)

--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -50,12 +50,9 @@ def get_system_message(prompt_template: str, prompt_context: PromptTemplateConte
     Returns a populated SystemMessage based on the provided prompt template and context.
     """
     input_variables = {v for _, v, _, _ in Formatter().parse(prompt_template) if v is not None}
-    context = prompt_context.get_context(input_variables)
-    if "current_datetime" in context:
-        # Render the volatile second-precision datetime at day precision so the cached system
-        # prompt prefix stays stable within a day. The precise time is injected into the latest
-        # message turn instead (see apps.pipelines.nodes.llm_node). See issue #3625.
-        context["current_datetime"] = prompt_context.get_current_date()
+    # coarse_datetime keeps the volatile second-precision value out of the cacheable system prompt;
+    # the precise time is injected into the latest message turn instead (see llm_node). See #3625.
+    context = prompt_context.get_context(input_variables, coarse_datetime=True)
     try:
         system_message = prompt_template.format(**context)
         return SystemMessage(content=system_message)

--- a/apps/pipelines/nodes/llm_node.py
+++ b/apps/pipelines/nodes/llm_node.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Annotated, cast
 
 from langchain.agents import create_agent
 from langchain.agents.middleware import AgentState
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.messages.utils import count_tokens_approximately
 from langchain_core.tools import BaseTool
 
@@ -14,7 +14,7 @@ from apps.chat.models import ChatMessageMetadataKeys
 from apps.experiments.models import ExperimentSession
 from apps.files.models import File
 from apps.pipelines.nodes.base import PipelineNode, PipelineState
-from apps.pipelines.nodes.helpers import get_agent_middleware, get_system_message
+from apps.pipelines.nodes.helpers import get_agent_middleware, get_system_message, prompt_uses_current_datetime
 from apps.pipelines.nodes.history_middleware import MessageSizeValidationMiddleware
 from apps.pipelines.nodes.tool_callbacks import ToolCallbacks
 from apps.service_providers.llm_service.datamodels import LlmChatResponse
@@ -41,10 +41,12 @@ def execute_sub_agent(node: PipelineNode, context: NodeContext):
     user_input = context.input
     session = context.session
     tool_callbacks = ToolCallbacks()
-    agent = build_node_agent(node, context, session, tool_callbacks)
+    prompt_context = _get_prompt_context(node, session, context)
+    agent = build_node_agent(node, context, session, tool_callbacks, prompt_context=prompt_context)
 
     attachments = list(context.attachments)
     formatted_input = format_multimodal_input(message=user_input, attachments=attachments)
+    _add_current_datetime_to_turn(node, prompt_context, formatted_input)
 
     inputs = StateSchema(
         messages=[formatted_input],
@@ -97,9 +99,14 @@ def _process_agent_output(node: PipelineNode, session: ExperimentSession, messag
 
 
 def build_node_agent(
-    node: PipelineNode, context: NodeContext, session: ExperimentSession, tool_callbacks: ToolCallbacks
+    node: PipelineNode,
+    context: NodeContext,
+    session: ExperimentSession,
+    tool_callbacks: ToolCallbacks,
+    prompt_context: PromptTemplateContext | None = None,
 ):
-    prompt_context = _get_prompt_context(node, session, context)
+    if prompt_context is None:
+        prompt_context = _get_prompt_context(node, session, context)
     tools = _get_configured_tools(node, session=session, tool_callbacks=tool_callbacks)
     system_message = get_system_message(prompt_template=node.prompt, prompt_context=prompt_context)
 
@@ -138,6 +145,28 @@ def _process_files(node: PipelineNode, cited_files: set[File], generated_files: 
         ChatMessageMetadataKeys.CITED_FILES: [file.id for file in cited_files],
         ChatMessageMetadataKeys.GENERATED_FILES: [file.id for file in generated_files],
     }
+
+
+def _add_current_datetime_to_turn(
+    node: PipelineNode, prompt_context: PromptTemplateContext, message: HumanMessage
+) -> None:
+    """Prepend the precise, tz-aware current datetime to the latest message turn.
+
+    Keeping the volatile value out of the cached system prompt prefix (see ``get_system_message``)
+    and on the newest, uncached turn instead lets prompt caching keep the large stable prefix warm
+    across turns. Only injected when the node's prompt opts into ``{current_datetime}``. See #3625.
+    """
+    if not prompt_uses_current_datetime(node.prompt):
+        return
+
+    datetime_block = {
+        "type": "text",
+        "text": f"<current_datetime>{prompt_context.get_current_datetime()}</current_datetime>",
+    }
+    if isinstance(message.content, list):
+        message.content.insert(0, datetime_block)
+    else:
+        message.content = [datetime_block, {"type": "text", "text": message.content}]
 
 
 def _get_prompt_context(node: PipelineNode, session: ExperimentSession, context: NodeContext):

--- a/apps/pipelines/nodes/llm_node.py
+++ b/apps/pipelines/nodes/llm_node.py
@@ -103,10 +103,8 @@ def build_node_agent(
     context: NodeContext,
     session: ExperimentSession,
     tool_callbacks: ToolCallbacks,
-    prompt_context: PromptTemplateContext | None = None,
+    prompt_context: PromptTemplateContext,
 ):
-    if prompt_context is None:
-        prompt_context = _get_prompt_context(node, session, context)
     tools = _get_configured_tools(node, session=session, tool_callbacks=tool_callbacks)
     system_message = get_system_message(prompt_template=node.prompt, prompt_context=prompt_context)
 

--- a/apps/pipelines/tests/test_llm_node.py
+++ b/apps/pipelines/tests/test_llm_node.py
@@ -4,8 +4,13 @@ import pytest
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from apps.pipelines.exceptions import PipelineNodeRunError
+from apps.pipelines.nodes.helpers import get_system_message, prompt_uses_current_datetime
 from apps.pipelines.nodes.history_middleware import MessageSizeValidationMiddleware
-from apps.pipelines.nodes.llm_node import _build_size_validation_middleware, build_node_agent
+from apps.pipelines.nodes.llm_node import (
+    _add_current_datetime_to_turn,
+    _build_size_validation_middleware,
+    build_node_agent,
+)
 from apps.pipelines.repository import RepositoryLookupError
 from apps.service_providers.llm_service.main import AnthropicLlmService, OpenAILlmService
 
@@ -50,6 +55,59 @@ class TestBuildNodeAgentPromptCaching:
 
         middleware = self._build_agent_middleware(monkeypatch, service)
         assert any(isinstance(m, AnthropicPromptCachingMiddleware) for m in middleware) == expected
+
+
+class TestCurrentDatetimeCachePreservation:
+    """`{current_datetime}` must stay out of the cached system prompt prefix.
+
+    It is coarsened to a day-precision date in the system prompt and the precise time is injected
+    into the latest (uncached) message turn instead. See issue #3625.
+    """
+
+    @pytest.mark.parametrize(
+        ("prompt", "expected"),
+        [
+            pytest.param("The time is {current_datetime}", True, id="used"),
+            pytest.param("Hello {participant_data}", False, id="other_var"),
+            pytest.param("No variables here", False, id="no_vars"),
+        ],
+    )
+    def test_prompt_uses_current_datetime(self, prompt, expected):
+        assert prompt_uses_current_datetime(prompt) is expected
+
+    def test_system_message_coarsens_current_datetime_to_date(self):
+        prompt_context = Mock()
+        prompt_context.get_context.return_value = {"current_datetime": "Monday, 16 June 2026 14:32:05 UTC"}
+        prompt_context.get_current_date.return_value = "Monday, 16 June 2026"
+
+        message = get_system_message("Today is {current_datetime}", prompt_context)
+
+        assert message.content == "Today is Monday, 16 June 2026"
+        assert "14:32:05" not in message.content
+        prompt_context.get_current_date.assert_called_once()
+
+    def test_add_current_datetime_to_turn_injects_leading_block(self):
+        node = Mock(prompt="Be useful {current_datetime}")
+        prompt_context = Mock()
+        prompt_context.get_current_datetime.return_value = "Monday, 16 June 2026 14:32:05 UTC"
+        message = HumanMessage(content=[{"type": "text", "text": "hi"}])
+
+        _add_current_datetime_to_turn(node, prompt_context, message)
+
+        assert message.content == [
+            {"type": "text", "text": "<current_datetime>Monday, 16 June 2026 14:32:05 UTC</current_datetime>"},
+            {"type": "text", "text": "hi"},
+        ]
+
+    def test_add_current_datetime_to_turn_noop_when_not_used(self):
+        node = Mock(prompt="Be useful {participant_data}")
+        prompt_context = Mock()
+        message = HumanMessage(content=[{"type": "text", "text": "hi"}])
+
+        _add_current_datetime_to_turn(node, prompt_context, message)
+
+        assert message.content == [{"type": "text", "text": "hi"}]
+        prompt_context.get_current_datetime.assert_not_called()
 
 
 class TestMessageSizeValidationMiddleware:

--- a/apps/pipelines/tests/test_llm_node.py
+++ b/apps/pipelines/tests/test_llm_node.py
@@ -27,7 +27,6 @@ class TestBuildNodeAgentPromptCaching:
 
         monkeypatch.setattr("apps.pipelines.nodes.llm_node.create_agent", fake_create_agent)
         monkeypatch.setattr("apps.pipelines.nodes.llm_node._get_configured_tools", lambda *args, **kwargs: [])
-        monkeypatch.setattr("apps.pipelines.nodes.llm_node._get_prompt_context", lambda *args, **kwargs: Mock())
         monkeypatch.setattr(
             "apps.pipelines.nodes.llm_node.get_system_message",
             lambda *args, **kwargs: SystemMessage(content="prompt"),
@@ -36,7 +35,7 @@ class TestBuildNodeAgentPromptCaching:
         node = Mock()
         node.get_llm_service.return_value = service
         node.build_history_middleware.return_value = None
-        build_node_agent(node, context=Mock(), session=Mock(), tool_callbacks=Mock())
+        build_node_agent(node, context=Mock(), session=Mock(), tool_callbacks=Mock(), prompt_context=Mock())
         return captured["middleware"]
 
     @pytest.mark.parametrize(

--- a/apps/pipelines/tests/test_llm_node.py
+++ b/apps/pipelines/tests/test_llm_node.py
@@ -75,16 +75,16 @@ class TestCurrentDatetimeCachePreservation:
     def test_prompt_uses_current_datetime(self, prompt, expected):
         assert prompt_uses_current_datetime(prompt) is expected
 
-    def test_system_message_coarsens_current_datetime_to_date(self):
+    def test_system_message_requests_coarse_datetime(self):
         prompt_context = Mock()
-        prompt_context.get_context.return_value = {"current_datetime": "Monday, 16 June 2026 14:32:05 UTC"}
-        prompt_context.get_current_date.return_value = "Monday, 16 June 2026"
+        prompt_context.get_context.return_value = {"current_datetime": "Tuesday, 16 June 2026"}
 
         message = get_system_message("Today is {current_datetime}", prompt_context)
 
-        assert message.content == "Today is Monday, 16 June 2026"
-        assert "14:32:05" not in message.content
-        prompt_context.get_current_date.assert_called_once()
+        assert message.content == "Today is Tuesday, 16 June 2026"
+        # The context must render the coarse (day-precision) value, not the consumer fixing it up.
+        _, kwargs = prompt_context.get_context.call_args
+        assert kwargs["coarse_datetime"] is True
 
     def test_add_current_datetime_to_turn_injects_leading_block(self):
         node = Mock(prompt="Be useful {current_datetime}")

--- a/apps/pipelines/tests/test_nodes_with_tools.py
+++ b/apps/pipelines/tests/test_nodes_with_tools.py
@@ -1,3 +1,4 @@
+import re
 from unittest import mock
 from unittest.mock import Mock, patch
 
@@ -159,6 +160,46 @@ def test_tool_call_with_annotated_inputs(get_llm_service, provider, provider_mod
     output = graph.invoke(state, config={"configurable": {"repo": ORMRepository(session=session)}})
     assert output["messages"][-1] == "123"
     assert output["participant_data"] == {"test": ["123", "next"], "other": "xyz"}
+
+
+@pytest.mark.django_db()
+@mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
+def test_current_datetime_kept_out_of_cached_system_prompt(get_llm_service, provider, provider_model):
+    """`{current_datetime}` is coarsened to a date in the (cached) system prompt and the precise
+    time is injected into the latest message turn instead. See issue #3625.
+    """
+    time_pattern = re.compile(r"\d{2}:\d{2}:\d{2}")
+
+    service = build_fake_llm_service(responses=["done"])
+    get_llm_service.return_value = service
+    nodes = [
+        start_node(),
+        llm_response_with_prompt_node(
+            str(provider.id),
+            str(provider_model.id),
+            prompt="Current time: {current_datetime}",
+            name="llm1",
+        ),
+        end_node(),
+    ]
+    pipeline = PipelineFactory.create()
+    session = ExperimentSessionFactory.create()
+    graph = create_runnable(pipeline, nodes)
+    state = PipelineState(messages=["hello"], experiment_session=session)
+    graph.invoke(state, config={"configurable": {"repo": ORMRepository(session=session)}})
+
+    messages = service.llm.get_call_messages()[0]
+    system_message = next(message for message in messages if message.type == "system")
+    human_message = messages[-1]
+    human_text = " ".join(
+        part["text"] for part in human_message.content if isinstance(part, dict) and part.get("type") == "text"
+    )
+
+    # System prompt is day-precision only -> stays cacheable within a day
+    assert not time_pattern.search(system_message.content)
+    # Precise, second-precision datetime lands on the newest (uncached) turn
+    assert "<current_datetime>" in human_text
+    assert time_pattern.search(human_text)
 
 
 @pytest.mark.django_db()

--- a/apps/service_providers/llm_service/prompt_context.py
+++ b/apps/service_providers/llm_service/prompt_context.py
@@ -46,20 +46,33 @@ class PromptTemplateContext:
             "collection_index_summaries": self.get_collection_index_summaries,
         }
 
-    def get_context(self, variables: list[str]) -> dict:
+    def get_context(self, variables: list[str], coarse_datetime: bool = False) -> dict:
+        """Build the prompt context for the given variables.
+
+        Set ``coarse_datetime=True`` when rendering a cacheable system prompt: ``current_datetime``
+        then resolves to a day-precision date so the cached prefix stays stable within a day. The
+        precise time is injected into the latest message turn instead. See issue #3625.
+        """
         context = {}
         for key, factory in self.factories.items():
             # allow partial matches to support format specifiers
             if any(var.startswith(key) for var in variables):
-                if key not in self.context_cache:
-                    self.context_cache[key] = factory()
-                context[key] = self.context_cache[key]
+                if key == "current_datetime" and coarse_datetime:
+                    # Cached under its own key so it never collides with the full-precision value.
+                    context[key] = self._cached("current_date", self.get_current_date)
+                else:
+                    context[key] = self._cached(key, factory)
 
         # add any extra context provided
         for key, value in self.extra.items():
             if key not in context:
                 context[key] = SafeAccessWrapper(value)
         return context
+
+    def _cached(self, key, factory):
+        if key not in self.context_cache:
+            self.context_cache[key] = factory()
+        return self.context_cache[key]
 
     def get_source_material(self):
         if self.source_material_id is None:

--- a/apps/service_providers/llm_service/prompt_context.py
+++ b/apps/service_providers/llm_service/prompt_context.py
@@ -103,6 +103,14 @@ class PromptTemplateContext:
     def get_current_datetime(self):
         return pretty_date(timezone.now(), self.participant_data_proxy.get_timezone())
 
+    def get_current_date(self):
+        """Day-precision, tz-aware date.
+
+        Used in place of the volatile second-precision datetime when rendering the cacheable
+        system prompt so the prompt prefix stays stable within a day. See issue #3625.
+        """
+        return pretty_date(timezone.now(), self.participant_data_proxy.get_timezone(), include_time=False)
+
 
 class SafeAccessWrapper(dict):
     """Allow access to nested data structures without raising exceptions.

--- a/apps/service_providers/tests/test_prompt_context.py
+++ b/apps/service_providers/tests/test_prompt_context.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import Mock, patch
 
 import pytest
@@ -40,6 +41,19 @@ def test_builds_context_with_specified_variables(mock_session, mock_participant_
     assert "participant_data" not in result
 
     mock_participant_data_proxy.get.assert_not_called()
+
+
+def test_coarse_datetime_renders_day_precision(mock_session):
+    """With coarse_datetime, current_datetime resolves to a day-precision date (no time). See #3625."""
+    repo = InMemoryPipelineRepository(session=mock_session)
+    context = PromptTemplateContext(mock_session, repo)
+
+    full = context.get_context(["current_datetime"])["current_datetime"]
+    coarse = context.get_context(["current_datetime"], coarse_datetime=True)["current_datetime"]
+
+    time_pattern = re.compile(r"\d{2}:\d{2}:\d{2}")
+    assert time_pattern.search(full)
+    assert not time_pattern.search(coarse)
 
 
 def test_repeated_calls_are_cached(mock_session, mock_participant_data_proxy):

--- a/apps/utils/tests/test_time.py
+++ b/apps/utils/tests/test_time.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+import pytz
+
+from apps.utils.time import pretty_date
+
+
+def test_pretty_date_includes_time_by_default():
+    date = datetime(2026, 6, 16, 14, 32, 5, tzinfo=pytz.UTC)
+    assert pretty_date(date, "UTC") == "Tuesday, 16 June 2026 14:32:05 UTC"
+
+
+def test_pretty_date_day_precision():
+    date = datetime(2026, 6, 16, 14, 32, 5, tzinfo=pytz.UTC)
+    assert pretty_date(date, "UTC", include_time=False) == "Tuesday, 16 June 2026"

--- a/apps/utils/time.py
+++ b/apps/utils/time.py
@@ -27,8 +27,12 @@ def timedelta_to_relative_delta(timedelta: timedelta):
     return relativedelta(seconds=timedelta.total_seconds())
 
 
-def pretty_date(date: datetime, as_timezone: str | None = None) -> str:
-    """Returns the date like this: 'Monday, 1 January 2024 08:00:00 UTC'"""
+def pretty_date(date: datetime, as_timezone: str | None = None, include_time: bool = True) -> str:
+    """Returns the date like this: 'Monday, 1 January 2024 08:00:00 UTC'.
+
+    Set ``include_time=False`` for a day-precision rendering ('Monday, 1 January 2024').
+    """
     as_timezone = as_timezone or get_current_timezone_name()
     date = date.astimezone(pytz.timezone(as_timezone))
-    return date.strftime("%A, %d %B %Y %H:%M:%S %Z")
+    fmt = "%A, %d %B %Y %H:%M:%S %Z" if include_time else "%A, %d %B %Y"
+    return date.strftime(fmt)


### PR DESCRIPTION
### Product Description
no change

### Technical Description
`{current_datetime}` was substituted with second-precision time into the **system prompt** on every turn. Prompt caching is prefix-based (tools → system → messages), so a value that changes every request invalidated the entire cached prefix every turn — the cache effectively never hit beyond turn one (#3625).

The volatile value now lives only on the newest, uncached turn:
- **System prompt**: `{current_datetime}` renders to a day-precision, tz-aware date, so the cached prefix stays stable within a day.
- **Latest turn**: the precise second-precision datetime is injected as a leading `<current_datetime>…</current_datetime>` block, but only when the node's prompt actually uses `{current_datetime}` — bots that don't opt in are unchanged.

Scope is the LLM node path only. Routers can't reference `current_datetime` (excluded from their `known_vars`), and the Assistant / EventBot / evaluation paths render datetime through a different path that this doesn't touch.

Day-precision vs. dropping it entirely was a deliberate choice: keeping a date in the system prompt preserves the meaning of existing prompts (e.g. "Today is {current_datetime}") while still allowing a full day of cache hits.

### Migrations
N/A — no migrations.

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update