### PR TITLE
feat: expose public event API on chat widget

### DIFF
--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.spec.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.spec.tsx
@@ -599,6 +599,49 @@ describe('ocs-chat', () => {
       expect(capturedRequestBody.context).toEqual(freshCtx);
     });
 
+    it('dispatches ocs:message:received for each non-user message via startMessagePolling', async () => {
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget chatbot-id="bot-1" visible></open-chat-studio-widget>`,
+      });
+
+      const component = page.rootInstance as OcsChat;
+      component.activeSessionId = 'poll-session';
+
+      const receivedEvents: CustomEvent[] = [];
+      page.root!.addEventListener('ocs:message:received', (e: Event) => {
+        receivedEvents.push(e as CustomEvent);
+      });
+
+      let capturedCallbacks: any = null;
+      (component as any).chatService = {
+        sendMessage: jest.fn(),
+        pollTask: jest.fn().mockReturnValue({ cancel: jest.fn() }),
+        stopMessagePolling: jest.fn(),
+        startMessagePolling: jest.fn().mockImplementation((_sessionId: string, callbacks: any) => {
+          capturedCallbacks = callbacks;
+          return { stop: jest.fn() };
+        }),
+        setSessionToken: jest.fn(),
+      };
+
+      // Trigger startMessagePolling by calling the private method directly
+      (component as any).startMessagePolling();
+
+      const assistantMessage = { created_at: '2026-01-01T00:00:00Z', role: 'assistant', content: 'Hello!' };
+      const userMessage = { created_at: '2026-01-01T00:00:01Z', role: 'user', content: 'Hi' };
+
+      capturedCallbacks.onMessages([assistantMessage, userMessage]);
+      await page.waitForChanges();
+
+      // Only the assistant message should fire ocs:message:received
+      expect(receivedEvents).toHaveLength(1);
+      expect(receivedEvents[0].detail).toEqual({
+        message: { ...assistantMessage },
+        sessionId: 'poll-session',
+      });
+    });
+
     // ocs:session:started is tested in ocs-chat_session_handling.spec.tsx
     // which has the full ChatSessionService module mock wired up.
 

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.spec.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.spec.tsx
@@ -453,4 +453,173 @@ describe('ocs-chat', () => {
       expect(starterQuestions).toBeTruthy();
     });
   });
+
+  describe('Public event API', () => {
+    function collectEvents(widget: Element, ...names: string[]): Record<string, CustomEvent[]> {
+      const collected: Record<string, CustomEvent[]> = {};
+      for (const name of names) {
+        collected[name] = [];
+        widget.addEventListener(name, (e: Event) => collected[name].push(e as CustomEvent));
+      }
+      return collected;
+    }
+
+    it('dispatches ocs:open when the widget becomes visible', async () => {
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget chatbot-id="bot-1"></open-chat-studio-widget>`,
+      });
+
+      const events = collectEvents(page.root!, 'ocs:open', 'ocs:close');
+
+      page.root!.visible = true;
+      await page.waitForChanges();
+
+      expect(events['ocs:open']).toHaveLength(1);
+      expect(events['ocs:close']).toHaveLength(0);
+    });
+
+    it('dispatches ocs:close when the widget is hidden', async () => {
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget chatbot-id="bot-1" visible></open-chat-studio-widget>`,
+      });
+
+      const events = collectEvents(page.root!, 'ocs:open', 'ocs:close');
+
+      page.root!.visible = false;
+      await page.waitForChanges();
+
+      expect(events['ocs:close']).toHaveLength(1);
+      expect(events['ocs:open']).toHaveLength(0);
+    });
+
+    it('ocs:open and ocs:close are composed and bubbling', async () => {
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget chatbot-id="bot-1"></open-chat-studio-widget>`,
+      });
+
+      let capturedOpen: CustomEvent | null = null;
+      page.root!.addEventListener('ocs:open', (e: Event) => {
+        capturedOpen = e as CustomEvent;
+      });
+
+      page.root!.visible = true;
+      await page.waitForChanges();
+
+      expect(capturedOpen).not.toBeNull();
+      expect((capturedOpen as unknown as CustomEvent).bubbles).toBe(true);
+      expect((capturedOpen as unknown as CustomEvent).composed).toBe(true);
+    });
+
+    it('ocs:message:before-send fires before ocs:message:sent', async () => {
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget chatbot-id="bot-1" visible></open-chat-studio-widget>`,
+      });
+
+      const component = page.rootInstance as OcsChat;
+      component.activeSessionId = 'session-abc';
+
+      const order: string[] = [];
+      page.root!.addEventListener('ocs:message:before-send', () => order.push('before'));
+      page.root!.addEventListener('ocs:message:sent', () => order.push('sent'));
+
+      (component as any).chatService = {
+        sendMessage: jest.fn().mockResolvedValue({ status: 'processing', task_id: 'task-1' }),
+        pollTask: jest.fn().mockReturnValue({ cancel: jest.fn() }),
+        stopMessagePolling: jest.fn(),
+        startMessagePolling: jest.fn().mockReturnValue({ stop: jest.fn() }),
+        setSessionToken: jest.fn(),
+      };
+
+      await (component as any).sendMessage('hello');
+
+      expect(order[0]).toBe('before');
+      expect(order[1]).toBe('sent');
+    });
+
+    it('ocs:message:before-send detail contains message and sessionId', async () => {
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget chatbot-id="bot-1" visible></open-chat-studio-widget>`,
+      });
+
+      const component = page.rootInstance as OcsChat;
+      component.activeSessionId = 'session-xyz';
+
+      let detail: any = null;
+      page.root!.addEventListener('ocs:message:before-send', (e: Event) => {
+        detail = (e as CustomEvent).detail;
+      });
+
+      (component as any).chatService = {
+        sendMessage: jest.fn().mockResolvedValue({ status: 'processing', task_id: 't1' }),
+        pollTask: jest.fn().mockReturnValue({ cancel: jest.fn() }),
+        stopMessagePolling: jest.fn(),
+        startMessagePolling: jest.fn().mockReturnValue({ stop: jest.fn() }),
+        setSessionToken: jest.fn(),
+      };
+
+      await (component as any).sendMessage('test message');
+
+      expect(detail).toEqual({ message: 'test message', sessionId: 'session-xyz' });
+    });
+
+    it('ocs:message:before-send allows pageContext to be updated before the API call', async () => {
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget chatbot-id="bot-1" visible></open-chat-studio-widget>`,
+      });
+
+      const component = page.rootInstance as OcsChat;
+      component.activeSessionId = 'session-ctx';
+
+      const freshCtx = { url: '/new-page', title: 'New Page' };
+      page.root!.addEventListener('ocs:message:before-send', () => {
+        // Simulate what an embedder would do: update pageContext at send time
+        page.root!.pageContext = freshCtx;
+      });
+
+      let capturedRequestBody: any = null;
+      (component as any).chatService = {
+        sendMessage: jest.fn().mockImplementation((_: string, body: unknown) => {
+          capturedRequestBody = body;
+          return Promise.resolve({ status: 'processing', task_id: 't1' });
+        }),
+        pollTask: jest.fn().mockReturnValue({ cancel: jest.fn() }),
+        stopMessagePolling: jest.fn(),
+        startMessagePolling: jest.fn().mockReturnValue({ stop: jest.fn() }),
+        setSessionToken: jest.fn(),
+      };
+
+      await (component as any).sendMessage('hello');
+
+      expect(capturedRequestBody.context).toEqual(freshCtx);
+    });
+
+    // ocs:session:started is tested in ocs-chat_session_handling.spec.tsx
+    // which has the full ChatSessionService module mock wired up.
+
+    it('dispatches ocs:session:ended with sessionId when session ends', async () => {
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget chatbot-id="bot-1" visible></open-chat-studio-widget>`,
+      });
+
+      const component = page.rootInstance as OcsChat;
+      component.activeSessionId = 'ending-session';
+      (component as any).chatService = { stopMessagePolling: jest.fn() };
+
+      let detail: any = null;
+      page.root!.addEventListener('ocs:session:ended', (e: Event) => {
+        detail = (e as CustomEvent).detail;
+      });
+
+      (component as any).handleSessionEnded();
+
+      expect(detail).toEqual({ sessionId: 'ending-session' });
+    });
+  });
 });

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -968,6 +968,14 @@ export class OcsChat {
         if (messages.length === 0) return;
         this.messages = [...this.messages, ...messages];
         this.saveSessionToStorage();
+        for (const message of messages) {
+          if (message.role !== 'user') {
+            this.dispatchWidgetEvent('ocs:message:received', {
+              message: { ...message },
+              sessionId: this.activeSessionId ?? '',
+            });
+          }
+        }
         this.scrollToBottom();
         this.focusInput();
       },

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -358,6 +358,27 @@ export class OcsChat {
     window.removeEventListener('resize', this.handleWindowResize);
   }
 
+  // ---------------------------------------------------------------------------
+  // Public event API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Dispatch a composed, bubbling CustomEvent on the host element so that
+   * embedders can listen with plain addEventListener outside the shadow root.
+   *
+   * All events are dispatched synchronously so that handlers can update
+   * reactive props (e.g. `pageContext`) before the calling code reads them.
+   */
+  private dispatchWidgetEvent<T extends Record<string, unknown> | null>(name: string, detail: T = null as unknown as T): void {
+    this.host.dispatchEvent(
+      new CustomEvent<T>(name, {
+        bubbles: true,
+        composed: true,
+        detail,
+      }),
+    );
+  }
+
   private applySessionToken(token?: string): void {
     this.currentSessionToken = token;
     this.chatService?.setSessionToken(token);
@@ -425,6 +446,7 @@ export class OcsChat {
       return;
     }
     this.sessionEnded = true;
+    this.dispatchWidgetEvent('ocs:session:ended', { sessionId: this.activeSessionId });
     this.stopMessagePolling();
     this.isTyping = false;
     this.typingProgressMessage = '';
@@ -556,6 +578,7 @@ export class OcsChat {
       this.activeSessionId = data.session_id;
       this.applySessionToken(data.session_token ?? undefined);
       this.saveSessionToStorage();
+      this.dispatchWidgetEvent('ocs:session:started', { sessionId: this.activeSessionId });
 
       this.startMessagePolling();
     } catch (_error) {
@@ -684,6 +707,13 @@ export class OcsChat {
       }
       this.scrollToBottom();
 
+      // Fire before-send first so handlers can update pageContext synchronously
+      // before we read internalPageContext into the request body.
+      this.dispatchWidgetEvent('ocs:message:before-send', {
+        message: message.trim(),
+        sessionId: this.activeSessionId ?? '',
+      });
+
       const requestBody: any = { message: message.trim() };
       if (this.allowAttachments && attachmentIds.length > 0) {
         requestBody.attachment_ids = attachmentIds;
@@ -703,6 +733,10 @@ export class OcsChat {
       }
 
       this.internalPageContext = undefined;
+      this.dispatchWidgetEvent('ocs:message:sent', {
+        message: message.trim(),
+        sessionId: this.activeSessionId,
+      });
       this.startTaskPolling(data.task_id);
     } catch (error) {
       if (epoch !== this.sessionEpoch) return;
@@ -831,6 +865,7 @@ export class OcsChat {
     }
 
     this.saveVisibleState(visible);
+    this.dispatchWidgetEvent(visible ? 'ocs:open' : 'ocs:close');
 
     if (this.isButtonDragging) {
       this.isButtonDragging = false;
@@ -873,6 +908,10 @@ export class OcsChat {
       onMessage: message => {
         this.messages = [...this.messages, message];
         this.saveSessionToStorage();
+        this.dispatchWidgetEvent('ocs:message:received', {
+          message: { ...message },
+          sessionId: this.activeSessionId ?? '',
+        });
         this.scrollToBottom();
         this.isTyping = false;
         this.typingProgressMessage = '';

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat_session_handling.spec.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat_session_handling.spec.tsx
@@ -903,6 +903,23 @@ describe('ocs-chat session tokens', () => {
     expect(systemMessage).toBeDefined();
   });
 
+  it('dispatches ocs:session:started when a new session is created', async () => {
+    // beforeEach configures mockStartSession to return session_id: 'test-session-id'
+    const page = await newSpecPage({
+      components: [OcsChat],
+      html: '<open-chat-studio-widget chatbot-id="test-bot" visible="true"></open-chat-studio-widget>',
+    });
+
+    const dispatched: CustomEvent[] = [];
+    page.root!.addEventListener('ocs:session:started', (e: Event) => dispatched.push(e as CustomEvent));
+
+    await page.rootInstance.sendMessage('hello');
+    await page.waitForChanges();
+
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].detail).toEqual({ sessionId: 'test-session-id' });
+  });
+
   it('on a bound 403 it surfaces an error and stays bound', async () => {
     const page = await newSpecPage({
       components: [OcsChat],


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->

Closes #3695

### Product Description

Adds a public JavaScript event API to the chat widget so embedders can react to widget lifecycle events using standard `addEventListener`. This enables use cases like tracking when a user opens the widget, monitoring messages, or lazily updating page context just before a message is sent.

### Technical Description

All events are dispatched on the `<open-chat-studio-widget>` host element with `bubbles: true, composed: true` so they escape the shadow DOM and are catchable on the host page.

| Event | Fired when | Detail |
|---|---|---|
| `ocs:open` | Widget becomes visible | — |
| `ocs:close` | Widget is hidden | — |
| `ocs:message:before-send` | Before message is sent to the API | `{ message, sessionId }` |
| `ocs:message:sent` | Message dispatched to the API | `{ message, sessionId }` |
| `ocs:message:received` | Bot reply delivered | `{ message: ChatMessage, sessionId }` |
| `ocs:session:started` | New session created | `{ sessionId }` |
| `ocs:session:ended` | Server ended the session | `{ sessionId }` |

A shared `dispatchWidgetEvent` helper is used throughout to keep payloads consistent.

Key design decisions:
- `ocs:message:before-send` fires **synchronously** before the API call, so a handler can update `pageContext` and have it picked up in that same send
- `ocs:message:received` is dispatched from **both** the `pollTask` path (direct reply to a sent message) and the `startMessagePolling` path (resumed/bound sessions, server-pushed messages), filtering to non-`user` roles to avoid echoing the participant's own messages.

### Demo

```js
const widget = document.querySelector("open-chat-studio-widget");

// Lazy pageContext update just before send
widget.addEventListener("ocs:message:before-send", () => {
  widget.pageContext = getClientPageContext();
});

// Track bot replies
widget.addEventListener("ocs:message:received", (e) => {
  console.log("Bot said:", e.detail.message.content);
});
```

### Docs and Changelog
- [x] This PR requires docs/changelog update
