### PR TITLE
perf: hash the message-tag subplan in the session tags filter

### DIFF
--- a/apps/experiments/filters.py
+++ b/apps/experiments/filters.py
@@ -74,22 +74,19 @@ class ChatMessageTagsFilter(ChoiceColumnFilter):
     def _chat_or_message_tag_exists(self, tag_names):
         """Match outer rows whose chat, or any of the chat's messages, carries one of ``tag_names``.
 
-        Both halves correlate directly on ``chat_id`` so Postgres can hash/semi-join them.
-        The message check filters ``ChatMessage`` on its own tags and clears the model's
-        default ``created_at`` ordering — that ordering is meaningless inside ``EXISTS`` and
-        would otherwise force a per-session sort of each chat's messages (which turned the
-        session-table count into a multi-minute query). Duplicate rows are harmless in ``EXISTS``.
+        Both halves correlate directly on ``chat_id`` at the top level so Postgres can
+        precompute each subquery once as a hashed subplan instead of re-running it per
+        session row.
         """
+        chat_ct = ContentType.objects.get_for_model(Chat)
         chat_tag_exists = Exists(
             CustomTaggedItem.objects.filter(
                 object_id=OuterRef("chat_id"),
-                content_type_id=ContentType.objects.get_for_model(Chat).id,
+                content_type_id=chat_ct.id,
                 tag__name__in=tag_names,
             )
         )
-        message_tag_exists = Exists(
-            ChatMessage.objects.filter(chat_id=OuterRef("chat_id"), tags__name__in=tag_names).order_by()
-        )
+        message_tag_exists = Exists(ChatMessage.objects.filter(chat_id=OuterRef("chat_id"), tags__name__in=tag_names))
         return chat_tag_exists | message_tag_exists
 
     def apply_any_of(self, queryset, value, timezone=None):

--- a/apps/experiments/filters.py
+++ b/apps/experiments/filters.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from typing import ClassVar
 
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Exists, OuterRef, Subquery
+from django.db.models import Exists, OuterRef
 
 from apps.annotations.models import CustomTaggedItem
 from apps.channels.models import ChannelPlatform
@@ -72,26 +72,23 @@ class ChatMessageTagsFilter(ChoiceColumnFilter):
         self.options = [tag.name for tag in team.tag_set.filter(is_system_tag=False)]
 
     def _chat_or_message_tag_exists(self, tag_names):
-        """Build a Q matching outer rows whose chat or any of its messages carries one of ``tag_names``."""
-        chat_ct = ContentType.objects.get_for_model(Chat)
-        chat_message_ct = ContentType.objects.get_for_model(ChatMessage)
+        """Match outer rows whose chat, or any of the chat's messages, carries one of ``tag_names``.
+
+        Both halves correlate directly on ``chat_id`` so Postgres can hash/semi-join them.
+        The message check filters ``ChatMessage`` on its own tags and clears the model's
+        default ``created_at`` ordering — that ordering is meaningless inside ``EXISTS`` and
+        would otherwise force a per-session sort of each chat's messages (which turned the
+        session-table count into a multi-minute query). Duplicate rows are harmless in ``EXISTS``.
+        """
         chat_tag_exists = Exists(
             CustomTaggedItem.objects.filter(
                 object_id=OuterRef("chat_id"),
-                content_type_id=chat_ct.id,
+                content_type_id=ContentType.objects.get_for_model(Chat).id,
                 tag__name__in=tag_names,
             )
         )
-        # Double OuterRef: the inner Subquery sits inside an Exists, so OuterRef("chat_id")
-        # would resolve to the Subquery's parent (CustomTaggedItem). One more OuterRef hop
-        # is needed to reach the outermost ExperimentSession queryset's chat_id. Don't
-        # collapse to a single OuterRef — that breaks the correlation.
         message_tag_exists = Exists(
-            CustomTaggedItem.objects.filter(
-                content_type_id=chat_message_ct.id,
-                tag__name__in=tag_names,
-                object_id__in=Subquery(ChatMessage.objects.filter(chat_id=OuterRef(OuterRef("chat_id"))).values("id")),
-            )
+            ChatMessage.objects.filter(chat_id=OuterRef("chat_id"), tags__name__in=tag_names).order_by()
         )
         return chat_tag_exists | message_tag_exists
 


### PR DESCRIPTION
### Product Description

For chatbots with many sessions, the **Sessions table would take minutes to load (and sometimes time out) whenever a Tags filter was applied**. One production request spent ~5.4 minutes, ~4.3 of them in a single query. This makes that page fast again.

### Technical Description

#### The slow query

The Sessions table paginates, and pagination needs a total row count:

```sql
SELECT COUNT(*) FROM experiments_experimentsession
WHERE team_id = ? AND NOT ( <chat has the tag> OR <any message in the chat has the tag> )
```

With a Tags filter applied, that `COUNT` took **~261 s** in production.

#### What the EXPLAIN told us

The `WHERE` has two subqueries — one for the chat's own tags, one for the chat's messages' tags. The plan labels them `SubPlan`s:

```
Filter: (team_id = 67 AND (NOT (hashed SubPlan 2)) AND (NOT (SubPlan 3)))
```

Read the two words carefully:

- **`hashed SubPlan 2`** (the chat-tag check): `hashed` means Postgres runs this subquery **once**, stores the answers in an in-memory lookup table, and then just checks that table for each row. Cheap.
- **`SubPlan 3`** (the message-tag check): **not** hashed. Its inner scan is `chat_chatmessage ... Filter: (chat_id = experimentsession.chat_id)` with a **`Sort (Sort Key: created_at)`** on top. `chat_id = experimentsession.chat_id` makes it *correlated* — it depends on the specific session row being looked at, so Postgres can't precompute it once. It re-runs the whole subquery **plus a sort, for every session row** (~10,500 times for that team). That per-row repetition is the minutes.

So: one half of the filter was free, the other half was quietly running thousands of times.

#### Why SubPlan 3 couldn't be hashed

The old code phrased "any message in this chat has the tag" as a **nested** subquery:

```python
Exists(CustomTaggedItem.objects.filter(
    content_type_id=<message ct>,
    tag__name__in=tag_names,
    object_id__in=Subquery(
        ChatMessage.objects.filter(chat_id=OuterRef(OuterRef("chat_id"))).values("id")  # ← problem
    ),
))
```

Two things stop Postgres from optimizing it:

1. **The link to the session is buried.** The correlation (`chat_id = <session>.chat_id`) sits two levels deep, inside an `IN (...)`. Postgres can't lift it out to precompute the subquery once, so it stays per-row.
2. **A pointless sort leaks in.** `ChatMessage` has `Meta.ordering = ["created_at"]`, and a plain `Subquery` keeps the model's default ordering, so `.values("id")` emits `ORDER BY created_at`. Ordering is meaningless inside `IN (...)`, but Postgres still does it — that's the per-session `Sort`.

#### The change

Ask the exact same question, but with a **flat, top-level correlation**:

```python
Exists(
    ChatMessage.objects.filter(chat_id=OuterRef("chat_id"), tags__name__in=tag_names)
)
```

- The session link (`chat_id = OuterRef("chat_id")`) is now at the top level — the **same shape as the chat check that was already `hashed`**.
- The sort disappears with the restructure itself: `Exists` compiles through Django's `Query.exists()`, which force-clears the model's default ordering. (The old code's sort survived because it sat in a plain `Subquery` inside `IN (...)`, where nothing clears it.) No explicit `.order_by()` is needed — I verified the generated SQL is identical with and without it.

#### The resulting EXPLAIN

The message check now becomes a self-contained plan that Postgres builds once:

```
Filter: (... AND (NOT (hashed SubPlan 2)) AND (NOT (hashed SubPlan 4)))
  SubPlan 4
    ->  Hash Join   (chat_chatmessage ⋈ hashed [customtaggeditem ⋈ tag])   # built once, no per-row correlation, no Sort
```

Both subplans are now `hashed` — computed once and probed — so the ~10,500× repetition and the per-session sort are gone.

#### Notes for the reviewer

- **Behaviour is unchanged.** It still matches sessions whose chat *or* any of its messages carries the tag. `EXISTS` also keeps it NULL-safe (unlike a `NOT IN (subquery)` rewrite).
- `.filter(tags__name__in=...)` can produce duplicate message rows via the tag join, but that's harmless inside `EXISTS` (it only checks existence), so no `.distinct()` is needed.
- **Hashing is the planner's choice, not a guarantee.** Postgres only hashes a subplan when the estimated result fits in `work_mem`; for a very common tag name it may fall back to per-row execution. Even then the flat shape is far cheaper than before — it's a simple indexable `chat_id = ?` probe with no nested correlation and no sort. A possible follow-up: resolve tag names to this team's tag IDs in `prepare()` and filter on `tag_id__in`, which would shrink the subplan and also close the pre-existing quirk where a same-named tag from another team can match.
- All 52 tests in `apps/experiments/tests/test_filters.py` and `test_message_filters.py` pass unchanged.

### Docs and Changelog
- [ ] This PR requires docs/changelog update
