### PR TITLE
Warn when renaming a CommCare Connect bot

### DIFF
--- a/apps/channels/forms.py
+++ b/apps/channels/forms.py
@@ -569,6 +569,14 @@ class CommCareConnectChannelForm(ExtraFormBase):
         max_length=100,
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.channel:
+            self.warning_message = (
+                "Changing the bot name updates the name shown to new participants on CommCare Connect. "
+                "Participants who have already connected may continue to see the previous name."
+            )
+
 
 class WidgetParams(forms.Widget):
     template_name = "channels/widgets/widget_params.html"


### PR DESCRIPTION
### Product Description
When editing a CommCare Connect channel, the bot name field now shows a warning that already-connected participants may keep seeing the previous name.

### Technical Description
New participants always get a channel created with the current bot name, but there's no reliable way to rename channels that Connect has already provisioned. Rather than re-registering every existing participant's channel in a loop — which would hammer Connect and isn't confirmed to update the display name anyway — we just surface a warning on the edit form so the operator knows the rename won't reach existing users.

### Migrations
N/A — no migrations.

### Docs and Changelog
- [ ] This PR requires docs/changelog update