### PR TITLE
Include document metadata in collection search results

### DIFF
--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, ClassVar, Union
+from xml.sax.saxutils import escape
 
 from asgiref.sync import async_to_sync
 from django.conf import settings
@@ -73,8 +74,12 @@ METADATA_BLOCKLIST = frozenset(
 
 def _format_metadata_value(value: Any) -> str:
     if isinstance(value, list | tuple):
-        return ", ".join(str(v) for v in value)
-    return str(value)
+        formatted = ", ".join(str(v) for v in value)
+    else:
+        formatted = str(value)
+    # Values become raw XML tag content (unlike the chunk text, which is wrapped in CDATA),
+    # so escape special characters to avoid malformed XML / breaking out of the structure.
+    return escape(formatted)
 
 
 def _sanitize_tag(key: str) -> str:
@@ -189,7 +194,7 @@ def _perform_collection_search(
         retrieved_chunks = "\n".join(
             [
                 CHUNK_TEMPLATE.format(
-                    file_name=embedding.file.name,
+                    file_name=escape(embedding.file.name),
                     file_id=embedding.file_id,
                     metadata=_format_metadata_block(embedding.file.metadata),
                     chunk=embedding.text,
@@ -220,9 +225,9 @@ def _format_result_with_collection(embedding: FileChunkEmbedding, collection) ->
     return f"""
 <file>
   <file_id>{embedding.file_id}</file_id>
-  <filename>{embedding.file.name}</filename>
+  <filename>{escape(embedding.file.name)}</filename>
   <collection_id>{collection.id}</collection_id>
-  <collection_name>{collection.name}</collection_name>{_format_metadata_block(embedding.file.metadata)}
+  <collection_name>{escape(collection.name)}</collection_name>{_format_metadata_block(embedding.file.metadata)}
   <context>
     <![CDATA[{embedding.text}]]>
   </context>

--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import logging
+import re
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -49,12 +50,60 @@ IMAGE_LINK_TEXT = "Reference link: `![](file:{team_slug}:{session_id}:{file_id})
 CHUNK_TEMPLATE = """
 <file>
   <file_id>{file_id}</file_id>
-  <filename>{file_name}</filename>
+  <filename>{file_name}</filename>{metadata}
   <context>
     <![CDATA[{chunk}]]>
   </context>
 </file>
 """
+
+# Keys stored on File.metadata that are OCS/loader internals or exact duplicates of other
+# fields (see JSONCollectionLoader). These are never surfaced to the LLM; every other
+# metadata key is included as-is so feeds can add useful fields without a code change.
+METADATA_BLOCKLIST = frozenset(
+    {
+        "collection_id",
+        "source_type",
+        "citation_text",  # duplicate of "title"
+        "citation_url",  # duplicate of "URI"
+        "source",  # langchain convention; duplicates "URI"/"link"
+    }
+)
+
+
+def _format_metadata_value(value: Any) -> str:
+    if isinstance(value, list | tuple):
+        return ", ".join(str(v) for v in value)
+    return str(value)
+
+
+def _sanitize_tag(key: str) -> str:
+    """Coerce an arbitrary metadata key into a valid XML tag name."""
+    tag = re.sub(r"[^A-Za-z0-9_.-]+", "_", key.strip())
+    if not tag or not re.match(r"[A-Za-z_]", tag):
+        tag = f"_{tag}"
+    return tag
+
+
+def _format_metadata_block(metadata: dict | None) -> str:
+    """Build a `<metadata>` XML block from the file metadata.
+
+    Every key is emitted except known internal/duplicate keys (see METADATA_BLOCKLIST)
+    and empty values. Returns an empty string when no relevant metadata is available.
+    """
+    if not metadata:
+        return ""
+    lines = []
+    for key, value in metadata.items():
+        if key in METADATA_BLOCKLIST or value in (None, "", [], {}):
+            continue
+        tag = _sanitize_tag(key)
+        lines.append(f"    <{tag}>{_format_metadata_value(value)}</{tag}>")
+    if not lines:
+        return ""
+    inner = "\n".join(lines)
+    return f"\n  <metadata>\n{inner}\n  </metadata>"
+
 
 CITATION_PROMPT = """**CRITICAL REQUIREMENT - MANDATORY CITATIONS:**
 
@@ -120,7 +169,7 @@ def _perform_collection_search(
         .filter(collection_id=collection.id)
         .order_by("distance")
         .select_related("file")
-        .only("text", "file__name")[:max_results]
+        .only("text", "file__name", "file__metadata")[:max_results]
     )
 
     if not embeddings:
@@ -140,7 +189,10 @@ def _perform_collection_search(
         retrieved_chunks = "\n".join(
             [
                 CHUNK_TEMPLATE.format(
-                    file_name=embedding.file.name, file_id=embedding.file_id, chunk=embedding.text
+                    file_name=embedding.file.name,
+                    file_id=embedding.file_id,
+                    metadata=_format_metadata_block(embedding.file.metadata),
+                    chunk=embedding.text,
                 ).strip()
                 for embedding in embeddings
             ]
@@ -170,7 +222,7 @@ def _format_result_with_collection(embedding: FileChunkEmbedding, collection) ->
   <file_id>{embedding.file_id}</file_id>
   <filename>{embedding.file.name}</filename>
   <collection_id>{collection.id}</collection_id>
-  <collection_name>{collection.name}</collection_name>
+  <collection_name>{collection.name}</collection_name>{_format_metadata_block(embedding.file.metadata)}
   <context>
     <![CDATA[{embedding.text}]]>
   </context>

--- a/apps/chat/tests/test_tools.py
+++ b/apps/chat/tests/test_tools.py
@@ -24,6 +24,7 @@ from apps.chat.agent.tools import (
     SearchIndexTool,
     SearchToolConfig,
     _convert_to_sync_tool,
+    _format_metadata_block,
     _get_search_tool_footer,
     _move_datetime_to_new_weekday_and_time,
     create_schedule_message,
@@ -514,6 +515,81 @@ class TestSearchIndexTool:
 {footer}
 """
         assert result == expected_result
+
+    def test_action_includes_file_metadata(self, team, local_index_manager_mock):
+        collection = CollectionFactory.create(team=team)
+        file = FileFactory.create(
+            team=team,
+            name="report.pdf",
+            metadata={
+                "title": "Annual Report",
+                "URI": "https://example.com/report",
+                "date": "2026-01-01",
+                "type": "report",
+                "authors": ["Alice", "Bob"],
+                # An unanticipated feed field should still be surfaced.
+                "section": "Methods",
+                # Internal/duplicate keys that should not be surfaced to the LLM.
+                "collection_id": collection.id,
+                "source_type": "json_collection",
+                "citation_url": "https://example.com/report",
+            },
+        )
+        vector_data = self.load_vector_data()
+        FileChunkEmbedding.objects.create(
+            team=team,
+            file=file,
+            collection=collection,
+            chunk_number=1,
+            text="Apples are great",
+            embedding=vector_data["Apples are great"],
+            page_number=0,
+        )
+
+        local_index_manager_mock.get_embedding_vector.return_value = vector_data["What are great fruit?"]
+        search_config = SearchToolConfig(index_id=collection.id, max_results=1, generate_citations=False)
+        result = SearchIndexTool(search_config=search_config).action(query="What are great fruit?")
+
+        assert "<metadata>" in result
+        assert "<title>Annual Report</title>" in result
+        assert "<URI>https://example.com/report</URI>" in result
+        assert "<date>2026-01-01</date>" in result
+        assert "<type>report</type>" in result
+        assert "<authors>Alice, Bob</authors>" in result
+        assert "<section>Methods</section>" in result
+        # Internal/duplicate keys must not leak to the LLM.
+        assert "collection_id" not in result
+        assert "source_type" not in result
+        assert "citation_url" not in result
+
+
+class TestFormatMetadataBlock:
+    def test_empty_metadata_returns_empty_string(self):
+        assert _format_metadata_block(None) == ""
+        assert _format_metadata_block({}) == ""
+
+    def test_only_blocklisted_fields_returns_empty_string(self):
+        assert _format_metadata_block({"collection_id": 1, "source_type": "json_collection"}) == ""
+
+    def test_skips_empty_values(self):
+        block = _format_metadata_block({"title": "", "date": None, "tags": [], "type": "report"})
+        assert block == "\n  <metadata>\n    <type>report</type>\n  </metadata>"
+
+    def test_lists_joined_with_commas(self):
+        block = _format_metadata_block({"authors": ["Alice", "Bob"]})
+        assert "<authors>Alice, Bob</authors>" in block
+
+    def test_unanticipated_fields_included(self):
+        block = _format_metadata_block({"some_custom_field": "value"})
+        assert "<some_custom_field>value</some_custom_field>" in block
+
+    def test_invalid_tag_characters_sanitized(self):
+        block = _format_metadata_block({"Some Field!": "value"})
+        assert "<Some_Field_>value</Some_Field_>" in block
+
+    def test_preserves_insertion_order(self):
+        block = _format_metadata_block({"title": "T", "date": "2026-01-01", "type": "report"})
+        assert block.index("<title>") < block.index("<date>") < block.index("<type>")
 
 
 def test_tools_present():

--- a/apps/chat/tests/test_tools.py
+++ b/apps/chat/tests/test_tools.py
@@ -591,6 +591,11 @@ class TestFormatMetadataBlock:
         block = _format_metadata_block({"title": "T", "date": "2026-01-01", "type": "report"})
         assert block.index("<title>") < block.index("<date>") < block.index("<type>")
 
+    def test_escapes_xml_special_characters(self):
+        block = _format_metadata_block({"title": "Q&A <draft>", "authors": ["A & B"]})
+        assert "<title>Q&amp;A &lt;draft&gt;</title>" in block
+        assert "<authors>A &amp; B</authors>" in block
+
 
 def test_tools_present():
     for tool in AgentTools.values:


### PR DESCRIPTION
### Product Description
LLM responses from collection index searches can now draw on document metadata (title, source URI, date, type, authors, etc.) alongside the retrieved content. Closes #3335.

### Technical Description
`_perform_collection_search` now reads `File.metadata` (already populated at index time by `JSONCollectionLoader`) and renders it into the `<file>` block sent to the LLM. The data is read from the related `File` via the existing `select_related("file")` — no new column, no migration.

Field selection is a blocklist, not a whitelist: every metadata key flows through except OCS/loader internals and exact duplicates (`collection_id`, `source_type`, `citation_text`, `citation_url`, `source`), so feeds can add useful fields without a code change. Since arbitrary keys become XML tag names, `_sanitize_tag` coerces them into valid tags.

Remote (OpenAI) index search is untouched — metadata there is handled via OpenAI's file search API.

### Migrations
N/A — no schema change.

### Docs and Changelog
- [ ] This PR requires docs/changelog update