### PR TITLE
feat: add pricing for MiniMax M2, M2.7, and M3 models

### DIFF
--- a/apps/cost_tracking/migrations/0005_rate_update_20260716.py
+++ b/apps/cost_tracking/migrations/0005_rate_update_20260716.py
@@ -1,0 +1,8 @@
+from django.db import migrations
+
+from apps.cost_tracking.migration_utils import load_pricing_data
+
+
+class Migration(migrations.Migration):
+    dependencies = [("cost_tracking", "0004_rate_update_20260702")]
+    operations = [load_pricing_data()]

--- a/apps/cost_tracking/seed_data/llm_pricing.json
+++ b/apps/cost_tracking/seed_data/llm_pricing.json
@@ -1262,5 +1262,47 @@
         "unit_price": "0.000025"
       }
     ]
+  },
+  {
+    "provider_type": "minimax",
+    "model_name": "MiniMax-M3",
+    "rules": [
+      {
+        "service_kind": "llm_input",
+        "unit_price": "0.0006"
+      },
+      {
+        "service_kind": "llm_output",
+        "unit_price": "0.0024"
+      }
+    ]
+  },
+  {
+    "provider_type": "minimax",
+    "model_name": "MiniMax-M2.7",
+    "rules": [
+      {
+        "service_kind": "llm_input",
+        "unit_price": "0.0003"
+      },
+      {
+        "service_kind": "llm_output",
+        "unit_price": "0.0012"
+      }
+    ]
+  },
+  {
+    "provider_type": "minimax",
+    "model_name": "MiniMax-M2",
+    "rules": [
+      {
+        "service_kind": "llm_input",
+        "unit_price": "0.0003"
+      },
+      {
+        "service_kind": "llm_output",
+        "unit_price": "0.0012"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Product Description
Adds cost-tracking pricing for the MiniMax models OCS already registers (`MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2`). Without this, the dashboard cannot compute costs for usage of these models, and the seed-coverage CI gate fails because these global models had no active `PricingRule` for `llm_input`/`llm_output`.

### Technical Description
Fixes https://github.com/dimagi/open-chat-studio/actions/runs/29473622383/job/87541781910

Following the `auto-update-models` workflow, pricing was pulled from llm-stats.com via the zeroeval Stats API. The reconcile script reads the detail payload's top-level `input_price`/`output_price`, which are `null` for these models — the rates only live under `providers[]` — so the automation couldn't fill them and they surfaced as a coverage gap. I took the rate from the `minimax` provider entry (matching OCS's `minimax` provider) and converted per the seed convention (per-1M ÷ 1000 = per-1K):

| Model | llm_input (per 1K) | llm_output (per 1K) |
| --- | --- | --- |
| MiniMax-M3 | 0.0006 | 0.0024 |
| MiniMax-M2.7 | 0.0003 | 0.0012 |
| MiniMax-M2 | 0.0003 | 0.0012 |

Changes:
- `apps/cost_tracking/seed_data/llm_pricing.json` — three new `minimax` entries.
- `apps/cost_tracking/migrations/0005_rate_update_20260716.py` — data migration calling `load_pricing_data()` so the new rows load on deploy.

Note: llm-stats prices M3 cheaper on third-party hosts (together/fireworks/novita at $0.30/$1.20 per 1M) than on MiniMax's own API ($0.60/$2.40 per 1M). The MiniMax-provider rate was used since the OCS provider is `minimax`.

Model metadata sourced from [llm-stats.com](https://llm-stats.com) via the zeroeval Stats API.

### Migrations
- [x] The migrations are backwards compatible

`load_pricing_data()` is additive — it only seeds/supersedes pricing rows — so the migration is inherently backwards-compatible.

### Demo
`uv run pytest apps/cost_tracking/tests/test_seed_coverage.py` now passes (previously failed on the missing minimax pricing); full `apps/cost_tracking/` suite green (90 passed).

### Docs and Changelog
- [ ] This PR requires docs/changelog update
