### PR TITLE
Add per-model usage cost breakdown to session detail API

### DIFF
--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -1420,6 +1420,10 @@ components:
           items:
             $ref: '#/components/schemas/Message'
           readOnly: true
+        usage:
+          allOf:
+          - $ref: '#/components/schemas/SessionUsage'
+          readOnly: true
         tags:
           type: array
           items:
@@ -1435,6 +1439,7 @@ components:
       - team
       - updated_at
       - url
+      - usage
     ExperimentStub:
       type: object
       description: A lightweight experiment representation for embedding in other
@@ -1767,6 +1772,21 @@ components:
         * `evaluations` - Evaluations
         * `embedded_widget` - Embedded Widget
         * `email` - Email
+    SessionModelUsage:
+      type: object
+      properties:
+        model_name:
+          type: string
+        cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,6}(?:\.\d{0,8})?$
+        tokens:
+          type: integer
+      required:
+      - cost
+      - model_name
+      - tokens
     SessionStatusEnum:
       enum:
       - active
@@ -1775,6 +1795,20 @@ components:
       description: |-
         * `active` - Active
         * `ended` - Ended
+    SessionUsage:
+      type: object
+      properties:
+        total_cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,6}(?:\.\d{0,8})?$
+        by_model:
+          type: array
+          items:
+            $ref: '#/components/schemas/SessionModelUsage'
+      required:
+      - by_model
+      - total_cost
     Team:
       type: object
       properties:

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -8,6 +8,7 @@ from taggit.serializers import TaggitSerializer, TagListSerializerField
 
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.models import ChatMessage, ChatMessageMetadataKeys, ChatMessageType
+from apps.cost_tracking.services.reporting import session_usage
 from apps.experiments.models import Experiment, ExperimentSession, Participant, ParticipantData
 from apps.files.models import File
 from apps.teams.models import Team
@@ -170,6 +171,17 @@ class MessageSerializer(TaggitSerializer, serializers.ModelSerializer):
         return data
 
 
+class SessionModelUsageSerializer(serializers.Serializer):
+    model_name = serializers.CharField()
+    cost = serializers.DecimalField(max_digits=14, decimal_places=8)
+    tokens = serializers.IntegerField()
+
+
+class SessionUsageSerializer(serializers.Serializer):
+    total_cost = serializers.DecimalField(max_digits=14, decimal_places=8)
+    by_model = SessionModelUsageSerializer(many=True)
+
+
 class ExperimentSessionSerializer(serializers.ModelSerializer):
     url = ApiUrlField(
         openapi_example="https://example.com/api/sessions/123e4567-e89b-12d3-a456-426614174000/",
@@ -182,6 +194,7 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
     experiment = ExperimentStubSerializer(read_only=True)
     participant = ParticipantSerializer(read_only=True)
     messages = serializers.SerializerMethodField()
+    usage = serializers.SerializerMethodField()
     tags = TagListSerializerField(source="chat.tags")
 
     class Meta:
@@ -197,6 +210,7 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
             "status",
             "platform",
             "messages",
+            "usage",
             "tags",
             "state",
         ]
@@ -206,6 +220,7 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
         super().__init__(*args, **kwargs)
         if not self._include_messages:
             self.fields.pop("messages")
+            self.fields.pop("usage")
         else:
             # hack to change the component name for the schema to include messages
             self._spectacular_annotation = {"component_name": "ExperimentSessionWithMessages"}
@@ -214,6 +229,10 @@ class ExperimentSessionSerializer(serializers.ModelSerializer):
     def get_messages(self, instance):
         messages = list(instance.chat.message_iterator())
         return MessageSerializer(reversed(messages), many=True, context=self.context).data
+
+    @extend_schema_field(SessionUsageSerializer)
+    def get_usage(self, instance):
+        return SessionUsageSerializer(session_usage(instance)).data
 
 
 class ExperimentSessionCreateSerializer(serializers.ModelSerializer):

--- a/apps/api/tests/test_session_api.py
+++ b/apps/api/tests/test_session_api.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 from django.urls import reverse
 from rest_framework import status
@@ -6,6 +8,7 @@ from rest_framework.fields import DateTimeField
 from apps.annotations.models import Tag, TagCategories
 from apps.chat.models import ChatAttachment
 from apps.experiments.models import ExperimentSession, Team
+from apps.utils.factories.cost_tracking import UsageRecordFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.files import FileFactory
 from apps.utils.factories.team import TeamWithUsersFactory
@@ -108,7 +111,7 @@ def test_list_sessions_count_only_on_first_page(experiment):
     assert len(second_page["results"]) == 1
 
 
-def get_session_json(session, expected_messages=None, expected_tags=None):
+def get_session_json(session, expected_messages=None, expected_tags=None, expected_usage=None):
     experiment = session.experiment
     data = {
         "url": f"http://testserver/api/sessions/{session.external_id}/",
@@ -134,6 +137,7 @@ def get_session_json(session, expected_messages=None, expected_tags=None):
     }
     if expected_messages is not None:
         data["messages"] = expected_messages
+        data["usage"] = expected_usage if expected_usage is not None else {"total_cost": "0.00000000", "by_model": []}
     return data
 
 
@@ -219,6 +223,27 @@ def test_retrieve_session(auth_method, session):
         ],
         expected_tags=["tag1"],
     )
+
+
+@pytest.mark.django_db()
+def test_retrieve_session_includes_usage_breakdown(session):
+    team = session.team
+    UsageRecordFactory.create(team=team, session=session, model_name="gpt-4o", cost=Decimal("1.00"), quantity=100)
+    UsageRecordFactory.create(team=team, session=session, model_name="gpt-4o", cost=Decimal("2.00"), quantity=200)
+    UsageRecordFactory.create(team=team, session=session, model_name="gpt-4o-mini", cost=Decimal("0.50"), quantity=50)
+
+    user = team.members.first()
+    client = ApiTestClient(user, team)
+    response = client.get(reverse("api:session-detail", kwargs={"id": session.external_id}))
+
+    assert response.status_code == 200
+    assert response.json()["usage"] == {
+        "total_cost": "3.50000000",
+        "by_model": [
+            {"model_name": "gpt-4o", "cost": "3.00000000", "tokens": 300},
+            {"model_name": "gpt-4o-mini", "cost": "0.50000000", "tokens": 50},
+        ],
+    }
 
 
 def _create_attachments(chat, message):

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -12,6 +12,7 @@ from django.db.models import Count, DecimalField, Q, Sum
 from django.db.models.functions import Coalesce
 
 from apps.cost_tracking.models import Confidence, PricingRule, UsageRecord
+from apps.experiments.models import ExperimentSession
 from apps.teams.models import Team
 
 logger = logging.getLogger("ocs.cost_tracking")
@@ -35,6 +36,23 @@ class CostSummary:
     unknown_call_count: int
     unpriced_call_count: int
     last_synced: datetime | None
+
+
+@dataclass(frozen=True)
+class ModelSpend:
+    """Per-model spend row for a single session's usage breakdown."""
+
+    model_name: str
+    cost: Decimal
+    tokens: int
+
+
+@dataclass(frozen=True)
+class SessionUsage:
+    """Whole-session usage: total cost plus a per-model breakdown."""
+
+    total_cost: Decimal
+    by_model: list[ModelSpend]
 
 
 @dataclass(frozen=True)
@@ -113,6 +131,27 @@ def top_n_bots(team: Team, *, start: datetime, end: datetime, limit: int = 10) -
         .order_by("-cost")[:limit]
     )
     return [_bot_spend_from_row(row) for row in rows]
+
+
+def session_usage(session: ExperimentSession) -> SessionUsage:
+    """Cost/token breakdown by model for a single session, plus the overall
+    total. Rows are ordered by descending cost. Uses the
+    `(team, session, timestamp)` index.
+    """
+    rows = (
+        UsageRecord.objects.filter(team_id=session.team_id, session=session)
+        .values("model_name")
+        .annotate(
+            cost=Coalesce(Sum("cost"), _ZERO, output_field=_COST_FIELD),
+            tokens=Coalesce(Sum("quantity"), _ZERO, output_field=_QUANTITY_FIELD),
+        )
+        .order_by("-cost")
+    )
+    by_model = [
+        ModelSpend(model_name=row["model_name"], cost=row["cost"], tokens=int(row["tokens"] or 0)) for row in rows
+    ]
+    total_cost = sum((row.cost for row in by_model), _ZERO)
+    return SessionUsage(total_cost=total_cost, by_model=by_model)
 
 
 def last_synced_at() -> datetime | None:

--- a/apps/cost_tracking/tests/test_reporting.py
+++ b/apps/cost_tracking/tests/test_reporting.py
@@ -11,6 +11,7 @@ from apps.cost_tracking.models import Confidence, PricingRule, ServiceKind
 from apps.cost_tracking.services.reporting import (
     cost_summary,
     last_synced_at,
+    session_usage,
     top_n_bots,
 )
 from apps.utils.factories.cost_tracking import UsageRecordFactory
@@ -238,6 +239,47 @@ class TestTopNBots:
         rows = top_n_bots(team, start=_NOW - timedelta(days=30), end=_NOW)
 
         assert rows == []
+
+
+@pytest.mark.django_db()
+class TestSessionUsage:
+    """Per-session, per-model cost/token breakdown and session scoping."""
+
+    def test_empty_when_no_records(self):
+        team = TeamFactory.create()
+        session = ExperimentSessionFactory.create(team=team)
+
+        usage = session_usage(session)
+
+        assert usage.total_cost == Decimal(0)
+        assert usage.by_model == []
+
+    def test_groups_by_model_with_total(self):
+        team = TeamFactory.create()
+        session = ExperimentSessionFactory.create(team=team)
+        _usage(team, cost="1.00", when=_NOW, session=session, model_name="gpt-4o", quantity=100)
+        _usage(team, cost="2.00", when=_NOW, session=session, model_name="gpt-4o", quantity=200)
+        _usage(team, cost="0.50", when=_NOW, session=session, model_name="gpt-4o-mini", quantity=50)
+
+        usage = session_usage(session)
+
+        assert usage.total_cost == Decimal("3.50000000")
+        assert [(m.model_name, m.cost, m.tokens) for m in usage.by_model] == [
+            ("gpt-4o", Decimal("3.00000000"), 300),
+            ("gpt-4o-mini", Decimal("0.50000000"), 50),
+        ]
+
+    def test_scoped_to_session(self):
+        team = TeamFactory.create()
+        session = ExperimentSessionFactory.create(team=team)
+        other = ExperimentSessionFactory.create(team=team)
+        _usage(team, cost="1.00", when=_NOW, session=session, model_name="gpt-4o")
+        _usage(team, cost="9.00", when=_NOW, session=other, model_name="gpt-4o")
+
+        usage = session_usage(session)
+
+        assert usage.total_cost == Decimal("1.00000000")
+        assert len(usage.by_model) == 1
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
### Product Description
The session detail API (`GET /api/v1/sessions/{id}/`) now returns a `usage` object with the session's total cost and a per-model cost/token breakdown, letting API consumers see what a conversation cost.

### Technical Description
`usage` is gated on the same detail-only path as `messages`, so it only appears on retrieve, not list. Aggregation lives in `reporting.session_usage()` as a single team-scoped group-by over `UsageRecord` (backed by the `(team, session, timestamp)` index), following the existing `top_n_bots` pattern.

Note: `cost`/`tokens` are summed across all `service_kind` rows (input/output/cached) per model. Currency is not surfaced — this matches the existing reporting convention that assumes USD.

### Migrations
N/A — no schema changes.

### Docs and Changelog
- [x] This PR requires docs/changelog update