### PR TITLE
Cost tracking UX improvements: pricing display, deprecated models, source badge

### DIFF
--- a/apps/cost_tracking/templatetags/cost_tracking.py
+++ b/apps/cost_tracking/templatetags/cost_tracking.py
@@ -22,3 +22,16 @@ def cost_display(value) -> str:
     if value == 0 or value >= Decimal("0.01"):
         return f"{value:.2f}"
     return f"{value:.4f}"
+
+
+@register.filter
+def per_million(value) -> str:
+    """Render a per-1K unit price as a per-1M display string (e.g. "3.00").
+
+    Model pricing is conventionally quoted per million tokens, matching the
+    override form's labels. Stored unit prices are per 1K tokens, so scale by
+    1000 and show 2 decimal places.
+    """
+    if value is None:
+        return "0.00"
+    return f"{Decimal(str(value)) * 1000:.2f}"

--- a/apps/cost_tracking/tests/test_templatetags.py
+++ b/apps/cost_tracking/tests/test_templatetags.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 import pytest
 
-from apps.cost_tracking.templatetags.cost_tracking import cost_display
+from apps.cost_tracking.templatetags.cost_tracking import cost_display, per_million
 
 
 @pytest.mark.parametrize(
@@ -23,3 +23,18 @@ from apps.cost_tracking.templatetags.cost_tracking import cost_display
 )
 def test_cost_display(value, expected):
     assert cost_display(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(None, "0.00", id="none"),
+        pytest.param(Decimal("0"), "0.00", id="zero"),
+        pytest.param(Decimal("0.003"), "3.00", id="per-1k-to-per-1m"),
+        pytest.param(Decimal("0.00001"), "0.01", id="sub-cent-per-million"),
+        pytest.param(Decimal("0.015"), "15.00", id="fifteen-per-million"),
+        pytest.param(Decimal("0.0000045720"), "0.00", id="rounds-to-zero"),
+    ],
+)
+def test_per_million(value, expected):
+    assert per_million(value) == expected

--- a/apps/service_providers/tests/test_pricing_override.py
+++ b/apps/service_providers/tests/test_pricing_override.py
@@ -1,6 +1,7 @@
 """Tests for the override / revert / create-with-pricing HTMX flow on
 the LLM provider model list."""
 
+from datetime import UTC, datetime
 from decimal import Decimal
 
 import pytest
@@ -9,6 +10,7 @@ from django.urls import reverse
 
 from apps.cost_tracking.models import PricingRule, PricingSource, ServiceKind
 from apps.service_providers.models import LlmProviderModel
+from apps.service_providers.views import _get_models_by_type
 from apps.teams.models import Flag
 from apps.utils.factories.team import TeamWithUsersFactory
 
@@ -187,3 +189,27 @@ class TestCreateModelWithPricing:
         assert response.status_code == 200
         assert LlmProviderModel.objects.filter(team=team, name="test-create-no-flag").exists()
         assert not PricingRule.objects.filter(team=team, model_name="test-create-no-flag").exists()
+
+
+@pytest.mark.django_db()
+class TestModelOrdering:
+    """`_get_models_by_type` orders each type bucket newest-first with
+    deprecated models sunk to the bottom."""
+
+    def _model(self, team, name, *, created, deprecated=False):
+        model = LlmProviderModel.objects.create(
+            team=team, type="openai", name=name, max_token_limit=128000, deprecated=deprecated
+        )
+        # created_at is auto_now_add, so override it after the fact.
+        LlmProviderModel.objects.filter(pk=model.pk).update(created_at=datetime(2026, 1, created, tzinfo=UTC))
+        return model
+
+    def test_orders_newest_first_with_deprecated_last(self):
+        team = TeamWithUsersFactory.create()
+        newest = self._model(team, "c-newest", created=3)
+        oldest = self._model(team, "a-oldest", created=1)
+        deprecated_new = self._model(team, "b-deprecated", created=2, deprecated=True)
+
+        ordered = _get_models_by_type(LlmProviderModel.objects.filter(team=team))["openai"]
+
+        assert ordered == [newest, oldest, deprecated_new]

--- a/apps/service_providers/views.py
+++ b/apps/service_providers/views.py
@@ -306,7 +306,11 @@ def _get_models_by_type(queryset):
     models_by_type = defaultdict(list)
     for model in queryset:
         models_by_type[model.type].append(model)
-    return {key: sorted(value, key=lambda x: x.name) for key, value in models_by_type.items()}
+    # Deprecated models sink to the bottom; otherwise newest first.
+    return {
+        key: sorted(value, key=lambda x: (getattr(x, "deprecated", False), -x.created_at.timestamp()))
+        for key, value in models_by_type.items()
+    }
 
 
 def _flatten(models_by_type: dict) -> list:

--- a/templates/dashboard/_cost_tracking_panel.html
+++ b/templates/dashboard/_cost_tracking_panel.html
@@ -39,12 +39,12 @@
           <div class="text-xs uppercase text-gray-500 dark:text-gray-400">{% translate "Estimated" %}</div>
           <div class="text-xl font-semibold text-gray-900 dark:text-gray-100">${{ cost_summary.estimated_cost|cost_display }}</div>
           {% if cost_summary.unknown_call_count %}
-            <div class="text-xs text-amber-600 mt-1">
+            <div class="text-xs text-yellow-800 mt-1">
               {% blocktranslate count counter=cost_summary.unknown_call_count %}{{ counter }} call with no usage data{% plural %}{{ counter }} calls with no usage data{% endblocktranslate %}
             </div>
           {% endif %}
           {% if cost_summary.unpriced_call_count %}
-            <div class="text-xs text-amber-600 mt-1">
+            <div class="text-xs text-yellow-800 mt-1">
               {% blocktranslate count counter=cost_summary.unpriced_call_count %}{{ counter }} call missing pricing{% plural %}{{ counter }} calls missing pricing{% endblocktranslate %}
             </div>
           {% endif %}

--- a/templates/service_providers/components/llm_model_row.html
+++ b/templates/service_providers/components/llm_model_row.html
@@ -1,4 +1,4 @@
-{% load default_tags %}
+{% load cost_tracking default_tags %}
 {% comment %}
   One row in the LLM provider model list. Rendered both inside the bulk
   list (llm_models.html) and standalone after HTMX swaps (override / revert
@@ -13,10 +13,10 @@
       {% with rates=pricing_lookup|get_item:model.id %}
         {% if rates %}
           <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-            {% if rates.llm_input %}in&nbsp;${{ rates.llm_input.unit_price|floatformat:5 }}/1K{% endif %}
-            {% if rates.llm_output %} · out&nbsp;${{ rates.llm_output.unit_price|floatformat:5 }}/1K{% endif %}
-            {% if rates.llm_cached_input %} · cached&nbsp;${{ rates.llm_cached_input.unit_price|floatformat:5 }}/1K{% endif %}
-            {% if rates.llm_cache_write %} · cache‑write&nbsp;${{ rates.llm_cache_write.unit_price|floatformat:5 }}/1K{% endif %}
+            {% if rates.llm_input %}in&nbsp;${{ rates.llm_input.unit_price|per_million }}/1M{% endif %}
+            {% if rates.llm_output %} · out&nbsp;${{ rates.llm_output.unit_price|per_million }}/1M{% endif %}
+            {% if rates.llm_cached_input %} · cached&nbsp;${{ rates.llm_cached_input.unit_price|per_million }}/1M{% endif %}
+            {% if rates.llm_cache_write %} · cache‑write&nbsp;${{ rates.llm_cache_write.unit_price|per_million }}/1M{% endif %}
             <span class="badge badge-xs badge-outline ml-1" data-testid="pricing-source-{{ model.id }}">
               {{ rates.primary.source }}{% if rates.primary.scope == "team" %} (override){% endif %}
             </span>

--- a/templates/service_providers/components/llm_model_row.html
+++ b/templates/service_providers/components/llm_model_row.html
@@ -6,13 +6,13 @@
   Required context: `model`, `show_delete`, `cost_tracking_enabled`,
   `pricing_lookup`.
 {% endcomment %}
-<div class="grid grid-cols-4 grid-flow-col-dense" id="model_{{ model.id }}">
+<div class="grid grid-cols-4 grid-flow-col-dense{% if model.deprecated %} text-base-content/50{% endif %}" id="model_{{ model.id }}">
   <div class="col-span-2">
     {{ model.display_name }}
     {% if cost_tracking_enabled %}
       {% with rates=pricing_lookup|get_item:model.id %}
         {% if rates %}
-          <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+          <div class="text-xs {% if not model.deprecated %}text-gray-500 dark:text-gray-400 {% endif %}mt-0.5">
             {% if rates.llm_input %}in&nbsp;${{ rates.llm_input.unit_price|per_million }}/1M{% endif %}
             {% if rates.llm_output %} · out&nbsp;${{ rates.llm_output.unit_price|per_million }}/1M{% endif %}
             {% if rates.llm_cached_input %} · cached&nbsp;${{ rates.llm_cached_input.unit_price|per_million }}/1M{% endif %}
@@ -24,35 +24,39 @@
                 {{ rates.primary.source }}
               </span>
             {% endif %}
-            <button class="btn btn-xs btn-ghost ml-1"
-                    title="Override pricing for this team"
-                    hx-get="{% url 'service_providers:pricing_override_form' request.team.slug model.id %}"
-                    hx-target="#pricing_override_modal_body"
-                    hx-swap="innerHTML"
-                    onclick="pricing_override_modal.showModal()">
-              <i class="fa-solid fa-pencil"></i>
-            </button>
-            {% if rates.has_team_override %}
-              <button class="btn btn-xs btn-ghost"
-                      title="Revert to global pricing"
-                      hx-post="{% url 'service_providers:pricing_revert' request.team.slug model.id %}"
-                      hx-target="#model_{{ model.id }}"
-                      hx-swap="outerHTML"
-                      hx-confirm="Remove the team override and fall back to the global rate?">
-                <i class="fa-solid fa-rotate-left"></i>
+            {% if not model.deprecated %}
+              <button class="btn btn-xs btn-ghost ml-1"
+                      title="Override pricing for this team"
+                      hx-get="{% url 'service_providers:pricing_override_form' request.team.slug model.id %}"
+                      hx-target="#pricing_override_modal_body"
+                      hx-swap="innerHTML"
+                      onclick="pricing_override_modal.showModal()">
+                <i class="fa-solid fa-pencil"></i>
               </button>
+              {% if rates.has_team_override %}
+                <button class="btn btn-xs btn-ghost"
+                        title="Revert to global pricing"
+                        hx-post="{% url 'service_providers:pricing_revert' request.team.slug model.id %}"
+                        hx-target="#model_{{ model.id }}"
+                        hx-swap="outerHTML"
+                        hx-confirm="Remove the team override and fall back to the global rate?">
+                  <i class="fa-solid fa-rotate-left"></i>
+                </button>
+              {% endif %}
             {% endif %}
           </div>
         {% else %}
-          <div class="text-xs text-yellow-800 mt-0.5" data-testid="unpriced-{{ model.id }}">
+          <div class="text-xs {% if not model.deprecated %}text-yellow-800 {% endif %}mt-0.5" data-testid="unpriced-{{ model.id }}">
             No pricing configured
-            <button class="btn btn-xs btn-ghost ml-1"
-                    hx-get="{% url 'service_providers:pricing_override_form' request.team.slug model.id %}"
-                    hx-target="#pricing_override_modal_body"
-                    hx-swap="innerHTML"
-                    onclick="pricing_override_modal.showModal()">
-              Set pricing
-            </button>
+            {% if not model.deprecated %}
+              <button class="btn btn-xs btn-ghost ml-1"
+                      hx-get="{% url 'service_providers:pricing_override_form' request.team.slug model.id %}"
+                      hx-target="#pricing_override_modal_body"
+                      hx-swap="innerHTML"
+                      onclick="pricing_override_modal.showModal()">
+                Set pricing
+              </button>
+            {% endif %}
           </div>
         {% endif %}
       {% endwith %}

--- a/templates/service_providers/components/llm_model_row.html
+++ b/templates/service_providers/components/llm_model_row.html
@@ -17,9 +17,13 @@
             {% if rates.llm_output %} · out&nbsp;${{ rates.llm_output.unit_price|per_million }}/1M{% endif %}
             {% if rates.llm_cached_input %} · cached&nbsp;${{ rates.llm_cached_input.unit_price|per_million }}/1M{% endif %}
             {% if rates.llm_cache_write %} · cache‑write&nbsp;${{ rates.llm_cache_write.unit_price|per_million }}/1M{% endif %}
-            <span class="badge badge-xs badge-outline ml-1" data-testid="pricing-source-{{ model.id }}">
-              {{ rates.primary.source }}{% if rates.primary.scope == "team" %} (override){% endif %}
-            </span>
+            {% if rates.primary.source != 'seed' or rates.primary.scope == 'team' %}
+              <span class="badge badge-xs badge-outline ml-1 tooltip"
+                    data-testid="pricing-source-{{ model.id }}"
+                    {% if rates.primary.scope == "team" %}data-tip="Custom pricing override set for this team"{% elif rates.primary.source == "manual" %}data-tip="Pricing was entered manually"{% elif rates.primary.source == "import" %}data-tip="Pricing was imported from an external source"{% endif %}>
+                {{ rates.primary.source }}
+              </span>
+            {% endif %}
             <button class="btn btn-xs btn-ghost ml-1"
                     title="Override pricing for this team"
                     hx-get="{% url 'service_providers:pricing_override_form' request.team.slug model.id %}"

--- a/templates/service_providers/components/llm_model_row.html
+++ b/templates/service_providers/components/llm_model_row.html
@@ -44,7 +44,7 @@
             {% endif %}
           </div>
         {% else %}
-          <div class="text-xs text-amber-600 mt-0.5" data-testid="unpriced-{{ model.id }}">
+          <div class="text-xs text-yellow-800 mt-0.5" data-testid="unpriced-{{ model.id }}">
             No pricing configured
             <button class="btn btn-xs btn-ghost ml-1"
                     hx-get="{% url 'service_providers:pricing_override_form' request.team.slug model.id %}"


### PR DESCRIPTION
### Product Description
UX improvements for cost tracking on the LLM provider model list (#3721):

- Rates now display per 1M tokens (e.g. `$3.00/1M`), matching the override form and industry convention, instead of per-1K with 5 decimals.
- The pricing edit / revert / "Set pricing" buttons are hidden for deprecated models.
- The source badge only shows when the source isn't the default `seed` (i.e. `manual`, `import`, or a team override).
- Sort models by date created (descending) with deprecated models at the end.
- Use a more muted color for the 'No pricing configured' text.

### Technical Description
Adds a `per_million` template filter to `cost_tracking` tags and updates `llm_model_row.html`. Render-level tests cover each behaviour.

### Migrations
- [ ] The migrations are backwards compatible

### Demo

**light mode**
<img width="861" height="408" alt="Screenshot from 2026-06-30 17-16-43" src="https://github.com/user-attachments/assets/83c7bad7-dcb1-4908-ad4a-60a676ca7093" />

<img width="868" height="208" alt="image" src="https://github.com/user-attachments/assets/ef2be4d6-4ba4-4d88-82c9-38d6037d17cd" />

**dark mode**
<img width="838" height="120" alt="image" src="https://github.com/user-attachments/assets/9cf46c00-d282-430e-9452-9cc93521fa44" />

<img width="838" height="120" alt="image" src="https://github.com/user-attachments/assets/6bbb3488-9422-4be7-a774-57c49e5b89b0" />


### Docs and Changelog
- [ ] This PR requires docs/changelog update

Closes #3721
