### PR TITLE
feat: load sync_team private key from env var

### DIFF
--- a/apps/teams/export/tests/test_command.py
+++ b/apps/teams/export/tests/test_command.py
@@ -13,7 +13,9 @@ from apps.teams.export.manifest import schema_checksum
 from apps.teams.export.translation import FKTranslationStore
 from apps.teams.management.commands import sync_team
 from apps.teams.management.commands.sync_team import (
+    PRIVATE_KEY_ENV_VAR,
     Command,
+    _load_private_key,
     check_sync_preconditions,
     force_delete_team,
     run_sync,
@@ -98,6 +100,50 @@ def _scenario(public_key):
         ],
     }
     return _manifest(entries), rows
+
+
+def _private_pem(private):
+    return private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def _unseals(loaded_key, public_key):
+    """The loaded private key can unseal what its matching public key sealed -- proves the right key
+    was loaded, not just that some key came back."""
+    return seal_mod.unseal(seal_mod.seal({"x": 1}, public_key), loaded_key) == {"x": 1}
+
+
+def test_load_private_key_from_flag_file(tmp_path, keypair):
+    public_key, private = keypair
+    key_file = tmp_path / "key.pem"
+    key_file.write_bytes(_private_pem(private))
+
+    assert _unseals(_load_private_key(str(key_file)), public_key)
+
+
+def test_load_private_key_from_env_holds_key_contents(monkeypatch, keypair):
+    """The env var carries the PEM key itself, not a path to it."""
+    public_key, private = keypair
+    monkeypatch.setenv(PRIVATE_KEY_ENV_VAR, _private_pem(private).decode())
+
+    assert _unseals(_load_private_key(None), public_key)
+
+
+def test_flag_file_takes_precedence_over_env(tmp_path, keypair, monkeypatch):
+    public_key, private = keypair
+    key_file = tmp_path / "key.pem"
+    key_file.write_bytes(_private_pem(private))
+    monkeypatch.setenv(PRIVATE_KEY_ENV_VAR, "not-a-real-key")  # would raise if the env were consulted
+
+    assert _unseals(_load_private_key(str(key_file)), public_key)
+
+
+def test_load_private_key_returns_none_when_unset(monkeypatch):
+    monkeypatch.delenv(PRIVATE_KEY_ENV_VAR, raising=False)
+    assert _load_private_key(None) is None
 
 
 def test_schema_checksum_mismatch_aborts(tmp_path, keypair):

--- a/apps/teams/management/commands/sync_team.py
+++ b/apps/teams/management/commands/sync_team.py
@@ -6,6 +6,7 @@ The command is a thin shell: it wires the resource fetcher to the import engine 
 translation store. Each run makes one pass over the manifest and exits; rerun to pick up new data.
 """
 
+import os
 import time
 from collections.abc import Sequence
 from datetime import timedelta
@@ -29,6 +30,7 @@ from apps.teams.utils import current_team
 from apps.utils.deletion import delete_object_with_auditing_of_related_objects
 
 FILES_CONFIRMED_FLAG = "files_confirmed"
+PRIVATE_KEY_ENV_VAR = "SYNC_TEAM_PRIVATE_KEY"
 MIGRATION_MODE_REQUIRED = "Migration mode needs to be enabled on the source team before you can continue."
 MISSING_PUBLIC_KEY_MESSAGE = (
     "The source team has no public key registered, so its secret data cannot be exported. "
@@ -59,6 +61,19 @@ def _friendly_http_error_message(exc: requests.HTTPError) -> str | None:
     for status_code, marker, message in _FRIENDLY_HTTP_ERRORS:
         if response.status_code == status_code and marker in detail:
             return message
+    return None
+
+
+def _load_private_key(private_key_path: str | None):
+    """Load the RSA private key used to unseal secret fields, or None when no key is configured.
+
+    The --private-key-path flag points to a key file and takes precedence. When it is omitted, the
+    SYNC_TEAM_PRIVATE_KEY env var is read for the key contents themselves (PEM), not a path to it."""
+    if private_key_path:
+        return load_private_key(Path(private_key_path).read_bytes())
+    env_key = os.environ.get(PRIVATE_KEY_ENV_VAR)
+    if env_key:
+        return load_private_key(env_key.encode())
     return None
 
 
@@ -260,7 +275,14 @@ class Command(BaseCommand):
             required=True,
             help="Names the local run state DB and identifies the team to drop when --force-delete is set.",
         )
-        parser.add_argument("--private-key-path", help="RSA private key used to unseal secret fields.")
+        parser.add_argument(
+            "--private-key-path",
+            help=(
+                "Path to the RSA private key file used to unseal secret fields. When omitted, the "
+                f"key is read from the {PRIVATE_KEY_ENV_VAR} env var, which holds the key itself "
+                "(PEM contents) rather than a path. The flag takes precedence over the env var."
+            ),
+        )
         parser.add_argument("--state-dir", default=".", help="Directory for the per-team SQLite state DB.")
         parser.add_argument("--limit", type=int, default=100, help="Page size for resource requests.")
         parser.add_argument(
@@ -276,9 +298,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         start_time = time.monotonic()
-        private_key = None
-        if options["private_key_path"]:
-            private_key = load_private_key(Path(options["private_key_path"]).read_bytes())
+        private_key = _load_private_key(options["private_key_path"])
 
         client = ResourceFetcher(options["source_url"], options["api_key"])
         enforce_schema = not options["skip_schema_check"]


### PR DESCRIPTION
### Product Description
The `sync_team` management command can now take the RSA private key (used to unseal secret fields during a team migration) from an environment variable instead of only a file on disk. This makes it easier to run the command in environments where writing a key file is awkward (CI, containers, secret managers that inject env vars).

### Technical Description
- Added the `SYNC_TEAM_PRIVATE_KEY` env var, which holds the key **contents** (PEM), not a path to a file.
- The existing `--private-key-path` flag still points to a key **file** and takes precedence when both are set.
- Extracted the resolution into `_load_private_key()`: reads the file when the flag is given, otherwise loads the key from the env var contents, returning `None` when neither is configured.
- Updated the flag's help text to document the distinction and precedence.

### Migrations
- [ ] The migrations are backwards compatible

_No migrations._

### Demo
_n/a — CLI behavior change._

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)