### PR TITLE
fix(reconcile_models): backfill missing pricing from LiteLLM

### DIFF
--- a/scripts/reconcile_models.py
+++ b/scripts/reconcile_models.py
@@ -267,19 +267,33 @@ def resolve_pricing_from_llm_stats(details: dict[str, Any]) -> dict[str, str] | 
     )
 
 
-def resolve_pricing_from_litellm(model_id: str, litellm_data: dict[str, Any]) -> dict[str, str] | None:
-    entry = litellm_data.get(model_id)
-    if entry is None:
-        return None
-    return _rates_from_raw(
-        {
-            "llm_input": entry.get("input_cost_per_token"),
-            "llm_output": entry.get("output_cost_per_token"),
-            "llm_cached_input": entry.get("cache_read_input_token_cost"),
-            "llm_cache_write": entry.get("cache_creation_input_token_cost"),
-        },
-        _per_token_to_per_1k,
-    )
+def resolve_pricing_from_litellm(
+    model_id: str,
+    litellm_data: dict[str, Any],
+    provider: str | None = None,
+) -> dict[str, str] | None:
+    """Look up ``model_id`` in the LiteLLM pricing table.
+
+    Tries the bare model ID first, then ``{provider}/{model_id}`` when a
+    provider is supplied.  This catches provider-namespaced entries such as
+    ``groq/gemma-7b-it`` that would be missed by a bare lookup.
+    """
+    candidates = [model_id]
+    if provider:
+        candidates.append(f"{provider}/{model_id}")
+    for key in candidates:
+        entry = litellm_data.get(key)
+        if entry is not None:
+            return _rates_from_raw(
+                {
+                    "llm_input": entry.get("input_cost_per_token"),
+                    "llm_output": entry.get("output_cost_per_token"),
+                    "llm_cached_input": entry.get("cache_read_input_token_cost"),
+                    "llm_cache_write": entry.get("cache_creation_input_token_cost"),
+                },
+                _per_token_to_per_1k,
+            )
+    return None
 
 
 def rates_from_detail(detail: dict) -> dict[str, str]:
@@ -640,7 +654,7 @@ def _migration_template(prev_name: str) -> str:
     )
 
 
-# Missing-pricing audit (digest replacement)
+# Missing-pricing audit + LiteLLM backfill
 
 
 @dataclass(frozen=True)
@@ -650,6 +664,40 @@ class MissingPricingEntry:
     provider_type: str
     model_name: str
     kinds_missing: tuple[str, ...]
+
+
+def backfill_missing_from_litellm(
+    missing: list[MissingPricingEntry],
+    litellm_data: dict[str, Any],
+) -> tuple[list[dict], list[MissingPricingEntry]]:
+    """Try to resolve missing-pricing entries from the LiteLLM price table.
+
+    For each entry in *missing*, attempts a litellm lookup (bare model ID first,
+    then ``provider/model_id`` as a fallback).  Entries whose required kinds are
+    all resolved are converted into seed-JSON dicts and returned in
+    *backfilled*; anything that can't be fully resolved stays in *still_missing*.
+
+    Returns:
+        (backfilled, still_missing)
+    """
+    backfilled: list[dict] = []
+    still_missing: list[MissingPricingEntry] = []
+
+    for entry in missing:
+        rates = resolve_pricing_from_litellm(entry.model_name, litellm_data, provider=entry.provider_type)
+        if rates and not (REQUIRED_SERVICE_KINDS - rates.keys()):
+            rules = [{"service_kind": k, "unit_price": v} for k, v in rates.items()]
+            backfilled.append(
+                {
+                    "provider_type": entry.provider_type,
+                    "model_name": entry.model_name,
+                    "rules": rules,
+                }
+            )
+        else:
+            still_missing.append(entry)
+
+    return backfilled, still_missing
 
 
 def audit_missing_pricing(
@@ -672,17 +720,35 @@ def audit_missing_pricing(
 # PR / issue body rendering
 
 
-def render_pr_body(changes: list[RateChange], unmatched: set[str]) -> str:
-    lines = [
-        "Detected rate changes on llm-stats.com against the in-repo seed.",
-        "The data migration loads them on deploy; the seed loader supersedes",
-        "each affected `PricingRule` (closes the old row, inserts a fresh one).",
-        "",
-        "| Provider | Model | Service | Old (per 1K) | New (per 1K) | Source |",
-        "| --- | --- | --- | --- | --- | --- |",
-        *(_change_row(c) for c in changes),
-        *_unmatched_section(unmatched),
-    ]
+def render_pr_body(changes: list[RateChange], unmatched: set[str], backfilled: list[dict] | None = None) -> str:
+    lines = []
+    if changes:
+        lines += [
+            "Detected rate changes on llm-stats.com against the in-repo seed.",
+            "The data migration loads them on deploy; the seed loader supersedes",
+            "each affected `PricingRule` (closes the old row, inserts a fresh one).",
+            "",
+            "| Provider | Model | Service | Old (per 1K) | New (per 1K) | Source |",
+            "| --- | --- | --- | --- | --- | --- |",
+            *(_change_row(c) for c in changes),
+        ]
+    if backfilled:
+        if lines:
+            lines.append("")
+        lines += [
+            "## Backfilled from LiteLLM",
+            "",
+            "The following models had no seed entry and were auto-priced using the",
+            "[LiteLLM model price table](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json).",
+            "Verify the rates before merging.",
+            "",
+            "| Provider | Model | Service | Price (per 1K) |",
+            "| --- | --- | --- | --- |",
+            *(_backfill_rows(e) for e in backfilled),
+        ]
+    lines += _unmatched_section(unmatched)
+    if not lines:
+        lines = ["No rate changes or new pricing entries."]
     return "\n".join(lines) + "\n"
 
 
@@ -692,6 +758,11 @@ def _change_row(c: RateChange) -> str:
         f"| {c.provider_type} | {c.model_name} | {c.service_kind} | "
         f"{old} | {c.new_price} | [llm-stats]({c.source_url}) |"
     )
+
+
+def _backfill_rows(entry: dict) -> str:
+    rules_str = ", ".join(f"{r['service_kind']}: {r['unit_price']}" for r in entry["rules"])
+    return f"| {entry['provider_type']} | {entry['model_name']} | {rules_str} |"
 
 
 def _unmatched_section(unmatched: set[str]) -> list[str]:
@@ -738,7 +809,8 @@ class _ReconcileResults:
     classification: dict
     changes: list[RateChange]
     unmatched_diff: set[str]
-    missing: list[MissingPricingEntry]
+    missing: list[MissingPricingEntry]  # truly unresolvable after litellm backfill
+    backfilled: list[dict]  # new seed entries resolved from litellm
 
 
 # Output assembly + GitHub Actions integration
@@ -755,6 +827,7 @@ def _assemble_payload(results: _ReconcileResults, *, run_date: str, days_lookbac
             "unpriced_candidates": len(results.classification["unpriced_models"]),
             "pricing_entries_generated": len(results.classification["pricing_entries"]),
             "price_changes": len(results.changes),
+            "backfilled_from_litellm": len(results.backfilled),
             "missing_pricing": len(results.missing),
         },
         "new_models": results.classification["new_models"],
@@ -763,6 +836,7 @@ def _assemble_payload(results: _ReconcileResults, *, run_date: str, days_lookbac
         "pricing_entries": results.classification["pricing_entries"],
         "price_changes": [c.__dict__ for c in results.changes],
         "unmatched_diff_models": sorted(results.unmatched_diff),
+        "backfilled_pricing": results.backfilled,
         "missing_pricing": [
             {"provider_type": e.provider_type, "model_name": e.model_name, "kinds_missing": list(e.kinds_missing)}
             for e in results.missing
@@ -789,15 +863,23 @@ def _new_models_outputs(new_models: list[dict]) -> list[str]:
 
 
 def _price_change_outputs(
-    changes: list[RateChange],
+    results: _ReconcileResults,
     today: datetime.date,
     body_path: Path | None,
 ) -> list[str]:
-    count = len(changes)
-    title = f"Pricing update: {count} rate change(s) ({today.isoformat()})" if count else ""
+    change_count = len(results.changes)
+    backfill_count = len(results.backfilled)
+    has_any = bool(change_count or backfill_count)
+    parts = []
+    if change_count:
+        parts.append(f"{change_count} rate change(s)")
+    if backfill_count:
+        parts.append(f"{backfill_count} backfilled from LiteLLM")
+    title = f"Pricing update: {', '.join(parts)} ({today.isoformat()})" if has_any else ""
     return [
-        f"has_price_changes={'true' if count else 'false'}",
-        f"price_change_count={count}",
+        f"has_price_changes={'true' if has_any else 'false'}",
+        f"price_change_count={change_count}",
+        f"backfilled_count={backfill_count}",
         f"pricing_pr_title={title}",
         f"pricing_pr_body_path={body_path or ''}",
     ]
@@ -846,17 +928,28 @@ def _commit_price_changes(
     today: datetime.date,
 ) -> Path | None:
     """Rewrite seed JSON + emit rate-update migration + write PR body.
-    No-op (returns None) when there are no rate changes.
+
+    Handles both upstream rate changes and LiteLLM-backfilled entries.  A
+    migration is generated whenever *either* list is non-empty so both kinds
+    of update are applied in the same deploy.
+    No-op (returns None) when both lists are empty.
     """
-    if not results.changes:
+    if not results.changes and not results.backfilled:
         return None
     seed_path = repo_root / LLM_PRICING_REL_PATH
     seed = load_seed(seed_path)
-    seed_path.write_text(json.dumps(apply_changes(seed, results.changes), indent=2) + "\n")
+    updated = apply_changes(seed, results.changes)
+    if results.backfilled:
+        # Append new entries that weren't in the seed at all.
+        existing_keys = {(e["provider_type"], e["model_name"]) for e in updated}
+        for entry in results.backfilled:
+            if (entry["provider_type"], entry["model_name"]) not in existing_keys:
+                updated.append(entry)
+    seed_path.write_text(json.dumps(updated, indent=2) + "\n")
     migration_path = generate_migration(repo_root / MIGRATIONS_DIR_REL_PATH, today)
     print(f"  -> wrote {migration_path.name} + updated seed")
     body_path = output_path.with_name(output_path.stem + ".pricing-body.md")
-    body_path.write_text(render_pr_body(results.changes, results.unmatched_diff))
+    body_path.write_text(render_pr_body(results.changes, results.unmatched_diff, results.backfilled))
     return body_path
 
 
@@ -893,10 +986,12 @@ def _run_reconciliation(repo_root: Path, bearer: str, days: int) -> _ReconcileRe
     print(f"  -> {len(changes)} rate change(s); {len(unmatched_diff)} unmatched")
 
     print("  Auditing missing pricing for OCS-managed models ...")
-    missing = audit_missing_pricing(active, index)
-    print(f"  -> {len(missing)} model(s) missing seed pricing")
+    all_missing = audit_missing_pricing(active, index)
+    print(f"  -> {len(all_missing)} model(s) missing seed pricing; attempting LiteLLM backfill ...")
+    backfilled, still_missing = backfill_missing_from_litellm(all_missing, litellm_data)
+    print(f"  -> backfilled {len(backfilled)}, still missing {len(still_missing)}")
 
-    return _ReconcileResults(candidates, classification, changes, unmatched_diff, missing)
+    return _ReconcileResults(candidates, classification, changes, unmatched_diff, still_missing, backfilled)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -914,6 +1009,7 @@ def main(argv: list[str] | None = None) -> int:
         run_date=datetime.datetime.now(datetime.UTC).isoformat(),
         days_lookback=args.days,
     )
+
     args.output.write_text(json.dumps(payload, indent=2))
 
     print()
@@ -923,7 +1019,7 @@ def main(argv: list[str] | None = None) -> int:
 
     _write_github_output(
         _new_models_outputs(results.classification["new_models"])
-        + _price_change_outputs(results.changes, today, pricing_body_path)
+        + _price_change_outputs(results, today, pricing_body_path)
         + _missing_pricing_outputs(results.missing, missing_body_path)
     )
     return 0

--- a/scripts/reconcile_models.py
+++ b/scripts/reconcile_models.py
@@ -957,7 +957,8 @@ def _commit_price_changes(
                 existing = updated[entry_index[key]]
                 rules_by_kind = {r["service_kind"]: r for r in existing["rules"]}
                 for rule in bf_entry["rules"]:
-                    rules_by_kind[rule["service_kind"]] = rule
+                    # Only fill gaps; never overwrite prices already curated in the seed.
+                    rules_by_kind.setdefault(rule["service_kind"], rule)
                 existing["rules"] = list(rules_by_kind.values())
             else:
                 updated.append(bf_entry)

--- a/scripts/reconcile_models.py
+++ b/scripts/reconcile_models.py
@@ -740,7 +740,7 @@ def render_pr_body(changes: list[RateChange], unmatched: set[str], backfilled: l
         lines += [
             "## Backfilled from LiteLLM",
             "",
-            "The following models had no seed entry and were auto-priced using the",
+            "The following models had missing or partial seed pricing and were auto-priced using the",
             "[LiteLLM model price table](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json).",
             "Verify the rates before merging.",
             "",
@@ -763,8 +763,11 @@ def _change_row(c: RateChange) -> str:
 
 
 def _backfill_rows(entry: dict) -> str:
-    rules_str = ", ".join(f"{r['service_kind']}: {r['unit_price']}" for r in entry["rules"])
-    return f"| {entry['provider_type']} | {entry['model_name']} | {rules_str} |"
+    """Return one table row per pricing rule, matching the 4-column header."""
+    return "\n".join(
+        f"| {entry['provider_type']} | {entry['model_name']} | {r['service_kind']} | {r['unit_price']} |"
+        for r in entry["rules"]
+    )
 
 
 def _unmatched_section(unmatched: set[str]) -> list[str]:

--- a/scripts/reconcile_models.py
+++ b/scripts/reconcile_models.py
@@ -412,7 +412,9 @@ def resolve_pricing(candidate: Candidate, litellm_data: dict[str, Any]) -> Prici
         rates = resolve_pricing_from_llm_stats(candidate.details)
         if rates:
             return PricingResult(rates, "llm_stats")
-    rates = resolve_pricing_from_litellm(candidate.id, litellm_data)
+    # Pass the upstream org (e.g. "groq") so provider-namespaced keys like
+    # "groq/gemma-7b-it" are tried as a fallback.
+    rates = resolve_pricing_from_litellm(candidate.id, litellm_data, provider=candidate.org)
     return PricingResult(rates, "litellm" if rates else None)
 
 
@@ -940,11 +942,22 @@ def _commit_price_changes(
     seed = load_seed(seed_path)
     updated = apply_changes(seed, results.changes)
     if results.backfilled:
-        # Append new entries that weren't in the seed at all.
-        existing_keys = {(e["provider_type"], e["model_name"]) for e in updated}
-        for entry in results.backfilled:
-            if (entry["provider_type"], entry["model_name"]) not in existing_keys:
-                updated.append(entry)
+        # Merge backfilled entries into the seed.  A model may already have a
+        # partial entry (e.g. only llm_cached_input); in that case we update its
+        # rules in place rather than silently skipping the backfilled data.
+        entry_index: dict[tuple[str, str], int] = {
+            (e["provider_type"], e["model_name"]): i for i, e in enumerate(updated)
+        }
+        for bf_entry in results.backfilled:
+            key = (bf_entry["provider_type"], bf_entry["model_name"])
+            if key in entry_index:
+                existing = updated[entry_index[key]]
+                rules_by_kind = {r["service_kind"]: r for r in existing["rules"]}
+                for rule in bf_entry["rules"]:
+                    rules_by_kind[rule["service_kind"]] = rule
+                existing["rules"] = list(rules_by_kind.values())
+            else:
+                updated.append(bf_entry)
     seed_path.write_text(json.dumps(updated, indent=2) + "\n")
     migration_path = generate_migration(repo_root / MIGRATIONS_DIR_REL_PATH, today)
     print(f"  -> wrote {migration_path.name} + updated seed")

--- a/scripts/test_reconcile_models.py
+++ b/scripts/test_reconcile_models.py
@@ -23,6 +23,7 @@ from reconcile_models import (
     _per_token_to_per_1k,
     apply_changes,
     audit_missing_pricing,
+    backfill_missing_from_litellm,
     build_pricing_entries,
     compute_changes,
     diffable_models,
@@ -200,6 +201,52 @@ def test_resolve_litellm_per_token_conversion():
 def test_resolve_litellm_returns_none(model_id, litellm_data):
     """Returns None when model is absent or has no pricing fields."""
     assert resolve_pricing_from_litellm(model_id, litellm_data) is None
+
+
+def test_resolve_litellm_provider_prefix_fallback():
+    """When the bare model ID is absent, tries ``provider/model_id``.
+    This is the groq/gemma-7b-it case: litellm keys it as ``groq/gemma-7b-it``
+    but OCS stores the model name as just ``gemma-7b-it``.
+    """
+    litellm_data = {
+        "groq/gemma-7b-it": {
+            "input_cost_per_token": 5e-08,
+            "output_cost_per_token": 8e-08,
+        }
+    }
+    result = resolve_pricing_from_litellm("gemma-7b-it", litellm_data, provider="groq")
+    assert result is not None
+    assert result["llm_input"] == "0.00005"
+    assert result["llm_output"] == "0.00008"
+
+
+def test_resolve_litellm_bare_name_takes_priority_over_prefix():
+    """If both bare and prefixed keys exist, bare wins."""
+    litellm_data = {
+        "some-model": {
+            "input_cost_per_token": 0.000001,
+            "output_cost_per_token": 0.000004,
+        },
+        "openai/some-model": {
+            "input_cost_per_token": 0.000009,
+            "output_cost_per_token": 0.000036,
+        },
+    }
+    result = resolve_pricing_from_litellm("some-model", litellm_data, provider="openai")
+    assert result is not None
+    assert result["llm_input"] == "0.001"  # bare: 0.000001 * 1000
+
+
+def test_resolve_litellm_no_provider_ignores_prefix():
+    """Without a provider, only the bare name is tried."""
+    litellm_data = {
+        "groq/gemma-7b-it": {
+            "input_cost_per_token": 5e-08,
+            "output_cost_per_token": 8e-08,
+        }
+    }
+    result = resolve_pricing_from_litellm("gemma-7b-it", litellm_data)
+    assert result is None
 
 
 # build_pricing_entries
@@ -764,6 +811,125 @@ def test_render_pr_body_hyphen_for_missing_old_price():
     body = render_pr_body([change], unmatched=set())
 
     assert "| - | 0.001 |" in body
+
+
+def test_render_pr_body_includes_backfill_section():
+    backfilled = [
+        {
+            "provider_type": "groq",
+            "model_name": "gemma-7b-it",
+            "rules": [
+                {"service_kind": "llm_input", "unit_price": "0.00005"},
+                {"service_kind": "llm_output", "unit_price": "0.00008"},
+            ],
+        }
+    ]
+    body = render_pr_body(changes=[], unmatched=set(), backfilled=backfilled)
+
+    assert "## Backfilled from LiteLLM" in body
+    assert "gemma-7b-it" in body
+    assert "groq" in body
+
+
+def test_render_pr_body_backfill_only_no_changes_section():
+    backfilled = [
+        {
+            "provider_type": "openai",
+            "model_name": "gpt-3.5-turbo",
+            "rules": [
+                {"service_kind": "llm_input", "unit_price": "0.0005"},
+                {"service_kind": "llm_output", "unit_price": "0.0015"},
+            ],
+        }
+    ]
+    body = render_pr_body(changes=[], unmatched=set(), backfilled=backfilled)
+
+    # There are no rate changes, so the changes table header should be absent
+    assert "Old (per 1K)" not in body
+    assert "## Backfilled from LiteLLM" in body
+
+
+# backfill_missing_from_litellm
+
+
+class TestBackfillMissingFromLitellm:
+    def _entry(self, provider, model, kinds=("llm_input", "llm_output")):
+        return MissingPricingEntry(provider, model, tuple(kinds))
+
+    def test_resolves_bare_name_match(self):
+        missing = [self._entry("openai", "gpt-3.5-turbo")]
+        litellm_data = {
+            "gpt-3.5-turbo": {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 1.5e-06,
+            }
+        }
+        backfilled, still_missing = backfill_missing_from_litellm(missing, litellm_data)
+
+        assert len(backfilled) == 1
+        assert still_missing == []
+        entry = backfilled[0]
+        assert entry["provider_type"] == "openai"
+        assert entry["model_name"] == "gpt-3.5-turbo"
+        rules = {r["service_kind"]: r["unit_price"] for r in entry["rules"]}
+        assert rules["llm_input"] == "0.0005"
+        assert rules["llm_output"] == "0.0015"
+
+    def test_resolves_provider_prefixed_key(self):
+        """groq/gemma-7b-it: bare lookup misses, prefixed lookup hits."""
+        missing = [self._entry("groq", "gemma-7b-it")]
+        litellm_data = {
+            "groq/gemma-7b-it": {
+                "input_cost_per_token": 5e-08,
+                "output_cost_per_token": 8e-08,
+            }
+        }
+        backfilled, still_missing = backfill_missing_from_litellm(missing, litellm_data)
+
+        assert len(backfilled) == 1
+        assert still_missing == []
+
+    def test_stays_missing_when_not_in_litellm(self):
+        missing = [self._entry("openai", "gpt-5.3")]
+        backfilled, still_missing = backfill_missing_from_litellm(missing, {})
+
+        assert backfilled == []
+        assert len(still_missing) == 1
+
+    def test_stays_missing_when_litellm_entry_lacks_required_kinds(self):
+        """A litellm entry with only cached_input (no input/output) isn't enough."""
+        missing = [self._entry("openai", "partial-model")]
+        litellm_data = {
+            "partial-model": {
+                "cache_read_input_token_cost": 0.000001,
+            }
+        }
+        backfilled, still_missing = backfill_missing_from_litellm(missing, litellm_data)
+
+        assert backfilled == []
+        assert len(still_missing) == 1
+
+    def test_mixed_resolved_and_unresolved(self):
+        missing = [
+            self._entry("openai", "gpt-3.5-turbo"),
+            self._entry("openai", "gpt-unknown"),
+        ]
+        litellm_data = {
+            "gpt-3.5-turbo": {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 1.5e-06,
+            }
+        }
+        backfilled, still_missing = backfill_missing_from_litellm(missing, litellm_data)
+
+        assert len(backfilled) == 1
+        assert len(still_missing) == 1
+        assert still_missing[0].model_name == "gpt-unknown"
+
+    def test_empty_missing_list(self):
+        backfilled, still_missing = backfill_missing_from_litellm([], {})
+        assert backfilled == []
+        assert still_missing == []
 
 
 # audit_missing_pricing

--- a/scripts/test_reconcile_models.py
+++ b/scripts/test_reconcile_models.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 from reconcile_models import (
     REQUIRED_SERVICE_KINDS,
+    Candidate,
     MissingPricingEntry,
     RateChange,
     _fmt,
@@ -35,6 +36,7 @@ from reconcile_models import (
     rates_from_detail,
     render_missing_pricing_issue_body,
     render_pr_body,
+    resolve_pricing,
     resolve_pricing_from_litellm,
     resolve_pricing_from_llm_stats,
     seed_index,
@@ -831,6 +833,64 @@ def test_render_pr_body_includes_backfill_section():
     assert "groq" in body
 
 
+def test_commit_price_changes_merges_backfill_into_partial_entry(repo_root, tmp_path):
+    """A backfilled entry whose (provider, model) already exists in the seed
+    (e.g. with only llm_cached_input) should have its rules merged in rather
+    than silently dropped.
+    """
+    from reconcile_models import (
+        _ReconcileResults,
+        _commit_price_changes,
+        load_seed,
+    )
+    import datetime
+
+    # Seed the file with a partial entry (cached_input only, no input/output).
+    seed_path = repo_root / "apps/cost_tracking/seed_data/llm_pricing.json"
+    partial_seed = [
+        {
+            "provider_type": "openai",
+            "model_name": "gpt-partial",
+            "rules": [{"service_kind": "llm_cached_input", "unit_price": "0.00025"}],
+        }
+    ]
+    seed_path.write_text(json.dumps(partial_seed))
+
+    # Ensure migrations dir exists.
+    migrations_dir = repo_root / "apps/cost_tracking/migrations"
+    migrations_dir.mkdir(parents=True, exist_ok=True)
+    (migrations_dir / "0001_initial.py").touch()
+
+    backfilled = [
+        {
+            "provider_type": "openai",
+            "model_name": "gpt-partial",
+            "rules": [
+                {"service_kind": "llm_input", "unit_price": "0.0005"},
+                {"service_kind": "llm_output", "unit_price": "0.0015"},
+            ],
+        }
+    ]
+    results = _ReconcileResults(
+        candidates=[],
+        classification={"new_models": [], "already_registered": [], "unpriced_models": [], "pricing_entries": []},
+        changes=[],
+        unmatched_diff=set(),
+        missing=[],
+        backfilled=backfilled,
+    )
+
+    _commit_price_changes(results, repo_root, tmp_path / "out.json", datetime.date(2026, 7, 1))
+
+    written = load_seed(seed_path)
+    assert len(written) == 1
+    rules_by_kind = {r["service_kind"]: r["unit_price"] for r in written[0]["rules"]}
+    # All three kinds should be present after the merge.
+    assert rules_by_kind["llm_cached_input"] == "0.00025"  # preserved
+    assert rules_by_kind["llm_input"] == "0.0005"  # backfilled
+    assert rules_by_kind["llm_output"] == "0.0015"  # backfilled
+
+
 def test_render_pr_body_backfill_only_no_changes_section():
     backfilled = [
         {
@@ -852,7 +912,7 @@ def test_render_pr_body_backfill_only_no_changes_section():
 # backfill_missing_from_litellm
 
 
-class TestBackfillMissingFromLitellm:
+class TestBackfillMissingFromLitellm:  # noqa: D101
     def _entry(self, provider, model, kinds=("llm_input", "llm_output")):
         return MissingPricingEntry(provider, model, tuple(kinds))
 
@@ -889,21 +949,25 @@ class TestBackfillMissingFromLitellm:
         assert len(backfilled) == 1
         assert still_missing == []
 
-    def test_stays_missing_when_not_in_litellm(self):
-        missing = [self._entry("openai", "gpt-5.3")]
-        backfilled, still_missing = backfill_missing_from_litellm(missing, {})
-
-        assert backfilled == []
-        assert len(still_missing) == 1
-
-    def test_stays_missing_when_litellm_entry_lacks_required_kinds(self):
-        """A litellm entry with only cached_input (no input/output) isn't enough."""
-        missing = [self._entry("openai", "partial-model")]
-        litellm_data = {
-            "partial-model": {
-                "cache_read_input_token_cost": 0.000001,
-            }
-        }
+    @pytest.mark.parametrize(
+        ("model_id", "litellm_data"),
+        [
+            pytest.param("gpt-5.3", {}, id="not_in_litellm"),
+            pytest.param(
+                "partial-model",
+                {"partial-model": {"cache_read_input_token_cost": 0.000001}},
+                id="cached_input_only_not_enough",
+            ),
+            pytest.param(
+                "groq-model",
+                {},  # neither bare nor prefixed key exists
+                id="provider_prefix_also_missing",
+            ),
+        ],
+    )
+    def test_stays_missing(self, model_id, litellm_data):
+        """Entry remains in still_missing when litellm can't fully resolve it."""
+        missing = [self._entry("openai", model_id)]
         backfilled, still_missing = backfill_missing_from_litellm(missing, litellm_data)
 
         assert backfilled == []
@@ -930,6 +994,32 @@ class TestBackfillMissingFromLitellm:
         backfilled, still_missing = backfill_missing_from_litellm([], {})
         assert backfilled == []
         assert still_missing == []
+
+
+# resolve_pricing — provider forwarding to litellm
+
+
+def test_resolve_pricing_passes_org_as_provider_to_litellm():
+    """resolve_pricing() forwards candidate.org so provider-namespaced litellm
+    keys (e.g. ``groq/gemma-7b-it``) are found via the prefix fallback.
+    """
+    candidate = Candidate(
+        {
+            "id": "gemma-7b-it",
+            "organization": {"id": "groq"},
+            "details_error": "HTTP 404: Not Found",  # force litellm path
+        }
+    )
+    litellm_data = {
+        "groq/gemma-7b-it": {
+            "input_cost_per_token": 5e-08,
+            "output_cost_per_token": 8e-08,
+        }
+    }
+    result = resolve_pricing(candidate, litellm_data)
+    assert result.rates is not None
+    assert result.source == "litellm"
+    assert result.rates["llm_input"] == "0.00005"
 
 
 # audit_missing_pricing

--- a/scripts/test_reconcile_models.py
+++ b/scripts/test_reconcile_models.py
@@ -17,6 +17,8 @@ from reconcile_models import (
     Candidate,
     MissingPricingEntry,
     RateChange,
+    _ReconcileResults,
+    _commit_price_changes,
     _fmt,
     _format_per_1k,
     _next_migration_number,
@@ -32,6 +34,7 @@ from reconcile_models import (
     load_active_default_models,
     load_priced_models,
     load_registered_models,
+    load_seed,
     process_candidates,
     rates_from_detail,
     render_missing_pricing_issue_body,
@@ -829,8 +832,9 @@ def test_render_pr_body_includes_backfill_section():
     body = render_pr_body(changes=[], unmatched=set(), backfilled=backfilled)
 
     assert "## Backfilled from LiteLLM" in body
-    assert "gemma-7b-it" in body
-    assert "groq" in body
+    # Each rule gets its own row with 4 cells.
+    assert "| groq | gemma-7b-it | llm_input | 0.00005 |" in body
+    assert "| groq | gemma-7b-it | llm_output | 0.00008 |" in body
 
 
 def test_commit_price_changes_merges_backfill_into_partial_entry(repo_root, tmp_path):
@@ -838,13 +842,6 @@ def test_commit_price_changes_merges_backfill_into_partial_entry(repo_root, tmp_
     (e.g. with only llm_cached_input) should have its rules merged in rather
     than silently dropped.
     """
-    from reconcile_models import (
-        _ReconcileResults,
-        _commit_price_changes,
-        load_seed,
-    )
-    import datetime
-
     # Seed the file with a partial entry (cached_input only, no input/output).
     seed_path = repo_root / "apps/cost_tracking/seed_data/llm_pricing.json"
     partial_seed = [

--- a/scripts/test_reconcile_models.py
+++ b/scripts/test_reconcile_models.py
@@ -888,6 +888,54 @@ def test_commit_price_changes_merges_backfill_into_partial_entry(repo_root, tmp_
     assert rules_by_kind["llm_output"] == "0.0015"  # backfilled
 
 
+def test_commit_price_changes_backfill_does_not_overwrite_curated_prices(repo_root, tmp_path):
+    """When the seed already has a curated price for a kind that LiteLLM also
+    returns, the curated value must be preserved — backfill only fills *gaps*.
+    """
+    # Seed has a curated llm_input; llm_output is missing.
+    seed_path = repo_root / "apps/cost_tracking/seed_data/llm_pricing.json"
+    curated_input = "0.00999"  # deliberately different from LiteLLM's value
+    partial_seed = [
+        {
+            "provider_type": "openai",
+            "model_name": "gpt-curated",
+            "rules": [{"service_kind": "llm_input", "unit_price": curated_input}],
+        }
+    ]
+    seed_path.write_text(json.dumps(partial_seed))
+
+    migrations_dir = repo_root / "apps/cost_tracking/migrations"
+    migrations_dir.mkdir(parents=True, exist_ok=True)
+    (migrations_dir / "0001_initial.py").touch()
+
+    # LiteLLM backfill returns BOTH input and output — input should not clobber
+    # the curated value.
+    backfilled = [
+        {
+            "provider_type": "openai",
+            "model_name": "gpt-curated",
+            "rules": [
+                {"service_kind": "llm_input", "unit_price": "0.00001"},  # different
+                {"service_kind": "llm_output", "unit_price": "0.00004"},
+            ],
+        }
+    ]
+    results = _ReconcileResults(
+        candidates=[],
+        classification={"new_models": [], "already_registered": [], "unpriced_models": [], "pricing_entries": []},
+        changes=[],
+        unmatched_diff=set(),
+        missing=[],
+        backfilled=backfilled,
+    )
+    _commit_price_changes(results, repo_root, tmp_path / "out.json", datetime.date(2026, 7, 1))
+
+    written = load_seed(seed_path)
+    rules_by_kind = {r["service_kind"]: r["unit_price"] for r in written[0]["rules"]}
+    assert rules_by_kind["llm_input"] == curated_input, "curated price must not be overwritten"
+    assert rules_by_kind["llm_output"] == "0.00004", "missing kind should be filled"
+
+
 def test_render_pr_body_backfill_only_no_changes_section():
     backfilled = [
         {


### PR DESCRIPTION
## Summary

Fixes two bugs in `scripts/reconcile_models.py` that caused the missing-pricing audit to leave out models that LiteLLM already has pricing for. Together these would have auto-seeded 9 of the 18 models in #3729 without manual intervention.

---

### Bug 1 — Missing-pricing path never tried LiteLLM

The audit only *reported* gaps (feeding a GitHub issue); it never attempted to auto-fill them from the LiteLLM fallback.

**Fix:** Added `backfill_missing_from_litellm()` which runs immediately after `audit_missing_pricing()`. It resolves what it can from LiteLLM and appends those new entries to the seed JSON (triggering the existing migration + PR flow). Only genuinely unresolvable models continue to the missing-pricing GitHub issue.

Backfilled entries appear in the Pricing update PR body under a dedicated **Backfilled from LiteLLM** section so they get reviewed before merge.

### Bug 2 — Groq models used bare-name lookup, missing provider-prefixed keys

LiteLLM keys Groq models as `groq/model-name`, but `resolve_pricing_from_litellm` looked up only the bare model name, always missing.

**Fix:** Added an optional `provider` parameter. The function now tries both `model-id` and `provider/model-id` before giving up. This also benefits the existing new-candidates path (where the function was already called).

---

### Models that would have been auto-seeded

| Provider | Model | LiteLLM key |
|---|---|---|
| anthropic | claude-3-7-sonnet-20250219 | exact match |
| anthropic | claude-opus-4-20250514 | exact match |
| anthropic | claude-sonnet-4-20250514 | exact match |
| openai | gpt-4.1-nano | exact match |
| azure | gpt-4.1-nano | exact match |
| google | gemini-2.0-flash | exact match |
| openai | chatgpt-4o-latest | exact match |
| openai | gpt-3.5-turbo | exact match |
| openai | gpt-3.5-turbo-1106 | exact match |
| groq | gemma-7b-it | `groq/gemma-7b-it` (prefix fallback) |

### Still needs manual pricing (not in LiteLLM)

- `anthropic/claude-3-5-haiku-latest` (alias, LiteLLM has the dated version)
- `groq/gemma2-9b-it` (deprecated, not in LiteLLM)
- `groq/whisper-large-v3-turbo` (ASR model — per-hour pricing, not per-token)
- `openai/gpt-5.3`, `openai/gpt-5.3-instant`, `openai/o4-mini-high`
- `perplexity/llama-3.1-sonar-{large,small}-128k-chat` (deprecated)

---

### Tests

All 81 tests pass. New tests cover:
- `resolve_pricing_from_litellm` with provider-prefix fallback (4 tests)
- `backfill_missing_from_litellm` (6 tests)
- `render_pr_body` with backfill section (2 tests)

---

Closes part of #3729 (the remaining models still need manual seed entries per the research comment on that issue).

- [ ] The migrations are backwards compatible