### PR TITLE
Return experiment stub in session API

### DIFF
--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -1316,7 +1316,7 @@ components:
           readOnly: true
         experiment:
           allOf:
-          - $ref: '#/components/schemas/Experiment'
+          - $ref: '#/components/schemas/ExperimentStub'
           readOnly: true
         participant:
           allOf:
@@ -1390,7 +1390,7 @@ components:
           readOnly: true
         experiment:
           allOf:
-          - $ref: '#/components/schemas/Experiment'
+          - $ref: '#/components/schemas/ExperimentStub'
           readOnly: true
         participant:
           allOf:
@@ -1429,6 +1429,35 @@ components:
       - tags
       - team
       - updated_at
+      - url
+    ExperimentStub:
+      type: object
+      description: A lightweight experiment representation for embedding in other
+        resources.
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 128
+        description:
+          type: string
+          nullable: true
+          title: A longer description of the experiment.
+        url:
+          type: string
+          format: uri
+          example: https://example.com/api/experiments/123e4567-e89b-12d3-a456-426614174000/
+          readOnly: true
+          title: API URL
+        version_number:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+      required:
+      - id
+      - name
       - url
     ExperimentVersion:
       type: object

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -58,6 +58,23 @@ class ExperimentSerializer(serializers.ModelSerializer):
         fields = ["id", "name", "url", "version_number", "versions"]
 
 
+class ExperimentStubSerializer(serializers.ModelSerializer):
+    """A lightweight experiment representation for embedding in other resources."""
+
+    url = ApiUrlField(
+        openapi_example="https://example.com/api/experiments/123e4567-e89b-12d3-a456-426614174000/",
+        view_name="api:experiment-detail",
+        lookup_field="public_id",
+        lookup_url_kwarg="id",
+        label="API URL",
+    )
+    id = serializers.UUIDField(source="public_id")
+
+    class Meta:
+        model = Experiment
+        fields = ["id", "name", "description", "url", "version_number"]
+
+
 class ParticipantSerializer(serializers.ModelSerializer):
     class Meta:
         model = Participant
@@ -162,7 +179,7 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
     )
     id = serializers.ReadOnlyField(source="external_id")
     team = TeamSerializer(read_only=True)
-    experiment = ExperimentSerializer(read_only=True)
+    experiment = ExperimentStubSerializer(read_only=True)
     participant = ParticipantSerializer(read_only=True)
     messages = serializers.SerializerMethodField()
     tags = TagListSerializerField(source="chat.tags")

--- a/apps/api/tests/test_session_api.py
+++ b/apps/api/tests/test_session_api.py
@@ -115,9 +115,9 @@ def get_session_json(session, expected_messages=None, expected_tags=None):
         "experiment": {
             "id": str(experiment.public_id),
             "name": experiment.name,
+            "description": experiment.description,
             "url": f"http://testserver/api/experiments/{experiment.public_id}/",
             "version_number": 1,
-            "versions": [],
         },
         "participant": {"identifier": session.participant.identifier, "remote_id": ""},
         "id": str(session.external_id),


### PR DESCRIPTION
### Product Description
no change

### Technical Description
The v1 session endpoints (`ExperimentSessionSerializer`) embedded the full `Experiment` representation, which carries the entire `versions` list — more than a session response needs. Sessions now embed a lightweight `ExperimentStub` (`id`, `name`, `description`, `url`, `version_number`). The full `Experiment` serializer is unchanged, so `/api/experiments/` is unaffected.

Note: `POST /api/chat/start` still returns the full experiment under `chatbot` — left as-is since it's a separate endpoint.

### Docs and Changelog
- [x] This PR requires docs/changelog update