### PR TITLE
test: cover DeleteEvaluation cross-team isolation

### DIFF
--- a/apps/evaluations/tests/test_delete_evaluation.py
+++ b/apps/evaluations/tests/test_delete_evaluation.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from apps.evaluations.models import EvaluationConfig, EvaluationRun
 from apps.utils.factories.evaluations import EvaluationConfigFactory
-from apps.utils.factories.team import MembershipFactory
+from apps.utils.factories.team import MembershipFactory, TeamFactory
 from apps.utils.factories.user import GroupFactory
 
 
@@ -52,6 +52,20 @@ def test_delete_evaluation_redirect_param_zero_does_not_redirect(client, team_wi
     assert response.status_code == 200
     assert "HX-Redirect" not in response.headers
     assert not EvaluationConfig.objects.filter(id=evaluation.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_evaluation_for_other_team_returns_404(client, team_with_users):
+    user = team_with_users.members.first()
+    other_team = TeamFactory.create()
+    evaluation = EvaluationConfigFactory.create(team=other_team)
+
+    client.force_login(user)
+    url = reverse("evaluations:delete", args=[team_with_users.slug, evaluation.id])
+    response = client.delete(url)
+
+    assert response.status_code == 404
+    assert EvaluationConfig.objects.filter(id=evaluation.id).exists()
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
### Product Description

No user-facing change, test-only.

### Technical Description

Closes #3791.

Follow-up to #3790. Code review on that PR flagged that `DeleteEvaluator`, `DeleteDataset`, and `DeleteAutoPopulationRule` needed cross-team isolation tests (confirming deleting another team's object via a guessed pk returns 404, not a leak), since that refactor replaced `DeleteView`'s queryset-based scoping with a hand-rolled `get_object_or_404(Model, team=request.team, pk=...)` in each view.

`DeleteEvaluation` has the exact same pattern and the exact same risk, but I missed adding the matching test for it before submitting #3790 for review.

Adds `test_delete_evaluation_for_other_team_returns_404` to `test_delete_evaluation.py`, mirroring the pattern already in the other three test files.

**Verification:** full `apps/evaluations/` suite green (291 tests), lint clean.

### Migrations

- [x] The migrations are backwards compatible

No migrations in this PR.

### Demo

Test-only change, nothing to demo.

### Docs and Changelog

- [ ] This PR requires docs/changelog update