### PR TITLE
Reflect stage failures in traces

### DIFF
--- a/apps/channels/channels_v2/channel_base.py
+++ b/apps/channels/channels_v2/channel_base.py
@@ -76,30 +76,34 @@ class ChannelBase(ABC):
             ctx = self._create_context(message)
             pipeline = self._build_pipeline()
 
-            try:
-                with self.trace_service.trace(
-                    trace_name=self.experiment.name,
-                    session=ctx.experiment_session,
-                    inputs={"input": message.model_dump(mode="json")},
-                ) as span:
+            with self.trace_service.trace(
+                trace_name=self.experiment.name,
+                session=ctx.experiment_session,
+                inputs={"input": message.model_dump(mode="json")},
+            ) as span:
+                try:
                     ctx = pipeline.process(ctx)
+                except GenerationCancelled:
+                    # Cancellation is control flow, not a failure -- close the
+                    # trace cleanly rather than letting it propagate through the
+                    # trace context manager and mark the trace as errored.
+                    span.set_outputs({"response": "", "cancelled": True})
+                    return ChatMessage(content="", message_type=ChatMessageType.AI)
 
-                    # Determine the response to return
-                    if ctx.early_exit_response is not None:
-                        response = ChatMessage(content=ctx.early_exit_response, message_type=ChatMessageType.AI)
-                    elif ctx.bot_response:
-                        response = ctx.bot_response
-                    else:
-                        response = ChatMessage(content="", message_type=ChatMessageType.AI)
+                # Determine the response to return
+                if ctx.early_exit_response is not None:
+                    response = ChatMessage(content=ctx.early_exit_response, message_type=ChatMessageType.AI)
+                elif ctx.bot_response:
+                    response = ctx.bot_response
+                else:
+                    response = ChatMessage(content="", message_type=ChatMessageType.AI)
 
-                    span.set_outputs({"response": response.content})
+                span.set_outputs({"response": response.content})
 
-                    # Update instance state (for backward compat during migration)
-                    self.experiment_session = ctx.experiment_session
+                # Update instance state (for backward compat during migration)
+                self.experiment_session = ctx.experiment_session
 
-                    return response
-            except GenerationCancelled:
-                return ChatMessage(content="", message_type=ChatMessageType.AI)
+                return response
 
     def _create_context(self, message: BaseMessage) -> MessageProcessingContext:
         ctx = MessageProcessingContext(

--- a/apps/channels/channels_v2/stages/base.py
+++ b/apps/channels/channels_v2/stages/base.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from datetime import date
+from enum import Enum
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from django.db.models import Model
 
 from apps.channels.channels_v2.exceptions import EarlyAbort, EarlyExitResponse
 from apps.service_providers.llm_service.runnables import GenerationCancelled
@@ -14,6 +18,20 @@ if TYPE_CHECKING:
 # They must not mark a stage's span as errored.
 _CONTROL_FLOW_SIGNALS = (EarlyExitResponse, EarlyAbort, GenerationCancelled)
 
+# Bounds for span-value serialization -- keep trace payloads small and cheap.
+_SPAN_LIST_LIMIT = 20
+_SPAN_MAX_DEPTH = 2
+_UNSET = object()
+
+# Field-list declarations use the real context attribute names, but trace spans
+# display friendlier keys free of legacy "experiment" naming. Applied per path
+# segment, so "experiment_session.experiment_versions" -> "session.chatbot_versions".
+_SPAN_KEY_ALIASES = {
+    "experiment_session": "session",
+    "experiment_channel": "channel",
+    "experiment_versions": "chatbot_versions",
+}
+
 
 class ProcessingStage(ABC):
     """Base class for stateless processing stages.
@@ -23,7 +41,17 @@ class ProcessingStage(ABC):
 
     Stages do NOT check early_exit_response -- the pipeline orchestrator
     handles short-circuiting. To exit early, raise EarlyExitResponse.
+
+    Observability: declare ``span_input_fields`` / ``span_output_fields`` as
+    context attribute paths (dotted paths allowed, e.g. ``"experiment_session.status"``)
+    to record them on the stage's trace span. Inputs are read before ``process``,
+    outputs after. Override ``get_span_inputs`` / ``get_span_outputs`` directly
+    when a derived value is needed instead of a raw context field.
     """
+
+    # Context attribute paths recorded on this stage's trace span.
+    span_input_fields: ClassVar[tuple[str, ...]] = ()
+    span_output_fields: ClassVar[tuple[str, ...]] = ()
 
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         """Override to add stage-specific preconditions.
@@ -42,14 +70,14 @@ class ProcessingStage(ABC):
         return None
 
     def get_span_inputs(self, ctx: MessageProcessingContext) -> dict[str, Any]:
-        """Override to record useful context on this stage's trace span.
-        Default: empty -- no inputs recorded."""
-        return {}
+        """Context recorded on this stage's span, from ``span_input_fields``.
+        Override for derived values that aren't raw context fields."""
+        return _summarize_span_fields(ctx, self.span_input_fields)
 
     def get_span_outputs(self, ctx: MessageProcessingContext) -> dict[str, Any]:
-        """Override to record useful outputs on this stage's trace span.
-        Default: empty -- no outputs recorded."""
-        return {}
+        """Context recorded on this stage's span, from ``span_output_fields``.
+        Override for derived values that aren't raw context fields."""
+        return _summarize_span_fields(ctx, self.span_output_fields)
 
     def __call__(self, ctx: MessageProcessingContext) -> None:
         """Execute stage inside a trace span, keeping the span's status honest.
@@ -114,3 +142,65 @@ class ProcessingStage(ABC):
             first = new_sending[0]
             root_exc = getattr(first, "original_exc", first)
         return messages, root_exc
+
+
+def _summarize_span_fields(ctx: MessageProcessingContext, field_paths: tuple[str, ...]) -> dict[str, Any]:
+    """Read each context attribute path and render it trace-safe.
+
+    Serialization must never break message processing, so any failure to read
+    or render a field degrades to a placeholder rather than raising.
+    """
+    summary: dict[str, Any] = {}
+    for path in field_paths:
+        key = _span_key(path)
+        try:
+            value = _resolve_path(ctx, path)
+            if value is _UNSET:
+                continue
+            summary[key] = _to_trace_value(value)
+        except Exception:
+            summary[key] = "<unserializable>"
+    return summary
+
+
+def _span_key(path: str) -> str:
+    """Map a context attribute path to its display key, aliasing legacy segments."""
+    return ".".join(_SPAN_KEY_ALIASES.get(part, part) for part in path.split("."))
+
+
+def _resolve_path(obj: Any, path: str) -> Any:
+    """Walk a dotted attribute path. Returns ``_UNSET`` if an attribute is
+    missing, ``None`` if any step along the way is None."""
+    for part in path.split("."):
+        if obj is None:
+            return None
+        obj = getattr(obj, part, _UNSET)
+        if obj is _UNSET:
+            return _UNSET
+    return obj
+
+
+def _to_trace_value(value: Any, depth: int = 0) -> Any:
+    """Render a value as JSON-safe primitives for a trace span.
+
+    Models collapse to ``{id, model}`` (never ``str(model)`` -- that can fire
+    queries); unknown objects collapse to their type name. Collections are
+    bounded by size and depth.
+    """
+    if value is None or isinstance(value, str | bool | int | float):
+        return value
+    if isinstance(value, Enum):
+        return _to_trace_value(value.value, depth)
+    if isinstance(value, date):  # date and datetime
+        return value.isoformat()
+    if isinstance(value, Model):
+        return {"id": value.pk, "model": str(value._meta.verbose_name)}
+    if isinstance(value, list | tuple | set):
+        if depth >= _SPAN_MAX_DEPTH:
+            return f"[{len(value)} items]"
+        return [_to_trace_value(item, depth + 1) for item in list(value)[:_SPAN_LIST_LIMIT]]
+    if isinstance(value, dict):
+        if depth >= _SPAN_MAX_DEPTH:
+            return f"{{{len(value)} keys}}"
+        return {str(k): _to_trace_value(v, depth + 1) for k, v in value.items()}
+    return f"<{type(value).__name__}>"

--- a/apps/channels/channels_v2/stages/base.py
+++ b/apps/channels/channels_v2/stages/base.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from apps.channels.channels_v2.exceptions import EarlyAbort, EarlyExitResponse
+from apps.service_providers.llm_service.runnables import GenerationCancelled
 
 if TYPE_CHECKING:
     from apps.channels.channels_v2.pipeline import MessageProcessingContext
+
+# Control-flow signals are not failures: they steer the pipeline (early exit,
+# silent abort, generation cancellation) rather than indicate something broke.
+# They must not mark a stage's span as errored.
+_CONTROL_FLOW_SIGNALS = (EarlyExitResponse, EarlyAbort, GenerationCancelled)
 
 
 class ProcessingStage(ABC):
@@ -33,13 +41,76 @@ class ProcessingStage(ABC):
         Default: None (no notification)."""
         return None
 
+    def get_span_inputs(self, ctx: MessageProcessingContext) -> dict[str, Any]:
+        """Override to record useful context on this stage's trace span.
+        Default: empty -- no inputs recorded."""
+        return {}
+
+    def get_span_outputs(self, ctx: MessageProcessingContext) -> dict[str, Any]:
+        """Override to record useful outputs on this stage's trace span.
+        Default: empty -- no outputs recorded."""
+        return {}
+
     def __call__(self, ctx: MessageProcessingContext) -> None:
-        """Execute stage: check should_run, run inside a trace span."""
+        """Execute stage inside a trace span, keeping the span's status honest.
+
+        Three outcomes are distinguished:
+
+        1. ``process`` raises a genuine exception -- it propagates out of the
+           span and the tracer records the span (and trace) as errored.
+        2. ``process`` raises a control-flow signal (early exit / abort /
+           cancellation) -- the signal is caught, the span closes cleanly, and
+           the signal is re-raised only after the span has exited so the tracer
+           does not mistake steering for failure.
+        3. ``process`` catches a failure itself and records it on the context
+           (``sending_exceptions`` / ``processing_errors``) instead of raising
+           -- those newly recorded errors are surfaced on the span so the trace
+           still reflects that something went wrong.
+        """
         if not self.should_run(ctx):
             return
+
         stage_name = self.__class__.__name__
+        sending_before = len(ctx.sending_exceptions)
+        errors_before = len(ctx.processing_errors)
+        deferred_signal: Exception | None = None
+
         with ctx.trace_service.span(
-            stage_name, inputs={}, notification_config=self.get_span_notification_config()
+            stage_name, inputs=self.get_span_inputs(ctx), notification_config=self.get_span_notification_config()
         ) as span:
-            self.process(ctx)
-            span.set_outputs({})
+            try:
+                self.process(ctx)
+            except _CONTROL_FLOW_SIGNALS as signal:
+                deferred_signal = signal
+
+            outputs = self.get_span_outputs(ctx)
+            messages, root_exc = self._new_handled_errors(ctx, sending_before, errors_before)
+            if messages:
+                outputs = {**outputs, "handled_errors": messages}
+                # Only a genuine failure the stage recovered from marks the span
+                # as errored. Errors recorded alongside a control-flow signal
+                # (e.g. a degraded fallback response) stay as context, not errors.
+                if deferred_signal is None:
+                    span.mark_span_as_error("; ".join(messages), exception=root_exc)
+            span.set_outputs(outputs)
+
+        if deferred_signal is not None:
+            raise deferred_signal
+
+    @staticmethod
+    def _new_handled_errors(
+        ctx: MessageProcessingContext, sending_before: int, errors_before: int
+    ) -> tuple[list[str], Exception | None]:
+        """Return errors the stage recorded on the context during this run.
+
+        Returns the human-readable messages and, when a sending exception was
+        recorded, the underlying exception (so the span gets a real traceback).
+        """
+        new_sending = ctx.sending_exceptions[sending_before:]
+        new_processing = ctx.processing_errors[errors_before:]
+        messages = [str(exc) for exc in new_sending] + list(new_processing)
+        root_exc: Exception | None = None
+        if new_sending:
+            first = new_sending[0]
+            root_exc = getattr(first, "original_exc", first)
+        return messages, root_exc

--- a/apps/channels/channels_v2/stages/core.py
+++ b/apps/channels/channels_v2/stages/core.py
@@ -116,6 +116,9 @@ def get_or_create_participant(
 class ParticipantValidationStage(ProcessingStage):
     """Validates the participant is allowed to interact with this experiment."""
 
+    span_input_fields = ("message.participant_id",)
+    span_output_fields = ("participant_allowed",)
+
     def process(self, ctx: MessageProcessingContext) -> None:
         ctx.participant_identifier = ctx.message.participant_id
 
@@ -142,6 +145,9 @@ class ParticipantResolverStage(ProcessingStage):
     If a participant_user is present in ctx.channel_context (e.g. web channels),
     it is associated with the participant on first contact or backfilled if missing.
     """
+
+    span_input_fields = ("participant_identifier", "experiment_channel.platform")
+    span_output_fields = ("participant.id", "participant_data.id")
 
     def process(self, ctx: MessageProcessingContext) -> None:
         normalized = ctx.experiment_channel.platform_enum.normalize_identifier(ctx.participant_identifier)
@@ -187,6 +193,9 @@ class SessionResolutionStage(ProcessingStage):
     For Web/Slack channels the session is pre-set on the context, so this
     stage becomes a no-op (Issue 4).
     """
+
+    span_input_fields = ("participant.id",)
+    span_output_fields = ("experiment_session.id", "experiment_session.status")
 
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         return True
@@ -263,6 +272,9 @@ class SessionResolutionStage(ProcessingStage):
 class MessageTypeValidationStage(ProcessingStage):
     """Validates the message type is supported by this channel."""
 
+    span_input_fields = ("message.content_type", "capabilities.supported_message_types")
+    span_output_fields = ("human_message_tags",)
+
     def process(self, ctx: MessageProcessingContext) -> None:
         if ctx.message.content_type not in ctx.capabilities.supported_message_types:
             # Tag the human message for analytics (PersistenceStage applies the tag)
@@ -300,6 +312,8 @@ class SessionActivationStage(ProcessingStage):
     proceed. This keeps the side effect out of ConsentFlowStage.should_run.
     """
 
+    span_output_fields = ("experiment_session.status",)
+
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         if ctx.experiment_session is None:
             return False
@@ -331,6 +345,8 @@ class ConsentCheckStage(ProcessingStage):
     Configured via ChannelCapabilities.consent_config. When unset, the
     stage is skipped entirely.
     """
+
+    span_input_fields = ("participant_data.id",)
 
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         return ctx.capabilities.consent_config is not None
@@ -370,6 +386,9 @@ class ConsentFlowStage(ProcessingStage):
     """
 
     USER_CONSENT_TEXT = "1"
+
+    span_input_fields = ("experiment_session.status",)
+    span_output_fields = ("experiment_session.status", "user_query")
 
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         # Skip if channel doesn't support conversational consent
@@ -471,6 +490,9 @@ class QueryExtractionStage(ProcessingStage):
     For voice messages, this transcribes the audio.
     """
 
+    span_input_fields = ("message.content_type",)
+    span_output_fields = ("user_query",)
+
     def process(self, ctx: MessageProcessingContext) -> None:
         if ctx.message.content_type == MESSAGE_TYPES.VOICE:
             try:
@@ -514,6 +536,9 @@ class ChatMessageCreationStage(ProcessingStage):
     This is a separate stage between query extraction and bot interaction,
     keeping extraction testable without the DB.
     """
+
+    span_input_fields = ("user_query",)
+    span_output_fields = ("human_message.id",)
 
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         return ctx.user_query is not None
@@ -591,6 +616,9 @@ class BotInteractionStage(ProcessingStage):
     runs terminal stages, and then re-raises.
     """
 
+    span_input_fields = ("user_query",)
+    span_output_fields = ("bot_response.content", "files_to_send")
+
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         return ctx.user_query is not None
 
@@ -624,6 +652,9 @@ class EvalsBotInteractionStage(ProcessingStage):
     bypassing the DB-backed ParticipantData model.
     """
 
+    span_input_fields = ("user_query",)
+    span_output_fields = ("bot_response.content", "files_to_send")
+
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         return ctx.user_query is not None
 
@@ -654,6 +685,9 @@ class ResponseFormattingStage(ProcessingStage):
     text -- the user still gets a useful response. This is NOT an
     unrecoverable error, so it does not propagate to the pipeline's catch-all.
     """
+
+    span_input_fields = ("bot_response.content",)
+    span_output_fields = ("formatted_message", "voice_audio", "files_to_send", "unsupported_files")
 
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         return ctx.bot_response is not None
@@ -766,6 +800,8 @@ class AttachmentHydrationStage(ProcessingStage):
     that reference a real session. No-op for channels that don't use
     this pattern.
     """
+
+    span_output_fields = ("message.attachments",)
 
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         return bool(

--- a/apps/channels/channels_v2/stages/terminal.py
+++ b/apps/channels/channels_v2/stages/terminal.py
@@ -173,6 +173,9 @@ class SendingErrorHandlerStage(ProcessingStage):
     def __init__(self, error_handlers: Sequence[DeliveryErrorHandler] = ()) -> None:
         self._error_handlers: tuple[DeliveryErrorHandler, ...] = tuple(error_handlers)
 
+    def get_span_inputs(self, ctx: MessageProcessingContext) -> dict:
+        return {"sending_exceptions": [str(exc) for exc in ctx.sending_exceptions]}
+
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         return bool(ctx.sending_exceptions)
 
@@ -231,6 +234,8 @@ class PersistenceStage(ProcessingStage):
     3. Voice attachments: Tags the bot response as "voice" and saves
        the synthesized audio as a file attachment.
     """
+
+    span_input_fields = ("early_exit_response", "human_message_tags", "voice_audio")
 
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         if not ctx.experiment_session:
@@ -303,6 +308,8 @@ class PersistenceStage(ProcessingStage):
 
 class ActivityTrackingStage(ProcessingStage):
     """TERMINAL STAGE: Updates session activity timestamp and experiment version tracking."""
+
+    span_output_fields = ("experiment_session.last_activity_at", "experiment_session.experiment_versions")
 
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         return ctx.experiment_session is not None

--- a/apps/channels/channels_v2/stages/terminal.py
+++ b/apps/channels/channels_v2/stages/terminal.py
@@ -82,6 +82,16 @@ class ResponseSendingStage(ProcessingStage):
     def should_run(self, ctx: MessageProcessingContext) -> bool:
         return ctx.formatted_message is not None or ctx.early_exit_response is not None
 
+    def get_span_inputs(self, ctx: MessageProcessingContext) -> dict:
+        """Record what is being delivered so a send failure has context on the span."""
+        message = ctx.early_exit_response if ctx.early_exit_response is not None else ctx.formatted_message
+        return {
+            "recipient": ctx.participant_identifier,
+            "message": message,
+            "is_voice": ctx.voice_audio is not None,
+            "files": [file.name for file in ctx.files_to_send],
+        }
+
     def process(self, ctx: MessageProcessingContext) -> None:
         try:
             if ctx.early_exit_response:

--- a/apps/channels/tests/channels/stages/test_span_field_summary.py
+++ b/apps/channels/tests/channels/stages/test_span_field_summary.py
@@ -1,0 +1,124 @@
+"""Tests for the declarative span input/output field serialization.
+
+Covers _summarize_span_fields / _to_trace_value: dotted-path resolution,
+trace-safe rendering, and the guarantee that serialization never raises.
+"""
+
+from datetime import date, datetime
+from enum import Enum
+from types import SimpleNamespace
+
+import pytest
+
+from apps.channels.channels_v2.stages.base import (
+    _SPAN_LIST_LIMIT,
+    ProcessingStage,
+    _summarize_span_fields,
+    _to_trace_value,
+)
+from apps.files.models import File
+
+from ..conftest import make_context, make_trace_service
+
+
+class _Color(Enum):
+    RED = "red"
+
+
+class _Exploding:
+    @property
+    def boom(self):
+        raise RuntimeError("do not read me")
+
+
+class TestToTraceValue:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param(None, None, id="none"),
+            pytest.param("hi", "hi", id="str"),
+            pytest.param(7, 7, id="int"),
+            pytest.param(True, True, id="bool"),
+            pytest.param(1.5, 1.5, id="float"),
+            pytest.param(_Color.RED, "red", id="enum_to_value"),
+        ],
+    )
+    def test_primitives_pass_through(self, value, expected):
+        assert _to_trace_value(value) == expected
+
+    def test_datetime_renders_isoformat(self):
+        assert _to_trace_value(date(2026, 7, 7)) == "2026-07-07"
+        assert _to_trace_value(datetime(2026, 7, 7, 8, 30)) == "2026-07-07T08:30:00"
+
+    def test_unknown_object_collapses_to_type_name(self):
+        assert _to_trace_value(object()) == "<object>"
+
+    def test_model_renders_id_and_verbose_name(self):
+        rendered = _to_trace_value(File())  # unsaved -- no DB needed
+        assert rendered == {"id": None, "model": str(File._meta.verbose_name)}
+
+    def test_lists_are_bounded(self):
+        rendered = _to_trace_value(list(range(_SPAN_LIST_LIMIT + 10)))
+        assert rendered == list(range(_SPAN_LIST_LIMIT))
+
+    def test_nested_collections_are_depth_capped(self):
+        # A list nested two levels down is summarized rather than expanded.
+        rendered = _to_trace_value([[["deep"]]])
+        assert rendered == [["[1 items]"]]
+
+
+class TestSummarizeSpanFields:
+    def test_resolves_dotted_paths(self):
+        ctx = SimpleNamespace(message=SimpleNamespace(content_type="text"), user_query="hello")
+        assert _summarize_span_fields(ctx, ("message.content_type", "user_query")) == {
+            "message.content_type": "text",
+            "user_query": "hello",
+        }
+
+    def test_missing_attribute_is_skipped(self):
+        ctx = SimpleNamespace(user_query="hi")
+        assert _summarize_span_fields(ctx, ("does_not_exist", "user_query")) == {"user_query": "hi"}
+
+    def test_none_along_path_yields_none(self):
+        ctx = SimpleNamespace(participant=None)
+        assert _summarize_span_fields(ctx, ("participant.id",)) == {"participant.id": None}
+
+    def test_serialization_failure_degrades_to_placeholder(self):
+        assert _summarize_span_fields(_Exploding(), ("boom",)) == {"boom": "<unserializable>"}
+
+    def test_legacy_named_segments_are_aliased_in_display_keys(self):
+        ctx = SimpleNamespace(
+            experiment_session=SimpleNamespace(status="active", experiment_versions=[1, 2]),
+            experiment_channel=SimpleNamespace(platform="connect"),
+        )
+        summary = _summarize_span_fields(
+            ctx,
+            ("experiment_session.status", "experiment_session.experiment_versions", "experiment_channel.platform"),
+        )
+        assert summary == {
+            "session.status": "active",
+            "session.chatbot_versions": [1, 2],
+            "channel.platform": "connect",
+        }
+
+
+class _StageWithFields(ProcessingStage):
+    span_input_fields = ("user_query",)
+    span_output_fields = ("formatted_message",)
+
+    def process(self, ctx):
+        ctx.formatted_message = "formatted!"
+
+
+class TestFieldsFlowToSpan:
+    def test_declared_fields_land_on_the_span(self):
+        trace_service = make_trace_service()
+        span = trace_service.span.return_value
+        ctx = make_context(trace_service=trace_service, user_query="what is up")
+
+        _StageWithFields()(ctx)
+
+        # inputs captured at span open, from span_input_fields
+        assert trace_service.span.call_args.kwargs["inputs"] == {"user_query": "what is up"}
+        # outputs captured after process, from span_output_fields
+        assert span.set_outputs.call_args[0][0] == {"formatted_message": "formatted!"}

--- a/apps/channels/tests/channels/stages/test_stage_span_status.py
+++ b/apps/channels/tests/channels/stages/test_stage_span_status.py
@@ -1,0 +1,156 @@
+"""Tests for ProcessingStage.__call__ span-status behavior.
+
+Verifies that a stage's trace span honestly reflects what happened:
+- genuine failures (raised or recorded on the context) mark the span as errored,
+- control-flow signals (early exit / abort / cancellation) do not.
+"""
+
+import pytest
+
+from apps.channels.channels_v2.exceptions import EarlyAbort, EarlyExitResponse
+from apps.channels.channels_v2.stages.base import ProcessingStage
+from apps.channels.channels_v2.stages.terminal import MessageDeliveryFailure
+from apps.service_providers.llm_service.runnables import GenerationCancelled
+
+from ..conftest import make_context, make_trace_service
+
+
+class _RecordsSendingException(ProcessingStage):
+    """Catches a delivery failure and records it instead of raising."""
+
+    def process(self, ctx):
+        ctx.sending_exceptions.append(MessageDeliveryFailure(ValueError("fcm 500"), context="text message"))
+
+
+class _RecordsProcessingError(ProcessingStage):
+    def process(self, ctx):
+        ctx.processing_errors.append("something degraded")
+
+
+class _RaisesSignal(ProcessingStage):
+    def __init__(self, signal):
+        self._signal = signal
+
+    def process(self, ctx):
+        raise self._signal
+
+
+class _RaisesGenuineError(ProcessingStage):
+    def process(self, ctx):
+        raise RuntimeError("kaboom")
+
+
+class _RecordsErrorThenEarlyExits(ProcessingStage):
+    def process(self, ctx):
+        ctx.processing_errors.append("fallback used")
+        raise EarlyExitResponse("here is a fallback reply")
+
+
+class _HappyStage(ProcessingStage):
+    def process(self, ctx):
+        pass
+
+
+class TestHandledErrorsMarkSpan:
+    def test_recorded_sending_exception_marks_span_as_error(self):
+        trace_service = make_trace_service()
+        span = trace_service.span.return_value
+        ctx = make_context(trace_service=trace_service)
+
+        _RecordsSendingException()(ctx)
+
+        span.mark_span_as_error.assert_called_once()
+        message, kwargs = span.mark_span_as_error.call_args
+        assert "fcm 500" in message[0]
+        # The underlying exception is passed so the span gets a real traceback.
+        assert isinstance(kwargs["exception"], ValueError)
+
+    def test_recorded_processing_error_marks_span_as_error(self):
+        trace_service = make_trace_service()
+        span = trace_service.span.return_value
+        ctx = make_context(trace_service=trace_service)
+
+        _RecordsProcessingError()(ctx)
+
+        span.mark_span_as_error.assert_called_once()
+        assert "something degraded" in span.mark_span_as_error.call_args[0][0]
+
+    def test_handled_errors_surface_in_span_outputs(self):
+        trace_service = make_trace_service()
+        span = trace_service.span.return_value
+        ctx = make_context(trace_service=trace_service)
+
+        _RecordsProcessingError()(ctx)
+
+        outputs = span.set_outputs.call_args[0][0]
+        assert outputs["handled_errors"] == ["something degraded"]
+
+    def test_only_newly_recorded_errors_are_attributed_to_the_stage(self):
+        """Pre-existing errors from earlier stages don't re-flag this stage's span."""
+        trace_service = make_trace_service()
+        span = trace_service.span.return_value
+        ctx = make_context(trace_service=trace_service, processing_errors=["earlier failure"])
+
+        _HappyStage()(ctx)
+
+        span.mark_span_as_error.assert_not_called()
+
+
+class TestControlFlowSignalsDoNotMarkSpan:
+    @pytest.mark.parametrize(
+        "signal",
+        [
+            EarlyExitResponse("done"),
+            EarlyAbort(),
+            GenerationCancelled("cancelled"),
+        ],
+        ids=["early_exit", "early_abort", "generation_cancelled"],
+    )
+    def test_signal_is_reraised_without_marking_span(self, signal):
+        trace_service = make_trace_service()
+        span = trace_service.span.return_value
+        ctx = make_context(trace_service=trace_service)
+
+        with pytest.raises(type(signal)):
+            _RaisesSignal(signal)(ctx)
+
+        span.mark_span_as_error.assert_not_called()
+        span.set_outputs.assert_called_once()
+
+    def test_error_recorded_alongside_signal_is_context_not_error(self):
+        """A degraded fallback recorded before an early exit is context, not a failure."""
+        trace_service = make_trace_service()
+        span = trace_service.span.return_value
+        ctx = make_context(trace_service=trace_service)
+
+        with pytest.raises(EarlyExitResponse):
+            _RecordsErrorThenEarlyExits()(ctx)
+
+        span.mark_span_as_error.assert_not_called()
+        assert span.set_outputs.call_args[0][0]["handled_errors"] == ["fallback used"]
+
+
+class TestGenuineExceptionsPropagate:
+    def test_raised_exception_propagates(self):
+        """Genuine exceptions propagate so the tracer's span CM records the error."""
+        trace_service = make_trace_service()
+        span = trace_service.span.return_value
+        ctx = make_context(trace_service=trace_service)
+
+        with pytest.raises(RuntimeError, match="kaboom"):
+            _RaisesGenuineError()(ctx)
+
+        # __call__ does not swallow or double-mark -- the span context manager owns this.
+        span.mark_span_as_error.assert_not_called()
+
+
+class TestHappyPath:
+    def test_no_error_recorded_when_stage_succeeds(self):
+        trace_service = make_trace_service()
+        span = trace_service.span.return_value
+        ctx = make_context(trace_service=trace_service)
+
+        _HappyStage()(ctx)
+
+        span.mark_span_as_error.assert_not_called()
+        span.set_outputs.assert_called_once()

--- a/apps/channels/tests/channels/test_new_user_message_trace.py
+++ b/apps/channels/tests/channels/test_new_user_message_trace.py
@@ -1,0 +1,37 @@
+"""Trace-status behavior of ChannelBase.new_user_message."""
+
+from unittest.mock import patch
+
+import pytest
+
+from apps.channels.channels_v2.pipeline import MessageProcessingPipeline
+from apps.channels.tests.message_examples import base_messages
+from apps.chat.models import ChatMessage
+from apps.service_providers.llm_service.runnables import GenerationCancelled
+from apps.utils.factories.experiment import ExperimentSessionFactory
+
+from .conftest import StubChannel, make_trace_service
+
+
+@pytest.mark.django_db()
+def test_generation_cancelled_closes_trace_without_error():
+    """A cancelled generation is control flow -- the trace must close cleanly.
+
+    Regression: previously GenerationCancelled propagated out of pipeline.process
+    and through the trace context manager, marking the whole trace as errored
+    before being caught.
+    """
+    session = ExperimentSessionFactory.create()
+    channel = StubChannel(session.experiment, session.experiment_channel, session)
+    trace_service = make_trace_service()
+    channel.trace_service = trace_service
+    trace_cm = trace_service.trace.return_value
+
+    with patch.object(MessageProcessingPipeline, "process", side_effect=GenerationCancelled(output="")):
+        response = channel.new_user_message(base_messages.text_message())
+
+    assert isinstance(response, ChatMessage)
+    assert response.content == ""
+    # No exception propagated through the trace context manager.
+    trace_cm.__exit__.assert_called_once_with(None, None, None)
+    trace_cm.set_outputs.assert_called_once_with({"response": "", "cancelled": True})

--- a/apps/service_providers/tests/test_langfuse_tracer.py
+++ b/apps/service_providers/tests/test_langfuse_tracer.py
@@ -136,6 +136,22 @@ def test_span_marks_level_error_when_exception_propagates(patched_tracer, mock_l
     assert span_context.error is not None
 
 
+def test_span_marks_level_error_when_marked_without_raising(patched_tracer, mock_langfuse_client, mock_session):
+    """A span marked as errored (without raising) must still surface as ERROR in Langfuse.
+
+    Stages that catch a failure and recover mark their span via
+    ``mark_span_as_error`` rather than propagating an exception.
+    """
+    trace_context = TraceContext(id=mock.sentinel.trace_id, name="test-trace")
+    span_context = TraceContext(id=mock.sentinel.span_id, name="recovered-span")
+
+    with patched_tracer.trace(trace_context=trace_context, session=mock_session):
+        with patched_tracer.span(span_context=span_context, inputs={}):
+            span_context.mark_span_as_error("delivery failed")
+
+    mock_langfuse_client._test_span.update.assert_any_call(level="ERROR", status_message=mock.ANY)
+
+
 def test_trace_marks_level_error_when_exception_propagates(patched_tracer, mock_langfuse_client, mock_session):
     """Same guarantee at the trace level: a propagating exception must mark the trace as ERROR."""
     trace_context = TraceContext(id=mock.sentinel.trace_id, name="test-trace")

--- a/apps/service_providers/tests/test_ocs_tracer.py
+++ b/apps/service_providers/tests/test_ocs_tracer.py
@@ -92,6 +92,27 @@ class TestOCSTracer:
         assert trace.status == "error"
         assert trace.error == error_message
 
+    def test_span_marked_as_error_without_raising_is_recorded(self, experiment):
+        """A span whose context is marked as error (without raising) fails the trace.
+
+        Stages that catch a failure and recover (e.g. a swallowed delivery
+        error) mark their span via ``mark_span_as_error`` rather than raising.
+        The trace must still reflect the failure.
+        """
+        tracer = OCSTracer(experiment, experiment.team_id)
+        session = ExperimentSessionFactory.create()
+
+        trace_context = TraceContext(id=uuid4(), name="test_trace")
+        span_context = TraceContext(id=uuid4(), name="ResponseSendingStage")
+
+        with tracer.trace(trace_context=trace_context, session=session):
+            with tracer.span(span_context=span_context, inputs={}):
+                span_context.mark_span_as_error("delivery failed")
+
+        trace = Trace.objects.get(trace_id=trace_context.id)
+        assert trace.status == "error"
+        assert "delivery failed" in trace.error
+
 
 class TestOCSCallbackHandler:
     def test_on_llm_error_records_error(self):

--- a/apps/service_providers/tracing/ocs_tracer.py
+++ b/apps/service_providers/tracing/ocs_tracer.py
@@ -241,10 +241,13 @@ class OCSTracer(Tracer):
             error_to_record = e
             raise
         finally:
-            if error_to_record:
+            # A span fails either by raising (error_to_record) or by recording
+            # an error on its context without raising (span_context.error), e.g.
+            # a stage that caught a delivery failure and recovered.
+            if error_to_record or span_context.has_error():
                 self.error_detected = True
                 if not self.error_message:
-                    self.error_message = str(error_to_record)
+                    self.error_message = str(error_to_record) if error_to_record else (span_context.error or "")
                 # First erroring span wins — captures innermost span (it exits before outer spans)
                 if not self.error_span_name:
                     self.error_span_name = span_context.name


### PR DESCRIPTION
### Product Description
No change.

### Technical Description
A CommCare Connect FCM delivery failure ([Sentry](https://dimagi.sentry.io/issues/7457992939/)) was reported to Sentry but the OCS/langfuse trace for the run showed no error. Root cause: in the v2 channel pipeline a stage's span only reflected failure when an exception *propagated through* the tracer's context manager. `ResponseSendingStage` catches send failures into `ctx.sending_exceptions` and recovers, so its span — and the whole trace — stayed green.

Fixing this surfaced the inverse problem too: `EarlyExitResponse`/`EarlyAbort`/`GenerationCancelled` are `Exception` subclasses, so normal consent flows, unsupported-message replies, `/reset`, and cancellations were being recorded as ERROR traces.

Span-status handling is now centralized in `ProcessingStage.__call__`, distinguishing three outcomes:
- genuine exception raised → propagates, tracer marks span + trace ERROR (unchanged);
- control-flow signal raised → caught, span closes clean, signal re-raised *after* the span exits;
- failure caught and recorded on the context → surfaced on the span via `mark_span_as_error`.

Supporting changes: the OCS tracer now fails a trace when a span is marked as error without raising (langfuse already did via `_update_span_from_context`); `new_user_message` catches `GenerationCancelled` inside the trace block; `ResponseSendingStage` records recipient/message context on its span.

Also adds input/output context to every stage span. Stages declare `span_input_fields` / `span_output_fields` as context attribute paths (dotted paths like `experiment_session.status` supported); the base renders them trace-safe — Django models collapse to `{id, model}` (never `str(model)`, which can fire queries), collections are size/depth bounded, and serialization never raises so observability can't break message processing.

Worth a reviewer's attention:
- **Behavior change:** consent/unsupported/reset/cancel traces flip from ERROR → SUCCESS, which may shift error-rate dashboards/metrics.
- The existing `message_delivery_failure_notification` still fires; no new trace-error notification fires for send failures because `ResponseSendingStage` carries no `notification_config`.
- Commits are atomic and ordered by dependency (tracer infra → stage span-status → cancellation → span I/O).

### Migrations
N/A — no migrations.

### Docs and Changelog
- [x] This PR requires docs/changelog update