### PR TITLE
fix(api): participants list endpoint reads the documented `chatbot` query param

### DIFF
--- a/apps/api/tests/test_participant_api.py
+++ b/apps/api/tests/test_participant_api.py
@@ -126,6 +126,60 @@ def test_list_participants_filter_by_experiment():
 
 
 @pytest.mark.django_db()
+def test_list_participants_filter_by_chatbot():
+    """The documented `chatbot` query param filters to that chatbot's participants/data."""
+    team = TeamWithUsersFactory.create()
+    experiment1 = ExperimentFactory.create(team=team)
+    experiment2 = ExperimentFactory.create(team=team)
+
+    p1 = ParticipantFactory.create(team=team, identifier="alice", platform="api")
+    p2 = ParticipantFactory.create(team=team, identifier="bob", platform="api")
+    p3 = ParticipantFactory.create(team=team, identifier="carol", platform="api")
+    ParticipantData.objects.create(team=team, participant=p1, experiment=experiment1, data={"x": 1})
+    ParticipantData.objects.create(team=team, participant=p2, experiment=experiment2, data={"x": 2})
+    ParticipantData.objects.create(team=team, participant=p3, experiment=experiment1, data={"x": 3})
+    ParticipantData.objects.create(team=team, participant=p3, experiment=experiment2, data={"x": 4})
+
+    user = team.members.first()
+    client = ApiTestClient(user, team)
+    url = reverse("api:participant-data") + f"?chatbot={experiment1.public_id}"
+    response = client.get(url)
+    assert response.status_code == 200
+    results = response.json()["results"]
+    by_identifier = {p["identifier"]: p for p in results}
+    assert set(by_identifier) == {"alice", "carol"}
+    # alice only has data for experiment1
+    assert len(by_identifier["alice"]["data"]) == 1
+    assert by_identifier["alice"]["data"][0]["chatbot_id"] == str(experiment1.public_id)
+    assert by_identifier["alice"]["data"][0]["data"] == {"x": 1}
+    # carol has data for both chatbots but only experiment1's data should be returned
+    assert len(by_identifier["carol"]["data"]) == 1
+    assert by_identifier["carol"]["data"][0]["chatbot_id"] == str(experiment1.public_id)
+    assert by_identifier["carol"]["data"][0]["data"] == {"x": 3}
+
+
+@pytest.mark.django_db()
+def test_list_participants_chatbot_takes_precedence_over_experiment_alias():
+    """When both are supplied, the documented `chatbot` param wins over the legacy `experiment` alias."""
+    team = TeamWithUsersFactory.create()
+    experiment1 = ExperimentFactory.create(team=team)
+    experiment2 = ExperimentFactory.create(team=team)
+
+    p1 = ParticipantFactory.create(team=team, identifier="alice", platform="api")
+    p2 = ParticipantFactory.create(team=team, identifier="bob", platform="api")
+    ParticipantData.objects.create(team=team, participant=p1, experiment=experiment1, data={"x": 1})
+    ParticipantData.objects.create(team=team, participant=p2, experiment=experiment2, data={"x": 2})
+
+    user = team.members.first()
+    client = ApiTestClient(user, team)
+    url = reverse("api:participant-data") + f"?chatbot={experiment1.public_id}&experiment={experiment2.public_id}"
+    response = client.get(url)
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert {p["identifier"] for p in results} == {"alice"}
+
+
+@pytest.mark.django_db()
 def test_list_participants_filter_by_experiment_unknown_returns_empty():
     team = TeamWithUsersFactory.create()
     experiment = ExperimentFactory.create(team=team)

--- a/apps/api/tests/test_participant_api.py
+++ b/apps/api/tests/test_participant_api.py
@@ -93,8 +93,17 @@ def test_list_participants_scoped_to_team():
     assert "t2user" not in identifiers
 
 
+# The endpoint accepts both the documented `chatbot` param and the deprecated `experiment`
+# alias; the same filtering behaviour must hold for either name.
+FILTER_PARAM_CASES = [
+    pytest.param("chatbot", id="documented_chatbot_param"),
+    pytest.param("experiment", id="deprecated_experiment_alias"),
+]
+
+
 @pytest.mark.django_db()
-def test_list_participants_filter_by_experiment():
+@pytest.mark.parametrize("filter_param", FILTER_PARAM_CASES)
+def test_list_participants_filter_by_chatbot(filter_param):
     team = TeamWithUsersFactory.create()
     experiment1 = ExperimentFactory.create(team=team)
     experiment2 = ExperimentFactory.create(team=team)
@@ -109,40 +118,7 @@ def test_list_participants_filter_by_experiment():
 
     user = team.members.first()
     client = ApiTestClient(user, team)
-    url = reverse("api:participant-data") + f"?experiment={experiment1.public_id}"
-    response = client.get(url)
-    assert response.status_code == 200
-    results = response.json()["results"]
-    by_identifier = {p["identifier"]: p for p in results}
-    assert set(by_identifier) == {"alice", "carol"}
-    # alice only has data for experiment1
-    assert len(by_identifier["alice"]["data"]) == 1
-    assert by_identifier["alice"]["data"][0]["chatbot_id"] == str(experiment1.public_id)
-    assert by_identifier["alice"]["data"][0]["data"] == {"x": 1}
-    # carol has data for both experiments but only experiment1's data should be returned
-    assert len(by_identifier["carol"]["data"]) == 1
-    assert by_identifier["carol"]["data"][0]["chatbot_id"] == str(experiment1.public_id)
-    assert by_identifier["carol"]["data"][0]["data"] == {"x": 3}
-
-
-@pytest.mark.django_db()
-def test_list_participants_filter_by_chatbot():
-    """The documented `chatbot` query param filters to that chatbot's participants/data."""
-    team = TeamWithUsersFactory.create()
-    experiment1 = ExperimentFactory.create(team=team)
-    experiment2 = ExperimentFactory.create(team=team)
-
-    p1 = ParticipantFactory.create(team=team, identifier="alice", platform="api")
-    p2 = ParticipantFactory.create(team=team, identifier="bob", platform="api")
-    p3 = ParticipantFactory.create(team=team, identifier="carol", platform="api")
-    ParticipantData.objects.create(team=team, participant=p1, experiment=experiment1, data={"x": 1})
-    ParticipantData.objects.create(team=team, participant=p2, experiment=experiment2, data={"x": 2})
-    ParticipantData.objects.create(team=team, participant=p3, experiment=experiment1, data={"x": 3})
-    ParticipantData.objects.create(team=team, participant=p3, experiment=experiment2, data={"x": 4})
-
-    user = team.members.first()
-    client = ApiTestClient(user, team)
-    url = reverse("api:participant-data") + f"?chatbot={experiment1.public_id}"
+    url = reverse("api:participant-data") + f"?{filter_param}={experiment1.public_id}"
     response = client.get(url)
     assert response.status_code == 200
     results = response.json()["results"]
@@ -180,7 +156,8 @@ def test_list_participants_chatbot_takes_precedence_over_experiment_alias():
 
 
 @pytest.mark.django_db()
-def test_list_participants_filter_by_experiment_unknown_returns_empty():
+@pytest.mark.parametrize("filter_param", FILTER_PARAM_CASES)
+def test_list_participants_filter_unknown_returns_empty(filter_param):
     team = TeamWithUsersFactory.create()
     experiment = ExperimentFactory.create(team=team)
     p1 = ParticipantFactory.create(team=team, identifier="alice", platform="api")
@@ -188,22 +165,24 @@ def test_list_participants_filter_by_experiment_unknown_returns_empty():
 
     user = team.members.first()
     client = ApiTestClient(user, team)
-    # nil UUID, no experiment owns this id
-    url = reverse("api:participant-data") + "?experiment=00000000-0000-0000-0000-000000000000"
+    # nil UUID, no chatbot owns this id
+    url = reverse("api:participant-data") + f"?{filter_param}=00000000-0000-0000-0000-000000000000"
     response = client.get(url)
     assert response.status_code == 200
     assert response.json()["results"] == []
 
 
 @pytest.mark.django_db()
-def test_list_participants_filter_by_experiment_invalid_uuid():
+@pytest.mark.parametrize("filter_param", FILTER_PARAM_CASES)
+def test_list_participants_filter_invalid_uuid(filter_param):
     team = TeamWithUsersFactory.create()
     user = team.members.first()
     client = ApiTestClient(user, team)
-    url = reverse("api:participant-data") + "?experiment=not-a-uuid"
+    url = reverse("api:participant-data") + f"?{filter_param}=not-a-uuid"
     response = client.get(url)
     assert response.status_code == 400
-    assert "experiment" in response.json()
+    # the validation error is reported under the param the caller actually used
+    assert filter_param in response.json()
 
 
 @pytest.mark.django_db()

--- a/apps/api/views/participants.py
+++ b/apps/api/views/participants.py
@@ -102,8 +102,11 @@ class ParticipantView(APIView):
             qs = qs.filter(platform=platform)
         # "chatbot" is the documented (OpenApiParameter) name; "experiment" is kept as a
         # deprecated fallback alias for older callers. Both take a chatbot/experiment public UUID.
-        chatbot_param = request.query_params.get("chatbot") or request.query_params.get("experiment")
-        if experiment_uuid := _parse_experiment_uuid(chatbot_param):
+        # Report validation errors under whichever param the caller actually used.
+        chatbot_param = request.query_params.get("chatbot")
+        param_name = "chatbot" if chatbot_param else "experiment"
+        chatbot_param = chatbot_param or request.query_params.get("experiment")
+        if experiment_uuid := _parse_experiment_uuid(chatbot_param, param_name=param_name):
             data_qs = data_qs.filter(experiment__public_id=experiment_uuid)
             qs = qs.filter(id__in=data_qs.values_list("participant_id", flat=True))
         qs = qs.prefetch_related(Prefetch("data_set", queryset=data_qs, to_attr="_prefetched_participant_data"))
@@ -192,13 +195,13 @@ class ParticipantView(APIView):
         return _update_participant_data(request)
 
 
-def _parse_experiment_uuid(value):
+def _parse_experiment_uuid(value, *, param_name="chatbot"):
     if not value:
         return None
     try:
         return uuid.UUID(value)
     except ValueError as e:
-        raise ValidationError({"experiment": "Must be a valid UUID."}) from e
+        raise ValidationError({param_name: "Must be a valid UUID."}) from e
 
 
 def _update_participant_data(request):

--- a/apps/api/views/participants.py
+++ b/apps/api/views/participants.py
@@ -100,7 +100,10 @@ class ParticipantView(APIView):
             qs = qs.filter(identifier=identifier)
         if platform := request.query_params.get("platform"):
             qs = qs.filter(platform=platform)
-        if experiment_uuid := _parse_experiment_uuid(request.query_params.get("experiment")):
+        # "chatbot" is the documented (OpenApiParameter) name; "experiment" is kept as a
+        # deprecated fallback alias for older callers. Both take a chatbot/experiment public UUID.
+        chatbot_param = request.query_params.get("chatbot") or request.query_params.get("experiment")
+        if experiment_uuid := _parse_experiment_uuid(chatbot_param):
             data_qs = data_qs.filter(experiment__public_id=experiment_uuid)
             qs = qs.filter(id__in=data_qs.values_list("participant_id", flat=True))
         qs = qs.prefetch_related(Prefetch("data_set", queryset=data_qs, to_attr="_prefetched_participant_data"))


### PR DESCRIPTION
## Problem

`GET /api/participants` (`ParticipantView.get`) documents a `chatbot` filter via `OpenApiParameter(name="chatbot", ...)`, and the generated `api-schemas/v1.yml` advertises `chatbot` as the query param. But the handler actually read the **wrong** param name:

```python
if experiment_uuid := _parse_experiment_uuid(request.query_params.get("experiment")):
```

So the documented `chatbot` filter was **silently ignored**. A caller sending `chatbot=<chatbot_public_id>` — e.g. Scout's OCS participant loader — got **all** of the team's participants instead of just that chatbot's. (The undocumented `experiment` name was the only one that worked.)

## Fix

Read the documented `chatbot` param, falling back to the legacy `experiment` name as a deprecated alias (so any caller/test still passing `experiment=` keeps working; `chatbot` wins when both are supplied):

```python
chatbot_param = request.query_params.get("chatbot") or request.query_params.get("experiment")
if experiment_uuid := _parse_experiment_uuid(chatbot_param):
```

The filter value is still a chatbot/experiment public UUID, so only the param **name** changes — `_parse_experiment_uuid` and the `experiment__public_id` filter logic are unchanged. The generated OpenAPI schema already documents `chatbot`, so code and contract are now aligned (no schema regen needed).

### Why keep `experiment` as a fallback?

Three existing tests in `apps/api/tests/test_participant_api.py` pass `?experiment=` to this endpoint (`test_list_participants_filter_by_experiment`, `..._unknown_returns_empty`, `..._invalid_uuid`). To avoid breaking any caller that adopted the undocumented name, `experiment` is retained as a deprecated alias rather than hard-removed. Happy to drop it entirely if the team prefers a clean break.

## Tests

Added:
- `test_list_participants_filter_by_chatbot` — the documented `chatbot` param filters to that chatbot's participants/data.
- `test_list_participants_chatbot_takes_precedence_over_experiment_alias` — `chatbot` wins over the legacy `experiment` alias when both are supplied.

Both **fail** on `main` (param ignored) and **pass** with this change. The existing `experiment` tests continue to pass via the fallback.

```
# before fix (origin/main view), new tests:
FAILED apps/api/tests/test_participant_api.py::test_list_participants_filter_by_chatbot
FAILED apps/api/tests/test_participant_api.py::test_list_participants_chatbot_takes_precedence_over_experiment_alias

# after fix, full module:
12 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)