### PR TITLE
refactor: standardize destructive-action confirmation dialogs

### DIFF
--- a/assets/javascript/alertify.js
+++ b/assets/javascript/alertify.js
@@ -10,7 +10,10 @@ window.confirmThenTrigger = function (elementId, message) {
     message: message,
     transition: 'fade',
     onok: function () {
-      htmx.trigger('#' + elementId, 'confirmed');
+      const element = document.getElementById(elementId);
+      if (element) {
+        htmx.trigger(element, 'confirmed');
+      }
     },
   }).show();
 };

--- a/assets/javascript/alertify.js
+++ b/assets/javascript/alertify.js
@@ -1,2 +1,16 @@
 import * as alertify from 'alertifyjs'
 window.alertify = alertify;
+
+// Canonical pattern for confirming a destructive htmx action with the styled
+// alertify modal instead of the native `hx-confirm` browser dialog. Pair with
+// `hx-trigger="confirmed"` and a unique element id on the triggering element.
+window.confirmThenTrigger = function (elementId, message) {
+  alertify.confirm().setting({
+    title: 'Confirm',
+    message: message,
+    transition: 'fade',
+    onok: function () {
+      htmx.trigger('#' + elementId, 'confirmed');
+    },
+  }).show();
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,11 @@ export default tseslint.config(
     "languageOptions": {
       "globals": {
         ...globals.browser,
-      }
+        htmx: "readonly",
+      },
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
   },
 );

--- a/templates/admin/flags/flag_list.html
+++ b/templates/admin/flags/flag_list.html
@@ -67,11 +67,13 @@
                     </a>
                     {% if show_legacy %}
                       <button
+                        id="delete-flag-{{ flag.id }}"
                         class="btn btn-sm btn-error"
                         hx-delete="{% url 'ocs_admin:delete_flag' flag.name %}"
                         hx-target="#flag-{{ flag.id }}"
                         hx-swap="outerHTML"
-                        hx-confirm="Are you sure you want to delete the legacy flag '{{ flag.name }}'? This action cannot be undone."
+                        hx-trigger="confirmed"
+                        onclick="confirmThenTrigger('delete-flag-{{ flag.id }}', 'Are you sure you want to delete the legacy flag \'{{ flag.name|escapejs }}\'? This action cannot be undone.')"
                         aria-label="Delete flag"
                       >
                         <i class="fa fa-trash" aria-hidden="true"></i>

--- a/templates/admin/flags/flag_list.html
+++ b/templates/admin/flags/flag_list.html
@@ -73,7 +73,7 @@
                         hx-target="#flag-{{ flag.id }}"
                         hx-swap="outerHTML"
                         hx-trigger="confirmed"
-                        onclick="confirmThenTrigger('delete-flag-{{ flag.id }}', 'Are you sure you want to delete the legacy flag \'{{ flag.name|escapejs }}\'? This action cannot be undone.')"
+                        onclick="confirmThenTrigger('delete-flag-{{ flag.id }}', 'Are you sure you want to delete the legacy flag \'{{ flag.name|escape|escapejs }}\'? This action cannot be undone.')"
                         aria-label="Delete flag"
                       >
                         <i class="fa fa-trash" aria-hidden="true"></i>

--- a/templates/chatbots/settings_content.html
+++ b/templates/chatbots/settings_content.html
@@ -33,9 +33,11 @@
                   hx-swap="outerHTML">
             Edit
           </button>
-          <button class="btn btn-error btn-sm"
+          <button id="archive-chatbot-button"
+                  class="btn btn-error btn-sm"
                   hx-post="{% url 'chatbots:archive' request.team.slug experiment.id %}"
-                  hx-confirm="Are you sure you wish to archive this chatbot?">
+                  hx-trigger="confirmed"
+                  onclick="confirmThenTrigger('archive-chatbot-button', 'Are you sure you wish to archive this chatbot?')">
             Archive
           </button>
         {% endif %}

--- a/templates/documents/partials/document_source_header.html
+++ b/templates/documents/partials/document_source_header.html
@@ -20,13 +20,15 @@
         hx-disabled-elt="this"
     ><i class="fa-solid fa-pencil"></i></a>
     <a
+        id="delete-document-source-{{ document_source.id }}"
         class="btn btn-ghost btn-sm join-item"
         hx-delete="{% url "documents:delete_document_source" team.slug collection.id document_source.id %}"
         hx-target="#document_source_{{ document_source.id }}"
         hx-swap="outerHTML"
         hx-indicator="#document_source_loading_{{ document_source.id }}"
         hx-disabled-elt="this"
-        hx-confirm="Are you sure you wish to delete this document source and all its data?"
+        hx-trigger="confirmed"
+        onclick="confirmThenTrigger('delete-document-source-{{ document_source.id }}', 'Are you sure you wish to delete this document source and all its data?')"
     ><i class="fa-solid fa-trash"></i></a>
     {% if not document_source.sync_task_id %}
       <a

--- a/templates/evaluations/evaluation_runs_home.html
+++ b/templates/evaluations/evaluation_runs_home.html
@@ -45,12 +45,7 @@
                   hx-post="{% url 'evaluations:clear_evaluation_runs' request.team.slug config.id %}"
                   hx-trigger="confirmed"
                   hx-disabled-elt="this"
-                  onclick="alertify.confirm().setting({
-                    title: 'Confirm',
-                    message: 'Clear all? This removes the tags these runs applied to their targets and deletes all run history and results. This cannot be undone.',
-                    transition: 'fade',
-                    onok: function() { htmx.trigger('#clear-all-runs-button', 'confirmed'); },
-                  }).show();">
+                  onclick="confirmThenTrigger('clear-all-runs-button', 'Clear all? This removes the tags these runs applied to their targets and deletes all run history and results. This cannot be undone.')">
             <i class="fa-solid fa-eraser htmx-hide"></i>
             <span class="loading loading-spinner loading-sm htmx-show"></span>
             Clear all
@@ -62,12 +57,7 @@
                   type="button"
                   hx-delete="{% url 'evaluations:delete' request.team.slug config.id %}?redirect=1"
                   hx-trigger="confirmed"
-                  onclick="alertify.confirm().setting({
-                    title: 'Confirm',
-                    message: 'Delete this evaluation? This will also delete all run history and results. This cannot be undone.',
-                    transition: 'fade',
-                    onok: function() { htmx.trigger('#delete-evaluation-button', 'confirmed'); },
-                  }).show();">
+                  onclick="confirmThenTrigger('delete-evaluation-button', 'Delete this evaluation? This will also delete all run history and results. This cannot be undone.')">
             <i class="fa-solid fa-trash"></i>
             Delete
           </button>

--- a/templates/participants/partials/participant_schedule_single.html
+++ b/templates/participants/partials/participant_schedule_single.html
@@ -71,13 +71,15 @@
       {% if perms.experiments.change_participant %}
         <div>
           <button
+            id="cancel-schedule-{{ schedule.external_id }}"
             class="btn btn-sm btn-ghost tooltip"
             data-tip="Cancel this schedule"
             {% if schedule.is_cancelled or schedule.is_complete %}disabled{% endif %}
             hx-post="{% url 'participants:cancel_schedule' request.team.slug participant_id schedule.external_id %}"
-            hx-confirm="Are you sure you want to cancel this schedule?"
+            hx-trigger="confirmed"
             hx-target="#schedule_{{ schedule.external_id }}"
             hx-swap="outerHTML"
+            onclick="confirmThenTrigger('cancel-schedule-{{ schedule.external_id }}', 'Are you sure you want to cancel this schedule?')"
           >
             <i class="fa-solid fa-ban"></i>
           </button>

--- a/templates/service_providers/components/llm_model_row.html
+++ b/templates/service_providers/components/llm_model_row.html
@@ -34,12 +34,14 @@
                 <i class="fa-solid fa-pencil"></i>
               </button>
               {% if rates.has_team_override %}
-                <button class="btn btn-xs btn-ghost"
+                <button id="revert-pricing-{{ model.id }}"
+                        class="btn btn-xs btn-ghost"
                         title="Revert to global pricing"
                         hx-post="{% url 'service_providers:pricing_revert' request.team.slug model.id %}"
                         hx-target="#model_{{ model.id }}"
                         hx-swap="outerHTML"
-                        hx-confirm="Remove the team override and fall back to the global rate?">
+                        hx-trigger="confirmed"
+                        onclick="confirmThenTrigger('revert-pricing-{{ model.id }}', 'Remove the team override and fall back to the global rate?')">
                   <i class="fa-solid fa-rotate-left"></i>
                 </button>
               {% endif %}
@@ -65,10 +67,13 @@
   <div class="place-self-center">{{ model.max_token_limit }}</div>
   {% if show_delete %}
     <div class="place-self-start">
-      <button class="btn btn-xs btn-ghost"
+      <button id="delete-llm-model-{{ model.id }}"
+              class="btn btn-xs btn-ghost"
               hx-delete="{% url 'service_providers:llm_provider_model_delete' request.team.slug model.id %}"
               hx-target="#model_{{ model.id }}"
-              hx-swap="outerHTML">
+              hx-swap="outerHTML"
+              hx-trigger="confirmed"
+              onclick="confirmThenTrigger('delete-llm-model-{{ model.id }}', 'Are you sure you want to delete \'{{ model.display_name|escapejs }}\'? This cannot be undone.')">
         <i class="fa-solid fa-trash"></i>
       </button>
     </div>

--- a/templates/service_providers/components/llm_model_row.html
+++ b/templates/service_providers/components/llm_model_row.html
@@ -73,7 +73,7 @@
               hx-target="#model_{{ model.id }}"
               hx-swap="outerHTML"
               hx-trigger="confirmed"
-              onclick="confirmThenTrigger('delete-llm-model-{{ model.id }}', 'Are you sure you want to delete \'{{ model.display_name|escapejs }}\'? This cannot be undone.')">
+              onclick="confirmThenTrigger('delete-llm-model-{{ model.id }}', 'Are you sure you want to delete \'{{ model.display_name|escape|escapejs }}\'? This cannot be undone.')">
         <i class="fa-solid fa-trash"></i>
       </button>
     </div>


### PR DESCRIPTION
### Product Description

Destructive actions across the app (deleting a flag, a document source, an evaluation, a custom LLM model; cancelling a schedule; archiving a chatbot; reverting a pricing override) now show the same styled confirmation dialog. Previously these were split across two inconsistent patterns - a styled modal in some places, the browser's native confirm popup in others - and one action (deleting a custom LLM model) had **no confirmation at all**.

Fixes #3386.

### Technical Description

Extracted the existing hand-rolled `alertify.confirm()` + htmx-trigger pattern (previously duplicated 3x) into a single reusable helper:

```js
// assets/javascript/alertify.js
window.confirmThenTrigger = function (elementId, message) {
  alertify.confirm().setting({
    title: 'Confirm',
    message: message,
    transition: 'fade',
    onok: function () {
      htmx.trigger('#' + elementId, 'confirmed');
    },
  }).show();
};
```

Each destructive button swaps `hx-confirm="..."` for a unique `id` + `hx-trigger="confirmed"` + `onclick="confirmThenTrigger('id', 'message')"`. No Python or view logic changed anywhere, this is markup plus one small JS helper.

**8 call sites migrated, across 6 templates:**

| File                                                              | Action                                                |
| ------------------------------------------------------------------ | ------------------------------------------------------ |
| `templates/admin/flags/flag_list.html`                            | Delete legacy flag                                    |
| `templates/documents/partials/document_source_header.html`        | Delete document source                                |
| `templates/evaluations/evaluation_runs_home.html`                 | Delete evaluation / Clear all runs                    |
| `templates/participants/partials/participant_schedule_single.html` | Cancel schedule                                       |
| `templates/chatbots/settings_content.html`                        | Archive chatbot                                       |
| `templates/service_providers/components/llm_model_row.html`       | Revert pricing override / **Delete custom LLM model** |

The custom-LLM-model delete button had no confirmation mechanism. 

**Scope, intentionally not touched:**

- `templates/analysis/detail.html`, `templates/evaluations/dataset_create_form.html`, `templates/human_annotations/queue_form.html`: Alpine.js-driven confirms (client-side array splice / form resubmit, not htmx-triggered) that already render the correct styled modal via a different mechanism.
- `templates/generic/action_ajax.html`: the table-actions framework partial, already correct.

Also includes a small drive-by ESLint tooling fix (`eslint.config.mjs`) needed to lint the new helper cleanly: pinned `parserOptions.tsconfigRootDir` (was ambiguous when a git worktree is nested inside the repo) and declared `htmx` as a known global.

**Found but explicitly out of scope for this PR** (noted for future follow-up issues):

- A handful of destructive actions still use raw JS `confirm()` rather than `hx-confirm` or alertify.
- Two pre-existing UX bugs in `delete_flag` (tab counter doesn't decrement, active tab resets after delete).
- Destructive-action button colour is inconsistent app-wide

### Migrations

- No migrations in this PR.

### Demo

All 8 confirmations are verified manually in a local browser session; each renders the same styled Alertify modal with the correct message. Screenshots attached below (drag into the PR description):

1. `01-flag-delete-confirm.png`: delete legacy flag
<img width="350" alt="01-flag-delete-confirm" src="https://github.com/user-attachments/assets/7014d2a0-24b3-4ddb-9ae9-f44cc721e857" />

2. `02-document-source-delete-confirm.png`: delete document source
<img width="350" alt="02-document-source-delete-confirm" src="https://github.com/user-attachments/assets/1f54cd51-35b4-45bb-9c10-0fe215b113ac" />

3. `03-evaluation-delete-confirm.png`: delete evaluation
<img width="350" alt="03-evaluation-delete-confirm" src="https://github.com/user-attachments/assets/e13e40dc-1023-400c-a3c9-fa31cb56f071" />

4. `04-evaluation-clear-all-confirm.png`: clear all runs
<img width="350" alt="04-evaluation-clear-all-confirm" src="https://github.com/user-attachments/assets/b5fb0e05-657d-4ac5-b4d7-241d38a6b1bd" />

5. `05-cancel-schedule-confirm.png`: cancel schedule
<img width="350" alt="05-cancel-schedule-confirm" src="https://github.com/user-attachments/assets/ab15bb78-bab2-47e3-8994-81e4594bbf84" />

6. `06-archive-chatbot-confirm.png`: archive chatbot
<img width="350" alt="06-archive-chatbot-confirm" src="https://github.com/user-attachments/assets/0da05a9a-034f-4294-b9f2-dc1cbcf645cb" />

7. `07-revert-pricing-confirm.png`: revert pricing override
<img width="350" alt="07-revert-pricing-confirm" src="https://github.com/user-attachments/assets/83ef78d5-4713-4d67-a4ca-7bac4aa7f838" />

8. `08-delete-llm-model-confirm.png`: delete custom LLM model (previously had zero confirmation)
<img width="350" alt="08-delete-llm-model-confirm" src="https://github.com/user-attachments/assets/6367ded6-22d2-4f90-b249-59bb7e0029bb" />

### Docs and Changelog

- [ ] This PR requires docs/changelog update

No user-facing behavior change beyond the confirmation dialog's visual style (and the one bug fix), so no docs/changelog update needed.
