### PR TITLE
fix: handle empty LLM response after tool call in pipeline

### DIFF
--- a/apps/pipelines/nodes/llm_node.py
+++ b/apps/pipelines/nodes/llm_node.py
@@ -53,7 +53,7 @@ def execute_sub_agent(node: PipelineNode, context: NodeContext):
         input_message_id=context.input_message_id,
     )
     result = agent.invoke(inputs)
-    final_message = result["messages"][-1]
+    final_message = _get_final_ai_message(result["messages"])
 
     ai_message, ai_message_metadata = _process_agent_output(node, session, final_message)
 
@@ -229,3 +229,20 @@ def _get_search_tool(node):
             allowed_collection_ids=node.collection_index_ids,
         )
         return search_tool
+
+
+def _get_final_ai_message(messages: list) -> AIMessage:
+    """Return the last AI message with non-empty content.
+
+    Claude (and some other models) sometimes respond with a non-empty message
+    alongside tool calls, then send an empty content array after receiving
+    the tool results — signalling completion via the tool flow rather than
+    a follow-up text turn.  In that case ``messages[-1]`` is empty and
+    we should use the last message that actually has content instead.
+    """
+    for message in reversed(messages):
+        if isinstance(message, AIMessage) and message.content:
+            return message
+    # Fallback: return the last message as-is (preserves existing behaviour
+    # when all AI messages are empty, e.g. pure tool-call chains).
+    return messages[-1]

--- a/apps/pipelines/tests/test_nodes_with_tools.py
+++ b/apps/pipelines/tests/test_nodes_with_tools.py
@@ -276,7 +276,9 @@ def test_empty_followup_after_tool_call_uses_earlier_message(get_llm_service, pr
     """
     first_response = AIMessage(
         content="I'll update your participant data now.",
-        tool_calls=[ToolCall(name=AgentTools.UPDATE_PARTICIPANT_DATA, args={"key": "mood", "value": "happy"}, id="tc1")],
+        tool_calls=[
+            ToolCall(name=AgentTools.UPDATE_PARTICIPANT_DATA, args={"key": "mood", "value": "happy"}, id="tc1")
+        ],
     )
     # Claude's follow-up after receiving the tool result – empty content array
     empty_followup = AIMessage(content=[])

--- a/apps/pipelines/tests/test_nodes_with_tools.py
+++ b/apps/pipelines/tests/test_nodes_with_tools.py
@@ -256,3 +256,52 @@ def test_tool_artifact_response(get_configured_tools, get_llm_service, provider,
 
 def _tool_call(name, args):
     return AIMessage(tool_calls=[ToolCall(name=name, args=args, id="123")], content="")
+
+
+@pytest.mark.django_db()
+@mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
+def test_empty_followup_after_tool_call_uses_earlier_message(get_llm_service, provider, provider_model):
+    """Regression test: Claude sometimes responds with a non-empty message + tool calls, then returns
+    an empty content array after the tool results are sent back.  OCS must use the last non-empty
+    AI message rather than the final empty one.
+
+    Scenario:
+      1. LLM responds: content="I'll update your data now." + tool_calls=[UPDATE_PARTICIPANT_DATA]
+      2. OCS executes the tool call and sends back the tool result.
+      3. LLM responds: content=[]  (empty – Claude signals it's done via tools, not text)
+
+    Bug: ``execute_sub_agent`` takes ``result["messages"][-1]`` which is the empty message,
+    producing an empty pipeline output.
+    Expected: the non-empty content from step 1 should be the pipeline output.
+    """
+    first_response = AIMessage(
+        content="I'll update your participant data now.",
+        tool_calls=[ToolCall(name=AgentTools.UPDATE_PARTICIPANT_DATA, args={"key": "mood", "value": "happy"}, id="tc1")],
+    )
+    # Claude's follow-up after receiving the tool result – empty content array
+    empty_followup = AIMessage(content=[])
+
+    service = build_fake_llm_service(responses=[first_response, empty_followup])
+    get_llm_service.return_value = service
+
+    nodes = [
+        start_node(),
+        llm_response_with_prompt_node(
+            str(provider.id),
+            str(provider_model.id),
+            prompt="Be helpful. {participant_data}",
+            name="llm1",
+            tools=[AgentTools.UPDATE_PARTICIPANT_DATA],
+        ),
+        end_node(),
+    ]
+    pipeline = PipelineFactory.create()
+    session = ExperimentSessionFactory.create()
+    graph = create_runnable(pipeline, nodes)
+    state = PipelineState(
+        messages=["Update my mood to happy"],
+        experiment_session=session,
+        participant_data={},
+    )
+    output = graph.invoke(state, config={"configurable": {"repo": ORMRepository(session=session)}})
+    assert output["messages"][-1] == "I'll update your participant data now."


### PR DESCRIPTION
### Product Description
Claude sometimes replies with a message **and** tool calls, then—after the tool results are sent back—returns an empty content array `[]` to signal it's done. OCS was surfacing that empty follow-up as the pipeline output, so the user saw a blank reply. This fixes that.

### Technical Description
`execute_sub_agent` in `llm_node.py` took `result["messages"][-1]`, which is the empty follow-up. It now uses `_get_final_ai_message()`, which walks the messages in reverse and returns the last `AIMessage` with non-empty content, falling back to the last message for pure tool-call chains. Includes a regression test.

### Migrations
- [ ] The migrations are backwards compatible

(No migrations.)

### Demo
N/A

### Docs and Changelog
- [x] This PR requires docs/changelog update
