### PR TITLE
Open Continue Chat in embedded widget when flag is active

### DIFF
--- a/apps/chatbots/tables.py
+++ b/apps/chatbots/tables.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 
 import django_tables2 as tables
@@ -6,7 +7,9 @@ from django.db.models import F
 from django.template.loader import get_template
 from django.urls import reverse
 from django_tables2 import columns
+from waffle import flag_is_active
 
+from apps.api.session_tokens import issue_session_token
 from apps.experiments.models import Experiment, ExperimentSession
 from apps.generics import actions, chips
 from apps.generics.actions import chip_action
@@ -22,6 +25,29 @@ def session_chat_url(url_name, request, record, value):
 
 def _show_chat_button(request, record):
     return record.participant.user == request.user and not record.is_complete and record.experiment.is_editable
+
+
+@dataclasses.dataclass
+class ContinueChatAction(actions.Action):
+    """Continue Chat action. When the chat widget flag is active it opens the session in the embedded
+    widget (a floating popup) instead of linking to the full-page chat UI."""
+
+    template: str = "chatbots/components/continue_chat_action.html"
+
+    def get_context(self, request, record, value):
+        ctxt = super().get_context(request, record, value)
+        if flag_is_active(request, "flag_chat_widget"):
+            ctxt.update(
+                {
+                    "use_widget": True,
+                    "chatbot_id": record.experiment.public_id,
+                    "session_external_id": record.external_id,
+                    "session_token": issue_session_token(record),
+                    "version_number": record.get_experiment_version_number(),
+                    "allow_attachments": record.experiment.file_uploads_enabled,
+                }
+            )
+        return ctxt
 
 
 def _name_label_factory(record, _):
@@ -128,7 +154,7 @@ class ChatbotSessionsTable(tables.Table):
 
     actions = actions.ActionsColumn(
         actions=[
-            actions.Action(
+            ContinueChatAction(
                 url_name="chatbots:chatbot_chat_session",
                 url_factory=session_chat_url,
                 icon_class="fa-solid fa-comment",

--- a/apps/chatbots/tests/test_chatbot_views.py
+++ b/apps/chatbots/tests/test_chatbot_views.py
@@ -1,3 +1,4 @@
+import re
 from datetime import UTC, datetime
 from unittest.mock import Mock, patch
 
@@ -360,6 +361,65 @@ def test_chatbot_sessions_table_view(team_with_users):
     response = view(request, team_slug=team.slug, experiment_id=experiment.id)
     assert response.status_code == 200
     assert isinstance(response.context_data["table"], ChatbotSessionsTable)
+
+
+@pytest.mark.django_db()
+def test_continue_chat_launcher_present_on_session_pages_when_flag_active(client, team_with_users):
+    """The session-chat widget launcher script renders on both the single-chatbot home and the
+    All Sessions page when the chat widget flag is active."""
+    team = team_with_users
+    user = team.members.first()
+    user.user_permissions.add(Permission.objects.get(codename="view_experiment"))
+    user.user_permissions.add(Permission.objects.get(codename="view_experimentsession"))
+    client.force_login(user)
+    experiment = ExperimentFactory.create(team=team)
+
+    with override_flag("flag_chat_widget", active=True):
+        single_home = client.get(reverse("chatbots:single_chatbot_home", args=[team.slug, experiment.id]))
+        all_sessions = client.get(reverse("chatbots:all_sessions_home", args=[team.slug]))
+
+    assert "chatbots/all_sessions_home.html" in [t.name for t in all_sessions.templates]
+    for response in (single_home, all_sessions):
+        assert response.status_code == 200
+        assert "window.ocsContinueSessionChat" in response.content.decode()
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("flag_active", [True, False])
+def test_continue_chat_action_respects_widget_flag(flag_active, client, team_with_users):
+    """With ``flag_chat_widget`` active the Continue Chat action opens the embedded widget;
+    otherwise it links to the full-page chat UI."""
+    team = team_with_users
+    user = team.members.first()
+    client.force_login(user)
+    experiment = ExperimentFactory.create(team=team)
+    session = ExperimentSessionFactory.create(
+        team=team,
+        experiment=experiment,
+        participant__team=team,
+        participant__user=user,
+        status=SessionStatus.ACTIVE,
+    )
+
+    url = reverse("chatbots:sessions-list", kwargs={"team_slug": team.slug, "experiment_id": experiment.id})
+    with override_flag("flag_chat_widget", active=flag_active):
+        response = client.get(url)
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    chat_url = reverse(
+        "chatbots:chatbot_chat_session",
+        args=[team.slug, experiment.id, session.get_experiment_version_number(), session.id],
+    )
+    if flag_active:
+        assert "ocsContinueSessionChat(this)" in content
+        assert f'data-session-id="{session.external_id}"' in content
+        token = re.search(r'data-session-token="([^"]+)"', content).group(1)
+        assert validate_session_token(token, session.external_id)
+        assert chat_url not in content
+    else:
+        assert "ocsContinueSessionChat" not in content
+        assert chat_url in content
 
 
 @pytest.mark.django_db()

--- a/apps/chatbots/tests/test_chatbot_views.py
+++ b/apps/chatbots/tests/test_chatbot_views.py
@@ -364,27 +364,6 @@ def test_chatbot_sessions_table_view(team_with_users):
 
 
 @pytest.mark.django_db()
-def test_continue_chat_launcher_present_on_session_pages_when_flag_active(client, team_with_users):
-    """The session-chat widget launcher script renders on both the single-chatbot home and the
-    All Sessions page when the chat widget flag is active."""
-    team = team_with_users
-    user = team.members.first()
-    user.user_permissions.add(Permission.objects.get(codename="view_experiment"))
-    user.user_permissions.add(Permission.objects.get(codename="view_experimentsession"))
-    client.force_login(user)
-    experiment = ExperimentFactory.create(team=team)
-
-    with override_flag("flag_chat_widget", active=True):
-        single_home = client.get(reverse("chatbots:single_chatbot_home", args=[team.slug, experiment.id]))
-        all_sessions = client.get(reverse("chatbots:all_sessions_home", args=[team.slug]))
-
-    assert "chatbots/all_sessions_home.html" in [t.name for t in all_sessions.templates]
-    for response in (single_home, all_sessions):
-        assert response.status_code == 200
-        assert "window.ocsContinueSessionChat" in response.content.decode()
-
-
-@pytest.mark.django_db()
 @pytest.mark.parametrize("flag_active", [True, False])
 def test_continue_chat_action_respects_widget_flag(flag_active, client, team_with_users):
     """With ``flag_chat_widget`` active the Continue Chat action opens the embedded widget;

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -915,7 +915,7 @@ def home(
 
 
 class AllSessionsHome(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateView):
-    template_name = "generic/object_home.html"
+    template_name = "chatbots/all_sessions_home.html"
     permission_required = "experiments.view_experimentsession"
 
     def get_context_data(self, team_slug: str, **kwargs):  # ty: ignore[invalid-method-override]

--- a/templates/chatbots/all_sessions_home.html
+++ b/templates/chatbots/all_sessions_home.html
@@ -1,0 +1,6 @@
+{% extends "generic/object_home.html" %}
+
+{% block app %}
+  {{ block.super }}
+  {% include "chatbots/components/session_chat_widget_launcher.html" %}
+{% endblock app %}

--- a/templates/chatbots/components/continue_chat_action.html
+++ b/templates/chatbots/components/continue_chat_action.html
@@ -1,0 +1,20 @@
+{% if use_widget %}
+  <button class="btn btn-sm join-item {{ button_style|default_if_none:"btn-ghost" }}"
+          {% if disabled %}disabled="disabled"{% endif %}
+          {% if title %}title="{{ title }}"{% endif %}
+          type="button"
+          data-chatbot-id="{{ chatbot_id }}"
+          data-session-id="{{ session_external_id }}"
+          data-session-token="{{ session_token }}"
+          data-version-number="{{ version_number }}"
+          data-allow-attachments="{{ allow_attachments|yesno:"true,false" }}"
+          onclick="ocsContinueSessionChat(this)"
+  >
+    {{ label }}
+    {% if icon_class %}
+      <i class="{{ icon_class }}"></i>
+    {% endif %}
+  </button>
+{% else %}
+  {% include "generic/action.html" %}
+{% endif %}

--- a/templates/chatbots/components/session_chat_widget_launcher.html
+++ b/templates/chatbots/components/session_chat_widget_launcher.html
@@ -18,6 +18,17 @@
         },
       };
 
+      // Apply the version-specific header text and colour theme to a widget element. Shared by the
+      // new-chat launcher (openChatWidget) and the continue-session launcher below.
+      window.ocsApplyWidgetVersionTheme = function (widget, versionNumber) {
+        const isPublished = versionNumber === 0;
+        widget.setAttribute('header-text', isPublished ? 'Published Version' : `Working Version (v${versionNumber})`);
+        const styles = isPublished ? widgetStyles.published : widgetStyles.working;
+        for (const [prop, value] of Object.entries(styles)) {
+          widget.style.setProperty(prop, value);
+        }
+      };
+
       // Open an existing session in a fresh, session-bound widget. A new element is mounted each
       // time because the widget binds to its session during load and does not re-bind on prop changes.
       window.ocsContinueSessionChat = function (button) {
@@ -25,9 +36,6 @@
         if (existing) {
           existing.remove();
         }
-
-        const versionNumber = parseInt(button.dataset.versionNumber, 10);
-        const isPublished = versionNumber === 0;
 
         const widget = document.createElement('open-chat-studio-widget');
         widget.id = 'continue-chat-widget';
@@ -39,7 +47,6 @@
         widget.setAttribute('visible', 'true');
         widget.setAttribute('position', 'right');
         widget.setAttribute('persistent-session', 'false');
-        widget.setAttribute('header-text', isPublished ? 'Published Version' : `Working Version (v${versionNumber})`);
         if (button.dataset.allowAttachments === 'true') {
           widget.setAttribute('allow-attachments', 'true');
         }
@@ -49,10 +56,7 @@
         if (userName) {
           widget.setAttribute('user-name', userName);
         }
-        const styles = isPublished ? widgetStyles.published : widgetStyles.working;
-        for (const [prop, value] of Object.entries(styles)) {
-          widget.style.setProperty(prop, value);
-        }
+        ocsApplyWidgetVersionTheme(widget, parseInt(button.dataset.versionNumber, 10));
         document.body.appendChild(widget);
       };
     })();

--- a/templates/chatbots/components/session_chat_widget_launcher.html
+++ b/templates/chatbots/components/session_chat_widget_launcher.html
@@ -1,0 +1,60 @@
+{% load waffle_tags %}
+{% flag "flag_chat_widget" %}
+  <script>
+    (function () {
+      const apiBaseUrl = "{{ request.scheme }}://{{ request.get_host }}";
+      const userId = "{{ request.user.email|escapejs }}";
+      const userName = "{{ request.user.get_full_name|escapejs }}";
+      const widgetStyles = {
+        published: {
+          '--header-bg-color': 'oklch(0.982 0.018 155.826)',
+          '--header-bg-hover-color': 'oklch(0.76 0.177 163.223)',
+          '--header-text-color': 'oklch(0.527 0.154 150.069)',
+        },
+        working: {
+          '--header-bg-color': 'oklch(0.987 0.026 102.212)',
+          '--header-bg-hover-color': 'oklch(0.82 0.189 84.429)',
+          '--header-text-color': 'oklch(0.476 0.114 61.907)',
+        },
+      };
+
+      // Open an existing session in a fresh, session-bound widget. A new element is mounted each
+      // time because the widget binds to its session during load and does not re-bind on prop changes.
+      window.ocsContinueSessionChat = function (button) {
+        const existing = document.getElementById('continue-chat-widget');
+        if (existing) {
+          existing.remove();
+        }
+
+        const versionNumber = parseInt(button.dataset.versionNumber, 10);
+        const isPublished = versionNumber === 0;
+
+        const widget = document.createElement('open-chat-studio-widget');
+        widget.id = 'continue-chat-widget';
+        widget.setAttribute('chatbot-id', button.dataset.chatbotId);
+        widget.setAttribute('session-id', button.dataset.sessionId);
+        widget.setAttribute('session-token', button.dataset.sessionToken);
+        widget.setAttribute('api-base-url', apiBaseUrl);
+        widget.setAttribute('show-button', 'false');
+        widget.setAttribute('visible', 'true');
+        widget.setAttribute('position', 'right');
+        widget.setAttribute('persistent-session', 'false');
+        widget.setAttribute('header-text', isPublished ? 'Published Version' : `Working Version (v${versionNumber})`);
+        if (button.dataset.allowAttachments === 'true') {
+          widget.setAttribute('allow-attachments', 'true');
+        }
+        if (userId) {
+          widget.setAttribute('user-id', userId);
+        }
+        if (userName) {
+          widget.setAttribute('user-name', userName);
+        }
+        const styles = isPublished ? widgetStyles.published : widgetStyles.working;
+        for (const [prop, value] of Object.entries(styles)) {
+          widget.style.setProperty(prop, value);
+        }
+        document.body.appendChild(widget);
+      };
+    })();
+  </script>
+{% endflag %}

--- a/templates/chatbots/single_chatbot_home.html
+++ b/templates/chatbots/single_chatbot_home.html
@@ -269,28 +269,12 @@
         persistent-session="false"
       ></open-chat-studio-widget>
       <script>
-        const widgetStyles = {
-          published: {
-            '--header-bg-color': 'oklch(0.982 0.018 155.826)',
-            '--header-bg-hover-color': 'oklch(0.76 0.177 163.223)',
-            '--header-text-color': 'oklch(0.527 0.154 150.069)',
-          },
-          working: {
-            '--header-bg-color': 'oklch(0.987 0.026 102.212)',
-            '--header-bg-hover-color': 'oklch(0.82 0.189 84.429)',
-            '--header-text-color': 'oklch(0.476 0.114 61.907)',
-          },
-        };
+        // ocsApplyWidgetVersionTheme is defined in the shared launcher partial included below.
         function openChatWidget(versionNumber) {
           const widget = document.getElementById('chatbot-widget');
           widget.versionNumber = versionNumber;
           widget.visible = true;
-          const isPublished = versionNumber === 0;
-          widget.headerText = isPublished ? 'Published Version' : `Working Version (v${versionNumber})`;
-          const styles = isPublished ? widgetStyles.published : widgetStyles.working;
-          for (const [prop, value] of Object.entries(styles)) {
-            widget.style.setProperty(prop, value);
-          }
+          ocsApplyWidgetVersionTheme(widget, versionNumber);
         }
       </script>
     {% endflag %}

--- a/templates/chatbots/single_chatbot_home.html
+++ b/templates/chatbots/single_chatbot_home.html
@@ -294,4 +294,5 @@
         }
       </script>
     {% endflag %}
+    {% include "chatbots/components/session_chat_widget_launcher.html" %}
 {% endblock app %}


### PR DESCRIPTION
### Product Description
When `flag_chat_widget` is on, the **Continue Chat** action in the sessions table now resumes the conversation in the embedded chat widget (a floating popup, same UX as the existing widget) instead of navigating to the full-page chat UI. With the flag off, behaviour is unchanged (full-page link). Applies to both the single-chatbot home page and the All Sessions page.

### Technical Description
The widget binds to its session only during `componentWillLoad` (no `@Watch` on `sessionId` in the published `open-chat-studio-widget@0.9.1`), so resuming a session needs a *freshly mounted* element rather than re-setting props on the existing one. `ocsContinueSessionChat` therefore creates a new session-bound widget on each click (removing any prior one). This also makes it work on the All Sessions page, which spans multiple chatbots and has no pre-existing widget.

The Continue Chat action carries a per-row signed `session_token` (`issue_session_token`) only when the flag is active; otherwise it falls back to the legacy link template, preserving the old path.

No changes to the widget package itself — purely OCS app/template code.

### Migrations
N/A — no migrations.

### Demo

<div>
    <a href="https://www.loom.com/share/097c55ca49ac453d98fe589c98df8602">
      <p>Chat Widget Reuses Previous Bot Sessions - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/097c55ca49ac453d98fe589c98df8602">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/097c55ca49ac453d98fe589c98df8602-db2ab3d3801c2347-full-play.gif#t=0.1">
    </a>
  </div>

### Docs and Changelog
- [ ] This PR requires docs/changelog update