### PR TITLE
Capture CommCare Connect 400 error bodies in Sentry

### DIFF
--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -31,6 +31,8 @@ def connect_channel_error_details(error: Exception, identifier: str) -> tuple[in
             identifier,
             status_code,
             error.response.text,
+            # Attach the exception for 400s so Sentry records the full error, not just a log message.
+            exc_info=error if status_code == 400 else None,
         )
         if status_code == 404:
             return 404, "Failed to create channel: Participant not found in CommCare Connect"

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -16,7 +16,11 @@ from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
-from apps.api.tasks import DuplicateConnectChannelError, create_connect_channel_for_participant
+from apps.api.tasks import (
+    DuplicateConnectChannelError,
+    connect_channel_error_details,
+    create_connect_channel_for_participant,
+)
 from apps.channels.models import ChannelPlatform
 from apps.experiments.models import ExperimentSession, Participant, ParticipantData, SessionStatus
 from apps.teams.backends import CHATBOT_ADMIN_GROUP, add_user_to_team
@@ -481,6 +485,27 @@ def test_update_participant_data_connect_channel_failure(httpx_mock, upstream, e
     participant_data = ParticipantData.objects.get(participant__identifier="connectid_3", experiment=experiment)
     assert participant_data.data == {"name": "John"}
     assert "commcare_connect_channel_id" not in participant_data.system_metadata
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expect_captured"),
+    [
+        pytest.param(400, True, id="400-captured"),
+        pytest.param(404, False, id="404-not-captured"),
+        pytest.param(500, False, id="500-not-captured"),
+    ],
+)
+def test_connect_channel_error_details_reports_400_to_sentry(status_code, expect_captured):
+    """400s from Connect attach the exception so Sentry records the full error; others don't."""
+    error = httpx.HTTPStatusError(
+        "error",
+        request=httpx.Request("POST", "http://connect/messaging/create_channel/"),
+        response=httpx.Response(status_code, text="bad request"),
+    )
+    with patch("apps.api.tasks.logger") as mock_logger:
+        connect_channel_error_details(error, "connectid_1")
+
+    assert mock_logger.error.call_args.kwargs["exc_info"] is (error if expect_captured else None)
 
 
 @pytest.mark.django_db()

--- a/apps/channels/clients/connect_client.py
+++ b/apps/channels/clients/connect_client.py
@@ -11,6 +11,20 @@ from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_afte
 logger = logging.getLogger("ocs.channels.connect")
 
 
+def _raise_for_status(response: httpx.Response) -> None:
+    """Raise on HTTP errors, attaching the response body so it surfaces in logs and Sentry.
+
+    ``httpx.HTTPStatusError`` only stringifies the status line, so the CommCare Connect error
+    body (e.g. ``{"errors": "no_user_consent"}``) would otherwise be lost. The note preserves the
+    exception type and grouping while making the reason visible.
+    """
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        e.add_note(f"Response body: {response.text}")
+        raise
+
+
 class Message(TypedDict):
     timestamp: str
     message_id: UUID
@@ -52,7 +66,7 @@ class CommCareConnectClient:
         if channel_name:
             data["channel_name"] = channel_name
         response = self.client.post(url, json=data)
-        response.raise_for_status()
+        _raise_for_status(response)
         return response.json()
 
     def decrypt_messages(self, key: bytes, messages: list[Message]) -> list[str]:
@@ -95,7 +109,7 @@ class CommCareConnectClient:
     def _send_fcm(self, payload: dict) -> None:
         url = f"{self._base_url}/messaging/send_fcm/"
         response = self.client.post(url, json=payload)
-        response.raise_for_status()
+        _raise_for_status(response)
 
     def _encrypt_message(self, key: bytes, message: str) -> tuple[str, str, str]:
         cipher = AES.new(key, AES.MODE_GCM)

--- a/apps/channels/tests/test_connect_client.py
+++ b/apps/channels/tests/test_connect_client.py
@@ -85,6 +85,22 @@ class TestConnectClient:
         assert messages[0] == "this is a secret message"
 
     @override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
+    def test_send_message_error_attaches_response_body(self, httpx_mock):
+        """A 400 from Connect attaches the response body as a note so it's visible in Sentry."""
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{settings.COMMCARE_CONNECT_SERVER_URL}/messaging/send_fcm/",
+            json={"errors": "no_user_consent"},
+            status_code=400,
+        )
+
+        connect_client = CommCareConnectClient()
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            connect_client.send_message_to_user(str(uuid4()), message="hi", encryption_key=os.urandom(32))
+
+        assert any("no_user_consent" in note for note in exc_info.value.__notes__)
+
+    @override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
     def test_send_message_to_user(self, httpx_mock):
         httpx_mock.add_response(
             method="POST",


### PR DESCRIPTION
### Product Description
no change

### Technical Description
Connect 400s were reaching Sentry but without the reason: `httpx.HTTPStatusError` only stringifies the status line, so the server's JSON body (`{"errors": "no_user_consent"}`, `channel_does_not_exist`, etc.) was lost.

- Client (`connect_client.py`): `_raise_for_status` attaches the response body as an exception *note* on any Connect HTTP error, for both `create_channel` and `_send_fcm`. Note (rather than message rewrite) keeps the exception type — so the existing `connect_channel_error_details` mapping still works — and preserves Sentry grouping (type + value + stacktrace).
- Create path (`tasks.py`): attach the exception via `exc_info` on 400s so it's logged as a proper exception event instead of a bare message.

### Migrations
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update