### PR TITLE
fix: audited team deletion — serialize schema fields and respect PROTECT ordering

### DIFF
--- a/apps/audit/service.py
+++ b/apps/audit/service.py
@@ -1,9 +1,8 @@
-import json
-
+from django.core.exceptions import FieldDoesNotExist
 from django_pydantic_field.v2.fields import PydanticSchemaField
 from field_audit import AuditService as AuditServiceOriginal
 from field_audit.global_context import is_audit_enabled
-from pydantic import BaseModel
+from pydantic_core import to_jsonable_python
 
 
 class AuditService(AuditServiceOriginal):
@@ -17,8 +16,31 @@ class AuditService(AuditServiceOriginal):
     def get_field_value(self, instance, field_name, bootstrap=False):
         field = instance._meta.get_field(field_name)
         if isinstance(field, PydanticSchemaField):
-            value = field.value_from_object(instance)
-            if value and isinstance(value, BaseModel):
-                return json.loads(value.model_dump_json())
-            return value
+            return to_jsonable_python(field.value_from_object(instance))
         return super().get_field_value(instance, field_name, bootstrap)
+
+    def make_audit_event_from_values(self, old_values, new_values, object_pk, object_cls, request):
+        # The delete path fetches values via ``QuerySet.values()``, which returns pydantic objects for
+        # SchemaFields (bypassing ``get_field_value``). Serialize them so the delta is JSON safe.
+        return super().make_audit_event_from_values(
+            _values_to_json_safe(old_values, object_cls),
+            _values_to_json_safe(new_values, object_cls),
+            object_pk,
+            object_cls,
+            request,
+        )
+
+
+def _values_to_json_safe(values, object_cls):
+    return {
+        name: to_jsonable_python(value) if _is_schema_field(object_cls, name) else value
+        for name, value in values.items()
+    }
+
+
+def _is_schema_field(object_cls, name):
+    try:
+        field = object_cls._meta.get_field(name)
+    except FieldDoesNotExist:
+        return False
+    return isinstance(field, PydanticSchemaField)

--- a/apps/audit/tests/models.py
+++ b/apps/audit/tests/models.py
@@ -6,6 +6,7 @@ rebuilding the test database (use `--create-db`).
 
 from django.db import models
 from django_pydantic_field import SchemaField
+from field_audit import audit_fields
 from pydantic import BaseModel, HttpUrl
 
 
@@ -17,6 +18,7 @@ class TestSchema(BaseModel):
     url_attr: HttpUrl
 
 
+@audit_fields("config")
 class ModelWithSchemaField(models.Model):
     config = SchemaField(TestSchema)
 

--- a/apps/audit/tests/test_service.py
+++ b/apps/audit/tests/test_service.py
@@ -1,3 +1,7 @@
+import json
+
+from field_audit import enable_audit
+
 from apps.audit.service import AuditService
 from apps.audit.tests.models import ModelWithSchemaField, TestSchema
 
@@ -8,3 +12,16 @@ def test_serialize_schema_field():
 
     value = AuditService().get_field_value(model, "config")
     assert value == {"att1": "value", "att2": 42, "url_attr": "http://example.com/"}
+
+
+def test_make_audit_event_from_values_serializes_schema_field():
+    """The audited delete path passes raw ``QuerySet.values()`` output (pydantic models for
+    SchemaFields) here, so the resulting delta must be JSON serializable."""
+    config = TestSchema(att1="value", att2=42, url_attr="http://example.com")
+    with enable_audit():
+        event = AuditService().make_audit_event_from_values(
+            {"config": config}, {}, object_pk=1, object_cls=ModelWithSchemaField, request=None
+        )
+
+    assert event.delta == {"config": {"old": {"att1": "value", "att2": 42, "url_attr": "http://example.com/"}}}
+    json.dumps(event.delta)  # must not raise

--- a/apps/utils/deletion.py
+++ b/apps/utils/deletion.py
@@ -45,10 +45,11 @@ def delete_object_with_auditing_of_related_objects(obj):
     with transaction.atomic():
         _perform_updates_for_delete(updates_not_part_of_delete)
 
-        for model, instances in reversed(collector.data.items()):
+        for model in _deletion_order(collector.data):
             if model._meta.auto_created:
                 continue
 
+            instances = collector.data[model]
             audit_kwargs = {}
             if model in get_audited_models() and isinstance(model._default_manager, AuditingManager):
                 audit_kwargs["audit_action"] = AuditAction.AUDIT
@@ -56,6 +57,54 @@ def delete_object_with_auditing_of_related_objects(obj):
             _, stats = model.objects.filter(pk__in=[instance.pk for instance in instances]).delete(**audit_kwargs)
             counter.update(stats)
     return dict(counter)
+
+
+def _deletion_order(collector_data):
+    """Order the collected models so each is safe to delete before the next.
+
+    Reversing ``collector_data`` already respects CASCADE relations, so that is our starting point.
+    On top of it we honour PROTECT (and RESTRICT, same effect here) foreign keys: a model that
+    PROTECT-references another collected model must be deleted first, otherwise deleting the
+    referenced model raises ``ProtectedError``.
+
+    CASCADE foreign keys impose the same referencer-first ordering: deleting the referenced model
+    first would cascade-delete the referencer's rows outside its own audited delete. The base order
+    already satisfies this, but it is added as an explicit constraint so PROTECT-driven reordering
+    cannot violate it.
+    """
+    base_order = list(reversed(collector_data))
+
+    # on_delete behaviors that require the referencing model's rows to be gone first
+    ordering_on_delete = (models.PROTECT, models.RESTRICT, models.CASCADE)
+
+    # must_follow[target] = models that must be deleted before `target`
+    must_follow = {model: set() for model in base_order}
+    for model in base_order:
+        for field in model._meta.concrete_fields:
+            if not isinstance(field, models.ForeignKey):
+                continue
+            if field.remote_field.on_delete not in ordering_on_delete:
+                continue
+            target = field.related_model
+            if target is not model and target in must_follow:
+                must_follow[target].add(model)
+
+    # Repeatedly pick the first model in `remaining` whose blockers have all been handled.
+    # Since `remaining` is in base order, models keep their original position unless a
+    # constraint forces them to wait.
+    ordered = []
+    done = set()
+    remaining = list(base_order)
+    while remaining:
+        model = next((m for m in remaining if must_follow[m] <= done), None)
+        if model is None:
+            # A constraint cycle; fall back to base order for what's left.
+            ordered.extend(remaining)
+            break
+        ordered.append(model)
+        done.add(model)
+        remaining.remove(model)
+    return ordered
 
 
 def _perform_updates_for_delete(updates_not_part_of_delete):
@@ -87,10 +136,10 @@ def _queryset_update_with_auditing(queryset, **kw):
     Copied from `field_audit.models.AuditingQuerySet.update` so that it can be called with querysets
     that are not AuditingQuerySets.
     """
-    from field_audit import AuditService  # noqa: PLC0415 - init-order: apps.py loads before app registry is ready
+    from field_audit import get_audit_service  # noqa: PLC0415 - init-order: apps.py loads before app registry is ready
     from field_audit.models import AuditEvent  # noqa: PLC0415 - init-order: apps.py loads before app registry is ready
 
-    audit_service = AuditService()
+    audit_service = get_audit_service()
     fields_to_update = set(kw.keys())
     audited_fields = set(audit_service.get_field_names(queryset.model))
     fields_to_audit = fields_to_update & audited_fields

--- a/apps/utils/tests/models.py
+++ b/apps/utils/tests/models.py
@@ -4,13 +4,15 @@ These only exist in the test database. Changes to the model classes require
 rebuilding the test database (use `--create-db`).
 
 Audited models: Collection, Bot, Tool
-Unaudited models: Param
+Unaudited models: Param, Webhook, CycleA, CycleB
 
 Relationships:
 - Bot -> Collection (CASCADE)
 - Bot -> Tool (M2M)
 - Tool -> Collection (SET_NULL)
 - Param -> Tool (CASCADE)
+- Webhook -> Bot (PROTECT)
+- CycleA <-> CycleB (PROTECT both ways, for deletion-order cycle tests)
 """
 
 from django.db import models
@@ -57,6 +59,27 @@ class Collection(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class Webhook(models.Model):
+    bot = models.ForeignKey(Bot, on_delete=models.PROTECT)
+
+    def __str__(self):
+        return str(self.pk)
+
+
+class CycleA(models.Model):
+    other = models.ForeignKey("CycleB", on_delete=models.PROTECT, null=True)
+
+    def __str__(self):
+        return str(self.pk)
+
+
+class CycleB(models.Model):
+    other = models.ForeignKey(CycleA, on_delete=models.PROTECT, null=True)
+
+    def __str__(self):
+        return str(self.pk)
 
 
 MODEL_NAMES = [f"{model.__module__}.{model.__name__}" for model in [Bot, Tool, Collection, Param]]

--- a/apps/utils/tests/test_delete_with_auditing.py
+++ b/apps/utils/tests/test_delete_with_auditing.py
@@ -2,9 +2,15 @@ import pytest
 from field_audit import enable_audit
 from field_audit.models import AuditEvent
 
-from apps.utils.deletion import delete_object_with_auditing_of_related_objects
+from apps.annotations.models import Tag
+from apps.documents.models import DocumentSource
+from apps.evaluations.models import EvaluatorTagRule
+from apps.service_providers.models import AuthProvider
+from apps.utils.deletion import _deletion_order, delete_object_with_auditing_of_related_objects
 from apps.utils.factories.assistants import OpenAiAssistantFactory
-from apps.utils.factories.service_provider_factories import LlmProviderFactory
+from apps.utils.factories.documents import DocumentSourceFactory
+from apps.utils.factories.evaluations import EvaluatorTagRuleFactory
+from apps.utils.factories.service_provider_factories import AuthProviderFactory, LlmProviderFactory
 from apps.utils.factories.team import TeamFactory
 
 
@@ -68,3 +74,81 @@ def test_deleting_a_team_does_not_remove_llm_providers_from_other_teams():
         delete_object_with_auditing_of_related_objects(team_to_delete)
         assistant.refresh_from_db()
         assert assistant.llm_provider is not None
+
+
+@pytest.mark.django_db()
+def test_deleting_a_team_with_protected_fk_between_owned_objects():
+    """Deleting a team must not fail when one team-owned object PROTECT-references another.
+
+    A DocumentSource has a PROTECT FK to an AuthProvider. Both belong to the team, so both are
+    deleted, but the DocumentSource must be deleted first -- otherwise deleting the AuthProvider
+    raises ProtectedError.
+    """
+    with enable_audit():
+        team = TeamFactory.create()
+        auth_provider = AuthProviderFactory.create(team=team)
+        DocumentSourceFactory.create(team=team, collection__team=team, auth_provider=auth_provider)
+
+        delete_object_with_auditing_of_related_objects(team)
+
+        assert not DocumentSource.objects.filter(team=team).exists()
+        assert not AuthProvider.objects.filter(team=team).exists()
+
+
+@pytest.mark.django_db()
+def test_deleting_a_team_with_protected_tag_reference():
+    """Same ordering guarantee for the evaluations EvaluatorTagRule -> Tag PROTECT FK."""
+    with enable_audit():
+        team = TeamFactory.create()
+        EvaluatorTagRuleFactory.create(team=team)
+
+        delete_object_with_auditing_of_related_objects(team)
+
+        assert not EvaluatorTagRule.objects.filter(team=team).exists()
+        assert not Tag.objects.filter(team=team).exists()
+
+
+def test_deletion_order_keeps_base_order_without_protect_constraints():
+    from apps.utils.tests.models import (  # noqa: PLC0415 - lazy: test models require setup_test_app() to run first
+        Collection,
+        Param,
+        Tool,
+    )
+
+    assert _deletion_order({Collection: [], Tool: [], Param: []}) == [Param, Tool, Collection]
+
+
+def test_deletion_order_moves_protect_referencer_first():
+    from apps.utils.tests.models import (  # noqa: PLC0415 - lazy: test models require setup_test_app() to run first
+        Bot,
+        Webhook,
+    )
+
+    # base order [Bot, Webhook] but Webhook PROTECT-references Bot
+    assert _deletion_order({Webhook: [], Bot: []}) == [Webhook, Bot]
+
+
+def test_deletion_order_does_not_leapfrog_cascade_references():
+    """A PROTECT-delayed model must not be leapfrogged past a model it CASCADE-references.
+
+    Base order [Bot, Collection, Webhook]. Webhook PROTECT-references Bot, delaying Bot. Bot
+    CASCADE-references Collection, so Collection must still be deleted after Bot -- deleting
+    Collection first would cascade-delete Bot's rows outside the audited per-model delete.
+    """
+    from apps.utils.tests.models import (  # noqa: PLC0415 - lazy: test models require setup_test_app() to run first
+        Bot,
+        Collection,
+        Webhook,
+    )
+
+    order = _deletion_order({Webhook: [], Collection: [], Bot: []})
+    assert order.index(Webhook) < order.index(Bot) < order.index(Collection)
+
+
+def test_deletion_order_protect_cycle_falls_back_to_base_order():
+    from apps.utils.tests.models import (  # noqa: PLC0415 - lazy: test models require setup_test_app() to run first
+        CycleA,
+        CycleB,
+    )
+
+    assert _deletion_order({CycleA: [], CycleB: []}) == [CycleB, CycleA]


### PR DESCRIPTION
### Product Description
No user-facing change. Fixes two crashes when deleting a team.

### Technical Description
Deleting a team runs every owned object through the audited delete path (`delete_object_with_auditing_of_related_objects`). Two things broke there:

- **Schema-field serialization.** The delete path builds audit deltas from raw `QuerySet.values()`, which returns pydantic model instances for `PydanticSchemaField`s (bypassing `get_field_value`). Those aren't JSON-serializable, so the resulting delta blew up. `AuditService.make_audit_event_from_values` now runs schema-field values through `to_jsonable_python` before delegating. `get_field_value` was simplified onto the same helper.
- **Deletion ordering.** Models were deleted in plain reversed-collector order, which respects CASCADE but not PROTECT/RESTRICT FKs *between* team-owned objects (e.g. `DocumentSource → AuthProvider`, `EvaluatorTagRule → Tag`), raising `ProtectedError`. `_deletion_order` now topologically sorts so a referencer is always deleted before its target, while preserving the base order (and the CASCADE referencer-first invariant) wherever no constraint forces a move. Constraint cycles fall back to base order rather than erroring.

Worth a look during review:
- `_deletion_order` treats CASCADE as an explicit ordering constraint too, so PROTECT-driven reordering can't accidentally place a model ahead of one it CASCADE-references (covered by `test_deletion_order_does_not_leapfrog_cascade_references`).
- The `field_audit.AuditService()` → `get_audit_service()` swap in `_queryset_update_with_auditing` picks up this project's `AuditService` subclass rather than the library default.

### Migrations
N/A — no schema changes. New models under `apps/utils/tests/` and `apps/audit/tests/` are test-only.

### Docs and Changelog
- [ ] This PR requires docs/changelog update