### PR TITLE
fix: re-send page context on SPA navigation

### DIFF
--- a/assets/javascript/modules/chat-widget-context.js
+++ b/assets/javascript/modules/chat-widget-context.js
@@ -3,6 +3,9 @@
  * Provides functions to extract and set page context on the chat widget.
  */
 
+/** Module-level flag to prevent double-patching history methods. */
+let _navigationListenerActive = false;
+
 /**
  * Extract client-side page context information for the chat widget.
  * Returns an object with URL, title, hash, and breadcrumbs.
@@ -71,4 +74,60 @@ export function initChatWidgetPageContext(serverContext = {}) {
       ...widgetPageContext,
     };
   }
+}
+
+/**
+ * Set up listeners for SPA navigation events so that page context is
+ * automatically refreshed on every client-side route change.
+ *
+ * Patches `history.pushState` and `history.replaceState` to detect
+ * programmatic navigations, and also listens for the browser's `popstate`
+ * event (back/forward). After each navigation the function re-calls
+ * `initChatWidgetPageContext` with the same `serverContext` so the widget
+ * receives fresh `url`, `title`, and `breadcrumbs` values.
+ *
+ * Should be called once per page load — calling it multiple times is safe
+ * (subsequent calls are no-ops and log a warning).
+ *
+ * @param {Object} serverContext - Same server context passed to initChatWidgetPageContext
+ * @returns {Function} Cleanup function that removes all listeners and
+ *   restores the original history methods.
+ */
+export function setupNavigationListener(serverContext = {}) {
+  if (_navigationListenerActive) {
+    console.warn('[open-chat-studio] setupNavigationListener has already been called. It should only be called once per page.');
+    return () => {};
+  }
+  _navigationListenerActive = true;
+
+  const onNavigate = () => {
+    initChatWidgetPageContext(serverContext);
+    // Dispatch a custom event so the widget can detect the URL change even
+    // when no pageContext prop is provided by the host page.
+    window.dispatchEvent(new CustomEvent('ocs-navigation'));
+  };
+
+  // Patch pushState / replaceState — these are used by all major SPA routers
+  // but do not fire a popstate event on their own.
+  const originalPushState = history.pushState.bind(history);
+  const originalReplaceState = history.replaceState.bind(history);
+
+  history.pushState = function (...args) {
+    originalPushState(...args);
+    onNavigate();
+  };
+
+  history.replaceState = function (...args) {
+    originalReplaceState(...args);
+    onNavigate();
+  };
+
+  window.addEventListener('popstate', onNavigate);
+
+  return () => {
+    history.pushState = originalPushState;
+    history.replaceState = originalReplaceState;
+    window.removeEventListener('popstate', onNavigate);
+    _navigationListenerActive = false;
+  };
 }

--- a/assets/javascript/modules/chat-widget-context.test.js
+++ b/assets/javascript/modules/chat-widget-context.test.js
@@ -1,0 +1,158 @@
+/**
+ * Tests for chat-widget-context.js
+ */
+
+// Reset modules before each test so module-level state (_navigationListenerActive) is fresh.
+beforeEach(() => {
+  jest.resetModules();
+  // Provide a minimal DOM environment
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function makeWidget(pageContext = null) {
+  const widget = document.createElement('open-chat-studio-widget');
+  if (pageContext !== null) {
+    widget.pageContext = pageContext;
+  }
+  document.body.appendChild(widget);
+  return widget;
+}
+
+describe('getClientPageContext', () => {
+  it('returns url, title, and empty breadcrumbs when no nav element present', async () => {
+    const { getClientPageContext } = await import('./chat-widget-context.js');
+    document.title = 'Test Page';
+
+    const ctx = getClientPageContext();
+
+    expect(ctx.title).toBe('Test Page');
+    expect(typeof ctx.url).toBe('string');
+    expect(Array.isArray(ctx.breadcrumbs)).toBe(true);
+    expect(ctx.breadcrumbs).toHaveLength(0);
+  });
+
+  it('extracts breadcrumbs from aria-label="breadcrumbs" nav', async () => {
+    const { getClientPageContext } = await import('./chat-widget-context.js');
+
+    document.body.innerHTML = `
+      <nav aria-label="breadcrumbs">
+        <ol><li>Home</li><li>Settings</li></ol>
+      </nav>
+    `;
+
+    const ctx = getClientPageContext();
+
+    expect(ctx.breadcrumbs).toEqual(['Home', 'Settings']);
+  });
+});
+
+describe('initChatWidgetPageContext', () => {
+  it('sets pageContext on the widget element', async () => {
+    const { initChatWidgetPageContext } = await import('./chat-widget-context.js');
+    const widget = makeWidget();
+    document.title = 'My Page';
+
+    initChatWidgetPageContext({ team: 'my-team', activeTab: 'chat', pageTitle: null, messages: [] });
+
+    expect(widget.pageContext).toBeDefined();
+    expect(widget.pageContext.team).toBe('my-team');
+    expect(widget.pageContext.activeTab).toBe('chat');
+  });
+
+  it('does nothing when no widget element is present', async () => {
+    const { initChatWidgetPageContext } = await import('./chat-widget-context.js');
+    // No widget in DOM — should not throw
+    expect(() => initChatWidgetPageContext({})).not.toThrow();
+  });
+});
+
+describe('setupNavigationListener', () => {
+  it('re-initializes page context on popstate', async () => {
+    const { initChatWidgetPageContext, setupNavigationListener } = await import('./chat-widget-context.js');
+    const widget = makeWidget();
+
+    setupNavigationListener({ team: 'acme' });
+
+    // Simulate browser back/forward
+    window.dispatchEvent(new PopStateEvent('popstate'));
+
+    expect(widget.pageContext).toBeDefined();
+    expect(widget.pageContext.team).toBe('acme');
+  });
+
+  it('dispatches ocs-navigation custom event on popstate', async () => {
+    const { setupNavigationListener } = await import('./chat-widget-context.js');
+    makeWidget();
+
+    const spy = jest.fn();
+    window.addEventListener('ocs-navigation', spy);
+
+    setupNavigationListener({});
+    window.dispatchEvent(new PopStateEvent('popstate'));
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    window.removeEventListener('ocs-navigation', spy);
+  });
+
+  it('patches history.pushState to trigger context update', async () => {
+    const { setupNavigationListener } = await import('./chat-widget-context.js');
+    const widget = makeWidget();
+
+    setupNavigationListener({ team: 'spa-team' });
+
+    history.pushState({}, '', '/new-page');
+
+    expect(widget.pageContext).toBeDefined();
+    expect(widget.pageContext.team).toBe('spa-team');
+  });
+
+  it('patches history.replaceState to trigger context update', async () => {
+    const { setupNavigationListener } = await import('./chat-widget-context.js');
+    const widget = makeWidget();
+
+    setupNavigationListener({ team: 'replace-team' });
+
+    history.replaceState({}, '', '/replaced-page');
+
+    expect(widget.pageContext).toBeDefined();
+    expect(widget.pageContext.team).toBe('replace-team');
+  });
+
+  it('cleanup function restores original history methods and removes listeners', async () => {
+    const { setupNavigationListener } = await import('./chat-widget-context.js');
+    const widget = makeWidget();
+
+    const originalPushState = history.pushState;
+    const cleanup = setupNavigationListener({});
+
+    expect(history.pushState).not.toBe(originalPushState);
+
+    cleanup();
+
+    expect(history.pushState).toBe(originalPushState);
+
+    // After cleanup, pushState should not update the widget
+    widget.pageContext = undefined;
+    history.pushState({}, '', '/after-cleanup');
+    expect(widget.pageContext).toBeUndefined();
+  });
+
+  it('warns and returns a no-op when called a second time', async () => {
+    const { setupNavigationListener } = await import('./chat-widget-context.js');
+    makeWidget();
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    setupNavigationListener({});
+    const cleanup2 = setupNavigationListener({});
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(typeof cleanup2).toBe('function');
+    // cleanup2 should be a no-op (calling it shouldn't throw)
+    expect(() => cleanup2()).not.toThrow();
+  });
+});

--- a/assets/javascript/modules/chat-widget-context.test.js
+++ b/assets/javascript/modules/chat-widget-context.test.js
@@ -72,7 +72,7 @@ describe('initChatWidgetPageContext', () => {
 
 describe('setupNavigationListener', () => {
   it('re-initializes page context on popstate', async () => {
-    const { initChatWidgetPageContext, setupNavigationListener } = await import('./chat-widget-context.js');
+    const { setupNavigationListener } = await import('./chat-widget-context.js');
     const widget = makeWidget();
 
     setupNavigationListener({ team: 'acme' });

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.spec.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.spec.tsx
@@ -436,6 +436,9 @@ describe('ocs-chat', () => {
     });
 
     afterEach(() => {
+      if (originalHref) {
+        Object.defineProperty(window, 'location', originalHref);
+      }
       jest.restoreAllMocks();
     });
 

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.spec.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.spec.tsx
@@ -427,6 +427,107 @@ describe('ocs-chat', () => {
     });
   });
 
+  describe('Navigation-triggered page context updates', () => {
+    let originalHref: PropertyDescriptor | undefined;
+
+    beforeEach(() => {
+      // Allow tests to control window.location.href
+      originalHref = Object.getOwnPropertyDescriptor(window, 'location');
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    function setUrl(url: string) {
+      Object.defineProperty(window, 'location', {
+        value: { href: url, pathname: new URL(url).pathname, hash: new URL(url).hash },
+        writable: true,
+        configurable: true,
+      });
+    }
+
+    it('sets internalPageContext to minimal URL context on popstate when no pageContext prop is set', async () => {
+      setUrl('https://example.com/page-a');
+
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget chatbot-id="bot-1"></open-chat-studio-widget>`,
+      });
+
+      const component = page.rootInstance as OcsChat;
+      // No pageContext prop set
+      expect(component.pageContext).toBeUndefined();
+
+      // Simulate SPA navigation
+      setUrl('https://example.com/page-b');
+      window.dispatchEvent(new Event('popstate'));
+      await page.waitForChanges();
+
+      expect((component as any).internalPageContext).toEqual({ url: 'https://example.com/page-b' });
+    });
+
+    it('re-loads pageContext prop on popstate when pageContext is set', async () => {
+      setUrl('https://example.com/page-a');
+
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget chatbot-id="bot-1"></open-chat-studio-widget>`,
+      });
+
+      const component = page.rootInstance as OcsChat;
+      const ctx = { url: '/page-a', title: 'Page A' };
+      component.pageContext = ctx;
+      await page.waitForChanges();
+
+      // Clear internalPageContext as if a message was already sent
+      (component as any).internalPageContext = undefined;
+
+      // Simulate SPA navigation
+      setUrl('https://example.com/page-b');
+      const newCtx = { url: '/page-b', title: 'Page B' };
+      component.pageContext = newCtx;
+      window.dispatchEvent(new Event('popstate'));
+      await page.waitForChanges();
+
+      expect((component as any).internalPageContext).toEqual(newCtx);
+    });
+
+    it('does not update internalPageContext when URL has not changed', async () => {
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget chatbot-id="bot-1"></open-chat-studio-widget>`,
+      });
+
+      const component = page.rootInstance as OcsChat;
+      // componentDidLoad already set currentPageUrl = window.location.href.
+      // Clearing internalPageContext simulates a state after a message was sent.
+      (component as any).internalPageContext = undefined;
+
+      // Dispatch popstate without changing the URL — should be a no-op.
+      window.dispatchEvent(new Event('popstate'));
+      await page.waitForChanges();
+
+      expect((component as any).internalPageContext).toBeUndefined();
+    });
+
+    it('responds to ocs-navigation custom event', async () => {
+      setUrl('https://example.com/page-a');
+
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget chatbot-id="bot-1"></open-chat-studio-widget>`,
+      });
+
+      const component = page.rootInstance as OcsChat;
+      setUrl('https://example.com/page-b');
+      window.dispatchEvent(new CustomEvent('ocs-navigation'));
+      await page.waitForChanges();
+
+      expect((component as any).internalPageContext).toEqual({ url: 'https://example.com/page-b' });
+    });
+  });
+
   describe('Combined Welcome Messages and Starter Questions', () => {
     it('should display both welcome messages and starter questions from translations', async () => {
       const page = await newSpecPage({

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -277,6 +277,8 @@ export class OcsChat {
   private chatWindowFullscreenWidth: number = 1024;
   private positionInitialized: boolean = false;
   private internalPageContext?: Record<string, any>;
+  private currentPageUrl: string = '';
+  private navigationCleanupFn?: () => void;
   private sessionEpoch: number = 0;
   private currentSessionToken?: string;
   @Element() host: HTMLElement;
@@ -349,6 +351,9 @@ export class OcsChat {
     }, 0);
 
     window.addEventListener('resize', this.handleWindowResize);
+
+    this.currentPageUrl = window.location.href;
+    this.setupNavigationListeners();
   }
 
   disconnectedCallback() {
@@ -356,6 +361,8 @@ export class OcsChat {
     this.removeEventListeners();
     this.removeButtonEventListeners();
     window.removeEventListener('resize', this.handleWindowResize);
+    this.navigationCleanupFn?.();
+    this.navigationCleanupFn = undefined;
   }
 
   private applySessionToken(token?: string): void {
@@ -1096,6 +1103,53 @@ export class OcsChat {
   private endDrag(): void {
     this.isDragging = false;
     this.removeEventListeners();
+  }
+
+  /**
+   * Set up listeners for client-side navigation so that page context is
+   * re-sent to the bot whenever the URL changes (e.g. in SPAs).
+   *
+   * Listens for:
+   * - `popstate` — browser back/forward button
+   * - `ocs-navigation` — custom event dispatched by chat-widget-context.js
+   *   when `setupNavigationListener()` detects a pushState/replaceState call
+   */
+  private setupNavigationListeners(): void {
+    const handler = () => this.handleNavigationChange();
+    window.addEventListener('popstate', handler);
+    window.addEventListener('ocs-navigation', handler);
+    this.navigationCleanupFn = () => {
+      window.removeEventListener('popstate', handler);
+      window.removeEventListener('ocs-navigation', handler);
+    };
+  }
+
+  /**
+   * Called when a client-side navigation event is detected. If the URL has
+   * changed, marks the page context as stale so it is re-sent with the next
+   * outgoing message.
+   *
+   * - When `pageContext` prop is set: re-loads it (the host page is expected
+   *   to have already updated the prop via `setupNavigationListener`).
+   * - When no `pageContext` prop is configured: falls back to a minimal
+   *   context containing the new URL so the bot always knows where the user is.
+   */
+  private handleNavigationChange(): void {
+    const newUrl = window.location.href;
+    if (newUrl === this.currentPageUrl) {
+      return;
+    }
+    this.currentPageUrl = newUrl;
+
+    if (this.pageContext) {
+      // The host page (via setupNavigationListener) will have already updated
+      // the pageContext prop, triggering @Watch. Re-calling loadInternalPageContext
+      // here ensures we pick up the new value even if the Watch hasn't fired yet.
+      this.loadInternalPageContext();
+    } else {
+      // No external pageContext configured: send the new URL as minimal context.
+      this.internalPageContext = { url: newUrl };
+    }
   }
 
   private addEventListeners(): void {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,4 +17,12 @@ export default tseslint.config(
       }
     },
   },
+  {
+    files: ["**/*.test.js", "**/*.test.ts", "**/*.spec.ts", "**/*.spec.tsx"],
+    "languageOptions": {
+      "globals": {
+        ...globals.jest,
+      }
+    },
+  },
 );

--- a/templates/web/app/app_base.html
+++ b/templates/web/app/app_base.html
@@ -43,8 +43,8 @@
     >
     </open-chat-studio-widget>
     <script type="module">
-      import { initChatWidgetPageContext } from '{% static "js/modules/chat-widget-context.js" %}';
-      initChatWidgetPageContext({
+      import { initChatWidgetPageContext, setupNavigationListener } from '{% static "js/modules/chat-widget-context.js" %}';
+      const serverContext = {
         team: {% if request.team %}"{{ request.team.slug }}"{% else %}null{% endif %},
         activeTab: {% if active_tab %}"{{ active_tab }}"{% else %}null{% endif %},
         pageTitle: {% if page_title %}"{{ page_title|escapejs }}"{% else %}null{% endif %},
@@ -53,7 +53,9 @@
             { text: "{{ message.message|escapejs }}", level: "{{ message.tags|escapejs }}" }{% if not forloop.last %},{% endif %}
           {% endfor %}
         ]
-      });
+      };
+      initChatWidgetPageContext(serverContext);
+      setupNavigationListener(serverContext);
     </script>
   {% endif %}
 {% endblock footer %}


### PR DESCRIPTION
$Fixes #3691\n\n## What\n\nThe chat widget only sent `pageContext` once (on the first user message) and never re-sent it after client-side navigation. In SPAs, the URL and page title change without a full reload, so the bot was receiving stale (or no) context after the first route change.\n\n## Changes\n\n### `chat-widget-context.js`\n- Add `setupNavigationListener(serverContext)` — patches `history.pushState` / `history.replaceState` and listens for `popstate`. On each navigation it calls `initChatWidgetPageContext()` (so the widget prop is refreshed with new URL, title, breadcrumbs) and dispatches an `ocs-navigation` custom event.\n- Module-level guard prevents double-patching if called more than once.\n- New `chat-widget-context.test.js` covers all branches.\n\n### `app_base.html`\n- Import and call `setupNavigationListener()` alongside `initChatWidgetPageContext()` so OCS's own web app picks this up automatically.\n\n### `ocs-chat.tsx` (widget)\n- Tracks `currentPageUrl` from `componentDidLoad`.\n- Adds `setupNavigationListeners()` that listens for `popstate` and `ocs-navigation`; cleaned up in `disconnectedCallback`.\n- `handleNavigationChange()` fires on a real URL change:\n  - Re-calls `loadInternalPageContext()` when the `pageContext` prop is set (picks up the freshly-updated prop for the next send).\n  - Falls back to `internalPageContext = { url }` for embedders not using `chat-widget-context.js`.\n- 4 new spec cases.\n\n## How to test\n\n1. Open the OCS web app and navigate between pages — each new page visited should provide fresh context to the bot.\n2. For a third-party SPA embed: after calling `setupNavigationListener(serverContext)` once on page load, navigate with `history.pushState` — the widget automatically picks up the new URL on the next message.