### PR TITLE
Fix pricing rule collision in cost summary test

### DIFF
--- a/apps/cost_tracking/tests/test_reporting.py
+++ b/apps/cost_tracking/tests/test_reporting.py
@@ -102,7 +102,7 @@ class TestCostSummary:
         rule = PricingRule.objects.create(
             team=None,
             provider_type="openai",
-            model_name="gpt-4o-mini",
+            model_name="test-priced-model",
             service_kind=ServiceKind.LLM_INPUT,
             unit_price="0.0001",
         )


### PR DESCRIPTION
### Product Description
no change

### Technical Description
`test_counts_unpriced_rows_excluding_unknown` failed on `main` with an `IntegrityError` on `unique_active_pricing_rule`: it created a `(team=None, openai, gpt-4o-mini, llm_input)` rule that already exists from the `0002_seed_pricing` seed migration. The rule is only used as a direct FK on the priced row, so its `model_name` is irrelevant to the assertion — switched it to a unique name, matching how the sibling test already avoids the collision.

### Docs and Changelog
- [ ] This PR requires docs/changelog update