### PR TITLE
Speed up deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,7 +109,25 @@ jobs:
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
         echo "image_latest=$ECR_REGISTRY/$ECR_REPOSITORY:latest" >> "$GITHUB_OUTPUT"
 
+    - name: Check for pre-built image
+      # The Lint and Test workflow pre-builds the prod image (tagged by SHA) in
+      # parallel with the tests, so the common main->prod deploy can skip the
+      # build entirely. Manual dev deploys (and the rare case where the pre-build
+      # hasn't finished) fall through to the build step below.
+      id: check-image
+      run: |
+        if aws ecr describe-images \
+             --repository-name "$ECR_REPOSITORY" \
+             --image-ids imageTag="${{ github.sha }}" >/dev/null 2>&1; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+          echo "Image ${{ github.sha }} already in ECR — skipping build"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+          echo "Image ${{ github.sha }} not found in ECR — building"
+        fi
+
     - name: Build and push
+      if: steps.check-image.outputs.exists != 'true'
       uses: docker/build-push-action@v7
       with:
         tags: |
@@ -118,7 +136,7 @@ jobs:
         file: Dockerfile
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        outputs: type=image,push=true,oci-mediatypes=true,compression=zstd,compression-level=3,force-compression=true
+        outputs: type=image,push=true,oci-mediatypes=true,compression=zstd,compression-level=3
 
 
     - name: Update ECS task def for Django web container

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -64,6 +64,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set variables
         run: |

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -13,7 +13,6 @@ on:
       - 'cypress/**'
       - 'cypress.config.ts'
       - 'cypress.env.json'
-      - 'Dockerfile'
       - 'docker-compose-dev.yml'
       - 'heroku.yml'
       - 'app.json'
@@ -35,7 +34,6 @@ on:
       - 'cypress/**'
       - 'cypress.config.ts'
       - 'cypress.env.json'
-      - 'Dockerfile'
       - 'docker-compose-dev.yml'
       - 'heroku.yml'
       - 'app.json'
@@ -54,6 +52,58 @@ permissions:
   contents: read
 
 jobs:
+  build-image:
+    # Pre-build the prod container image (tagged by commit SHA) in parallel with
+    # the tests, so the Deploy workflow — which chains off this one — can skip the
+    # build and go straight to migrate + deploy. Only runs on main pushes, so
+    # PR/fork code never receives AWS credentials.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set variables
+        run: |
+          APP_NAME="${{ fromJSON(vars.DEPLOY_APP_NAME)['prod'] }}"
+          echo "ECR_REPOSITORY=$APP_NAME-prod-ecr-repo" >> "$GITHUB_ENV"
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v6.2.1
+        with:
+          role-to-assume: "arn:aws:iam::${{ fromJSON(vars.AWS_ACCOUNT)['prod'] }}:role/github_deploy"
+          role-session-name: GithubBuild
+          aws-region: ${{ fromJSON(vars.DEPLOY_AWS_REGION)['prod'] }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2.1.6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Get image names
+        id: image-name
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "image_latest=$ECR_REGISTRY/$ECR_REPOSITORY:latest" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          tags: |
+            ${{ steps.image-name.outputs.image }}
+            ${{ steps.image-name.outputs.image_latest }}
+          file: Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=image,push=true,oci-mediatypes=true,compression=zstd,compression-level=3
+
   build-frontend:
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,14 @@ RUN --mount=type=cache,target=/root/.cache \
       --group prod \
       --compile-bytecode
 
-FROM node:24 AS build-node
-RUN nodejs -v && npm -v
+FROM node:24-slim AS build-node
+RUN node -v && npm -v
 WORKDIR /code
+
+# Install node dependencies first so this layer stays cached until the
+# lockfile changes (template/asset edits no longer bust it).
+COPY package.json package-lock.json /code/
+RUN npm ci
 
 # keep in sync with tailwind.config.js
 COPY *.json *.js .babelrc /code/
@@ -42,7 +47,6 @@ COPY config/settings.py /code/config/settings.py
 COPY templates /code/templates/
 COPY assets /code/assets/
 
-RUN npm install
 RUN npm run build
 
 FROM python:3.13-slim-bullseye


### PR DESCRIPTION
### Product Description
No change — CI/deploy tooling only.

### Technical Description
Cuts deploy time in two ways:

- **Image built off the deploy critical path.** A new `build-image` job in Lint and Test builds and pushes the prod image (tagged by SHA) in parallel with the tests, on main pushes only. Deploy now checks ECR for that SHA and skips its own build when present — so the automatic main→prod deploy goes straight to migrate + deploy. Manual dev dispatches (separate ECR repo) and the rare case where the pre-build hasn't finished fall through to deploy's existing build. If the pre-build fails, the whole Lint and Test run fails and deploy doesn't fire.
- **Dockerfile layer caching.** `npm ci` now runs before `templates/`/`assets/` are copied, so frontend/template edits no longer bust the node install layer. Also switched `build-node` to `node:24-slim` and dropped `force-compression=true` from the push (no longer re-compresses unchanged layers).

`Dockerfile` was removed from Lint and Test's `paths-ignore` so the new build job (and tests) run on Dockerfile changes. Side effect: Dockerfile-only changes to main now trigger a deploy, which previously they silently did not.

Worth a look: the `build-image` job gets `id-token: write` to assume the prod deploy role. It's gated to `push` on `main`, so PR/fork code never receives credentials.

### Migrations
N/A — no migrations.

### Docs and Changelog
- [ ] This PR requires docs/changelog update