### PR TITLE
refactor: migrate evaluations DeleteViews off deprecated DeleteView

### DIFF
--- a/apps/evaluations/tests/test_delete_auto_population_rule.py
+++ b/apps/evaluations/tests/test_delete_auto_population_rule.py
@@ -1,0 +1,41 @@
+import pytest
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from apps.evaluations.models import DatasetAutoPopulationRule
+from apps.utils.factories.evaluations import DatasetAutoPopulationRuleFactory
+from apps.utils.factories.team import MembershipFactory
+from apps.utils.factories.user import GroupFactory
+
+
+@pytest.mark.django_db()
+def test_delete_auto_population_rule(client, team_with_users):
+    user = team_with_users.members.first()
+    rule = DatasetAutoPopulationRuleFactory.create(team=team_with_users)
+
+    client.force_login(user)
+    url = reverse("evaluations:auto_population_rule_delete", args=[team_with_users.slug, rule.id])
+    response = client.delete(url)
+
+    assert response.status_code == 200
+    assert not DatasetAutoPopulationRule.objects.filter(id=rule.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_auto_population_rule_without_change_perm_is_forbidden(client, team_with_users):
+    view_perm = Permission.objects.get(
+        content_type=ContentType.objects.get_for_model(DatasetAutoPopulationRule),
+        codename="view_datasetautopopulationrule",
+    )
+    limited_group = GroupFactory.create(name="evaluations-view-only")
+    limited_group.permissions.add(view_perm)
+    membership = MembershipFactory.create(team=team_with_users, groups=[limited_group])
+    rule = DatasetAutoPopulationRuleFactory.create(team=team_with_users)
+
+    client.force_login(membership.user)
+    url = reverse("evaluations:auto_population_rule_delete", args=[team_with_users.slug, rule.id])
+    response = client.delete(url)
+
+    assert response.status_code == 403
+    assert DatasetAutoPopulationRule.objects.filter(id=rule.id).exists()

--- a/apps/evaluations/tests/test_delete_auto_population_rule.py
+++ b/apps/evaluations/tests/test_delete_auto_population_rule.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from apps.evaluations.models import DatasetAutoPopulationRule
 from apps.utils.factories.evaluations import DatasetAutoPopulationRuleFactory
-from apps.utils.factories.team import MembershipFactory
+from apps.utils.factories.team import MembershipFactory, TeamFactory
 from apps.utils.factories.user import GroupFactory
 
 
@@ -30,6 +30,44 @@ def test_delete_auto_population_rule_without_change_perm_is_forbidden(client, te
     )
     limited_group = GroupFactory.create(name="evaluations-view-only")
     limited_group.permissions.add(view_perm)
+    membership = MembershipFactory.create(team=team_with_users, groups=[limited_group])
+    rule = DatasetAutoPopulationRuleFactory.create(team=team_with_users)
+
+    client.force_login(membership.user)
+    url = reverse("evaluations:auto_population_rule_delete", args=[team_with_users.slug, rule.id])
+    response = client.delete(url)
+
+    assert response.status_code == 403
+    assert DatasetAutoPopulationRule.objects.filter(id=rule.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_auto_population_rule_for_other_team_returns_404(client, team_with_users):
+    user = team_with_users.members.first()
+    other_team = TeamFactory.create()
+    rule = DatasetAutoPopulationRuleFactory.create(team=other_team)
+
+    client.force_login(user)
+    url = reverse("evaluations:auto_population_rule_delete", args=[team_with_users.slug, rule.id])
+    response = client.delete(url)
+
+    assert response.status_code == 404
+    assert DatasetAutoPopulationRule.objects.filter(id=rule.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_auto_population_rule_requires_change_dataset_perm_not_delete_perm(client, team_with_users):
+    """Delete is gated on change_evaluationdataset, not a delete-specific permission.
+
+    Non-obvious choice worth locking down: a user granted only
+    delete_datasetautopopulationrule (no change_evaluationdataset) must still be forbidden.
+    """
+    delete_perm = Permission.objects.get(
+        content_type=ContentType.objects.get_for_model(DatasetAutoPopulationRule),
+        codename="delete_datasetautopopulationrule",
+    )
+    limited_group = GroupFactory.create(name="evaluations-delete-rule-only")
+    limited_group.permissions.add(delete_perm)
     membership = MembershipFactory.create(team=team_with_users, groups=[limited_group])
     rule = DatasetAutoPopulationRuleFactory.create(team=team_with_users)
 

--- a/apps/evaluations/tests/test_delete_dataset.py
+++ b/apps/evaluations/tests/test_delete_dataset.py
@@ -1,0 +1,41 @@
+import pytest
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from apps.evaluations.models import EvaluationDataset
+from apps.utils.factories.evaluations import EvaluationDatasetFactory
+from apps.utils.factories.team import MembershipFactory
+from apps.utils.factories.user import GroupFactory
+
+
+@pytest.mark.django_db()
+def test_delete_dataset(client, team_with_users):
+    user = team_with_users.members.first()
+    dataset = EvaluationDatasetFactory.create(team=team_with_users)
+
+    client.force_login(user)
+    url = reverse("evaluations:dataset_delete", args=[team_with_users.slug, dataset.id])
+    response = client.delete(url)
+
+    assert response.status_code == 200
+    assert not EvaluationDataset.objects.filter(id=dataset.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_dataset_without_delete_perm_is_forbidden(client, team_with_users):
+    view_perm = Permission.objects.get(
+        content_type=ContentType.objects.get_for_model(EvaluationDataset),
+        codename="view_evaluationdataset",
+    )
+    limited_group = GroupFactory.create(name="evaluations-view-only")
+    limited_group.permissions.add(view_perm)
+    membership = MembershipFactory.create(team=team_with_users, groups=[limited_group])
+    dataset = EvaluationDatasetFactory.create(team=team_with_users)
+
+    client.force_login(membership.user)
+    url = reverse("evaluations:dataset_delete", args=[team_with_users.slug, dataset.id])
+    response = client.delete(url)
+
+    assert response.status_code == 403
+    assert EvaluationDataset.objects.filter(id=dataset.id).exists()

--- a/apps/evaluations/tests/test_delete_dataset.py
+++ b/apps/evaluations/tests/test_delete_dataset.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from apps.evaluations.models import EvaluationDataset
 from apps.utils.factories.evaluations import EvaluationDatasetFactory
-from apps.utils.factories.team import MembershipFactory
+from apps.utils.factories.team import MembershipFactory, TeamFactory
 from apps.utils.factories.user import GroupFactory
 
 
@@ -38,4 +38,18 @@ def test_delete_dataset_without_delete_perm_is_forbidden(client, team_with_users
     response = client.delete(url)
 
     assert response.status_code == 403
+    assert EvaluationDataset.objects.filter(id=dataset.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_dataset_for_other_team_returns_404(client, team_with_users):
+    user = team_with_users.members.first()
+    other_team = TeamFactory.create()
+    dataset = EvaluationDatasetFactory.create(team=other_team)
+
+    client.force_login(user)
+    url = reverse("evaluations:dataset_delete", args=[team_with_users.slug, dataset.id])
+    response = client.delete(url)
+
+    assert response.status_code == 404
     assert EvaluationDataset.objects.filter(id=dataset.id).exists()

--- a/apps/evaluations/tests/test_delete_evaluator.py
+++ b/apps/evaluations/tests/test_delete_evaluator.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from apps.evaluations.models import Evaluator
 from apps.utils.factories.evaluations import EvaluatorFactory
-from apps.utils.factories.team import MembershipFactory
+from apps.utils.factories.team import MembershipFactory, TeamFactory
 from apps.utils.factories.user import GroupFactory
 
 
@@ -38,4 +38,18 @@ def test_delete_evaluator_without_delete_perm_is_forbidden(client, team_with_use
     response = client.delete(url)
 
     assert response.status_code == 403
+    assert Evaluator.objects.filter(id=evaluator.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_evaluator_for_other_team_returns_404(client, team_with_users):
+    user = team_with_users.members.first()
+    other_team = TeamFactory.create()
+    evaluator = EvaluatorFactory.create(team=other_team)
+
+    client.force_login(user)
+    url = reverse("evaluations:evaluator_delete", args=[team_with_users.slug, evaluator.id])
+    response = client.delete(url)
+
+    assert response.status_code == 404
     assert Evaluator.objects.filter(id=evaluator.id).exists()

--- a/apps/evaluations/tests/test_delete_evaluator.py
+++ b/apps/evaluations/tests/test_delete_evaluator.py
@@ -1,0 +1,41 @@
+import pytest
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from apps.evaluations.models import Evaluator
+from apps.utils.factories.evaluations import EvaluatorFactory
+from apps.utils.factories.team import MembershipFactory
+from apps.utils.factories.user import GroupFactory
+
+
+@pytest.mark.django_db()
+def test_delete_evaluator(client, team_with_users):
+    user = team_with_users.members.first()
+    evaluator = EvaluatorFactory.create(team=team_with_users)
+
+    client.force_login(user)
+    url = reverse("evaluations:evaluator_delete", args=[team_with_users.slug, evaluator.id])
+    response = client.delete(url)
+
+    assert response.status_code == 200
+    assert not Evaluator.objects.filter(id=evaluator.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_evaluator_without_delete_perm_is_forbidden(client, team_with_users):
+    view_perm = Permission.objects.get(
+        content_type=ContentType.objects.get_for_model(Evaluator),
+        codename="view_evaluator",
+    )
+    limited_group = GroupFactory.create(name="evaluations-view-only")
+    limited_group.permissions.add(view_perm)
+    membership = MembershipFactory.create(team=team_with_users, groups=[limited_group])
+    evaluator = EvaluatorFactory.create(team=team_with_users)
+
+    client.force_login(membership.user)
+    url = reverse("evaluations:evaluator_delete", args=[team_with_users.slug, evaluator.id])
+    response = client.delete(url)
+
+    assert response.status_code == 403
+    assert Evaluator.objects.filter(id=evaluator.id).exists()

--- a/apps/evaluations/views/auto_population_views.py
+++ b/apps/evaluations/views/auto_population_views.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.views.decorators.http import require_POST
-from django.views.generic import CreateView, DeleteView, UpdateView
+from django.views.generic import CreateView, UpdateView, View
 
 from apps.evaluations.forms import DatasetAutoPopulationRuleForm
 from apps.evaluations.models import DatasetAutoPopulationRule, EvaluationDataset, EvaluationMode
@@ -87,21 +87,11 @@ class EditAutoPopulationRule(_RuleViewMixin, UpdateView):
         return response
 
 
-class DeleteAutoPopulationRule(LoginAndTeamRequiredMixin, PermissionRequiredMixin, DeleteView):
+class DeleteAutoPopulationRule(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
     permission_required = "evaluations.change_evaluationdataset"
-    model = DatasetAutoPopulationRule
-
-    def get_queryset(self):
-        return DatasetAutoPopulationRule.objects.filter(team=self.request.team)
-
-    def get_success_url(self):
-        return reverse(
-            "evaluations:dataset_edit",
-            args=[self.request.team.slug, self.get_object().dataset_id],
-        )
 
     def delete(self, request, *args, **kwargs):
-        self.get_object().delete()
+        get_object_or_404(DatasetAutoPopulationRule, team=request.team, pk=kwargs["pk"]).delete()
         return HttpResponse(status=200)
 
 

--- a/apps/evaluations/views/dataset_views.py
+++ b/apps/evaluations/views/dataset_views.py
@@ -18,7 +18,7 @@ from django.utils import timezone
 from django.utils.html import escape
 from django.views import View
 from django.views.decorators.http import require_http_methods, require_POST
-from django.views.generic import CreateView, DeleteView, TemplateView, UpdateView
+from django.views.generic import CreateView, TemplateView, UpdateView
 from django_htmx.http import reswap, retarget
 from django_tables2 import LazyPaginator, SingleTableView
 
@@ -155,17 +155,13 @@ class EditDataset(LoginAndTeamRequiredMixin, PermissionRequiredMixin, UpdateView
         return reverse("evaluations:dataset_edit", args=[self.request.team.slug, self.object.pk])
 
 
-class DeleteDataset(LoginAndTeamRequiredMixin, PermissionRequiredMixin, DeleteView):
+class DeleteDataset(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
     permission_required = "evaluations.delete_evaluationdataset"
-    model = EvaluationDataset
-
-    def get_queryset(self):
-        return EvaluationDataset.objects.filter(team=self.request.team)
 
     def delete(self, request, *args, **kwargs):
         """Handle AJAX delete requests."""
-        self.object = self.get_object()
-        self.object.delete()
+        dataset = get_object_or_404(EvaluationDataset, team=request.team, pk=kwargs["pk"])
+        dataset.delete()
 
         return HttpResponse(status=200)
 

--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -18,7 +18,7 @@ from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_http_methods, require_POST
-from django.views.generic import CreateView, DeleteView, TemplateView, UpdateView, View
+from django.views.generic import CreateView, TemplateView, UpdateView, View
 from django_tables2 import SingleTableView, columns, tables
 
 from apps.evaluations.const import EVALUATION_RUN_FIXED_HEADERS
@@ -124,16 +124,12 @@ class EditEvaluation(LoginAndTeamRequiredMixin, PermissionRequiredMixin, UpdateV
         return reverse("evaluations:home", args=[self.request.team.slug])
 
 
-class DeleteEvaluation(LoginAndTeamRequiredMixin, PermissionRequiredMixin, DeleteView):
+class DeleteEvaluation(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
     permission_required = "evaluations.delete_evaluationconfig"
-    model = EvaluationConfig
-
-    def get_queryset(self):
-        return EvaluationConfig.objects.filter(team=self.request.team)
 
     def delete(self, request, *args, **kwargs):
-        self.object = self.get_object()
-        self.object.delete()
+        evaluation = get_object_or_404(EvaluationConfig, team=request.team, pk=kwargs["pk"])
+        evaluation.delete()
         response = HttpResponse(status=200)
         if request.GET.get("redirect") == "1":
             response["HX-Redirect"] = reverse("evaluations:home", args=[self.request.team.slug])

--- a/apps/evaluations/views/evaluator_views.py
+++ b/apps/evaluations/views/evaluator_views.py
@@ -5,9 +5,9 @@ from functools import lru_cache
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db import transaction
 from django.http import HttpResponse
-from django.shortcuts import redirect
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.views.generic import CreateView, DeleteView, TemplateView, UpdateView
+from django.views.generic import CreateView, TemplateView, UpdateView, View
 from django_tables2 import SingleTableView
 
 from apps.annotations.models import Tag
@@ -175,16 +175,12 @@ class EditEvaluator(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Evaluato
         return reverse("evaluations:evaluator_home", args=[self.request.team.slug])
 
 
-class DeleteEvaluator(LoginAndTeamRequiredMixin, PermissionRequiredMixin, DeleteView):
+class DeleteEvaluator(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
     permission_required = "evaluations.delete_evaluator"
-    model = Evaluator
-
-    def get_queryset(self):
-        return Evaluator.objects.filter(team=self.request.team)
 
     def delete(self, request, *args, **kwargs):
-        self.object = self.get_object()
-        self.object.delete()
+        evaluator = get_object_or_404(Evaluator, team=request.team, pk=kwargs["pk"])
+        evaluator.delete()
         return HttpResponse(status=200)
 
 


### PR DESCRIPTION
### Product Description

No user-facing change.

### Technical Description

Closes #3384.

The issue proposed a straight rename from `delete()` to `form_valid()`, but these views receive real HTTP `DELETE` requests via htmx, and `form_valid()` is only reachable via `POST`. The literal rename 500s (confirmed locally). Instead, `DeleteEvaluator`, `DeleteDataset`, `DeleteEvaluation`, and `DeleteAutoPopulationRule` are switched from `DeleteView` to a plain `View`, matching the existing `DeleteFile`/`DeleteCustomAction` pattern. No URL, verb, or response changes. No `urls.py` changes needed.

Added characterisation tests for the three views that had none, plus cross-team isolation coverage for all three.

**Verification:** full `apps/evaluations/` suite green (290 tests), lint clean, manually verified in-browser.

### Migrations

- [x] The migrations are backwards compatible

No migrations in this PR.

### Demo

Non-visual refactor, nothing to demo.

### Docs and Changelog

- [ ] This PR requires docs/changelog update
