### PR TITLE
feat: index ExperimentSession on (team, first_activity_at)

### DIFF
--- a/apps/experiments/migrations/0146_expsession_team_firstact_idx.py
+++ b/apps/experiments/migrations/0146_expsession_team_firstact_idx.py
@@ -1,6 +1,4 @@
-from django.contrib.postgres.operations import (
-    AddIndexConcurrently,  # ty: ignore[unresolved-import]
-)
+from django.contrib.postgres.operations import AddIndexConcurrently
 from django.db import migrations, models
 
 

--- a/apps/experiments/migrations/0146_expsession_team_firstact_idx.py
+++ b/apps/experiments/migrations/0146_expsession_team_firstact_idx.py
@@ -1,0 +1,25 @@
+from django.contrib.postgres.operations import (
+    AddIndexConcurrently,  # ty: ignore[unresolved-import]
+)
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("bot_channels", "0028_notify_widget_version_release_0_10_0"),
+        ("chat", "0025_chatmessage_chatmessage_created_at_idx"),
+        ("experiments", "0145_experimentsession_expsession_created_at_idx_and_more"),
+        ("teams", "0014_team_is_migrating"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="experimentsession",
+            index=models.Index(
+                fields=["team", "first_activity_at"],
+                name="expsession_team_firstact_idx",
+            ),
+        ),
+    ]

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1502,6 +1502,7 @@ class ExperimentSession(BaseTeamModel):
         ordering = ["-created_at"]
         indexes = [
             models.Index(fields=["team", "-last_activity_at"], name="expsession_team_lastact_idx"),
+            models.Index(fields=["team", "first_activity_at"], name="expsession_team_firstact_idx"),
             # Supports the global (cross-team) date-range scans in the admin dashboard.
             models.Index(fields=["created_at"], name="expsession_created_at_idx"),
         ]


### PR DESCRIPTION
### Product Description
No change — performance only. Speeds up the "First Message" filter on the sessions list.

### Technical Description
The `first_message` session filter queries the denormalized `first_activity_at` column, which had no index backing it (unlike `last_activity_at`, covered by `expsession_team_lastact_idx`). Adds a matching `(team, first_activity_at)` index.

Note the list view still orders by `last_activity_at`, so Postgres uses the new index to find matching rows and then sorts — the win is avoiding the scan over the team's full session set.

### Migrations
- [x] The migrations are backwards compatible

Index is created with `AddIndexConcurrently` (`atomic = False`), same pattern as `0134`/`0145`, so no table lock during deploy.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
