### PR TITLE
Treat 400 MESSAGE_ID_ALREADY_EXISTS from Connect as success

### DIFF
--- a/apps/channels/clients/connect_client.py
+++ b/apps/channels/clients/connect_client.py
@@ -1,5 +1,4 @@
 import base64
-import json
 import logging
 from typing import TypedDict
 from uuid import UUID, uuid4
@@ -124,7 +123,9 @@ class CommCareConnectClient:
     def _is_message_already_exists(response: httpx.Response) -> bool:
         try:
             return response.json().get("errors") == MESSAGE_ID_ALREADY_EXISTS
-        except (json.JSONDecodeError, AttributeError):
+        except (ValueError, AttributeError):
+            # ValueError covers both a non-JSON body and an undecodable one (UnicodeDecodeError);
+            # AttributeError covers valid JSON that isn't an object. All mean "not the dedupe error".
             return False
 
     def _encrypt_message(self, key: bytes, message: str) -> tuple[str, str, str]:

--- a/apps/channels/clients/connect_client.py
+++ b/apps/channels/clients/connect_client.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import logging
 from typing import TypedDict
 from uuid import UUID, uuid4
@@ -9,6 +10,11 @@ from django.conf import settings
 from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger("ocs.channels.connect")
+
+# Connect returns this in a 400 body when a message with the same message_id was already
+# received. Because we reuse the message_id across retries, this happens when a prior attempt
+# timed out client-side but actually arrived — the message is delivered, so it's not an error.
+MESSAGE_ID_ALREADY_EXISTS = "MESSAGE_ID_ALREADY_EXISTS"
 
 
 def _raise_for_status(response: httpx.Response) -> None:
@@ -109,7 +115,17 @@ class CommCareConnectClient:
     def _send_fcm(self, payload: dict) -> None:
         url = f"{self._base_url}/messaging/send_fcm/"
         response = self.client.post(url, json=payload)
+        if response.status_code == 400 and self._is_message_already_exists(response):
+            logger.info("Message %s already delivered to Connect; treating as success", payload.get("message_id"))
+            return
         _raise_for_status(response)
+
+    @staticmethod
+    def _is_message_already_exists(response: httpx.Response) -> bool:
+        try:
+            return response.json().get("errors") == MESSAGE_ID_ALREADY_EXISTS
+        except (json.JSONDecodeError, AttributeError):
+            return False
 
     def _encrypt_message(self, key: bytes, message: str) -> tuple[str, str, str]:
         cipher = AES.new(key, AES.MODE_GCM)

--- a/apps/channels/tests/test_connect_client.py
+++ b/apps/channels/tests/test_connect_client.py
@@ -57,6 +57,15 @@ class TestConnectClientSendRetry:
         assert len(httpx_mock.get_requests()) == 2
 
     @override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
+    def test_malformed_400_body_still_raises(self, httpx_mock, disable_retry_wait):
+        """A 400 with an undecodable body must not be swallowed; it still raises via _raise_for_status."""
+        httpx_mock.add_response(method="POST", url=self._send_url, content=b"\xff\xfe", status_code=400)
+
+        client = CommCareConnectClient()
+        with pytest.raises(httpx.HTTPStatusError):
+            client.send_message_to_user(str(uuid4()), message="hello", encryption_key=os.urandom(32))
+
+    @override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
     def test_message_id_stable_across_retries(self, httpx_mock, disable_retry_wait):
         httpx_mock.add_exception(httpx.ReadTimeout("read timed out"), url=self._send_url)
         httpx_mock.add_response(method="POST", url=self._send_url, status_code=200)

--- a/apps/channels/tests/test_connect_client.py
+++ b/apps/channels/tests/test_connect_client.py
@@ -44,6 +44,19 @@ class TestConnectClientSendRetry:
         assert len(requests) == 2
 
     @override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
+    def test_message_already_exists_treated_as_success(self, httpx_mock, disable_retry_wait):
+        """A timeout followed by a 400 MESSAGE_ID_ALREADY_EXISTS means the message arrived; not an error."""
+        httpx_mock.add_exception(httpx.ReadTimeout("read timed out"), url=self._send_url)
+        httpx_mock.add_response(
+            method="POST", url=self._send_url, json={"errors": "MESSAGE_ID_ALREADY_EXISTS"}, status_code=400
+        )
+
+        client = CommCareConnectClient()
+        client.send_message_to_user(str(uuid4()), message="hello", encryption_key=os.urandom(32))
+
+        assert len(httpx_mock.get_requests()) == 2
+
+    @override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
     def test_message_id_stable_across_retries(self, httpx_mock, disable_retry_wait):
         httpx_mock.add_exception(httpx.ReadTimeout("read timed out"), url=self._send_url)
         httpx_mock.add_response(method="POST", url=self._send_url, status_code=200)


### PR DESCRIPTION
### Product Description
no change

### Technical Description
`send_message_to_user` retries transient timeouts while reusing the same `message_id`. When the first attempt times out client-side but actually reaches Connect, the retry gets back a `400 {"errors": "MESSAGE_ID_ALREADY_EXISTS"}` — the message *was* delivered, so this is a successful send, not an error. `_send_fcm` now short-circuits that specific 400 (logs at info, returns); every other 400 still raises with the body attached as before.

### Docs and Changelog
- [ ] This PR requires docs/changelog update