### PR TITLE
fix: add signup link to login page when signup is enabled

### DIFF
--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -30,4 +30,10 @@
       <a class="auth-link" href="{% url 'account_reset_password' %}">{% translate "Forgot password?" %}</a>
     </div>
   {% endif %}
+  {% if signup_enabled %}
+    <div class="auth-foot">
+      {% translate "Don't have an account?" %}
+      <a class="auth-link" href="{% url 'account_signup' %}">{% translate "Sign up." %}</a>
+    </div>
+  {% endif %}
 {% endblock auth_body %}


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->


### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->
The sign up link was missing when it is enabled

### Migrations
<!--
There may be a potentially long window during the deployment where migrations are applied, but the old code is still running. We need to ensure that migrations can be applied to the current running code without breaking it, to the extent possible.

Delete this section if there are no migration.
 -->
- [ ] The migrations are backwards compatible


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
<img width="651" height="512" alt="image" src="https://github.com/user-attachments/assets/876365af-be4e-4338-a109-5e73a2f24857" />


### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
