### PR TITLE
Backfill CSV chat exports and clean up orphaned files

### DIFF
--- a/apps/files/management/commands/backfill_file_purpose.py
+++ b/apps/files/management/commands/backfill_file_purpose.py
@@ -22,7 +22,9 @@ RULES: list[tuple[str, Q]] = [
     (FilePurpose.ASSISTANT, Q(toolresources__isnull=False)),
     (FilePurpose.MESSAGE_MEDIA, Q(chatattachment__isnull=False)),
     (FilePurpose.ASSISTANT, Q(external_source="openai")),
-    (FilePurpose.DATA_EXPORT, Q(content_type="application/gzip", name__icontains="Chat Export")),
+    # Chat exports are named "<experiment> Chat Export <timestamp>.csv[.gz]". Current
+    # exports are gzipped (application/gzip); older ones are plain text/csv. Match both.
+    (FilePurpose.DATA_EXPORT, Q(name__icontains="Chat Export") & Q(content_type__in=["application/gzip", "text/csv"])),
     (FilePurpose.DATA_EXPORT, Q(content_type="text/csv", name__icontains="_latest_results_")),
     # Collection exports are named "<slug>_files_<timestamp>.zip"; match that pattern
     # so an arbitrary user-uploaded ZIP isn't classified as an export (and expired).

--- a/apps/files/management/commands/cleanup_orphaned_files.py
+++ b/apps/files/management/commands/cleanup_orphaned_files.py
@@ -1,0 +1,78 @@
+from collections import defaultdict
+
+from django.db.models import Q
+
+from apps.data_migrations.management.commands.base import IdempotentCommand
+from apps.files.models import File
+from apps.utils.deletion import get_related_m2m_objects
+
+# Export name patterns (see backfill_file_purpose). Excluded defensively so an
+# export that has not yet been classified/expired is never treated as an orphan.
+EXPORT_NAME_PATTERNS = (
+    Q(name__icontains="Chat Export") | Q(name__icontains="_latest_results_") | Q(name__icontains="_files_")
+)
+
+# A file is an orphan-cleanup candidate only if it has no live reference of any
+# kind: no collection/document-source membership, no assistant tool resource, no
+# chat attachment, no voice sample FK, no external (OpenAI) source, and no version
+# relationship (a working copy or a version of one is retained for history, not
+# deleted). purpose="" restricts this to the legacy rows the backfill left behind.
+UNREFERENCED = Q(
+    collections__isnull=True,
+    document_sources__isnull=True,
+    toolresources__isnull=True,
+    chatattachment__isnull=True,
+    syntheticvoice__isnull=True,
+    working_version__isnull=True,
+    versions__isnull=True,
+)
+
+DELETE_BATCH_SIZE = 500
+
+
+class Command(IdempotentCommand):
+    help = "Delete legacy orphaned files (purpose unset, no live reference) and their storage objects"
+    migration_name = "cleanup_orphaned_files_2026_07_03"
+
+    def perform_migration(self, dry_run=False):
+        candidates = self._candidates()
+
+        # Belt-and-braces: the ORM filter above only knows the relations we named,
+        # so re-check every candidate against all m2m relations generically and
+        # drop anything that turns out to be referenced by a relation we missed.
+        referenced = get_related_m2m_objects(candidates)
+        orphans = [f for f in candidates if f not in referenced]
+        skipped = len(candidates) - len(orphans)
+
+        by_team: dict[str, int] = defaultdict(int)
+        total_bytes = 0
+        for f in orphans:
+            by_team[f.team.slug] += 1
+            total_bytes += f.content_size or 0
+
+        for slug in sorted(by_team):
+            self.stdout.write(f"  {slug}: {by_team[slug]}")
+        self.stdout.write(f"  orphans to delete: {len(orphans)} ({total_bytes / 1_000_000:.1f} MB)")
+        if skipped:
+            self.stdout.write(f"  skipped (referenced via other relation): {skipped}")
+
+        if not dry_run and orphans:
+            self._delete([f.pk for f in orphans])
+
+        return {"deleted": 0 if dry_run else len(orphans)}
+
+    @staticmethod
+    def _candidates() -> list[File]:
+        return list(
+            File.objects.filter(UNREFERENCED, purpose="")
+            .exclude(external_source="openai")
+            .exclude(EXPORT_NAME_PATTERNS)
+            .select_related("team")
+        )
+
+    @staticmethod
+    def _delete(ids: list[int]) -> None:
+        # Per-instance signals fire on queryset delete, so django_cleanup removes
+        # each underlying storage object as its row is deleted.
+        for start in range(0, len(ids), DELETE_BATCH_SIZE):
+            File.objects.filter(pk__in=ids[start : start + DELETE_BATCH_SIZE]).delete()

--- a/apps/files/management/commands/cleanup_orphaned_files.py
+++ b/apps/files/management/commands/cleanup_orphaned_files.py
@@ -14,11 +14,14 @@ EXPORT_NAME_PATTERNS = (
 
 # A file is an orphan-cleanup candidate only if it has no live reference of any
 # kind: no collection/document-source membership, no assistant tool resource, no
-# chat attachment, no voice sample FK, no external (OpenAI) source, and no version
-# relationship. Archived files are excluded outright — archiving is how the app
-# deliberately retains a file (e.g. version history) after its references are
-# removed, so an unreferenced archived file is preserved, not garbage.
-# purpose="" restricts this to the legacy rows the backfill left behind.
+# chat attachment, no voice sample FK, no chunk embedding, no external (OpenAI)
+# source, and no version relationship. Archived files are excluded outright —
+# archiving is how the app deliberately retains a file (e.g. version history)
+# after its references are removed, so an unreferenced archived file is preserved,
+# not garbage. purpose="" restricts this to the legacy rows the backfill left
+# behind. Reverse FKs (e.g. filechunkembedding) must be listed explicitly: the
+# get_related_m2m_objects re-check below only covers m2m relations, not plain
+# reverse foreign keys.
 UNREFERENCED = Q(
     is_archived=False,
     collections__isnull=True,
@@ -26,6 +29,7 @@ UNREFERENCED = Q(
     toolresources__isnull=True,
     chatattachment__isnull=True,
     syntheticvoice__isnull=True,
+    filechunkembedding__isnull=True,
     working_version__isnull=True,
     versions__isnull=True,
 )

--- a/apps/files/management/commands/cleanup_orphaned_files.py
+++ b/apps/files/management/commands/cleanup_orphaned_files.py
@@ -15,9 +15,12 @@ EXPORT_NAME_PATTERNS = (
 # A file is an orphan-cleanup candidate only if it has no live reference of any
 # kind: no collection/document-source membership, no assistant tool resource, no
 # chat attachment, no voice sample FK, no external (OpenAI) source, and no version
-# relationship (a working copy or a version of one is retained for history, not
-# deleted). purpose="" restricts this to the legacy rows the backfill left behind.
+# relationship. Archived files are excluded outright — archiving is how the app
+# deliberately retains a file (e.g. version history) after its references are
+# removed, so an unreferenced archived file is preserved, not garbage.
+# purpose="" restricts this to the legacy rows the backfill left behind.
 UNREFERENCED = Q(
+    is_archived=False,
     collections__isnull=True,
     document_sources__isnull=True,
     toolresources__isnull=True,

--- a/apps/files/tests/test_backfill_purpose.py
+++ b/apps/files/tests/test_backfill_purpose.py
@@ -37,6 +37,7 @@ def test_backfill_assigns_purpose_by_relation_and_pattern():
 
     openai_file = FileFactory.create(external_source="openai")
     gzip_export = FileFactory.create(content_type="application/gzip", name="My Bot Chat Export 2026-06-30.csv.gz")
+    csv_export = FileFactory.create(content_type="text/csv", name="My Bot Chat Export 2025-08-21_09-51-47.csv")
     eval_export = FileFactory.create(content_type="text/csv", name="config_latest_results_2026-06-30.csv")
     zip_export = FileFactory.create(content_type="application/zip", name="my-collection_files_20260630.zip")
 
@@ -51,6 +52,7 @@ def test_backfill_assigns_purpose_by_relation_and_pattern():
     assert File.objects.get(pk=code_file.pk).purpose == FilePurpose.MESSAGE_MEDIA
     assert File.objects.get(pk=ocs_file.pk).purpose == FilePurpose.MESSAGE_MEDIA
     assert File.objects.get(pk=gzip_export.pk).purpose == FilePurpose.DATA_EXPORT
+    assert File.objects.get(pk=csv_export.pk).purpose == FilePurpose.DATA_EXPORT
     assert File.objects.get(pk=eval_export.pk).purpose == FilePurpose.DATA_EXPORT
     assert File.objects.get(pk=zip_export.pk).purpose == FilePurpose.DATA_EXPORT
 

--- a/apps/files/tests/test_cleanup_orphaned_files.py
+++ b/apps/files/tests/test_cleanup_orphaned_files.py
@@ -60,6 +60,18 @@ def test_keeps_versioned_files():
 
 
 @pytest.mark.django_db()
+def test_keeps_archived_files():
+    # Archiving is how the app retains a file after its references are removed,
+    # so an unreferenced archived file must not be treated as an orphan.
+    archived = FileFactory.create(is_archived=True)
+
+    _run()
+
+    # get_all() bypasses the manager's default is_archived=False filter.
+    assert File.objects.get_all().filter(pk=archived.pk).exists()
+
+
+@pytest.mark.django_db()
 def test_dry_run_deletes_nothing():
     orphan = FileFactory.create()
 

--- a/apps/files/tests/test_cleanup_orphaned_files.py
+++ b/apps/files/tests/test_cleanup_orphaned_files.py
@@ -1,0 +1,68 @@
+import pytest
+from django.core.management import call_command
+
+from apps.assistants.models import ToolResources
+from apps.files.models import File, FilePurpose
+from apps.utils.factories.assistants import OpenAiAssistantFactory
+from apps.utils.factories.documents import CollectionFileFactory
+from apps.utils.factories.experiment import ChatAttachmentFactory, SyntheticVoiceFactory
+from apps.utils.factories.files import FileFactory
+
+
+def _run():
+    call_command("cleanup_orphaned_files")
+
+
+@pytest.mark.django_db()
+def test_deletes_unreferenced_legacy_files():
+    orphan = FileFactory.create(name="clv_source_material.txt", content_type="text/plain")
+
+    _run()
+
+    assert not File.objects.filter(pk=orphan.pk).exists()
+
+
+@pytest.mark.django_db()
+def test_keeps_referenced_and_special_files():
+    collection_file = CollectionFileFactory.create()
+
+    assistant = OpenAiAssistantFactory.create()
+    tool_resource = ToolResources.objects.create(assistant=assistant, tool_type="code_interpreter")
+    tool_file = FileFactory.create(team=assistant.team)
+    tool_resource.files.add(tool_file)
+
+    attachment = ChatAttachmentFactory.create(tool_type="ocs_attachments")
+    attached_file = FileFactory.create(team=attachment.chat.team)
+    attachment.files.add(attached_file)
+
+    voice_file = FileFactory.create()
+    SyntheticVoiceFactory.create(file=voice_file)
+
+    openai_file = FileFactory.create(external_source="openai")
+    export = FileFactory.create(content_type="text/csv", name="My Bot Chat Export 2025-08-21.csv")
+    classified = FileFactory.create(purpose=FilePurpose.MESSAGE_MEDIA)
+
+    _run()
+
+    for kept in [collection_file.file, tool_file, attached_file, voice_file, openai_file, export, classified]:
+        assert File.objects.filter(pk=kept.pk).exists(), kept.name
+
+
+@pytest.mark.django_db()
+def test_keeps_versioned_files():
+    working = FileFactory.create()
+    version = working.create_new_version()
+
+    _run()
+
+    assert File.objects.filter(pk=working.pk).exists()
+    assert File.objects.filter(pk=version.pk).exists()
+
+
+@pytest.mark.django_db()
+def test_dry_run_deletes_nothing():
+    orphan = FileFactory.create()
+
+    call_command("cleanup_orphaned_files", "--dry-run")
+
+    assert File.objects.filter(pk=orphan.pk).exists()

--- a/apps/files/tests/test_cleanup_orphaned_files.py
+++ b/apps/files/tests/test_cleanup_orphaned_files.py
@@ -6,7 +6,7 @@ from apps.files.models import File, FilePurpose
 from apps.utils.factories.assistants import OpenAiAssistantFactory
 from apps.utils.factories.documents import CollectionFileFactory
 from apps.utils.factories.experiment import ChatAttachmentFactory, SyntheticVoiceFactory
-from apps.utils.factories.files import FileFactory
+from apps.utils.factories.files import FileChunkEmbeddingFactory, FileFactory
 
 
 def _run():
@@ -38,13 +38,27 @@ def test_keeps_referenced_and_special_files():
     voice_file = FileFactory.create()
     SyntheticVoiceFactory.create(file=voice_file)
 
+    # Referenced only by a chunk embedding (reverse FK, not m2m), and not a
+    # collection member — the case the generic m2m re-check cannot catch.
+    embedding_file = FileChunkEmbeddingFactory.create().file
+
     openai_file = FileFactory.create(external_source="openai")
     export = FileFactory.create(content_type="text/csv", name="My Bot Chat Export 2025-08-21.csv")
     classified = FileFactory.create(purpose=FilePurpose.MESSAGE_MEDIA)
 
     _run()
 
-    for kept in [collection_file.file, tool_file, attached_file, voice_file, openai_file, export, classified]:
+    kept_files = [
+        collection_file.file,
+        tool_file,
+        attached_file,
+        voice_file,
+        embedding_file,
+        openai_file,
+        export,
+        classified,
+    ]
+    for kept in kept_files:
         assert File.objects.filter(pk=kept.pk).exists(), kept.name
 
 


### PR DESCRIPTION
### Product Description
No user-facing change.

### Technical Description
Follow-up to the `backfill_file_purpose` run, which left 735 files unclassified. Investigation showed two distinct groups:

- **Legacy CSV chat exports** — named `<bot> Chat Export <timestamp>.csv` (pre-gzip, `text/csv`). The export rule only matched gzipped exports, so these fell through. Broadened the rule to match both content types, keyed on the app-generated "Chat Export" substring (kept the `content_type` guard so a user upload named "Chat Export" isn't misclassified).
- **Fully-orphaned legacy uploads** — old collection source material (`purpose=""`, `is_archived=False`, no embeddings) with no `CollectionFile`/tool-resource/attachment link left. These have no relation to key a purpose on, so rather than mislabel them, `cleanup_orphaned_files` deletes them.

Review focus — `cleanup_orphaned_files` deletes rows (and, via `django_cleanup`, their storage). It only targets files that are provably unreferenced: the ORM filter excludes every known relation (collections, document sources, tool resources, chat attachments, voice-sample FK, versions, OpenAI source, export name patterns), and a generic `get_related_m2m_objects` pass re-checks each candidate against *all* M2M relations and skips anything referenced by a relation the filter didn't name. `is_used()` only inspects M2M relations — the `syntheticvoice` FK exclusion is what keeps voice samples safe.

Both are `IdempotentCommand`s with `--dry-run`; deploy order is backfill (`--force`) → cleanup `--dry-run` → cleanup.

### Migrations
N/A — no schema migrations.

### Docs and Changelog
- [ ] This PR requires docs/changelog update