### PR TITLE
refactor: standardize delete() signature style across evaluations delete views

### DIFF
--- a/apps/evaluations/views/auto_population_views.py
+++ b/apps/evaluations/views/auto_population_views.py
@@ -90,8 +90,8 @@ class EditAutoPopulationRule(_RuleViewMixin, UpdateView):
 class DeleteAutoPopulationRule(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
     permission_required = "evaluations.change_evaluationdataset"
 
-    def delete(self, request, *args, **kwargs):
-        get_object_or_404(DatasetAutoPopulationRule, team=request.team, pk=kwargs["pk"]).delete()
+    def delete(self, request, team_slug: str, pk: int):
+        get_object_or_404(DatasetAutoPopulationRule, team=request.team, pk=pk).delete()
         return HttpResponse(status=200)
 
 

--- a/apps/evaluations/views/dataset_views.py
+++ b/apps/evaluations/views/dataset_views.py
@@ -158,9 +158,9 @@ class EditDataset(LoginAndTeamRequiredMixin, PermissionRequiredMixin, UpdateView
 class DeleteDataset(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
     permission_required = "evaluations.delete_evaluationdataset"
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request, team_slug: str, pk: int):
         """Handle AJAX delete requests."""
-        dataset = get_object_or_404(EvaluationDataset, team=request.team, pk=kwargs["pk"])
+        dataset = get_object_or_404(EvaluationDataset, team=request.team, pk=pk)
         dataset.delete()
 
         return HttpResponse(status=200)

--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -127,8 +127,8 @@ class EditEvaluation(LoginAndTeamRequiredMixin, PermissionRequiredMixin, UpdateV
 class DeleteEvaluation(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
     permission_required = "evaluations.delete_evaluationconfig"
 
-    def delete(self, request, *args, **kwargs):
-        evaluation = get_object_or_404(EvaluationConfig, team=request.team, pk=kwargs["pk"])
+    def delete(self, request, team_slug: str, pk: int):
+        evaluation = get_object_or_404(EvaluationConfig, team=request.team, pk=pk)
         evaluation.delete()
         response = HttpResponse(status=200)
         if request.GET.get("redirect") == "1":

--- a/apps/evaluations/views/evaluator_views.py
+++ b/apps/evaluations/views/evaluator_views.py
@@ -178,8 +178,8 @@ class EditEvaluator(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Evaluato
 class DeleteEvaluator(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
     permission_required = "evaluations.delete_evaluator"
 
-    def delete(self, request, *args, **kwargs):
-        evaluator = get_object_or_404(Evaluator, team=request.team, pk=kwargs["pk"])
+    def delete(self, request, team_slug: str, pk: int):
+        evaluator = get_object_or_404(Evaluator, team=request.team, pk=pk)
         evaluator.delete()
         return HttpResponse(status=200)
 


### PR DESCRIPTION
### Product Description

No user-facing change.

### Technical Description

Closes #3792.

Follow-up to #3790. `DeleteFile` (`apps/files/views.py:289`) and `DeleteCustomAction` (`apps/custom_actions/views.py:160`) use an explicit `def delete(self, request, team_slug: str, pk: int):` signature. The four views migrated in #3790 instead used `def delete(self, request, *args, **kwargs):` with `kwargs["pk"]`. Functionally identical, Django's URL resolver passes the same kwargs either way, but since #3790 explicitly modeled itself on those two views, matching their signature style is more consistent. Flagged as Minor in code review on #3790.

Considered extracting a shared base/mixin instead (the `get_object_or_404(Model, team=request.team, pk=pk)` line is now duplicated across 6 views), but the bodies diverge meaningfully beyond that one line (`DeleteFile`/`DeleteCustomAction` do reference-checking and return conditional modal responses, `DeleteCustomAction` additionally wraps in `transaction.atomic()` with row-level locking, `DeleteEvaluation` branches on a redirect query param) - a mixin would only share one line while still requiring most callers to override the rest, so kept this as a signature-only change.

No test changes needed: existing tests exercise the URL/response contract, not the view's internal parameter style. Confirmed by running the full suite unchanged.

**Verification:** full `apps/evaluations/` suite green (290 tests), `ruff check`/`ruff format --check` clean, `ty check` clean.

### Migrations

- [x] The migrations are backwards compatible

No migrations in this PR.

### Demo

Non-visual, cosmetic refactor, nothing to demo.

### Docs and Changelog

- [ ] This PR requires docs/changelog update