### PR TITLE
feat: export archived records and back-fill file content in team sync

### DIFF
--- a/apps/documents/tasks.py
+++ b/apps/documents/tasks.py
@@ -234,7 +234,7 @@ def async_create_collection_version(self, collection_id: int):
 )
 def delete_collection_task(self, collection_id: int):
     try:
-        collection = Collection.objects.get(id=collection_id)
+        collection = Collection.objects.get_all().get(id=collection_id)
     except Collection.DoesNotExist:
         return
 

--- a/apps/documents/tests/test_tasks.py
+++ b/apps/documents/tests/test_tasks.py
@@ -15,6 +15,7 @@ from apps.documents.models import CollectionFile, FileStatus
 from apps.documents.tasks import (
     async_create_collection_version,
     create_collection_zip_task,
+    delete_collection_task,
     index_collection_files_task,
     migrate_vector_stores,
     sync_all_document_sources_task,
@@ -35,6 +36,24 @@ def collection(db):
         is_index=True,
         is_remote_index=True,
     )
+
+
+@pytest.mark.django_db()
+def test_delete_collection_task_deletes_files_of_archived_collection():
+    """delete_collection_task runs after Collection.archive() has already set is_archived=True, so it
+    must load the archived row and delete its files. Regression: fetching via Collection.objects (which
+    hides archived rows) made the task a silent no-op, leaving CollectionFile rows orphaned."""
+    collection = CollectionFactory.create(is_index=False)
+    file = FileFactory.create(team=collection.team)
+    collection.files.add(file)
+    collection.is_archived = True
+    collection.save(update_fields=["is_archived"])
+    assert CollectionFile.objects.filter(collection=collection).exists()
+
+    with patch("apps.documents.utils.get_related_m2m_objects", return_value=[]):
+        delete_collection_task(collection.id)
+
+    assert not CollectionFile.objects.filter(collection=collection).exists()
 
 
 @pytest.mark.django_db()

--- a/apps/teams/export/client.py
+++ b/apps/teams/export/client.py
@@ -9,6 +9,16 @@ import requests
 _API_KEY_HEADER = "X-Api-Key"
 
 
+class FileContentNotFound(Exception):
+    """The source's file content API returned 404 -- the source is missing the blob too, so it can't
+    be backfilled. Distinct from other HTTP errors so the importer can record it and carry on rather
+    than aborting the sync."""
+
+    def __init__(self, file_id: int) -> None:
+        self.file_id = file_id
+        super().__init__(f"file {file_id} has no content on the source")
+
+
 class ResourceFetcher:
     def __init__(self, base_url, api_key, *, session=None, sleep=time.sleep):
         self.base_url = base_url.rstrip("/")
@@ -49,7 +59,24 @@ class ResourceFetcher:
                 break
             cursor = page["cursor"]
 
+    def get_file_content(self, file_id: int) -> bytes:
+        """The raw bytes of a file, from the source's file content API (``/api/files/<id>/content``).
+        Used to backfill a synced file whose blob is missing from this server's storage. A 404 means
+        the source is missing the blob too; raise ``FileContentNotFound`` so the caller can record it
+        and carry on. Other client errors surface as-is."""
+        try:
+            return self._request(f"/api/files/{file_id}/content").content
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                raise FileContentNotFound(file_id) from exc
+            raise
+
     def _get(self, path, params=None) -> dict:
+        return self._request(path, params).json()
+
+    def _request(self, path: str, params: dict | None = None) -> requests.Response:
+        """GET ``path`` with the API key header, retrying transient transport errors (timeouts, 5xx,
+        connection resets) with backoff and failing fast on 4xx. Returns the raw response."""
         url = self.base_url + path
         headers = {_API_KEY_HEADER: self.api_key}
         for attempt in range(self.max_retries):
@@ -68,5 +95,5 @@ class ResourceFetcher:
                 continue
 
             response.raise_for_status()
-            return response.json()
+            return response
         raise RuntimeError("request retries exhausted without a response")  # unreachable with max_retries >= 1

--- a/apps/teams/export/importer.py
+++ b/apps/teams/export/importer.py
@@ -312,11 +312,13 @@ class Importer:
         self, model_label: str, model: type[models.Model], source_pk: int, row: dict, field_values: dict
     ) -> tuple[models.Model, bool]:
         """Find the existing target row (via the translation map, then a model-specific natural-key
-        match) or create it. Returns (instance, created)."""
+        match) or create it. Returns (instance, created). The lookup goes through ``_base_manager`` so
+        an archived or soft-deleted target row -- hidden by the default manager -- is still matched on
+        re-import rather than duplicated (which would break the unique external_id on channels)."""
         target_pk = self.store.get_target(model_label, source_pk)
         instance = None
-        if target_pk is not None and model.objects.filter(pk=target_pk).exists():
-            instance = model.objects.get(pk=target_pk)
+        if target_pk is not None and model._base_manager.filter(pk=target_pk).exists():
+            instance = model._base_manager.get(pk=target_pk)
         elif model_label in _MATCH_EXISTING:
             instance = _MATCH_EXISTING[model_label](model, row, self.store, self.target_team)
 

--- a/apps/teams/export/importer.py
+++ b/apps/teams/export/importer.py
@@ -5,10 +5,11 @@ plain functions plus a thin loop so the transforms can be unit-tested without a 
 import contextlib
 import copy
 import functools
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
+from django.core.files.base import ContentFile
 from django.db import models, transaction
 from django.db.models.signals import m2m_changed, post_delete, post_save, pre_delete, pre_save
 from django.utils.dateparse import parse_datetime
@@ -18,6 +19,7 @@ from apps.teams.models import Flag, Membership
 from apps.teams.utils import set_current_team
 from apps.utils.fields import as_int
 
+from .client import FileContentNotFound
 from .manifest import (
     EXCLUDE_REGISTRY,
     GLOBAL_CONFIG,
@@ -177,12 +179,22 @@ _NO_UPDATE_MODELS = {"users.customuser"}
 
 
 class Importer:
-    def __init__(self, store: FKTranslationStore, private_key=None, on_user_created=None):
+    def __init__(
+        self,
+        store: FKTranslationStore,
+        private_key=None,
+        on_user_created=None,
+        fetch_file_content: Callable[[int], bytes] | None = None,
+    ):
         """``private_key`` unseals secret fields when supplied; ``on_user_created`` is called once
-        per newly created user (e.g. to send an invite)."""
+        per newly created user (e.g. to send an invite); ``fetch_file_content`` is a ``(source_pk) ->
+        bytes`` callable used to backfill a file whose blob is missing from this server's storage.
+        When it's None (the default), a missing blob surfaces as an error instead."""
         self.store = store
         self.private_key = private_key
         self.on_user_created = on_user_created
+        self.fetch_file_content = fetch_file_content
+        self.missing_files: list[str] = []
         # The single team every resource is imported into. Captured from the team row (first in the
         # manifest) and assigned to every team-scoped row, since the per-row team FK isn't exported.
         self.target_team = None
@@ -240,7 +252,7 @@ class Importer:
     ) -> tuple[models.Model, bool]:
         with transaction.atomic():
             field_values, m2m_values, timestamps = self._build_values(model_label, model, row)
-            instance, created = self._get_or_create(model_label, model, source_pk, row, field_values)
+            instance, created = self._create_or_update(model_label, model, source_pk, row, field_values)
 
             for name, target_pks in m2m_values.items():
                 getattr(instance, name).set([pk for pk in target_pks if pk is not None])
@@ -252,6 +264,49 @@ class Importer:
 
             self.store.record(model_label, source_pk, instance.pk)
         return instance, created
+
+    def _create_or_update(
+        self, model_label: str, model: type[models.Model], source_pk: int, row: dict, field_values: dict
+    ) -> tuple[models.Model, bool]:
+        """Create or update the row. Saving a ``files.file`` whose blob is missing from this server's
+        storage raises FileNotFoundError (File.save reads its size from storage); delegate that to
+        ``_handle_missing_object`` to recover, rather than let it abort the sync."""
+        try:
+            return self._get_or_create(model_label, model, source_pk, row, field_values)
+        except FileNotFoundError as exc:
+            return self._handle_missing_object(exc, model_label, model, source_pk, row, field_values)
+
+    def _handle_missing_object(
+        self,
+        exc: FileNotFoundError,
+        model_label: str,
+        model: type[models.Model],
+        source_pk: int,
+        row: dict,
+        field_values: dict,
+    ) -> tuple[models.Model, bool]:
+        """Recover a row whose backing storage object is missing. Only files are recoverable today:
+        backfill the blob from the source and retry, or on a 404 import the row without content and
+        record it. Anything else re-raises."""
+        fetch = self.fetch_file_content
+        if model_label != "files.file" or fetch is None:
+            raise exc
+        name = field_values["file"]
+        print(f"fetching content for missing file '{name}' from source")
+        try:
+            content = fetch(source_pk)
+        except FileContentNotFound:
+            print(f"file '{name}' has no content on the source; importing without it")
+            self.missing_files.append(name)
+            field_values["file"] = ""
+            return self._get_or_create(model_label, model, source_pk, row, field_values)
+        self._write_file_content(model, name, content)
+        return self._get_or_create(model_label, model, source_pk, row, field_values)
+
+    def _write_file_content(self, model: type[models.Model], name: str, content: bytes) -> None:
+        """Write a backfilled file's bytes to this server's storage at the path the row carries, so
+        the retried save finds the blob."""
+        model._meta.get_field("file").storage.save(name, ContentFile(content))
 
     def _get_or_create(
         self, model_label: str, model: type[models.Model], source_pk: int, row: dict, field_values: dict

--- a/apps/teams/export/manifest.py
+++ b/apps/teams/export/manifest.py
@@ -231,8 +231,13 @@ def model_has_team_field(model: type[Model]) -> bool:
 
 
 def team_scoped_queryset(entry: ManifestEntry, team) -> QuerySet:
-    """The model's rows for this team, including any shared global rows."""
+    """The model's rows for this team, including any shared global rows and any archived rows.
+
+    Versioned models filter ``is_archived=False`` on their default manager; ``get_all()`` bypasses
+    that so archived rows are shared across servers along with the live ones."""
     model = entry_model(entry.model)
+    manager = model.objects
+    base = manager.get_all() if hasattr(manager, "get_all") else manager
     paths = TEAM_PATH_REGISTRY.get(entry.model, "team")
     if isinstance(paths, str):
         paths = [paths]
@@ -242,7 +247,7 @@ def team_scoped_queryset(entry: ManifestEntry, team) -> QuerySet:
     spec = GLOBAL_CONFIG.get(entry.model)
     if spec:
         team_q |= Q(**{f"{spec.null_field}__isnull": True})
-    queryset = model.objects.filter(team_q)
+    queryset = base.filter(team_q)
     if len(paths) > 1:
         queryset = queryset.distinct()
     extra_filter = EXTRA_FILTERS.get(entry.model)

--- a/apps/teams/export/manifest.py
+++ b/apps/teams/export/manifest.py
@@ -231,13 +231,14 @@ def model_has_team_field(model: type[Model]) -> bool:
 
 
 def team_scoped_queryset(entry: ManifestEntry, team) -> QuerySet:
-    """The model's rows for this team, including any shared global rows and any archived rows.
+    """The model's rows for this team, including any shared global rows and any archived or
+    soft-deleted rows.
 
-    Versioned models filter ``is_archived=False`` on their default manager; ``get_all()`` bypasses
-    that so archived rows are shared across servers along with the live ones."""
+    Some default managers hide rows: versioned models filter ``is_archived=False`` and
+    ``ExperimentChannel`` filters ``deleted=False``. ``_base_manager`` is Django's unfiltered manager
+    (docs: Model._base_manager), so those rows are shared across servers along with the live ones."""
     model = entry_model(entry.model)
-    manager = model.objects
-    base = manager.get_all() if hasattr(manager, "get_all") else manager
+    base = model._base_manager
     paths = TEAM_PATH_REGISTRY.get(entry.model, "team")
     if isinstance(paths, str):
         paths = [paths]

--- a/apps/teams/export/tests/test_client.py
+++ b/apps/teams/export/tests/test_client.py
@@ -1,13 +1,14 @@
 import pytest
 import requests
 
-from apps.teams.export.client import ResourceFetcher
+from apps.teams.export.client import FileContentNotFound, ResourceFetcher
 
 
 class FakeResponse:
-    def __init__(self, status_code=200, json_data=None):
+    def __init__(self, status_code=200, json_data=None, content=b""):
         self.status_code = status_code
         self._json = json_data or {}
+        self.content = content
         self.closed = False
 
     def json(self):
@@ -15,7 +16,7 @@ class FakeResponse:
 
     def raise_for_status(self):
         if self.status_code >= 400:
-            raise requests.HTTPError(f"{self.status_code}")
+            raise requests.HTTPError(f"{self.status_code}", response=self)
 
     def close(self):
         self.closed = True
@@ -109,3 +110,27 @@ def test_client_error_is_not_retried():
     with pytest.raises(requests.HTTPError):
         _client(session).get_manifest()
     assert len(session.calls) == 1
+
+
+def test_get_file_content_hits_file_content_endpoint_and_returns_bytes():
+    session = FakeSession([FakeResponse(content=b"file-bytes")])
+    assert _client(session).get_file_content(42) == b"file-bytes"
+    call = session.calls[0]
+    assert call["url"] == "https://src.example/api/files/42/content"
+    assert call["headers"]["X-Api-Key"] == "secret-key"
+
+
+def test_get_file_content_missing_file_raises_file_content_not_found():
+    """A 404 means the source is also missing the blob -- raise a domain error (not retried) so the
+    importer can report it and carry on rather than aborting the whole sync."""
+    session = FakeSession([FakeResponse(404)])
+    with pytest.raises(FileContentNotFound):
+        _client(session).get_file_content(99)
+    assert len(session.calls) == 1
+
+
+def test_get_file_content_other_client_error_still_raises_http_error():
+    """A non-404 client error isn't a 'file is gone' signal, so it surfaces as-is."""
+    session = FakeSession([FakeResponse(403)])
+    with pytest.raises(requests.HTTPError):
+        _client(session).get_file_content(99)

--- a/apps/teams/export/tests/test_command.py
+++ b/apps/teams/export/tests/test_command.py
@@ -55,6 +55,9 @@ class FakeClient:
         self.iter_calls.append((resource, start_cursor))
         return list(self.rows_by_resource.get(resource, []))
 
+    def get_file_content(self, file_id):
+        return b""
+
 
 def _manifest(entries, checksum=None):
     return {"schema_checksum": checksum if checksum is not None else schema_checksum(), "entries": entries}

--- a/apps/teams/export/tests/test_importer.py
+++ b/apps/teams/export/tests/test_importer.py
@@ -1,10 +1,12 @@
 from datetime import UTC, datetime
 
 import pytest
+import requests
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
+from django.core.files.base import ContentFile
 from django.db import models
 from django.db.models.signals import post_save
 
@@ -12,10 +14,12 @@ from apps.annotations.models import Tag, UserComment
 from apps.api.export.serializers import build_resource_serializer
 from apps.chat.models import Chat, ChatMessage
 from apps.experiments.models import ConsentForm, ExperimentSession
+from apps.files.models import File
 from apps.human_annotations.models import AnnotationQueue
 from apps.pipelines.models import Node, Pipeline
 from apps.service_providers.models import LlmProvider
 from apps.teams.export import seal as seal_mod
+from apps.teams.export.client import FileContentNotFound
 from apps.teams.export.importer import Importer, MissingGlobalRow, UnresolvedForeignKey, mute_signals
 from apps.teams.export.manifest import GLOBAL_CONFIG, MANIFEST_ENTRIES, entry_model, generic_fk_fields
 from apps.teams.export.translation import FKTranslationStore
@@ -669,6 +673,140 @@ def test_m2m_member_with_untranslated_target_raises(store):
 
     with pytest.raises(UnresolvedForeignKey):
         importer.import_rows("human_annotations.annotationqueue", [_annotation_queue_row(600, assignees=[71, 72])])
+
+
+# ---------------------------------------------------------------------------
+# File content backfill
+# ---------------------------------------------------------------------------
+
+FILE_STORAGE = File._meta.get_field("file").storage
+
+
+class _RecordingFetcher:
+    """Stand-in for ResourceFetcher.get_file_content: records the source pks it's asked for and
+    returns canned bytes (or raises, to simulate the source also missing the blob)."""
+
+    def __init__(self, content=b"remote-bytes", error=None):
+        self.content = content
+        self.error = error
+        self.calls = []
+
+    def __call__(self, source_pk):
+        self.calls.append(source_pk)
+        if self.error is not None:
+            raise self.error
+        return self.content
+
+
+def _file_row(source_id=501, *, path="synced-file.txt", external_id="", external_source=""):
+    """A serialized files.file row whose ``file`` field is the stored relative ``path`` (as the export
+    serializer emits it). The blob is not written to storage here, so importing it hits the missing-file
+    path unless the caller seeds storage first. ``name`` is deterministic so tests can look the row up."""
+    file = FileFactory.build()
+    file.pk = source_id
+    file.name = f"file-{source_id}"
+    file.file = path
+    file.external_id = external_id
+    file.external_source = external_source
+    file.working_version = None
+    return dict(build_resource_serializer(File)(file, context={"public_key": None}).data)
+
+
+def _clear_storage(*paths):
+    # delete() is a safe no-op when the object is absent -- and unlike exists(), it doesn't depend on
+    # the storage backend reporting existence reliably (real S3 is used in tests), so a stale blob
+    # from a prior run can't make a "missing file" case silently find content.
+    for path in paths:
+        if path:
+            FILE_STORAGE.delete(path)
+
+
+def test_importing_file_backfills_missing_blob_from_the_source(store):
+    """A file row whose blob isn't in this server's storage is backfilled: the bytes are fetched from
+    the source's file content API (keyed by the source pk) and written at the stored path."""
+    _clear_storage("backfilled-501.txt")
+    fetcher = _RecordingFetcher(content=b"remote-bytes")
+    importer = Importer(store, fetch_file_content=fetcher)
+    importer.import_rows("teams.team", [_team_row()])
+
+    importer.import_rows("files.file", [_file_row(501, path="backfilled-501.txt")])
+
+    assert fetcher.calls == [501]
+    file = File.objects.get(pk=store.get_target("files.file", 501))
+    assert file.file.read() == b"remote-bytes"
+    _clear_storage("backfilled-501.txt")
+
+
+def test_importing_file_with_present_blob_does_not_fetch(store):
+    """When the blob is already in storage (the operator copied it across), the file imports without
+    touching the content API."""
+    saved_path = FILE_STORAGE.save("present-502.txt", ContentFile(b"already-here"))
+    fetcher = _RecordingFetcher()
+    importer = Importer(store, fetch_file_content=fetcher)
+    importer.import_rows("teams.team", [_team_row()])
+
+    importer.import_rows("files.file", [_file_row(502, path=saved_path)])
+
+    assert fetcher.calls == []
+    file = File.objects.get(pk=store.get_target("files.file", 502))
+    assert file.file.read() == b"already-here"
+    _clear_storage(saved_path)
+
+
+def test_importing_file_without_a_fetcher_raises_when_blob_missing(store):
+    """With no fetcher wired in (the default), a missing blob surfaces as it does today -- File.save()
+    reads its size from storage and fails -- rather than being silently swallowed."""
+    _clear_storage("missing-503.txt")
+    importer = Importer(store)
+    importer.import_rows("teams.team", [_team_row()])
+
+    with pytest.raises(FileNotFoundError):
+        importer.import_rows("files.file", [_file_row(503, path="missing-503.txt")])
+
+
+def test_importing_external_file_without_a_blob_is_imported_without_fetch(store):
+    """External-source rows (e.g. OpenAI assistant files) carry no local blob, so File.save() never
+    reads a size and there's nothing to backfill."""
+    fetcher = _RecordingFetcher()
+    importer = Importer(store, fetch_file_content=fetcher)
+    importer.import_rows("teams.team", [_team_row()])
+
+    importer.import_rows("files.file", [_file_row(504, path="", external_id="ext-1", external_source="openai")])
+
+    assert fetcher.calls == []
+    file = File.objects.get(pk=store.get_target("files.file", 504))
+    assert not file.file
+
+
+def test_file_not_found_on_source_imports_the_row_without_content_and_records_it(store):
+    """A 404 from the content API means the source is missing the blob too. Rather than aborting,
+    import the file's metadata without content (so references to it still resolve) and record it so
+    the operator gets a report of what couldn't be recovered."""
+    _clear_storage("gone-505.txt")
+    fetcher = _RecordingFetcher(error=FileContentNotFound(505))
+    importer = Importer(store, fetch_file_content=fetcher)
+    importer.import_rows("teams.team", [_team_row()])
+
+    importer.import_rows("files.file", [_file_row(505, path="gone-505.txt")])
+
+    file = File.objects.get(pk=store.get_target("files.file", 505))
+    assert not file.file
+    assert "gone-505.txt" in importer.missing_files
+
+
+def test_non_404_fetch_failure_aborts_import_and_commits_no_row(store):
+    """A transport/server error isn't a 'file is gone' signal, so the sync still aborts and the row
+    rolls back rather than silently landing a file with no content."""
+    _clear_storage("fail-507.txt")
+    fetcher = _RecordingFetcher(error=requests.HTTPError("500"))
+    importer = Importer(store, fetch_file_content=fetcher)
+    importer.import_rows("teams.team", [_team_row()])
+
+    with pytest.raises(requests.HTTPError):
+        importer.import_rows("files.file", [_file_row(507, path="fail-507.txt")])
+
+    assert store.get_target("files.file", 507) is None
+    assert not File.objects.filter(name="file-507").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/apps/teams/export/tests/test_importer.py
+++ b/apps/teams/export/tests/test_importer.py
@@ -12,6 +12,7 @@ from django.db.models.signals import post_save
 
 from apps.annotations.models import Tag, UserComment
 from apps.api.export.serializers import build_resource_serializer
+from apps.channels.models import ExperimentChannel
 from apps.chat.models import Chat, ChatMessage
 from apps.experiments.models import ConsentForm, ExperimentSession
 from apps.files.models import File
@@ -184,6 +185,36 @@ def test_rerun_does_not_duplicate(store):
     importer.import_rows("teams.team", [_team_row()])
     assert store.get_target("teams.team", 9001) == first_pk
     assert Team.objects.filter(slug="imported-team-xyz").count() == 1
+
+
+def test_reimporting_soft_deleted_channel_is_idempotent(store):
+    """A soft-deleted channel is exported (deleted=True). Re-importing it must map to the existing
+    target row, not create a duplicate -- so the existence check has to see deleted rows, which the
+    default manager filters out. A duplicate would also violate the channel's unique external_id."""
+    importer = Importer(store)
+    importer.import_rows("teams.team", [_team_row()])  # captures the target team
+
+    channel_row = {
+        "id": 555,
+        "name": "Deleted TG",
+        "experiment": None,
+        "deleted": True,
+        "extra_data": {"bot_token": "x"},
+        "external_id": "31cfe1e9-4b5a-4ffd-8d17-e8cb161d3921",
+        "platform": "telegram",
+        "messaging_provider": None,
+        "widget_version": None,
+        "widget_version_updated_at": None,
+        "created_at": PAST,
+        "updated_at": PAST,
+    }
+    importer.import_rows("bot_channels.experimentchannel", [dict(channel_row)])
+    first_pk = store.get_target("bot_channels.experimentchannel", 555)
+    importer.import_rows("bot_channels.experimentchannel", [dict(channel_row)])
+
+    assert store.get_target("bot_channels.experimentchannel", 555) == first_pk
+    channels = ExperimentChannel.objects.get_unfiltered_queryset()
+    assert channels.filter(external_id=channel_row["external_id"]).count() == 1
 
 
 # A natural-key sample per GLOBAL_CONFIG model, used to build a matching pair of rows. Keyed by

--- a/apps/teams/export/tests/test_manifest.py
+++ b/apps/teams/export/tests/test_manifest.py
@@ -5,6 +5,7 @@ from apps.annotations.models import TaggedModelMixin, UserCommentsMixin
 from apps.api.export.serializers import build_resource_serializer
 from apps.files.models import FilePurpose
 from apps.teams.export import manifest
+from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.cost_tracking import PricingRuleFactory
 from apps.utils.factories.documents import CollectionFactory, CollectionFileFactory
 from apps.utils.factories.experiment import ExperimentFactory
@@ -210,7 +211,7 @@ def test_files_queryset_excludes_data_export_files():
 
 @pytest.mark.django_db()
 def test_collection_files_queryset_includes_files_of_archived_collections():
-    """Archived collections are exported (team_scoped_queryset uses get_all()), so their CollectionFile
+    """Archived collections are exported (team_scoped_queryset uses _base_manager), so their CollectionFile
     rows must be exported too -- otherwise the archived collection would arrive on the target with no
     files. The queryset must return files of both live and archived collections."""
     team = TeamFactory()
@@ -232,7 +233,7 @@ def test_collection_files_queryset_includes_files_of_archived_collections():
 @pytest.mark.django_db()
 def test_queryset_includes_archived_rows_of_versioned_models():
     """Versioned models filter is_archived=False on their default manager. The export must bypass that
-    (via get_all()) so archived rows are shared across servers along with the live ones."""
+    (via _base_manager) so archived rows are shared across servers along with the live ones."""
     team = TeamFactory()
     live = ExperimentFactory(team=team)
     archived = ExperimentFactory(team=team, is_archived=True)
@@ -241,6 +242,21 @@ def test_queryset_includes_archived_rows_of_versioned_models():
     pks = set(manifest.team_scoped_queryset(entry, team).values_list("pk", flat=True))
     assert live.pk in pks
     assert archived.pk in pks
+
+
+@pytest.mark.django_db()
+def test_queryset_includes_soft_deleted_channels():
+    """ExperimentChannel's default manager filters deleted=False. The export bypasses that (via
+    _base_manager) so soft-deleted channels are shared across servers too, keeping the snapshot
+    faithful."""
+    team = TeamFactory()
+    live = ExperimentChannelFactory(team=team)
+    deleted = ExperimentChannelFactory(team=team, deleted=True)
+
+    entry = manifest.get_manifest_entry("chatbot_channels")
+    pks = set(manifest.team_scoped_queryset(entry, team).values_list("pk", flat=True))
+    assert live.pk in pks
+    assert deleted.pk in pks
 
 
 @pytest.mark.django_db()

--- a/apps/teams/export/tests/test_manifest.py
+++ b/apps/teams/export/tests/test_manifest.py
@@ -6,6 +6,8 @@ from apps.api.export.serializers import build_resource_serializer
 from apps.files.models import FilePurpose
 from apps.teams.export import manifest
 from apps.utils.factories.cost_tracking import PricingRuleFactory
+from apps.utils.factories.documents import CollectionFactory, CollectionFileFactory
+from apps.utils.factories.experiment import ExperimentFactory
 from apps.utils.factories.files import FileFactory
 from apps.utils.factories.service_provider_factories import LlmProviderModelFactory
 from apps.utils.factories.team import TeamFactory
@@ -204,6 +206,41 @@ def test_files_queryset_excludes_data_export_files():
     pks = set(manifest.team_scoped_queryset(entry, team).values_list("pk", flat=True))
     assert kept.pk in pks
     assert export_file.pk not in pks
+
+
+@pytest.mark.django_db()
+def test_collection_files_queryset_includes_files_of_archived_collections():
+    """Archived collections are exported (team_scoped_queryset uses get_all()), so their CollectionFile
+    rows must be exported too -- otherwise the archived collection would arrive on the target with no
+    files. The queryset must return files of both live and archived collections."""
+    team = TeamFactory()
+    # llm_provider/embedding_provider_model share a per-team unique key, so leave them unset to keep
+    # two collections in the same team from colliding -- this test only cares about is_archived.
+    live_collection = CollectionFactory(team=team, llm_provider=None, embedding_provider_model=None)
+    archived_collection = CollectionFactory(
+        team=team, llm_provider=None, embedding_provider_model=None, is_archived=True
+    )
+    live = CollectionFileFactory(collection=live_collection)
+    of_archived = CollectionFileFactory(collection=archived_collection)
+
+    entry = manifest.get_manifest_entry("collection_files")
+    pks = set(manifest.team_scoped_queryset(entry, team).values_list("pk", flat=True))
+    assert live.pk in pks
+    assert of_archived.pk in pks
+
+
+@pytest.mark.django_db()
+def test_queryset_includes_archived_rows_of_versioned_models():
+    """Versioned models filter is_archived=False on their default manager. The export must bypass that
+    (via get_all()) so archived rows are shared across servers along with the live ones."""
+    team = TeamFactory()
+    live = ExperimentFactory(team=team)
+    archived = ExperimentFactory(team=team, is_archived=True)
+
+    entry = manifest.get_manifest_entry("chatbots")
+    pks = set(manifest.team_scoped_queryset(entry, team).values_list("pk", flat=True))
+    assert live.pk in pks
+    assert archived.pk in pks
 
 
 @pytest.mark.django_db()

--- a/apps/teams/management/commands/sync_team.py
+++ b/apps/teams/management/commands/sync_team.py
@@ -7,6 +7,7 @@ translation store. Each run makes one pass over the manifest and exits; rerun to
 """
 
 import time
+from collections.abc import Sequence
 from datetime import timedelta
 from pathlib import Path
 
@@ -207,7 +208,12 @@ def run_sync(
 ):
     manifest = check_sync_preconditions(client, private_key, enforce_schema)
 
-    importer = Importer(store, private_key=private_key, on_user_created=on_user_created)
+    importer = Importer(
+        store,
+        private_key=private_key,
+        on_user_created=on_user_created,
+        fetch_file_content=client.get_file_content,
+    )
     try:
         with mute_signals():
             load_team(importer, client, store, write)
@@ -284,7 +290,7 @@ class Command(BaseCommand):
 
         check_sync_preconditions(client, private_key, enforce_schema, store=store)
 
-        run_sync(
+        importer = run_sync(
             client,
             store,
             private_key,
@@ -295,7 +301,12 @@ class Command(BaseCommand):
         )
 
         duration = timedelta(seconds=round(time.monotonic() - start_time))
-        self._report(sync_complete=not store.has_unfilled_targets(), team_slug=options["team_slug"], duration=duration)
+        self._report(
+            sync_complete=not store.has_unfilled_targets(),
+            team_slug=options["team_slug"],
+            duration=duration,
+            missing_files=importer.missing_files,
+        )
 
     def _run_force_delete(self, options):
         """Confirm and delete the local team plus its sync state."""
@@ -307,18 +318,35 @@ class Command(BaseCommand):
             write=lambda message: self.stdout.write(self.style.WARNING(message)),
         )
 
-    def _report(self, *, sync_complete: bool, team_slug: str, duration: timedelta | None = None) -> None:
+    def _report(
+        self,
+        *,
+        sync_complete: bool,
+        team_slug: str,
+        duration: timedelta | None = None,
+        missing_files: Sequence[str] = (),
+    ) -> None:
         """Print everything the operator needs after a sync, so ``handle`` stays a thin wiring shell:
-        which resources need manual setup, whether the sync finished or must be rerun, how long the
-        run took, and the follow-up step for channel webhooks (a separate command -- see
-        ``reregister_webhooks``). Sections are headed and blank-line separated so the report stands
-        apart from the row-by-row progress log above it."""
+        which resources need manual setup, which files the source had no content for, whether the sync
+        finished or must be rerun, how long the run took, and the follow-up step for channel webhooks
+        (a separate command -- see ``reregister_webhooks``). Sections are headed and blank-line
+        separated so the report stands apart from the row-by-row progress log above it."""
         self.stdout.write("")
         self.stdout.write(self.style.MIGRATE_HEADING("Sync report"))
         self.stdout.write(self.style.MIGRATE_HEADING("=" * 60))
 
         if duration is not None:
             self.stdout.write(f"Duration: {duration}")
+
+        if missing_files:
+            self.stdout.write("")
+            self.stdout.write(
+                self.style.WARNING(
+                    f"{len(missing_files)} file(s) had no content on the source and were imported without it:"
+                )
+            )
+            for name in missing_files:
+                self.stdout.write(f"  - {name}")
 
         self.stdout.write("")
         self.stdout.write(self.style.WARNING("Channel webhooks were not re-registered."))
@@ -345,7 +373,8 @@ class Command(BaseCommand):
         self.stdout.write(
             self.style.WARNING(
                 f"--force-delete will permanently delete the local team '{team_slug}' and all its data "
-                "before re-importing."
+                "before re-importing. This also removes the team's files from backend storage, so they "
+                "must be re-imported after the delete completes."
             )
         )
         return _prompt("Type 'yes' to continue: ") == "yes"

--- a/apps/teams/tasks.py
+++ b/apps/teams/tasks.py
@@ -52,11 +52,12 @@ def delete_team_async(team_id, user_email, notify_recipients="self"):
 def get_team_files_queryset(team):
     """Files for the team to include in a data export, excluding export artifacts.
 
-    The File manager already excludes archived files. We include versioned copies
-    (not just working versions) so the export is a complete snapshot, and drop
+    ``get_all()`` bypasses the File manager's ``is_archived=False`` filter so archived files are
+    included -- they're part of the export API snapshot, so their bytes must ship too. We include
+    versioned copies (not just working versions) so the export is a complete snapshot, and drop
     previously generated export zips.
     """
-    return File.objects.filter(team=team).exclude(purpose=FilePurpose.DATA_EXPORT).order_by("id")
+    return File.objects.get_all().filter(team=team).exclude(purpose=FilePurpose.DATA_EXPORT).order_by("id")
 
 
 def _export_arcname(file: File) -> str:

--- a/apps/teams/tests/test_file_export.py
+++ b/apps/teams/tests/test_file_export.py
@@ -49,10 +49,12 @@ class TestCreateTeamFilesZipTask:
         assert zf.read(f2.file.name) == b"world"
         assert zf.testzip() is None
 
-    def test_excludes_archived_files(self, team):
+    def test_includes_archived_files(self, team):
+        # Archived File rows are part of the export API snapshot, so their bytes must be in the zip too
+        # -- otherwise an imported archived row would point at a blob that was never uploaded.
         keep = FileFactory(team=team, file__data=b"x", file__filename="keep.txt")
-        FileFactory(team=team, is_archived=True, file__data=b"y", file__filename="drop.txt")
-        assert _zip_from_task(team).namelist() == [keep.file.name]
+        archived = FileFactory(team=team, is_archived=True, file__data=b"y", file__filename="archived.txt")
+        assert set(_zip_from_task(team).namelist()) == {keep.file.name, archived.file.name}
 
     def test_includes_versioned_copies(self, team):
         working = FileFactory(team=team, file__data=b"w", file__filename="w.txt")


### PR DESCRIPTION
### Product Description
Makes team-to-team sync a faithful, complete snapshot. Two gaps are closed:

1. **Archived records are now exported.** Previously, archiving a chatbot, pipeline, collection, file, etc. silently dropped it (and its file bytes) from the export, so an archived resource never made it to the target server.
2. **Missing file content is back-filled on import.** When a file's bytes aren't already present in the target's storage, the importer fetches them from the source rather than failing.

### Technical Description
**Export archived records** (`feat: export archived records in the team export API`)
- Versioned models filter `is_archived=False` on their default manager. `team_scoped_queryset()` now calls `model.objects.get_all()` (the `VersionsObjectManagerMixin` escape hatch) when available to bypass that filter, so archived rows are served for every versioned model.
- `get_team_files_queryset()` (the file-blob zip) also uses `File.objects.get_all()`, so archived files' bytes ship too — otherwise imported archived `File` rows would reference blobs that were never uploaded. (Archiving a file never removes its storage blob, so the bytes are available.)

**Back-fill missing file content** (`feat: back-fill missing file content when syncing a team`)
- On import, if a file's blob is missing from target storage, fetch it from the source's file-content API and write it before saving the row, instead of failing.
- A `404` from the source means the source is missing the blob too: the row is imported without content (so references still resolve) and the file is listed in the sync report. Other fetch errors abort the sync.
- Force-delete now warns that it also clears the team's files from backend storage (they must be re-imported).

**Fix archived-collection deletion** (`fix: delete files of archived collections in delete_collection_task`)
- `delete_collection_task` runs after `Collection.archive()` has set `is_archived=True`, but it loaded the row via `Collection.objects`, whose manager hides archived rows — so the task was a silent no-op that left `CollectionFile` rows orphaned. It now loads the row with `get_all()`.

### Migrations
No migrations in this PR.
- [x] The migrations are backwards compatible

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
