### PR TITLE
Upgrade chat widget to 0.10.0

### DIFF
--- a/apps/channels/widget_versions.py
+++ b/apps/channels/widget_versions.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.utils.http import http_date
 from packaging.version import InvalidVersion, Version
 
-LATEST_VERSION = "0.9.1"
+LATEST_VERSION = "0.10.0"
 
 # Widgets older than 0.5.1 (Sept 2025) do not send the x-ocs-widget-version
 # header, so a missing/unparseable version is treated as older than everything.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "js-cookie": "^3.0.7",
         "js-tiktoken": "^1.0.21",
         "lodash": "^4.17.23",
-        "open-chat-studio-widget": "^0.9.1",
+        "open-chat-studio-widget": "^0.10.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-error-boundary": "^6.0.1",
@@ -145,6 +145,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.6.tgz",
       "integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.6",
@@ -1937,6 +1938,7 @@
     "node_modules/@codemirror/view": {
       "version": "6.35.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "style-mod": "^4.1.0",
@@ -3686,6 +3688,7 @@
     "node_modules/@types/react": {
       "version": "19.2.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3921,6 +3924,7 @@
       "version": "8.54.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4603,6 +4607,7 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5208,6 +5213,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5358,6 +5364,7 @@
     "node_modules/chart.js": {
       "version": "4.5.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -5840,6 +5847,7 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5956,6 +5964,7 @@
     "node_modules/date-fns": {
       "version": "4.1.0",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -6341,6 +6350,7 @@
       "version": "9.39.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7343,6 +7353,7 @@
     "node_modules/immer": {
       "version": "10.1.1",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -8934,9 +8945,9 @@
       }
     },
     "node_modules/open-chat-studio-widget": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/open-chat-studio-widget/-/open-chat-studio-widget-0.9.1.tgz",
-      "integrity": "sha512-pz2AWosTsYoJDVZdbbwnPedqIv/D0amRqDb8Y0KtEYUGpSxDz+NIr2IcntfxgvxuF9n9Md5VCudVMDLa9RJb0Q==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/open-chat-studio-widget/-/open-chat-studio-widget-0.10.0.tgz",
+      "integrity": "sha512-BVPxwH39aQULpH170CQdI2B97a/RyVScNNT12twvtDKquyvdoFB8UcoF8Ib9FwXJjjC2njdEuanC8BLMtHxjPg==",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.27.0",
@@ -9162,6 +9173,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9466,6 +9478,7 @@
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9473,6 +9486,7 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9930,6 +9944,7 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.18.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10416,7 +10431,8 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.1.5",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -10523,6 +10539,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10742,6 +10759,7 @@
       "version": "5.7.2",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10804,6 +10822,7 @@
       "version": "8.46.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -11034,6 +11053,7 @@
     "node_modules/webpack": {
       "version": "5.105.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "js-cookie": "^3.0.7",
     "js-tiktoken": "^1.0.21",
     "lodash": "^4.17.23",
-    "open-chat-studio-widget": "^0.9.1",
+    "open-chat-studio-widget": "^0.10.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-error-boundary": "^6.0.1",


### PR DESCRIPTION
### Product Description
Bumps the embedded chat widget to the published `0.10.0` release.

### Technical Description
Updates the npm dependency (`package.json`/`package-lock.json`) and `LATEST_VERSION` in `apps/channels/widget_versions.py`, which drives the script URL and the outdated-version UI badge. No new deprecation cutoff — `DEPRECATIONS` is unchanged.

### Migrations
- [x] The migrations are backwards compatible

N/A — no migrations.

### Docs and Changelog
- [ ] This PR requires docs/changelog update