### PR TITLE
refactor: migrate Slack channel to channels_v2 architecture

### DIFF
--- a/apps/channels/channels_v2/slack_channel.py
+++ b/apps/channels/channels_v2/slack_channel.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from apps.channels.channels_v2.callbacks import ChannelCallbacks
+from apps.channels.channels_v2.channel_base import ChannelBase
+from apps.channels.channels_v2.sender import ChannelSender
+from apps.channels.datamodels import SlackMessage
+from apps.channels.models import ChannelPlatform
+from apps.chat.channels import MESSAGE_TYPES
+from apps.chat.exceptions import ChannelException
+from apps.service_providers.file_limits import can_send_on_slack
+from apps.slack.utils import parse_session_external_id
+
+if TYPE_CHECKING:
+    from apps.channels.channels_v2.pipeline import MessageProcessingContext
+    from apps.channels.models import ExperimentChannel
+    from apps.experiments.models import Experiment, ExperimentSession
+    from apps.files.models import File
+    from apps.service_providers.messaging_service import SlackService
+
+logger = logging.getLogger("ocs.channels")
+
+
+class SlackSender(ChannelSender):
+    """Delivers messages to a Slack channel + thread via the messaging service.
+
+    Slack sends are scoped to a channel + thread rather than the participant
+    identifier. bind(ctx) is called after context creation; the channel_id and
+    thread_ts resolve from the inbound message, falling back to the session's
+    external_id for ad hoc sends where there is no inbound message.
+    """
+
+    def __init__(self, service: SlackService) -> None:
+        self._service = service
+        self._ctx: MessageProcessingContext | None = None
+
+    def bind(self, ctx: MessageProcessingContext) -> None:
+        self._ctx = ctx
+
+    def _resolve_destination(self) -> tuple[str, str]:
+        """Return the (channel_id, thread_ts) to send to."""
+        if self._ctx is None:
+            raise ChannelException("SlackSender used before bind()")
+        if isinstance(self._ctx.message, SlackMessage):
+            return self._ctx.message.channel_id, self._ctx.message.thread_ts
+        return parse_session_external_id(self._ctx.experiment_session.external_id)
+
+    def send_text(self, text: str, recipient: str) -> None:
+        channel_id, thread_ts = self._resolve_destination()
+        self._service.send_text_message(
+            text,
+            from_="",
+            to=channel_id,
+            platform=ChannelPlatform.SLACK,
+            thread_ts=thread_ts,
+        )
+
+    def send_file(self, file: File, recipient: str, session_id: int) -> None:
+        channel_id, thread_ts = self._resolve_destination()
+        self._service.send_file_message(
+            file=file,
+            to=channel_id,
+            thread_ts=thread_ts,
+        )
+
+
+class SlackChannel(ChannelBase):
+    """Message handler for Slack.
+
+    Sessions map to Slack threads and are always pre-set (created by the
+    Slack event listener before the pipeline runs), so SessionResolutionStage
+    is a no-op. That also means /reset is not intercepted and reaches the bot
+    as a normal message — reset never worked on Slack; starting a new thread
+    starts a new session. Text-only inbound; supports file replies, no voice.
+    """
+
+    supports_multimedia = True
+    supported_message_types = (MESSAGE_TYPES.TEXT,)
+
+    def __init__(
+        self,
+        experiment: Experiment,
+        experiment_channel: ExperimentChannel,
+        experiment_session: ExperimentSession | None = None,
+        messaging_service: SlackService | None = None,
+    ):
+        if not experiment_session:
+            raise ChannelException("SlackChannel requires an existing session")
+        super().__init__(experiment, experiment_channel, experiment_session)
+        self._messaging_service = messaging_service
+
+    @property
+    def messaging_service(self) -> SlackService:
+        if not self._messaging_service:
+            self._messaging_service = self.experiment_channel.messaging_provider.get_messaging_service()
+        return self._messaging_service
+
+    def _get_sender(self) -> SlackSender:
+        return SlackSender(service=self.messaging_service)
+
+    def _get_callbacks(self) -> ChannelCallbacks:
+        return ChannelCallbacks()
+
+    def _can_send_file(self, file: File) -> bool:
+        return can_send_on_slack(file.content_type or "", file.content_size or 0).supported

--- a/apps/channels/tests/channels/concrete/test_slack_channel.py
+++ b/apps/channels/tests/channels/concrete/test_slack_channel.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from apps.channels.channels_v2.slack_channel import SlackChannel
+from apps.chat.channels import MESSAGE_TYPES
+from apps.chat.exceptions import ChannelException
+
+
+def _make_channel(messaging_service=None):
+    return SlackChannel(
+        experiment=MagicMock(),
+        experiment_channel=MagicMock(),
+        experiment_session=MagicMock(),
+        messaging_service=messaging_service,
+    )
+
+
+class TestSlackChannelInit:
+    def test_requires_existing_session(self):
+        with pytest.raises(ChannelException, match="SlackChannel requires an existing session"):
+            SlackChannel(
+                experiment=MagicMock(),
+                experiment_channel=MagicMock(),
+            )
+
+    def test_accepts_session(self):
+        channel = _make_channel()
+        assert channel.experiment_session is not None
+
+
+class TestSlackChannelMessagingService:
+    def test_injected_service_is_used(self):
+        service = MagicMock()
+        channel = _make_channel(messaging_service=service)
+        assert channel.messaging_service is service
+        channel.experiment_channel.messaging_provider.get_messaging_service.assert_not_called()
+
+    def test_lazy_service_from_provider(self):
+        channel = _make_channel()
+        service = channel.messaging_service
+        assert service is channel.experiment_channel.messaging_provider.get_messaging_service.return_value
+        # Cached on subsequent access
+        assert channel.messaging_service is service
+        channel.experiment_channel.messaging_provider.get_messaging_service.assert_called_once()
+
+
+class TestSlackChannelCapabilities:
+    def test_capabilities(self):
+        channel = _make_channel()
+        caps = channel._get_capabilities()
+        assert caps.supports_voice_replies is False
+        assert caps.supports_files is True
+        assert caps.supports_conversational_consent is True
+        assert caps.supported_message_types == (MESSAGE_TYPES.TEXT,)
+
+    @pytest.mark.parametrize(
+        ("content_type", "content_size", "expected"),
+        [
+            pytest.param("application/pdf", 2 * 1024 * 1024, True, id="pdf_within_limit"),
+            pytest.param("image/png", 60 * 1024 * 1024, False, id="image_over_50mb"),
+            pytest.param("text/csv", 1024, False, id="unsupported_type"),
+        ],
+    )
+    def test_can_send_file(self, content_type, content_size, expected):
+        channel = _make_channel()
+        file = MagicMock()
+        file.content_type = content_type
+        file.content_size = content_size
+        assert channel._can_send_file(file) is expected

--- a/apps/channels/tests/channels/senders/test_slack_sender.py
+++ b/apps/channels/tests/channels/senders/test_slack_sender.py
@@ -1,0 +1,92 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from apps.channels.channels_v2.slack_channel import SlackSender
+from apps.channels.datamodels import SlackMessage
+from apps.channels.models import ChannelPlatform
+from apps.channels.tests.channels.conftest import make_context
+from apps.slack.utils import make_session_external_id
+
+
+@pytest.fixture()
+def slack_service():
+    return MagicMock()
+
+
+@pytest.fixture()
+def sender(slack_service):
+    return SlackSender(service=slack_service)
+
+
+def _bind_with_message(sender):
+    message = SlackMessage(
+        participant_id="SLACK_USER_ID",
+        channel_id="channel_from_message",
+        thread_ts="thread_from_message",
+        message_text="Hello",
+    )
+    ctx = make_context(message=message)
+    sender.bind(ctx)
+    return ctx
+
+
+def _bind_without_message(sender):
+    session = MagicMock()
+    session.external_id = make_session_external_id("channel_from_session", "thread_from_session")
+    ctx = make_context(experiment_session=session)
+    ctx.message = None  # Ad hoc sends have no inbound message
+    sender.bind(ctx)
+    return ctx
+
+
+class TestSendText:
+    def test_uses_channel_and_thread_from_inbound_message(self, sender, slack_service):
+        _bind_with_message(sender)
+        sender.send_text("hello", "SLACK_USER_ID")
+        slack_service.send_text_message.assert_called_once_with(
+            "hello",
+            from_="",
+            to="channel_from_message",
+            platform=ChannelPlatform.SLACK,
+            thread_ts="thread_from_message",
+        )
+
+    def test_falls_back_to_session_external_id(self, sender, slack_service):
+        _bind_without_message(sender)
+        sender.send_text("hello", "SLACK_USER_ID")
+        slack_service.send_text_message.assert_called_once_with(
+            "hello",
+            from_="",
+            to="channel_from_session",
+            platform=ChannelPlatform.SLACK,
+            thread_ts="thread_from_session",
+        )
+
+
+class TestSendVoice:
+    def test_not_supported(self, sender):
+        with pytest.raises(NotImplementedError):
+            sender.send_voice(MagicMock(), "SLACK_USER_ID")
+
+
+class TestSendFile:
+    def test_uses_channel_and_thread_from_inbound_message(self, sender, slack_service):
+        _bind_with_message(sender)
+        file = MagicMock()
+        sender.send_file(file, "SLACK_USER_ID", session_id=42)
+        slack_service.send_file_message.assert_called_once_with(
+            file=file,
+            to="channel_from_message",
+            thread_ts="thread_from_message",
+        )
+
+    def test_falls_back_to_session_external_id(self, sender, slack_service):
+        _bind_without_message(sender)
+        file = MagicMock()
+        sender.send_file(file, "SLACK_USER_ID", session_id=42)
+        slack_service.send_file_message.assert_called_once_with(
+            file=file,
+            to="channel_from_session",
+            thread_ts="thread_from_session",
+        )

--- a/apps/channels/tests/test_slack_channel.py
+++ b/apps/channels/tests/test_slack_channel.py
@@ -5,9 +5,9 @@ from unittest.mock import Mock
 import pytest
 from mock.mock import patch
 
+from apps.channels.channels_v2.slack_channel import SlackChannel
 from apps.channels.datamodels import SlackMessage
 from apps.channels.models import ChannelPlatform, ExperimentChannel
-from apps.chat.channels import SlackChannel
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.files.models import File
 from apps.service_providers.messaging_service import SlackService
@@ -59,11 +59,16 @@ def test_handle_user_message(bot_process_input, slack_channel, slack_service):
     )
     response = SlackChannel(slack_channel.experiment, slack_channel, session, slack_service).new_user_message(message)
     assert response.content == "Hi"
+    slack_service.client.chat_postMessage.assert_called_once_with(
+        channel="channel_id",
+        text="Hi",
+        thread_ts="thread_ts",
+    )
 
 
 @pytest.mark.django_db()
 @patch("apps.chat.bots.EventBot.get_user_message")
-@patch("apps.chat.channels.SlackChannel.messaging_service")
+@patch("apps.channels.channels_v2.slack_channel.SlackChannel.messaging_service")
 def test_ad_hoc_bot_message(messaging_service, get_user_message, slack_channel):
     get_user_message.return_value = "Hi"
     session = SlackChannel.start_new_session(
@@ -80,7 +85,6 @@ def test_ad_hoc_bot_message(messaging_service, get_user_message, slack_channel):
             to="channel_id",
             platform=ChannelPlatform.SLACK,
             thread_ts="thread_ts",
-            last_activity_at=mock.ANY,
         )
     ]
 
@@ -115,8 +119,12 @@ def test_send_message_to_user_with_file(slack_channel, slack_service):
     slack_service.client.files_upload_v2 = Mock()
     file = make_mock_file("document.pdf", "application/pdf", 2 * 1024 * 1024)
 
-    with patch.object(channel, "send_text_to_user") as mock_send_text:
-        channel.send_message_to_user("Here's your file", files=[file])
+    channel.send_message_to_user("Here's your file", files=[file])
 
-        slack_service.client.files_upload_v2.assert_called_once()
-        mock_send_text.assert_called_once_with("Here's your file")
+    slack_service.client.files_upload_v2.assert_called_once()
+    assert slack_service.client.files_upload_v2.call_args.kwargs["channels"] == "channel_id"
+    slack_service.client.chat_postMessage.assert_called_once_with(
+        channel="channel_id",
+        text="Here's your file",
+        thread_ts="thread_ts",
+    )

--- a/apps/chat/channels.py
+++ b/apps/chat/channels.py
@@ -50,14 +50,13 @@ from apps.ocs_notifications.notifications import (
     audio_transcription_failure_notification,
     file_delivery_failure_notification,
 )
-from apps.service_providers.file_limits import can_send_on_slack, can_send_on_telegram
+from apps.service_providers.file_limits import can_send_on_telegram
 from apps.service_providers.llm_service.history_managers import ExperimentHistoryManager
 from apps.service_providers.llm_service.runnables import GenerationCancelled
 from apps.service_providers.models import MessagingProviderType
 from apps.service_providers.speech_service import SynthesizedAudio
 from apps.service_providers.tracing import TraceInfo, TracingService
 from apps.service_providers.tracing.base import SpanNotificationConfig, TraceContext
-from apps.slack.utils import parse_session_external_id
 from apps.teams.utils import current_team
 from apps.users.models import CustomUser
 
@@ -348,7 +347,9 @@ class ChannelBase(ABC):
 
             channel_cls = NewSureAdhereChannel
         elif platform == "slack":
-            channel_cls = SlackChannel
+            from apps.channels.channels_v2.slack_channel import SlackChannel as NewSlackChannel  # noqa: PLC0415
+
+            channel_cls = NewSlackChannel
         elif platform == "commcare_connect":
             from apps.channels.channels_v2.connect_channel import (  # noqa: PLC0415
                 CommCareConnectChannel as NewCommCareConnectChannel,
@@ -1334,62 +1335,6 @@ class ApiChannel(ChannelBase):
     def send_text_to_user(self, bot_message: str):  # ty: ignore[invalid-method-override]
         # The bot cannot send messages to this client, since it wouldn't know where to send it to
         pass
-
-
-class SlackChannel(ChannelBase):
-    voice_replies_supported = False
-    supported_message_types = [MESSAGE_TYPES.TEXT]
-    supports_multimedia = True
-
-    def __init__(
-        self,
-        experiment: Experiment,
-        experiment_channel: ExperimentChannel,
-        experiment_session: ExperimentSession,
-        messaging_service=None,
-    ):
-        super().__init__(experiment, experiment_channel, experiment_session)
-        self._messaging_service = messaging_service
-
-    @property
-    def messaging_service(self):
-        if not self._messaging_service:
-            self._messaging_service = self.experiment_channel.messaging_provider.get_messaging_service()
-        return self._messaging_service
-
-    def send_text_to_user(self, text: str):
-        if not self.message:
-            channel_id, thread_ts = parse_session_external_id(self.experiment_session.external_id)
-        else:
-            channel_id = self.message.channel_id
-            thread_ts = self.message.thread_ts
-        self.messaging_service.send_text_message(
-            text,
-            from_="",
-            to=channel_id,
-            platform=ChannelPlatform.SLACK,
-            thread_ts=thread_ts,
-            last_activity_at=self.last_activity_at,
-        )
-
-    def _ensure_sessions_exists(self):
-        if not self.experiment_session:
-            raise ChannelException("WebChannel requires an existing session")
-
-    def _can_send_file(self, file: File) -> bool:
-        return can_send_on_slack(file.content_type or "", file.content_size or 0).supported
-
-    def send_file_to_user(self, file: File):
-        if not self.message:
-            channel_id, thread_ts = parse_session_external_id(self.experiment_session.external_id)
-        else:
-            channel_id = self.message.channel_id
-            thread_ts = self.message.thread_ts
-        self.messaging_service.send_file_message(
-            file=file,
-            to=channel_id,
-            thread_ts=thread_ts,
-        )
 
 
 # TODO: remove after channels refactor — replaced by apps.channels.channels_v2.connect_channel.CommCareConnectChannel

--- a/apps/slack/slack_listeners.py
+++ b/apps/slack/slack_listeners.py
@@ -13,10 +13,10 @@ import re
 from django.db.models import Q
 from slack_bolt import BoltContext, BoltResponse
 
+from apps.channels.channels_v2.slack_channel import SlackChannel
 from apps.channels.const import SLACK_ALL_CHANNELS
 from apps.channels.datamodels import SlackMessage
 from apps.channels.models import ChannelPlatform, ExperimentChannel
-from apps.chat.channels import SlackChannel
 from apps.chatbots.version_resolver import resolve_published_or_working
 from apps.experiments.models import ExperimentSession
 from apps.service_providers.messaging_service import SlackService


### PR DESCRIPTION
### Product Description
No change.

### Technical Description
Next channel in the channels_v2 migration (same pattern as SureAdhere and Facebook). `SlackChannel` moves to the v2 stage pipeline with a dedicated `SlackSender`; the legacy class is deleted from `apps/chat/channels.py` and `slack_listeners` routes through the new one.

Two deliberate behavior notes:

- `/reset` is no longer intercepted for Slack — it reaches the bot as a normal message. On the legacy channel it was silently swallowed (no reply, and the reset never actually happened since Slack sessions are pre-set per thread), so nothing functional is lost. Documented in the class docstring.
- `last_activity_at` is dropped from sends; `SlackService.send_text_message` ignores it (it's a WhatsApp service-window concept).

The legacy integration tests in `apps/channels/tests/test_slack_channel.py` are kept and now assert the actual `chat_postMessage`/`files_upload_v2` client calls instead of patching the send method.

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)