### PR TITLE
Backfill node resource FKs

### DIFF
--- a/apps/pipelines/migrations/0027_backfill_node_fks.py
+++ b/apps/pipelines/migrations/0027_backfill_node_fks.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+from apps.data_migrations.utils.migrations import RunDataMigration
+
+
+class Migration(migrations.Migration):
+    # Non-atomic so the command's batches commit independently (it sets atomic = False for the
+    # same reason). An atomic migration would wrap the whole backfill in a single transaction.
+    atomic = False
+
+    dependencies = [
+        ("pipelines", "0026_node_resource_fks"),
+        ("data_migrations", "0001_initial"),
+    ]
+
+    operations = [
+        RunDataMigration("backfill_node_fks"),
+    ]


### PR DESCRIPTION
### Product Description
no change

### Technical Description
 This command was already run manually in production.

### Migrations
- [x] The migrations are backwards compatible

Old code keeps reading from `params` JSON; this only populates the new mirror columns, which old code doesn't depend on.

### Docs and Changelog
- [ ] This PR requires docs/changelog update