### PR TITLE
Upgrade daisyUI to v5.6 with accessibility fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "autoprefixer": "^10.4.20",
         "babel-loader": "^10.0.0",
         "css-loader": "^7.1.4",
-        "daisyui": "^5.5.20",
+        "daisyui": "^5.6.0",
         "enquirer": "^2.4.1",
         "eslint": "^9.39.1",
         "eslint-plugin-react": "^7.37.4",
@@ -145,7 +145,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.6.tgz",
       "integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.6",
@@ -1938,7 +1937,6 @@
     "node_modules/@codemirror/view": {
       "version": "6.35.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "style-mod": "^4.1.0",
@@ -3688,7 +3686,6 @@
     "node_modules/@types/react": {
       "version": "19.2.7",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3924,7 +3921,6 @@
       "version": "8.54.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4607,7 +4603,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5213,7 +5208,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5364,7 +5358,6 @@
     "node_modules/chart.js": {
       "version": "4.5.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -5847,7 +5840,6 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5891,9 +5883,9 @@
       }
     },
     "node_modules/daisyui": {
-      "version": "5.5.20",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.20.tgz",
-      "integrity": "sha512-HemJcjl0Gk9rQ8BcgofN6p+EURrqftQG9wK1Hkxs98i49xe68+QxpNvry+PyxwkIUgrbMpNmZ5ZWjmtffAjfhQ==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.6.6.tgz",
+      "integrity": "sha512-UFiuIZYucF7ylrnY3PT1SqwaEbVB10mqTZRyeRchZk0bud+HihYLLhXdxGDVmR/ftrM9G9YVr9FFPRVVIZJ5hA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5964,7 +5956,6 @@
     "node_modules/date-fns": {
       "version": "4.1.0",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -6350,7 +6341,6 @@
       "version": "9.39.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7353,7 +7343,6 @@
     "node_modules/immer": {
       "version": "10.1.1",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -9173,7 +9162,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9478,7 +9466,6 @@
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9486,7 +9473,6 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9944,7 +9930,6 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.18.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10431,8 +10416,7 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.1.5",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -10539,7 +10523,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10759,7 +10742,6 @@
       "version": "5.7.2",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10822,7 +10804,6 @@
       "version": "8.46.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -11053,7 +11034,6 @@
     "node_modules/webpack": {
       "version": "5.105.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "autoprefixer": "^10.4.20",
     "babel-loader": "^10.0.0",
     "css-loader": "^7.1.4",
-    "daisyui": "^5.5.20",
+    "daisyui": "^5.6.0",
     "enquirer": "^2.4.1",
     "eslint": "^9.39.1",
     "eslint-plugin-react": "^7.37.4",

--- a/templates/experiments/filters.html
+++ b/templates/experiments/filters.html
@@ -123,7 +123,6 @@
                           type="button"
                           @click="selectAllTagOptions(index)"
                           :disabled="areAllTagsSelected(index)"
-                          :class="areAllTagsSelected(index) ? 'btn-disabled' : ''"
                           class="btn btn-xs btn-outline flex-1">
                           Select All
                         </button>
@@ -131,7 +130,6 @@
                           type="button"
                           @click="clearAllOptions(index)"
                           :disabled="filter.selectedValues.length === 0"
-                          :class="filter.selectedValues.length === 0 ? 'btn-disabled' : ''"
                           class="btn btn-xs btn-outline flex-1">
                           Clear All
                         </button>

--- a/templates/filters/inline_filter_editor.html
+++ b/templates/filters/inline_filter_editor.html
@@ -98,7 +98,6 @@
                         type="button"
                         @click="selectAllTagOptions(index)"
                         :disabled="areAllTagsSelected(index)"
-                        :class="areAllTagsSelected(index) ? 'btn-disabled' : ''"
                         class="btn btn-xs btn-outline flex-1">
                         Select All
                       </button>
@@ -106,7 +105,6 @@
                         type="button"
                         @click="clearAllOptions(index)"
                         :disabled="filter.selectedValues.length === 0"
-                        :class="filter.selectedValues.length === 0 ? 'btn-disabled' : ''"
                         class="btn btn-xs btn-outline flex-1">
                         Clear All
                       </button>

--- a/templates/generic/action.html
+++ b/templates/generic/action.html
@@ -1,5 +1,5 @@
 {% if action_url %}
-  <a href="{{ action_url }}" class="btn btn-sm join-item {{ button_style|default_if_none:"btn-ghost" }}" {% if disabled %}disabled="disabled"{% endif %} {% if title %}title="{{ title }}"{% endif %} {% if open_url_in_new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>
+  <a href="{% if not disabled %}{{ action_url }}{% endif %}" class="btn btn-sm join-item {{ button_style|default_if_none:"btn-ghost" }}{% if disabled %} pointer-events-none{% endif %}" {% if disabled %}aria-disabled="true"{% endif %} {% if title %}title="{{ title }}"{% endif %} {% if open_url_in_new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>
     {{ label }}
     {% if icon_class %}
       <i class="{{ icon_class }}"></i>

--- a/templates/generic/action.html
+++ b/templates/generic/action.html
@@ -1,5 +1,5 @@
 {% if action_url %}
-  <a href="{% if not disabled %}{{ action_url }}{% endif %}" class="btn btn-sm join-item {{ button_style|default_if_none:"btn-ghost" }}{% if disabled %} pointer-events-none{% endif %}" {% if disabled %}aria-disabled="true"{% endif %} {% if title %}title="{{ title }}"{% endif %} {% if open_url_in_new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>
+  <a {% if not disabled %}href="{{ action_url }}"{% endif %} class="btn btn-sm join-item {{ button_style|default_if_none:"btn-ghost" }}{% if disabled %} pointer-events-none{% endif %}" {% if disabled %}aria-disabled="true"{% endif %} {% if title %}title="{{ title }}"{% endif %} {% if not disabled and open_url_in_new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>
     {{ label }}
     {% if icon_class %}
       <i class="{{ icon_class }}"></i>


### PR DESCRIPTION
## Summary

Upgrades daisyUI from `^5.5.20` to `^5.6.0` and addresses two accessibility issues surfaced during the review.

## Changes

### 1. daisyUI version bump (`package.json`)
Picks up all v5.6 improvements automatically:
- New components: Aura, Megamenu, OTP
- Tooltip alignment modifiers (`tooltip-start/center/end`)
- Selectable card states (aria-checked, checkbox/radio focus)
- Smoother collapse/details animation
- `aria-disabled` support on buttons (see fix below)
- Reduced-motion support for loading animations

### 2. Fix invalid `disabled` attribute on `<a>` (`templates/generic/action.html`)
The `disabled` attribute is not valid HTML on anchor elements — browsers ignore it, so disabled action links were still navigable and focusable.

Fixed by:
- Replacing `disabled="disabled"` with `aria-disabled="true"` (semantic + now styled by daisyUI v5.6)
- Adding `pointer-events-none` to prevent clicks
- Suppressing `href` when disabled (stops keyboard navigation)

### 3. Remove redundant `btn-disabled` class bindings in filter templates
In `templates/filters/inline_filter_editor.html` and `templates/experiments/filters.html`, buttons were binding both `:disabled="condition"` (native) and `:class="condition ? 'btn-disabled' : ''"` — the latter is redundant since DaisyUI styles the native `disabled` attribute directly on `<button>` elements.

## Testing
- Verify disabled action links no longer navigate when clicked
- Confirm filter "Select All" / "Clear All" buttons still visually disable correctly
- `npm run build` to confirm no daisyUI compilation issues