### PR TITLE
fix: only select columns the widget notification commands use

### DIFF
--- a/apps/data_migrations/management/commands/notify_deprecated_widget_versions.py
+++ b/apps/data_migrations/management/commands/notify_deprecated_widget_versions.py
@@ -60,9 +60,19 @@ class Command(IdempotentCommand):
             return {}
 
         cutoff = timezone.now() - RECENT_ACTIVITY_WINDOW
-        channels = ExperimentChannel.objects.filter(
-            platform=ChannelPlatform.EMBEDDED_WIDGET, deleted=False
-        ).select_related("experiment", "team")
+        channels = (
+            ExperimentChannel.objects.filter(platform=ChannelPlatform.EMBEDDED_WIDGET, deleted=False)
+            .select_related("experiment", "team")
+            .only(
+                "widget_version",
+                "team__slug",
+                "team__name",
+                "experiment__name",
+                "experiment__team",
+                "experiment__working_version",
+                "experiment__version_number",
+            )
+        )
         if not channels.exists():
             return {}
         channels_with_recent_sessions = set(

--- a/apps/data_migrations/management/commands/notify_widget_version_release.py
+++ b/apps/data_migrations/management/commands/notify_widget_version_release.py
@@ -52,9 +52,18 @@ class Command(IdempotentCommand):
         return f"Notified {len(affected_by_team)} team(s)"
 
     def _collect_affected_teams(self) -> dict:
-        channels = ExperimentChannel.objects.filter(
-            platform=ChannelPlatform.EMBEDDED_WIDGET, deleted=False
-        ).select_related("experiment", "team")
+        channels = (
+            ExperimentChannel.objects.filter(platform=ChannelPlatform.EMBEDDED_WIDGET, deleted=False)
+            .select_related("experiment", "team")
+            .only(
+                "team__slug",
+                "team__name",
+                "experiment__name",
+                "experiment__team",
+                "experiment__working_version",
+                "experiment__version_number",
+            )
+        )
 
         affected_by_team = {}
         for channel in channels:


### PR DESCRIPTION
### Product Description
No change.

### Technical Description
The `python-tests` job on main is failing ([run](https://github.com/dimagi/open-chat-studio/actions/runs/28869026588)) with `column teams_team.files_export_id does not exist` on every DB-backed test. The widget notification commands run inside data migrations (`RunDataMigration`, e.g. `bot_channels.0028`) and query live models with `select_related("team")`, which puts every `Team`/`Experiment` column into the JOIN's SELECT clause — even with zero rows. On a fresh database the migration graph is free to order `bot_channels.0028` before `teams.0013` (added in #3720), so the query references a column that doesn't exist yet and the migration run fails. PR runs use `--no-migrations`, so only main caught it.

Fix: restrict both commands' queries with `.only(...)` to the columns their code path actually touches, all of which predate the migrations that invoke them. Unlisted columns become deferred and are never referenced in SQL.

Bumping `bot_channels.0028`'s dependency to `teams.0013` was considered and rejected: 0028 is already applied in production while `teams.0013` isn't, so the new dependency would raise `InconsistentMigrationHistory` on the next prod migrate.

Verified with a full fresh-DB migration run (`pytest apps/data_migrations/ --create-db`), which reproduced the failure before the fix.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)