### PR TITLE
JSON collection: document filtering options

### DIFF
--- a/apps/documents/datamodels.py
+++ b/apps/documents/datamodels.py
@@ -1,7 +1,10 @@
-from typing import Any
+from typing import Any, Literal
 
 import pydantic
 from pydantic import HttpUrl, field_validator
+
+# Audio/video types markitdown cannot extract useful text from.
+DEFAULT_UNSUPPORTED_FILE_TYPES = ["mp3", "mp4", "wav", "ogg", "avi", "mov", "mkv"]
 
 
 class ChunkingStrategy(pydantic.BaseModel):
@@ -106,6 +109,26 @@ class ConfluenceSourceConfig(pydantic.BaseModel):
         return self.base_url
 
 
+class MetadataFilter(pydantic.BaseModel):
+    """A single condition evaluated against a feed item's raw metadata."""
+
+    field: str = pydantic.Field(description="Name of the item metadata field to test")
+    operator: Literal["eq", "in"] = pydantic.Field(default="eq", description="Comparison operator")
+    value: Any = pydantic.Field(default=None, description="Value to compare the field against")
+
+    def matches(self, item: dict[str, Any]) -> bool:
+        """Return True if `item` satisfies this filter."""
+        item_value = item.get(self.field)
+        if self.operator == "eq":
+            return item_value == self.value
+        # "in": item matches if the item's value (or any element of a list-valued field)
+        # is one of the allowed values.
+        allowed = self.value if isinstance(self.value, list) else [self.value]
+        if isinstance(item_value, list):
+            return any(element in allowed for element in item_value)
+        return item_value in allowed
+
+
 class JSONCollectionSourceConfig(pydantic.BaseModel):
     json_url: HttpUrl = pydantic.Field(description="URL of the JSON feed")
     request_timeout: int = pydantic.Field(
@@ -114,6 +137,19 @@ class JSONCollectionSourceConfig(pydantic.BaseModel):
         le=300,
         description="HTTP request timeout in seconds, applied to JSON fetch and each attachment download",
     )
+    metadata_filters: list[MetadataFilter] = pydantic.Field(
+        default_factory=list,
+        description="Only items satisfying all of these conditions are indexed",
+    )
+    unsupported_file_types: list[str] = pydantic.Field(
+        default_factory=lambda: list(DEFAULT_UNSUPPORTED_FILE_TYPES),
+        description="Attachment file types to skip without downloading (case-insensitive)",
+    )
+
+    def is_unsupported_file_type(self, file_type: str | None) -> bool:
+        if not file_type:
+            return False
+        return file_type.lower() in {t.lower() for t in self.unsupported_file_types}
 
     def __str__(self) -> str:
         return str(self.json_url)

--- a/apps/documents/document_source_service.py
+++ b/apps/documents/document_source_service.py
@@ -174,6 +174,7 @@ class DocumentSourceManager:
         filename = self._extract_filename(document, identifier)
         content_file = ContentFile(document.page_content.encode("utf-8"), name=filename)
         existing_file = collection_file.file
+        existing_file.name = filename
         existing_file.file = content_file
         existing_file.content_size = content_file.size
         existing_file.metadata = document.metadata

--- a/apps/documents/document_source_service.py
+++ b/apps/documents/document_source_service.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from urllib.parse import unquote
 
 from django.core.files.base import ContentFile
 from django.db import transaction
@@ -189,12 +190,13 @@ class DocumentSourceManager:
         if path := document.metadata.get("path"):
             return path
 
-        # Try to get filename from metadata
+        # Try to get filename from metadata. `source` is often a URL, so decode any
+        # percent-encoding (e.g. "%20" -> " ") to get a human-readable filename.
         if "source" in document.metadata:
             source = document.metadata["source"]
             if "/" in source:
-                return source.split("/")[-1]
-            return source
+                return unquote(source.split("/")[-1])
+            return unquote(source)
 
         # Fall back to using part of the identifier
         if ":" in identifier:

--- a/apps/documents/forms.py
+++ b/apps/documents/forms.py
@@ -5,6 +5,7 @@ from django.db.models import Q, Subquery
 
 from apps.assistants.models import OpenAiAssistant, ToolResources
 from apps.documents.datamodels import (
+    DEFAULT_UNSUPPORTED_FILE_TYPES,
     ConfluenceSourceConfig,
     DocumentSourceConfig,
     GitHubSourceConfig,
@@ -397,6 +398,15 @@ class CreateCollectionFromAssistantForm(forms.Form):
             raise forms.ValidationError("A collection with this name already exists.")
 
 
+class MetadataFilterWidget(forms.Widget):
+    """Alpine-backed editor for a list of ``{field, operator, value}`` metadata filters.
+
+    The value round-trips as a JSON string via the form's ``JSONField``.
+    """
+
+    template_name = "django/forms/widgets/metadata_filters.html"
+
+
 class JSONCollectionDocumentSourceForm(DocumentSourceForm):
     requires_auth = True
     allowed_auth_types = [AuthProviderType.bearer, AuthProviderType.basic, AuthProviderType.api_key]
@@ -404,6 +414,7 @@ class JSONCollectionDocumentSourceForm(DocumentSourceForm):
         "Optional. The same credentials are sent with the JSON feed request and every attachment download. "
         "Leave blank for public feeds."
     )
+    custom_template = "documents/partials/json_collection_form.html"
 
     json_url = forms.URLField(
         label="JSON Feed URL",
@@ -417,6 +428,27 @@ class JSONCollectionDocumentSourceForm(DocumentSourceForm):
         label="Request Timeout (seconds)",
         help_text="HTTP timeout applied to the JSON fetch and each attachment download",
     )
+    metadata_filters = forms.JSONField(
+        required=False,
+        label="Metadata Filters",
+        help_text="Only index items that satisfy all of these conditions.",
+        widget=MetadataFilterWidget(),
+    )
+    unsupported_file_types = forms.CharField(
+        required=False,
+        initial=", ".join(DEFAULT_UNSUPPORTED_FILE_TYPES),
+        label="Unsupported File Types",
+        help_text="Comma-separated attachment file types to skip without downloading (case-insensitive).",
+        widget=forms.TextInput(attrs={"placeholder": ", ".join(DEFAULT_UNSUPPORTED_FILE_TYPES)}),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # `unsupported_file_types` round-trips from the config as a list; render it as a
+        # comma-separated string for the text input.
+        file_types = self.initial.get("unsupported_file_types")
+        if isinstance(file_types, list):
+            self.initial["unsupported_file_types"] = ", ".join(file_types)
 
     def _get_config_from_instance(self, instance):
         return instance.config.json_collection
@@ -440,10 +472,13 @@ class JSONCollectionDocumentSourceForm(DocumentSourceForm):
         if self.errors:
             return cleaned_data
 
+        file_types = [t.strip() for t in (cleaned_data.get("unsupported_file_types") or "").split(",") if t.strip()]
         try:
             json_collection_config = JSONCollectionSourceConfig(
                 json_url=cleaned_data["json_url"],
                 request_timeout=cleaned_data["request_timeout"],
+                metadata_filters=cleaned_data.get("metadata_filters") or [],
+                unsupported_file_types=file_types,
             )
         except pydantic.ValidationError as e:
             raise forms.ValidationError(f"Invalid config: {str(e)}") from None

--- a/apps/documents/source_loaders/json_collection.py
+++ b/apps/documents/source_loaders/json_collection.py
@@ -58,17 +58,11 @@ class JSONCollectionLoader(BaseDocumentLoader[JSONCollectionSourceConfig]):
             )
             return
 
-        # Evaluate metadata filters against the raw item before any network I/O.
-        unmatched = next((f for f in self.config.metadata_filters if not f.matches(item)), None)
-        if unmatched is not None:
-            logger.debug(
-                "Skipping item %s: did not satisfy metadata filter on %r",
-                uri or title,
-                unmatched.field,
-            )
+        # All filtering happens before any network I/O.
+        if not self._passes_metadata_filters(item, label=uri or title):
             return
 
-        fetchable = [a for a in (item.get("attachments") or []) if a.get("link")]
+        fetchable = self._fetchable_attachments(item)
         if not fetchable:
             logger.debug(
                 "Skipping item %s: no attachments with a document link",
@@ -78,6 +72,18 @@ class JSONCollectionLoader(BaseDocumentLoader[JSONCollectionSourceConfig]):
 
         item_metadata = self._build_item_metadata(item, title=title, uri=uri)
         yield from self._yield_attachment_documents(item_metadata, fetchable, uri)
+
+    def _passes_metadata_filters(self, item: dict[str, Any], *, label: str | None) -> bool:
+        """Evaluate the configured metadata filters against the raw item."""
+        unmatched = next((f for f in self.config.metadata_filters if not f.matches(item)), None)
+        if unmatched is not None:
+            logger.debug("Skipping item %s: did not satisfy metadata filter on %r", label, unmatched.field)
+            return False
+        return True
+
+    @staticmethod
+    def _fetchable_attachments(item: dict[str, Any]) -> list[dict[str, Any]]:
+        return [a for a in (item.get("attachments") or []) if a.get("link")]
 
     def _build_item_metadata(self, item: dict[str, Any], *, title: str | None, uri: str | None) -> dict[str, Any]:
         metadata: dict[str, Any] = {

--- a/apps/documents/source_loaders/json_collection.py
+++ b/apps/documents/source_loaders/json_collection.py
@@ -58,24 +58,26 @@ class JSONCollectionLoader(BaseDocumentLoader[JSONCollectionSourceConfig]):
             )
             return
 
-        item_metadata = self._build_item_metadata(item, title=title, uri=uri)
-        fetchable = [a for a in (item.get("attachments") or []) if a.get("link")]
-
-        if fetchable:
-            yield from self._yield_attachment_documents(item_metadata, fetchable, uri)
+        # Evaluate metadata filters against the raw item before any network I/O.
+        unmatched = next((f for f in self.config.metadata_filters if not f.matches(item)), None)
+        if unmatched is not None:
+            logger.debug(
+                "Skipping item %s: did not satisfy metadata filter on %r",
+                uri or title,
+                unmatched.field,
+            )
             return
 
-        # Fallback: no fetchable attachments
-        if title:
-            yield Document(
-                page_content=title,
-                metadata={**item_metadata, "source": uri or ""},
+        fetchable = [a for a in (item.get("attachments") or []) if a.get("link")]
+        if not fetchable:
+            logger.debug(
+                "Skipping item %s: no attachments with a document link",
+                uri or title,
             )
-        else:
-            logger.warning(
-                "Skipping item with no fetchable attachments and no title (URI=%s)",
-                uri,
-            )
+            return
+
+        item_metadata = self._build_item_metadata(item, title=title, uri=uri)
+        yield from self._yield_attachment_documents(item_metadata, fetchable, uri)
 
     def _build_item_metadata(self, item: dict[str, Any], *, title: str | None, uri: str | None) -> dict[str, Any]:
         metadata: dict[str, Any] = {
@@ -111,6 +113,15 @@ class JSONCollectionLoader(BaseDocumentLoader[JSONCollectionSourceConfig]):
     ) -> Iterator[Document]:
         for attachment in fetchable:
             link = attachment["link"]
+            file_type = attachment.get("file_type")
+            if self.config.is_unsupported_file_type(file_type):
+                logger.warning(
+                    "Skipping attachment %s for item %s: unsupported file type %r",
+                    link,
+                    item_uri,
+                    file_type,
+                )
+                continue
             try:
                 text = self._fetch_and_extract(link)
             except Exception as exc:  # noqa: BLE001 -- caught and logged per design

--- a/apps/documents/tests/test_document_sources.py
+++ b/apps/documents/tests/test_document_sources.py
@@ -168,6 +168,23 @@ class TestDocumentSourceManager:
         manager._remove_files.assert_called_once()
         manager._index_files.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            pytest.param(
+                "https://example.com/files/Loa%20Loa_bringing%20an%20end.pdf",
+                "Loa Loa_bringing an end.pdf",
+                id="url-encoded-path",
+            ),
+            pytest.param("https://example.com/plain.pdf", "plain.pdf", id="plain-path"),
+            pytest.param("just_a_name.pdf", "just_a_name.pdf", id="no-slash"),
+        ],
+    )
+    def test_extract_filename_url_decodes_source(self, document_source, source, expected):
+        manager = DocumentSourceManager(document_source)
+        document = Document(page_content="x", metadata={"source": source})
+        assert manager._extract_filename(document, source) == expected
+
     def test_sync_log_created(self, document_source):
         initial_count = DocumentSourceSyncLog.objects.count()
 

--- a/apps/documents/tests/test_document_sources.py
+++ b/apps/documents/tests/test_document_sources.py
@@ -185,6 +185,23 @@ class TestDocumentSourceManager:
         document = Document(page_content="x", metadata={"source": source})
         assert manager._extract_filename(document, source) == expected
 
+    @patch("apps.documents.document_source_service.create_loader")
+    def test_update_file_refreshes_decoded_name(self, create_loader, collection, document_source):
+        url = "https://example.com/files/My%20Doc.pdf"
+        docs = [Mock(page_content="v1", metadata={"source": url, "sha": "v1", "source_type": "test"})]
+        create_loader.return_value = MockLoader(collection, docs)
+        manager = DocumentSourceManager(document_source)
+        manager._index_files = Mock()  # ty: ignore[invalid-assignment]
+        manager.sync_collection()
+
+        updated_docs = [Mock(page_content="v2", metadata={"source": url, "sha": "v2", "source_type": "test"})]
+        create_loader.return_value = MockLoader(collection, updated_docs)
+        manager.sync_collection()
+
+        file = CollectionFile.objects.get(collection=collection).file
+        assert file.name == "My Doc.pdf"
+        assert file.file.read() == b"v2"
+
     def test_sync_log_created(self, document_source):
         initial_count = DocumentSourceSyncLog.objects.count()
 

--- a/apps/documents/tests/test_forms.py
+++ b/apps/documents/tests/test_forms.py
@@ -3,10 +3,11 @@ from unittest.mock import Mock
 import pytest
 from django.db.models import Q
 
+from apps.documents.datamodels import DocumentSourceConfig, JSONCollectionSourceConfig
 from apps.documents.forms import CollectionForm, JSONCollectionDocumentSourceForm
 from apps.documents.models import SourceType
 from apps.service_providers.models import AuthProviderType, LlmProviderTypes
-from apps.utils.factories.documents import CollectionFactory
+from apps.utils.factories.documents import CollectionFactory, DocumentSourceFactory
 from apps.utils.factories.service_provider_factories import (
     AuthProviderFactory,
     EmbeddingProviderModelFactory,
@@ -214,3 +215,69 @@ class TestJSONCollectionDocumentSourceForm:
         )
         assert form.is_valid(), form.errors
         assert form.cleaned_data["auth_provider"] == provider
+
+    def test_metadata_filter_widget_renders(self, collection):
+        """The custom widget + form template render without error and emit the editor markup."""
+        instance = DocumentSourceFactory.create(
+            collection=collection,
+            source_type=SourceType.JSON_COLLECTION,
+            config=DocumentSourceConfig(
+                json_collection=JSONCollectionSourceConfig(
+                    json_url="https://example.com/feed.json",
+                    metadata_filters=[{"field": "status", "operator": "eq", "value": "published"}],
+                )
+            ),
+        )
+        form = JSONCollectionDocumentSourceForm(collection=collection, instance=instance, initial={})
+        html = str(form["metadata_filters"])
+        assert "metadataFilterEditor" in html
+        assert "published" in html
+
+    def test_metadata_filters_and_file_types_parsed_into_config(self, collection):
+        form = JSONCollectionDocumentSourceForm(
+            collection=collection,
+            data={
+                "source_type": SourceType.JSON_COLLECTION,
+                "auto_sync_enabled": False,
+                "json_url": "https://example.com/feed.json",
+                "request_timeout": 30,
+                "metadata_filters": '[{"field": "status", "operator": "eq", "value": "published"}]',
+                "unsupported_file_types": "mp3, MP4 , wav",
+            },
+        )
+        assert form.is_valid(), form.errors
+        config = form.cleaned_data["config"].json_collection
+        assert len(config.metadata_filters) == 1
+        assert config.metadata_filters[0].field == "status"
+        assert config.metadata_filters[0].operator == "eq"
+        assert config.metadata_filters[0].value == "published"
+        assert config.unsupported_file_types == ["mp3", "MP4", "wav"]
+
+    def test_invalid_metadata_filter_operator_rejected(self, collection):
+        form = JSONCollectionDocumentSourceForm(
+            collection=collection,
+            data={
+                "source_type": SourceType.JSON_COLLECTION,
+                "auto_sync_enabled": False,
+                "json_url": "https://example.com/feed.json",
+                "request_timeout": 30,
+                "metadata_filters": '[{"field": "status", "operator": "bogus", "value": "x"}]',
+            },
+        )
+        assert not form.is_valid()
+
+    def test_existing_config_round_trips_to_initial(self, collection):
+        instance = DocumentSourceFactory.create(
+            collection=collection,
+            source_type=SourceType.JSON_COLLECTION,
+            config=DocumentSourceConfig(
+                json_collection=JSONCollectionSourceConfig(
+                    json_url="https://example.com/feed.json",
+                    metadata_filters=[{"field": "status", "operator": "eq", "value": "published"}],
+                    unsupported_file_types=["mp3", "wav"],
+                )
+            ),
+        )
+        form = JSONCollectionDocumentSourceForm(collection=collection, instance=instance, initial={})
+        assert form.initial["unsupported_file_types"] == "mp3, wav"
+        assert form.initial["metadata_filters"] == [{"field": "status", "operator": "eq", "value": "published"}]

--- a/apps/documents/tests/test_json_collection_loader.py
+++ b/apps/documents/tests/test_json_collection_loader.py
@@ -148,38 +148,37 @@ class TestLoadDocumentsAttachments:
         assert docs[1].metadata["source"] == "https://example.com/a-2.pdf"
 
 
-class TestLoadDocumentsFallback:
-    def test_no_attachments_field_yields_fallback(self, json_config, httpx_mock):
-        feed = [
-            {
-                "title": "T",
-                "URI": "https://example.com/page",
-                "date": "01/01/2025",
-            }
-        ]
+def _single_attachment_item(**item_fields):
+    """Feed item with one fetchable PDF attachment, plus any extra item-level fields."""
+    return {
+        "title": "T",
+        "URI": "https://example.com/p",
+        "attachments": [{"file_type": "pdf", "title": "f", "link": "https://example.com/file.pdf"}],
+        **item_fields,
+    }
+
+
+class TestLoadDocumentsNoFetchableLink:
+    """Items with no fetchable document link are skipped (no title-only fallback)."""
+
+    def test_no_attachments_field_yields_nothing(self, json_config, httpx_mock, caplog):
+        feed = [{"title": "T", "URI": "https://example.com/page", "date": "01/01/2025"}]
         httpx_mock.add_response(url="https://example.com/feed.json", json=feed)
 
         loader = _make_loader(json_config)
-        docs = list(loader.load_documents())
+        with caplog.at_level(logging.DEBUG, logger="apps.documents.source_loaders.json_collection"):
+            docs = list(loader.load_documents())
 
-        assert len(docs) == 1
-        assert docs[0].page_content == "T"
-        assert docs[0].metadata["source"] == "https://example.com/page"
-        assert docs[0].metadata["title"] == "T"
-        assert docs[0].metadata["URI"] == "https://example.com/page"
-        assert docs[0].metadata["citation_text"] == "T"
-        assert docs[0].metadata["citation_url"] == "https://example.com/page"
-        assert "link" not in docs[0].metadata
+        assert docs == []
+        assert any("no attachments with a document link" in record.message for record in caplog.records)
 
-    def test_empty_attachments_yields_fallback(self, json_config, httpx_mock):
+    def test_empty_attachments_yields_nothing(self, json_config, httpx_mock):
         feed = [{"title": "T", "URI": "https://example.com/page", "attachments": []}]
         httpx_mock.add_response(url="https://example.com/feed.json", json=feed)
         loader = _make_loader(json_config)
-        docs = list(loader.load_documents())
-        assert len(docs) == 1
-        assert docs[0].page_content == "T"
+        assert list(loader.load_documents()) == []
 
-    def test_attachments_without_links_yields_fallback(self, json_config, httpx_mock):
+    def test_attachments_without_links_yields_nothing(self, json_config, httpx_mock):
         feed = [
             {
                 "title": "T",
@@ -189,26 +188,29 @@ class TestLoadDocumentsFallback:
         ]
         httpx_mock.add_response(url="https://example.com/feed.json", json=feed)
         loader = _make_loader(json_config)
-        docs = list(loader.load_documents())
-        assert len(docs) == 1
-        assert docs[0].page_content == "T"
+        assert list(loader.load_documents()) == []
 
+
+class TestItemMetadataPropagation:
     def test_optional_metadata_fields_propagate_when_present(self, json_config, httpx_mock):
         feed = [
-            {
-                "title": "T",
-                "URI": "https://example.com/p",
-                "authors": "Alice",
-                "publisher": "Pub",
-                "countries": ["US", "CA"],
-                "diseases": ["malaria"],
-                "tags": ["health"],
-                "regions": ["AFRO"],
-            }
+            _single_attachment_item(
+                authors="Alice",
+                publisher="Pub",
+                countries=["US", "CA"],
+                diseases=["malaria"],
+                tags=["health"],
+                regions=["AFRO"],
+            )
         ]
         httpx_mock.add_response(url="https://example.com/feed.json", json=feed)
+        httpx_mock.add_response(url="https://example.com/file.pdf", content=b"PDF")
         loader = _make_loader(json_config)
-        docs = list(loader.load_documents())
+        with mock.patch(
+            "apps.documents.source_loaders.json_collection.markitdown_read",
+            return_value=_stub_doc("body"),
+        ):
+            docs = list(loader.load_documents())
         meta = docs[0].metadata
         for k, v in [
             ("authors", "Alice"),
@@ -221,24 +223,162 @@ class TestLoadDocumentsFallback:
             assert meta[k] == v
 
     def test_optional_metadata_fields_absent_when_missing(self, json_config, httpx_mock):
-        feed = [{"title": "T", "URI": "https://example.com/p"}]
+        feed = [_single_attachment_item()]
         httpx_mock.add_response(url="https://example.com/feed.json", json=feed)
+        httpx_mock.add_response(url="https://example.com/file.pdf", content=b"PDF")
         loader = _make_loader(json_config)
-        meta = list(loader.load_documents())[0].metadata
+        with mock.patch(
+            "apps.documents.source_loaders.json_collection.markitdown_read",
+            return_value=_stub_doc("body"),
+        ):
+            meta = list(loader.load_documents())[0].metadata
         for k in ("authors", "publisher", "countries", "diseases", "tags", "regions"):
             assert k not in meta
 
     def test_item_missing_title_and_uri_is_skipped(self, json_config, httpx_mock, caplog):
-        feed = [{"date": "01/01/2025"}, {"title": "OK", "URI": "https://example.com/p"}]
+        feed = [{"date": "01/01/2025"}, _single_attachment_item(title="OK")]
         httpx_mock.add_response(url="https://example.com/feed.json", json=feed)
+        httpx_mock.add_response(url="https://example.com/file.pdf", content=b"PDF")
         loader = _make_loader(json_config)
 
         with caplog.at_level(logging.WARNING, logger="apps.documents.source_loaders.json_collection"):
-            docs = list(loader.load_documents())
+            with mock.patch(
+                "apps.documents.source_loaders.json_collection.markitdown_read",
+                return_value=_stub_doc("body"),
+            ):
+                docs = list(loader.load_documents())
 
         assert len(docs) == 1
         assert docs[0].metadata["title"] == "OK"
         assert any("neither 'title' nor 'URI'" in record.message for record in caplog.records)
+
+
+class TestMetadataFilters:
+    def _feed_item(self, **fields):
+        return _single_attachment_item(**fields)
+
+    @pytest.mark.parametrize(
+        ("filters", "item_fields", "expected_count"),
+        [
+            pytest.param(
+                [{"field": "status", "operator": "eq", "value": "published"}],
+                {"status": "published"},
+                1,
+                id="eq-match",
+            ),
+            pytest.param(
+                [{"field": "status", "operator": "eq", "value": "published"}],
+                {"status": "draft"},
+                0,
+                id="eq-no-match",
+            ),
+            pytest.param(
+                [{"field": "status", "operator": "eq", "value": "published"}],
+                {},
+                0,
+                id="eq-missing-field",
+            ),
+            pytest.param(
+                [{"field": "languages", "operator": "in", "value": ["en", "fr"]}],
+                {"languages": ["es", "fr"]},
+                1,
+                id="in-list-field-intersects",
+            ),
+            pytest.param(
+                [{"field": "languages", "operator": "in", "value": ["en", "fr"]}],
+                {"languages": ["es", "de"]},
+                0,
+                id="in-list-field-disjoint",
+            ),
+            pytest.param(
+                [{"field": "type", "operator": "in", "value": ["report", "memo"]}],
+                {"type": "report"},
+                1,
+                id="in-scalar-field-match",
+            ),
+            pytest.param(
+                [
+                    {"field": "status", "operator": "eq", "value": "published"},
+                    {"field": "type", "operator": "in", "value": ["report"]},
+                ],
+                {"status": "published", "type": "memo"},
+                0,
+                id="multiple-filters-are-anded",
+            ),
+        ],
+    )
+    def test_filters(self, httpx_mock, filters, item_fields, expected_count):
+        config = JSONCollectionSourceConfig(json_url="https://example.com/feed.json", metadata_filters=filters)
+        httpx_mock.add_response(url="https://example.com/feed.json", json=[self._feed_item(**item_fields)])
+        if expected_count:
+            httpx_mock.add_response(url="https://example.com/file.pdf", content=b"PDF")
+        loader = _make_loader(config)
+        with mock.patch(
+            "apps.documents.source_loaders.json_collection.markitdown_read",
+            return_value=_stub_doc("body"),
+        ):
+            docs = list(loader.load_documents())
+        assert len(docs) == expected_count
+
+    def test_filtered_item_is_not_fetched(self, httpx_mock, caplog):
+        """A filtered-out item must not trigger any attachment download."""
+        config = JSONCollectionSourceConfig(
+            json_url="https://example.com/feed.json",
+            metadata_filters=[{"field": "status", "operator": "eq", "value": "published"}],
+        )
+        httpx_mock.add_response(url="https://example.com/feed.json", json=[self._feed_item(status="draft")])
+        # No response registered for file.pdf: if the loader tried to fetch it, httpx_mock would error.
+        loader = _make_loader(config)
+        with caplog.at_level(logging.DEBUG, logger="apps.documents.source_loaders.json_collection"):
+            docs = list(loader.load_documents())
+        assert docs == []
+        assert any("did not satisfy metadata filter" in record.message for record in caplog.records)
+
+
+class TestUnsupportedFileTypes:
+    def test_unsupported_attachment_skipped_without_fetch(self, json_config, httpx_mock, caplog):
+        feed = [
+            {
+                "title": "T",
+                "URI": "https://example.com/page",
+                "attachments": [
+                    {"file_type": "mp3", "title": "audio", "link": "https://example.com/a.mp3"},
+                    {"file_type": "pdf", "title": "doc", "link": "https://example.com/b.pdf"},
+                ],
+            }
+        ]
+        httpx_mock.add_response(url="https://example.com/feed.json", json=feed)
+        # Only the pdf is fetched; no response is registered for the mp3.
+        httpx_mock.add_response(url="https://example.com/b.pdf", content=b"PDF")
+        loader = _make_loader(json_config)
+        with caplog.at_level(logging.WARNING, logger="apps.documents.source_loaders.json_collection"):
+            with mock.patch(
+                "apps.documents.source_loaders.json_collection.markitdown_read",
+                return_value=_stub_doc("body"),
+            ):
+                docs = list(loader.load_documents())
+        assert len(docs) == 1
+        assert docs[0].metadata["link"] == "https://example.com/b.pdf"
+        assert any("unsupported file type" in record.message for record in caplog.records)
+
+    def test_blocklist_is_case_insensitive(self, json_config, httpx_mock):
+        feed = [
+            {
+                "title": "T",
+                "URI": "https://example.com/page",
+                "attachments": [{"file_type": "MP4", "title": "video", "link": "https://example.com/v.mp4"}],
+            }
+        ]
+        httpx_mock.add_response(url="https://example.com/feed.json", json=feed)
+        loader = _make_loader(json_config)
+        assert list(loader.load_documents()) == []
+
+    def test_custom_blocklist(self, httpx_mock):
+        config = JSONCollectionSourceConfig(json_url="https://example.com/feed.json", unsupported_file_types=["pdf"])
+        feed = [_single_attachment_item()]
+        httpx_mock.add_response(url="https://example.com/feed.json", json=feed)
+        loader = _make_loader(config)
+        assert list(loader.load_documents()) == []
 
 
 class TestLoadDocumentsAttachmentFailures:

--- a/templates/django/forms/widgets/metadata_filters.html
+++ b/templates/django/forms/widgets/metadata_filters.html
@@ -1,0 +1,49 @@
+<script>
+  // Defined as a global (not via Alpine.data/alpine:init) so it resolves when this
+  // widget is injected into the page by HTMX, after Alpine has already initialised.
+  window.metadataFilterEditor = function (initial = []) {
+    return {
+      rows: (initial || []).map(filter => ({
+        field: filter.field || '',
+        operator: filter.operator || 'eq',
+        value: Array.isArray(filter.value) ? filter.value.join(', ') : (filter.value ?? ''),
+      })),
+      addRow() {
+        this.rows.push({field: '', operator: 'eq', value: ''});
+      },
+      removeRow(index) {
+        this.rows.splice(index, 1);
+      },
+      serialize() {
+        const filters = this.rows
+          .filter(row => row.field.trim())
+          .map(row => ({
+            field: row.field.trim(),
+            operator: row.operator,
+            value: row.operator === 'in'
+              ? String(row.value).split(',').map(part => part.trim()).filter(Boolean)
+              : row.value,
+          }));
+        return JSON.stringify(filters);
+      },
+    };
+  };
+</script>
+
+<div x-data="metadataFilterEditor({{ widget.value|default:'[]' }})" class="w-full">
+  <template x-for="(row, index) in rows" :key="index">
+    <div class="flex gap-2 mb-2 items-center">
+      <input type="text" class="input input-sm input-bordered flex-1 min-w-0" placeholder="field" x-model="row.field">
+      <select class="select select-sm select-bordered w-28 shrink-0" x-model="row.operator">
+        <option value="eq">equals</option>
+        <option value="in">in</option>
+      </select>
+      <input type="text" class="input input-sm input-bordered flex-1 min-w-0"
+             :placeholder="row.operator === 'in' ? 'comma-separated values' : 'value'"
+             x-model="row.value">
+      <button type="button" class="btn btn-sm btn-ghost shrink-0" @click="removeRow(index)">Remove</button>
+    </div>
+  </template>
+  <button type="button" class="btn btn-sm" @click="addRow()">Add filter</button>
+  <input type="hidden" name="{{ widget.name }}" :value="serialize()">
+</div>

--- a/templates/documents/document_source_form_dialog.html
+++ b/templates/documents/document_source_form_dialog.html
@@ -1,7 +1,7 @@
 {% load form_tags i18n %}
 
 <dialog id="new_document_source_modal" class="modal" open>
-  <div class="modal-box">
+  <div class="modal-box w-11/12 max-w-3xl">
     <form method="dialog">
       <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
     </form>

--- a/templates/documents/partials/json_collection_form.html
+++ b/templates/documents/partials/json_collection_form.html
@@ -1,0 +1,2 @@
+{% load form_tags %}
+{% render_form_fields form "source_type" "auto_sync_enabled" "auth_provider" "json_url" "request_timeout" "unsupported_file_types" "metadata_filters" %}


### PR DESCRIPTION
Closes #3336.

### Product Description
Operators configuring a JSON collection source can now control what gets indexed: filter items by metadata field (e.g. only `status == published`), skip unsupported attachment types (audio/video markitdown can't read), and ignore entries that have no document link.

### Technical Description
Filtering config lives on `JSONCollectionSourceConfig` and is evaluated in `_process_item` before any network I/O. The previous title-only fallback is gone — items with no fetchable attachment link are now skipped outright (#3336 item 3).

Worth a look:
- The metadata-filter form field is a custom Alpine widget registered as a `window.` global rather than via `alpine:init`. The config form is injected through HTMX after Alpine has already initialised, so an `alpine:init` listener never fires for it.
- Existing sources transparently pick up the default unsupported-type blocklist (mp3/mp4/wav/…) since it's a pydantic default — a behaviour change, but the intended one.

Also folds in two filename fixes that surfaced while dogfooding: source URLs were stored percent-encoded (`My%20Doc.pdf`), and `_update_file` recomputed the filename but never wrote it back to `File.name`. Existing rows keep their stale names until the item next changes and re-syncs (opted against a data migration).

### Migrations
N/A — config is a pydantic-backed JSON field; new fields have defaults.

### Docs and Changelog
- [x] This PR requires docs/changelog update