### PR TITLE
fix: update tests broken by recent merges

### DIFF
--- a/apps/api/tests/test_chat_api_anon.py
+++ b/apps/api/tests/test_chat_api_anon.py
@@ -22,7 +22,7 @@ def session(experiment):
 @pytest.mark.django_db()
 def test_start_chat_session(team_with_users, api_client, experiment):
     url = reverse("api:chat:start-session")
-    session_state = {"source": "widget", "page_url": "https://example.com"}
+    session_state = {"page_url": "https://example.com"}
     data = {
         "chatbot_id": experiment.public_id,
         "session_data": session_state,

--- a/apps/pipelines/tests/test_node_resource_fks.py
+++ b/apps/pipelines/tests/test_node_resource_fks.py
@@ -268,7 +268,7 @@ def test_backfill_node_fks_command():
         node.collection_indexes.clear()
 
     out = StringIO()
-    call_command("backfill_node_fks", stdout=out)
+    call_command("backfill_node_fks", force=True, stdout=out)
 
     for node in nodes:
         node.refresh_from_db()
@@ -285,8 +285,8 @@ def test_backfill_node_fks_command_is_idempotent():
         type="LLMResponseWithPrompt",
         params={"llm_provider_id": provider.id},
     )
-    call_command("backfill_node_fks", stdout=StringIO())
-    call_command("backfill_node_fks", stdout=StringIO())
+    call_command("backfill_node_fks", force=True, stdout=StringIO())
+    call_command("backfill_node_fks", force=True, stdout=StringIO())
     node.refresh_from_db()
     assert node.llm_provider_id == provider.id
 
@@ -298,7 +298,7 @@ def test_backfill_nulls_dangling_scalar_fk():
         type="LLMResponseWithPrompt",
         params={"llm_provider_id": 999999},
     )
-    call_command("backfill_node_fks", stdout=StringIO())
+    call_command("backfill_node_fks", force=True, stdout=StringIO())
     node.refresh_from_db()
     assert node.llm_provider_id is None
 
@@ -310,7 +310,7 @@ def test_backfill_skips_dangling_collection_index_id():
         type="LLMResponseWithPrompt",
         params={"collection_index_ids": [999999]},
     )
-    call_command("backfill_node_fks", stdout=StringIO())
+    call_command("backfill_node_fks", force=True, stdout=StringIO())
     assert node.collection_indexes.count() == 0
 
 
@@ -338,7 +338,7 @@ def test_backfill_links_all_resources_when_they_exist():
         params={**expected, "collection_index_ids": [index.id]},
     )
 
-    call_command("backfill_node_fks", stdout=StringIO())
+    call_command("backfill_node_fks", force=True, stdout=StringIO())
     node.refresh_from_db()
 
     for attr, resource_id in expected.items():
@@ -366,7 +366,7 @@ def test_backfill_keeps_scalar_fk_to_archived_resource():
             "assistant_id": assistant.id,
         },
     )
-    call_command("backfill_node_fks", stdout=StringIO())
+    call_command("backfill_node_fks", force=True, stdout=StringIO())
     node.refresh_from_db()
     assert node.collection_id == collection.id
     assert node.source_material_id == source_material.id
@@ -382,5 +382,5 @@ def test_backfill_drops_archived_collection_index():
         type="LLMResponseWithPrompt",
         params={"collection_index_ids": [valid_index.id, archived_index.id]},
     )
-    call_command("backfill_node_fks", stdout=StringIO())
+    call_command("backfill_node_fks", force=True, stdout=StringIO())
     assert set(node.collection_indexes.values_list("id", flat=True)) == {valid_index.id}


### PR DESCRIPTION
Fixes the 6 failing tests on `main` from the most recent CI run.

## Root causes

### `test_start_chat_session` (broken by #3658)

The test sent `session_data={"source": "widget"}`, which #3658 now uses to detect pre-token widgets and opt them out of session token enforcement. The endpoint correctly returned `session_token: null` — but the test then asserted the token was non-null.

**Fix:** remove `"source": "widget"` from `session_state` so the request is treated as a direct API caller (gets a real token, matching the original intent of the test).

### `test_backfill_node_fks_*` — 5 tests (broken by #3657)

Migration `0027_backfill_node_fks` runs `call_command("backfill_node_fks")` during the test-DB setup, which marks the command as applied in the `CustomMigration` table. When the tests then call `call_command("backfill_node_fks")`, `IdempotentCommand` sees it's already applied and returns early — nothing gets backfilled. The tests that were asserting FKs were populated all saw `None`.

**Fix:** add `force=True` to every `call_command("backfill_node_fks")` in the test file. This bypasses the idempotency guard so the command actually runs during tests (which need to set up and re-backfill their own fixture data anyway).