### PR TITLE
Freeze time in cost tracking panel tests

### DIFF
--- a/apps/dashboard/tests/test_cost_tracking_panel.py
+++ b/apps/dashboard/tests/test_cost_tracking_panel.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 
 import pytest
 from django.urls import reverse
+from time_machine import travel
 
 from apps.cost_tracking.models import Confidence
 from apps.teams.models import Flag
@@ -12,6 +13,16 @@ from apps.utils.factories.cost_tracking import UsageRecordFactory
 from apps.utils.factories.experiment import ExperimentFactory
 
 _NOW = datetime(2026, 6, 15, 12, 0, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _freeze_now():
+    """Anchor "now" to _NOW so the dashboard's default date window deterministically
+    covers the seeded usage. Without this the tests rot: the default window is
+    [now - 30 days, now] against real time, so once wall-clock time passes _NOW + 30
+    days the window no longer includes the test data and the assertions fail."""
+    with travel(_NOW, tick=False):
+        yield
 
 
 def _enable_flag_for(team):


### PR DESCRIPTION
### Product Description
None (test-only fix).

### Technical Description
Four tests in `test_cost_tracking_panel.py` seed usage at `_NOW` but assert against the dashboard's *default* date window, which is `[now − 30 days, now]` computed from real wall-clock time. Once real time passed `_NOW + 30 days` the seeded data fell out of the window and the tests failed on `main` (2026-07-15 run) — a time-bomb that reads as flakiness.

Anchor `now` to `_NOW` via a `time_machine.travel` autouse fixture so the default window deterministically covers the test data.

### Migrations
- [x] The migrations are backwards compatible

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update