### PR TITLE
fix: run teams.0013 before service_providers.0059 data migration

### DIFF
--- a/apps/service_providers/migrations/0059_delete_claude_sonnet_4_20250514.py
+++ b/apps/service_providers/migrations/0059_delete_claude_sonnet_4_20250514.py
@@ -7,6 +7,9 @@ from apps.service_providers.migration_utils import llm_model_migration
 class Migration(migrations.Migration):
     dependencies = [
         ("service_providers", "0058_add_claude_sonnet_5"),
+        # The data migration below queries Team with live models, so all Team
+        # schema changes must be applied first.
+        ("teams", "0013_team_files_export_team_files_export_task_id"),
     ]
 
     operations = [


### PR DESCRIPTION
### Product Description
No change.

### Technical Description
The `remove_deprecated_models` data migration in `service_providers.0059` queries `Team` with live models, but declared no dependency on `teams.0013` (added in the same release, #3720). In production the migration plan ran 0059 first, so the `Team` SELECT referenced `files_export_id`/`files_export_task_id` before those columns existed and failed with `ProgrammingError: column teams_team.files_export_id does not exist` (Sentry issue 7598189103).

Adding the dependency forces `teams.0013` to apply first. 0059's transaction rolled back fully in production, so it is still unapplied and will rerun cleanly on the next deploy.

### Migrations
- [x] The migrations are backwards compatible

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)