### PR TITLE
Add widget version release notification

### DIFF
--- a/apps/data_migrations/management/commands/notify_widget_version_release.py
+++ b/apps/data_migrations/management/commands/notify_widget_version_release.py
@@ -1,0 +1,71 @@
+from apps.channels import widget_versions
+from apps.channels.models import ChannelPlatform, ExperimentChannel
+from apps.data_migrations.management.commands.base import IdempotentCommand
+from apps.ocs_notifications.notifications import widget_version_release_notification
+
+
+class Command(IdempotentCommand):
+    help = "Notify teams that a new embedded chat widget version is available"
+    # Fixed slug: each release ships its own Django data migration
+    # (RunDataMigration with force=True), so this never needs bumping.
+    # See docs/developer_guides/widget_versioning.md
+    migration_name = "notify_widget_version_release"
+    disable_audit = True
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        # "--version" is reserved by Django's BaseCommand, hence "--widget-version".
+        parser.add_argument("--widget-version", default=widget_versions.LATEST_VERSION)
+        parser.add_argument("--notes", default="")
+        parser.add_argument("--changelog-url", default="")
+
+    def handle(self, *args, **options):
+        self.widget_version = options["widget_version"]
+        self.notes = options.get("notes") or ""
+        self.changelog_url = options.get("changelog_url") or widget_versions.widget_docs_url()
+        super().handle(*args, **options)
+
+    def perform_migration(self, dry_run=False):
+        affected_by_team = self._collect_affected_teams()
+        if not affected_by_team:
+            self.stdout.write(self.style.SUCCESS("No teams use the embedded chat widget"))
+            return
+
+        self.stdout.write(f"Found {len(affected_by_team)} team(s) using the embedded widget")
+        if self.verbosity > 1:
+            self._print_details(affected_by_team)
+
+        if dry_run:
+            self.stdout.write(f"Would notify {len(affected_by_team)} team(s) about widget {self.widget_version}")
+            return
+
+        for data in affected_by_team.values():
+            widget_version_release_notification(
+                team=data["team"],
+                version=self.widget_version,
+                notes=self.notes,
+                changelog_url=self.changelog_url,
+                affected_chatbots=data["chatbots"],
+            )
+
+        self.stdout.write(self.style.SUCCESS(f"Notified {len(affected_by_team)} team(s)"))
+        return f"Notified {len(affected_by_team)} team(s)"
+
+    def _collect_affected_teams(self) -> dict:
+        channels = ExperimentChannel.objects.filter(
+            platform=ChannelPlatform.EMBEDDED_WIDGET, deleted=False
+        ).select_related("experiment", "team")
+
+        affected_by_team = {}
+        for channel in channels:
+            team_data = affected_by_team.setdefault(
+                channel.team_id,
+                {"team": channel.team, "chatbots": {}},
+            )
+            team_data["chatbots"][channel.experiment.name] = channel.experiment.get_absolute_url()
+        return affected_by_team
+
+    def _print_details(self, affected_by_team: dict) -> None:
+        for data in affected_by_team.values():
+            self.stdout.write(f"  Team: {data['team'].name}")
+            self.stdout.write(f"    Chatbots: {sorted(data['chatbots'])}")

--- a/apps/data_migrations/tests/test_notify_widget_version_release.py
+++ b/apps/data_migrations/tests/test_notify_widget_version_release.py
@@ -1,0 +1,74 @@
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+
+from apps.channels.models import ChannelPlatform
+from apps.utils.factories.channels import ExperimentChannelFactory
+
+NOTIFY_PATCH = (
+    "apps.data_migrations.management.commands.notify_widget_version_release.widget_version_release_notification"
+)
+
+
+def _widget_channel(**kwargs):
+    return ExperimentChannelFactory(
+        platform=ChannelPlatform.EMBEDDED_WIDGET,
+        extra_data={"widget_token": "tok", "allowed_domains": ["example.com"]},
+        **kwargs,
+    )
+
+
+@pytest.mark.django_db()
+class TestNotifyWidgetVersionReleaseCommand:
+    @patch(NOTIFY_PATCH)
+    def test_no_widget_channels(self, mock_notify, capsys):
+        call_command("notify_widget_version_release", widget_version="0.10.0", force=True)
+        mock_notify.assert_not_called()
+        assert "No teams use the embedded chat widget" in capsys.readouterr().out
+
+    @patch(NOTIFY_PATCH)
+    def test_notifies_every_widget_team_regardless_of_version(self, mock_notify):
+        channel = _widget_channel()
+        call_command(
+            "notify_widget_version_release",
+            widget_version="0.10.0",
+            notes="Adds dark mode.",
+            force=True,
+        )
+        mock_notify.assert_called_once()
+        kwargs = mock_notify.call_args.kwargs
+        assert kwargs["team"] == channel.team
+        assert kwargs["version"] == "0.10.0"
+        assert kwargs["notes"] == "Adds dark mode."
+        assert channel.experiment.name in kwargs["affected_chatbots"]
+
+    @patch(NOTIFY_PATCH)
+    def test_groups_chatbots_by_team(self, mock_notify):
+        channel = _widget_channel()
+        other = _widget_channel(team=channel.team)
+        call_command("notify_widget_version_release", widget_version="0.10.0", force=True)
+        mock_notify.assert_called_once()
+        chatbots = mock_notify.call_args.kwargs["affected_chatbots"]
+        assert channel.experiment.name in chatbots
+        assert other.experiment.name in chatbots
+
+    @patch(NOTIFY_PATCH)
+    def test_ignores_non_widget_channels(self, mock_notify):
+        ExperimentChannelFactory(platform=ChannelPlatform.TELEGRAM)
+        call_command("notify_widget_version_release", widget_version="0.10.0", force=True)
+        mock_notify.assert_not_called()
+
+    @patch(NOTIFY_PATCH)
+    def test_defaults_to_latest_version(self, mock_notify):
+        _widget_channel()
+        with patch("apps.channels.widget_versions.LATEST_VERSION", "9.9.9"):
+            call_command("notify_widget_version_release", force=True)
+        assert mock_notify.call_args.kwargs["version"] == "9.9.9"
+
+    @patch(NOTIFY_PATCH)
+    def test_dry_run_does_not_notify(self, mock_notify, capsys):
+        _widget_channel()
+        call_command("notify_widget_version_release", widget_version="0.10.0", dry_run=True, force=True)
+        mock_notify.assert_not_called()
+        assert "Would notify" in capsys.readouterr().out

--- a/apps/ocs_notifications/notifications.py
+++ b/apps/ocs_notifications/notifications.py
@@ -292,6 +292,32 @@ def deprecated_widget_version_notification(
     )
 
 
+@silence_exceptions(logger, log_message="Failed to create widget version release notification")
+def widget_version_release_notification(
+    team,
+    version: str,
+    notes: str,
+    changelog_url: str,
+    affected_chatbots: dict[str, str],
+) -> None:
+    """Notify a team that a new embedded chat widget version is available."""
+    message = f"Version {version} of the embedded chat widget is now available."
+    if notes:
+        message += f" {notes}"
+    message += " Update the embed snippet on your site to use the latest version."
+    create_notification(
+        title=f"Chat Widget {version} Released",
+        message=message,
+        level=LevelChoices.INFO,
+        team=team,
+        slug="widget-version-release",
+        # Keyed on the version so each release opens its own notification thread.
+        event_data={"version": version},
+        permissions=["bot_channels.change_experimentchannel"],
+        links={**affected_chatbots, "Release Notes": changelog_url},
+    )
+
+
 @silence_exceptions(logger, log_message="Failed to create deleted model notification")
 def deleted_model_notification(
     team,

--- a/docs/developer_guides/widget_versioning.md
+++ b/docs/developer_guides/widget_versioning.md
@@ -18,6 +18,31 @@ version policy lives in `apps/channels/widget_versions.py`.
 2. In the same PR, bump `LATEST_VERSION` in `apps/channels/widget_versions.py`.
    The embed snippet (`{% widget_script_url %}`) and the "update available"
    badges follow automatically.
+3. Optionally announce the release in-app. Add a data migration in
+   `apps/channels/migrations/` that triggers the notification on deploy, with the
+   version and release notes inline:
+
+        from apps.data_migrations.utils.migrations import RunDataMigration
+
+        operations = [
+            RunDataMigration(
+                "notify_widget_version_release",
+                command_options={
+                    "force": True,
+                    "widget_version": "0.10.0",
+                    "notes": "Adds dark mode and faster load times.",
+                    "changelog_url": "https://docs.openchatstudio.com/chat_widget/",
+                },
+            ),
+        ]
+
+   `widget_version` defaults to `LATEST_VERSION` and `changelog_url` to the chat
+   widget docs, so both can be omitted. Every team with an embedded-widget
+   channel gets an INFO notification linking to their widget chatbots and the
+   changelog. The command slug is fixed; Django tracks each migration's single
+   run, so `force=True` is required and nothing needs bumping. Preview with:
+
+        python manage.py notify_widget_version_release --dry-run --widget-version 0.10.0
 
 ## Deprecating old versions
 


### PR DESCRIPTION
### Product Description
When a new chat widget version is released, teams using the embedded widget get an in-app notification with release notes and a link to the changelog — the companion to the existing widget *deprecation* notification. Includes the 0.10.0 announcement.

### Technical Description
Mirrors the deprecation flow: a per-release Django data migration triggers an `IdempotentCommand` (`notify_widget_version_release`) that notifies every team with a non-deleted embedded-widget channel via `create_notification` (INFO level). Version, release notes, and changelog URL ride in as `command_options` on `RunDataMigration` so each release authors them inline; `widget_version` defaults to `LATEST_VERSION` and the changelog URL to the widget docs.

The `--widget-version` arg avoids Django's reserved `--version`. Slug is fixed and `force=True`, relying on Django's per-migration run-once tracking — same as the deprecation command.

Migration `0028` is the first release announcement (0.10.0). Note `LATEST_VERSION` is still `0.9.1` on this branch, so the embed snippet/badges keep serving 0.9.1 until a separate release PR bumps it.

### Migrations
- [x] The migrations are backwards compatible

Data-only migration: fires the notification command on deploy, no schema change.

### Docs and Changelog
- [ ] This PR requires docs/changelog update