### PR TITLE
Speed up the CI test suite

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -223,13 +223,20 @@ jobs:
             -c "ALTER SYSTEM SET full_page_writes = off;" \
             -c "ALTER SYSTEM SET checkpoint_completion_target = 0.9;" \
             -c "SELECT pg_reload_conf();"
-      - name: Set coverage flags
-        id: cov_flags
+          # Create extensions in template1 so test databases inherit them. This lets PR runs
+          # use --no-migrations (the extensions are normally created by a migration).
+          PGPASSWORD=postgres_password psql -h localhost -U postgres -d template1 \
+            -c "CREATE EXTENSION IF NOT EXISTS vector;" \
+            -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+      - name: Set test flags
+        id: test_flags
         run: |
+          # On main, run with migrations (and coverage) so migrations stay exercised before deploy.
+          # On PRs, skip migrations for faster feedback.
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "flags=--cov --cov-report=xml" >> "$GITHUB_OUTPUT"
           else
-            echo "flags=" >> "$GITHUB_OUTPUT"
+            echo "flags=--no-migrations" >> "$GITHUB_OUTPUT"
           fi
       - name: Run Tests
         env:
@@ -237,7 +244,7 @@ jobs:
           DJANGO_DATABASE_PASSWORD: postgres_password
           SECRET_KEY: secret-test-key
           PYTHONWARNINGS: default
-        run: uv run pytest -n auto ${{ steps.cov_flags.outputs.flags }} --junitxml=junit.xml -o junit_family=legacy
+        run: uv run pytest -n auto ${{ steps.test_flags.outputs.flags }} --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload results to Codecov
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -233,7 +233,7 @@ jobs:
         run: |
           # On main, run with migrations (and coverage) so migrations stay exercised before deploy.
           # On PRs, skip migrations for faster feedback.
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
             echo "flags=--cov --cov-report=xml" >> "$GITHUB_OUTPUT"
           else
             echo "flags=--no-migrations" >> "$GITHUB_OUTPUT"

--- a/apps/banners/tests/test_banners.py
+++ b/apps/banners/tests/test_banners.py
@@ -83,7 +83,7 @@ class BannerServiceTests(TestCase):
             feature_flag=cls.test_flag,
         )
 
-        cls.site2 = Site.objects.create(id=2, domain="example.com", name="example")
+        cls.site2 = Site.objects.create(id=2, domain="second-site.example.com", name="example")
         cls.site1_banner = Banner.objects.create(
             title="Site Banner",
             message="Site banner",

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -52,6 +52,15 @@ def experiment_session():
     return ExperimentSessionFactory.create()
 
 
+@pytest.fixture()
+def general_synthetic_voices():
+    """The general (non-team-scoped) voices normally seeded by data migrations."""
+    return [
+        SyntheticVoiceFactory.create(service=service, voice_provider=None)
+        for service in (SyntheticVoice.AWS, SyntheticVoice.OpenAI, SyntheticVoice.Azure)
+    ]
+
+
 class TestSyntheticVoice:
     @pytest.mark.django_db()
     def test_team_scoped_services(self):
@@ -68,13 +77,13 @@ class TestSyntheticVoice:
         assert voices_queryset.count() == SyntheticVoice.objects.count()
 
     @pytest.mark.django_db()
-    def test_get_for_team_excludes_service(self):
+    def test_get_for_team_excludes_service(self, general_synthetic_voices):
         voices_queryset = SyntheticVoice.get_for_team(team=None, exclude_services=[SyntheticVoice.AWS])
         services = set(voices_queryset.values_list("service", flat=True))
         assert services == {SyntheticVoice.OpenAI, SyntheticVoice.Azure}
 
     @pytest.mark.django_db()
-    def test_get_for_team_do_not_include_other_team_exclusive_voices(self):
+    def test_get_for_team_do_not_include_other_team_exclusive_voices(self, general_synthetic_voices):
         """Tests that `get_for_team` returns both general and team exclusive synthetic voices. Exclusive synthetic
         voices are those whose service is one of SyntheticVoice.TEAM_SCOPED_SERVICES
         """

--- a/apps/service_providers/tests/test_models.py
+++ b/apps/service_providers/tests/test_models.py
@@ -48,6 +48,9 @@ def pipeline(llm_provider, llm_provider_model):
 class TestServiceProviderModel:
     @pytest.mark.django_db()
     def test_provider_models_for_team_includes_global(self, llm_provider_model):
+        # Global models are normally seeded by a data migration; create them explicitly so the test
+        # does not depend on migration-seeded data.
+        LlmProviderModelFactory.create_batch(2, team=None)
         team_models = LlmProviderModel.objects.for_team(llm_provider_model.team).all()
         # There is a single team model that we just created in the factory
         assert len([m for m in team_models if m.team == llm_provider_model.team]) == 1

--- a/config/settings.py
+++ b/config/settings.py
@@ -39,6 +39,8 @@ IS_TESTING = "pytest" in sys.modules
 USE_DEBUG_TOOLBAR = env.bool("USE_DEBUG_TOOLBAR", default=DEBUG)
 if IS_TESTING:
     USE_DEBUG_TOOLBAR = False
+    # Use a fast (insecure) hasher in tests; the default PBKDF2 hasher is deliberately slow.
+    PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 
 ALLOWED_HOSTS = ["*"]
 CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
@@ -570,10 +572,9 @@ CACHES = {
 }
 
 if IS_TESTING:
-    # Isolate the cache per pytest-xdist worker. Workers get separate databases
-    # but share one Redis, so without this, cached DB-backed objects (e.g. waffle
-    # flags) leak between workers and cause flaky failures.
-    CACHES["default"]["KEY_PREFIX"] = os.environ.get("PYTEST_XDIST_WORKER", "test")
+    # Use an in-process cache for tests: faster than Redis (no network round-trips) and
+    # naturally isolated per pytest-xdist worker, since each worker is a separate process.
+    CACHES["default"] = {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}
 
 # Waffle config
 WAFFLE_FLAG_MODEL = "teams.Flag"


### PR DESCRIPTION
### Product Description
No change — CI/test tooling only.

### Technical Description
PR test runs were taking ~14 min, almost entirely in the test-execution step. The dominant cost was that each pytest-xdist worker rebuilds its test database by running all 444 migrations (~70s/worker), which is why more cores never helped — adding workers just multiplies the migration build. Two per-operation costs piled on top: the default PBKDF2 password hasher (run on every factory user) and Redis round-trips for cached lookups.

Changes:
- **PR runs use `pytest --no-migrations`** (schema built from models). `main` keeps migrations + coverage so migrations stay exercised before deploy (they're otherwise only applied at deploy time). The `vector`/`pg_trgm` extensions are created in `template1` in the Postgres setup step, since they're normally created by a migration.
- **Test fixes** so the suite passes under `--no-migrations`: a handful of tests depended on data created by `RunPython` migrations (default Site, synthetic voices, global provider models). They now create that data in-test. Each fix is a strict superset of existing data, so the tests pass **both** with and without migrations.
- **MD5 password hasher + `LocMemCache`** under `IS_TESTING`. LocMemCache is per-process, so xdist workers are naturally isolated and the old `KEY_PREFIX` hack is gone.

Local full suite (16 cores): 12:01 → 3:05, identical pass count (3835 passed), 0 failures. The hasher/cache wins are CPU/IO savings independent of worker count, so PR CI should see a comparable proportional drop.

Review focus: the `--no-migrations` (PR) vs migrations (main) split in `lint_and_test.yml`, and that the test data fixes hold in both modes.

### Migrations
N/A — no new migrations. This changes how migrations are run in CI (skipped on PRs), not the migrations themselves.

### Docs and Changelog
- [ ] This PR requires docs/changelog update