### PR TITLE
Cost tracking: dashboard panel improvements (#3723)

### DIFF
--- a/apps/cost_tracking/README.md
+++ b/apps/cost_tracking/README.md
@@ -61,5 +61,5 @@ apps/cost_tracking/
     pricing.py              PricingResolver + cache
     recorder.py             record_usage_bulk + UsageEvent / TraceContext
     estimation.py           tiktoken + response_text helpers
-    reporting.py            cost_summary, top_n_bots, last_synced_at
+    reporting.py            cost_summary, costs_by_experiment, coverage_gaps, cost_timeseries, last_synced_at
 ```

--- a/apps/cost_tracking/README.md
+++ b/apps/cost_tracking/README.md
@@ -61,5 +61,5 @@ apps/cost_tracking/
     pricing.py              PricingResolver + cache
     recorder.py             record_usage_bulk + UsageEvent / TraceContext
     estimation.py           tiktoken + response_text helpers
-    reporting.py            cost_summary, costs_by_experiment, coverage_gaps, cost_timeseries, last_synced_at
+    reporting.py            cost_summary, costs_by_experiment, coverage_gaps, cost_timeseries
 ```

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -81,38 +81,36 @@ class CoverageGaps:
     unknown: list[ModelCoverageGap]
 
 
-def _scoped_records(
-    team: Team,
-    *,
-    experiment_ids: list[int] | None = None,
-    platform_names: list[str] | None = None,
-    participant_ids: list[int] | None = None,
-):
+@dataclass(frozen=True)
+class CostFilters:
+    """The dashboard filters the cost read path honours, bundled so the
+    reporting functions take one argument instead of three parallel lists.
+    Tags are intentionally absent - usage records aren't tagged directly.
+    """
+
+    experiment_ids: list[int] | None = None
+    platform_names: list[str] | None = None
+    participant_ids: list[int] | None = None
+
+
+def _scoped_records(team: Team, filters: CostFilters | None = None):
     """Team-scoped UsageRecords with the dashboard's chatbot / participant /
     platform filters applied (mirrors the cost panel's other charts). Platform
     is matched via the record's session, so records with no session are excluded
-    when a platform filter is set. Tags are intentionally not supported here -
-    usage records aren't tagged directly.
+    when a platform filter is set.
     """
+    filters = filters or CostFilters()
     qs = UsageRecord.objects.filter(team=team)
-    if experiment_ids:
-        qs = qs.filter(experiment_id__in=experiment_ids)
-    if participant_ids:
-        qs = qs.filter(participant_id__in=participant_ids)
-    if platform_names:
-        qs = qs.filter(session__platform__in=platform_names)
+    if filters.experiment_ids:
+        qs = qs.filter(experiment_id__in=filters.experiment_ids)
+    if filters.participant_ids:
+        qs = qs.filter(participant_id__in=filters.participant_ids)
+    if filters.platform_names:
+        qs = qs.filter(session__platform__in=filters.platform_names)
     return qs
 
 
-def cost_summary(
-    team: Team,
-    *,
-    start: datetime,
-    end: datetime,
-    experiment_ids: list[int] | None = None,
-    platform_names: list[str] | None = None,
-    participant_ids: list[int] | None = None,
-) -> CostSummary:
+def cost_summary(team: Team, *, start: datetime, end: datetime, filters: CostFilters | None = None) -> CostSummary:
     """Total cost in [start, end), delta vs the equal-length prior period,
     and a confidence breakdown so the dashboard footer can show what share
     of the spend is estimated.
@@ -121,9 +119,7 @@ def cost_summary(
     period_q = Q(timestamp__gte=start, timestamp__lt=end)
     previous_q = Q(timestamp__gte=previous_start, timestamp__lt=start)
 
-    agg = _scoped_records(
-        team, experiment_ids=experiment_ids, platform_names=platform_names, participant_ids=participant_ids
-    ).aggregate(
+    agg = _scoped_records(team, filters).aggregate(
         total=Coalesce(Sum("cost", filter=period_q), _ZERO, output_field=_COST_FIELD),
         previous=Coalesce(Sum("cost", filter=previous_q), _ZERO, output_field=_COST_FIELD),
         exact=Coalesce(
@@ -158,22 +154,14 @@ def cost_summary(
 
 
 def costs_by_experiment(
-    team: Team,
-    *,
-    start: datetime,
-    end: datetime,
-    experiment_ids: list[int] | None = None,
-    platform_names: list[str] | None = None,
-    participant_ids: list[int] | None = None,
+    team: Team, *, start: datetime, end: datetime, filters: CostFilters | None = None
 ) -> dict[int, Decimal]:
     """Total cost per experiment in the period, keyed by `experiment_id`.
     Feeds the dashboard's Bot Performance table cost column. Records with a
     null experiment (e.g. trace whose experiment was hard-deleted) are excluded.
     """
     rows = (
-        _scoped_records(
-            team, experiment_ids=experiment_ids, platform_names=platform_names, participant_ids=participant_ids
-        )
+        _scoped_records(team, filters)
         .filter(timestamp__gte=start, timestamp__lt=end, experiment__isnull=False)
         .values("experiment_id")
         .annotate(cost=Coalesce(Sum("cost"), _ZERO, output_field=_COST_FIELD))
@@ -202,15 +190,7 @@ def session_usage(session: ExperimentSession) -> SessionUsage:
     return SessionUsage(total_cost=total_cost, by_model=by_model)
 
 
-def coverage_gaps(
-    team: Team,
-    *,
-    start: datetime,
-    end: datetime,
-    experiment_ids: list[int] | None = None,
-    platform_names: list[str] | None = None,
-    participant_ids: list[int] | None = None,
-) -> CoverageGaps:
+def coverage_gaps(team: Team, *, start: datetime, end: datetime, filters: CostFilters | None = None) -> CoverageGaps:
     """The models behind the period's unpriced / no-usage warnings, so the
     panel can list which models are responsible. Single grouped query over the
     `(team, model_name, timestamp)` index; buckets with a zero count in a
@@ -218,9 +198,7 @@ def coverage_gaps(
     """
     period_q = Q(timestamp__gte=start, timestamp__lt=end)
     rows = (
-        _scoped_records(
-            team, experiment_ids=experiment_ids, platform_names=platform_names, participant_ids=participant_ids
-        )
+        _scoped_records(team, filters)
         .filter(period_q & (Q(confidence=Confidence.UNKNOWN) | Q(pricing_rule__isnull=True)))
         .values("provider_type", "model_name")
         .annotate(
@@ -241,14 +219,7 @@ def coverage_gaps(
 
 
 def cost_timeseries(
-    team: Team,
-    *,
-    start: datetime,
-    end: datetime,
-    granularity: str = "daily",
-    experiment_ids: list[int] | None = None,
-    platform_names: list[str] | None = None,
-    participant_ids: list[int] | None = None,
+    team: Team, *, start: datetime, end: datetime, granularity: str = "daily", filters: CostFilters | None = None
 ) -> list[dict]:
     """Spend per time bucket in [start, end), ordered chronologically. Costs
     are returned as floats for direct JSON/Chart.js consumption. Empty buckets
@@ -256,9 +227,7 @@ def cost_timeseries(
     """
     trunc = _GRANULARITY_TRUNC.get(granularity, TruncDate)
     rows = (
-        _scoped_records(
-            team, experiment_ids=experiment_ids, platform_names=platform_names, participant_ids=participant_ids
-        )
+        _scoped_records(team, filters)
         .filter(timestamp__gte=start, timestamp__lt=end)
         .annotate(bucket=trunc("timestamp"))
         .values("bucket")

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -63,7 +63,38 @@ class CoverageGaps:
     unknown: list[ModelCoverageGap]
 
 
-def cost_summary(team: Team, *, start: datetime, end: datetime) -> CostSummary:
+def _scoped_records(
+    team: Team,
+    *,
+    experiment_ids: list[int] | None = None,
+    platform_names: list[str] | None = None,
+    participant_ids: list[int] | None = None,
+):
+    """Team-scoped UsageRecords with the dashboard's chatbot / participant /
+    platform filters applied (mirrors the cost panel's other charts). Platform
+    is matched via the record's session, so records with no session are excluded
+    when a platform filter is set. Tags are intentionally not supported here -
+    usage records aren't tagged directly.
+    """
+    qs = UsageRecord.objects.filter(team=team)
+    if experiment_ids:
+        qs = qs.filter(experiment_id__in=experiment_ids)
+    if participant_ids:
+        qs = qs.filter(participant_id__in=participant_ids)
+    if platform_names:
+        qs = qs.filter(session__platform__in=platform_names)
+    return qs
+
+
+def cost_summary(
+    team: Team,
+    *,
+    start: datetime,
+    end: datetime,
+    experiment_ids: list[int] | None = None,
+    platform_names: list[str] | None = None,
+    participant_ids: list[int] | None = None,
+) -> CostSummary:
     """Total cost in [start, end), delta vs the equal-length prior period,
     and a confidence breakdown so the dashboard footer can show what share
     of the spend is estimated.
@@ -72,7 +103,9 @@ def cost_summary(team: Team, *, start: datetime, end: datetime) -> CostSummary:
     period_q = Q(timestamp__gte=start, timestamp__lt=end)
     previous_q = Q(timestamp__gte=previous_start, timestamp__lt=start)
 
-    agg = UsageRecord.objects.filter(team=team).aggregate(
+    agg = _scoped_records(
+        team, experiment_ids=experiment_ids, platform_names=platform_names, participant_ids=participant_ids
+    ).aggregate(
         total=Coalesce(Sum("cost", filter=period_q), _ZERO, output_field=_COST_FIELD),
         previous=Coalesce(Sum("cost", filter=previous_q), _ZERO, output_field=_COST_FIELD),
         exact=Coalesce(
@@ -106,25 +139,39 @@ def cost_summary(team: Team, *, start: datetime, end: datetime) -> CostSummary:
     )
 
 
-def costs_by_experiment(team: Team, *, start: datetime, end: datetime) -> dict[int, Decimal]:
+def costs_by_experiment(
+    team: Team,
+    *,
+    start: datetime,
+    end: datetime,
+    experiment_ids: list[int] | None = None,
+    platform_names: list[str] | None = None,
+    participant_ids: list[int] | None = None,
+) -> dict[int, Decimal]:
     """Total cost per experiment in the period, keyed by `experiment_id`.
     Feeds the dashboard's Bot Performance table cost column. Records with a
     null experiment (e.g. trace whose experiment was hard-deleted) are excluded.
     """
     rows = (
-        UsageRecord.objects.filter(
-            team=team,
-            timestamp__gte=start,
-            timestamp__lt=end,
-            experiment__isnull=False,
+        _scoped_records(
+            team, experiment_ids=experiment_ids, platform_names=platform_names, participant_ids=participant_ids
         )
+        .filter(timestamp__gte=start, timestamp__lt=end, experiment__isnull=False)
         .values("experiment_id")
         .annotate(cost=Coalesce(Sum("cost"), _ZERO, output_field=_COST_FIELD))
     )
     return {row["experiment_id"]: row["cost"] for row in rows}
 
 
-def coverage_gaps(team: Team, *, start: datetime, end: datetime) -> CoverageGaps:
+def coverage_gaps(
+    team: Team,
+    *,
+    start: datetime,
+    end: datetime,
+    experiment_ids: list[int] | None = None,
+    platform_names: list[str] | None = None,
+    participant_ids: list[int] | None = None,
+) -> CoverageGaps:
     """The models behind the period's unpriced / no-usage warnings, so the
     panel can list which models are responsible. Single grouped query over the
     `(team, model_name, timestamp)` index; buckets with a zero count in a
@@ -132,7 +179,9 @@ def coverage_gaps(team: Team, *, start: datetime, end: datetime) -> CoverageGaps
     """
     period_q = Q(timestamp__gte=start, timestamp__lt=end)
     rows = (
-        UsageRecord.objects.filter(team=team)
+        _scoped_records(
+            team, experiment_ids=experiment_ids, platform_names=platform_names, participant_ids=participant_ids
+        )
         .filter(period_q & (Q(confidence=Confidence.UNKNOWN) | Q(pricing_rule__isnull=True)))
         .values("provider_type", "model_name")
         .annotate(
@@ -152,14 +201,26 @@ def coverage_gaps(team: Team, *, start: datetime, end: datetime) -> CoverageGaps
     return CoverageGaps(unpriced=unpriced, unknown=unknown)
 
 
-def cost_timeseries(team: Team, *, start: datetime, end: datetime, granularity: str = "daily") -> list[dict]:
+def cost_timeseries(
+    team: Team,
+    *,
+    start: datetime,
+    end: datetime,
+    granularity: str = "daily",
+    experiment_ids: list[int] | None = None,
+    platform_names: list[str] | None = None,
+    participant_ids: list[int] | None = None,
+) -> list[dict]:
     """Spend per time bucket in [start, end), ordered chronologically. Costs
     are returned as floats for direct JSON/Chart.js consumption. Empty buckets
     (no usage) are absent - the chart plots what's recorded.
     """
     trunc = _GRANULARITY_TRUNC.get(granularity, TruncDate)
     rows = (
-        UsageRecord.objects.filter(team=team, timestamp__gte=start, timestamp__lt=end)
+        _scoped_records(
+            team, experiment_ids=experiment_ids, platform_names=platform_names, participant_ids=participant_ids
+        )
+        .filter(timestamp__gte=start, timestamp__lt=end)
         .annotate(bucket=trunc("timestamp"))
         .values("bucket")
         .annotate(cost=Coalesce(Sum("cost"), _ZERO, output_field=_COST_FIELD))

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from decimal import Decimal
 
 from django.db.models import Count, DecimalField, Q, Sum
-from django.db.models.functions import Coalesce
+from django.db.models.functions import Coalesce, TruncDate, TruncMonth, TruncWeek
 
 from apps.cost_tracking.models import Confidence, PricingRule, UsageRecord
 from apps.teams.models import Team
@@ -18,7 +18,6 @@ logger = logging.getLogger("ocs.cost_tracking")
 
 _ZERO = Decimal(0)
 _COST_FIELD = DecimalField(max_digits=14, decimal_places=8)
-_QUANTITY_FIELD = DecimalField(max_digits=18, decimal_places=4)
 
 
 @dataclass(frozen=True)
@@ -37,16 +36,32 @@ class CostSummary:
     last_synced: datetime | None
 
 
-@dataclass(frozen=True)
-class BotSpend:
-    """Per-experiment spend row for the by-bot table."""
+_GRANULARITY_TRUNC = {
+    "daily": TruncDate,
+    "weekly": TruncWeek,
+    "monthly": TruncMonth,
+}
 
-    experiment_id: int
-    experiment_name: str
-    cost: Decimal
-    tokens: int
-    sessions: int
-    cost_per_session: Decimal | None
+
+@dataclass(frozen=True)
+class ModelCoverageGap:
+    """One (provider, model) with calls the dashboard couldn't fully account
+    for - either unpriced (no matching rule) or missing usage data.
+    """
+
+    provider_type: str
+    model_name: str
+    call_count: int
+
+
+@dataclass(frozen=True)
+class CoverageGaps:
+    """The models behind the panel's `unpriced_call_count` /
+    `unknown_call_count`, so the warnings can name what's responsible.
+    """
+
+    unpriced: list[ModelCoverageGap]
+    unknown: list[ModelCoverageGap]
 
 
 def cost_summary(team: Team, *, start: datetime, end: datetime) -> CostSummary:
@@ -93,9 +108,10 @@ def cost_summary(team: Team, *, start: datetime, end: datetime) -> CostSummary:
     )
 
 
-def top_n_bots(team: Team, *, start: datetime, end: datetime, limit: int = 10) -> list[BotSpend]:
-    """Top experiments by cost in the period. Records with a null experiment
-    (e.g. trace whose experiment was hard-deleted) are excluded.
+def costs_by_experiment(team: Team, *, start: datetime, end: datetime) -> dict[int, Decimal]:
+    """Total cost per experiment in the period, keyed by `experiment_id`.
+    Feeds the dashboard's Bot Performance table cost column. Records with a
+    null experiment (e.g. trace whose experiment was hard-deleted) are excluded.
     """
     rows = (
         UsageRecord.objects.filter(
@@ -104,15 +120,54 @@ def top_n_bots(team: Team, *, start: datetime, end: datetime, limit: int = 10) -
             timestamp__lt=end,
             experiment__isnull=False,
         )
-        .values("experiment_id", "experiment__name")
-        .annotate(
-            cost=Coalesce(Sum("cost"), _ZERO, output_field=_COST_FIELD),
-            tokens=Coalesce(Sum("quantity"), _ZERO, output_field=_QUANTITY_FIELD),
-            sessions=Count("session_id", distinct=True),
-        )
-        .order_by("-cost")[:limit]
+        .values("experiment_id")
+        .annotate(cost=Coalesce(Sum("cost"), _ZERO, output_field=_COST_FIELD))
     )
-    return [_bot_spend_from_row(row) for row in rows]
+    return {row["experiment_id"]: row["cost"] for row in rows}
+
+
+def coverage_gaps(team: Team, *, start: datetime, end: datetime) -> CoverageGaps:
+    """The models behind the period's unpriced / no-usage warnings, so the
+    panel can list which models are responsible. Single grouped query over the
+    `(team, model_name, timestamp)` index; buckets with a zero count in a
+    category are dropped. Each list is sorted by call count, descending.
+    """
+    period_q = Q(timestamp__gte=start, timestamp__lt=end)
+    rows = (
+        UsageRecord.objects.filter(team=team)
+        .filter(period_q & (Q(confidence=Confidence.UNKNOWN) | Q(pricing_rule__isnull=True)))
+        .values("provider_type", "model_name")
+        .annotate(
+            unknown_count=Count("id", filter=Q(confidence=Confidence.UNKNOWN)),
+            unpriced_count=Count("id", filter=Q(pricing_rule__isnull=True) & ~Q(confidence=Confidence.UNKNOWN)),
+        )
+        .order_by()
+    )
+    unpriced, unknown = [], []
+    for row in rows:
+        if row["unpriced_count"]:
+            unpriced.append(_coverage_gap_from_row(row, row["unpriced_count"]))
+        if row["unknown_count"]:
+            unknown.append(_coverage_gap_from_row(row, row["unknown_count"]))
+    unpriced.sort(key=lambda gap: gap.call_count, reverse=True)
+    unknown.sort(key=lambda gap: gap.call_count, reverse=True)
+    return CoverageGaps(unpriced=unpriced, unknown=unknown)
+
+
+def cost_timeseries(team: Team, *, start: datetime, end: datetime, granularity: str = "daily") -> list[dict]:
+    """Spend per time bucket in [start, end), ordered chronologically. Costs
+    are returned as floats for direct JSON/Chart.js consumption. Empty buckets
+    (no usage) are absent - the chart plots what's recorded.
+    """
+    trunc = _GRANULARITY_TRUNC.get(granularity, TruncDate)
+    rows = (
+        UsageRecord.objects.filter(team=team, timestamp__gte=start, timestamp__lt=end)
+        .annotate(bucket=trunc("timestamp"))
+        .values("bucket")
+        .annotate(cost=Coalesce(Sum("cost"), _ZERO, output_field=_COST_FIELD))
+        .order_by("bucket")
+    )
+    return [{"date": row["bucket"], "cost": float(row["cost"])} for row in rows]
 
 
 def last_synced_at() -> datetime | None:
@@ -127,16 +182,11 @@ def last_synced_at() -> datetime | None:
     )
 
 
-def _bot_spend_from_row(row: dict) -> BotSpend:
-    sessions = row["sessions"]
-    cost = row["cost"]
-    return BotSpend(
-        experiment_id=row["experiment_id"],
-        experiment_name=row["experiment__name"],
-        cost=cost,
-        tokens=int(row["tokens"] or 0),
-        sessions=sessions,
-        cost_per_session=(cost / sessions) if sessions else None,
+def _coverage_gap_from_row(row: dict, call_count: int) -> ModelCoverageGap:
+    return ModelCoverageGap(
+        provider_type=row["provider_type"],
+        model_name=row["model_name"],
+        call_count=call_count,
     )
 
 

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -11,7 +11,7 @@ from decimal import Decimal
 from django.db.models import Count, DecimalField, Q, Sum
 from django.db.models.functions import Coalesce, TruncDate, TruncMonth, TruncWeek
 
-from apps.cost_tracking.models import Confidence, PricingRule, UsageRecord
+from apps.cost_tracking.models import Confidence, UsageRecord
 from apps.teams.models import Team
 
 logger = logging.getLogger("ocs.cost_tracking")
@@ -33,7 +33,6 @@ class CostSummary:
     estimated_cost: Decimal
     unknown_call_count: int
     unpriced_call_count: int
-    last_synced: datetime | None
 
 
 _GRANULARITY_TRUNC = {
@@ -104,7 +103,6 @@ def cost_summary(team: Team, *, start: datetime, end: datetime) -> CostSummary:
         estimated_cost=agg["estimated"],
         unknown_call_count=agg["unknown_rows"],
         unpriced_call_count=agg["unpriced_rows"],
-        last_synced=last_synced_at(),
     )
 
 
@@ -168,18 +166,6 @@ def cost_timeseries(team: Team, *, start: datetime, end: datetime, granularity: 
         .order_by("bucket")
     )
     return [{"date": row["bucket"], "cost": float(row["cost"])} for row in rows]
-
-
-def last_synced_at() -> datetime | None:
-    """Most recent `effective_from` on a globally-scoped PricingRule.
-    The dashboard footer renders "Pricing last synced YYYY-MM-DD".
-    """
-    return (
-        PricingRule.objects.filter(team__isnull=True)
-        .order_by("-effective_from")
-        .values_list("effective_from", flat=True)
-        .first()
-    )
 
 
 def _coverage_gap_from_row(row: dict, call_count: int) -> ModelCoverageGap:

--- a/apps/cost_tracking/tests/test_reporting.py
+++ b/apps/cost_tracking/tests/test_reporting.py
@@ -9,6 +9,7 @@ from django.test.utils import CaptureQueriesContext
 
 from apps.cost_tracking.models import Confidence, PricingRule, ServiceKind
 from apps.cost_tracking.services.reporting import (
+    CostFilters,
     cost_summary,
     cost_timeseries,
     costs_by_experiment,
@@ -335,7 +336,9 @@ class TestCostFilters:
         _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=keep)
         _usage(team, cost="9.00", when=_NOW - timedelta(days=1), experiment=drop)
 
-        summary = cost_summary(team, start=_NOW - timedelta(days=30), end=_NOW, experiment_ids=[keep.id])
+        summary = cost_summary(
+            team, start=_NOW - timedelta(days=30), end=_NOW, filters=CostFilters(experiment_ids=[keep.id])
+        )
 
         assert summary.total_cost == Decimal("1.00")
 
@@ -346,7 +349,9 @@ class TestCostFilters:
         _usage(team, cost="2.00", when=_NOW - timedelta(days=45), experiment=keep)
         _usage(team, cost="9.00", when=_NOW - timedelta(days=45), experiment=drop)
 
-        summary = cost_summary(team, start=_NOW - timedelta(days=30), end=_NOW, experiment_ids=[keep.id])
+        summary = cost_summary(
+            team, start=_NOW - timedelta(days=30), end=_NOW, filters=CostFilters(experiment_ids=[keep.id])
+        )
 
         assert summary.previous_period_cost == Decimal("2.00")
 
@@ -358,7 +363,9 @@ class TestCostFilters:
         _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=exp, participant=keep.participant)
         _usage(team, cost="9.00", when=_NOW - timedelta(days=1), experiment=exp, participant=drop.participant)
 
-        series = cost_timeseries(team, start=_NOW - timedelta(days=30), end=_NOW, participant_ids=[keep.participant_id])
+        series = cost_timeseries(
+            team, start=_NOW - timedelta(days=30), end=_NOW, filters=CostFilters(participant_ids=[keep.participant_id])
+        )
 
         assert [point["cost"] for point in series] == [1.0]
 
@@ -370,7 +377,9 @@ class TestCostFilters:
         _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=exp, session=web)
         _usage(team, cost="9.00", when=_NOW - timedelta(days=1), experiment=exp, session=api)
 
-        series = cost_timeseries(team, start=_NOW - timedelta(days=30), end=_NOW, platform_names=["web"])
+        series = cost_timeseries(
+            team, start=_NOW - timedelta(days=30), end=_NOW, filters=CostFilters(platform_names=["web"])
+        )
 
         assert [point["cost"] for point in series] == [1.0]
 
@@ -381,7 +390,9 @@ class TestCostFilters:
         _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=keep)
         _usage(team, cost="9.00", when=_NOW - timedelta(days=1), experiment=drop)
 
-        costs = costs_by_experiment(team, start=_NOW - timedelta(days=30), end=_NOW, experiment_ids=[keep.id])
+        costs = costs_by_experiment(
+            team, start=_NOW - timedelta(days=30), end=_NOW, filters=CostFilters(experiment_ids=[keep.id])
+        )
 
         assert costs == {keep.id: Decimal("1.00000000")}
 
@@ -392,6 +403,8 @@ class TestCostFilters:
         _usage(team, cost="0.00", when=_NOW - timedelta(days=1), experiment=keep, model_name="keep-model")
         _usage(team, cost="0.00", when=_NOW - timedelta(days=1), experiment=drop, model_name="drop-model")
 
-        gaps = coverage_gaps(team, start=_NOW - timedelta(days=30), end=_NOW, experiment_ids=[keep.id])
+        gaps = coverage_gaps(
+            team, start=_NOW - timedelta(days=30), end=_NOW, filters=CostFilters(experiment_ids=[keep.id])
+        )
 
         assert [g.model_name for g in gaps.unpriced] == ["keep-model"]

--- a/apps/cost_tracking/tests/test_reporting.py
+++ b/apps/cost_tracking/tests/test_reporting.py
@@ -13,7 +13,6 @@ from apps.cost_tracking.services.reporting import (
     cost_timeseries,
     costs_by_experiment,
     coverage_gaps,
-    last_synced_at,
 )
 from apps.utils.factories.cost_tracking import UsageRecordFactory
 from apps.utils.factories.experiment import ExperimentFactory
@@ -123,22 +122,6 @@ class TestCostSummary:
         assert summary.unpriced_call_count == 3
         assert summary.unknown_call_count == 1
 
-    def test_last_synced_returned_in_summary(self):
-        team = TeamFactory.create()
-        newer = PricingRule.objects.create(
-            team=None,
-            provider_type="openai",
-            model_name="test-model-newer",
-            service_kind=ServiceKind.LLM_INPUT,
-            unit_price="0.00015",
-        )
-        future = newer.effective_from + timedelta(days=365)
-        PricingRule.objects.filter(pk=newer.pk).update(effective_from=future)
-
-        summary = cost_summary(team, start=_NOW - timedelta(days=30), end=_NOW)
-
-        assert summary.last_synced == future
-
     def test_single_query_for_aggregate(self):
         team = TeamFactory.create()
         _usage(team, cost="1.00", when=_NOW - timedelta(days=1))
@@ -146,8 +129,8 @@ class TestCostSummary:
         with CaptureQueriesContext(connection) as ctx:
             cost_summary(team, start=_NOW - timedelta(days=30), end=_NOW)
 
-        # One aggregate over UsageRecord + one for last_synced - no N+1.
-        assert len(ctx.captured_queries) == 2
+        # Single aggregate over UsageRecord - no N+1.
+        assert len(ctx.captured_queries) == 1
 
 
 @pytest.mark.django_db()
@@ -295,40 +278,3 @@ class TestCostTimeseries:
         _usage(other, cost="999.00", when=_NOW - timedelta(days=1))
 
         assert cost_timeseries(team, start=_NOW - timedelta(days=30), end=_NOW) == []
-
-
-@pytest.mark.django_db()
-class TestLastSyncedAt:
-    """The seed migration always inserts global rules - these tests prune
-    them first so the assertions speak only to behaviour under test.
-    """
-
-    def test_none_when_no_global_rules(self):
-        PricingRule.objects.all().delete()
-        assert last_synced_at() is None
-
-    def test_ignores_team_scoped_rules(self):
-        PricingRule.objects.filter(team__isnull=True).delete()
-        team = TeamFactory.create()
-        PricingRule.objects.create(
-            team=team,
-            provider_type="openai",
-            model_name="test-model",
-            service_kind=ServiceKind.LLM_INPUT,
-            unit_price="0.00015",
-        )
-
-        assert last_synced_at() is None
-
-    def test_returns_most_recent_global_effective_from(self):
-        newer = PricingRule.objects.create(
-            team=None,
-            provider_type="openai",
-            model_name="test-model-newer",
-            service_kind=ServiceKind.LLM_INPUT,
-            unit_price="0.00015",
-        )
-        future = newer.effective_from + timedelta(days=365)
-        PricingRule.objects.filter(pk=newer.pk).update(effective_from=future)
-
-        assert last_synced_at() == future

--- a/apps/cost_tracking/tests/test_reporting.py
+++ b/apps/cost_tracking/tests/test_reporting.py
@@ -10,11 +10,13 @@ from django.test.utils import CaptureQueriesContext
 from apps.cost_tracking.models import Confidence, PricingRule, ServiceKind
 from apps.cost_tracking.services.reporting import (
     cost_summary,
+    cost_timeseries,
+    costs_by_experiment,
+    coverage_gaps,
     last_synced_at,
-    top_n_bots,
 )
 from apps.utils.factories.cost_tracking import UsageRecordFactory
-from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
+from apps.utils.factories.experiment import ExperimentFactory
 from apps.utils.factories.team import TeamFactory
 
 _NOW = datetime(2026, 6, 15, 12, 0, tzinfo=UTC)
@@ -149,10 +151,10 @@ class TestCostSummary:
 
 
 @pytest.mark.django_db()
-class TestTopNBots:
-    """Ordering, exclusions, aggregation, team scoping."""
+class TestCostsByExperiment:
+    """Per-experiment cost map feeding the Bot Performance table."""
 
-    def test_single_query_for_aggregate(self):
+    def test_single_query(self):
         team = TeamFactory.create()
         exp_a = ExperimentFactory.create(team=team, name="bot-a")
         exp_b = ExperimentFactory.create(team=team, name="bot-b")
@@ -160,74 +162,33 @@ class TestTopNBots:
         _usage(team, cost="2.00", when=_NOW - timedelta(days=2), experiment=exp_b)
 
         with CaptureQueriesContext(connection) as ctx:
-            top_n_bots(team, start=_NOW - timedelta(days=30), end=_NOW)
+            costs_by_experiment(team, start=_NOW - timedelta(days=30), end=_NOW)
 
         # Single GROUP BY query — no N+1 per experiment.
         assert len(ctx.captured_queries) == 1
 
-    def test_orders_by_cost_descending(self):
+    def test_aggregates_per_experiment(self):
         team = TeamFactory.create()
-        cheap = ExperimentFactory.create(team=team, name="cheap")
-        expensive = ExperimentFactory.create(team=team, name="expensive")
-        _usage(team, cost="0.10", when=_NOW - timedelta(days=1), experiment=cheap)
-        _usage(team, cost="5.00", when=_NOW - timedelta(days=1), experiment=expensive)
+        exp = ExperimentFactory.create(team=team, name="bot")
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=exp)
+        _usage(team, cost="2.00", when=_NOW - timedelta(days=2), experiment=exp)
 
-        rows = top_n_bots(team, start=_NOW - timedelta(days=30), end=_NOW)
+        costs = costs_by_experiment(team, start=_NOW - timedelta(days=30), end=_NOW)
 
-        assert [r.experiment_name for r in rows] == ["expensive", "cheap"]
+        assert costs == {exp.id: Decimal("3.00000000")}
 
     def test_excludes_records_with_null_experiment(self):
         team = TeamFactory.create()
         _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=None)
 
-        rows = top_n_bots(team, start=_NOW - timedelta(days=30), end=_NOW)
+        assert costs_by_experiment(team, start=_NOW - timedelta(days=30), end=_NOW) == {}
 
-        assert rows == []
-
-    def test_aggregates_per_experiment(self):
-        team = TeamFactory.create()
-        exp = ExperimentFactory.create(team=team, name="bot")
-        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=exp, quantity=100)
-        _usage(team, cost="2.00", when=_NOW - timedelta(days=2), experiment=exp, quantity=200)
-
-        rows = top_n_bots(team, start=_NOW - timedelta(days=30), end=_NOW)
-
-        assert len(rows) == 1
-        assert rows[0].cost == Decimal("3.00000000")
-        assert rows[0].tokens == 300
-
-    def test_cost_per_session_divides_when_sessions_present(self):
+    def test_excludes_records_outside_window(self):
         team = TeamFactory.create()
         exp = ExperimentFactory.create(team=team)
-        s1 = ExperimentSessionFactory.create(experiment=exp, team=team)
-        s2 = ExperimentSessionFactory.create(experiment=exp, team=team)
-        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=exp, session=s1)
-        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=exp, session=s2)
+        _usage(team, cost="9.99", when=_NOW - timedelta(days=40), experiment=exp)
 
-        rows = top_n_bots(team, start=_NOW - timedelta(days=30), end=_NOW)
-
-        assert rows[0].sessions == 2
-        assert rows[0].cost_per_session == Decimal("1.00000000")
-
-    def test_cost_per_session_none_when_no_sessions(self):
-        team = TeamFactory.create()
-        exp = ExperimentFactory.create(team=team)
-        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=exp, session=None)
-
-        rows = top_n_bots(team, start=_NOW - timedelta(days=30), end=_NOW)
-
-        assert rows[0].sessions == 0
-        assert rows[0].cost_per_session is None
-
-    def test_limit_truncates(self):
-        team = TeamFactory.create()
-        for i in range(15):
-            exp = ExperimentFactory.create(team=team, name=f"bot-{i}")
-            _usage(team, cost=str(i + 1), when=_NOW - timedelta(days=1), experiment=exp)
-
-        rows = top_n_bots(team, start=_NOW - timedelta(days=30), end=_NOW, limit=5)
-
-        assert len(rows) == 5
+        assert costs_by_experiment(team, start=_NOW - timedelta(days=30), end=_NOW) == {}
 
     def test_team_scoped(self):
         team = TeamFactory.create()
@@ -235,9 +196,105 @@ class TestTopNBots:
         exp_other = ExperimentFactory.create(team=other)
         _usage(other, cost="999.00", when=_NOW - timedelta(days=1), experiment=exp_other)
 
-        rows = top_n_bots(team, start=_NOW - timedelta(days=30), end=_NOW)
+        assert costs_by_experiment(team, start=_NOW - timedelta(days=30), end=_NOW) == {}
 
-        assert rows == []
+
+@pytest.mark.django_db()
+class TestCoverageGaps:
+    """The models behind the unpriced / no-usage warning counts."""
+
+    def test_groups_unpriced_and_unknown_by_model(self):
+        team = TeamFactory.create()
+        rule = PricingRule.objects.create(
+            team=None,
+            provider_type="openai",
+            model_name="priced-model",
+            service_kind=ServiceKind.LLM_INPUT,
+            unit_price="0.0001",
+        )
+        # Unpriced (no rule, non-UNKNOWN) across two calls of one model.
+        _usage(
+            team, cost="0.00", when=_NOW - timedelta(days=1), model_name="unpriced-model", confidence=Confidence.EXACT
+        )
+        _usage(
+            team, cost="0.00", when=_NOW - timedelta(days=2), model_name="unpriced-model", confidence=Confidence.EXACT
+        )
+        # No-usage (UNKNOWN) call of another model.
+        _usage(
+            team, cost="0.00", when=_NOW - timedelta(days=3), model_name="unknown-model", confidence=Confidence.UNKNOWN
+        )
+        # A priced call - must not appear in either list.
+        _usage(team, cost="0.50", when=_NOW - timedelta(days=4), model_name="priced-model", pricing_rule=rule)
+
+        gaps = coverage_gaps(team, start=_NOW - timedelta(days=30), end=_NOW)
+
+        assert [(g.model_name, g.call_count) for g in gaps.unpriced] == [("unpriced-model", 2)]
+        assert [(g.model_name, g.call_count) for g in gaps.unknown] == [("unknown-model", 1)]
+
+    def test_sorted_by_call_count_descending(self):
+        team = TeamFactory.create()
+        for _ in range(3):
+            _usage(team, cost="0.00", when=_NOW - timedelta(days=1), model_name="loud", confidence=Confidence.EXACT)
+        _usage(team, cost="0.00", when=_NOW - timedelta(days=1), model_name="quiet", confidence=Confidence.EXACT)
+
+        gaps = coverage_gaps(team, start=_NOW - timedelta(days=30), end=_NOW)
+
+        assert [g.model_name for g in gaps.unpriced] == ["loud", "quiet"]
+
+    def test_single_query(self):
+        team = TeamFactory.create()
+        _usage(team, cost="0.00", when=_NOW - timedelta(days=1), confidence=Confidence.EXACT)
+
+        with CaptureQueriesContext(connection) as ctx:
+            coverage_gaps(team, start=_NOW - timedelta(days=30), end=_NOW)
+
+        assert len(ctx.captured_queries) == 1
+
+    def test_empty_when_all_priced(self):
+        team = TeamFactory.create()
+        rule = PricingRule.objects.create(
+            team=None,
+            provider_type="openai",
+            model_name="priced-model",
+            service_kind=ServiceKind.LLM_INPUT,
+            unit_price="0.0001",
+        )
+        _usage(team, cost="0.50", when=_NOW - timedelta(days=1), model_name="priced-model", pricing_rule=rule)
+
+        gaps = coverage_gaps(team, start=_NOW - timedelta(days=30), end=_NOW)
+
+        assert gaps.unpriced == []
+        assert gaps.unknown == []
+
+
+@pytest.mark.django_db()
+class TestCostTimeseries:
+    """Per-bucket spend for the panel's daily-spend chart."""
+
+    def test_buckets_by_day_ordered(self):
+        team = TeamFactory.create()
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=2))
+        _usage(team, cost="0.50", when=_NOW - timedelta(days=2))
+        _usage(team, cost="2.00", when=_NOW - timedelta(days=1))
+
+        series = cost_timeseries(team, start=_NOW - timedelta(days=30), end=_NOW)
+
+        assert [point["cost"] for point in series] == [1.5, 2.0]
+
+    def test_costs_are_floats(self):
+        team = TeamFactory.create()
+        _usage(team, cost="1.25", when=_NOW - timedelta(days=1))
+
+        series = cost_timeseries(team, start=_NOW - timedelta(days=30), end=_NOW)
+
+        assert isinstance(series[0]["cost"], float)
+
+    def test_team_scoped(self):
+        team = TeamFactory.create()
+        other = TeamFactory.create()
+        _usage(other, cost="999.00", when=_NOW - timedelta(days=1))
+
+        assert cost_timeseries(team, start=_NOW - timedelta(days=30), end=_NOW) == []
 
 
 @pytest.mark.django_db()

--- a/apps/cost_tracking/tests/test_reporting.py
+++ b/apps/cost_tracking/tests/test_reporting.py
@@ -15,7 +15,7 @@ from apps.cost_tracking.services.reporting import (
     coverage_gaps,
 )
 from apps.utils.factories.cost_tracking import UsageRecordFactory
-from apps.utils.factories.experiment import ExperimentFactory
+from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.team import TeamFactory
 
 _NOW = datetime(2026, 6, 15, 12, 0, tzinfo=UTC)
@@ -278,3 +278,78 @@ class TestCostTimeseries:
         _usage(other, cost="999.00", when=_NOW - timedelta(days=1))
 
         assert cost_timeseries(team, start=_NOW - timedelta(days=30), end=_NOW) == []
+
+
+@pytest.mark.django_db()
+class TestCostFilters:
+    """The cost read path honours the dashboard's chatbot / participant /
+    platform filters (but not tags). Verified across the four public functions.
+    """
+
+    def test_cost_summary_filters_by_experiment(self):
+        team = TeamFactory.create()
+        keep = ExperimentFactory.create(team=team)
+        drop = ExperimentFactory.create(team=team)
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=keep)
+        _usage(team, cost="9.00", when=_NOW - timedelta(days=1), experiment=drop)
+
+        summary = cost_summary(team, start=_NOW - timedelta(days=30), end=_NOW, experiment_ids=[keep.id])
+
+        assert summary.total_cost == Decimal("1.00")
+
+    def test_cost_summary_filters_prior_period_too(self):
+        team = TeamFactory.create()
+        keep = ExperimentFactory.create(team=team)
+        drop = ExperimentFactory.create(team=team)
+        _usage(team, cost="2.00", when=_NOW - timedelta(days=45), experiment=keep)
+        _usage(team, cost="9.00", when=_NOW - timedelta(days=45), experiment=drop)
+
+        summary = cost_summary(team, start=_NOW - timedelta(days=30), end=_NOW, experiment_ids=[keep.id])
+
+        assert summary.previous_period_cost == Decimal("2.00")
+
+    def test_timeseries_filters_by_participant(self):
+        team = TeamFactory.create()
+        exp = ExperimentFactory.create(team=team)
+        keep = ExperimentSessionFactory.create(experiment=exp, team=team)
+        drop = ExperimentSessionFactory.create(experiment=exp, team=team)
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=exp, participant=keep.participant)
+        _usage(team, cost="9.00", when=_NOW - timedelta(days=1), experiment=exp, participant=drop.participant)
+
+        series = cost_timeseries(team, start=_NOW - timedelta(days=30), end=_NOW, participant_ids=[keep.participant_id])
+
+        assert [point["cost"] for point in series] == [1.0]
+
+    def test_timeseries_filters_by_platform_via_session(self):
+        team = TeamFactory.create()
+        exp = ExperimentFactory.create(team=team)
+        web = ExperimentSessionFactory.create(experiment=exp, team=team, platform="web")
+        api = ExperimentSessionFactory.create(experiment=exp, team=team, platform="api")
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=exp, session=web)
+        _usage(team, cost="9.00", when=_NOW - timedelta(days=1), experiment=exp, session=api)
+
+        series = cost_timeseries(team, start=_NOW - timedelta(days=30), end=_NOW, platform_names=["web"])
+
+        assert [point["cost"] for point in series] == [1.0]
+
+    def test_costs_by_experiment_filters_by_experiment(self):
+        team = TeamFactory.create()
+        keep = ExperimentFactory.create(team=team)
+        drop = ExperimentFactory.create(team=team)
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=keep)
+        _usage(team, cost="9.00", when=_NOW - timedelta(days=1), experiment=drop)
+
+        costs = costs_by_experiment(team, start=_NOW - timedelta(days=30), end=_NOW, experiment_ids=[keep.id])
+
+        assert costs == {keep.id: Decimal("1.00000000")}
+
+    def test_coverage_gaps_filters_by_experiment(self):
+        team = TeamFactory.create()
+        keep = ExperimentFactory.create(team=team)
+        drop = ExperimentFactory.create(team=team)
+        _usage(team, cost="0.00", when=_NOW - timedelta(days=1), experiment=keep, model_name="keep-model")
+        _usage(team, cost="0.00", when=_NOW - timedelta(days=1), experiment=drop, model_name="drop-model")
+
+        gaps = coverage_gaps(team, start=_NOW - timedelta(days=30), end=_NOW, experiment_ids=[keep.id])
+
+        assert [g.model_name for g in gaps.unpriced] == ["keep-model"]

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 from apps.annotations.models import CustomTaggedItem, TagCategories
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
-from apps.cost_tracking.services.reporting import costs_by_experiment
+from apps.cost_tracking.services.reporting import CostFilters, costs_by_experiment
 from apps.experiments.models import Experiment, ExperimentSession, Participant
 
 from ..trace.models import Trace
@@ -324,99 +324,17 @@ class DashboardService:
         cached_data = DashboardCache.get_cached_data(self.team, cache_key)
 
         if not cached_data:
-            querysets = self.get_filtered_queryset_base(**cache_filters)
-            # Pre-compute session stats
-            # The alternative for better performance would be to use a raw SQL Query
-            session_stats = (
-                querysets["sessions"]
-                .order_by()
-                .values("experiment_id")
-                .annotate(
-                    participants_count=Count("participant", distinct=True),
-                    sessions_count=Count("id", distinct=True),
-                    messages_count=Count("chat__messages", distinct=True),
-                )
-            )
+            cached_data = self._compute_bot_performance(cache_filters, include_cost)
+            DashboardCache.set_cached_data(self.team, cache_key, cached_data)
 
-            stats_dict = {stat["experiment_id"]: stat for stat in session_stats}
-
-            # Use sessions base (already constrained/deduped) to avoid message join inflation
-            session_durations = (
-                querysets["sessions"]
-                .filter(ended_at__isnull=False)
-                .values("experiment_id")
-                .annotate(
-                    completed_sessions_count=Count("id", distinct=True),
-                    average_session_duration=Avg(
-                        ExpressionWrapper(F("ended_at") - F("created_at"), output_field=DurationField())
-                    ),
-                )
-            )
-            dur_map = {s["experiment_id"]: s for s in session_durations}
-
-            experiments_base = querysets["experiments"]
-
-            cost_map = (
-                costs_by_experiment(
-                    self.team,
-                    start=querysets["start_date"],
-                    end=querysets["end_date"],
-                    **{
-                        k: cache_filters[k]
-                        for k in ("experiment_ids", "platform_names", "participant_ids")
-                        if cache_filters.get(k)
-                    },
-                )
-                if include_cost
-                else {}
-            )
-
-            performance_data = []
-            for experiment in experiments_base:
-                stats = stats_dict.get(
-                    experiment.id, {"participants_count": 0, "sessions_count": 0, "messages_count": 0}
-                )
-                participants_count = stats["participants_count"]
-                sessions_count = stats["sessions_count"]
-                messages_count = stats["messages_count"]
-                completed_sessions = dur_map.get(experiment.id, {}).get("completed_sessions_count", 0)
-                avg_duration = (
-                    dur_map.get(experiment.id, {}).get("average_session_duration") or timedelta()
-                ).total_seconds() / 60
-                completion_rate = (completed_sessions / sessions_count) if sessions_count else 0
-
-                experiment_url = reverse(
-                    "chatbots:single_chatbot_home",
-                    kwargs={"team_slug": self.team.slug, "experiment_id": experiment.id},
-                )
-                row = {
-                    "experiment_id": experiment.id,
-                    "experiment_name": experiment.name,
-                    "experiment_url": experiment_url,
-                    "participants": participants_count,
-                    "sessions": sessions_count,
-                    "messages": messages_count,
-                    "avg_session_duration": avg_duration,
-                    "completion_rate": completion_rate,
-                    "avg_messages_per_session": messages_count / sessions_count if sessions_count > 0 else 0,
-                }
-                if include_cost:
-                    cost = float(cost_map.get(experiment.id, 0))
-                    row["cost"] = cost
-                    row["cost_per_session"] = (cost / sessions_count) if sessions_count else None
-                performance_data.append(row)
-
-            DashboardCache.set_cached_data(self.team, cache_key, performance_data)
-            cached_data = performance_data
-
-        # Apply ordering
+        # Apply ordering. Cost fields are only sortable when they're present.
         reverse_order = order_dir.lower() == "desc"
-        if order_by in self.VALID_ORDER_FIELDS:
-            # `.get` guards cost fields, absent when the cost flag is off.
-            cached_data.sort(key=lambda x: x.get(order_by) or 0, reverse=reverse_order)
-        else:
-            # Default to messages if invalid order_by
-            cached_data.sort(key=lambda x: x["messages"], reverse=True)
+        valid_order_fields = self.VALID_ORDER_FIELDS
+        if not include_cost:
+            valid_order_fields = [f for f in valid_order_fields if f not in ("cost", "cost_per_session")]
+        sort_field = order_by if order_by in valid_order_fields else "messages"
+        # sorted() (not list.sort()) so we never mutate the cached list in place.
+        cached_data = sorted(cached_data, key=lambda x: x.get(sort_field) or 0, reverse=reverse_order)
 
         # Apply pagination
         total_count = len(cached_data)
@@ -435,6 +353,86 @@ class DashboardService:
             "order_by": order_by,
             "order_dir": order_dir,
         }
+
+    def _compute_bot_performance(self, cache_filters: dict, include_cost: bool) -> list[dict[str, Any]]:
+        """Build the (uncached, unordered) per-experiment performance rows."""
+        querysets = self.get_filtered_queryset_base(**cache_filters)
+        # Pre-compute session stats.
+        # The alternative for better performance would be to use a raw SQL Query
+        session_stats = (
+            querysets["sessions"]
+            .order_by()
+            .values("experiment_id")
+            .annotate(
+                participants_count=Count("participant", distinct=True),
+                sessions_count=Count("id", distinct=True),
+                messages_count=Count("chat__messages", distinct=True),
+            )
+        )
+        stats_dict = {stat["experiment_id"]: stat for stat in session_stats}
+
+        # Use sessions base (already constrained/deduped) to avoid message join inflation
+        session_durations = (
+            querysets["sessions"]
+            .filter(ended_at__isnull=False)
+            .values("experiment_id")
+            .annotate(
+                completed_sessions_count=Count("id", distinct=True),
+                average_session_duration=Avg(
+                    ExpressionWrapper(F("ended_at") - F("created_at"), output_field=DurationField())
+                ),
+            )
+        )
+        dur_map = {s["experiment_id"]: s for s in session_durations}
+
+        cost_map = (
+            costs_by_experiment(
+                self.team,
+                start=querysets["start_date"],
+                end=querysets["end_date"],
+                filters=CostFilters(
+                    experiment_ids=cache_filters.get("experiment_ids"),
+                    platform_names=cache_filters.get("platform_names"),
+                    participant_ids=cache_filters.get("participant_ids"),
+                ),
+            )
+            if include_cost
+            else {}
+        )
+
+        return [
+            self._bot_performance_row(experiment, stats_dict, dur_map, cost_map, include_cost)
+            for experiment in querysets["experiments"]
+        ]
+
+    def _bot_performance_row(self, experiment, stats_dict, dur_map, cost_map, include_cost: bool) -> dict[str, Any]:
+        stats = stats_dict.get(experiment.id, {"participants_count": 0, "sessions_count": 0, "messages_count": 0})
+        sessions_count = stats["sessions_count"]
+        messages_count = stats["messages_count"]
+        completed_sessions = dur_map.get(experiment.id, {}).get("completed_sessions_count", 0)
+        avg_duration = (
+            dur_map.get(experiment.id, {}).get("average_session_duration") or timedelta()
+        ).total_seconds() / 60
+
+        row = {
+            "experiment_id": experiment.id,
+            "experiment_name": experiment.name,
+            "experiment_url": reverse(
+                "chatbots:single_chatbot_home",
+                kwargs={"team_slug": self.team.slug, "experiment_id": experiment.id},
+            ),
+            "participants": stats["participants_count"],
+            "sessions": sessions_count,
+            "messages": messages_count,
+            "avg_session_duration": avg_duration,
+            "completion_rate": (completed_sessions / sessions_count) if sessions_count else 0,
+            "avg_messages_per_session": messages_count / sessions_count if sessions_count > 0 else 0,
+        }
+        if include_cost:
+            cost = float(cost_map.get(experiment.id, 0))
+            row["cost"] = cost
+            row["cost_per_session"] = (cost / sessions_count) if sessions_count else None
+        return row
 
     def get_user_engagement_data(self, limit: int = 10, **filters) -> dict[str, Any]:
         """Get user engagement analysis data"""

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from apps.annotations.models import CustomTaggedItem, TagCategories
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
+from apps.cost_tracking.services.reporting import costs_by_experiment
 from apps.experiments.models import Experiment, ExperimentSession, Participant
 
 from ..trace.models import Trace
@@ -36,6 +37,8 @@ class DashboardService:
         "completion_rate",
         "avg_session_duration",
         "avg_messages_per_session",
+        "cost",
+        "cost_per_session",
     ]
 
     def __init__(self, team):
@@ -301,13 +304,23 @@ class DashboardService:
         return data
 
     def get_bot_performance_summary(
-        self, page: int = 1, page_size: int = 10, order_by: str = "messages", order_dir: str = "desc", **filters
+        self,
+        page: int = 1,
+        page_size: int = 10,
+        order_by: str = "messages",
+        order_dir: str = "desc",
+        include_cost: bool = False,
+        **filters,
     ) -> dict[str, Any]:
-        """Get bot performance summary with rankings, pagination, and ordering"""
+        """Get bot performance summary with rankings, pagination, and ordering.
+
+        When `include_cost` is set (team has the cost-monitoring flag), each row
+        gains `cost` and `cost_per_session` sourced from UsageRecord.
+        """
 
         # Extract pagination/ordering from filters for cache key
         cache_filters = {k: v for k, v in filters.items() if k not in ["page", "page_size", "order_by", "order_dir"]}
-        cache_key = f"bot_performance_{self._cache_key(cache_filters)}"
+        cache_key = f"bot_performance_{'cost_' if include_cost else ''}{self._cache_key(cache_filters)}"
         cached_data = DashboardCache.get_cached_data(self.team, cache_key)
 
         if not cached_data:
@@ -343,6 +356,12 @@ class DashboardService:
 
             experiments_base = querysets["experiments"]
 
+            cost_map = (
+                costs_by_experiment(self.team, start=querysets["start_date"], end=querysets["end_date"])
+                if include_cost
+                else {}
+            )
+
             performance_data = []
             for experiment in experiments_base:
                 stats = stats_dict.get(
@@ -361,19 +380,22 @@ class DashboardService:
                     "chatbots:single_chatbot_home",
                     kwargs={"team_slug": self.team.slug, "experiment_id": experiment.id},
                 )
-                performance_data.append(
-                    {
-                        "experiment_id": experiment.id,
-                        "experiment_name": experiment.name,
-                        "experiment_url": experiment_url,
-                        "participants": participants_count,
-                        "sessions": sessions_count,
-                        "messages": messages_count,
-                        "avg_session_duration": avg_duration,
-                        "completion_rate": completion_rate,
-                        "avg_messages_per_session": messages_count / sessions_count if sessions_count > 0 else 0,
-                    }
-                )
+                row = {
+                    "experiment_id": experiment.id,
+                    "experiment_name": experiment.name,
+                    "experiment_url": experiment_url,
+                    "participants": participants_count,
+                    "sessions": sessions_count,
+                    "messages": messages_count,
+                    "avg_session_duration": avg_duration,
+                    "completion_rate": completion_rate,
+                    "avg_messages_per_session": messages_count / sessions_count if sessions_count > 0 else 0,
+                }
+                if include_cost:
+                    cost = float(cost_map.get(experiment.id, 0))
+                    row["cost"] = cost
+                    row["cost_per_session"] = (cost / sessions_count) if sessions_count else None
+                performance_data.append(row)
 
             DashboardCache.set_cached_data(self.team, cache_key, performance_data)
             cached_data = performance_data
@@ -381,7 +403,8 @@ class DashboardService:
         # Apply ordering
         reverse_order = order_dir.lower() == "desc"
         if order_by in self.VALID_ORDER_FIELDS:
-            cached_data.sort(key=lambda x: x[order_by] or 0, reverse=reverse_order)
+            # `.get` guards cost fields, absent when the cost flag is off.
+            cached_data.sort(key=lambda x: x.get(order_by) or 0, reverse=reverse_order)
         else:
             # Default to messages if invalid order_by
             cached_data.sort(key=lambda x: x["messages"], reverse=True)

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -357,7 +357,16 @@ class DashboardService:
             experiments_base = querysets["experiments"]
 
             cost_map = (
-                costs_by_experiment(self.team, start=querysets["start_date"], end=querysets["end_date"])
+                costs_by_experiment(
+                    self.team,
+                    start=querysets["start_date"],
+                    end=querysets["end_date"],
+                    **{
+                        k: cache_filters[k]
+                        for k in ("experiment_ids", "platform_names", "participant_ids")
+                        if cache_filters.get(k)
+                    },
+                )
                 if include_cost
                 else {}
             )

--- a/apps/dashboard/tests/test_cost_tracking_panel.py
+++ b/apps/dashboard/tests/test_cost_tracking_panel.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 import pytest
 from django.urls import reverse
 
+from apps.cost_tracking.models import Confidence
 from apps.teams.models import Flag
 from apps.utils.factories.cost_tracking import UsageRecordFactory
 
@@ -53,24 +54,49 @@ class TestCostTrackingPanel:
         assert response.context["cost_summary"].total_cost == Decimal("2.50000000")
         assert b"2.50" in response.content
 
-    def test_lists_top_bots(self, authenticated_client, team, experiment):
-        _enable_flag_for(team)
-        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=experiment)
-
-        response = self._get_dashboard(authenticated_client, team)
-
-        bots = response.context["cost_top_bots"]
-        assert len(bots) == 1
-        assert bots[0].experiment_name == experiment.name
-
     def test_empty_state_when_no_usage(self, authenticated_client, team):
         _enable_flag_for(team)
 
         response = self._get_dashboard(authenticated_client, team)
 
         assert response.context["cost_summary"].total_cost == Decimal(0)
-        assert response.context["cost_top_bots"] == []
         assert b"No chatbot usage in this period." in response.content
+
+    def test_hides_exact_estimated_split_without_estimated_spend(self, authenticated_client, team):
+        _enable_flag_for(team)
+        _usage(team, cost="2.00", when=_NOW - timedelta(days=1), confidence=Confidence.EXACT)
+
+        response = self._get_dashboard(authenticated_client, team)
+
+        assert response.context["cost_summary"].estimated_cost == Decimal(0)
+        assert b">Estimated<" not in response.content
+        assert b">Exact<" not in response.content
+
+    def test_shows_exact_estimated_split_with_estimated_spend(self, authenticated_client, team):
+        _enable_flag_for(team)
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), confidence=Confidence.EXACT)
+        _usage(team, cost="0.50", when=_NOW - timedelta(days=1), confidence=Confidence.ESTIMATED)
+
+        response = self._get_dashboard(authenticated_client, team)
+
+        assert response.context["cost_summary"].estimated_cost > 0
+        assert b">Estimated<" in response.content
+        assert b">Exact<" in response.content
+
+    def test_coverage_gap_detail_lists_models(self, authenticated_client, team):
+        _enable_flag_for(team)
+        _usage(
+            team,
+            cost="0.00",
+            when=_NOW - timedelta(days=1),
+            model_name="mystery-model",
+            confidence=Confidence.EXACT,
+        )
+
+        response = self._get_dashboard(authenticated_client, team)
+
+        assert response.context["cost_summary"].unpriced_call_count == 1
+        assert b"mystery-model" in response.content
 
     def test_other_team_data_isolated(self, authenticated_client, team, experiment_team):
         _enable_flag_for(team)
@@ -129,3 +155,59 @@ class TestCostTrackingPanelEndpoint:
         response = authenticated_client.get(self._url(team))
 
         assert b"999" not in response.content
+
+
+@pytest.mark.django_db()
+class TestCostTimeseriesEndpoint:
+    """`api/cost-timeseries/` feeds the panel's daily-spend chart. Flag-gated."""
+
+    def _url(self, team):
+        return reverse("dashboard:api_cost_timeseries", kwargs={"team_slug": team.slug})
+
+    def test_empty_when_flag_off(self, authenticated_client, team):
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=1))
+
+        response = authenticated_client.get(self._url(team))
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_returns_series_when_flag_on(self, authenticated_client, team):
+        _enable_flag_for(team)
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=1))
+
+        response = authenticated_client.get(
+            self._url(team) + "?date_range=custom&start_date=2026-06-01&end_date=2026-06-20"
+        )
+
+        payload = response.json()
+        assert len(payload) == 1
+        assert payload[0]["cost"] == 1.0
+
+
+@pytest.mark.django_db()
+class TestBotPerformanceCostColumns:
+    """The Bot Performance API surfaces cost only when the team has the flag."""
+
+    _RANGE = "?date_range=custom&start_date=2026-06-01&end_date=2026-06-20"
+
+    def _url(self, team):
+        return reverse("dashboard:api_bot_performance", kwargs={"team_slug": team.slug})
+
+    def test_no_cost_fields_when_flag_off(self, authenticated_client, team, experiment):
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=experiment)
+
+        response = authenticated_client.get(self._url(team) + self._RANGE)
+
+        results = response.json()["results"]
+        assert results
+        assert "cost" not in results[0]
+
+    def test_cost_fields_present_when_flag_on(self, authenticated_client, team, experiment):
+        _enable_flag_for(team)
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=experiment)
+
+        response = authenticated_client.get(self._url(team) + self._RANGE)
+
+        row = next(r for r in response.json()["results"] if r["experiment_id"] == experiment.id)
+        assert row["cost"] == 1.0

--- a/apps/dashboard/tests/test_cost_tracking_panel.py
+++ b/apps/dashboard/tests/test_cost_tracking_panel.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from apps.cost_tracking.models import Confidence
 from apps.teams.models import Flag
 from apps.utils.factories.cost_tracking import UsageRecordFactory
+from apps.utils.factories.experiment import ExperimentFactory
 
 _NOW = datetime(2026, 6, 15, 12, 0, tzinfo=UTC)
 
@@ -183,6 +184,18 @@ class TestCostTimeseriesEndpoint:
         payload = response.json()
         assert len(payload) == 1
         assert payload[0]["cost"] == 1.0
+
+    def test_respects_experiment_filter(self, authenticated_client, team, experiment):
+        _enable_flag_for(team)
+        other_experiment = ExperimentFactory.create(team=team)
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=experiment)
+        base = self._url(team) + "?date_range=custom&start_date=2026-06-01&end_date=2026-06-20"
+
+        matching = authenticated_client.get(base + f"&experiments={experiment.id}")
+        other = authenticated_client.get(base + f"&experiments={other_experiment.id}")
+
+        assert matching.json()[0]["cost"] == 1.0
+        assert other.json() == []
 
 
 @pytest.mark.django_db()

--- a/apps/dashboard/urls.py
+++ b/apps/dashboard/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     path("api/tag-analytics/", views.TagAnalyticsApiView.as_view(), name="api_tag_analytics"),
     path("api/average-response-time/", views.AverageResponseTimeApiView.as_view(), name="api_average_response_time"),
     path("api/cost-tracking-panel/", views.CostTrackingPanelView.as_view(), name="api_cost_tracking_panel"),
+    path("api/cost-timeseries/", views.CostTrackingApiView.as_view(), name="api_cost_timeseries"),
     # Filter management
     path("filters/save/", views.SaveFilterView.as_view(), name="save_filter"),
     path("filters/load/<int:filter_id>/", views.LoadFilterView.as_view(), name="load_filter"),

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -8,7 +8,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 from waffle import flag_is_active
 
-from apps.cost_tracking.services.reporting import cost_summary, cost_timeseries, coverage_gaps
+from apps.cost_tracking.services.reporting import CostFilters, cost_summary, cost_timeseries, coverage_gaps
 from apps.teams.decorators import login_and_team_required
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 
@@ -18,9 +18,6 @@ from .services import DashboardService
 
 COST_TRACKING_FLAG = "flag_ai_cost_monitoring"
 DEFAULT_COST_PERIOD_DAYS = 30
-# Dashboard filters the cost read path honours. Tags are excluded - usage
-# records aren't tagged directly.
-_COST_FILTER_KEYS = ("experiment_ids", "platform_names", "participant_ids")
 
 
 def _cost_tracking_context(request, filter_form: DashboardFilterForm) -> dict:
@@ -32,23 +29,27 @@ def _cost_tracking_context(request, filter_form: DashboardFilterForm) -> dict:
     start, end, filters = _cost_panel_scope(filter_form)
     return {
         "cost_tracking_enabled": True,
-        "cost_summary": cost_summary(request.team, start=start, end=end, **filters),
-        "cost_coverage_gaps": coverage_gaps(request.team, start=start, end=end, **filters),
+        "cost_summary": cost_summary(request.team, start=start, end=end, filters=filters),
+        "cost_coverage_gaps": coverage_gaps(request.team, start=start, end=end, filters=filters),
     }
 
 
-def _cost_panel_scope(filter_form: DashboardFilterForm) -> tuple[datetime, datetime, dict]:
+def _cost_panel_scope(filter_form: DashboardFilterForm) -> tuple[datetime, datetime, CostFilters]:
     """Mirror the dashboard's date range and (chatbot / platform / participant)
     filters so the panel stays in sync with the rest of the charts. Falls back
     to the last 30 days when no date range is set.
     """
     start = end = None
-    filters: dict = {}
+    filters = CostFilters()
     if filter_form.is_valid():
         params = filter_form.get_filter_params()
         start = params.get("start_date")
         end = params.get("end_date")
-        filters = {key: params[key] for key in _COST_FILTER_KEYS if params.get(key)}
+        filters = CostFilters(
+            experiment_ids=params.get("experiment_ids"),
+            platform_names=params.get("platform_names"),
+            participant_ids=params.get("participant_ids"),
+        )
     if not (start and end):
         end = timezone.now()
         start = end - timedelta(days=DEFAULT_COST_PERIOD_DAYS)
@@ -196,7 +197,7 @@ class CostTrackingApiView(DashboardApiView):
             return self.json_response([])
         start, end, filters = _cost_panel_scope(DashboardFilterForm(data=request.GET, team=request.team))
         granularity = request.GET.get("granularity", "daily")
-        data = cost_timeseries(request.team, start=start, end=end, granularity=granularity, **filters)
+        data = cost_timeseries(request.team, start=start, end=end, granularity=granularity, filters=filters)
         return self.json_response(data)
 
 

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -8,7 +8,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 from waffle import flag_is_active
 
-from apps.cost_tracking.services.reporting import cost_summary, top_n_bots
+from apps.cost_tracking.services.reporting import cost_summary, cost_timeseries, coverage_gaps
 from apps.teams.decorators import login_and_team_required
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 
@@ -30,7 +30,7 @@ def _cost_tracking_context(request, filter_form: DashboardFilterForm) -> dict:
     return {
         "cost_tracking_enabled": True,
         "cost_summary": cost_summary(request.team, start=start, end=end),
-        "cost_top_bots": top_n_bots(request.team, start=start, end=end),
+        "cost_coverage_gaps": coverage_gaps(request.team, start=start, end=end),
     }
 
 
@@ -169,8 +169,27 @@ class BotPerformanceApiView(DashboardApiView):
         order_dir = request.GET.get("order_dir", "desc")
 
         data = service.get_bot_performance_summary(
-            page=page, page_size=page_size, order_by=order_by, order_dir=order_dir, **filter_params
+            page=page,
+            page_size=page_size,
+            order_by=order_by,
+            order_dir=order_dir,
+            include_cost=flag_is_active(request, COST_TRACKING_FLAG),
+            **filter_params,
         )
+        return self.json_response(data)
+
+
+class CostTrackingApiView(DashboardApiView):
+    """Cost-tracking data endpoint, gated on the team's cost-monitoring flag.
+    Returns an empty payload when the flag is off so the frontend can no-op.
+    """
+
+    def get(self, request, *args, **kwargs):
+        if not flag_is_active(request, COST_TRACKING_FLAG):
+            return self.json_response([])
+        start, end = _cost_panel_period(DashboardFilterForm(data=request.GET, team=request.team))
+        granularity = request.GET.get("granularity", "daily")
+        data = cost_timeseries(request.team, start=start, end=end, granularity=granularity)
         return self.json_response(data)
 
 

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -18,6 +18,9 @@ from .services import DashboardService
 
 COST_TRACKING_FLAG = "flag_ai_cost_monitoring"
 DEFAULT_COST_PERIOD_DAYS = 30
+# Dashboard filters the cost read path honours. Tags are excluded - usage
+# records aren't tagged directly.
+_COST_FILTER_KEYS = ("experiment_ids", "platform_names", "participant_ids")
 
 
 def _cost_tracking_context(request, filter_form: DashboardFilterForm) -> dict:
@@ -26,26 +29,30 @@ def _cost_tracking_context(request, filter_form: DashboardFilterForm) -> dict:
     """
     if not flag_is_active(request, COST_TRACKING_FLAG):
         return {"cost_tracking_enabled": False}
-    start, end = _cost_panel_period(filter_form)
+    start, end, filters = _cost_panel_scope(filter_form)
     return {
         "cost_tracking_enabled": True,
-        "cost_summary": cost_summary(request.team, start=start, end=end),
-        "cost_coverage_gaps": coverage_gaps(request.team, start=start, end=end),
+        "cost_summary": cost_summary(request.team, start=start, end=end, **filters),
+        "cost_coverage_gaps": coverage_gaps(request.team, start=start, end=end, **filters),
     }
 
 
-def _cost_panel_period(filter_form: DashboardFilterForm) -> tuple[datetime, datetime]:
-    """Mirror the dashboard's date range so the panel stays in sync with the
-    rest of the charts. Falls back to the last 30 days when no filter is set.
+def _cost_panel_scope(filter_form: DashboardFilterForm) -> tuple[datetime, datetime, dict]:
+    """Mirror the dashboard's date range and (chatbot / platform / participant)
+    filters so the panel stays in sync with the rest of the charts. Falls back
+    to the last 30 days when no date range is set.
     """
+    start = end = None
+    filters: dict = {}
     if filter_form.is_valid():
         params = filter_form.get_filter_params()
         start = params.get("start_date")
         end = params.get("end_date")
-        if start and end:
-            return start, end
-    end = timezone.now()
-    return end - timedelta(days=DEFAULT_COST_PERIOD_DAYS), end
+        filters = {key: params[key] for key in _COST_FILTER_KEYS if params.get(key)}
+    if not (start and end):
+        end = timezone.now()
+        start = end - timedelta(days=DEFAULT_COST_PERIOD_DAYS)
+    return start, end, filters
 
 
 @method_decorator(login_and_team_required, name="dispatch")
@@ -187,9 +194,9 @@ class CostTrackingApiView(DashboardApiView):
     def get(self, request, *args, **kwargs):
         if not flag_is_active(request, COST_TRACKING_FLAG):
             return self.json_response([])
-        start, end = _cost_panel_period(DashboardFilterForm(data=request.GET, team=request.team))
+        start, end, filters = _cost_panel_scope(DashboardFilterForm(data=request.GET, team=request.team))
         granularity = request.GET.get("granularity", "daily")
-        data = cost_timeseries(request.team, start=start, end=end, granularity=granularity)
+        data = cost_timeseries(request.team, start=start, end=end, granularity=granularity, **filters)
         return self.json_response(data)
 
 

--- a/apps/web/management/commands/bootstrap_data.py
+++ b/apps/web/management/commands/bootstrap_data.py
@@ -10,13 +10,18 @@ Usage:
     python manage.py bootstrap_data --skip-sample-data  # Only create user/team
 """
 
+from datetime import timedelta
+from decimal import Decimal
+
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 
 from apps.annotations.models import Tag
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.models import ChatMessage, ChatMessageType
+from apps.cost_tracking.models import Confidence, PricingRule, ServiceKind, UsageRecord
 from apps.documents.models import Collection
 from apps.evaluations.models import (
     EvaluationConfig,
@@ -35,7 +40,7 @@ from apps.service_providers.llm_service.credentials import (
 from apps.service_providers.models import LlmProvider, LlmProviderTypes
 from apps.service_providers.utils import get_first_llm_provider_model
 from apps.teams import backends
-from apps.teams.models import Membership, Team
+from apps.teams.models import Flag, Membership, Team
 from apps.trace.models import Trace, TraceStatus
 
 _PIPELINE_NAMES = [
@@ -69,6 +74,12 @@ _EVALUATION_DATASET_MESSAGES = [
     ("Thanks for the fast shipping!", "Glad to hear it — enjoy!"),
     ("This product doesn't match the description.", "I understand, let me help you with a return."),
 ]
+_COST_TRACKING_FLAG = "flag_ai_cost_monitoring"
+# Fake model names for the unpriced / no-usage rows so the panel's coverage-gap
+# warnings have something to list.
+_UNPRICED_MODEL = "experimental-model-x"
+_UNKNOWN_MODEL = "legacy-model-y"
+_USAGE_DAYS = 14
 
 
 class Command(BaseCommand):
@@ -194,6 +205,7 @@ class Command(BaseCommand):
         tags = self._seed_tags(user, team)
         sessions = self._seed_participants_and_sessions(user, team, experiments, tags)
         self._seed_traces(team, sessions)
+        self._seed_usage_records(team, sessions, llm_provider)
         files = self._seed_files(team)
         self._seed_collection(team, files)
         self._seed_evaluation(team, llm_provider, llm_model)
@@ -359,6 +371,117 @@ class Command(BaseCommand):
                 n_completion_tokens=50,
             )
         self.stdout.write(self.style.SUCCESS(f"  Created {len(sessions)} trace(s)"))
+
+    def _seed_usage_records(self, team, sessions: list[ExperimentSession], llm_provider) -> None:
+        """Seed cost-tracking UsageRecords so the dashboard's Cost Tracking panel
+        has data: priced spend spread over the last two weeks (for the daily-spend
+        chart and per-bot costs), plus a few estimated / unpriced / no-usage rows
+        so the confidence split and coverage-gap warnings render.
+        """
+        if not sessions:
+            return
+        self.stdout.write("")
+        self.stdout.write("--- Creating Usage Records ---")
+
+        provider_type = llm_provider.type
+        # Any global rule serves as the "priced" anchor - the panel only checks
+        # whether a rule is linked, not that it matches the model.
+        priced_rule = PricingRule.objects.filter(team__isnull=True).order_by("id").first()
+        priced_model = priced_rule.model_name if priced_rule else "gpt-4o-mini"
+        now = timezone.now()
+
+        created = 0
+        # Priced, exact spend: each session bills a little every day, with a
+        # per-session multiplier so bots differ in the Bot Performance table.
+        for day in range(_USAGE_DAYS):
+            timestamp = now - timedelta(days=day, hours=3)
+            for idx, session in enumerate(sessions):
+                cost = Decimal("0.02") * (idx + 1) * (1 + day % 3)
+                created += self._create_usage_record(
+                    team,
+                    session,
+                    provider_type,
+                    priced_model,
+                    quantity=400 + 50 * idx,
+                    cost=cost,
+                    confidence=Confidence.EXACT,
+                    pricing_rule=priced_rule,
+                    timestamp=timestamp,
+                )
+
+        # A couple of estimated rows so the Exact/Estimated split shows.
+        for session in sessions[:2]:
+            created += self._create_usage_record(
+                team,
+                session,
+                provider_type,
+                priced_model,
+                quantity=300,
+                cost=Decimal("0.015"),
+                confidence=Confidence.ESTIMATED,
+                pricing_rule=priced_rule,
+                timestamp=now - timedelta(days=1),
+            )
+
+        # Unpriced rows (no rule) → "calls missing pricing" coverage gap.
+        for session in sessions[:2]:
+            created += self._create_usage_record(
+                team,
+                session,
+                provider_type,
+                _UNPRICED_MODEL,
+                quantity=200,
+                cost=Decimal(0),
+                confidence=Confidence.EXACT,
+                pricing_rule=None,
+                timestamp=now - timedelta(days=2),
+            )
+
+        # Unknown-confidence rows → "calls with no usage data" coverage gap.
+        created += self._create_usage_record(
+            team,
+            sessions[0],
+            provider_type,
+            _UNKNOWN_MODEL,
+            quantity=None,
+            cost=Decimal(0),
+            confidence=Confidence.UNKNOWN,
+            pricing_rule=None,
+            timestamp=now - timedelta(days=1),
+        )
+
+        self.stdout.write(self.style.SUCCESS(f"  Created {created} usage record(s)"))
+        self._enable_cost_tracking_flag(team)
+
+    def _create_usage_record(
+        self, team, session, provider_type, model_name, *, quantity, cost, confidence, pricing_rule, timestamp
+    ) -> int:
+        """Create one UsageRecord and stamp its timestamp (auto_now_add can't be
+        set on create). Returns 1 so callers can tally."""
+        record = UsageRecord.objects.create(
+            team=team,
+            experiment=session.experiment,
+            session=session,
+            participant=session.participant,
+            service_kind=ServiceKind.LLM_INPUT,
+            provider_type=provider_type,
+            model_name=model_name,
+            quantity=quantity,
+            unit_price=Decimal("0.00015"),
+            cost=cost,
+            confidence=confidence,
+            pricing_rule=pricing_rule,
+        )
+        UsageRecord.objects.filter(pk=record.pk).update(timestamp=timestamp)
+        return 1
+
+    def _enable_cost_tracking_flag(self, team) -> None:
+        """The Cost Tracking panel is gated on this team-scoped flag, so enable
+        it here to make the seeded records visible on the dashboard."""
+        flag, _ = Flag.objects.get_or_create(name=_COST_TRACKING_FLAG)
+        flag.teams.add(team)
+        flag.flush()
+        self.stdout.write(self.style.SUCCESS(f"  Enabled '{_COST_TRACKING_FLAG}' flag for team"))
 
     def _seed_files(self, team) -> list[File]:
         self.stdout.write("")

--- a/apps/web/management/commands/bootstrap_data.py
+++ b/apps/web/management/commands/bootstrap_data.py
@@ -378,16 +378,25 @@ class Command(BaseCommand):
         chart and per-bot costs), plus a few estimated / unpriced / no-usage rows
         so the confidence split and coverage-gap warnings render.
         """
+        # Rerun-safe: an already-seeded team yields no new sessions upstream, so
+        # rehydrate from the DB rather than skipping usage seeding and the flag.
+        if not sessions:
+            sessions = list(
+                ExperimentSession.objects.filter(team=team).select_related("experiment", "participant").order_by("id")
+            )
         if not sessions:
             return
         self.stdout.write("")
         self.stdout.write("--- Creating Usage Records ---")
 
+        # Idempotent: clear prior seed rows so reruns don't inflate dashboard totals.
+        UsageRecord.objects.filter(team=team).delete()
+
         provider_type = llm_provider.type
-        # Any global rule serves as the "priced" anchor - the panel only checks
-        # whether a rule is linked, not that it matches the model.
-        priced_rule = PricingRule.objects.filter(team__isnull=True).order_by("id").first()
-        priced_model = priced_rule.model_name if priced_rule else "gpt-4o-mini"
+        # Priced rows must carry a rule, else reporting counts them as unpriced
+        # coverage gaps. Ensure a global rule exists to anchor them.
+        priced_rule = self._ensure_global_pricing_rule()
+        priced_model = priced_rule.model_name
         now = timezone.now()
 
         created = 0
@@ -474,6 +483,20 @@ class Command(BaseCommand):
         )
         UsageRecord.objects.filter(pk=record.pk).update(timestamp=timestamp)
         return 1
+
+    def _ensure_global_pricing_rule(self) -> PricingRule:
+        """A global PricingRule to anchor the 'priced' seed rows, created as a
+        placeholder if the pricing seed migration hasn't populated one."""
+        rule = PricingRule.objects.filter(team__isnull=True).order_by("id").first()
+        if rule is None:
+            rule = PricingRule.objects.create(
+                team=None,
+                provider_type="openai",
+                model_name="gpt-4o-mini",
+                service_kind=ServiceKind.LLM_INPUT,
+                unit_price=Decimal("0.00015"),
+            )
+        return rule
 
     def _enable_cost_tracking_flag(self, team) -> None:
         """The Cost Tracking panel is gated on this team-scoped flag, so enable

--- a/assets/javascript/dashboard/charts.js
+++ b/assets/javascript/dashboard/charts.js
@@ -17,15 +17,15 @@ class ChartManager {
             light: '#F3F4F6',
             dark: '#374151'
         };
-        
+
         this.setupChartDefaults();
     }
-    
+
     setupChartDefaults() {
         Chart.defaults.font.family = '"Inter", sans-serif';
         Chart.defaults.font.size = 12;
         Chart.defaults.color = '#6B7280';
-        
+
         // Default chart options
         this.defaultOptions = {
             responsive: true,
@@ -70,13 +70,13 @@ class ChartManager {
             }
         };
     }
-    
+
     renderActiveParticipantsChart(data) {
         const ctx = document.getElementById('activeParticipantsChart');
         if (!ctx) return;
-        
+
         this.destroyChart('activeParticipants');
-        
+
         const chartData = {
             labels: data.map(item => this.formatDateLabel(item.date)),
             datasets: [{
@@ -90,7 +90,7 @@ class ChartManager {
                 pointHoverRadius: 6
             }]
         };
-        
+
         const options = {
             ...this.defaultOptions,
             plugins: {
@@ -110,18 +110,18 @@ class ChartManager {
                 }
             }
         };
-        
+
         this.charts.activeParticipants = new Chart(ctx, {
             type: 'line',
             data: chartData,
             options: options
         });
     }
-    
+
     renderSessionAnalyticsChart(data) {
         const ctx = document.getElementById('sessionAnalyticsChart');
         if (!ctx) return;
-        
+
         this.destroyChart('sessionAnalytics');
 
         const chartData = {
@@ -164,15 +164,15 @@ class ChartManager {
             options: options
         });
     }
-    
+
     renderMessageVolumeChart(data) {
         const ctx = document.getElementById('messageVolumeChart');
         if (!ctx) return;
-        
+
         this.destroyChart('messageVolume');
-        
+
         const labels = data.totals?.map(item => this.formatDateLabel(item.date)) || [];
-        
+
         const chartData = {
             labels: labels,
             datasets: [
@@ -194,7 +194,7 @@ class ChartManager {
                 }
             ]
         };
-        
+
         const options = {
             ...this.defaultOptions,
             plugins: {
@@ -214,7 +214,7 @@ class ChartManager {
                 }
             }
         };
-        
+
         this.charts.messageVolume = new Chart(ctx, {
             type: 'line',
             data: chartData,
@@ -280,16 +280,16 @@ class ChartManager {
             options: options
         });
     }
-    
+
     renderChannelBreakdownChart(data) {
         const ctx = document.getElementById('channelBreakdownChart');
         if (!ctx) return;
-        
+
         this.destroyChart('channelBreakdown');
-        
+
         const channels = data.platforms || [];
         const totalSessions = data.totals?.sessions || 1;
-        
+
         const chartData = {
             labels: channels.map(channel => channel.platform || 'Unknown'),
             datasets: [{
@@ -306,7 +306,7 @@ class ChartManager {
                 borderColor: '#ffffff'
             }]
         };
-        
+
         const options = {
             responsive: true,
             maintainAspectRatio: false,
@@ -347,20 +347,20 @@ class ChartManager {
                 }
             }
         };
-        
+
         this.charts.channelBreakdown = new Chart(ctx, {
             type: 'doughnut',
             data: chartData,
             options: options
         });
     }
-    
+
     renderSessionLengthChart(distributionData) {
         const ctx = document.getElementById('sessionLengthChart');
         if (!ctx) return;
-        
+
         this.destroyChart('sessionLength');
-        
+
         const chartData = {
             labels: distributionData.map(bin => bin.label),
             datasets: [{
@@ -371,7 +371,7 @@ class ChartManager {
                 borderWidth: 1
             }]
         };
-        
+
         const options = {
             ...this.defaultOptions,
             plugins: {
@@ -398,33 +398,83 @@ class ChartManager {
                 }
             }
         };
-        
+
         this.charts.sessionLength = new Chart(ctx, {
             type: 'bar',
             data: chartData,
             options: options
         });
     }
-    
+
+    renderCostTimeseriesChart(data) {
+        const ctx = document.getElementById('costTimeseriesChart');
+        if (!ctx) return;
+
+        this.destroyChart('costTimeseries');
+
+        const chartData = {
+            labels: (data || []).map(item => this.formatDateLabel(item.date)),
+            datasets: [{
+                label: 'Spend',
+                data: (data || []).map(item => item.cost),
+                backgroundColor: this.colorPalette.primary + '80',
+                borderColor: this.colorPalette.primary,
+                borderWidth: 1
+            }]
+        };
+
+        const formatCost = (value) => `$${(value || 0).toFixed(2)}`;
+
+        const options = {
+            ...this.defaultOptions,
+            plugins: {
+                ...this.defaultOptions.plugins,
+                legend: {
+                    display: false
+                },
+                tooltip: {
+                    callbacks: {
+                        label: (context) => `Spend: ${formatCost(context.parsed.y)}`
+                    }
+                }
+            },
+            scales: {
+                ...this.defaultOptions.scales,
+                y: {
+                    ...this.defaultOptions.scales.y,
+                    ticks: {
+                        callback: (value) => formatCost(value)
+                    }
+                }
+            }
+        };
+
+        this.charts.costTimeseries = new Chart(ctx, {
+            type: 'bar',
+            data: chartData,
+            options: options
+        });
+    }
+
     destroyChart(chartKey) {
         if (this.charts[chartKey]) {
             this.charts[chartKey].destroy();
             delete this.charts[chartKey];
         }
     }
-    
+
     destroyAllCharts() {
         Object.keys(this.charts).forEach(key => {
             this.destroyChart(key);
         });
     }
-    
+
     formatDateLabel(dateString) {
         const date = new Date(dateString);
         const now = new Date();
         const diffTime = Math.abs(now - date);
         const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-        
+
         if (diffDays <= 7) {
             // Show day of week for recent dates
             return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
@@ -436,13 +486,13 @@ class ChartManager {
             return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
         }
     }
-    
+
     updateChartTheme(isDarkMode) {
         const textColor = isDarkMode ? '#F3F4F6' : '#374151';
         const gridColor = isDarkMode ? 'rgba(156, 163, 175, 0.2)' : 'rgba(156, 163, 175, 0.1)';
-        
+
         Chart.defaults.color = textColor;
-        
+
         Object.values(this.charts).forEach(chart => {
             if (chart.options.scales) {
                 if (chart.options.scales.x) {
@@ -457,11 +507,11 @@ class ChartManager {
                     chart.options.scales.y1.ticks.color = textColor;
                 }
             }
-            
+
             if (chart.options.plugins?.legend?.labels) {
                 chart.options.plugins.legend.labels.color = textColor;
             }
-            
+
             chart.update('none');
         });
     }
@@ -470,7 +520,7 @@ class ChartManager {
 // Initialize chart manager when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
     window.chartManager = new ChartManager();
-    
+
     // Listen for theme changes
     const observer = new MutationObserver((mutations) => {
         mutations.forEach((mutation) => {
@@ -480,7 +530,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     });
-    
+
     observer.observe(document.documentElement, {
         attributes: true,
         attributeFilter: ['data-theme']

--- a/assets/javascript/dashboard/charts.js
+++ b/assets/javascript/dashboard/charts.js
@@ -423,7 +423,13 @@ class ChartManager {
             }]
         };
 
-        const formatCost = (value) => `$${(value || 0).toFixed(2)}`;
+        // Mirror main.js's formatCurrency: 4 decimals below $0.01 so sub-cent
+        // daily spend doesn't flatten to $0.00 on the axis/tooltip.
+        const formatCost = (value) => {
+            const num = value || 0;
+            const decimals = num !== 0 && num < 0.01 ? 4 : 2;
+            return `$${num.toFixed(decimals)}`;
+        };
 
         const options = {
             ...this.defaultOptions,

--- a/assets/javascript/dashboard/main.js
+++ b/assets/javascript/dashboard/main.js
@@ -365,9 +365,23 @@ function dashboard() {
                 const response = await fetch(`api/cost-tracking-panel/?${urlParams}`);
                 if (response.ok) {
                     container.innerHTML = await response.text();
+                    // The panel HTML (and its chart canvas) is replaced on each
+                    // refresh, so render the chart after the swap.
+                    await this.loadCostTimeseriesChart();
                 }
             } catch (error) {
                 console.error("Failed to refresh cost tracking panel:", error);
+            }
+        },
+
+        async loadCostTimeseriesChart() {
+            if (!document.getElementById("costTimeseriesChart")) return;
+
+            try {
+                const data = await this.apiRequest('api/cost-timeseries/');
+                window.chartManager.renderCostTimeseriesChart(data);
+            } catch (error) {
+                console.error("Failed to load cost timeseries chart:", error);
             }
         },
 
@@ -724,6 +738,14 @@ function dashboard() {
                 return (num / 1000).toFixed(1) + 'K';
             }
             return num.toString();
+        },
+
+        // Mirrors the server-side `cost_display` filter: 2 decimals for $0.01+,
+        // 4 for sub-cent so small early-usage spend doesn't flatten to $0.00.
+        formatCurrency(value) {
+            const num = value || 0;
+            const decimals = num !== 0 && num < 0.01 ? 4 : 2;
+            return `$${num.toFixed(decimals)}`;
         },
 
         formatDuration(minutes) {

--- a/templates/dashboard/_cost_tracking_panel.html
+++ b/templates/dashboard/_cost_tracking_panel.html
@@ -5,18 +5,8 @@
 {% endcomment %}
 <div class="card bg-base-100 shadow-xl mb-8" data-testid="cost-tracking-panel">
   <div class="card-body">
-    <div class="card-title flex items-center justify-between">
-      <div>
-        <span>{% translate "Cost Tracking" %}</span>
-        <div class="text-xs text-gray-500 dark:text-gray-400 mt-1 font-normal">
-          {{ cost_summary.period_start|date:"M j" }} – {{ cost_summary.period_end|date:"M j, Y" }}
-        </div>
-      </div>
-      {% if cost_summary.last_synced %}
-        <span class="text-xs text-gray-500 dark:text-gray-400">
-          {% blocktranslate with synced=cost_summary.last_synced|date:"Y-m-d" %}Pricing last synced {{ synced }}{% endblocktranslate %}
-        </span>
-      {% endif %}
+    <div class="card-title">
+      <span>{% translate "Cost Tracking" %}</span>
     </div>
 
     {% if cost_summary.total_cost or cost_summary.unknown_call_count or cost_summary.unpriced_call_count %}

--- a/templates/dashboard/_cost_tracking_panel.html
+++ b/templates/dashboard/_cost_tracking_panel.html
@@ -5,8 +5,13 @@
 {% endcomment %}
 <div class="card bg-base-100 shadow-xl mb-8" data-testid="cost-tracking-panel">
   <div class="card-body">
-    <div class="card-title">
+    <div class="card-title flex items-center gap-1">
       <span>{% translate "Cost Tracking" %}</span>
+
+      {% blocktranslate asvar cost_tracking_info %}
+        Costs are estimated from recorded token usage times the configured price for each model. "Exact" figures use token counts reported by the provider; "Estimated" figures fall back to token estimates when usage data is missing. Pricing can be incomplete or out of date, so treat these numbers as a guide to relative spend, not an authoritative bill.
+      {% endblocktranslate %}
+      {% include "generic/help.html" with help_content=cost_tracking_info %}
     </div>
 
     {% if cost_summary.total_cost or cost_summary.unknown_call_count or cost_summary.unpriced_call_count %}

--- a/templates/dashboard/_cost_tracking_panel.html
+++ b/templates/dashboard/_cost_tracking_panel.html
@@ -20,7 +20,8 @@
     </div>
 
     {% if cost_summary.total_cost or cost_summary.unknown_call_count or cost_summary.unpriced_call_count %}
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-4">
+      {# 3-col split only when there's estimated spend to break out; otherwise the headline stands alone. #}
+      <div class="grid grid-cols-1 gap-6 mt-4 {% if cost_summary.estimated_cost > 0 %}md:grid-cols-3{% endif %}">
         <div>
           <div class="text-xs uppercase text-gray-500 dark:text-gray-400">{% translate "LLM spend" %}</div>
           <div class="text-3xl font-bold text-gray-900 dark:text-gray-100">${{ cost_summary.total_cost|cost_display }}</div>
@@ -31,56 +32,54 @@
             </div>
           {% endif %}
         </div>
-        <div>
-          <div class="text-xs uppercase text-gray-500 dark:text-gray-400">{% translate "Exact" %}</div>
-          <div class="text-xl font-semibold text-gray-900 dark:text-gray-100">${{ cost_summary.exact_cost|cost_display }}</div>
-        </div>
-        <div>
-          <div class="text-xs uppercase text-gray-500 dark:text-gray-400">{% translate "Estimated" %}</div>
-          <div class="text-xl font-semibold text-gray-900 dark:text-gray-100">${{ cost_summary.estimated_cost|cost_display }}</div>
-          {% if cost_summary.unknown_call_count %}
-            <div class="text-xs text-yellow-800 mt-1">
-              {% blocktranslate count counter=cost_summary.unknown_call_count %}{{ counter }} call with no usage data{% plural %}{{ counter }} calls with no usage data{% endblocktranslate %}
-            </div>
-          {% endif %}
-          {% if cost_summary.unpriced_call_count %}
-            <div class="text-xs text-yellow-800 mt-1">
-              {% blocktranslate count counter=cost_summary.unpriced_call_count %}{{ counter }} call missing pricing{% plural %}{{ counter }} calls missing pricing{% endblocktranslate %}
-            </div>
-          {% endif %}
-        </div>
+        {% if cost_summary.estimated_cost > 0 %}
+          <div>
+            <div class="text-xs uppercase text-gray-500 dark:text-gray-400">{% translate "Exact" %}</div>
+            <div class="text-xl font-semibold text-gray-900 dark:text-gray-100">${{ cost_summary.exact_cost|cost_display }}</div>
+          </div>
+          <div>
+            <div class="text-xs uppercase text-gray-500 dark:text-gray-400">{% translate "Estimated" %}</div>
+            <div class="text-xl font-semibold text-gray-900 dark:text-gray-100">${{ cost_summary.estimated_cost|cost_display }}</div>
+          </div>
+        {% endif %}
       </div>
 
-      {% if cost_top_bots %}
-        <div class="mt-6 overflow-x-auto">
-          <table class="table table-zebra w-full">
-            <thead>
-              <tr>
-                <th>{% translate "Chatbot" %}</th>
-                <th class="text-right">{% translate "Cost" %}</th>
-                <th class="text-right">{% translate "Tokens" %}</th>
-                <th class="text-right">{% translate "Sessions" %}</th>
-                <th class="text-right">{% translate "Cost / session" %}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for bot in cost_top_bots %}
-                <tr>
-                  <td>{{ bot.experiment_name }}</td>
-                  <td class="text-right">${{ bot.cost|cost_display }}</td>
-                  <td class="text-right">{{ bot.tokens }}</td>
-                  <td class="text-right">{{ bot.sessions }}</td>
-                  <td class="text-right">
-                    {% if bot.cost_per_session is not None %}
-                      ${{ bot.cost_per_session|cost_display }}
-                    {% else %}
-                      -
-                    {% endif %}
-                  </td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
+      {# Coverage warnings: each count expands to the models responsible so the numbers are actionable. #}
+      {% if cost_summary.unknown_call_count or cost_summary.unpriced_call_count %}
+        <div class="mt-4 space-y-2">
+          {% if cost_summary.unknown_call_count %}
+            <details class="text-xs text-yellow-800 dark:text-yellow-500">
+              <summary class="cursor-pointer">
+                {% blocktranslate count counter=cost_summary.unknown_call_count %}{{ counter }} call with no usage data{% plural %}{{ counter }} calls with no usage data{% endblocktranslate %}
+              </summary>
+              <ul class="mt-1 ml-4 list-disc">
+                {% for gap in cost_coverage_gaps.unknown %}
+                  <li>{{ gap.provider_type }} / {{ gap.model_name }} ({{ gap.call_count }})</li>
+                {% endfor %}
+              </ul>
+            </details>
+          {% endif %}
+          {% if cost_summary.unpriced_call_count %}
+            <details class="text-xs text-yellow-800 dark:text-yellow-500">
+              <summary class="cursor-pointer">
+                {% blocktranslate count counter=cost_summary.unpriced_call_count %}{{ counter }} call missing pricing{% plural %}{{ counter }} calls missing pricing{% endblocktranslate %}
+              </summary>
+              <ul class="mt-1 ml-4 list-disc">
+                {% for gap in cost_coverage_gaps.unpriced %}
+                  <li>{{ gap.provider_type }} / {{ gap.model_name }} ({{ gap.call_count }})</li>
+                {% endfor %}
+              </ul>
+            </details>
+          {% endif %}
+        </div>
+      {% endif %}
+
+      {% if cost_summary.total_cost %}
+        <div class="mt-6">
+          <div class="text-xs uppercase text-gray-500 dark:text-gray-400 mb-2">{% translate "Daily spend" %}</div>
+          <div class="h-64">
+            <canvas id="costTimeseriesChart"></canvas>
+          </div>
         </div>
       {% endif %}
     {% else %}

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -273,6 +273,20 @@
                     <i :class="getSortIcon('completion_rate')" class="text-xs"></i>
                   </div>
                 </th>
+                {% if cost_tracking_enabled %}
+                  <th class="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 text-right" @click="sortBotPerformance('cost')">
+                    <div class="flex items-center justify-end gap-1">
+                      {% translate "Cost" %}
+                      <i :class="getSortIcon('cost')" class="text-xs"></i>
+                    </div>
+                  </th>
+                  <th class="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 text-right" @click="sortBotPerformance('cost_per_session')">
+                    <div class="flex items-center justify-end gap-1">
+                      {% translate "Cost / session" %}
+                      <i :class="getSortIcon('cost_per_session')" class="text-xs"></i>
+                    </div>
+                  </th>
+                {% endif %}
               </tr>
             </thead>
             <tbody>
@@ -296,6 +310,10 @@
                       <span class="text-xs" x-text="`${(item.completion_rate * 100).toFixed(1)}%`"></span>
                     </div>
                   </td>
+                  {% if cost_tracking_enabled %}
+                    <td class="text-right" x-text="formatCurrency(item.cost)"></td>
+                    <td class="text-right" x-text="item.cost_per_session != null ? formatCurrency(item.cost_per_session) : '-'"></td>
+                  {% endif %}
                 </tr>
               </template>
             </tbody>


### PR DESCRIPTION
Implements #3723 (split from #3721).

### Product Description
The dashboard Cost Tracking panel gains a daily-spend chart, coverage-gap warnings that expand to name which models are unpriced / missing usage data, and per-bot **Cost** / **Cost per session** columns on the Bot Performance table. The panel now respects the dashboard's chatbot, participant, and channel filters (previously date-only).

### Technical Description
- **Filters in the cost read path.** All four reporting functions (`cost_summary`, `coverage_gaps`, `cost_timeseries`, `costs_by_experiment`) route through a shared `_scoped_records` helper. Chatbot/participant are direct FKs; platform is matched via the record's session (records with no session drop out under a platform filter). Tags are intentionally not supported — usage records aren't tagged directly. `cost_summary` applies the filters to the prior-period aggregate too, so the delta stays correct.
- **Per-bot cost merged into the existing Bot Performance JSON table** rather than a separate panel table. `get_bot_performance_summary` gains `include_cost` (set from the team's cost flag in the view); cost columns render only when the flag is on and are sortable. The panel's old top-N table and the now-dead `top_n_bots`/`BotSpend` were removed.
- **Timeseries chart** is a new flag-gated `api/cost-timeseries/` endpoint + Chart.js renderer. The panel is server-rendered HTML that gets swapped on filter change, so the chart is (re)rendered right after the partial swap.
- Dropped the panel's period-range subtitle and "Pricing last synced" line, and pruned the now-unused `last_synced` field / `last_synced_at()` with it.

Worth a look: the platform filter uses `session__platform`, so usage records with a null session are excluded when a platform filter is active — flagged as intended, not a bug.

### Migrations
None.

### Demo


https://github.com/user-attachments/assets/284b748f-2278-46c7-ac93-8ee1f44d4f00



### Docs and Changelog
- [x] This PR requires docs/changelog update