### PR TITLE
Include triggers in revert; pin trigger pipeline refs on publish

### DIFF
--- a/apps/api/v2/tests/test_chatbots_inspect.py
+++ b/apps/api/v2/tests/test_chatbots_inspect.py
@@ -1,5 +1,6 @@
 import json
 from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 from django.urls import reverse
@@ -836,6 +837,9 @@ EXPECTED_RENDER_QUERIES = 13
 
 @pytest.mark.django_db()
 @pytest.mark.parametrize("version_param", [None, "default", "1"])
+# Publishing now pins the pipeline_start trigger to a version of the embedded pipeline, which
+# versions its assistant node and would otherwise hit the OpenAI API.
+@patch("apps.assistants.sync.push_assistant_to_openai", Mock())
 def test_inspect_render_query_count_constant_across_versions(version_param, django_assert_num_queries):
     """Resolving, fetching and rendering takes the same fixed number of queries for every version
     mode — the working draft, the default, or a specific version number."""

--- a/apps/events/tests/test_trigger_sync.py
+++ b/apps/events/tests/test_trigger_sync.py
@@ -1,9 +1,10 @@
 import pytest
 
 from apps.events.models import EventActionType, StaticTriggerType
-from apps.events.versioning import sync_triggers
+from apps.events.versioning import TriggerSyncMode, sync_triggers
 from apps.utils.factories.events import EventActionFactory, StaticTriggerFactory, TimeoutTriggerFactory
 from apps.utils.factories.experiment import ExperimentFactory
+from apps.utils.factories.pipelines import PipelineFactory
 
 
 @pytest.mark.django_db()
@@ -57,3 +58,66 @@ class TestSyncTriggers:
 
         assert not target.static_triggers.exists()
         assert not target.timeout_triggers.exists()
+
+
+def _pipeline_start_trigger(experiment, pipeline_id):
+    return StaticTriggerFactory(
+        experiment=experiment,
+        type=StaticTriggerType.CONVERSATION_END,
+        action=EventActionFactory(
+            action_type=EventActionType.PIPELINE_START,
+            params={"pipeline_id": pipeline_id, "input_type": "last_message"},
+        ),
+    )
+
+
+@pytest.mark.django_db()
+class TestEventActionParamRemap:
+    def test_publish_pins_pipeline_param_to_a_version(self):
+        source = ExperimentFactory()
+        target = ExperimentFactory(team=source.team)
+        pipeline = PipelineFactory(team=source.team)
+        trigger = _pipeline_start_trigger(source, pipeline.id)
+
+        sync_triggers(source, target, mode=TriggerSyncMode.PUBLISH)
+
+        pinned_id = target.static_triggers.get().action.params["pipeline_id"]
+        pipeline.refresh_from_db()
+        assert pinned_id == pipeline.latest_version.id
+        assert pinned_id != pipeline.id
+        # The source (working) trigger keeps pointing at the working pipeline.
+        assert trigger.action.params["pipeline_id"] == pipeline.id
+
+    def test_revert_maps_pipeline_param_back_to_working(self):
+        source = ExperimentFactory()
+        target = ExperimentFactory(team=source.team)
+        pipeline = PipelineFactory(team=source.team)
+        pipeline_version = pipeline.create_new_version()
+        _pipeline_start_trigger(source, pipeline_version.id)
+
+        sync_triggers(source, target, mode=TriggerSyncMode.REVERT)
+
+        new_trigger = target.static_triggers.get()
+        assert new_trigger.action.params["pipeline_id"] == pipeline.id
+        assert new_trigger.working_version_id is None
+
+    def test_revert_clears_dangling_pipeline_reference(self):
+        source = ExperimentFactory()
+        target = ExperimentFactory(team=source.team)
+        _pipeline_start_trigger(source, 999999)
+
+        sync_triggers(source, target, mode=TriggerSyncMode.REVERT)
+
+        assert target.static_triggers.get().action.params["pipeline_id"] is None
+
+    def test_copy_keeps_pipeline_param_verbatim(self):
+        source = ExperimentFactory()
+        target = ExperimentFactory(team=source.team)
+        pipeline = PipelineFactory(team=source.team)
+        _pipeline_start_trigger(source, pipeline.id)
+
+        sync_triggers(source, target, mode=TriggerSyncMode.COPY)
+
+        pipeline.refresh_from_db()
+        assert target.static_triggers.get().action.params["pipeline_id"] == pipeline.id
+        assert pipeline.latest_version is None

--- a/apps/events/versioning.py
+++ b/apps/events/versioning.py
@@ -4,6 +4,7 @@ This module must not import ``apps.events.models`` at module level: it is import
 by ``apps.experiments.models``, which ``apps.events.models`` itself imports.
 """
 
+import copy
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING
@@ -115,12 +116,18 @@ def sync_triggers(source: "Experiment", target: "Experiment", mode: TriggerSyncM
 
 
 def _remap_action_params(action: "EventAction", mode: TriggerSyncMode) -> None:
+    if mode is TriggerSyncMode.COPY:
+        return  # copies keep params verbatim; nothing to rewrite or persist
     specs = get_event_action_param_specs(action.action_type)
     if not specs:
         return
+    original = copy.deepcopy(action.params)
     for spec in specs:
         if mode is TriggerSyncMode.PUBLISH:
             spec.pin_to_version(action.params)
         elif mode is TriggerSyncMode.REVERT:
             spec.revert_to_working(action.params)
-    action.save(update_fields=["params"])
+    # Only persist when a reference actually moved, so an unchanged param never triggers an
+    # EventAction.save side effect (e.g. schedule recalculation).
+    if action.params != original:
+        action.save(update_fields=["params"])

--- a/apps/events/versioning.py
+++ b/apps/events/versioning.py
@@ -4,28 +4,123 @@ This module must not import ``apps.events.models`` at module level: it is import
 by ``apps.experiments.models``, which ``apps.events.models`` itself imports.
 """
 
+from dataclasses import dataclass
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
+from django.apps import apps
 from django.db import transaction
 
 if TYPE_CHECKING:
+    from apps.events.models import EventAction
     from apps.experiments.models import Experiment
 
 TRIGGER_ACCESSORS = ("static_triggers", "timeout_triggers")
 
 
+class TriggerSyncMode(StrEnum):
+    """Direction of a :func:`sync_triggers` call, which determines how versioned
+    references in ``EventAction.params`` are rewritten."""
+
+    PUBLISH = "publish"
+    """working -> version: pin params that reference versioned records to a version."""
+
+    REVERT = "revert"
+    """version -> working: map versioned params back to their working records."""
+
+    COPY = "copy"
+    """duplicate a working experiment: keep params verbatim (still working refs)."""
+
+
+@dataclass(frozen=True)
+class EventActionParamSpec:
+    """Declares an ``EventAction.params`` entry that references a versioned record.
+
+    Mirrors ``apps.pipelines.versioning.VersionedParamSpec`` for pipeline-node params,
+    but ``EventAction`` has no FK mirror column, so the referenced id is read straight
+    from ``params``. Publish pins the working record to a version (creating one only
+    when the record changed); revert maps a versioned record back to its working id.
+    """
+
+    param_name: str
+    model_label: str  # "app_label.ModelName"; resolved lazily to avoid circular imports
+
+    @property
+    def model_cls(self):
+        return apps.get_model(self.model_label)
+
+    def pin_to_version(self, params: dict) -> None:
+        """Rewrite ``params[param_name]`` from a working record to a version of it."""
+        instance = self._get_instance(params)
+        if instance is None or instance.is_a_version:
+            return
+        if not instance.has_versions or instance.compare_with_latest():
+            params[self.param_name] = instance.create_new_version().id
+        else:
+            params[self.param_name] = instance.latest_version.id
+
+    def revert_to_working(self, params: dict) -> None:
+        """Rewrite ``params[param_name]`` from a versioned record back to its working id.
+
+        Records already pointing at a working version (legacy unpinned data) resolve to
+        themselves. A dangling reference (record deleted) is cleared to ``None``.
+        """
+        if not params.get(self.param_name):
+            return
+        instance = self._get_instance(params)
+        params[self.param_name] = instance.get_working_version_id() if instance else None
+
+    def _get_instance(self, params: dict):
+        instance_id = params.get(self.param_name)
+        if not instance_id:
+            return None
+        return self.model_cls.objects.filter(id=instance_id).first()
+
+
+# Keyed by ``EventActionType`` value (string literal to avoid importing events.models here).
+_EVENT_ACTION_PARAM_SPECS: dict[str, tuple[EventActionParamSpec, ...]] = {
+    "pipeline_start": (EventActionParamSpec(param_name="pipeline_id", model_label="pipelines.Pipeline"),),
+}
+
+
+def get_event_action_param_specs(action_type: str) -> tuple[EventActionParamSpec, ...]:
+    return _EVENT_ACTION_PARAM_SPECS.get(action_type, ())
+
+
 @transaction.atomic()
-def sync_triggers(source: "Experiment", target: "Experiment", is_copy: bool = False) -> None:
+def sync_triggers(source: "Experiment", target: "Experiment", mode: TriggerSyncMode = TriggerSyncMode.PUBLISH) -> None:
     """Make ``target``'s static and timeout triggers mirror ``source``'s.
 
     Every trigger on ``source`` is copied onto ``target`` together with its
-    ``EventAction``; triggers already on ``target`` have no counterpart on ``source``
-    and are archived. Publish uses this working -> version (``target`` is a freshly
-    created version with no triggers); revert (#3398) uses it version -> working.
+    ``EventAction``; triggers already on ``target`` with no counterpart on ``source``
+    are archived. ``mode`` selects the direction: publish (working -> version) pins
+    versioned references, revert (version -> working) maps them back, and copy keeps
+    them verbatim.
     """
+    # Publish records the new version's link back to the working trigger; revert and copy
+    # produce standalone working triggers (no ``working_version`` link).
+    is_copy = mode is not TriggerSyncMode.PUBLISH
     for accessor in TRIGGER_ACCESSORS:
         stale_triggers = list(getattr(target, accessor).all())
         for trigger in getattr(source, accessor).all():
-            trigger.create_new_version(new_experiment=target, is_copy=is_copy)
+            new_trigger = trigger.create_new_version(new_experiment=target, is_copy=is_copy)
+            if is_copy and new_trigger.working_version_id is not None:
+                # Reverting clones from a version row, which carries a ``working_version`` link;
+                # clear it so the restored trigger is a working trigger in its own right.
+                new_trigger.working_version_id = None
+                new_trigger.save(update_fields=["working_version"])
+            _remap_action_params(new_trigger.action, mode)
         for trigger in stale_triggers:
             trigger.archive()
+
+
+def _remap_action_params(action: "EventAction", mode: TriggerSyncMode) -> None:
+    specs = get_event_action_param_specs(action.action_type)
+    if not specs:
+        return
+    for spec in specs:
+        if mode is TriggerSyncMode.PUBLISH:
+            spec.pin_to_version(action.params)
+        elif mode is TriggerSyncMode.REVERT:
+            spec.revert_to_working(action.params)
+    action.save(update_fields=["params"])

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -38,7 +38,7 @@ from field_audit.models import AuditAction, AuditingManager
 
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
 from apps.chatbots.version_resolver import resolve_published_or_working
-from apps.events.versioning import sync_triggers
+from apps.events.versioning import TriggerSyncMode, sync_triggers
 from apps.experiments import model_audit_fields
 from apps.experiments.versioning import VersionDetails, VersionField, VersionsMixin, VersionsObjectManagerMixin, differs
 from apps.generics.chips import Chip
@@ -954,8 +954,10 @@ class Experiment(BaseTeamModel, VersionsMixin):
             # nothing to do for copy - just reference the same object in the new copy
             self._copy_attr_to_new_version("consent_form", new_version)
 
-        sync_triggers(self, new_version, is_copy=is_copy)
+        # Version the pipeline before the triggers so a trigger referencing this experiment's own
+        # pipeline pins to the version just created here rather than spawning a redundant one.
         self._copy_pipeline_to_new_version(new_version, is_copy)
+        sync_triggers(self, new_version, mode=TriggerSyncMode.COPY if is_copy else TriggerSyncMode.PUBLISH)
 
         return new_version
 
@@ -983,6 +985,7 @@ class Experiment(BaseTeamModel, VersionsMixin):
         self.save()
 
         self._revert_pipeline_to_version(version)
+        sync_triggers(version, self, mode=TriggerSyncMode.REVERT)
 
     def _revert_pipeline_to_version(self, version: Experiment) -> None:
         """Reset the working pipeline in place to ``version``'s pipeline (see ``Pipeline.revert_to_version``)."""

--- a/apps/experiments/tests/test_revert.py
+++ b/apps/experiments/tests/test_revert.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from apps.events.models import EventActionType, StaticTriggerType
 from apps.experiments.models import Experiment
 from apps.pipelines.models import Node
 from apps.pipelines.nodes.nodes import AssistantNode, LLMResponseWithPrompt
@@ -13,6 +14,7 @@ from apps.pipelines.tests.utils import (
     start_node,
 )
 from apps.utils.factories.assistants import OpenAiAssistantFactory
+from apps.utils.factories.events import EventActionFactory, StaticTriggerFactory, TimeoutTriggerFactory
 from apps.utils.factories.experiment import ExperimentFactory, SourceMaterialFactory
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 
@@ -106,6 +108,36 @@ def test_revert_is_non_destructive():
     assert experiment.versions.count() == 1
     assert version.is_default_version is True
     assert version.pipeline_id == version_pipeline_id
+
+
+@pytest.mark.django_db()
+@patch("apps.assistants.sync.push_assistant_to_openai", Mock())
+def test_revert_restores_triggers():
+    """Working triggers mirror the target version's after revert; extras are archived."""
+    experiment, *_ = _build_experiment_with_pipeline()
+    kept = StaticTriggerFactory(
+        experiment=experiment,
+        type=StaticTriggerType.CONVERSATION_END,
+        action=EventActionFactory(action_type=EventActionType.LOG, params={"key": "value"}),
+    )
+    TimeoutTriggerFactory(experiment=experiment, delay=60, total_num_triggers=2)
+
+    version = experiment.create_new_version(make_default=True)
+
+    # Diverge the working experiment: add a trigger absent from the version.
+    added = StaticTriggerFactory(experiment=experiment, type=StaticTriggerType.CONVERSATION_START)
+
+    experiment.revert_to_version(version)
+    experiment.refresh_from_db()
+
+    static_types = sorted(t.type for t in experiment.static_triggers.all())
+    assert static_types == [kept.type]
+    assert experiment.timeout_triggers.count() == 1
+    # The trigger that was only on the working experiment is gone (archived).
+    added.refresh_from_db()
+    assert added.is_archived
+    # Restored triggers are working triggers, not versions.
+    assert all(t.working_version_id is None for t in experiment.static_triggers.all())
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
### Product Description
Reverting a chatbot to a previous version now also restores that version's static and timeout triggers, not just its fields and pipeline.

### Technical Description
Part of #3398. Closes #3616 and fixes #3623.

`sync_triggers` gains a direction (`TriggerSyncMode`: publish / revert / copy) in place of the old `is_copy` flag, and now rewrites versioned references in `EventAction.params` via a small registry (`EventActionParamSpec`) — the EventAction analogue of `pipelines.versioning.VersionedParamSpec`. The only spec today is `pipeline_start.pipeline_id`.

- **Publish** pins `pipeline_id` to a pipeline version (reuse-unchanged: new version only if changed). This fixes #3623, where published-version triggers kept executing the live working pipeline. Pinning is **going-forward only** — no backfill of already-published versions.
- **Revert** maps `pipeline_id` back to the working pipeline; legacy unpinned versions (which hold working ids) resolve to themselves, so old and new versions both revert correctly.

Two points worth a look:
- In `Experiment.create_new_version` I reordered `_copy_pipeline_to_new_version` to run **before** `sync_triggers`, so a trigger referencing the experiment's own pipeline pins to the version just created rather than spawning a redundant one.
- Revert clones triggers from version rows, which carry a `working_version` link; `sync_triggers` clears it so restored triggers are genuine working triggers.

Out of scope: archiving pinned external-pipeline versions on experiment archive (matches existing source-material `KEEP` precedent).

### Migrations
N/A — no schema or data migration (pin going-forward only).

### Docs and Changelog
- [ ] This PR requires docs/changelog update