### PR TITLE
Drop orphaned django_otp tables

### DIFF
--- a/apps/users/migrations/0007_drop_django_otp_tables.py
+++ b/apps/users/migrations/0007_drop_django_otp_tables.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+# Tables left behind by django-allauth-2fa / django-otp after the allauth.mfa
+# migration (see 0005_migrate_2fa_data). The apps are no longer installed, so
+# these tables are orphaned and can be dropped.
+DROP_SQL = """
+DROP TABLE IF EXISTS otp_static_statictoken CASCADE;
+DROP TABLE IF EXISTS otp_static_staticdevice CASCADE;
+DROP TABLE IF EXISTS otp_totp_totpdevice CASCADE;
+"""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0006_alter_customuser_options_alter_customuser_managers"),
+    ]
+
+    operations = [
+        migrations.RunSQL(DROP_SQL, reverse_sql=migrations.RunSQL.noop),
+    ]


### PR DESCRIPTION
### Product Description
no change

### Technical Description
Cleanup from #2617. After 2FA data was migrated to `allauth.mfa` (migration `0005_migrate_2fa_data`), the legacy `django-allauth-2fa` / `django-otp` apps were removed but their tables were left behind. This drops them: `otp_static_statictoken`, `otp_static_staticdevice`, `otp_totp_totpdevice`.

`DROP TABLE IF EXISTS ... CASCADE` so it's a no-op where the tables never existed (e.g. local dev) and handles the statictoken→staticdevice FK. Reverse is a no-op.

Closes #2631

### Migrations
- [x] The migrations are backwards compatible

The tables are already unmanaged (apps uninstalled), so dropping them does not affect running code.

### Docs and Changelog
- [ ] This PR requires docs/changelog update