### PR TITLE
Record cost tracking data for all teams; flag gates UI only

### DIFF
--- a/apps/service_providers/tracing/ocs_tracer.py
+++ b/apps/service_providers/tracing/ocs_tracer.py
@@ -10,11 +10,12 @@ from django.core.cache import cache
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.outputs import LLMResult
 
+from apps.cost_tracking.services.recorder import TraceContext as CostTraceContext
+from apps.cost_tracking.services.recorder import record_usage_bulk
 from apps.experiments.models import Experiment, ExperimentSession
 from apps.ocs_notifications.notifications import trace_error_notification
 from apps.service_providers.tracing.const import OCS_TRACE_PROVIDER, SpanLevel
 from apps.service_providers.tracing.metrics import MetricsCollector
-from apps.teams.models import Flag, Team
 from apps.trace.models import Trace, TraceStatus
 
 from .base import SpanNotificationConfig, TraceContext, Tracer
@@ -39,7 +40,6 @@ class OCSTracer(Tracer):
         self.error_span_name: str = ""
         self.error_notification_config: SpanNotificationConfig | None = None
         self.metrics_collector: MetricsCollector | None = None
-        self.cost_tracking_enabled: bool = False
 
     @property
     def ready(self) -> bool:
@@ -92,7 +92,6 @@ class OCSTracer(Tracer):
 
         self.start_time = time.time()
         self.metrics_collector = MetricsCollector(start_time=self.start_time)
-        self.cost_tracking_enabled = self._evaluate_cost_tracking_flag()
 
         try:
             yield trace_context
@@ -156,28 +155,22 @@ class OCSTracer(Tracer):
     def _record_costs(self) -> None:
         """Drain the collector's accumulated usage into UsageRecord rows.
 
-        Short-circuits when the flag is off so the cost path is zero-work
-        for teams that haven't opted in. `record_usage_bulk` swallows DB
-        errors internally; the outer `_finalize_trace` try/except catches
-        anything else (e.g. an unexpected helper failure).
+        Cost data is recorded for every team; the `flag_ai_cost_monitoring`
+        flag only gates the UI, not this write path. `record_usage_bulk`
+        swallows DB errors internally; the outer `_finalize_trace` try/except
+        catches anything else (e.g. an unexpected helper failure).
         """
-        if not self.cost_tracking_enabled:
-            return
         if not self.metrics_collector:
             return
         if not self.trace_record:
             return
-        from apps.cost_tracking.services.recorder import (  # noqa: PLC0415 - lazy: cost_tracking only imported when the flag is on
-            TraceContext,
-            record_usage_bulk,
-        )
 
         events = list(self.metrics_collector.iter_cost_events())
         if not events:
             return
         record_usage_bulk(
             events,
-            TraceContext(
+            CostTraceContext(
                 team_id=self.team_id,
                 trace_id=self.trace_record.id,
                 experiment_id=self.trace_record.experiment_id,
@@ -185,13 +178,6 @@ class OCSTracer(Tracer):
                 participant_id=self.trace_record.participant_id,
             ),
         )
-
-    def _evaluate_cost_tracking_flag(self) -> bool:
-        """Look up the team-scoped `flag_ai_cost_monitoring` flag once per
-        trace entry. `Flag.get` is the cached classmethod; `Team(pk=...)`
-        avoids a DB fetch since `is_active_for_team` only reads `.pk`.
-        """
-        return Flag.get("flag_ai_cost_monitoring").is_active_for_team(Team(pk=self.team_id))
 
     def _fire_error_notification_if_needed(self) -> None:
         """Fire notification if a span declared one and the trace errored."""
@@ -217,7 +203,6 @@ class OCSTracer(Tracer):
         self.error_span_name = ""
         self.error_notification_config = None
         self.metrics_collector = None
-        self.cost_tracking_enabled = False
 
     @contextmanager
     def span(

--- a/apps/service_providers/tracing/ocs_tracer.py
+++ b/apps/service_providers/tracing/ocs_tracer.py
@@ -155,8 +155,7 @@ class OCSTracer(Tracer):
     def _record_costs(self) -> None:
         """Drain the collector's accumulated usage into UsageRecord rows.
 
-        Cost data is recorded for every team; the `flag_ai_cost_monitoring`
-        flag only gates the UI, not this write path. `record_usage_bulk`
+        Cost data is recorded for every team; `record_usage_bulk`
         swallows DB errors internally; the outer `_finalize_trace` try/except
         catches anything else (e.g. an unexpected helper failure).
         """

--- a/apps/service_providers/tracing/tests/test_ocs_tracer_cost.py
+++ b/apps/service_providers/tracing/tests/test_ocs_tracer_cost.py
@@ -1,6 +1,5 @@
 """Integration tests for the cost-tracking drain hooked into OCSTracer."""
 
-from contextlib import contextmanager
 from decimal import Decimal
 from unittest.mock import Mock, patch
 from uuid import uuid4
@@ -13,7 +12,6 @@ from apps.cost_tracking.models import PricingRule, ServiceKind, UsageRecord
 from apps.service_providers.tracing.base import TraceContext
 from apps.service_providers.tracing.metrics import MetricsCollector
 from apps.service_providers.tracing.ocs_tracer import OCSTracer
-from apps.teams.models import Flag
 from apps.trace.models import Trace, TraceStatus
 from apps.utils.factories.experiment import ExperimentSessionFactory
 
@@ -29,18 +27,6 @@ def _llm_result(input_tokens: int, output_tokens: int, model: str = "test-model"
         response_metadata={"model_name": model},
     )
     return LLMResult(generations=[[ChatGeneration(message=message, text="response")]], llm_output=None)
-
-
-@contextmanager
-def enable_team_flag(name: str, team):
-    flag, _ = Flag.objects.get_or_create(name=name)
-    flag.teams.add(team)
-    flag.flush()
-    try:
-        yield flag
-    finally:
-        flag.teams.remove(team)
-        flag.flush()
 
 
 def _seed_rule(provider: str, model: str, kind: ServiceKind, unit_price: str) -> PricingRule:
@@ -69,18 +55,8 @@ class TestRecordCostsShortCircuits:
         collector._exact_usage = {("openai", "gpt-4o-mini"): {"input_tokens": 10, "output_tokens": 5}}
         return collector
 
-    def test_short_circuits_when_flag_off(self, experiment):
-        tracer = OCSTracer(experiment, experiment.team_id)
-        tracer.cost_tracking_enabled = False
-        tracer.metrics_collector = self._collector_with_events()
-        tracer.trace_record = Mock(spec=Trace)
-        with patch("apps.cost_tracking.services.recorder.record_usage_bulk") as recorder:
-            tracer._record_costs()
-            recorder.assert_not_called()
-
     def test_short_circuits_when_collector_missing(self, experiment):
         tracer = OCSTracer(experiment, experiment.team_id)
-        tracer.cost_tracking_enabled = True
         tracer.metrics_collector = None
         tracer.trace_record = Mock(spec=Trace)
         with patch("apps.cost_tracking.services.recorder.record_usage_bulk") as recorder:
@@ -89,7 +65,6 @@ class TestRecordCostsShortCircuits:
 
     def test_short_circuits_when_trace_record_missing(self, experiment):
         tracer = OCSTracer(experiment, experiment.team_id)
-        tracer.cost_tracking_enabled = True
         tracer.metrics_collector = self._collector_with_events()
         tracer.trace_record = None
         with patch("apps.cost_tracking.services.recorder.record_usage_bulk") as recorder:
@@ -99,7 +74,6 @@ class TestRecordCostsShortCircuits:
     def test_short_circuits_when_no_events(self, experiment):
         """A trace with no LLM calls (`iter_cost_events` yields nothing) doesn't call the recorder."""
         tracer = OCSTracer(experiment, experiment.team_id)
-        tracer.cost_tracking_enabled = True
         tracer.metrics_collector = MetricsCollector(start_time=0.0)
         tracer.trace_record = Mock(spec=Trace)
         with patch("apps.cost_tracking.services.recorder.record_usage_bulk") as recorder:
@@ -111,40 +85,14 @@ class TestRecordCostsShortCircuits:
 
 
 @pytest.mark.django_db()
-class TestCostTrackingFlagGate:
-    """`cost_tracking_enabled` reflects the team-scoped Waffle flag at trace entry."""
-
-    def test_disabled_by_default(self, experiment):
-        tracer = OCSTracer(experiment, experiment.team_id)
-        session = ExperimentSessionFactory.create(experiment=experiment, team=experiment.team)
-        with tracer.trace(trace_context=TraceContext(id=uuid4(), name="t"), session=session):
-            assert tracer.cost_tracking_enabled is False
-
-    def test_enabled_when_flag_active_for_team(self, experiment):
-        tracer = OCSTracer(experiment, experiment.team_id)
-        session = ExperimentSessionFactory.create(experiment=experiment, team=experiment.team)
-        with (
-            enable_team_flag("flag_ai_cost_monitoring", experiment.team),
-            tracer.trace(trace_context=TraceContext(id=uuid4(), name="t"), session=session),
-        ):
-            assert tracer.cost_tracking_enabled is True
-
-    def test_reset_between_traces(self, experiment):
-        tracer = OCSTracer(experiment, experiment.team_id)
-        session = ExperimentSessionFactory.create(experiment=experiment, team=experiment.team)
-        with enable_team_flag("flag_ai_cost_monitoring", experiment.team):
-            with tracer.trace(trace_context=TraceContext(id=uuid4(), name="t"), session=session):
-                pass
-        # Outside the context, the per-trace state should be cleared.
-        assert tracer.cost_tracking_enabled is False
-        assert tracer.metrics_collector is None
-
-
-@pytest.mark.django_db()
 class TestCostRecordingEndToEnd:
-    """Full path: trace context -> LLM callbacks -> finalisation writes UsageRecord rows."""
+    """Full path: trace context -> LLM callbacks -> finalisation writes UsageRecord rows.
 
-    def test_writes_usage_records_when_flag_on(self, experiment):
+    Cost data is recorded for every team regardless of the `flag_ai_cost_monitoring`
+    flag; the flag only gates the UI.
+    """
+
+    def test_writes_usage_records_for_all_teams(self, experiment):
         _seed_rule("openai", "test-model", ServiceKind.LLM_INPUT, "0.00015")
         _seed_rule("openai", "test-model", ServiceKind.LLM_OUTPUT, "0.00060")
 
@@ -153,10 +101,7 @@ class TestCostRecordingEndToEnd:
         ctx = TraceContext(id=uuid4(), name="t")
         run_id = uuid4()
 
-        with (
-            enable_team_flag("flag_ai_cost_monitoring", experiment.team),
-            tracer.trace(trace_context=ctx, session=session),
-        ):
+        with tracer.trace(trace_context=ctx, session=session):
             tracer.metrics_collector.on_llm_start(
                 {},
                 ["hello world"],
@@ -176,26 +121,6 @@ class TestCostRecordingEndToEnd:
         assert all(r.trace_id is not None for r in rows)
         assert all(r.session_id == session.id for r in rows)
 
-    def test_writes_nothing_when_flag_off(self, experiment):
-        _seed_rule("openai", "test-model", ServiceKind.LLM_INPUT, "0.00015")
-
-        tracer = OCSTracer(experiment, experiment.team_id)
-        session = ExperimentSessionFactory.create(experiment=experiment, team=experiment.team)
-        ctx = TraceContext(id=uuid4(), name="t")
-        run_id = uuid4()
-
-        with tracer.trace(trace_context=ctx, session=session):
-            tracer.metrics_collector.on_llm_start(
-                {},
-                ["hello world"],
-                run_id=run_id,
-                invocation_params={"model": "test-model"},
-                metadata={"ocs_provider_type": "openai"},
-            )
-            tracer.metrics_collector.on_llm_end(_llm_result(1000, 500), run_id=run_id)
-
-        assert UsageRecord.objects.filter(team=experiment.team).count() == 0
-
     def test_trace_finalisation_continues_when_recorder_fails(self, experiment):
         """A cost-recording failure must not block trace_record.save() —
         outer try/except logs and continues."""
@@ -204,7 +129,6 @@ class TestCostRecordingEndToEnd:
         ctx = TraceContext(id=uuid4(), name="t")
 
         with (
-            enable_team_flag("flag_ai_cost_monitoring", experiment.team),
             patch(
                 "apps.service_providers.tracing.ocs_tracer.OCSTracer._record_costs",
                 side_effect=RuntimeError("simulated failure"),

--- a/apps/service_providers/tracing/tests/test_ocs_tracer_cost.py
+++ b/apps/service_providers/tracing/tests/test_ocs_tracer_cost.py
@@ -59,7 +59,7 @@ class TestRecordCostsShortCircuits:
         tracer = OCSTracer(experiment, experiment.team_id)
         tracer.metrics_collector = None
         tracer.trace_record = Mock(spec=Trace)
-        with patch("apps.cost_tracking.services.recorder.record_usage_bulk") as recorder:
+        with patch("apps.service_providers.tracing.ocs_tracer.record_usage_bulk") as recorder:
             tracer._record_costs()
             recorder.assert_not_called()
 
@@ -67,7 +67,7 @@ class TestRecordCostsShortCircuits:
         tracer = OCSTracer(experiment, experiment.team_id)
         tracer.metrics_collector = self._collector_with_events()
         tracer.trace_record = None
-        with patch("apps.cost_tracking.services.recorder.record_usage_bulk") as recorder:
+        with patch("apps.service_providers.tracing.ocs_tracer.record_usage_bulk") as recorder:
             tracer._record_costs()
             recorder.assert_not_called()
 
@@ -76,7 +76,7 @@ class TestRecordCostsShortCircuits:
         tracer = OCSTracer(experiment, experiment.team_id)
         tracer.metrics_collector = MetricsCollector(start_time=0.0)
         tracer.trace_record = Mock(spec=Trace)
-        with patch("apps.cost_tracking.services.recorder.record_usage_bulk") as recorder:
+        with patch("apps.service_providers.tracing.ocs_tracer.record_usage_bulk") as recorder:
             tracer._record_costs()
             recorder.assert_not_called()
 

--- a/apps/teams/flags.py
+++ b/apps/teams/flags.py
@@ -76,7 +76,7 @@ class Flags(FlagInfo, Enum):
 
     AI_COST_MONITORING = (
         "flag_ai_cost_monitoring",
-        "AI cost tracking - record per-call cost and surface a usage dashboard",
+        "AI cost tracking - surface the usage dashboard and pricing UI (data is recorded for all teams)",
         "",
         [],
         True,


### PR DESCRIPTION
### Product Description
No user-facing change. Cost/usage data is now captured for every team so it's already there when a team is later granted the dashboard, rather than starting empty at flag-flip time.

### Technical Description
Previously `flag_ai_cost_monitoring` gated both the write path (recording `UsageRecord`s) and the UI. This decouples them: `OCSTracer._record_costs` now runs for all teams, and the flag only controls the dashboard/pricing UI (already the case in `dashboard/views.py` and `service_providers/views.py`).

Worth noting: recording now runs on every trace. Pricing resolution is Redis-cached (24h TTL) and unpriced models write rows with `cost=0`, so the per-trace overhead is a cache hit plus one bulk insert. The recorder import moved to module level (aliased to avoid the name clash with the tracing `TraceContext`) since the lazy import only existed for the removed flag path.

### Migrations
N/A — no schema change.

### Docs and Changelog
- [ ] This PR requires docs/changelog update