### PR TITLE
Guard backfill_node_fks against dangling resource references

### DIFF
--- a/apps/pipelines/management/commands/backfill_node_fks.py
+++ b/apps/pipelines/management/commands/backfill_node_fks.py
@@ -1,9 +1,12 @@
 import logging
 from collections import defaultdict
 
+from django.core.management import CommandError
+
 from apps.data_migrations.management.commands.base import IdempotentCommand
 from apps.documents.models import Collection
 from apps.pipelines.models import Node
+from apps.teams.models import Team
 from apps.utils.fields import as_int
 
 logger = logging.getLogger(__name__)
@@ -16,18 +19,40 @@ class Command(IdempotentCommand):
     migration_name = "backfill_node_resource_fks_2026_06_17"
     atomic = False  # batches are independent; let each commit on its own
 
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument("--team", help="Slug of the team to backfill (default: all teams)", required=False)
+
+    def handle(self, *args, **options):
+        team_slug = options.get("team")
+        if team_slug:
+            try:
+                self.team = Team.objects.get(slug=team_slug)
+            except Team.DoesNotExist:
+                raise CommandError(f"Team '{team_slug}' does not exist.") from None
+        else:
+            self.team = None
+        super().handle(*args, **options)
+
+    def _base_qs(self):
+        qs = Node.objects.get_all().filter(is_archived=False)
+        if self.team:
+            qs = qs.filter(pipeline__team=self.team)
+        return qs
+
     def perform_migration(self, dry_run=False):
         # get_all() bypasses the default manager's is_archived=False filter so the mirror is
         # backfilled on every node — working versions, published versions, and soft-deleted
         # (archived) versions alike. Archived versions still hold references that the mirror must reflect.
-        node_ids = list(Node.objects.get_all().values_list("id", flat=True))
+        node_ids = list(self._base_qs().values_list("id", flat=True))
         total = len(node_ids)
 
+        scope = f"team '{self.team.slug}'" if self.team else "all teams"
         if dry_run:
-            self.stdout.write(f"Would backfill FK fields for {total} nodes")
+            self.stdout.write(f"Would backfill FK fields for {total} nodes ({scope})")
             return
 
-        self.stdout.write(f"Backfilling FK fields for {total} nodes...")
+        self.stdout.write(f"Backfilling FK fields for {total} nodes ({scope})...")
 
         fk_fields = Node.resource_fk_fields()
         fk_id_attrs = [f"{name}_id" for name in fk_fields]
@@ -35,7 +60,7 @@ class Command(IdempotentCommand):
 
         for start in range(0, total, BATCH_SIZE):
             chunk_ids = node_ids[start : start + BATCH_SIZE]
-            nodes = list(Node.objects.get_all().filter(id__in=chunk_ids).only("id", "params", *fk_id_attrs))
+            nodes = list(self._base_qs().filter(id__in=chunk_ids).only("id", "params", *fk_id_attrs))
             self._backfill_scalar_fks(nodes, fk_id_attrs)
             self._backfill_collection_indexes(nodes)
             processed += len(nodes)

--- a/apps/pipelines/management/commands/backfill_node_fks.py
+++ b/apps/pipelines/management/commands/backfill_node_fks.py
@@ -29,6 +29,9 @@ class Command(IdempotentCommand):
                 self.team = Team.objects.get(slug=team_slug)
             except Team.DoesNotExist:
                 raise CommandError(f"Team '{team_slug}' does not exist.") from None
+            # Scope the idempotency marker per team so a targeted run doesn't mark the whole
+            # migration applied and turn a later full (or other-team) run into a no-op.
+            self.migration_name = f"{self.migration_name}__team_{self.team.id}"
         else:
             self.team = None
         super().handle(*args, **options)
@@ -79,6 +82,14 @@ class Command(IdempotentCommand):
         self.stdout.write(self.style.SUCCESS(f"Done. Processed: {processed}"))
         return processed
 
+    @staticmethod
+    def _resolve_fk_value(params, attr, valid_ids):
+        """Return the params id for attr, or None if it's missing, malformed, or dangling."""
+        value = as_int(params.get(attr))
+        if value is not None and value not in valid_ids:
+            return None
+        return value
+
     def _backfill_scalar_fks(self, nodes, fk_id_attrs, valid_fk_ids):
         """Mirror the scalar FK columns from params, bulk-updating only the nodes that changed.
 
@@ -89,9 +100,7 @@ class Command(IdempotentCommand):
             params = node.params or {}
             node_changed = False
             for attr in fk_id_attrs:
-                value = as_int(params.get(attr))
-                if value is not None and value not in valid_fk_ids[attr]:
-                    value = None
+                value = self._resolve_fk_value(params, attr, valid_fk_ids[attr])
                 if getattr(node, attr) != value:
                     setattr(node, attr, value)
                     node_changed = True

--- a/apps/pipelines/management/commands/backfill_node_fks.py
+++ b/apps/pipelines/management/commands/backfill_node_fks.py
@@ -1,11 +1,8 @@
 import logging
 from collections import defaultdict
 
-from django.core.management import CommandError
-
 from apps.data_migrations.management.commands.base import IdempotentCommand
 from apps.pipelines.models import Node
-from apps.teams.models import Team
 from apps.utils.fields import as_int
 
 logger = logging.getLogger(__name__)
@@ -17,30 +14,6 @@ class Command(IdempotentCommand):
     help = "Backfill resource FK fields on Node from params JSON."
     migration_name = "backfill_node_resource_fks_2026_06_17"
     atomic = False  # batches are independent; let each commit on its own
-
-    def add_arguments(self, parser):
-        super().add_arguments(parser)
-        parser.add_argument("--team", help="Slug of the team to backfill (default: all teams)", required=False)
-
-    def handle(self, *args, **options):
-        team_slug = options.get("team")
-        if team_slug:
-            try:
-                self.team = Team.objects.get(slug=team_slug)
-            except Team.DoesNotExist:
-                raise CommandError(f"Team '{team_slug}' does not exist.") from None
-            # Scope the idempotency marker per team so a targeted run doesn't mark the whole
-            # migration applied and turn a later full (or other-team) run into a no-op.
-            self.migration_name = f"{self.migration_name}__team_{self.team.id}"
-        else:
-            self.team = None
-        super().handle(*args, **options)
-
-    def _base_qs(self):
-        qs = Node.objects.get_all()
-        if self.team:
-            qs = qs.filter(pipeline__team=self.team)
-        return qs
 
     def _load_valid_fk_ids(self, fk_fields):
         """Pre-fetch all valid IDs for each resource FK to guard against dangling references."""
@@ -56,15 +29,14 @@ class Command(IdempotentCommand):
         # get_all() bypasses the default manager's is_archived=False filter so the mirror is
         # backfilled on every node — working versions, published versions, and soft-deleted
         # (archived) versions alike. Archived versions still hold references that the mirror must reflect.
-        node_ids = list(self._base_qs().values_list("id", flat=True))
+        node_ids = list(Node.objects.get_all().values_list("id", flat=True))
         total = len(node_ids)
 
-        scope = f"team '{self.team.slug}'" if self.team else "all teams"
         if dry_run:
-            self.stdout.write(f"Would backfill FK fields for {total} nodes ({scope})")
+            self.stdout.write(f"Would backfill FK fields for {total} nodes")
             return
 
-        self.stdout.write(f"Backfilling FK fields for {total} nodes ({scope})...")
+        self.stdout.write(f"Backfilling FK fields for {total} nodes...")
 
         fk_fields = Node.resource_fk_fields()
         fk_id_attrs = [f"{name}_id" for name in fk_fields]
@@ -73,7 +45,7 @@ class Command(IdempotentCommand):
 
         for start in range(0, total, BATCH_SIZE):
             chunk_ids = node_ids[start : start + BATCH_SIZE]
-            nodes = list(self._base_qs().filter(id__in=chunk_ids).only("id", "params", *fk_id_attrs))
+            nodes = list(Node.objects.get_all().filter(id__in=chunk_ids).only("id", "params", *fk_id_attrs))
             self._backfill_scalar_fks(nodes, fk_id_attrs, valid_fk_ids)
             self._backfill_collection_indexes(nodes, valid_fk_ids["collection_id"])
             processed += len(nodes)

--- a/apps/pipelines/management/commands/backfill_node_fks.py
+++ b/apps/pipelines/management/commands/backfill_node_fks.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from django.core.management import CommandError
 
 from apps.data_migrations.management.commands.base import IdempotentCommand
-from apps.documents.models import Collection
 from apps.pipelines.models import Node
 from apps.teams.models import Team
 from apps.utils.fields import as_int
@@ -35,10 +34,20 @@ class Command(IdempotentCommand):
         super().handle(*args, **options)
 
     def _base_qs(self):
-        qs = Node.objects.get_all().filter(is_archived=False)
+        qs = Node.objects.get_all()
         if self.team:
             qs = qs.filter(pipeline__team=self.team)
         return qs
+
+    def _load_valid_fk_ids(self, fk_fields):
+        """Pre-fetch all valid IDs for each resource FK to guard against dangling references."""
+        valid = {}
+        for name in fk_fields:
+            field = Node._meta.get_field(name)
+            ids = set(field.related_model.objects.values_list("id", flat=True))
+            valid[f"{name}_id"] = ids
+            self.stdout.write(f"  Loaded {len(ids)} valid {name} IDs")
+        return valid
 
     def perform_migration(self, dry_run=False):
         # get_all() bypasses the default manager's is_archived=False filter so the mirror is
@@ -56,27 +65,33 @@ class Command(IdempotentCommand):
 
         fk_fields = Node.resource_fk_fields()
         fk_id_attrs = [f"{name}_id" for name in fk_fields]
+        valid_fk_ids = self._load_valid_fk_ids(fk_fields)
         processed = 0
 
         for start in range(0, total, BATCH_SIZE):
             chunk_ids = node_ids[start : start + BATCH_SIZE]
             nodes = list(self._base_qs().filter(id__in=chunk_ids).only("id", "params", *fk_id_attrs))
-            self._backfill_scalar_fks(nodes, fk_id_attrs)
-            self._backfill_collection_indexes(nodes)
+            self._backfill_scalar_fks(nodes, fk_id_attrs, valid_fk_ids)
+            self._backfill_collection_indexes(nodes, valid_fk_ids["collection_id"])
             processed += len(nodes)
             self.stdout.write(f"  ...{processed}/{total}")
 
         self.stdout.write(self.style.SUCCESS(f"Done. Processed: {processed}"))
         return processed
 
-    def _backfill_scalar_fks(self, nodes, fk_id_attrs):
-        """Mirror the scalar FK columns from params, bulk-updating only the nodes that changed."""
+    def _backfill_scalar_fks(self, nodes, fk_id_attrs, valid_fk_ids):
+        """Mirror the scalar FK columns from params, bulk-updating only the nodes that changed.
+
+        IDs that don't exist in valid_fk_ids are treated as None to avoid integrity errors.
+        """
         changed = []
         for node in nodes:
             params = node.params or {}
             node_changed = False
             for attr in fk_id_attrs:
                 value = as_int(params.get(attr))
+                if value is not None and value not in valid_fk_ids[attr]:
+                    value = None
                 if getattr(node, attr) != value:
                     setattr(node, attr, value)
                     node_changed = True
@@ -88,30 +103,22 @@ class Command(IdempotentCommand):
             Node.objects.get_all().bulk_update(changed, fk_id_attrs, batch_size=BATCH_SIZE)
         self.stdout.write(f"    scalar FKs: {len(changed)}/{len(nodes)} nodes updated")
 
-    def _backfill_collection_indexes(self, nodes):
+    def _backfill_collection_indexes(self, nodes, valid_collection_ids):
         """Reconcile the collection_indexes M2M through table to mirror collection_index_ids in params.
 
         Mirrors Node._sync_resource_fk_fields: ids are coerced via as_int (malformed values dropped)
-        and filtered to Collections that still exist via the default manager (archived ones are dropped).
+        and intersected with the preloaded valid_collection_ids set (non-existent ones are dropped).
         """
         through = Node.collection_indexes.through
         node_ids = [node.id for node in nodes]
 
         desired_by_node = {}
-        referenced_ids = set()
         for node in nodes:
             raw_ids = (node.params or {}).get("collection_index_ids") or []
             if not isinstance(raw_ids, list | tuple | set):
                 raw_ids = [raw_ids]
             ids = {parsed for parsed in map(as_int, raw_ids) if parsed is not None}
             desired_by_node[node.id] = ids
-            referenced_ids |= ids
-
-        valid_ids = (
-            set(Collection.objects.filter(id__in=referenced_ids).values_list("id", flat=True))
-            if referenced_ids
-            else set()
-        )
 
         existing_by_node = defaultdict(set)
         row_pk = {}
@@ -124,7 +131,7 @@ class Command(IdempotentCommand):
         to_create = []
         stale_row_ids = []
         for node in nodes:
-            desired = desired_by_node[node.id] & valid_ids
+            desired = desired_by_node[node.id] & valid_collection_ids
             current = existing_by_node.get(node.id, set())
             to_create.extend(through(node_id=node.id, collection_id=cid) for cid in desired - current)
             stale_row_ids.extend(row_pk[(node.id, cid)] for cid in current - desired)

--- a/apps/pipelines/management/commands/backfill_node_fks.py
+++ b/apps/pipelines/management/commands/backfill_node_fks.py
@@ -16,14 +16,34 @@ class Command(IdempotentCommand):
     atomic = False  # batches are independent; let each commit on its own
 
     def _load_valid_fk_ids(self, fk_fields):
-        """Pre-fetch all valid IDs for each resource FK to guard against dangling references."""
+        """Pre-fetch valid IDs for each scalar resource FK to guard against dangling references.
+
+        Uses the archive-inclusive ``_base_manager``: archiving is a soft-delete, so an archived
+        row still exists and its FK is satisfiable. The default manager on the versioned resource
+        models (Collection, SourceMaterial, OpenAiAssistant) filters ``is_archived=False``, which
+        would treat a valid reference to an archived resource as dangling and wrongly null it out.
+        Mirrors ``perform_migration``'s use of ``get_all()`` for the same reason.
+        """
         valid = {}
         for name in fk_fields:
             field = Node._meta.get_field(name)
-            ids = set(field.related_model.objects.values_list("id", flat=True))
+            ids = set(field.related_model._base_manager.values_list("id", flat=True))
             valid[f"{name}_id"] = ids
             self.stdout.write(f"  Loaded {len(ids)} valid {name} IDs")
         return valid
+
+    def _load_valid_collection_index_ids(self):
+        """Valid IDs for the collection_indexes M2M.
+
+        Unlike the scalar FKs, the runtime mirror sets this M2M from ``Collection.objects`` (the
+        default, archive-FILTERING manager) — see ``Node._sync_resource_fk_fields`` — so archived
+        collections are intentionally dropped here to keep the backfill in step with what a later
+        ``save()`` would write.
+        """
+        collection_model = Node._meta.get_field("collection_indexes").related_model
+        ids = set(collection_model.objects.values_list("id", flat=True))
+        self.stdout.write(f"  Loaded {len(ids)} valid collection index IDs")
+        return ids
 
     def perform_migration(self, dry_run=False):
         # get_all() bypasses the default manager's is_archived=False filter so the mirror is
@@ -41,13 +61,14 @@ class Command(IdempotentCommand):
         fk_fields = Node.resource_fk_fields()
         fk_id_attrs = [f"{name}_id" for name in fk_fields]
         valid_fk_ids = self._load_valid_fk_ids(fk_fields)
+        valid_index_ids = self._load_valid_collection_index_ids()
         processed = 0
 
         for start in range(0, total, BATCH_SIZE):
             chunk_ids = node_ids[start : start + BATCH_SIZE]
             nodes = list(Node.objects.get_all().filter(id__in=chunk_ids).only("id", "params", *fk_id_attrs))
             self._backfill_scalar_fks(nodes, fk_id_attrs, valid_fk_ids)
-            self._backfill_collection_indexes(nodes, valid_fk_ids["collection_id"])
+            self._backfill_collection_indexes(nodes, valid_index_ids)
             processed += len(nodes)
             self.stdout.write(f"  ...{processed}/{total}")
 

--- a/apps/pipelines/tests/test_node_resource_fks.py
+++ b/apps/pipelines/tests/test_node_resource_fks.py
@@ -292,6 +292,28 @@ def test_backfill_node_fks_command_is_idempotent():
 
 
 @pytest.mark.django_db()
+def test_team_scoped_run_does_not_block_other_teams():
+    """A --team run scopes its idempotency marker, so a later run for a different team still executes."""
+    provider = LlmProviderFactory.create()
+    pipeline_a = PipelineFactory.create()
+    pipeline_b = PipelineFactory.create()
+    node_a = NodeFactory.create(
+        type="LLMResponseWithPrompt", params={"llm_provider_id": provider.id}, pipeline=pipeline_a
+    )
+    node_b = NodeFactory.create(
+        type="LLMResponseWithPrompt", params={"llm_provider_id": provider.id}, pipeline=pipeline_b
+    )
+
+    call_command("backfill_node_fks", team=pipeline_a.team.slug, stdout=StringIO())
+    call_command("backfill_node_fks", team=pipeline_b.team.slug, stdout=StringIO())
+
+    node_a.refresh_from_db()
+    node_b.refresh_from_db()
+    assert node_a.llm_provider_id == provider.id
+    assert node_b.llm_provider_id == provider.id
+
+
+@pytest.mark.django_db()
 def test_backfill_nulls_dangling_scalar_fk():
     """A scalar FK ID in params that references a deleted resource is set to None, not written as-is."""
     node = NodeFactory.create(

--- a/apps/pipelines/tests/test_node_resource_fks.py
+++ b/apps/pipelines/tests/test_node_resource_fks.py
@@ -346,3 +346,41 @@ def test_backfill_links_all_resources_when_they_exist():
     # Every resource FK on the model is now populated — nothing left dangling.
     assert all(getattr(node, f"{name}_id") is not None for name in Node.resource_fk_fields())
     assert set(node.collection_indexes.values_list("id", flat=True)) == {index.id}
+
+
+@pytest.mark.django_db()
+def test_backfill_keeps_scalar_fk_to_archived_resource():
+    """Archiving is a soft-delete: the row still exists, so a scalar FK to it stays linked.
+
+    The versioned resource managers filter is_archived=False, but the FK is still satisfiable,
+    so the backfill must not treat an archived-but-existing reference as dangling.
+    """
+    collection = CollectionFactory.create(is_archived=True)
+    source_material = SourceMaterialFactory.create(is_archived=True)
+    assistant = OpenAiAssistantFactory.create(is_archived=True)
+    node = NodeFactory.create(
+        type="LLMResponseWithPrompt",
+        params={
+            "collection_id": collection.id,
+            "source_material_id": source_material.id,
+            "assistant_id": assistant.id,
+        },
+    )
+    call_command("backfill_node_fks", stdout=StringIO())
+    node.refresh_from_db()
+    assert node.collection_id == collection.id
+    assert node.source_material_id == source_material.id
+    assert node.assistant_id == assistant.id
+
+
+@pytest.mark.django_db()
+def test_backfill_drops_archived_collection_index():
+    """The collection_indexes M2M mirrors runtime Collection.objects, which excludes archived rows."""
+    valid_index = CollectionFactory.create(is_index=True)
+    archived_index = CollectionFactory.create(is_index=True, is_archived=True)
+    node = NodeFactory.create(
+        type="LLMResponseWithPrompt",
+        params={"collection_index_ids": [valid_index.id, archived_index.id]},
+    )
+    call_command("backfill_node_fks", stdout=StringIO())
+    assert set(node.collection_indexes.values_list("id", flat=True)) == {valid_index.id}

--- a/apps/pipelines/tests/test_node_resource_fks.py
+++ b/apps/pipelines/tests/test_node_resource_fks.py
@@ -289,3 +289,60 @@ def test_backfill_node_fks_command_is_idempotent():
     call_command("backfill_node_fks", stdout=StringIO())
     node.refresh_from_db()
     assert node.llm_provider_id == provider.id
+
+
+@pytest.mark.django_db()
+def test_backfill_nulls_dangling_scalar_fk():
+    """A scalar FK ID in params that references a deleted resource is set to None, not written as-is."""
+    node = NodeFactory.create(
+        type="LLMResponseWithPrompt",
+        params={"llm_provider_id": 999999},
+    )
+    call_command("backfill_node_fks", stdout=StringIO())
+    node.refresh_from_db()
+    assert node.llm_provider_id is None
+
+
+@pytest.mark.django_db()
+def test_backfill_skips_dangling_collection_index_id():
+    """A collection_index_id in params that references a non-existent collection is not linked."""
+    node = NodeFactory.create(
+        type="LLMResponseWithPrompt",
+        params={"collection_index_ids": [999999]},
+    )
+    call_command("backfill_node_fks", stdout=StringIO())
+    assert node.collection_indexes.count() == 0
+
+
+@pytest.mark.django_db()
+def test_backfill_links_all_resources_when_they_exist():
+    """When every resource referenced in params exists, all scalar FKs and the M2M are linked."""
+    provider = LlmProviderFactory.create()
+    model = LlmProviderModelFactory.create()
+    source_material = SourceMaterialFactory.create()
+    collection = CollectionFactory.create()
+    assistant = OpenAiAssistantFactory.create()
+    voice = SyntheticVoiceFactory.create()
+    index = CollectionFactory.create(is_index=True)
+
+    expected = {
+        "llm_provider_id": provider.id,
+        "llm_provider_model_id": model.id,
+        "source_material_id": source_material.id,
+        "collection_id": collection.id,
+        "assistant_id": assistant.id,
+        "synthetic_voice_id": voice.id,
+    }
+    node = NodeFactory.create(
+        type="LLMResponseWithPrompt",
+        params={**expected, "collection_index_ids": [index.id]},
+    )
+
+    call_command("backfill_node_fks", stdout=StringIO())
+    node.refresh_from_db()
+
+    for attr, resource_id in expected.items():
+        assert getattr(node, attr) == resource_id, f"{attr} not linked"
+    # Every resource FK on the model is now populated — nothing left dangling.
+    assert all(getattr(node, f"{name}_id") is not None for name in Node.resource_fk_fields())
+    assert set(node.collection_indexes.values_list("id", flat=True)) == {index.id}

--- a/apps/pipelines/tests/test_node_resource_fks.py
+++ b/apps/pipelines/tests/test_node_resource_fks.py
@@ -292,28 +292,6 @@ def test_backfill_node_fks_command_is_idempotent():
 
 
 @pytest.mark.django_db()
-def test_team_scoped_run_does_not_block_other_teams():
-    """A --team run scopes its idempotency marker, so a later run for a different team still executes."""
-    provider = LlmProviderFactory.create()
-    pipeline_a = PipelineFactory.create()
-    pipeline_b = PipelineFactory.create()
-    node_a = NodeFactory.create(
-        type="LLMResponseWithPrompt", params={"llm_provider_id": provider.id}, pipeline=pipeline_a
-    )
-    node_b = NodeFactory.create(
-        type="LLMResponseWithPrompt", params={"llm_provider_id": provider.id}, pipeline=pipeline_b
-    )
-
-    call_command("backfill_node_fks", team=pipeline_a.team.slug, stdout=StringIO())
-    call_command("backfill_node_fks", team=pipeline_b.team.slug, stdout=StringIO())
-
-    node_a.refresh_from_db()
-    node_b.refresh_from_db()
-    assert node_a.llm_provider_id == provider.id
-    assert node_b.llm_provider_id == provider.id
-
-
-@pytest.mark.django_db()
 def test_backfill_nulls_dangling_scalar_fk():
     """A scalar FK ID in params that references a deleted resource is set to None, not written as-is."""
     node = NodeFactory.create(


### PR DESCRIPTION
### Product Description
No change — internal data-migration management command.

### Technical Description
Hardens the `backfill_node_fks` command against dangling references in `params`.

Before the node loop, valid IDs for every resource FK (and the `collection_indexes` M2M, which shares the `Collection` model) are preloaded into sets. Any id in `params` that no longer points to an existing resource is nulled out for scalar FKs / skipped for the M2M, so the backfill can't write a dangling id that would fail the (deferred) FK constraint at commit. This also replaces the per-batch `Collection.objects.filter(...)` query with a single preloaded set.

Note: `get_all()` (no `is_archived` filter) is intentional — archived node versions still mirror references and must be backfilled (covered by the existing command test).

### Migrations
N/A — no schema migration. This is a `data_migrations` management command run manually.

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update