### PR TITLE
feat: add progress bar for chat export

### DIFF
--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -200,6 +200,10 @@ def generate_export_rows(
     session_cache: dict[int, dict] = {}
     processed = 0
 
+    def report(count):
+        if progress_callback:
+            progress_callback(count)
+
     while True:
         chunk = list(base_qs.filter(pk__gt=last_pk)[:EXPORT_CHUNK_SIZE])
         if not chunk:
@@ -208,15 +212,17 @@ def generate_export_rows(
         for message in chunk:
             yield _yield_row_for_message(message, session_cache, experiment, translation_language)
             processed += 1
-            if progress_callback and processed % PROGRESS_UPDATE_INTERVAL == 0:
-                progress_callback(processed)
+            if processed % PROGRESS_UPDATE_INTERVAL == 0:
+                report(processed)
 
         last_pk = chunk[-1].pk
         if len(chunk) < EXPORT_CHUNK_SIZE:
             break
 
-    if progress_callback and processed and processed % PROGRESS_UPDATE_INTERVAL != 0:
-        progress_callback(processed)
+    # Report the final tally so the last partial interval (and exports smaller than one
+    # interval) still reach 100%. processed == 0 is a no-op since 0 % INTERVAL == 0.
+    if processed % PROGRESS_UPDATE_INTERVAL != 0:
+        report(processed)
 
 
 def export_rows_to_csv_stream(rows: Iterator[list]) -> Generator[str]:

--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -18,6 +18,7 @@ from apps.web.dynamic_filters.datastructures import FilterParams
 _SPOOLED_MAX_BYTES = 10 * 1024 * 1024  # 10 MB threshold before spilling to disk
 
 EXPORT_CHUNK_SIZE = 1000
+PROGRESS_UPDATE_INTERVAL = 100
 
 UTF8_BOM = "\ufeff"  # Prepended to CSV exports so Excel detects UTF-8 encoding.
 
@@ -206,13 +207,16 @@ def generate_export_rows(
 
         for message in chunk:
             yield _yield_row_for_message(message, session_cache, experiment, translation_language)
-            if progress_callback:
-                processed += 1
+            processed += 1
+            if progress_callback and processed % PROGRESS_UPDATE_INTERVAL == 0:
                 progress_callback(processed)
 
         last_pk = chunk[-1].pk
         if len(chunk) < EXPORT_CHUNK_SIZE:
             break
+
+    if progress_callback and processed and processed % PROGRESS_UPDATE_INTERVAL != 0:
+        progress_callback(processed)
 
 
 def export_rows_to_csv_stream(rows: Iterator[list]) -> Generator[str]:

--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -65,6 +65,14 @@ def _get_participant_data_for_message(message) -> dict:
     return {}
 
 
+def count_export_messages(sessions_queryset) -> int:
+    """Total number of messages an export of these sessions will produce.
+
+    Used as the denominator for export progress reporting.
+    """
+    return _build_message_queryset(sessions_queryset).count()
+
+
 def _build_message_queryset(sessions_queryset):
     """Return the base ChatMessage queryset for export, ordered by pk for keyset pagination."""
     return (
@@ -172,7 +180,9 @@ def _yield_row_for_message(message, session_cache, experiment, translation_langu
     return _build_message_row(message, participant_data, sc, experiment, trace_id, translation_language)
 
 
-def generate_export_rows(experiment, sessions_queryset, translation_language=None) -> Generator[list]:
+def generate_export_rows(
+    experiment, sessions_queryset, translation_language=None, progress_callback=None
+) -> Generator[list]:
     """Yield the header row, then one data row per message across all matching sessions.
 
     Messages are processed in chunks of EXPORT_CHUNK_SIZE using keyset pagination so
@@ -187,6 +197,7 @@ def generate_export_rows(experiment, sessions_queryset, translation_language=Non
     base_qs = _build_message_queryset(sessions_queryset)
     last_pk = 0
     session_cache: dict[int, dict] = {}
+    processed = 0
 
     while True:
         chunk = list(base_qs.filter(pk__gt=last_pk)[:EXPORT_CHUNK_SIZE])
@@ -195,6 +206,9 @@ def generate_export_rows(experiment, sessions_queryset, translation_language=Non
 
         for message in chunk:
             yield _yield_row_for_message(message, session_cache, experiment, translation_language)
+            if progress_callback:
+                processed += 1
+                progress_callback(processed)
 
         last_pk = chunk[-1].pk
         if len(chunk) < EXPORT_CHUNK_SIZE:
@@ -219,7 +233,7 @@ def export_rows_to_csv_stream(rows: Iterator[list]) -> Generator[str]:
 
 
 def export_to_tempfile(
-    experiment, sessions_queryset, translation_language=None, compress=False
+    experiment, sessions_queryset, translation_language=None, compress=False, progress_callback=None
 ) -> io.BufferedRandom | tempfile.SpooledTemporaryFile[bytes]:
     """Write the CSV export to a temporary file and return it, seeked to 0.
 
@@ -250,7 +264,7 @@ def export_to_tempfile(
         tmp = tempfile.TemporaryFile(mode="wb+")  # noqa: SIM115
         with gzip.open(tmp, "wt", encoding="utf-8", newline="") as gz:
             writer = csv.writer(gz, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
-            for row in generate_export_rows(experiment, sessions_queryset, translation_language):
+            for row in generate_export_rows(experiment, sessions_queryset, translation_language, progress_callback):
                 writer.writerow(row)
     else:
         # Wrap in a TextIOWrapper so csv.writer receives a text-mode file object.
@@ -259,7 +273,7 @@ def export_to_tempfile(
         tmp = tempfile.SpooledTemporaryFile(max_size=_SPOOLED_MAX_BYTES, mode="wb+")  # noqa: SIM115
         text_wrapper = io.TextIOWrapper(tmp, encoding="utf-8", newline="")
         writer = csv.writer(text_wrapper, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
-        for row in generate_export_rows(experiment, sessions_queryset, translation_language):
+        for row in generate_export_rows(experiment, sessions_queryset, translation_language, progress_callback):
             writer.writerow(row)
         text_wrapper.flush()
         text_wrapper.detach()

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -37,6 +37,7 @@ def async_export_chat(self, experiment_id: int, query_params: dict, time_zone) -
 
     def report_progress(current):
         progress_recorder.set_progress(current, total, description=f"Processing {current} of {total} messages")
+        logger.info("Chat export '%s': processed %s/%s messages", experiment.name, current, total)
 
     # Use a spooled temp file so small exports stay in memory while large ones spill
     # to disk, avoiding a single large in-memory allocation for the whole CSV.

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 from celery.app import shared_task
 from celery.utils.log import get_task_logger
+from celery_progress.backend import ProgressRecorder
 from django.core.files.base import ContentFile
 from django.utils import timezone
 from langchain_core.messages import AIMessage, HumanMessage
@@ -13,7 +14,7 @@ from apps.channels.datamodels import Attachment, BaseMessage
 from apps.channels.web_channel import WebChannel
 from apps.chat.bots import create_conversation
 from apps.chat.exceptions import UserReportableError
-from apps.experiments.export import export_to_tempfile, get_filtered_sessions
+from apps.experiments.export import count_export_messages, export_to_tempfile, get_filtered_sessions
 from apps.experiments.models import Experiment, ExperimentSession, PromptBuilderHistory, SourceMaterial
 from apps.files.models import File, FilePurpose
 from apps.service_providers.llm_service.retry import with_llm_retry
@@ -30,11 +31,18 @@ def async_export_chat(self, experiment_id: int, query_params: dict, time_zone) -
     experiment = Experiment.objects.get(id=experiment_id)
     filtered_sessions = get_filtered_sessions(experiment, query_params, time_zone)
     filename = f"{experiment.name} Chat Export {timezone.now().strftime('%Y-%m-%d_%H-%M-%S')}.csv.gz"
+
+    progress_recorder = ProgressRecorder(self)
+    total = count_export_messages(filtered_sessions)
+
+    def report_progress(current):
+        progress_recorder.set_progress(current, total, description=f"Processing {current} of {total} messages")
+
     # Use a spooled temp file so small exports stay in memory while large ones spill
     # to disk, avoiding a single large in-memory allocation for the whole CSV.
     # compress=True writes a gzip stream, reducing file size by ~80–90% for typical
     # chat exports and dramatically cutting S3 storage and download time.
-    with export_to_tempfile(experiment, filtered_sessions, compress=True) as tmp:
+    with export_to_tempfile(experiment, filtered_sessions, compress=True, progress_callback=report_progress) as tmp:
         file_obj = File.objects.create(
             name=filename,
             team=experiment.team,

--- a/apps/experiments/tests/test_export.py
+++ b/apps/experiments/tests/test_export.py
@@ -6,7 +6,13 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from apps.chat.models import ChatMessage, ChatMessageType
-from apps.experiments.export import UTF8_BOM, export_rows_to_csv_stream, filtered_export_to_csv
+from apps.experiments.export import (
+    UTF8_BOM,
+    count_export_messages,
+    export_rows_to_csv_stream,
+    filtered_export_to_csv,
+    generate_export_rows,
+)
 from apps.service_providers.tracing import OCS_TRACE_PROVIDER
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
@@ -355,3 +361,38 @@ def test_export_rows_to_csv_stream_preserves_special_characters():
     rows = [["Message"], ["I’m at the café"]]
     output = "".join(export_rows_to_csv_stream(iter(rows)))
     assert "I’m at the café" in output
+
+
+def _make_session_with_messages(count: int):
+    session = ExperimentSessionFactory.create()
+    for i in range(count):
+        ChatMessage.objects.create(
+            chat=session.chat,
+            content=f"message {i}",
+            message_type=ChatMessageType.HUMAN,
+        )
+    return session
+
+
+@pytest.mark.django_db()
+def test_count_export_messages():
+    session = _make_session_with_messages(3)
+    assert count_export_messages(session.experiment.sessions.all()) == 3
+
+
+@pytest.mark.django_db()
+def test_generate_export_rows_reports_progress_per_message():
+    """progress_callback is called once per message with the cumulative message count."""
+    session = _make_session_with_messages(5)
+    calls = []
+
+    with patch("apps.experiments.export.EXPORT_CHUNK_SIZE", 2):
+        list(
+            generate_export_rows(
+                session.experiment,
+                session.experiment.sessions.all(),
+                progress_callback=calls.append,
+            )
+        )
+
+    assert calls == [1, 2, 3, 4, 5]

--- a/apps/experiments/tests/test_export.py
+++ b/apps/experiments/tests/test_export.py
@@ -381,8 +381,27 @@ def test_count_export_messages():
 
 
 @pytest.mark.django_db()
-def test_generate_export_rows_reports_progress_per_message():
-    """progress_callback is called once per message with the cumulative message count."""
+def test_generate_export_rows_reports_progress_every_interval():
+    """progress_callback fires every PROGRESS_UPDATE_INTERVAL messages, plus a final total."""
+    session = _make_session_with_messages(5)
+    calls = []
+
+    with patch("apps.experiments.export.PROGRESS_UPDATE_INTERVAL", 2):
+        list(
+            generate_export_rows(
+                session.experiment,
+                session.experiment.sessions.all(),
+                progress_callback=calls.append,
+            )
+        )
+
+    # Fires at 2 and 4 (every interval), then a final flush at 5 (partial interval).
+    assert calls == [2, 4, 5]
+
+
+@pytest.mark.django_db()
+def test_generate_export_rows_progress_interval_independent_of_chunk_size():
+    """Progress cadence follows PROGRESS_UPDATE_INTERVAL, not the DB read batch size."""
     session = _make_session_with_messages(5)
     calls = []
 
@@ -395,4 +414,4 @@ def test_generate_export_rows_reports_progress_per_message():
             )
         )
 
-    assert calls == [1, 2, 3, 4, 5]
+    assert calls == [5]

--- a/apps/experiments/tests/test_tasks.py
+++ b/apps/experiments/tests/test_tasks.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,16 +21,19 @@ def test_async_export_chat_returns_file_id():
 
 @pytest.mark.django_db()
 @patch("apps.experiments.tasks.ProgressRecorder")
-def test_async_export_chat_reports_progress(mock_recorder_cls):
+def test_async_export_chat_reports_progress(mock_recorder_cls, caplog):
     recorder = mock_recorder_cls.return_value
     session = ExperimentSessionFactory.create()
     for i in range(2):
         ChatMessage.objects.create(chat=session.chat, content=f"m{i}", message_type=ChatMessageType.HUMAN)
 
-    async_export_chat.run(session.experiment_id, {}, "UTC")
+    with caplog.at_level(logging.INFO, logger="ocs.experiments"):
+        async_export_chat.run(session.experiment_id, {}, "UTC")
 
     # Final progress update reports all messages processed against the total.
     recorder.set_progress.assert_called_with(2, 2, description="Processing 2 of 2 messages")
+    # Progress is also logged (with the experiment name) so it can be tracked in the shell.
+    assert f"Chat export '{session.experiment.name}': processed 2/2 messages" in caplog.text
 
 
 @pytest.mark.django_db()

--- a/apps/experiments/tests/test_tasks.py
+++ b/apps/experiments/tests/test_tasks.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.test import override_settings
 
+from apps.chat.models import ChatMessage, ChatMessageType
 from apps.experiments.tasks import async_create_experiment_version, async_export_chat, get_response_for_webchat_task
 from apps.files.models import File, FilePurpose
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
@@ -15,6 +16,20 @@ def test_async_export_chat_returns_file_id():
     file = File.objects.get(id=result["file_id"])
     assert file.purpose == FilePurpose.DATA_EXPORT
     assert file.expiry_date is not None
+
+
+@pytest.mark.django_db()
+@patch("apps.experiments.tasks.ProgressRecorder")
+def test_async_export_chat_reports_progress(mock_recorder_cls):
+    recorder = mock_recorder_cls.return_value
+    session = ExperimentSessionFactory.create()
+    for i in range(2):
+        ChatMessage.objects.create(chat=session.chat, content=f"m{i}", message_type=ChatMessageType.HUMAN)
+
+    async_export_chat.run(session.experiment_id, {}, "UTC")
+
+    # Final progress update reports all messages processed against the total.
+    recorder.set_progress.assert_called_with(2, 2, description="Processing 2 of 2 messages")
 
 
 @pytest.mark.django_db()

--- a/apps/experiments/urls.py
+++ b/apps/experiments/urls.py
@@ -89,11 +89,6 @@ urlpatterns = [
     path("e/<int:experiment_id>/events/", include("apps.events.urls")),
     # superuser tools
     path("e/<int:experiment_id>/exports/generate", views.generate_chat_export, name="generate_chat_export"),
-    path(
-        "e/<int:experiment_id>/exports/result/<slug:task_id>",
-        views.get_export_download_link,
-        name="get_export_download_link",
-    ),
     # public links
     path(
         "e/<uuid:experiment_id>/s/<str:session_id>/",

--- a/apps/experiments/views/__init__.py
+++ b/apps/experiments/views/__init__.py
@@ -20,7 +20,6 @@ from .experiment import (  # noqa: F401
     experiment_session_messages_view,
     generate_chat_export,
     get_experiment_version_names,
-    get_export_download_link,
     get_image_html,
     get_message_response,
     get_release_status_badge,

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -5,8 +5,6 @@ from typing import cast
 from urllib.parse import urlencode, urlparse
 
 import jwt
-from celery.result import AsyncResult
-from celery_progress.backend import Progress
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required
@@ -435,21 +433,6 @@ def generate_chat_export(request, team_slug: str, experiment_id: str):
     return TemplateResponse(
         request, "experiments/components/exports.html", {"experiment": experiment, "task_id": task_id}
     )
-
-
-@permission_required("experiments.download_chats", raise_exception=True)
-@login_and_team_required
-def get_export_download_link(request, team_slug: str, experiment_id: str, task_id: str):
-    experiment = get_object_or_404(Experiment, id=experiment_id, team=request.team)
-    info = Progress(AsyncResult(task_id)).get_info()
-    context: dict[str, object] = {"experiment": experiment}
-    if info["complete"] and info["success"]:
-        file_id = info["result"]["file_id"]
-        download_url = reverse("files:base", kwargs={"team_slug": team_slug, "pk": file_id}) + "?allow_s3=1"
-        context["export_download_url"] = download_url
-    else:
-        context["task_id"] = task_id
-    return TemplateResponse(request, "experiments/components/exports.html", context)
 
 
 def _record_consent_and_redirect(

--- a/templates/chatbots/single_chatbot_home.html
+++ b/templates/chatbots/single_chatbot_home.html
@@ -4,6 +4,7 @@
 {% block page_head %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'css/editors.css' %}">
+  <script src="{% static 'celery_progress/celery_progress.js' %}"></script>
 {% endblock page_head %}
 
 {% block page_js %}

--- a/templates/experiments/components/exports.html
+++ b/templates/experiments/components/exports.html
@@ -58,7 +58,10 @@
             function resetGenerateButton() {
               if (!generateBtn) return;
               generateBtn.disabled = false;
-              generateBtn.innerHTML = '<i class="fa-solid fa-file-export"></i> ' + GENERATE_LABEL;
+              // Set the label via textContent, not innerHTML: escapejs guards the JS string
+              // context but not HTML, so a translated label with <, > or & stays literal text.
+              generateBtn.innerHTML = '<i class="fa-solid fa-file-export"></i> ';
+              generateBtn.appendChild(document.createTextNode(GENERATE_LABEL));
             }
 
             function showError(message) {
@@ -86,7 +89,8 @@
                   return;
                 }
                 if (downloadLink) {
-                  downloadLink.href = downloadBaseUrl.replace(/\/0(\/?$)/, "/" + fileId + "$1") + "?allow_s3";
+                  // Function replacement so a "$" in fileId can't be read as a $-substitution.
+                  downloadLink.href = downloadBaseUrl.replace(/\/0(\/?$)/, (_m, p1) => "/" + fileId + p1) + "?allow_s3";
                   downloadLink.style.display = "";
                 }
                 if (progressEl) progressEl.style.display = "none";

--- a/templates/experiments/components/exports.html
+++ b/templates/experiments/components/exports.html
@@ -1,30 +1,115 @@
-<div class="flex flex-row gap-1" id="chat-exports">
-    <button class="btn btn-sm btn-outline btn-primary no-animation"
+{% load i18n %}
+<div class="flex flex-row gap-2 items-center" id="chat-exports">
+    <button id="chat-export-generate-btn"
+            class="btn btn-sm btn-outline btn-primary no-animation"
             hx-post="{% url 'experiments:generate_chat_export' team.slug experiment.id %}"
             hx-trigger="click"
             hx-swap="outerHTML"
             hx-target="#chat-exports"
             {% if task_id %}disabled{% endif %}>
-        <i class="fa-solid fa-file-export"></i>
         {% if task_id %}
-            <span class="loading loading-bars loading-xs"></span> Generating
+            <span class="loading loading-bars loading-xs"></span> {% translate "Generating" %}
         {% else %}
-            Generate Chat Export
+            <i class="fa-solid fa-file-export"></i> {% translate "Generate Chat Export" %}
         {% endif %}
     </button>
 
     {% if task_id %}
-        <div
-            hx-get="{% url 'experiments:get_export_download_link' team.slug experiment.id task_id %}"
-            hx-trigger="every 2s"
-            hx-swap="outerHTML"
-            hx-target="#chat-exports"
-        ></div>
-    {% endif %}
-    {% if export_download_url %}
-        <a class="text-sm font-medium hover:link btn btn-sm btn-outline" href="{{ export_download_url }}">
-            <i class="fa-solid fa-download"></i>
-            Download export
+        <div id="chat-export-progress" class="flex items-center gap-2">
+            <div class="progress-wrapper progress w-32 bg-base-300 rounded-full overflow-hidden h-2">
+                <div id="chat-export-bar"
+                     class="progress-bar h-full bg-primary transition-all duration-300 ease-out"
+                     style="width: 0%"></div>
+            </div>
+            <span id="chat-export-percent" class="text-xs text-base-content/70">0%</span>
+        </div>
+
+        <a id="chat-export-download" class="btn btn-sm btn-outline btn-primary" href="#" style="display: none;">
+            <i class="fa-solid fa-download"></i> {% translate "Download export" %}
         </a>
+
+        <span id="chat-export-error" class="text-xs text-error" style="display: none;"></span>
+
+        {% translate "Generate Chat Export" as generate_label %}
+        {% translate "No file was created. Please try again." as msg_no_file %}
+        {% translate "An error occurred while creating the export." as msg_generic_error %}
+        {% translate "Network error — check your connection." as msg_network_error %}
+        {% translate "Server error — please try again." as msg_server_error %}
+        <script>
+          (function () {
+            const progressUrl = "{% url 'celery_progress:task_status' task_id %}";
+            const downloadBaseUrl = "{% url 'files:base' team.slug 0 %}";
+
+            // Translated strings piped through escapejs so locales with quotes/apostrophes
+            // (e.g. French) can't break out of these JS string literals.
+            const GENERATE_LABEL = '{{ generate_label|escapejs }}';
+            const MSG_NO_FILE = '{{ msg_no_file|escapejs }}';
+            const MSG_GENERIC_ERROR = '{{ msg_generic_error|escapejs }}';
+            const MSG_NETWORK_ERROR = '{{ msg_network_error|escapejs }}';
+            const MSG_SERVER_ERROR = '{{ msg_server_error|escapejs }}';
+
+            const generateBtn = document.getElementById("chat-export-generate-btn");
+            const progressEl = document.getElementById("chat-export-progress");
+            const bar = document.getElementById("chat-export-bar");
+            const percentEl = document.getElementById("chat-export-percent");
+            const downloadLink = document.getElementById("chat-export-download");
+            const errorEl = document.getElementById("chat-export-error");
+
+            function resetGenerateButton() {
+              if (!generateBtn) return;
+              generateBtn.disabled = false;
+              generateBtn.innerHTML = '<i class="fa-solid fa-file-export"></i> ' + GENERATE_LABEL;
+            }
+
+            function showError(message) {
+              if (progressEl) progressEl.style.display = "none";
+              if (errorEl) {
+                errorEl.textContent = message;
+                errorEl.style.display = "";
+              }
+              resetGenerateButton();
+            }
+
+            CeleryProgressBar.initProgressBar(progressUrl, {
+              pollInterval: 500,
+
+              onProgress: function (_bar, _msg, progress) {
+                const percent = progress.percent || 0;
+                if (bar) bar.style.width = percent + "%";
+                if (percentEl) percentEl.textContent = Math.round(percent) + "%";
+              },
+
+              onSuccess: function (_bar, _msg, result) {
+                const fileId = result && result.file_id;
+                if (!fileId) {
+                  showError(MSG_NO_FILE);
+                  return;
+                }
+                if (downloadLink) {
+                  downloadLink.href = downloadBaseUrl.replace(/\/0(\/?$)/, "/" + fileId + "$1") + "?allow_s3";
+                  downloadLink.style.display = "";
+                }
+                if (progressEl) progressEl.style.display = "none";
+                resetGenerateButton();
+              },
+
+              onError: function () {
+                showError(MSG_GENERIC_ERROR);
+              },
+
+              onTaskError: function (_bar, _msg, excMessage) {
+                showError(excMessage || MSG_GENERIC_ERROR);
+              },
+
+              onNetworkError: function () {
+                showError(MSG_NETWORK_ERROR);
+              },
+
+              onHttpError: function () {
+                showError(MSG_SERVER_ERROR);
+              },
+            });
+          })();
+        </script>
     {% endif %}
 </div>


### PR DESCRIPTION
### Product Description
Chat exports can take a while for chatbots with lots of sessions. Previously the "Generate Chat Export" button just showed an indeterminate spinner, so users had no idea how far along the export was. This adds a live percentage progress bar (like the team-files export already has), so users can see real progress and know roughly how long is left.

### Technical Description
- `async_export_chat` now reports progress via `celery_progress.ProgressRecorder`. The total is the message count (`count_export_messages`), and progress is updated once per export chunk (1000 messages) so we don't spam Redis.
- `generate_export_rows` / `export_to_tempfile` gained an optional `progress_callback` (defaults to `None`, so the streaming export in `analysis/views.py` and all other callers are unaffected).
- Frontend: a compact inline progress bar in the sessions toolbar, driven by the `celery-progress` JS lib. `onSuccess` builds the download link client-side from the returned `file_id`. This replaces the old every-2s HTMX polling of `get_export_download_link` with the single celery-progress poll loop, and that now-unused view/URL is removed.
- Translated strings interpolated into the inline `<script>` are piped through `escapejs` so locales with apostrophes (e.g. French) can't break out of the JS string literals.

### Demo
https://www.loom.com/share/42f8d76bbfe34eda8e5df135a9380138

### Docs and Changelog
- [x] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
