### PR TITLE
Fix migration ordering for widget release notification

### DIFF
--- a/apps/channels/migrations/0028_notify_widget_version_release_0_10_0.py
+++ b/apps/channels/migrations/0028_notify_widget_version_release_0_10_0.py
@@ -7,6 +7,9 @@ class Migration(migrations.Migration):
     dependencies = [
         ("bot_channels", "0027_notify_widget_deprecation_below_0_6_0"),
         ("data_migrations", "0001_initial"),
+        # The command loads the live Team model (all columns), so the schema
+        # for those fields must be in place before it runs.
+        ("teams", "0012_team_metadata"),
     ]
 
     operations = [

--- a/apps/channels/migrations/0028_notify_widget_version_release_0_10_0.py
+++ b/apps/channels/migrations/0028_notify_widget_version_release_0_10_0.py
@@ -7,8 +7,6 @@ class Migration(migrations.Migration):
     dependencies = [
         ("bot_channels", "0027_notify_widget_deprecation_below_0_6_0"),
         ("data_migrations", "0001_initial"),
-        # The command loads the live Team model (all columns), so the schema
-        # for those fields must be in place before it runs.
         ("teams", "0012_team_metadata"),
     ]
 


### PR DESCRIPTION
### Technical Description
Migrations failed on a fresh DB with `column teams_team.public_key does not exist`. `channels.0028` invokes the `notify_widget_version_release` management command, which queries through the live `Team` model (`.select_related("team")` loads every column), but only depended on `bot_channels.0027` and `data_migrations.0001` — so Django could schedule it before the `teams` migrations that add `public_key` (0011) and metadata (0012). Added a dependency on `teams.0012_team_metadata`.

Recurring trap for `RunDataMigration`-based migrations that go through live models — they must depend on the migrations supplying that schema.

### Migrations
- [x] The migrations are backwards compatible

### Docs and Changelog
- [ ] This PR requires docs/changelog update