### PR TITLE
Migrate SureAdhere to v2 channels framework

### DIFF
--- a/apps/channels/channels_v2/sureadhere_channel.py
+++ b/apps/channels/channels_v2/sureadhere_channel.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from apps.channels.channels_v2.callbacks import ChannelCallbacks
+from apps.channels.channels_v2.capabilities import ChannelCapabilities
+from apps.channels.channels_v2.channel_base import ChannelBase
+from apps.channels.channels_v2.sender import ChannelSender
+from apps.channels.models import ChannelPlatform
+
+if TYPE_CHECKING:
+    from apps.channels.channels_v2.pipeline import MessageProcessingContext
+    from apps.channels.models import ExperimentChannel
+    from apps.experiments.models import Experiment, ExperimentSession
+    from apps.service_providers.messaging_service import MessagingService
+
+logger = logging.getLogger("ocs.channels")
+
+
+class SureAdhereSender(ChannelSender):
+    """Delivers text messages over SureAdhere via the configured messaging service.
+
+    SureAdhere is text-only: voice and file sending are not supported, so only
+    send_text is overridden.
+    """
+
+    def __init__(self, service: MessagingService, tenant_id: str) -> None:
+        self._service = service
+        self._tenant_id = tenant_id
+        self._ctx: MessageProcessingContext | None = None
+
+    def bind(self, ctx: MessageProcessingContext) -> None:
+        self._ctx = ctx
+
+    def send_text(self, text: str, recipient: str) -> None:
+        self._service.send_text_message(
+            message=text,
+            from_=self._tenant_id,
+            to=recipient,
+            platform=ChannelPlatform.SUREADHERE,
+            last_activity_at=self._ctx.last_activity_at if self._ctx else None,
+        )
+
+
+class SureAdhereChannel(ChannelBase):
+    """Text-only channel backed by the SureAdhere messaging service.
+
+    Capabilities (supported message types) are read from the messaging service,
+    which is text-only. No voice, multimedia, or file support.
+    """
+
+    def __init__(
+        self,
+        experiment: Experiment,
+        experiment_channel: ExperimentChannel,
+        experiment_session: ExperimentSession | None = None,
+    ) -> None:
+        super().__init__(experiment, experiment_channel, experiment_session)
+        self._messaging_service_cache: MessagingService | None = None
+
+    @property
+    def messaging_service(self) -> MessagingService:
+        if self._messaging_service_cache is None:
+            self._messaging_service_cache = self.experiment_channel.messaging_provider.get_messaging_service()
+        return self._messaging_service_cache
+
+    @property
+    def _tenant_id(self) -> str:
+        return self.experiment_channel.extra_data.get("sureadhere_tenant_id")
+
+    def _get_sender(self) -> SureAdhereSender:
+        return SureAdhereSender(service=self.messaging_service, tenant_id=self._tenant_id)
+
+    def _get_callbacks(self) -> ChannelCallbacks:
+        return ChannelCallbacks()
+
+    def _get_capabilities(self) -> ChannelCapabilities:
+        return ChannelCapabilities(
+            supports_voice_replies=self.messaging_service.voice_replies_supported,
+            supports_files=self.messaging_service.supports_multimedia,
+            supports_conversational_consent=True,
+            supported_message_types=tuple(self.messaging_service.supported_message_types),
+        )

--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -10,6 +10,7 @@ from twilio.request_validator import RequestValidator
 from apps.channels.channels_v2.api_channel import ApiChannel
 from apps.channels.channels_v2.connect_channel import CommCareConnectChannel
 from apps.channels.channels_v2.evaluation_channel import EvaluationChannel
+from apps.channels.channels_v2.sureadhere_channel import SureAdhereChannel
 from apps.channels.channels_v2.telegram_channel import TelegramChannel
 from apps.channels.channels_v2.whatsapp_channel import WhatsappChannel
 from apps.channels.clients.connect_client import CommCareConnectClient, Message
@@ -24,7 +25,6 @@ from apps.channels.datamodels import EmailMessage as EmailMessageDatamodel
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.channels import (
     FacebookMessengerChannel,
-    SureAdhereChannel,
 )
 from apps.chat.models import ChatMessage
 from apps.chatbots.version_resolver import resolve_published_or_working

--- a/apps/channels/tests/test_sureadhere_integration.py
+++ b/apps/channels/tests/test_sureadhere_integration.py
@@ -47,4 +47,9 @@ class TestSureAdhere:
             sureadhere_tenant_id=sureadhere_channel.extra_data["sureadhere_tenant_id"],
             message_data=sureadhere_messages.inbound_message(),
         )
-        send_text_message.assert_called()
+        send_text_message.assert_called_once()
+        kwargs = send_text_message.call_args.kwargs
+        assert kwargs["message"] == "Hi"
+        assert kwargs["from_"] == sureadhere_channel.extra_data["sureadhere_tenant_id"]
+        assert kwargs["to"] == "6225"
+        assert kwargs["platform"] == ChannelPlatform.SUREADHERE

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -344,7 +344,11 @@ class ChannelBase(ABC):
 
             channel_cls = NewApiChannel
         elif platform == "sureadhere":
-            channel_cls = SureAdhereChannel
+            from apps.channels.channels_v2.sureadhere_channel import (  # noqa: PLC0415
+                SureAdhereChannel as NewSureAdhereChannel,
+            )
+
+            channel_cls = NewSureAdhereChannel
         elif platform == "slack":
             channel_cls = SlackChannel
         elif platform == "commcare_connect":
@@ -1243,23 +1247,6 @@ class WhatsappChannel(ChannelBase):
             )
         except Exception:
             logger.exception("Failed to send typing indicator")
-
-
-class SureAdhereChannel(ChannelBase):
-    def send_text_to_user(self, text: str):
-        from_ = self.experiment_channel.extra_data.get("sureadhere_tenant_id")
-        to_patient = self.participant_identifier
-        self.messaging_service.send_text_message(
-            message=text,
-            from_=from_,
-            to=to_patient,
-            platform=ChannelPlatform.SUREADHERE,
-            last_activity_at=self.last_activity_at,
-        )
-
-    @property
-    def supported_message_types(self):
-        return self.messaging_service.supported_message_types
 
 
 class FacebookMessengerChannel(ChannelBase):


### PR DESCRIPTION
### Product Description
No change. Internal refactor — SureAdhere messaging behaves identically.

### Technical Description
Moves SureAdhere onto the v2 channels framework (#3329), replacing the old `ChannelBase` subclass in `apps/chat/channels.py` with a pipeline-based channel in `channels_v2/`.

SureAdhere is text-only, so the new channel is minimal: a `SureAdhereSender` that delivers via the messaging service (`from_=tenant_id`, `to=recipient`), default no-op callbacks (no voice/transcription), and capabilities read from the messaging service. Both dispatch points (`handle_sureadhere_message` task and `get_channel_class_for_platform`) now resolve the v2 class.

### Migrations
N/A — no schema changes.

### Docs and Changelog
- [ ] This PR requires docs/changelog update