### PR TITLE
Fix incorrect function name in code node help text

### DIFF
--- a/apps/help/code_generate_system_prompt.md
+++ b/apps/help/code_generate_system_prompt.md
@@ -84,7 +84,7 @@ def get_node_output(node_name: str) -> Any:
     Returns the output of the specified node if it has been executed.
     If the node has not been executed, it returns `None`.
 
-def abort_pipeline(message, tag_name: str = None) -> None:
+def abort_with_message(message, tag_name: str = None) -> None:
     Calling this will terminate the pipeline execution. No further nodes will get executed in
     any branch of the pipeline graph.
 


### PR DESCRIPTION
### Product Description
The Python code generation help text referenced a `abort_pipeline` function that doesn't exist in the sandbox — user code exposes it as `abort_with_message`. Generated code calling `abort_pipeline` would fail at runtime.

### Technical Description
The help prompt name now matches the key exposed to sandboxed code in `CodeNode` (`abort_with_message`); `abort_pipeline` is only the internal implementation name.

### Docs and Changelog
- [x] This PR requires docs/changelog update