### PR TITLE
Null dangling scalar FK ids in Node param sync

### DIFF
--- a/apps/data_migrations/tests/test_remove_deprecated_models.py
+++ b/apps/data_migrations/tests/test_remove_deprecated_models.py
@@ -7,10 +7,16 @@ from apps.pipelines.models import Pipeline
 from apps.service_providers.models import LlmProviderModel
 from apps.utils.factories.experiment import ExperimentFactory
 from apps.utils.factories.pipelines import PipelineFactory
-from apps.utils.factories.service_provider_factories import LlmProviderModelFactory
+from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 
 
-def _make_pipeline_referencing(llm_provider_model):
+def _make_pipeline_referencing(llm_provider_model, llm_provider=None):
+    params = {
+        "llm_provider_model_id": str(llm_provider_model.id),
+        "prompt": "You are a helpful assistant",
+    }
+    if llm_provider is not None:
+        params["llm_provider_id"] = str(llm_provider.id)
     pipeline: Pipeline = PipelineFactory()  # ty: ignore[invalid-assignment]
     pipeline.data["nodes"].append(
         {
@@ -19,10 +25,7 @@ def _make_pipeline_referencing(llm_provider_model):
                 "id": "1",
                 "label": "LLM",
                 "type": "LLMResponseWithPrompt",
-                "params": {
-                    "llm_provider_model_id": str(llm_provider_model.id),
-                    "prompt": "You are a helpful assistant",
-                },
+                "params": params,
             },
         }
     )
@@ -75,6 +78,34 @@ class TestRemoveDeprecatedModelsCommand:
         node.refresh_from_db()
         assert node.params["llm_provider_model_id"] == replacement_model.id
         assert node.llm_provider_model_id == replacement_model.id
+
+    @patch("apps.data_migrations.management.commands.remove_deprecated_models.deleted_model_notification")
+    def test_stale_deleted_provider_in_params_not_resurrected(self, mock_notify):
+        """Regression: a node whose params still reference an already-deleted LlmProvider must
+        not have that dangling id re-derived into the llm_provider_id FK column when the node is
+        touched. Resurrecting it violated the deferred FK constraint at commit on prod deploy."""
+        model = LlmProviderModelFactory(team=None, type="openai", name="gpt-4-old")
+        provider = LlmProviderFactory()
+        provider_id = provider.id
+        pipeline = _make_pipeline_referencing(model, llm_provider=provider)
+        node = pipeline.node_set.get(type="LLMResponseWithPrompt")
+        assert node.llm_provider_id == provider_id
+
+        # Delete the provider: SET_NULL nulls the FK column but the stale id lingers in params.
+        provider.delete()
+        node.refresh_from_db()
+        assert node.llm_provider_id is None
+        assert str(node.params["llm_provider_id"]) == str(provider_id)
+
+        deleted_models = [("openai", "gpt-4-old")]
+        with patch(
+            "apps.data_migrations.management.commands.remove_deprecated_models.DELETED_MODELS",
+            deleted_models,
+        ):
+            call_command("remove_deprecated_models", force=True)
+
+        node.refresh_from_db()
+        assert node.llm_provider_id is None
 
     @patch("apps.data_migrations.management.commands.remove_deprecated_models.deleted_model_notification")
     def test_notifies_affected_team(self, mock_notify):

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -485,14 +485,15 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
         """Populate FK/M2M fields from the params JSON.
 
         The FK columns are a derived mirror of the IDs in params (non-int/boolean values
-        map to null). We don't pre-check that a scalar id still exists: a resource can't
-        be deleted while a working node references it — the delete guards check
-        pipeline-node usage (see apps.utils.deletion.get_related_objects /
-        get_related_pipelines_queryset) — so a live node's params never holds a dangling
-        id, and the DB FK constraint surfaces any that slip through. Versions may point at
-        a since-deleted resource, but they're never re-synced. The collection_indexes M2M
-        is set from a Collection queryset, which drops ids that no longer exist. Only
-        saves when a scalar FK changed.
+        map to null). A dangling scalar id is coerced to null rather than written straight
+        through: not every SET_NULL resource is protected by a delete guard (an LlmProvider,
+        for one, can be deleted while a node references it — SET_NULL nulls the FK column but
+        the stale id lingers in params), so re-deriving it verbatim would resurrect the
+        dangling reference and trip the deferred DB FK constraint at commit. Existence is
+        checked against ``_base_manager`` so a still-valid reference to a soft-deleted
+        (archived) resource isn't mistaken for dangling. This mirrors the collection_indexes
+        M2M below and the ``backfill_node_fks`` command. Versions may point at a since-deleted
+        resource, but they're never re-synced. Only saves when a scalar FK changed.
         """
         from apps.documents.models import Collection  # noqa: PLC0415 - avoid circular import
 
@@ -500,6 +501,10 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
         update_fields = []
         for field_name in self.resource_fk_fields():
             value = as_int(params.get(f"{field_name}_id"))
+            if value is not None:
+                related_model = self._meta.get_field(field_name).related_model
+                if not related_model._base_manager.filter(pk=value).exists():
+                    value = None
             if getattr(self, f"{field_name}_id") != value:
                 setattr(self, f"{field_name}_id", value)
                 update_fields.append(f"{field_name}_id")

--- a/apps/pipelines/tests/test_node_resource_fks.py
+++ b/apps/pipelines/tests/test_node_resource_fks.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 from django.core.management import call_command
-from django.db import transaction
 
 from apps.pipelines.models import Node
 from apps.utils.factories.assistants import OpenAiAssistantFactory
@@ -104,20 +103,31 @@ class TestNodeResourceFKSync:
         node.update_from_params()
         assert set(node.collection_indexes.values_list("id", flat=True)) == {c1.id}
 
-    def test_stale_scalar_fk_id_is_set_not_nulled(self):
-        """We no longer pre-check existence before setting the FK: the id from params is
-        written straight to the column. Delete guards ensure a live node's params never
-        holds a dangling id, and the (deferred) DB FK constraint is the backstop at
-        commit — so the code doesn't silently null a non-existent id anymore."""
+    def test_stale_scalar_fk_id_is_nulled(self):
+        """A scalar FK id in params that references a deleted resource is coerced to null,
+        not written straight to the column. Not every SET_NULL resource has a delete guard
+        (e.g. LlmProvider), so a stale id can linger in params after the resource is gone;
+        resurrecting it would trip the deferred DB FK constraint at commit."""
         node = NodeFactory.create(
             type="LLMResponseWithPrompt",
             params={"llm_provider_id": 999999},
         )
-        with transaction.atomic():
-            node.update_from_params()
-            assert node.llm_provider_id == 999999
-            # Roll back so the deferred FK violation isn't checked at commit/teardown.
-            transaction.set_rollback(True)
+        node.update_from_params()
+        node.refresh_from_db()
+        assert node.llm_provider_id is None
+
+    def test_scalar_fk_to_archived_resource_is_kept(self):
+        """Archiving is a soft-delete: the row still exists, so a scalar FK to it stays
+        linked. Existence is checked against _base_manager, not the archive-filtering
+        default manager, so a valid reference isn't mistaken for dangling."""
+        source_material = SourceMaterialFactory.create(is_archived=True)
+        node = NodeFactory.create(
+            type="LLMResponseWithPrompt",
+            params={"source_material_id": source_material.id},
+        )
+        node.update_from_params()
+        node.refresh_from_db()
+        assert node.source_material_id == source_material.id
 
     def test_update_nodes_from_data_populates_fks(self):
         provider = LlmProviderFactory.create()


### PR DESCRIPTION
### Product Description
No change.

### Technical Description
Production deploy of migration `service_providers.0059_delete_claude_sonnet_4_20250514` failed at COMMIT with a `ForeignKeyViolation` on `pipelines_node.llm_provider_id` (a deleted provider). The data migration itself succeeded — the deferred FK constraint fired at commit.

Root cause: `Node._sync_resource_fk_fields` re-derives every resource FK column from the `params` JSON but never checked that the referenced row still exists. `LlmProvider.delete()` has no guard against node references (unlike `LlmProviderModel`), so deleting one leaves `on_delete=SET_NULL` to null the FK column while the stale id lingers in `params`. When the migration touched such a node, sync resurrected the dangling id into the column, and the deferred constraint blew up at commit.

Fix: coerce a scalar FK id to null when the referenced row no longer exists, matching what `backfill_node_fks` and the `collection_indexes` M2M already do. Existence is checked via `_base_manager` so a valid reference to a soft-deleted (archived) resource isn't mistaken for dangling.

Migration 0059 rolled back cleanly (idempotency timestamp included), so it re-runs and succeeds on redeploy — no migration change needed.

### Migrations
N/A — no new migration; unblocks an existing one on redeploy.

### Docs and Changelog
- [ ] This PR requires docs/changelog update