### PR TITLE
Document ordering param on session list API

### DIFF
--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -593,12 +593,17 @@ paths:
         schema:
           type: string
         description: Experiment ID to filter sessions by
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
+      - in: query
+        name: ordering
         schema:
           type: string
+          enum:
+          - -created_at
+          - created_at
+        description: 'Which field to use when ordering the results. Available fields:
+          `created_at`. Prefix a field with `-` for descending order (e.g. `-created_at`),
+          or omit the prefix for ascending order (e.g. `created_at`). Defaults to
+          `-created_at`.'
       - name: page_size
         required: false
         in: query

--- a/apps/api/views/sessions.py
+++ b/apps/api/views/sessions.py
@@ -69,6 +69,17 @@ tags_response_serializer = inline_serializer(
                 location=OpenApiParameter.QUERY,
                 description="Experiment versions (comma separated) to filter sessions by",
             ),
+            OpenApiParameter(
+                name="ordering",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                enum=["created_at", "-created_at"],
+                description=(
+                    "Which field to use when ordering the results. Available fields: `created_at`. "
+                    "Prefix a field with `-` for descending order (e.g. `-created_at`), or omit the "
+                    "prefix for ascending order (e.g. `created_at`). Defaults to `-created_at`."
+                ),
+            ),
         ],
     ),
     retrieve=extend_schema(
@@ -161,7 +172,7 @@ class ExperimentSessionViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
             try:
                 serializers.UUIDField().run_validation(experiment_id)
             except serializers.ValidationError:
-                raise serializers.ValidationError({"experiment": [f'"{experiment_id}" is not a valid UUID.']})
+                raise serializers.ValidationError({"experiment": [f'"{experiment_id}" is not a valid UUID.']}) from None
             queryset = queryset.filter(experiment__public_id=experiment_id)
         if versions_param := self.request.query_params.get("versions"):
             version_list = versions_param.split(",")


### PR DESCRIPTION
### Product Description
no change

### Technical Description
The auto-generated OpenAPI schema for `GET /api/sessions/` described the `ordering` query param only as "Which field to use when ordering the results" — it didn't say which fields were valid or how to request ascending vs descending. Added an explicit `OpenApiParameter` (overriding drf-spectacular's default) that lists the available field (`created_at`) and the `-` prefix convention, plus an `enum` so docs/clients render the valid values. `api-schemas/v1.yml` is regenerated to match.

Also fixed a pre-existing B904 lint error in the same file (`raise ... from None` on the experiment-UUID validation) that the pre-commit hook flagged.

### Migrations
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update