### PR TITLE
Use deployment host in API docs example URLs

### DIFF
--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -487,8 +487,8 @@ paths:
               examples:
                 ListParticipants:
                   value:
-                    next: http://api.example.org/accounts/?cursor=cD00ODY%3D"
-                    previous: http://api.example.org/accounts/?cursor=cj0xJnA9NDg3
+                    next: https://example.com/api/?cursor=cD00ODY%3D
+                    previous: https://example.com/api/?cursor=cj0xJnA9NDg3
                     results:
                     - id: e172ff63-2469-419f-a828-783fc9291bc7
                       identifier: part1
@@ -1283,6 +1283,7 @@ components:
         url:
           type: string
           format: uri
+          example: https://example.com/api/experiments/123e4567-e89b-12d3-a456-426614174000/
           readOnly: true
           title: API URL
         version_number:
@@ -1304,6 +1305,7 @@ components:
         url:
           type: string
           format: uri
+          example: https://example.com/api/sessions/123e4567-e89b-12d3-a456-426614174000/
           readOnly: true
         id:
           type: string
@@ -1377,6 +1379,7 @@ components:
         url:
           type: string
           format: uri
+          example: https://example.com/api/sessions/123e4567-e89b-12d3-a456-426614174000/
           readOnly: true
         id:
           type: string
@@ -1456,6 +1459,7 @@ components:
         content_url:
           type: string
           format: uri
+          example: https://example.com/api/files/42/content
           readOnly: true
       required:
       - content_url
@@ -1519,12 +1523,12 @@ components:
           type: string
           nullable: true
           format: uri
-          example: http://api.example.org/accounts/?cursor=cD00ODY%3D"
+          example: https://example.com/api/?cursor=cD00ODY%3D
         previous:
           type: string
           nullable: true
           format: uri
-          example: http://api.example.org/accounts/?cursor=cj0xJnA9NDg3
+          example: https://example.com/api/?cursor=cj0xJnA9NDg3
         results:
           type: array
           items:
@@ -1543,12 +1547,12 @@ components:
           type: string
           nullable: true
           format: uri
-          example: http://api.example.org/accounts/?cursor=cD00ODY%3D"
+          example: https://example.com/api/?cursor=cD00ODY%3D
         previous:
           type: string
           nullable: true
           format: uri
-          example: http://api.example.org/accounts/?cursor=cj0xJnA9NDg3
+          example: https://example.com/api/?cursor=cj0xJnA9NDg3
         results:
           type: array
           items:
@@ -1567,12 +1571,12 @@ components:
           type: string
           nullable: true
           format: uri
-          example: http://api.example.org/accounts/?cursor=cD00ODY%3D"
+          example: https://example.com/api/?cursor=cD00ODY%3D
         previous:
           type: string
           nullable: true
           format: uri
-          example: http://api.example.org/accounts/?cursor=cj0xJnA9NDg3
+          example: https://example.com/api/?cursor=cj0xJnA9NDg3
         results:
           type: array
           items:
@@ -1799,6 +1803,7 @@ components:
         url:
           type: string
           format: uri
+          example: https://example.com/api/sessions/123e4567-e89b-12d3-a456-426614174000/
           readOnly: true
         team:
           allOf:

--- a/api-schemas/v2.yml
+++ b/api-schemas/v2.yml
@@ -256,6 +256,7 @@ components:
         url:
           type: string
           format: uri
+          example: https://example.com/api/v2/chatbots/123e4567-e89b-12d3-a456-426614174000/
           readOnly: true
           title: API URL
         version_number:
@@ -1105,12 +1106,12 @@ components:
           type: string
           nullable: true
           format: uri
-          example: http://api.example.org/accounts/?cursor=cD00ODY%3D"
+          example: https://example.com/api/?cursor=cD00ODY%3D
         previous:
           type: string
           nullable: true
           format: uri
-          example: http://api.example.org/accounts/?cursor=cj0xJnA9NDg3
+          example: https://example.com/api/?cursor=cj0xJnA9NDg3
         results:
           type: array
           items:

--- a/apps/api/schema.py
+++ b/apps/api/schema.py
@@ -1,9 +1,22 @@
+import copy
+
 from django.conf import settings
 from drf_spectacular.authentication import TokenScheme
-from drf_spectacular.extensions import OpenApiAuthenticationExtension
+from drf_spectacular.extensions import OpenApiAuthenticationExtension, OpenApiSerializerFieldExtension
 from rest_framework.permissions import SAFE_METHODS
 
 from apps.oauth.permissions import TokenHasOAuthResourceScope, TokenHasOAuthScope
+
+# Placeholder hosts baked into the schema: DRF hardcodes ``api.example.org`` in the cursor
+# pagination ``next``/``previous`` examples, and our serializer/operation examples use
+# ``example.com``. ``set_example_urls`` rewrites both to the serving deployment's host.
+_PLACEHOLDER_HOSTS = ("https://example.com", "http://example.com")
+_PAGINATION_PLACEHOLDER = "http://api.example.org/accounts/"
+
+# Host used when no request is available (the offline ``spectacular`` management command that builds
+# the committed ``api-schemas/*.yml``). Keeps those artifacts deterministic and deployment-neutral;
+# live-served schemas use the real request host instead.
+_FALLBACK_BASE_URL = "https://example.com"
 
 
 def exclude_legacy_participants_path(endpoints):
@@ -54,6 +67,61 @@ def prune_unused_tags(result, **kwargs):
     }
     if "tags" in result:
         result["tags"] = [tag for tag in result["tags"] if tag["name"] in used]
+    return result
+
+
+def _deployment_root(request) -> str:
+    """Root URL (``scheme://host``, no trailing slash) of the deployment serving this schema.
+
+    Uses the incoming request host when the schema is served live — so the ReDoc docs pages, which
+    fetch the live schema, show URLs for the actual deployment. Falls back to a fixed placeholder for
+    the offline ``spectacular`` management command, which runs without a request.
+    """
+    if request is not None:
+        return request.build_absolute_uri("/").rstrip("/")
+    return _FALLBACK_BASE_URL
+
+
+def _swap_host(value: str, base: str) -> str:
+    """Rewrite a placeholder-host example URL to point at ``base``; leave other strings untouched."""
+    if value.startswith(_PAGINATION_PLACEHOLDER):
+        # DRF's ``/accounts/`` path is a generic placeholder, and it appends a stray ``"`` to the
+        # ``next`` cursor example — drop both.
+        return value.replace(_PAGINATION_PLACEHOLDER, f"{base}/api/").rstrip('"')
+    for host in _PLACEHOLDER_HOSTS:
+        if value.startswith(host):
+            return base + value[len(host) :]
+    return value
+
+
+def _rewrite_example_urls(node, base: str) -> None:
+    """Recursively rewrite placeholder-host URLs in every string value of ``node`` in place."""
+    items = node.items() if isinstance(node, dict) else enumerate(node) if isinstance(node, list) else ()
+    for key, value in items:
+        if isinstance(value, str):
+            node[key] = _swap_host(value, base)
+        elif isinstance(value, dict | list):
+            _rewrite_example_urls(value, base)
+
+
+class ApiUrlFieldExtension(OpenApiSerializerFieldExtension):
+    """Emit the ``example`` carried by ``apps.api.serializers.ApiUrlField`` into the schema."""
+
+    target_class = "apps.api.serializers.ApiUrlField"
+
+    def map_serializer_field(self, auto_schema, direction):
+        return {"type": "string", "format": "uri", "example": self.target.openapi_example}
+
+
+def set_example_urls(result, request=None, **kwargs):
+    """Point example URLs at the serving deployment instead of the ``example.com``/``example.org``
+    placeholders baked into the schema. A postprocessing hook (signature: ``result`` -> ``result``).
+
+    Deep-copies first: some example values are module-level ``OpenApiExample`` dicts that
+    drf-spectacular embeds by reference and reuses across generations, so an in-place rewrite would
+    leak one request's host into every later schema build."""
+    result = copy.deepcopy(result)
+    _rewrite_example_urls(result, _deployment_root(request))
     return result
 
 

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -13,6 +13,29 @@ from apps.files.models import File
 from apps.teams.models import Team
 
 
+class ApiUrlField(serializers.HyperlinkedIdentityField):
+    """``HyperlinkedIdentityField`` that documents a concrete ``example`` URL in the OpenAPI schema.
+
+    Without an example, ReDoc samples a ``format: uri`` field as ``http://example.com``. The schema
+    (with the example) is emitted by ``apps.api.schema.ApiUrlFieldExtension``; the placeholder host
+    in ``openapi_example`` is then rewritten to the serving deployment's host by
+    ``apps.api.schema.set_example_urls``.
+
+    ``openapi_example`` is kept off ``_kwargs`` (so ``HyperlinkedIdentityField.__init__`` doesn't
+    reject it) and re-applied in ``__deepcopy__``, since DRF clones declared fields per serializer
+    instance by re-instantiating from ``_args``/``_kwargs`` alone.
+    """
+
+    def __init__(self, *args, openapi_example: str = "", **kwargs):
+        self.openapi_example = openapi_example
+        super().__init__(*args, **kwargs)
+
+    def __deepcopy__(self, memo):
+        clone = super().__deepcopy__(memo)
+        clone.openapi_example = self.openapi_example
+        return clone
+
+
 class ExperimentVersionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Experiment
@@ -20,8 +43,12 @@ class ExperimentVersionSerializer(serializers.ModelSerializer):
 
 
 class ExperimentSerializer(serializers.ModelSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name="api:experiment-detail", lookup_field="public_id", lookup_url_kwarg="id", label="API URL"
+    url = ApiUrlField(
+        openapi_example="https://example.com/api/experiments/123e4567-e89b-12d3-a456-426614174000/",
+        view_name="api:experiment-detail",
+        lookup_field="public_id",
+        lookup_url_kwarg="id",
+        label="API URL",
     )
     id = serializers.UUIDField(source="public_id")
     versions = ExperimentVersionSerializer(many=True)
@@ -77,8 +104,11 @@ class TeamSerializer(serializers.ModelSerializer):
 
 class FileSerializer(serializers.ModelSerializer):
     size = serializers.IntegerField(source="content_size")
-    content_url = serializers.HyperlinkedIdentityField(
-        view_name="api:file-content", lookup_field="id", lookup_url_kwarg="pk"
+    content_url = ApiUrlField(
+        openapi_example="https://example.com/api/files/42/content",
+        view_name="api:file-content",
+        lookup_field="id",
+        lookup_url_kwarg="pk",
     )
 
     class Meta:
@@ -124,8 +154,11 @@ class MessageSerializer(TaggitSerializer, serializers.ModelSerializer):
 
 
 class ExperimentSessionSerializer(serializers.ModelSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name="api:session-detail", lookup_field="external_id", lookup_url_kwarg="id"
+    url = ApiUrlField(
+        openapi_example="https://example.com/api/sessions/123e4567-e89b-12d3-a456-426614174000/",
+        view_name="api:session-detail",
+        lookup_field="external_id",
+        lookup_url_kwarg="id",
     )
     id = serializers.ReadOnlyField(source="external_id")
     team = TeamSerializer(read_only=True)
@@ -347,8 +380,11 @@ class TriggerBotMessageRequest(serializers.Serializer):
 
 class TriggerBotMessageResponse(serializers.ModelSerializer):
     session_id = serializers.ReadOnlyField(source="external_id")
-    url = serializers.HyperlinkedIdentityField(
-        view_name="api:session-detail", lookup_field="external_id", lookup_url_kwarg="id"
+    url = ApiUrlField(
+        openapi_example="https://example.com/api/sessions/123e4567-e89b-12d3-a456-426614174000/",
+        view_name="api:session-detail",
+        lookup_field="external_id",
+        lookup_url_kwarg="id",
     )
     team = TeamSerializer(read_only=True)
     channel = serializers.CharField(source="platform", read_only=True)

--- a/apps/api/tests/test_schema.py
+++ b/apps/api/tests/test_schema.py
@@ -3,12 +3,52 @@ import yaml
 from django.core.management import call_command
 from django.test import Client
 
+from apps.api.schema import _swap_host
+
 
 def test_schema_filters():
     c = Client()
     response = c.get("/api/schema/")
     response_yaml = response.content.decode("utf-8")
     assert "/cms/" not in response_yaml
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(
+            'http://api.example.org/accounts/?cursor=cD00ODY%3D"',
+            "https://ocs.example/api/?cursor=cD00ODY%3D",
+            id="pagination-cursor-drops-accounts-path-and-stray-quote",
+        ),
+        pytest.param(
+            "https://example.com/api/v2/chatbots/123/",
+            "https://ocs.example/api/v2/chatbots/123/",
+            id="url-field-host-swapped-path-kept",
+        ),
+        pytest.param("http://example.com", "https://ocs.example", id="bare-placeholder-host"),
+        pytest.param("test@example.com", "test@example.com", id="email-left-untouched"),
+        pytest.param("https://docs.openchatstudio.com/api/", "https://docs.openchatstudio.com/api/", id="other-host"),
+    ],
+)
+def test_swap_host(value, expected):
+    assert _swap_host(value, "https://ocs.example") == expected
+
+
+def test_served_schema_uses_request_host():
+    """The live-served schema points example URLs at the requesting deployment's host, not the
+    ``example.com``/``example.org`` placeholders baked into the committed schema files."""
+    response = Client().get("/api/v2/schema/", HTTP_HOST="chatbots.example.test")
+    schema = yaml.safe_load(response.content)
+    chatbot = schema["components"]["schemas"]["Chatbot"]["properties"]["url"]
+    assert chatbot["example"] == "http://chatbots.example.test/api/v2/chatbots/123e4567-e89b-12d3-a456-426614174000/"
+
+    pagination = schema["components"]["schemas"]["PaginatedChatbotList"]["properties"]["next"]
+    assert pagination["example"] == "http://chatbots.example.test/api/?cursor=cD00ODY%3D"
+
+    body = response.content.decode()
+    assert "api.example.org" not in body
+    assert "example.com" not in body
 
 
 @pytest.mark.parametrize(

--- a/apps/api/v2/serializers.py
+++ b/apps/api/v2/serializers.py
@@ -1,7 +1,7 @@
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from apps.api.serializers import TeamSerializer
+from apps.api.serializers import ApiUrlField, TeamSerializer
 from apps.experiments.models import Experiment
 from apps.users.helpers import user_has_confirmed_email_address
 from apps.users.models import CustomUser
@@ -20,8 +20,12 @@ class ChatbotSerializer(serializers.ModelSerializer):
     "chatbots" rather than "experiments" (ADR-0023).
     """
 
-    url = serializers.HyperlinkedIdentityField(
-        view_name="api:v2:chatbot-detail", lookup_field="public_id", lookup_url_kwarg="id", label="API URL"
+    url = ApiUrlField(
+        openapi_example="https://example.com/api/v2/chatbots/123e4567-e89b-12d3-a456-426614174000/",
+        view_name="api:v2:chatbot-detail",
+        lookup_field="public_id",
+        lookup_url_kwarg="id",
+        label="API URL",
     )
     id = serializers.UUIDField(source="public_id")
     versions = ChatbotVersionSerializer(many=True)

--- a/config/settings.py
+++ b/config/settings.py
@@ -461,6 +461,7 @@ SPECTACULAR_SETTINGS = {
         "drf_spectacular.hooks.postprocess_schema_enums",
         "apps.api.schema.prune_unused_tags",
         "apps.api.schema.set_export_description",
+        "apps.api.schema.set_example_urls",
     ],
     "PREPROCESSING_HOOKS": [
         "apps.api.schema.exclude_legacy_participants_path",


### PR DESCRIPTION
### Product Description
The ReDoc API docs showed example URLs with placeholder hosts — pagination `next`/`previous` as `http://api.example.org/accounts/?cursor=...` (with a stray `"` from DRF) and `url`/`content_url` fields as `http://example.com`. They now reflect the deployment actually serving the docs.

### Technical Description
The docs pages fetch the live schema, and drf-spectacular passes the `request` to postprocessing hooks, so `set_example_urls` rewrites the placeholder hosts to the request host at serve time. The offline `spectacular` command (which builds the committed `api-schemas/*.yml`) has no request, so it falls back to a fixed `https://example.com` — keeping those artifacts deterministic.

Two things worth a look:
- The hook deep-copies the schema before rewriting. Some example values are module-level `OpenApiExample` dicts that drf-spectacular embeds by reference and reuses across generations; an in-place rewrite leaked one request's host into every later build (a test caught this).
- `http://example.com` on the `url` fields wasn't in the schema at all — ReDoc auto-samples `format: uri` fields with no example. `ApiUrlField` gives them a concrete example. A plain `extend_schema_field` on the field instance silently fails because DRF deep-copies declared fields per serializer and drops the annotation, hence the subclass with `__deepcopy__`.

### Migrations
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update