### PR TITLE
[Docs] Improve accuracy of RAG index manager & citations

### DIFF
--- a/docs/developer_guides/code_systems/citations.md
+++ b/docs/developer_guides/code_systems/citations.md
@@ -26,7 +26,7 @@ This processing step occurs in `_process_agent_output()` in `apps/pipelines/node
 Example transformation:
 
 **Input from LLM:**
-```
+```text
 The sky is blue <CIT 123 />. The grass is green <CIT 456 />.
 ```
 

--- a/docs/developer_guides/code_systems/citations.md
+++ b/docs/developer_guides/code_systems/citations.md
@@ -1,0 +1,41 @@
+# Citations
+
+The platform has a built-in mechanism for citing sources used by the LLM, particularly when retrieving information from indexed documents. This process involves generation, parsing, and final rendering of citations.
+
+This assumes the LLM has retrieved content from a document collection — see [Index Manager Classes](index_managers.md) for how that retrieval works.
+
+## 1. Citation Generation
+
+When an agent uses a tool like `SearchIndexTool` to query a document collection, it gains access to the content of relevant files. The LLM is instructed to cite its sources by embedding a special tag in its response whenever it uses information from a file.
+
+The citation format is `<CIT file-id />`, where `file-id` is the unique identifier of the cited `File` model instance. This format is defined by the `OCS_CITATION_PATTERN` constant found in `apps.chat.agent.tools`.
+
+## 2. Building the Reference Section
+
+After the LLM generates a response containing these citation tags, the system processes the message to create a human-readable reference section. This is handled by `apps.service_providers.llm_service.utils.populate_reference_section_from_citations`.
+
+This method performs three main actions:
+1. It scans the AI message for all instances of the `<CIT file-id />` pattern.
+2. Each tag is replaced with a footnote-style reference (e.g., `[^1]`, `[^2]`). It keeps track of cited files to reuse reference numbers for multiple citations of the same file.
+3. It appends a markdown-formatted reference list to the end of the message. Each entry includes the reference number, the original file name, and a download link for that file.
+
+This processing step occurs within the `invoke` method of the `LLMChat` runnable (`apps/service_providers/llm_service/runnables.py`) before the final message is saved and sent to the user.
+
+Example transformation:
+
+**Input from LLM:**
+```
+The sky is blue <CIT 123 />. The grass is green <CIT 456 />.
+```
+
+**Output after processing:**
+```markdown
+The sky is blue [^1]. The grass is green [^2].
+
+[^1]: [document_a.pdf](https://example.com/download/123)
+[^2]: [source_b.txt](https://example.com/download/456)
+```
+
+## 3. Final Rendering in Channels
+
+The markdown-formatted message, now including footnote-style references, is passed to the channel layer for final display to the user. In `apps/chat/channels.py`, a function named `_format_reference_section` is responsible for parsing this markdown and rendering it appropriately for the specific channel (e.g., converting it to HTML for the web interface). This ensures that users see a clean, clickable list of citations in the final UI.

--- a/docs/developer_guides/code_systems/citations.md
+++ b/docs/developer_guides/code_systems/citations.md
@@ -2,13 +2,15 @@
 
 The platform has a built-in mechanism for citing sources used by the LLM, particularly when retrieving information from indexed documents. This process involves generation, parsing, and final rendering of citations.
 
+This page covers the `<CIT file-id />` tag mechanism used by **pipeline nodes** (`apps/pipelines/nodes/llm_node.py`). The legacy OpenAI Assistants feature has its own separate citation handling and does not use this tag scheme.
+
 This assumes the LLM has retrieved content from a document collection — see [Index Manager Classes](index_managers.md) for how that retrieval works.
 
 ## 1. Citation Generation
 
 When an agent uses a tool like `SearchIndexTool` to query a document collection, it gains access to the content of relevant files. The LLM is instructed to cite its sources by embedding a special tag in its response whenever it uses information from a file.
 
-The citation format is `<CIT file-id />`, where `file-id` is the unique identifier of the cited `File` model instance. This format is defined by the `OCS_CITATION_PATTERN` constant found in `apps.chat.agent.tools`.
+The citation format is `<CIT file-id />`, where `file-id` is the unique identifier of the cited `File` model instance. This format is defined by the `OCS_CITATION_PATTERN` constant found in `apps.chat.agent.constants`.
 
 ## 2. Building the Reference Section
 
@@ -19,7 +21,7 @@ This method performs three main actions:
 2. Each tag is replaced with a footnote-style reference (e.g., `[^1]`, `[^2]`). It keeps track of cited files to reuse reference numbers for multiple citations of the same file.
 3. It appends a markdown-formatted reference list to the end of the message. Each entry includes the reference number, the original file name, and a download link for that file.
 
-This processing step occurs within the `invoke` method of the `LLMChat` runnable (`apps/service_providers/llm_service/runnables.py`) before the final message is saved and sent to the user.
+This processing step occurs in `_process_agent_output()` in `apps/pipelines/nodes/llm_node.py`, before the final message is saved and sent to the user.
 
 Example transformation:
 
@@ -38,4 +40,6 @@ The sky is blue [^1]. The grass is green [^2].
 
 ## 3. Final Rendering in Channels
 
-The markdown-formatted message, now including footnote-style references, is passed to the channel layer for final display to the user. In `apps/chat/channels.py`, a function named `_format_reference_section` is responsible for parsing this markdown and rendering it appropriately for the specific channel (e.g., converting it to HTML for the web interface). This ensures that users see a clean, clickable list of citations in the final UI.
+The markdown-formatted message, now including footnote-style references, is passed to the channel layer for final display to the user.
+
+In `apps/chat/channels.py`, a function named `_format_reference_section` adapts this markdown for the specific channel's capabilities — it rewrites `[^1]`-style footnotes to `[1]` for non-web channels, and for each cited file shows either just the filename (if the channel can send the file natively) or the filename with a download link (if it can't). The message stays in markdown; any HTML rendering happens elsewhere, in the web interface's own message rendering.

--- a/docs/developer_guides/code_systems/index_managers.md
+++ b/docs/developer_guides/code_systems/index_managers.md
@@ -1,14 +1,15 @@
 # Index Manager Classes
 
-Index managers provide an abstraction layer for managing document embeddings and vector stores in Open Chat Studio. They are LLM provider-specific implementations that enable both remote (provider-hosted) and local (self-hosted) indexing strategies for [document collections](https://docs.openchatstudio.com/concepts/collections/indexed/).
+Index managers provide an abstraction layer for managing document embeddings and vector stores in Open Chat Studio. They are LLM provider-specific implementations that enable both remote (provider-hosted) and local (self-hosted) indexing strategies for document collections.
 
-For AI-generated technical documentation on indexed collections, RAG and index managers, visit
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/dimagi/open-chat-studio/7-document-collections-and-rag)
+Index managers are the implementation layer behind [indexed collections](https://docs.openchatstudio.com/concepts/collections/indexed/), the user-facing feature that lets a chatbot search uploaded documents for relevant information before responding (retrieval-augmented generation).
+
+See also: [DeepWiki: Document Collections and RAG](https://deepwiki.com/dimagi/open-chat-studio/7-document-collections-and-rag) for AI-generated Q&A-style exploration of this code.
 
 ## Architecture Overview
 
 The system supports two indexing strategies:
-- **Remote indexing**: Vector stores are created and managed by external providers (e.g.,OpenAI)
+- **Remote indexing**: Vector stores are created and managed by external providers (e.g., OpenAI)
 - **Local indexing**: Embeddings are generated locally and stored in the application database
 
 The index manager system follows an abstract base class pattern with two main hierarchies:
@@ -86,7 +87,7 @@ index_manager.delete_remote_index()
 
 ### Local Index Operations
 
-`get_embedding_vector` requires an `input_type` of `"document"` or `"query"`. For Voyage and Google embedding providers this routes to different underlying calls (`embed_documents` vs `embed_query`) which return different vectors — labelling each side correctly is what makes retrieval work as well as the provider can deliver. OpenAI's API currently treats `embed_documents` and `embed_query` identically (its embeddings have no input-type concept), so the choice is behaviourally a no-op there today; the routing is still applied, in case that ever changes upstream or behind an OpenAI-compatible proxy.
+`get_embedding_vector` requires an `input_type` of `"document"` or `"query"`. For Voyage and Google embedding providers, this routes to different underlying calls (`embed_documents` vs `embed_query`), which return different vectors — labelling each side correctly is what makes retrieval work as well as the provider can deliver. OpenAI's API currently treats `embed_documents` and `embed_query` identically (its embeddings have no input-type concept), so the choice is behaviourally a no-op there today; the routing is still applied in case that ever changes upstream or behind an OpenAI-compatible proxy.
 
 ```python
 # Embed a retrieval query (matches the path used by Collection.get_query_vector)
@@ -141,40 +142,4 @@ def get_index_manager(self):
 
 ## Citations
 
-The platform has a built-in mechanism for citing sources used by the LLM, particularly when retrieving information from indexed documents. This process involves generation, parsing, and final rendering of citations.
-
-### 1. Citation Generation
-
-When an agent uses a tool like `SearchIndexTool` to query a document collection, it gains access to the content of relevant files. The LLM is instructed to cite its sources by embedding a special tag in its response whenever it uses information from a file.
-
-The citation format is `<CIT file-id />`, where `file-id` is the unique identifier of the cited `File` model instance. This format is defined by the `OCS_CITATION_PATTERN` constant found in `apps.chat.agent.tools`.
-
-### 2. Building the Reference Section
-
-After the LLM generates a response containing these citation tags, the system processes the message to create a human-readable reference section. This is handled by the `apps.service_providers.llm_service.utils.populate_reference_section_from_citations`).
-
-This method performs three main actions:
-1.  It scans the AI message for all instances of the `<CIT file-id />` pattern.
-2.  Each tag is replaced with a footnote-style reference (e.g., `[^1]`, `[^2]`). It keeps track of cited files to reuse reference numbers for multiple citations of the same file.
-3.  It appends a markdown-formatted reference list to the end of the message. Each entry includes the reference number, the original file name, and a download link for that file.
-
-This processing step occurs within the `invoke` method of the `LLMChat` runnable (`apps/service_providers/llm_service/runnables.py`) before the final message is saved and sent to the user.
-
-Example transformation:
-
-**Input from LLM:**
-```
-The sky is blue <CIT 123 />. The grass is green <CIT 456 />.
-```
-
-**Output after processing:**
-```markdown
-The sky is blue [^1]. The grass is green [^2].
-
-[^1]: [document_a.pdf](https://example.com/download/123)
-[^2]: [source_b.txt](https://example.com/download/456)
-```
-
-### 3. Final Rendering in Channels
-
-The markdown-formatted message, now including footnote-style references, is passed to the channel layer for final display to the user. In `apps/chat/channels.py`, a function named `_format_reference_section` is responsible for parsing this markdown and rendering it appropriately for the specific channel (e.g., converting it to HTML for the web interface). This ensures that users see a clean, clickable list of citations in the final UI.
+Once content is retrieved through an index manager, the LLM cites the source files it used and the platform renders those citations as a reference section. See [Citations](citations.md) for how that works.

--- a/docs/developer_guides/code_systems/index_managers.md
+++ b/docs/developer_guides/code_systems/index_managers.md
@@ -9,8 +9,9 @@ See also: [DeepWiki: Document Collections and RAG](https://deepwiki.com/dimagi/o
 ## Architecture Overview
 
 The system supports two indexing strategies:
+
 - **Remote indexing**: Vector stores are created and managed by external providers (e.g., OpenAI)
-- **Local indexing**: Embeddings are generated locally and stored in the application database
+- **Local indexing**: Embeddings are generated locally and stored in the application database - PostgreSQL with the pgvector extension.
 
 The index manager system follows an abstract base class pattern with two main hierarchies:
 
@@ -24,22 +25,21 @@ LocalIndexManager (ABC)
 └── VoyageAILocalIndexManager
 ```
 
+### Core Classes
 
-## Core Classes
-
-### RemoteIndexManager
+#### RemoteIndexManager
 
 Abstract base class for managing vector stores in remote indexing services. Provides a common interface for interacting with external vector store providers.
 
-### OpenAIRemoteIndexManager
+- **OpenAIRemoteIndexManager**: OpenAI-specific implementation for managing file uploads and vector stores using [OpenAI's vector store API](https://developers.openai.com/api/reference/resources/vector_stores).
 
-OpenAI-specific implementation for managing file uploads and vector stores using [OpenAI's vector store API](https://developers.openai.com/api/reference/resources/vector_stores).
-
-### LocalIndexManager
+#### LocalIndexManager
 
 Abstract base class for managing local embedding operations. Handles text processing and embedding generation on the application side.
 
-## Usage Example
+- **OpenAILocalIndexManager, GoogleLocalIndexManager, VoyageAILocalIndexManager**: wrap LangChain's embedding integrations.
+
+## Usage Examples
 
 ### Getting an Index Manager
 
@@ -56,8 +56,9 @@ index_manager = collection.get_index_manager()
 ```
 
 The method returns:
-- `RemoteIndexManager` instance if `collection.is_remote_index` is `True`
-- `LocalIndexManager` instance if `collection.is_remote_index` is `False`
+
+- `RemoteIndexManager` instance if the collection is an index (`is_index`) and `is_remote_index` is `True`
+- `LocalIndexManager` instance otherwise
 
 ### Remote Index Operations
 

--- a/docs/developer_guides/code_systems/index_managers.md
+++ b/docs/developer_guides/code_systems/index_managers.md
@@ -1,8 +1,15 @@
 # Index Manager Classes
 
-Index managers provide an abstraction layer for managing document embeddings and vector stores in Open Chat Studio. They are LLM provider-specific implementations that enable both remote (provider-hosted) and local (self-hosted) indexing strategies for document collections.
+Index managers provide an abstraction layer for managing document embeddings and vector stores in Open Chat Studio. They are LLM provider-specific implementations that enable both remote (provider-hosted) and local (self-hosted) indexing strategies for [document collections](https://docs.openchatstudio.com/concepts/collections/indexed/).
+
+For AI-generated technical documentation on indexed collections, RAG and index managers, visit
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/dimagi/open-chat-studio/7-document-collections-and-rag)
 
 ## Architecture Overview
+
+The system supports two indexing strategies:
+- **Remote indexing**: Vector stores are created and managed by external providers (e.g.,OpenAI)
+- **Local indexing**: Embeddings are generated locally and stored in the application database
 
 The index manager system follows an abstract base class pattern with two main hierarchies:
 
@@ -16,9 +23,6 @@ LocalIndexManager (ABC)
 └── VoyageAILocalIndexManager
 ```
 
-The system supports two indexing strategies:
-- **Remote indexing**: Vector stores are created and managed by external providers (e.g., OpenAI)
-- **Local indexing**: Embeddings are generated locally and stored in the application database
 
 ## Core Classes
 
@@ -28,7 +32,7 @@ Abstract base class for managing vector stores in remote indexing services. Prov
 
 ### OpenAIRemoteIndexManager
 
-OpenAI-specific implementation for managing vector stores using OpenAI's vector store API.
+OpenAI-specific implementation for managing file uploads and vector stores using [OpenAI's vector store API](https://developers.openai.com/api/reference/resources/vector_stores).
 
 ### LocalIndexManager
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,7 @@ nav:
       - Slack Channel Integration: developer_guides/code_systems/slack_channel_integration.md
       - Meta Cloud API Integration: developer_guides/code_systems/meta_cloud_api_integration.md
       - Index Managers: developer_guides/code_systems/index_managers.md
+      - Citations: developer_guides/code_systems/citations.md
       - Notifications: developer_guides/code_systems/notifications.md
     - Testing:
       - Integration Testing: developer_guides/testing/integration_testing.md


### PR DESCRIPTION
### Product Description

No change — developer documentation only.

### Technical Description

index_managers.md had drifted from the code and it currently does not include information on the searching/retrieval for how a chatbot actually finds relevant chunks at chat time.

**The main aim of this PR**: Accuracy and clean up so that addition section can be added on search/retrieval in later PR

Details:

1. Splits the Citations section into its own page (citations.md), since it serves a different reader (someone debugging citation rendering doesn't need embedding-provider details, and vice versa).
2. Corrects several inaccuracies found by checking the docs against the current source for citations.md
3. Collection.get_index_manager()'s routing depends on both is_index and is_remote_index; the doc only mentioned the latter.
4. Adds a link to the user-facing docs so new developers get feature context before the class-level details.


### Docs and Changelog
- [ ] This PR requires docs/changelog update
