### PR TITLE
Reseed AI pricing data via migration

### DIFF
--- a/apps/cost_tracking/migrations/0002_seed_pricing.py
+++ b/apps/cost_tracking/migrations/0002_seed_pricing.py
@@ -1,13 +1,9 @@
 from django.db import migrations
 
-from apps.cost_tracking.migration_utils import load_pricing_data
-
 
 class Migration(migrations.Migration):
     dependencies = [
         ("cost_tracking", "0001_initial"),
     ]
 
-    operations = [
-        load_pricing_data(),
-    ]
+    operations = []

--- a/apps/cost_tracking/migrations/0003_seed_pricing.py
+++ b/apps/cost_tracking/migrations/0003_seed_pricing.py
@@ -1,0 +1,13 @@
+from django.db import migrations
+
+from apps.cost_tracking.migration_utils import load_pricing_data
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cost_tracking", "0002_seed_pricing"),
+    ]
+
+    operations = [
+        load_pricing_data(),
+    ]


### PR DESCRIPTION
### Product Description
no change

### Technical Description
Adds `0003_seed_pricing` to re-run `load_ai_pricing` so updated entries in `seed_data/llm_pricing.json` get applied, and empties the operation from `0002_seed_pricing`. Keeping `0002` in place (no-op) preserves the migration graph for environments that already applied it.

### Migrations
- [x] The migrations are backwards compatible

### Docs and Changelog
- [ ] This PR requires docs/changelog update