### PR TITLE
Add team metadata columns to admin usage export

### DIFF
--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -40,7 +40,13 @@ def get_participant_stats(start: datetime, end: datetime):
 
 
 def usage_to_csv(start: datetime, end: datetime):
-    return _write_data_to_csv(["Team", "Run Count", "Total Tokens"], get_usage_data(start, end))
+    metadata_fields = get_team_metadata_fields()
+    headers = ["Team", "Run Count", "Total Tokens"] + [field["label"] for field in metadata_fields]
+    rows = (
+        (team_name, run_count, total_tokens, *(metadata.get(field["key"], "") for field in metadata_fields))
+        for team_name, run_count, total_tokens, metadata in get_usage_data(start, end)
+    )
+    return _write_data_to_csv(headers, rows)
 
 
 def get_usage_data(start: datetime, end: datetime):
@@ -54,7 +60,7 @@ def get_usage_data(start: datetime, end: datetime):
         Trace.objects.filter(timestamp__gte=start, timestamp__lt=end)
         .exclude(status=TraceStatus.PENDING)
         .exclude(session__platform=ChannelPlatform.EVALUATIONS)
-        .values("team_id", "team__name")
+        .values("team_id", "team__name", "team__metadata")
         .annotate(
             run_count=Count("id"),
             total_tokens=Coalesce(Sum("n_total_tokens"), Value(0)),
@@ -62,7 +68,7 @@ def get_usage_data(start: datetime, end: datetime):
         .order_by("-run_count", "team__name")
     )
     for data in usage_data:
-        yield data["team__name"], data["run_count"], data["total_tokens"]
+        yield data["team__name"], data["run_count"], data["total_tokens"], data["team__metadata"] or {}
 
 
 def get_whatsapp_numbers():

--- a/apps/admin/tests/test_queries.py
+++ b/apps/admin/tests/test_queries.py
@@ -14,6 +14,7 @@ from apps.admin.queries import (
     get_whatsapp_number_data,
     team_metadata_to_csv,
     top_teams_to_csv,
+    usage_to_csv,
 )
 from apps.admin.views import _compute_growth
 from apps.channels.models import ChannelPlatform
@@ -77,6 +78,25 @@ class TestTeamMetadataExports:
         assert lines[0] == "Team,Messages,Sessions,Participants,Team Owner"
         assert lines[1].startswith("Team A,")
         assert lines[1].endswith(",Jane Doe")
+
+    def test_usage_csv_includes_metadata_columns(self, date_range, settings):
+        settings.TEAM_METADATA_FIELDS = [{"key": "team_owner", "label": "Team Owner"}]
+        start, end = date_range
+        team = TeamFactory.create(name="Team A", metadata={"team_owner": "Jane Doe"})
+        session = ExperimentSessionFactory.create(team=team, experiment__team=team)
+        TraceFactory.create(
+            team=team,
+            experiment=session.experiment,
+            session=session,
+            participant=session.participant,
+            status=TraceStatus.SUCCESS,
+            n_total_tokens=100,
+        )
+
+        csv_output = usage_to_csv(start, end)
+        lines = csv_output.strip().splitlines()
+        assert lines[0] == "Team,Run Count,Total Tokens,Team Owner"
+        assert lines[1] == "Team A,1,100,Jane Doe"
 
     def test_team_metadata_csv_lists_all_teams(self, settings):
         settings.TEAM_METADATA_FIELDS = [{"key": "team_owner", "label": "Team Owner"}]
@@ -314,7 +334,7 @@ class TestGetUsageData:
         self._make_trace(session=session_a, tokens=50)
         self._make_trace(session=session_b, tokens=200)
 
-        rows = {team: (run_count, tokens) for team, run_count, tokens in get_usage_data(start, end)}
+        rows = {team: (run_count, tokens) for team, run_count, tokens, _ in get_usage_data(start, end)}
         assert rows["Team A"] == (2, 150)
         assert rows["Team B"] == (1, 200)
 
@@ -353,7 +373,7 @@ class TestGetUsageData:
         self._make_trace(session=eval_session, tokens=99999)
 
         rows = list(get_usage_data(start, end))
-        assert rows == [("T", 1, 100)]
+        assert rows == [("T", 1, 100, {})]
 
     def test_excludes_pending_traces_but_includes_errors(self, date_range):
         start, end = date_range
@@ -364,7 +384,7 @@ class TestGetUsageData:
         self._make_trace(session=session, status=TraceStatus.PENDING, tokens=99999)
 
         rows = list(get_usage_data(start, end))
-        assert rows == [("T", 2, 15)]
+        assert rows == [("T", 2, 15, {})]
 
     def test_handles_null_token_counts(self, date_range):
         start, end = date_range
@@ -379,7 +399,7 @@ class TestGetUsageData:
         )
 
         rows = list(get_usage_data(start, end))
-        assert rows == [("T", 1, 0)]
+        assert rows == [("T", 1, 0, {})]
 
     def test_does_not_merge_teams_sharing_a_display_name(self, date_range):
         # Team.name has no uniqueness constraint, so grouping by name alone would
@@ -413,7 +433,7 @@ class TestGetUsageData:
         Trace.objects.filter(id=in_window.id).update(timestamp=start + timedelta(seconds=1))
 
         rows = list(get_usage_data(start, end))
-        assert rows == [("T", 1, 10)]
+        assert rows == [("T", 1, 10, {})]
 
 
 class TestComputeGrowth:


### PR DESCRIPTION
### Product Description
The admin **Usage** CSV export now includes the configurable team metadata columns (e.g. Team Owner), matching the Top Teams and Team Metadata exports.

### Technical Description
`usage_to_csv` was the only metadata-aware-capable export still emitting just `Team, Run Count, Total Tokens`. It now appends one column per `TEAM_METADATA_FIELDS` entry, reusing the same `get_team_metadata_fields()` flow as the other exports. The metadata comes from the existing per-`team_id` aggregation in `get_usage_data` (added `team__metadata` to `.values()`), so no extra query — `get_usage_data` now yields the metadata dict as a 4th tuple element.

### Migrations
N/A — no schema changes.

### Docs and Changelog
- [ ] This PR requires docs/changelog update