### PR TITLE
fix: filter session tags by id to avoid pathological query plan

### DIFF
--- a/apps/experiments/filters.py
+++ b/apps/experiments/filters.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Exists, OuterRef
 
-from apps.annotations.models import CustomTaggedItem
+from apps.annotations.models import CustomTaggedItem, Tag
 from apps.channels.models import ChannelPlatform
 from apps.chat.models import Chat, ChatMessage
 from apps.experiments.models import Experiment
@@ -78,15 +78,16 @@ class ChatMessageTagsFilter(ChoiceColumnFilter):
         precompute each subquery once as a hashed subplan instead of re-running it per
         session row.
         """
+        tag_ids = list(Tag.objects.filter(name__in=tag_names).values_list("id", flat=True))
         chat_ct = ContentType.objects.get_for_model(Chat)
         chat_tag_exists = Exists(
             CustomTaggedItem.objects.filter(
                 object_id=OuterRef("chat_id"),
                 content_type_id=chat_ct.id,
-                tag__name__in=tag_names,
+                tag_id__in=tag_ids,
             )
         )
-        message_tag_exists = Exists(ChatMessage.objects.filter(chat_id=OuterRef("chat_id"), tags__name__in=tag_names))
+        message_tag_exists = Exists(ChatMessage.objects.filter(chat_id=OuterRef("chat_id"), tags__in=tag_ids))
         return chat_tag_exists | message_tag_exists
 
     def apply_any_of(self, queryset, value, timezone=None):

--- a/apps/experiments/tests/test_filters.py
+++ b/apps/experiments/tests/test_filters.py
@@ -315,6 +315,51 @@ class TestExperimentSessionFilters:
         assert filtered.count() == 1
         assert filtered.first() == sessions[1]
 
+    def test_tags_filter_resolves_names_to_ids_and_avoids_tag_name_join(self, sessions_with_tags):
+        """Regression guard: the tags filter must filter on ``tag_id`` rather than join
+        ``annotations_tag`` on ``name``. The name join hides the tag's identity from the
+        planner, which then estimates the match count from the table-wide average and, for
+        a rare tag, picks a catastrophic brute-force join order on large teams.
+        """
+        sessions, _ = sessions_with_tags
+        params = {
+            "filter_0_column": "tags",
+            "filter_0_operator": Operators.ANY_OF,
+            "filter_0_value": json.dumps(["important"]),
+        }
+        qs = ExperimentSessionFilter().apply(
+            sessions[0].experiment.sessions.all(), FilterParams(_get_querydict(params))
+        )
+        sql = str(qs.query).lower()
+        assert "annotations_tag" not in sql, sql
+        assert "tag_id" in sql, sql
+
+    def test_tags_filter_stays_team_scoped_with_colliding_tag_names(self):
+        """Tag names are resolved globally (apply has no ``team``), so a different team's
+        identically-named tag also resolves to an id. The object correlation must still
+        keep matches within the team: a chat can only carry its own team's tags.
+        """
+        session = ExperimentSessionFactory.create()
+        tag = _get_tag(team=session.team, name="shared")
+        session.chat.add_tag(tag, team=session.team, added_by=None)
+        untagged = ExperimentSessionFactory.create(experiment=session.experiment)
+
+        # A different team with a tag of the same name, applied to its own chat.
+        other = ExperimentSessionFactory.create()
+        other_tag = _get_tag(team=other.team, name="shared")
+        other.chat.add_tag(other_tag, team=other.team, added_by=None)
+
+        params = {
+            "filter_0_column": "tags",
+            "filter_0_operator": Operators.ANY_OF,
+            "filter_0_value": json.dumps(["shared"]),
+        }
+        filtered = ExperimentSessionFilter().apply(
+            session.experiment.sessions.all(), FilterParams(_get_querydict(params))
+        )
+        assert list(filtered) == [session]
+        assert untagged not in filtered
+
     def test_version_filters(self, sessions_with_versions):
         """Test version tag filtering"""
         sessions, version_tags = sessions_with_versions


### PR DESCRIPTION
### Product Description
The session/message **Tags filter** on the chatbot Sessions table could take ~15s on large teams. This hopefully makes it fast again. No user-visible behaviour change — the same sessions are returned.

### Technical Description
`ChatMessageTagsFilter` built its `EXISTS` subqueries by joining `annotations_tag` on `name` (`tag__name__in=...`, `tags__name__in=...`). This change resolves the selected tag names to ids once and filters the subqueries on the indexed `tag_id` column instead (`tag_id__in=[...]`, `tags__in=[...]`).

**Observations** (from a production `EXPLAIN (ANALYZE, BUFFERS)` on the sessions query with a version + tag-exclude filter):
- Runtime ~15s to return 25 rows; ~all of it in two nested loops with `Rows Removed by Join Filter: 13.5M` — the planner materialised the session rows and brute-forced the `chat_chat` / `participant` tables against them.
- The session-scan node was estimated at `rows=2` (actual 313) with a cost estimate of ~10.8M. The tag-exclusion subplans were what inflated that cost.
- The tag subquery's inner scan estimated ~1,500 matching `customtaggeditem` rows per tag while the actual was ~0 — a large over-estimate.
- Refreshing statistics (`ANALYZE`) did not change the estimate; the misestimate is structural, not staleness.

**Hypothesis:** because the tag is reached by **name** (a join to `annotations_tag`), the planner cannot know which `tag_id` the name resolves to at plan time, so it falls back to the table-wide average rows-per-`tag_id`. On a table where a few tags are heavily used, that average is far higher than a rare tag's true count. The inflated per-tag estimate inflates the tag-subplan cost, which inflates the session-scan cost, which tips the planner into the brute-force join order. Filtering by a literal `tag_id` lets the planner use per-value statistics, so the estimate (and cost) collapses to something sane and the normal indexed join order is chosen.

**Verification:** reproduced the pathology on a prod-shaped dataset (40k participants, rare version values, a rare tag among heavy ones). Same query, measured old vs new:
- Old (name join): **~3,150 ms** — `Seq Scan on experiments_participant` (40k) → `Rows Removed by Join Filter: 12,003,000`.
- New (`tag_id`): **~30 ms** — indexed lookups, no brute force. Both tag subqueries stay top-level-correlated on `chat_id`, so Postgres still runs them as **hashed** subplans.

Note: resolving names to ids is intentionally **not** team-scoped (the `apply()` path has no `team`). This is safe because the object correlation (`object_id = chat_id`) already confines matches to the team — a chat can only carry its own team's tags. A regression test covers this.

### Migrations
- [x] The migrations are backwards compatible

_No migrations — query-shape change only._

### Demo
`EXPLAIN ANALYZE` on the prod-shaped reproduction:

| Code | Execution time | Join strategy |
|---|---|---|
| Old (name join) | ~3,150 ms | brute-force `Seq Scan` + `Materialize`, 12M rows discarded |
| New (`tag_id`) | ~30 ms | indexed nested loops, hashed tag subplans |

### Docs and Changelog
- [ ] This PR requires docs/changelog update
