### PR TITLE
[Docs] Explain max_vector_stores for OpenAI remote index limt of 2

### DIFF
--- a/docs/developer_guides/code_systems/index_managers.md
+++ b/docs/developer_guides/code_systems/index_managers.md
@@ -33,6 +33,8 @@ Abstract base class for managing vector stores in remote indexing services. Prov
 
 - **OpenAIRemoteIndexManager**: OpenAI-specific implementation for managing file uploads and vector stores using [OpenAI's vector store API](https://developers.openai.com/api/reference/resources/vector_stores).
 
+  The API can search across 2 vector stores, but rejects more than 2 with a 400 error ("maximum of 2 vector stores allowed"). This isn't documented by OpenAI; it only surfaces as a runtime error. OCS enforces this at node-validation time via `LlmProviderTypes.openai.max_vector_stores`.
+
 #### LocalIndexManager
 
 Abstract base class for managing local embedding operations. Handles text processing and embedding generation on the application side.


### PR DESCRIPTION
### Product Description

Only doc changes

### Technical Description

The technical information behind the UI restriction documented for users here: https://docs.openchatstudio.com/concepts/collections/indexed/#remote-index

This PR reduces technical info about this in the user docs so it should be clear in dev docs https://github.com/dimagi/open-chat-studio-docs/pull/563

Added: 
The API can search across 2 vector stores, but rejects more than 2 with a 400 error ("maximum of 2 vector stores allowed"). This isn't documented by OpenAI; it only surfaces as a runtime error. OCS enforces this at node-validation time via LlmProviderTypes.openai.max_vector_stores.


### Docs and Changelog
- [ ] This PR requires docs/changelog update

### Note for reviewer

Not very important, however I learned a lot digging into proving that this error does occur and OCS has implemented a way to reduce the impact on users
