### PR TITLE
fix: send sunset headers to pre-header widgets

### DIFF
--- a/apps/api/tests/test_widget_version_tracking.py
+++ b/apps/api/tests/test_widget_version_tracking.py
@@ -34,9 +34,11 @@ def widget_channel(experiment):
     )
 
 
-def _start_session(api_client, widget_channel, **extra):
+def _start_session(api_client, widget_channel, session_data=None, **extra):
     url = reverse("api:chat:start-session")
     data = {"chatbot_id": widget_channel.experiment.public_id}
+    if session_data is not None:
+        data["session_data"] = session_data
     return api_client.post(
         url,
         data=data,
@@ -99,11 +101,23 @@ def test_no_sunset_headers_for_current_version(api_client, widget_channel):
 
 @pytest.mark.django_db()
 def test_no_sunset_headers_without_version_header(api_client, widget_channel):
-    # No x-ocs-widget-version header at all (curl, authed users): no deprecation headers
+    # No version header and no widget marker (curl, authed users): no deprecation headers
     with patch("apps.channels.widget_versions.DEPRECATIONS", [DEPRECATION]):
         response = _start_session(api_client, widget_channel)
     assert response.status_code == 201
     assert "Deprecation" not in response.headers
+
+
+@pytest.mark.django_db()
+def test_pre_header_widget_gets_sunset_headers(api_client, widget_channel):
+    # Pre-0.5.1 widgets (e.g. 0.4.8) send no version header but declare source=widget;
+    # they are older than every cutoff and must still get the deprecation headers.
+    with patch("apps.channels.widget_versions.DEPRECATIONS", [DEPRECATION]):
+        response = _start_session(api_client, widget_channel, session_data={"source": "widget"})
+    assert response.status_code == 201
+    assert response.headers["Deprecation"] == "true"
+    assert "Sunset" in response.headers
+    assert 'rel="successor-version"' in response.headers["Link"]
 
 
 @pytest.mark.django_db()

--- a/apps/api/tests/test_widget_version_tracking.py
+++ b/apps/api/tests/test_widget_version_tracking.py
@@ -60,12 +60,22 @@ def test_start_session_records_widget_version(api_client, widget_channel):
 
 @pytest.mark.django_db()
 def test_start_session_without_header_records_placeholder(api_client, widget_channel):
-    # An authenticated widget that sends no version header is a pre-0.5.1 widget;
-    # record the placeholder so the deprecation badge/notifications still fire.
-    response = _start_session(api_client, widget_channel)
+    # A pre-0.5.1 widget sends no version header but declares source=widget; record the
+    # placeholder so the deprecation badge/notifications still fire.
+    response = _start_session(api_client, widget_channel, session_data={"source": "widget"})
     assert response.status_code == 201
     widget_channel.refresh_from_db()
     assert widget_channel.widget_version == UNKNOWN_WIDGET_VERSION
+
+
+@pytest.mark.django_db()
+def test_start_session_non_widget_embed_key_records_nothing(api_client, widget_channel):
+    # An embed-key caller that is not a widget (no version header, no source=widget)
+    # must not be tagged with a placeholder version.
+    response = _start_session(api_client, widget_channel)
+    assert response.status_code == 201
+    widget_channel.refresh_from_db()
+    assert widget_channel.widget_version is None
 
 
 @pytest.mark.django_db()

--- a/apps/api/tests/test_widget_version_tracking.py
+++ b/apps/api/tests/test_widget_version_tracking.py
@@ -10,7 +10,7 @@ from rest_framework.test import APIClient
 
 from apps.api.session_tokens import issue_session_token
 from apps.channels.models import ChannelPlatform, ExperimentChannel
-from apps.channels.widget_versions import WidgetDeprecation
+from apps.channels.widget_versions import UNKNOWN_WIDGET_VERSION, WidgetDeprecation
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentSessionFactory
 
@@ -59,11 +59,13 @@ def test_start_session_records_widget_version(api_client, widget_channel):
 
 
 @pytest.mark.django_db()
-def test_start_session_without_header_records_nothing(api_client, widget_channel):
+def test_start_session_without_header_records_placeholder(api_client, widget_channel):
+    # An authenticated widget that sends no version header is a pre-0.5.1 widget;
+    # record the placeholder so the deprecation badge/notifications still fire.
     response = _start_session(api_client, widget_channel)
     assert response.status_code == 201
     widget_channel.refresh_from_db()
-    assert widget_channel.widget_version is None
+    assert widget_channel.widget_version == UNKNOWN_WIDGET_VERSION
 
 
 @pytest.mark.django_db()

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -194,6 +194,23 @@ def _issue_or_opt_out_session_token(request, session, use_session_token, session
     return None
 
 
+def _resolve_experiment_channel(request, team, session_data):
+    """Return the ExperimentChannel for this request.
+
+    Embed-key auth resolves to the widget's own channel; for widget traffic we also
+    record the reported version (or a placeholder for pre-0.5.1 widgets that send no
+    header). Recording is gated on `is_widget_request` so a non-widget caller using an
+    embed key isn't tagged with a placeholder version. Everything else (direct API
+    consumers) falls back to the team API channel.
+    """
+    if not isinstance(request.auth, ExperimentChannel):
+        return ExperimentChannel.objects.get_team_api_channel(team)
+    channel = request.auth
+    if is_widget_request(request, session_data):
+        channel.record_widget_version(request.headers.get(WIDGET_VERSION_HEADER))
+    return channel
+
+
 @extend_schema(
     operation_id="chat_start_session",
     summary="Start a new chat session for a widget",
@@ -306,13 +323,7 @@ def chat_start_session(request):
 
     team = experiment.team
 
-    # Check if authenticated via DRF EmbeddedWidgetAuthentication
-    if isinstance(request.auth, ExperimentChannel):
-        experiment_channel = request.auth
-        experiment_channel.record_widget_version(request.headers.get(WIDGET_VERSION_HEADER))
-    else:
-        # legacy flow
-        experiment_channel = ExperimentChannel.objects.get_team_api_channel(team)
+    experiment_channel = _resolve_experiment_channel(request, team, session_data)
 
     if request.user.is_authenticated:
         user = request.user

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -29,7 +29,12 @@ from apps.channels.channels_v2.api_channel import ApiChannel
 from apps.channels.datamodels import Attachment
 from apps.channels.models import ExperimentChannel
 from apps.channels.utils import get_experiment_session_cached
-from apps.channels.widget_versions import WIDGET_VERSION_HEADER, widget_sunset_headers
+from apps.channels.widget_versions import (
+    WIDGET_VERSION_HEADER,
+    is_widget_request,
+    mark_widget_request,
+    widget_sunset_headers,
+)
 from apps.chat.models import Chat, ChatAttachment, ChatMessage, ChatMessageType
 from apps.experiments.models import Experiment, Participant, ParticipantData
 from apps.experiments.task_utils import get_message_task_response
@@ -181,8 +186,7 @@ def _issue_or_opt_out_session_token(request, session, use_session_token, session
     to enforced. Returns the token, or None when opted out.
     """
     if use_session_token is None:
-        is_widget = WIDGET_VERSION_HEADER in request.headers or session_data.get("source") == "widget"
-        use_session_token = not is_widget
+        use_session_token = not is_widget_request(request, session_data)
     if use_session_token:
         return issue_session_token(session)
     session.session_token_required = False
@@ -269,6 +273,11 @@ def chat_start_session(request):
     session_data = data.get("session_data", {})
     remote_id = data.get("participant_remote_id", "")
     name = data.get("participant_name")
+
+    # Pre-0.5.1 widgets send no version header; flag them (via session_data.source)
+    # so deprecated old widgets still receive RFC 8594 sunset headers.
+    if is_widget_request(request, session_data):
+        mark_widget_request(request)
 
     # Security check: Only authenticated users can specify version numbers
     if version_number is not None and not request.user.is_authenticated:

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -237,12 +237,20 @@ class ExperimentChannel(BaseTeamModel):
     def record_widget_version(self, raw_version: str | None) -> None:
         """Persist the version reported by the widget (x-ocs-widget-version header).
 
+        Pre-0.5.1 widgets send no header; for those we record a placeholder so the
+        deprecation helpers (badge, team notifications) treat the channel as running
+        a known-old version rather than an unreported one. A present-but-unparseable
+        header is ignored as garbage, and the placeholder never overwrites a real
+        version already on record — a transient missing header must not downgrade it.
+
         Telemetry write: bypasses save() and auditing, throttled to one write
         per 24h unless the version changes.
         """
         version = widget_versions.clean_widget_version(raw_version)
         if version is None:
-            return
+            if raw_version is not None or self.widget_version is not None:
+                return
+            version = widget_versions.UNKNOWN_WIDGET_VERSION
         now = timezone.now()
         if self._widget_version_recently_recorded(version, now):
             return

--- a/apps/channels/tests/test_widget_versions.py
+++ b/apps/channels/tests/test_widget_versions.py
@@ -10,6 +10,7 @@ from apps.channels.forms import WidgetParams
 from apps.channels.models import ChannelPlatform
 from apps.channels.widget_versions import (
     LATEST_VERSION,
+    UNKNOWN_WIDGET_VERSION,
     WidgetDeprecation,
     clean_widget_version,
     get_deprecation,
@@ -175,10 +176,18 @@ class TestRecordWidgetVersion:
         widget_channel.refresh_from_db()
         assert widget_channel.widget_version is None
 
-    def test_ignores_missing_header(self, widget_channel):
+    def test_records_placeholder_when_no_header(self, widget_channel):
+        # Pre-0.5.1 widgets send no header — record a placeholder, not nothing.
         widget_channel.record_widget_version(None)
         widget_channel.refresh_from_db()
-        assert widget_channel.widget_version is None
+        assert widget_channel.widget_version == UNKNOWN_WIDGET_VERSION
+
+    def test_placeholder_does_not_overwrite_real_version(self, widget_channel):
+        widget_channel.record_widget_version("0.8.0")
+        widget_channel.refresh_from_db()  # each request loads a fresh channel
+        widget_channel.record_widget_version(None)
+        widget_channel.refresh_from_db()
+        assert widget_channel.widget_version == "0.8.0"
 
     def test_skips_write_when_fresh_and_unchanged(self, widget_channel):
         widget_channel.record_widget_version("0.8.0")
@@ -219,6 +228,14 @@ class TestWidgetUpdateStatusProperty:
 
     def test_widget_channel_without_version(self, widget_channel):
         assert widget_channel.widget_update_status is None
+
+    def test_widget_channel_with_placeholder_version(self, widget_channel):
+        # The placeholder recorded for pre-header widgets must surface a badge.
+        widget_channel.widget_version = UNKNOWN_WIDGET_VERSION
+        with patch("apps.channels.widget_versions.DEPRECATIONS", [DEPRECATION]):
+            status = widget_channel.widget_update_status
+        assert status is not None
+        assert status.deprecation is not None
 
     def test_non_widget_channel(self):
         channel = ExperimentChannelFactory()  # telegram

--- a/apps/channels/widget_versions.py
+++ b/apps/channels/widget_versions.py
@@ -20,6 +20,11 @@ LATEST_VERSION = "0.9.1"
 # header, so a missing/unparseable version is treated as older than everything.
 MAX_VERSION_LENGTH = 32
 
+# Recorded for widgets that authenticate but report no x-ocs-widget-version header
+# (pre-0.5.1, e.g. 0.4.x). The deprecation helpers treat it as older than every
+# release, and it matches the label teams already see for unreported versions.
+UNKNOWN_WIDGET_VERSION = "unknown"
+
 
 def widget_docs_url() -> str:
     """The published chat widget docs URL, from settings."""

--- a/apps/channels/widget_versions.py
+++ b/apps/channels/widget_versions.py
@@ -125,15 +125,45 @@ def get_widget_update_status(version: str | None) -> WidgetUpdateStatus | None:
 
 WIDGET_VERSION_HEADER = "x-ocs-widget-version"
 
+# Request attribute the view sets to flag a pre-header widget (see mark_widget_request).
+_WIDGET_REQUEST_ATTR = "_ocs_is_widget_request"
+
+
+def is_widget_request(request, session_data: dict | None = None) -> bool:
+    """Whether the request comes from an embedded chat widget.
+
+    Widgets 0.5.1+ send the x-ocs-widget-version header. Older widgets (e.g. 0.4.x)
+    send no header but declare `source == "widget"` in the start-session body.
+    """
+    if WIDGET_VERSION_HEADER in request.headers:
+        return True
+    return bool(session_data) and session_data.get("source") == "widget"
+
+
+def mark_widget_request(request) -> None:
+    """Flag a request as widget traffic so sunset headers still apply when the
+    widget sends no x-ocs-widget-version header (pre-0.5.1, e.g. 0.4.x).
+
+    The sunset-header decorator wraps the view from outside DRF's @api_view, so it
+    sees the underlying Django request rather than the DRF one the view holds. Flag
+    that underlying request (falling back to the request itself) so the marker
+    survives the DRF request/response boundary.
+    """
+    target = getattr(request, "_request", request)
+    setattr(target, _WIDGET_REQUEST_ATTR, True)
+
 
 def apply_widget_sunset_headers(request, response):
     """Add RFC 8594 headers when the calling widget's version is deprecated.
 
-    Only applies when the widget version header is present: requests without
-    it (API users, authenticated sessions) are not widget traffic.
+    Applies to widget traffic only: either the x-ocs-widget-version header is present
+    (0.5.1+) or the view flagged a pre-header widget via `mark_widget_request` (0.4.x
+    and older send no header). A missing/unparseable version is treated as older than
+    every deprecation cutoff. Other requests (API users, authenticated sessions) are
+    left untouched.
     """
     raw = request.headers.get(WIDGET_VERSION_HEADER)
-    if raw is None:
+    if raw is None and not getattr(request, _WIDGET_REQUEST_ATTR, False):
         return response
     deprecation = get_deprecation(clean_widget_version(raw))
     if deprecation:


### PR DESCRIPTION
### Product Description
Old chat widgets (pre-0.5.1, e.g. 0.4.8) are now correctly recognised as deprecated: they receive the RFC 8594 `Deprecation`/`Sunset` headers, and their channel surfaces the deprecation badge and feeds the team-notification command — none of which happened before.

### Technical Description
Pre-0.5.1 widgets send no `x-ocs-widget-version` header, and the deprecation machinery keyed entirely off that header, so they fell through two ways — the same blind spot the pre-token session-token fix (#3658) closed:

1. **Sunset headers** — `apply_widget_sunset_headers` bailed out whenever the header was absent. Now widget traffic is identified by the header **or** `session_data.source == "widget"` (extracted into a shared `is_widget_request`, reused by the session-token path), and `chat_start_session` flags pre-header widgets so the decorator still applies the headers.
2. **Version recording** — a headerless widget recorded nothing, so its channel read as "never reported" rather than deprecated (no badge from `get_widget_update_status`, invisible to the notification command). `record_widget_version` now stores an `"unknown"` placeholder, which the helpers already treat as older than every release.

Worth a closer look:
- Detection uses `session_data.source`, not embed-key auth — pre-header widgets use the legacy (no `X-Embed-Key`) flow, so `request.auth` wouldn't catch them.
- The sunset marker is set on `request._request`: `@widget_sunset_headers` wraps the view outside DRF's `@api_view`, so it sees the underlying Django request, not the DRF one the view holds.
- The placeholder ignores garbage headers and never overwrites a real recorded version (a transient missing header must not downgrade a channel). This guard relies on the channel being loaded fresh per request, which it is.

Header application is scoped to `chat_start_session` (the only endpoint where a headerless widget is identifiable from the request); `chat_send_message` already covers header-sending widgets, and pre-header widgets can't read response headers anyway.

### Docs and Changelog
- [ ] This PR requires docs/changelog update