### PR TITLE
[Docs] Fixed broken internal doc links

### DIFF
--- a/docs/developer_guides/code_systems/feature_flags.md
+++ b/docs/developer_guides/code_systems/feature_flags.md
@@ -6,7 +6,7 @@ Open Chat Studio uses [Django Waffle](https://waffle.readthedocs.io/) for featur
 
 Feature flags in Open Chat Studio are:
 - **Team-scoped**: Flags can be enabled/disabled per team
-- **Database-driven**: Stored in the database and configurable via a [custom admin page](../admin_guides/feature_flags.md)
+- **Database-driven**: Stored in the database and configurable via a [custom admin page](../../admin_guides/feature_flags.md)
 - **Cached**: Uses Redis for performance
 - **Convention-based**: New flags must follow naming conventions and be registered in `apps/teams/flags.py`
 

--- a/docs/developer_guides/feature_deprecation.md
+++ b/docs/developer_guides/feature_deprecation.md
@@ -103,7 +103,7 @@ holdout cannot block removal indefinitely.
 | Changelog/docs | Entry in the [docs repo](https://github.com/dimagi/open-chat-studio-docs) — see [User Docs](user_docs.md) | Every deprecation, day 0 |
 | In-feature warning | Warning callout on the feature's own templates with removal date + migration link | Used tier, day 0 → removal |
 | Banner | `apps/banners` `Banner` row; scoped location if one exists, else global; set `start_date`/`end_date` | Used tier, day 0 (optionally a second reminder banner for the final 2 weeks) |
-| In-product notification | `apps/ocs_notifications` notification to affected teams — see [Notifications](notifications.md) | Used tier, day 0 |
+| In-product notification | `apps/ocs_notifications` notification to affected teams — see [Notifications](../developer_guides/code_systems/notifications.md) | Used tier, day 0 |
 | Email | One-off shell script / management command emailing admins of affected teams, listing their configs | Used tier, day 0 |
 
 ## Read-only enforcement
@@ -128,7 +128,7 @@ The default data policy is a **two-phase drop**:
 
 **Phase 1 — code removal.** Models and columns are untouched; the feature is
 recoverable by reverting the PR. For versioned models (see
-[Object Versioning](versioning.md) and `docs/agents/django_model_versioning.md`):
+[Object Versioning](../developer_guides/code_systems/versioning.md) and `docs/agents/django_model_versioning.md`):
 
 - Remove the feature's `VersionField` entries from `_get_version_details` so
   the version-diff UI stops showing it.
@@ -142,7 +142,7 @@ recoverable by reverting the PR. For versioned models (see
   (`django-field-audit`) retains the history.
 - Then drop the columns/tables.
 - Audit `on_delete` behaviour before dropping FKs so cascades don't reach
-  version rows unexpectedly. See [Data Migrations](custom_migrations.md).
+  version rows unexpectedly. See [Data Migrations](../developer_guides/custom_migrations.md).
 
 ## HTTP surfaces
 

--- a/docs/developer_guides/managing_models.md
+++ b/docs/developer_guides/managing_models.md
@@ -215,7 +215,7 @@ When no replacement is specified:
 
 ## User Notifications
 
-Both the deprecation notification and the deletion command use the OCS notifications system (see [notifications guide](notifications.md)) rather than admin emails. Notifications are sent to team members with the `service_providers.change_llmprovidermodel` permission.
+Both the deprecation notification and the deletion command use the OCS notifications system (see [notifications guide](../developer_guides/code_systems/notifications.md)) rather than admin emails. Notifications are sent to team members with the `service_providers.change_llmprovidermodel` permission.
 
 Notifications include:
 - Which model was deprecated/deleted


### PR DESCRIPTION
### Product Description

Doc changes only. No code changes


### Technical Description

5 Internal doc Links fixed. 
I "broke" links when moving docs into a folder

#### Test

`uv run zensical serve --strict`

### Docs and Changelog
- [ ] This PR requires docs/changelog update