### PR TITLE
fix: remove stale trace.span content type that breaks team sync

### DIFF
--- a/apps/trace/migrations/0014_remove_stale_span_contenttype.py
+++ b/apps/trace/migrations/0014_remove_stale_span_contenttype.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+
+def remove_stale_span_contenttype(apps, schema_editor):
+    """Delete the leftover `trace.span` content type.
+
+    Span was a taggable model until it was dropped in 0008 with a bare DeleteModel, which left its
+    content type and every row pointing at it (tags, comments, auto-created permissions) behind.
+    Those dangling rows break the team-export sync: it resolves each generic FK's content type by
+    natural key on the target, and `trace.span` no longer resolves there. Deleting the content type
+    takes its CASCADE dependents with it (Django emulates the cascade in Python, so every referencing
+    app must be in this migration's dependencies). No-op once the content type is gone.
+    """
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    ContentType.objects.filter(app_label="trace", model="span").delete()
+
+
+class Migration(migrations.Migration):
+    # Every app with a FK into ContentType that could reference `trace.span` must be applied before
+    # this runs, so the cascade sees and removes its dangling rows rather than hitting an FK error.
+    dependencies = [
+        ("trace", "0013_trace_trace_timestamp_idx"),
+        ("contenttypes", "0002_remove_content_type_name"),
+        ("auth", "0012_alter_user_first_name_max_length"),
+        ("admin", "0003_logentry_add_action_flag_choices"),
+        ("taggit", "0006_rename_taggeditem_content_type_object_id_taggit_tagg_content_8fc721_idx"),
+        ("annotations", "0009_alter_tag_category"),
+        ("assessments", "0001_initial"),
+        ("events", "0027_timeouttrigger_config_changed_at"),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_stale_span_contenttype, migrations.RunPython.noop),
+    ]

--- a/apps/trace/tests/test_migration_0014_remove_stale_span_contenttype.py
+++ b/apps/trace/tests/test_migration_0014_remove_stale_span_contenttype.py
@@ -1,0 +1,68 @@
+import importlib
+
+import pytest
+from django.apps import apps as django_apps
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.db import connection
+
+from apps.annotations.models import CustomTaggedItem, UserComment
+from apps.utils.factories.annotations import TagFactory
+from apps.utils.factories.team import TeamFactory
+from apps.utils.factories.user import UserFactory
+
+_migration = importlib.import_module("apps.trace.migrations.0014_remove_stale_span_contenttype")
+remove_stale_span_contenttype = _migration.remove_stale_span_contenttype
+
+
+class FakeSchemaEditor:
+    connection = connection
+
+
+def _run_migration():
+    remove_stale_span_contenttype(django_apps, FakeSchemaEditor())
+
+
+@pytest.mark.django_db()
+def test_removes_stale_span_contenttype_and_dangling_dependents():
+    team = TeamFactory()
+    user = UserFactory()
+    span_ct = ContentType.objects.create(app_label="trace", model="span")
+
+    # Rows that dangle off the stale content type via generic/direct FKs. `object_id` points at a
+    # span row that no longer exists — that's exactly the dangling state 0008 left behind.
+    tagged_item = CustomTaggedItem.objects.create(
+        team=team, user=user, tag=TagFactory(team=team), content_type=span_ct, object_id=999
+    )
+    comment = UserComment.objects.create(team=team, user=user, comment="stale", content_type=span_ct, object_id=999)
+    permission = Permission.objects.create(content_type=span_ct, codename="view_span", name="Can view span")
+
+    _run_migration()
+
+    assert not ContentType.objects.filter(app_label="trace", model="span").exists()
+    assert not CustomTaggedItem.objects.filter(pk=tagged_item.pk).exists()
+    assert not UserComment.objects.filter(pk=comment.pk).exists()
+    assert not Permission.objects.filter(pk=permission.pk).exists()
+
+
+@pytest.mark.django_db()
+def test_leaves_other_contenttypes_and_their_dependents_untouched():
+    team = TeamFactory()
+    user = UserFactory()
+    other_ct = ContentType.objects.get_for_model(UserComment)
+    comment = UserComment.objects.create(team=team, user=user, comment="keep me", content_type=other_ct, object_id=1)
+
+    _run_migration()
+
+    assert ContentType.objects.filter(pk=other_ct.pk).exists()
+    assert UserComment.objects.filter(pk=comment.pk).exists()
+
+
+@pytest.mark.django_db()
+def test_is_a_noop_when_span_contenttype_already_gone():
+    assert not ContentType.objects.filter(app_label="trace", model="span").exists()
+
+    # Running against a DB that never had the stale row must not raise.
+    _run_migration()
+
+    assert not ContentType.objects.filter(app_label="trace", model="span").exists()


### PR DESCRIPTION
### Product Description
No user-facing change — internal cleanup

### Technical Description
`Span` was a taggable model until `trace/0008_delete_span` dropped it with a bare `DeleteModel` and no data cleanup. On any DB that had tagged spans, that left the `trace.span` row in `django_content_type` plus every row pointing at it (custom tagged items, user comments, auto-created `auth.Permission`s) dangling behind it.

### Migrations
- [x] The migrations are backwards compatible

Old code running mid-deploy references no live `Span`; only the dangling data pointed at the content type, and that's exactly what's being removed.

### Docs and Changelog
- [ ] This PR requires docs/changelog update