### PR TITLE
feat: pivot annotations export to one column per annotator

### DIFF
--- a/apps/human_annotations/tests/test_views.py
+++ b/apps/human_annotations/tests/test_views.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import json
+from datetime import UTC, datetime
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -18,6 +19,7 @@ from apps.human_annotations.models import (
     AnnotationStatus,
 )
 from apps.human_annotations.tables import AnnotationSessionsSelectionTable
+from apps.human_annotations.views.queue_views import ExportAnnotations
 from apps.teams.backends import ANNOTATION_REVIEWER_GROUP
 from apps.teams.models import Flag
 from apps.utils.factories.evaluations import EvaluationDatasetFactory, EvaluationMessageFactory
@@ -27,6 +29,7 @@ from apps.utils.factories.human_annotations import (
     AnnotationQueueFactory,
 )
 from apps.utils.factories.team import MembershipFactory, TeamWithUsersFactory
+from apps.utils.factories.user import UserFactory
 
 User = get_user_model()
 
@@ -756,6 +759,264 @@ def test_edit_annotation_works_after_item_completed(client, team_with_users, que
 
 # ===== Export =====
 
+# ----- _pivot_annotations -----
+
+
+def _pivot(queue):
+    """Build the same querysets ExportAnnotations.get() does and run the pivot."""
+    annotations = Annotation.objects.filter(item__queue=queue, status=AnnotationStatus.SUBMITTED)
+    flagged_items = AnnotationItem.objects.filter(queue=queue, status=AnnotationItemStatus.FLAGGED)
+    return ExportAnnotations()._pivot_annotations(annotations, flagged_items, list(queue.schema.keys()))
+
+
+@pytest.mark.django_db()
+def test_pivot_single_annotator_single_field():
+    queue = AnnotationQueueFactory.create(schema={"quality_score": {"type": "int", "description": "Quality"}})
+    item = AnnotationItemFactory.create(queue=queue)
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    Annotation.objects.create(
+        item=item, team=queue.team, reviewer=alice, data={"quality_score": 5}, status=AnnotationStatus.SUBMITTED
+    )
+
+    fieldnames, rows = _pivot(queue)
+
+    assert fieldnames == [
+        "item_id",
+        "item_type",
+        "session_id",
+        "flagged",
+        "flags",
+        "field",
+        "authoritative_annotator",
+        "annotated_at",
+        "alice@example.com",
+    ]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["item_id"] == item.pk
+    assert row["item_type"] == item.item_type
+    assert row["field"] == "quality_score"
+    assert row["flagged"] is False
+    assert row["alice@example.com"] == 5
+
+
+@pytest.mark.django_db()
+def test_pivot_multiple_schema_fields_produces_one_row_per_field():
+    queue = AnnotationQueueFactory.create()  # default schema: quality_score, notes
+    item = AnnotationItemFactory.create(queue=queue)
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    Annotation.objects.create(
+        item=item,
+        team=queue.team,
+        reviewer=alice,
+        data={"quality_score": 5, "notes": "Great"},
+        status=AnnotationStatus.SUBMITTED,
+    )
+
+    _, rows = _pivot(queue)
+
+    assert len(rows) == 2
+    rows_by_field = {r["field"]: r for r in rows}
+    assert rows_by_field.keys() == {"quality_score", "notes"}
+    assert rows_by_field["quality_score"]["alice@example.com"] == 5
+    assert rows_by_field["notes"]["alice@example.com"] == "Great"
+
+
+@pytest.mark.parametrize(
+    ("alice_score", "bob_score"),
+    [
+        pytest.param(5, 5, id="agreeing"),
+        pytest.param(5, 2, id="disagreeing"),
+    ],
+)
+@pytest.mark.django_db()
+def test_pivot_two_annotators_values_attributed_to_correct_columns(alice_score, bob_score):
+    queue = AnnotationQueueFactory.create(schema={"quality_score": {"type": "int", "description": "Quality"}})
+    item = AnnotationItemFactory.create(queue=queue)
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    bob = UserFactory.create(username="bob@example.com", email="bob@example.com")
+    Annotation.objects.create(
+        item=item,
+        team=queue.team,
+        reviewer=alice,
+        data={"quality_score": alice_score},
+        status=AnnotationStatus.SUBMITTED,
+    )
+    Annotation.objects.create(
+        item=item, team=queue.team, reviewer=bob, data={"quality_score": bob_score}, status=AnnotationStatus.SUBMITTED
+    )
+
+    _, rows = _pivot(queue)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["alice@example.com"] == alice_score
+    assert row["bob@example.com"] == bob_score
+
+
+@pytest.mark.django_db()
+def test_pivot_three_annotators_each_value_attributed_to_own_column():
+    queue = AnnotationQueueFactory.create(schema={"quality_score": {"type": "int", "description": "Quality"}})
+    item = AnnotationItemFactory.create(queue=queue)
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    bob = UserFactory.create(username="bob@example.com", email="bob@example.com")
+    carol = UserFactory.create(username="carol@example.com", email="carol@example.com")
+    Annotation.objects.create(
+        item=item, team=queue.team, reviewer=alice, data={"quality_score": 5}, status=AnnotationStatus.SUBMITTED
+    )
+    Annotation.objects.create(
+        item=item, team=queue.team, reviewer=bob, data={"quality_score": 3}, status=AnnotationStatus.SUBMITTED
+    )
+    Annotation.objects.create(
+        item=item, team=queue.team, reviewer=carol, data={"quality_score": 1}, status=AnnotationStatus.SUBMITTED
+    )
+
+    fieldnames, rows = _pivot(queue)
+
+    assert fieldnames[8:] == ["alice@example.com", "bob@example.com", "carol@example.com"]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["alice@example.com"] == 5
+    assert row["bob@example.com"] == 3
+    assert row["carol@example.com"] == 1
+
+
+@pytest.mark.django_db()
+def test_pivot_authoritative_annotator_populated_when_pick_set():
+    queue = AnnotationQueueFactory.create(
+        schema={"quality_score": {"type": "int", "description": "Quality"}}, num_reviews_required=1
+    )
+    item = AnnotationItemFactory.create(queue=queue)
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    # num_reviews_required=1 means a single submitted review auto-marks itself authoritative.
+    Annotation.objects.create(
+        item=item, team=queue.team, reviewer=alice, data={"quality_score": 5}, status=AnnotationStatus.SUBMITTED
+    )
+
+    _, rows = _pivot(queue)
+
+    assert rows[0]["authoritative_annotator"] == "alice@example.com"
+
+
+@pytest.mark.django_db()
+def test_pivot_authoritative_annotator_blank_when_no_pick_set():
+    queue = AnnotationQueueFactory.create(
+        schema={"quality_score": {"type": "int", "description": "Quality"}}, num_reviews_required=2
+    )
+    item = AnnotationItemFactory.create(queue=queue)
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    bob = UserFactory.create(username="bob@example.com", email="bob@example.com")
+    Annotation.objects.create(
+        item=item, team=queue.team, reviewer=alice, data={"quality_score": 5}, status=AnnotationStatus.SUBMITTED
+    )
+    Annotation.objects.create(
+        item=item, team=queue.team, reviewer=bob, data={"quality_score": 2}, status=AnnotationStatus.SUBMITTED
+    )
+
+    _, rows = _pivot(queue)
+
+    assert rows[0]["authoritative_annotator"] == ""
+
+
+@pytest.mark.django_db()
+def test_pivot_annotated_at_is_max_created_at_across_item_annotations():
+    queue = AnnotationQueueFactory.create(
+        schema={"quality_score": {"type": "int", "description": "Quality"}}, num_reviews_required=2
+    )
+    item = AnnotationItemFactory.create(queue=queue)
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    bob = UserFactory.create(username="bob@example.com", email="bob@example.com")
+    earlier = Annotation.objects.create(
+        item=item, team=queue.team, reviewer=alice, data={"quality_score": 5}, status=AnnotationStatus.SUBMITTED
+    )
+    Annotation.objects.filter(pk=earlier.pk).update(created_at=datetime(2024, 1, 1, tzinfo=UTC))
+    later = Annotation.objects.create(
+        item=item, team=queue.team, reviewer=bob, data={"quality_score": 2}, status=AnnotationStatus.SUBMITTED
+    )
+    Annotation.objects.filter(pk=later.pk).update(created_at=datetime(2024, 6, 1, tzinfo=UTC))
+
+    _, rows = _pivot(queue)
+
+    assert rows[0]["annotated_at"] == datetime(2024, 6, 1, tzinfo=UTC).isoformat()
+
+
+@pytest.mark.django_db()
+def test_pivot_flagged_item_with_no_annotations_produces_one_blank_row():
+    queue = AnnotationQueueFactory.create(schema={"quality_score": {"type": "int", "description": "Quality"}})
+    normal_item = AnnotationItemFactory.create(queue=queue)
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    Annotation.objects.create(
+        item=normal_item,
+        team=queue.team,
+        reviewer=alice,
+        data={"quality_score": 5},
+        status=AnnotationStatus.SUBMITTED,
+    )
+    flag_reason = "Needs review"
+    flagged_item = AnnotationItemFactory.create(
+        queue=queue,
+        status=AnnotationItemStatus.FLAGGED,
+        flags=[{"user": "alice", "user_id": alice.id, "reason": flag_reason, "timestamp": "2024-01-01T00:00:00"}],
+    )
+
+    _, rows = _pivot(queue)
+
+    flagged_rows = [r for r in rows if r["item_id"] == flagged_item.pk]
+    assert len(flagged_rows) == 1
+    row = flagged_rows[0]
+    assert row["flagged"] is True
+    assert row["field"] == ""
+    assert row["authoritative_annotator"] == ""
+    assert row["annotated_at"] == ""
+    assert row["alice@example.com"] == ""
+    assert flag_reason in row["flags"]
+
+
+@pytest.mark.django_db()
+def test_pivot_pending_item_with_no_annotations_produces_no_rows():
+    queue = AnnotationQueueFactory.create(schema={"quality_score": {"type": "int", "description": "Quality"}})
+    annotated_item = AnnotationItemFactory.create(queue=queue)
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    Annotation.objects.create(
+        item=annotated_item,
+        team=queue.team,
+        reviewer=alice,
+        data={"quality_score": 5},
+        status=AnnotationStatus.SUBMITTED,
+    )
+    pending_item = AnnotationItemFactory.create(queue=queue)  # no annotation, not flagged
+
+    _, rows = _pivot(queue)
+
+    assert len(rows) == 1  # only the annotated item's single schema field
+    assert all(r["item_id"] != pending_item.pk for r in rows)
+
+
+@pytest.mark.django_db()
+def test_pivot_annotator_columns_sorted_alphabetically_regardless_of_submission_order():
+    queue = AnnotationQueueFactory.create(schema={"quality_score": {"type": "int", "description": "Quality"}})
+    item = AnnotationItemFactory.create(queue=queue)
+    zack = UserFactory.create(username="zack@example.com", email="zack@example.com")
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    mike = UserFactory.create(username="mike@example.com", email="mike@example.com")
+    # Submitted in reverse-alphabetical order on purpose.
+    Annotation.objects.create(
+        item=item, team=queue.team, reviewer=zack, data={"quality_score": 1}, status=AnnotationStatus.SUBMITTED
+    )
+
+    other_item = AnnotationItemFactory.create(queue=queue)
+    Annotation.objects.create(
+        item=other_item, team=queue.team, reviewer=mike, data={"quality_score": 2}, status=AnnotationStatus.SUBMITTED
+    )
+    Annotation.objects.create(
+        item=other_item, team=queue.team, reviewer=alice, data={"quality_score": 3}, status=AnnotationStatus.SUBMITTED
+    )
+
+    fieldnames, _ = _pivot(queue)
+
+    annotator_columns = fieldnames[8:]  # everything after the 8 fixed columns
+    assert annotator_columns == ["alice@example.com", "mike@example.com", "zack@example.com"]
+
 
 @pytest.mark.django_db()
 def test_export_csv(client, team_with_users, queue, user):
@@ -780,21 +1041,54 @@ def test_export_csv(client, team_with_users, queue, user):
     assert response.status_code == 200
     assert response["Content-Type"] == "text/csv"
     reader = csv.DictReader(io.StringIO(response.content.decode()))
-    rows = {int(r["item_id"]): r for r in reader}
-    assert len(rows) == 2
+    rows = list(reader)
 
-    # Normal item
-    normal = rows[item.pk]
-    assert normal["session_id"] == str(item.session.external_id)
-    assert normal["flagged"] == "False"
-    assert normal["quality_score"] == "5"
+    # Normal item: one row per schema field, value under the reviewer's email column
+    normal_rows = {r["field"]: r for r in rows if r["item_id"] == str(item.pk)}
+    assert normal_rows.keys() == {"quality_score", "notes"}
+    assert normal_rows["quality_score"][user.email] == "5"
+    assert normal_rows["notes"][user.email] == "Great"
+    assert normal_rows["quality_score"]["session_id"] == str(item.session.external_id)
+    assert normal_rows["quality_score"]["flagged"] == "False"
 
-    # Flagged item
-    flagged = rows[flagged_item.pk]
+    # Flagged item: exactly one row, no field, no annotator value
+    flagged_rows = [r for r in rows if r["item_id"] == str(flagged_item.pk)]
+    assert len(flagged_rows) == 1
+    flagged = flagged_rows[0]
     assert flagged["session_id"] == str(flagged_item.session.external_id)
     assert flagged["flagged"] == "True"
     assert flag_reason in flagged["flags"]
-    assert flagged["quality_score"] == ""
+    assert flagged["field"] == ""
+    assert flagged[user.email] == ""
+
+
+@pytest.mark.django_db()
+def test_export_csv_query_count_does_not_scale_with_annotation_count(
+    client, team_with_users, queue, user, django_assert_max_num_queries
+):
+    other_user = UserFactory.create(username="other@example.com", email="other@example.com")
+    for _ in range(3):
+        item = AnnotationItemFactory.create(queue=queue, team=team_with_users)
+        Annotation.objects.create(
+            item=item, team=team_with_users, reviewer=user, data={"quality_score": 5}, status=AnnotationStatus.SUBMITTED
+        )
+        Annotation.objects.create(
+            item=item,
+            team=team_with_users,
+            reviewer=other_user,
+            data={"quality_score": 3},
+            status=AnnotationStatus.SUBMITTED,
+        )
+    # 6 annotations from 2 distinct reviewers. Without select_related("reviewer") on the
+    # annotations queryset, accessing ann.reviewer.email in _pivot_annotations issues one
+    # query per annotation instead of per distinct reviewer - this bounds it regardless of
+    # how many annotations exist. Baseline with the fix in place is 12 (session/auth/permission
+    # overhead + queue/annotations/flagged_items lookups); ceiling leaves headroom for
+    # unrelated incidental query changes without masking a real N+1 regression.
+    url = reverse("human_annotations:queue_export", args=[team_with_users.slug, queue.pk])
+    with django_assert_max_num_queries(15):
+        response = client.get(url, {"format": "csv"})
+    assert response.status_code == 200
 
 
 @pytest.mark.django_db()
@@ -1631,7 +1925,7 @@ def test_queue_detail_shows_awaiting_resolution_callout(client, team_with_users,
 
 
 @pytest.mark.django_db()
-def test_export_csv_includes_is_authoritative(client, team_with_users, user):
+def test_export_csv_includes_authoritative_annotator(client, team_with_users, user):
     queue = AnnotationQueueFactory.create(team=team_with_users, created_by=user, num_reviews_required=1)
     item = AnnotationItemFactory.create(queue=queue, team=team_with_users)
     Annotation.objects.create(
@@ -1646,9 +1940,10 @@ def test_export_csv_includes_is_authoritative(client, team_with_users, user):
     reader = csv.DictReader(io.StringIO(content))
     fieldnames = reader.fieldnames
     assert fieldnames is not None
-    assert "is_authoritative" in fieldnames
+    assert "authoritative_annotator" in fieldnames
+    assert "is_authoritative" not in fieldnames
     rows = list(reader)
-    assert rows[0]["is_authoritative"] == "True"
+    assert rows[0]["authoritative_annotator"] == user.email
 
 
 @pytest.mark.django_db()

--- a/apps/human_annotations/tests/test_views.py
+++ b/apps/human_annotations/tests/test_views.py
@@ -973,6 +973,32 @@ def test_pivot_flagged_item_with_no_annotations_produces_one_blank_row():
 
 
 @pytest.mark.django_db()
+def test_pivot_flagged_item_with_submitted_annotation_produces_single_flagged_row():
+    """A flagged item can already have a submitted annotation (flagging doesn't block prior
+    submissions). It must not also produce a separate, contradictory blank flagged=True row."""
+    queue = AnnotationQueueFactory.create(schema={"quality_score": {"type": "int", "description": "Quality"}})
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    flag_reason = "Needs review"
+    item = AnnotationItemFactory.create(
+        queue=queue,
+        status=AnnotationItemStatus.FLAGGED,
+        flags=[{"user": "alice", "user_id": alice.id, "reason": flag_reason, "timestamp": "2024-01-01T00:00:00"}],
+    )
+    Annotation.objects.create(
+        item=item, team=queue.team, reviewer=alice, data={"quality_score": 5}, status=AnnotationStatus.SUBMITTED
+    )
+
+    _, rows = _pivot(queue)
+
+    item_rows = [r for r in rows if r["item_id"] == item.pk]
+    assert len(item_rows) == 1
+    row = item_rows[0]
+    assert row["flagged"] is True
+    assert row["field"] == "quality_score"
+    assert row["alice@example.com"] == 5
+
+
+@pytest.mark.django_db()
 def test_pivot_pending_item_with_no_annotations_produces_no_rows():
     queue = AnnotationQueueFactory.create(schema={"quality_score": {"type": "int", "description": "Quality"}})
     annotated_item = AnnotationItemFactory.create(queue=queue)
@@ -1060,6 +1086,39 @@ def test_export_csv(client, team_with_users, queue, user):
     assert flag_reason in flagged["flags"]
     assert flagged["field"] == ""
     assert flagged[user.email] == ""
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected_cell"),
+    [
+        pytest.param("=1+1", "'=1+1", id="equals-prefix"),
+        pytest.param("+1+1", "'+1+1", id="plus-prefix"),
+        pytest.param("-1+1", "'-1+1", id="minus-prefix"),
+        pytest.param("@SUM(A1)", "'@SUM(A1)", id="at-prefix"),
+        pytest.param("Great", "Great", id="ordinary-value-untouched"),
+    ],
+)
+@pytest.mark.django_db()
+def test_export_csv_neutralizes_formula_injection_in_annotation_values(
+    client, team_with_users, queue, user, raw_value, expected_cell
+):
+    """Annotation values are annotator-controlled free text. A leading =, +, -, or @ would
+    execute as a formula if the CSV is opened in spreadsheet software, so it must be neutralized."""
+    item = AnnotationItemFactory.create(queue=queue, team=team_with_users)
+    Annotation.objects.create(
+        item=item,
+        team=team_with_users,
+        reviewer=user,
+        data={"quality_score": 5, "notes": raw_value},
+        status=AnnotationStatus.SUBMITTED,
+    )
+    url = reverse("human_annotations:queue_export", args=[team_with_users.slug, queue.pk])
+    response = client.get(url, {"format": "csv"})
+    reader = csv.DictReader(io.StringIO(response.content.decode()))
+    rows = list(reader)
+
+    notes_row = next(r for r in rows if r["field"] == "notes")
+    assert notes_row[user.email] == expected_cell
 
 
 @pytest.mark.django_db()

--- a/apps/human_annotations/tests/test_views.py
+++ b/apps/human_annotations/tests/test_views.py
@@ -19,7 +19,7 @@ from apps.human_annotations.models import (
     AnnotationStatus,
 )
 from apps.human_annotations.tables import AnnotationSessionsSelectionTable
-from apps.human_annotations.views.queue_views import ExportAnnotations
+from apps.human_annotations.views.export_views import ExportAnnotations
 from apps.teams.backends import ANNOTATION_REVIEWER_GROUP
 from apps.teams.models import Flag
 from apps.utils.factories.evaluations import EvaluationDatasetFactory, EvaluationMessageFactory

--- a/apps/human_annotations/urls.py
+++ b/apps/human_annotations/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from apps.generics.urls import make_crud_urls
-from apps.human_annotations.views import annotate_views, queue_views
+from apps.human_annotations.views import annotate_views, export_views, queue_views
 
 app_name = "human_annotations"
 
@@ -31,7 +31,7 @@ urlpatterns = [
         queue_views.RemoveSessionFromQueue.as_view(),
         name="queue_remove_item",
     ),
-    path("queue/<int:pk>/export/", queue_views.ExportAnnotations.as_view(), name="queue_export"),
+    path("queue/<int:pk>/export/", export_views.ExportAnnotations.as_view(), name="queue_export"),
     # Session-side add to queue
     path(
         "sessions/<str:session_id>/add-to-queue/",

--- a/apps/human_annotations/views/export_views.py
+++ b/apps/human_annotations/views/export_views.py
@@ -1,0 +1,193 @@
+import csv
+import json
+import re
+
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
+from django.views import View
+
+from apps.teams.mixins import LoginAndTeamRequiredMixin
+
+from ..models import Annotation, AnnotationItem, AnnotationItemStatus, AnnotationQueue, AnnotationStatus
+
+
+def _safe_filename(name: str) -> str:
+    """Sanitize a string for use in Content-Disposition filename."""
+    return re.sub(r"[^\w\s\-.]", "_", name).strip()
+
+
+_CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
+def _neutralize_csv_formula(value):
+    """Prefix annotator-controlled values that could execute as a spreadsheet formula.
+
+    csv.DictWriter's quoting protects against delimiter injection but not formula
+    injection: a value starting with =, +, -, or @ runs as a formula when the export
+    is opened in Excel/Sheets. Prepending an apostrophe forces it to be read as text.
+    """
+    if isinstance(value, str) and value.startswith(_CSV_FORMULA_PREFIXES):
+        return f"'{value}"
+    return value
+
+
+class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
+    permission_required = "human_annotations.view_annotation"
+
+    def get(self, request, team_slug: str, pk: int):
+        queue = get_object_or_404(AnnotationQueue, id=pk, team=request.team)
+        export_format = request.GET.get("format", "csv")
+        annotations = Annotation.objects.filter(
+            item__queue=queue,
+            status=AnnotationStatus.SUBMITTED,
+        ).select_related(
+            "item",
+            "item__session",
+            "item__message",
+            "item__message__chat__experiment_session",
+            "reviewer",
+        )
+        flagged_items = AnnotationItem.objects.filter(queue=queue, status=AnnotationItemStatus.FLAGGED).select_related(
+            "session", "message", "message__chat__experiment_session"
+        )
+
+        if export_format == "jsonl":
+            return self._export_jsonl(queue, annotations, flagged_items)
+        return self._export_csv(queue, annotations, flagged_items)
+
+    def _get_session_external_id(self, item):
+        if item.session_id:
+            return str(item.session.external_id)
+        if item.message_id:
+            return str(item.message.chat.experiment_session.external_id)
+        return ""
+
+    def _build_flagged_row(self, item):
+        return {
+            "item_id": item.pk,
+            "item_type": item.item_type,
+            "session_id": self._get_session_external_id(item),
+            "annotated_at": "",
+            "flagged": True,
+            "is_authoritative": False,
+            "flags": item.flags,
+        }
+
+    def _pivot_annotations(self, annotations, flagged_items, schema_fields):
+        """Pivot (item, annotation) rows into (item, schema field) rows, one column per annotator.
+
+        `annotations` and `flagged_items` are the same querysets ExportAnnotations.get() builds.
+        Returns (fieldnames, rows) where every row dict has every key in fieldnames present.
+        """
+        flagged_items = list(flagged_items)
+        flagged_item_ids = {item.pk for item in flagged_items}
+
+        by_item = {}
+        for ann in annotations:
+            by_item.setdefault(ann.item_id, []).append(ann)
+
+        annotator_emails = sorted({ann.reviewer.email for ann in annotations})
+
+        fieldnames = [
+            "item_id",
+            "item_type",
+            "session_id",
+            "flagged",
+            "flags",
+            "field",
+            "authoritative_annotator",
+            "annotated_at",
+        ] + annotator_emails
+
+        rows = []
+        for item_id, item_annotations in by_item.items():
+            is_flagged = item_id in flagged_item_ids
+            rows.extend(self._pivot_item_rows(item_annotations, schema_fields, annotator_emails, is_flagged))
+        for item in flagged_items:
+            if item.pk in by_item:
+                continue
+            rows.append(self._pivot_flagged_row(item, annotator_emails))
+
+        return fieldnames, rows
+
+    def _pivot_item_rows(self, item_annotations, schema_fields, annotator_emails, is_flagged):
+        """Build one export row per schema field for a single item's annotations."""
+        item = item_annotations[0].item
+        authoritative = next((a for a in item_annotations if a.is_authoritative), None)
+        authoritative_email = authoritative.reviewer.email if authoritative else ""
+        annotated_at = max(a.created_at for a in item_annotations).isoformat()
+        data_by_email = {ann.reviewer.email: ann.data for ann in item_annotations}
+
+        base = {
+            "item_id": item.pk,
+            "item_type": item.item_type,
+            "session_id": self._get_session_external_id(item),
+            "flagged": is_flagged,
+            "flags": json.dumps(item.flags),
+            "authoritative_annotator": authoritative_email,
+            "annotated_at": annotated_at,
+        }
+        rows = []
+        for field in schema_fields:
+            row = dict(base, field=field)
+            for email in annotator_emails:
+                row[email] = _neutralize_csv_formula(data_by_email.get(email, {}).get(field, ""))
+            rows.append(row)
+        return rows
+
+    def _pivot_flagged_row(self, item, annotator_emails):
+        """Build the single blank row representing a flagged item with no annotations."""
+        row = {
+            "item_id": item.pk,
+            "item_type": item.item_type,
+            "session_id": self._get_session_external_id(item),
+            "flagged": True,
+            "flags": json.dumps(item.flags),
+            "field": "",
+            "authoritative_annotator": "",
+            "annotated_at": "",
+        }
+        for email in annotator_emails:
+            row[email] = ""
+        return row
+
+    def _export_csv(self, queue, annotations, flagged_items):
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = f'attachment; filename="{_safe_filename(queue.name)}_annotations.csv"'
+
+        schema_fields = list(queue.schema.keys())
+        fieldnames, rows = self._pivot_annotations(annotations, flagged_items, schema_fields)
+
+        writer = csv.DictWriter(response, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+        return response
+
+    def _export_jsonl(self, queue, annotations, flagged_items):
+        lines = []
+        for ann in annotations:
+            record = {
+                "item_id": ann.item_id,
+                "item_type": ann.item.item_type,
+                "session_id": self._get_session_external_id(ann.item),
+                "annotated_at": ann.created_at.isoformat(),
+                "flagged": False,
+                "is_authoritative": ann.is_authoritative,
+                "flags": ann.item.flags,
+                "annotation": ann.data,
+            }
+            lines.append(json.dumps(record))
+
+        for item in flagged_items:
+            record = self._build_flagged_row(item)
+            # Flagged items have no annotation data; emit an empty dict so every record has the same shape.
+            record["annotation"] = {}
+            lines.append(json.dumps(record))
+
+        content = "\n".join(lines)
+        response = HttpResponse(content, content_type="application/jsonl")
+        response["Content-Disposition"] = f'attachment; filename="{_safe_filename(queue.name)}_annotations.jsonl"'
+        return response

--- a/apps/human_annotations/views/queue_views.py
+++ b/apps/human_annotations/views/queue_views.py
@@ -1,8 +1,5 @@
 import contextlib
-import csv
-import json
 import random
-import re
 import uuid
 
 from django.contrib import messages
@@ -38,7 +35,6 @@ from ..forms import AnnotationQueueForm, ImportFromDatasetForm
 from ..models import (
     Annotation,
     AnnotationItem,
-    AnnotationItemStatus,
     AnnotationItemType,
     AnnotationQueue,
     AnnotationStatus,
@@ -47,26 +43,6 @@ from ..models import (
 from ..tables import AnnotationItemTable, AnnotationQueueTable, AnnotationSessionsSelectionTable
 
 User = get_user_model()
-
-
-def _safe_filename(name: str) -> str:
-    """Sanitize a string for use in Content-Disposition filename."""
-    return re.sub(r"[^\w\s\-.]", "_", name).strip()
-
-
-_CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
-
-
-def _neutralize_csv_formula(value):
-    """Prefix annotator-controlled values that could execute as a spreadsheet formula.
-
-    csv.DictWriter's quoting protects against delimiter injection but not formula
-    injection: a value starting with =, +, -, or @ runs as a formula when the export
-    is opened in Excel/Sheets. Prepending an apostrophe forces it to be read as text.
-    """
-    if isinstance(value, str) and value.startswith(_CSV_FORMULA_PREFIXES):
-        return f"'{value}"
-    return value
 
 
 class AnnotationQueueHome(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateView):
@@ -523,167 +499,6 @@ class ManageAssignees(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
         queue.assignees.set(users)
         messages.success(request, "Assignees updated.")
         return redirect("human_annotations:queue_detail", team_slug=team_slug, pk=pk)
-
-
-class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
-    permission_required = "human_annotations.view_annotation"
-
-    def get(self, request, team_slug: str, pk: int):
-        queue = get_object_or_404(AnnotationQueue, id=pk, team=request.team)
-        export_format = request.GET.get("format", "csv")
-        annotations = Annotation.objects.filter(
-            item__queue=queue,
-            status=AnnotationStatus.SUBMITTED,
-        ).select_related(
-            "item",
-            "item__session",
-            "item__message",
-            "item__message__chat__experiment_session",
-            "reviewer",
-        )
-        flagged_items = AnnotationItem.objects.filter(queue=queue, status=AnnotationItemStatus.FLAGGED).select_related(
-            "session", "message", "message__chat__experiment_session"
-        )
-
-        if export_format == "jsonl":
-            return self._export_jsonl(queue, annotations, flagged_items)
-        return self._export_csv(queue, annotations, flagged_items)
-
-    def _get_session_external_id(self, item):
-        if item.session_id:
-            return str(item.session.external_id)
-        if item.message_id:
-            return str(item.message.chat.experiment_session.external_id)
-        return ""
-
-    def _build_flagged_row(self, item):
-        return {
-            "item_id": item.pk,
-            "item_type": item.item_type,
-            "session_id": self._get_session_external_id(item),
-            "annotated_at": "",
-            "flagged": True,
-            "is_authoritative": False,
-            "flags": item.flags,
-        }
-
-    def _pivot_annotations(self, annotations, flagged_items, schema_fields):
-        """Pivot (item, annotation) rows into (item, schema field) rows, one column per annotator.
-
-        `annotations` and `flagged_items` are the same querysets ExportAnnotations.get() builds.
-        Returns (fieldnames, rows) where every row dict has every key in fieldnames present.
-        """
-        flagged_items = list(flagged_items)
-        flagged_item_ids = {item.pk for item in flagged_items}
-
-        by_item = {}
-        for ann in annotations:
-            by_item.setdefault(ann.item_id, []).append(ann)
-
-        annotator_emails = sorted({ann.reviewer.email for ann in annotations})
-
-        fieldnames = [
-            "item_id",
-            "item_type",
-            "session_id",
-            "flagged",
-            "flags",
-            "field",
-            "authoritative_annotator",
-            "annotated_at",
-        ] + annotator_emails
-
-        rows = []
-        for item_id, item_annotations in by_item.items():
-            is_flagged = item_id in flagged_item_ids
-            rows.extend(self._pivot_item_rows(item_annotations, schema_fields, annotator_emails, is_flagged))
-        for item in flagged_items:
-            if item.pk in by_item:
-                continue
-            rows.append(self._pivot_flagged_row(item, annotator_emails))
-
-        return fieldnames, rows
-
-    def _pivot_item_rows(self, item_annotations, schema_fields, annotator_emails, is_flagged):
-        """Build one export row per schema field for a single item's annotations."""
-        item = item_annotations[0].item
-        authoritative = next((a for a in item_annotations if a.is_authoritative), None)
-        authoritative_email = authoritative.reviewer.email if authoritative else ""
-        annotated_at = max(a.created_at for a in item_annotations).isoformat()
-        data_by_email = {ann.reviewer.email: ann.data for ann in item_annotations}
-
-        base = {
-            "item_id": item.pk,
-            "item_type": item.item_type,
-            "session_id": self._get_session_external_id(item),
-            "flagged": is_flagged,
-            "flags": json.dumps(item.flags),
-            "authoritative_annotator": authoritative_email,
-            "annotated_at": annotated_at,
-        }
-        rows = []
-        for field in schema_fields:
-            row = dict(base, field=field)
-            for email in annotator_emails:
-                row[email] = _neutralize_csv_formula(data_by_email.get(email, {}).get(field, ""))
-            rows.append(row)
-        return rows
-
-    def _pivot_flagged_row(self, item, annotator_emails):
-        """Build the single blank row representing a flagged item with no annotations."""
-        row = {
-            "item_id": item.pk,
-            "item_type": item.item_type,
-            "session_id": self._get_session_external_id(item),
-            "flagged": True,
-            "flags": json.dumps(item.flags),
-            "field": "",
-            "authoritative_annotator": "",
-            "annotated_at": "",
-        }
-        for email in annotator_emails:
-            row[email] = ""
-        return row
-
-    def _export_csv(self, queue, annotations, flagged_items):
-        response = HttpResponse(content_type="text/csv")
-        response["Content-Disposition"] = f'attachment; filename="{_safe_filename(queue.name)}_annotations.csv"'
-
-        schema_fields = list(queue.schema.keys())
-        fieldnames, rows = self._pivot_annotations(annotations, flagged_items, schema_fields)
-
-        writer = csv.DictWriter(response, fieldnames=fieldnames)
-        writer.writeheader()
-        for row in rows:
-            writer.writerow(row)
-
-        return response
-
-    def _export_jsonl(self, queue, annotations, flagged_items):
-        lines = []
-        for ann in annotations:
-            record = {
-                "item_id": ann.item_id,
-                "item_type": ann.item.item_type,
-                "session_id": self._get_session_external_id(ann.item),
-                "annotated_at": ann.created_at.isoformat(),
-                "flagged": False,
-                "is_authoritative": ann.is_authoritative,
-                "flags": ann.item.flags,
-                "annotation": ann.data,
-            }
-            lines.append(json.dumps(record))
-
-        for item in flagged_items:
-            record = self._build_flagged_row(item)
-            # Flagged items have no annotation data; emit an empty dict so every record has the same shape.
-            record["annotation"] = {}
-            lines.append(json.dumps(record))
-
-        content = "\n".join(lines)
-        response = HttpResponse(content, content_type="application/jsonl")
-        response["Content-Disposition"] = f'attachment; filename="{_safe_filename(queue.name)}_annotations.jsonl"'
-        return response
 
 
 class ImportFromDataset(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):

--- a/apps/human_annotations/views/queue_views.py
+++ b/apps/human_annotations/views/queue_views.py
@@ -524,6 +524,7 @@ class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View
             "item__session",
             "item__message",
             "item__message__chat__experiment_session",
+            "reviewer",
         )
         flagged_items = AnnotationItem.objects.filter(queue=queue, status=AnnotationItemStatus.FLAGGED).select_related(
             "session", "message", "message__chat__experiment_session"
@@ -551,43 +552,80 @@ class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View
             "flags": item.flags,
         }
 
+    def _pivot_annotations(self, annotations, flagged_items, schema_fields):
+        """Pivot (item, annotation) rows into (item, schema field) rows, one column per annotator.
+
+        `annotations` and `flagged_items` are the same querysets ExportAnnotations.get() builds.
+        Returns (fieldnames, rows) where every row dict has every key in fieldnames present.
+        """
+        by_item = {}
+        for ann in annotations:
+            by_item.setdefault(ann.item_id, []).append(ann)
+
+        annotator_emails = sorted({ann.reviewer.email for ann in annotations})
+
+        fieldnames = [
+            "item_id",
+            "item_type",
+            "session_id",
+            "flagged",
+            "flags",
+            "field",
+            "authoritative_annotator",
+            "annotated_at",
+        ] + annotator_emails
+
+        rows = []
+        for item_annotations in by_item.values():
+            item = item_annotations[0].item
+            authoritative = next((a for a in item_annotations if a.is_authoritative), None)
+            authoritative_email = authoritative.reviewer.email if authoritative else ""
+            annotated_at = max(a.created_at for a in item_annotations).isoformat()
+
+            base = {
+                "item_id": item.pk,
+                "item_type": item.item_type,
+                "session_id": self._get_session_external_id(item),
+                "flagged": False,
+                "flags": json.dumps(item.flags),
+                "authoritative_annotator": authoritative_email,
+                "annotated_at": annotated_at,
+            }
+            for field in schema_fields:
+                row = dict(base, field=field)
+                for email in annotator_emails:
+                    row[email] = ""
+                for ann in item_annotations:
+                    row[ann.reviewer.email] = ann.data.get(field, "")
+                rows.append(row)
+
+        for item in flagged_items:
+            row = {
+                "item_id": item.pk,
+                "item_type": item.item_type,
+                "session_id": self._get_session_external_id(item),
+                "flagged": True,
+                "flags": json.dumps(item.flags),
+                "field": "",
+                "authoritative_annotator": "",
+                "annotated_at": "",
+            }
+            for email in annotator_emails:
+                row[email] = ""
+            rows.append(row)
+
+        return fieldnames, rows
+
     def _export_csv(self, queue, annotations, flagged_items):
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = f'attachment; filename="{_safe_filename(queue.name)}_annotations.csv"'
 
         schema_fields = list(queue.schema.keys())
-        fieldnames = [
-            "item_id",
-            "item_type",
-            "session_id",
-            "annotated_at",
-            "flagged",
-            "is_authoritative",
-            "flags",
-        ] + schema_fields
+        fieldnames, rows = self._pivot_annotations(annotations, flagged_items, schema_fields)
 
         writer = csv.DictWriter(response, fieldnames=fieldnames)
         writer.writeheader()
-
-        for ann in annotations:
-            row = {
-                "item_id": ann.item_id,
-                "item_type": ann.item.item_type,
-                "session_id": self._get_session_external_id(ann.item),
-                "annotated_at": ann.created_at.isoformat(),
-                "flagged": False,
-                "is_authoritative": ann.is_authoritative,
-                "flags": json.dumps(ann.item.flags),
-            }
-            for field in schema_fields:
-                row[field] = ann.data.get(field, "")
-            writer.writerow(row)
-
-        for item in flagged_items:
-            row = self._build_flagged_row(item)
-            row["flags"] = json.dumps(row["flags"])
-            for field in schema_fields:
-                row[field] = ""
+        for row in rows:
             writer.writerow(row)
 
         return response

--- a/apps/human_annotations/views/queue_views.py
+++ b/apps/human_annotations/views/queue_views.py
@@ -54,6 +54,21 @@ def _safe_filename(name: str) -> str:
     return re.sub(r"[^\w\s\-.]", "_", name).strip()
 
 
+_CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
+def _neutralize_csv_formula(value):
+    """Prefix annotator-controlled values that could execute as a spreadsheet formula.
+
+    csv.DictWriter's quoting protects against delimiter injection but not formula
+    injection: a value starting with =, +, -, or @ runs as a formula when the export
+    is opened in Excel/Sheets. Prepending an apostrophe forces it to be read as text.
+    """
+    if isinstance(value, str) and value.startswith(_CSV_FORMULA_PREFIXES):
+        return f"'{value}"
+    return value
+
+
 class AnnotationQueueHome(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateView):
     template_name = "generic/object_home.html"
     permission_required = "human_annotations.view_annotationqueue"
@@ -558,6 +573,9 @@ class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View
         `annotations` and `flagged_items` are the same querysets ExportAnnotations.get() builds.
         Returns (fieldnames, rows) where every row dict has every key in fieldnames present.
         """
+        flagged_items = list(flagged_items)
+        flagged_item_ids = {item.pk for item in flagged_items}
+
         by_item = {}
         for ann in annotations:
             by_item.setdefault(ann.item_id, []).append(ann)
@@ -576,14 +594,17 @@ class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View
         ] + annotator_emails
 
         rows = []
-        for item_annotations in by_item.values():
-            rows.extend(self._pivot_item_rows(item_annotations, schema_fields, annotator_emails))
+        for item_id, item_annotations in by_item.items():
+            is_flagged = item_id in flagged_item_ids
+            rows.extend(self._pivot_item_rows(item_annotations, schema_fields, annotator_emails, is_flagged))
         for item in flagged_items:
+            if item.pk in by_item:
+                continue
             rows.append(self._pivot_flagged_row(item, annotator_emails))
 
         return fieldnames, rows
 
-    def _pivot_item_rows(self, item_annotations, schema_fields, annotator_emails):
+    def _pivot_item_rows(self, item_annotations, schema_fields, annotator_emails, is_flagged):
         """Build one export row per schema field for a single item's annotations."""
         item = item_annotations[0].item
         authoritative = next((a for a in item_annotations if a.is_authoritative), None)
@@ -595,7 +616,7 @@ class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View
             "item_id": item.pk,
             "item_type": item.item_type,
             "session_id": self._get_session_external_id(item),
-            "flagged": False,
+            "flagged": is_flagged,
             "flags": json.dumps(item.flags),
             "authoritative_annotator": authoritative_email,
             "annotated_at": annotated_at,
@@ -604,7 +625,7 @@ class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View
         for field in schema_fields:
             row = dict(base, field=field)
             for email in annotator_emails:
-                row[email] = data_by_email.get(email, {}).get(field, "")
+                row[email] = _neutralize_csv_formula(data_by_email.get(email, {}).get(field, ""))
             rows.append(row)
         return rows
 

--- a/apps/human_annotations/views/queue_views.py
+++ b/apps/human_annotations/views/queue_views.py
@@ -577,44 +577,52 @@ class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View
 
         rows = []
         for item_annotations in by_item.values():
-            item = item_annotations[0].item
-            authoritative = next((a for a in item_annotations if a.is_authoritative), None)
-            authoritative_email = authoritative.reviewer.email if authoritative else ""
-            annotated_at = max(a.created_at for a in item_annotations).isoformat()
-
-            base = {
-                "item_id": item.pk,
-                "item_type": item.item_type,
-                "session_id": self._get_session_external_id(item),
-                "flagged": False,
-                "flags": json.dumps(item.flags),
-                "authoritative_annotator": authoritative_email,
-                "annotated_at": annotated_at,
-            }
-            for field in schema_fields:
-                row = dict(base, field=field)
-                for email in annotator_emails:
-                    row[email] = ""
-                for ann in item_annotations:
-                    row[ann.reviewer.email] = ann.data.get(field, "")
-                rows.append(row)
-
+            rows.extend(self._pivot_item_rows(item_annotations, schema_fields, annotator_emails))
         for item in flagged_items:
-            row = {
-                "item_id": item.pk,
-                "item_type": item.item_type,
-                "session_id": self._get_session_external_id(item),
-                "flagged": True,
-                "flags": json.dumps(item.flags),
-                "field": "",
-                "authoritative_annotator": "",
-                "annotated_at": "",
-            }
-            for email in annotator_emails:
-                row[email] = ""
-            rows.append(row)
+            rows.append(self._pivot_flagged_row(item, annotator_emails))
 
         return fieldnames, rows
+
+    def _pivot_item_rows(self, item_annotations, schema_fields, annotator_emails):
+        """Build one export row per schema field for a single item's annotations."""
+        item = item_annotations[0].item
+        authoritative = next((a for a in item_annotations if a.is_authoritative), None)
+        authoritative_email = authoritative.reviewer.email if authoritative else ""
+        annotated_at = max(a.created_at for a in item_annotations).isoformat()
+        data_by_email = {ann.reviewer.email: ann.data for ann in item_annotations}
+
+        base = {
+            "item_id": item.pk,
+            "item_type": item.item_type,
+            "session_id": self._get_session_external_id(item),
+            "flagged": False,
+            "flags": json.dumps(item.flags),
+            "authoritative_annotator": authoritative_email,
+            "annotated_at": annotated_at,
+        }
+        rows = []
+        for field in schema_fields:
+            row = dict(base, field=field)
+            for email in annotator_emails:
+                row[email] = data_by_email.get(email, {}).get(field, "")
+            rows.append(row)
+        return rows
+
+    def _pivot_flagged_row(self, item, annotator_emails):
+        """Build the single blank row representing a flagged item with no annotations."""
+        row = {
+            "item_id": item.pk,
+            "item_type": item.item_type,
+            "session_id": self._get_session_external_id(item),
+            "flagged": True,
+            "flags": json.dumps(item.flags),
+            "field": "",
+            "authoritative_annotator": "",
+            "annotated_at": "",
+        }
+        for email in annotator_emails:
+            row[email] = ""
+        return row
 
     def _export_csv(self, queue, annotations, flagged_items):
         response = HttpResponse(content_type="text/csv")


### PR DESCRIPTION
### Product Description
The annotations CSV export previously listed one row per (item, annotation), interleaving every annotator's results into a single flat table. Comparing annotators on the same item required manual filtering back in the OCS UI.

The export now pivots to one row per (item, schema field), with each annotator's value in its own column. This makes side-by-side comparison and attribution immediate from the exported file alone. An `authoritative_annotator` column also shows which annotator's response was picked as authoritative, when applicable.

Closes #3321

### Technical Description
- Added `ExportAnnotations._pivot_annotations()` to reshape the flat `(item, annotation)` queryset into `(item, schema field)` rows, with one column per distinct annotator email (sorted alphabetically for stable output).
- `authoritative_annotator` replaces the old boolean `is_authoritative` flag in the CSV output with the actual annotator's email (blank if no pick has been made yet). The JSONL export is unchanged and still uses `is_authoritative`.
- `annotated_at` is the max `created_at` across an item's annotations.
- Flagged items with no annotations still produce a single blank row.
- Added `select_related("reviewer")` to the annotations queryset to avoid an N+1 query per annotation when reading `reviewer.email` during pivoting; covered by a query-count regression test.
- JSONL export path is untouched.

### Migrations
- [x] The migrations are backwards compatible (N/A — no migrations in this PR)

### Demo
Before (flat, one row per annotation):
```
item_id,item_type,session_id,flagged,field,reviewer,is_authoritative,value
67,session,d99c...,False,tone,fatima.alrashid@example.com,False,friendly and encouraging
67,session,d99c...,False,tone,marcus.bello@example.com,False,overly casual for a language tutor
```

After (pivoted, one row per field, one column per annotator):
```
item_id,item_type,session_id,flagged,flags,field,authoritative_annotator,annotated_at,fatima.alrashid@example.com,marcus.bello@example.com
67,session,d99c...,False,[],tone,,2026-07-15T13:16:33...,friendly and encouraging,overly casual for a language tutor
67,session,d99c...,False,[],accuracy,,2026-07-15T13:16:33...,"fully accurate, corrected grammar well","partially accurate, missed grammar correction"
```

### Docs and Changelog
- [ ] This PR requires docs/changelog update
