### PR TITLE
fix: opt pre-header widgets out of session token enforcement

### DIFF
--- a/apps/api/tests/test_chat_session_token.py
+++ b/apps/api/tests/test_chat_session_token.py
@@ -206,6 +206,19 @@ def test_old_widget_implicitly_opts_out(api_client, experiment):
 
 
 @pytest.mark.django_db()
+def test_pre_header_widget_implicitly_opts_out(api_client, experiment):
+    """Widgets older than 0.5.1 send no version header; they are still pre-token widgets.
+
+    They identify themselves via session_data.source and must opt out, otherwise the
+    session would require a token the widget never sends.
+    """
+    response = start_session(api_client, experiment, {"session_data": {"source": "widget"}})
+    body = response.json()
+    assert body["session_token"] is None
+    assert ExperimentSession.objects.get(external_id=body["session_id"]).session_token_required is False
+
+
+@pytest.mark.django_db()
 def test_authenticated_start_then_poll_without_token(api_client, experiment, team_with_users):
     """Authenticated users rely on the auth bypass, not the returned token."""
     user = team_with_users.members.first()

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -170,15 +170,19 @@ def chat_upload_file(request, session_id):
     return Response({"files": uploaded_files}, status=status.HTTP_201_CREATED)
 
 
-def _issue_or_opt_out_session_token(request, session, use_session_token):
+def _issue_or_opt_out_session_token(request, session, use_session_token, session_data):
     """Issue a session token, or opt the session out of token enforcement.
 
-    `use_session_token` is the request preference (True/False/None). When None, a
-    pre-token widget (identified by the x-ocs-widget-version header) opts out;
-    everything else defaults to enforced. Returns the token, or None when opted out.
+    `use_session_token` is the request preference (True/False/None). A token-aware
+    widget always sends it explicitly (True), so an unset field from widget traffic
+    means a pre-token widget — opt out. Widget traffic is identified by the
+    x-ocs-widget-version header (sent by 0.5.1+) or, for older widgets that send no
+    header, by `session_data.source`. Everything else (direct API consumers) defaults
+    to enforced. Returns the token, or None when opted out.
     """
     if use_session_token is None:
-        use_session_token = "x-ocs-widget-version" not in request.headers
+        is_widget = WIDGET_VERSION_HEADER in request.headers or session_data.get("source") == "widget"
+        use_session_token = not is_widget
     if use_session_token:
         return issue_session_token(session)
     session.session_token_required = False
@@ -350,7 +354,7 @@ def chat_start_session(request):
         session.state = session_data
         session.save(update_fields=["state"])
 
-    session_token = _issue_or_opt_out_session_token(request, session, data.get("use_session_token"))
+    session_token = _issue_or_opt_out_session_token(request, session, data.get("use_session_token"), session_data)
 
     # Prepare response data
     response_data = {


### PR DESCRIPTION
### Product Description
Chat widgets older than 0.5.1 (e.g. 0.4.8, seen on espen.afro.who.int) were broken: the chat would start but every poll/message returned `403 session_token_required`.

### Technical Description
`chat_start_session` decided token enforcement from `"x-ocs-widget-version" not in request.headers`. That header only exists on widgets ≥ 0.5.1, so older widgets — which don't support tokens — fell into the "enforce" branch, got issued a `session_token`, never echoed it back, and 403'd on every subsequent request.

A token-aware widget always sends `use_session_token: true` explicitly, so an unset field from widget traffic is necessarily pre-token. The fix widens widget detection to also match header-less old widgets via `session_data.source == "widget"` (which even 0.4.8 sends). Direct API consumers (no header, no widget source) still default to enforced, preserving the secure-by-default posture.

The one judgement call: `source == "widget"` is the discriminator for header-less clients. A non-widget API consumer that both sends `source: "widget"` and relies on token enforcement would now be opted out — unlikely given the field is widget-specific by construction, but flagging it.

### Migrations
N/A — no migrations.

### Demo
N/A — covered by `test_pre_header_widget_implicitly_opts_out`, which reproduces the header-less widget start and asserts no token is required (fails on `main`).

### Docs and Changelog
- [ ] This PR requires docs/changelog update