### PR TITLE
feat: pivot JSONL annotations export to one record per item

### DIFF
--- a/apps/human_annotations/tests/test_views.py
+++ b/apps/human_annotations/tests/test_views.py
@@ -1151,6 +1151,31 @@ def test_export_csv_query_count_does_not_scale_with_annotation_count(
 
 
 @pytest.mark.django_db()
+def test_export_jsonl_query_count_does_not_scale_with_annotation_count(
+    client, team_with_users, queue, user, django_assert_max_num_queries
+):
+    other_user = UserFactory.create(username="other@example.com", email="other@example.com")
+    for _ in range(3):
+        item = AnnotationItemFactory.create(queue=queue, team=team_with_users)
+        Annotation.objects.create(
+            item=item, team=team_with_users, reviewer=user, data={"quality_score": 5}, status=AnnotationStatus.SUBMITTED
+        )
+        Annotation.objects.create(
+            item=item,
+            team=team_with_users,
+            reviewer=other_user,
+            data={"quality_score": 3},
+            status=AnnotationStatus.SUBMITTED,
+        )
+    # Same N+1 guard as the CSV path: _jsonl_item_record reads ann.reviewer.email, covered by the
+    # shared select_related("reviewer") on the annotations queryset. Ceiling matches the CSV test.
+    url = reverse("human_annotations:queue_export", args=[team_with_users.slug, queue.pk])
+    with django_assert_max_num_queries(15):
+        response = client.get(url, {"format": "jsonl"})
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db()
 def test_export_jsonl(client, team_with_users, queue, user):
     item = AnnotationItemFactory.create(queue=queue, team=team_with_users)
     Annotation.objects.create(
@@ -1191,25 +1216,143 @@ def test_export_jsonl(client, team_with_users, queue, user):
     records = [json.loads(line) for line in response.content.decode().strip().split("\n")]
     records_by_item = {r["item_id"]: r for r in records}
 
-    # Normal item — has submitted annotation
+    # Normal item — one record per item, per-field values keyed by annotator
     normal = records_by_item[item.pk]
-    assert normal["annotation"]["quality_score"] == 5
+    assert normal["fields"]["quality_score"] == {user.email: 5}
     assert normal["session_id"] == str(item.session.external_id)
     assert normal["flagged"] is False
     assert normal["flags"] == []
+    assert "annotation" not in normal
 
-    # Flagged item — no annotation, but still appears in export
+    # Flagged item — no annotation, but still appears in export with empty fields
     flagged = records_by_item[flagged_item.pk]
     assert flagged["flagged"] is True
     assert flagged["flags"] == [
         {"user": user.username, "user_id": user.id, "reason": flag_reason, "timestamp": "2024-01-01T00:00:00"}
     ]
     assert flagged["annotated_at"] == ""
-    assert flagged["annotation"] == {}
+    assert flagged["fields"] == {}
 
     # Message item — session_id falls back to message.chat.experiment_session
     msg = records_by_item[message_item.pk]
     assert msg["session_id"] == str(experiment_session.external_id)
+
+
+@pytest.mark.django_db()
+def test_export_jsonl_pivots_to_one_record_per_item_with_fields_nested(client, team_with_users):
+    """Option B: one JSONL record per item, item-level facts once, per-field values keyed by annotator."""
+    queue = AnnotationQueueFactory.create(
+        team=team_with_users,
+        num_reviews_required=2,
+        schema={
+            "tone": {"type": "string", "description": "Tone"},
+            "accuracy": {"type": "string", "description": "Accuracy"},
+        },
+    )
+    item = AnnotationItemFactory.create(queue=queue, team=team_with_users)
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    bob = UserFactory.create(username="bob@example.com", email="bob@example.com")
+    Annotation.objects.create(
+        item=item,
+        team=team_with_users,
+        reviewer=alice,
+        data={"tone": "friendly and encouraging", "accuracy": "fully accurate"},
+        status=AnnotationStatus.SUBMITTED,
+    )
+    bob_annotation = Annotation.objects.create(
+        item=item,
+        team=team_with_users,
+        reviewer=bob,
+        data={"tone": "overly casual", "accuracy": "partially accurate"},
+        status=AnnotationStatus.SUBMITTED,
+    )
+    Annotation.objects.filter(pk=bob_annotation.pk).update(is_authoritative=True)
+
+    url = reverse("human_annotations:queue_export", args=[team_with_users.slug, queue.pk])
+    response = client.get(url, {"format": "jsonl"})
+
+    assert response.status_code == 200
+    lines = response.content.decode().strip().split("\n")
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+
+    assert record["item_id"] == item.pk
+    assert record["item_type"] == item.item_type
+    assert record["flagged"] is False
+    assert record["authoritative_annotator"] == "bob@example.com"
+    assert record["fields"] == {
+        "tone": {"alice@example.com": "friendly and encouraging", "bob@example.com": "overly casual"},
+        "accuracy": {"alice@example.com": "fully accurate", "bob@example.com": "partially accurate"},
+    }
+    # Annotator keys are sorted for deterministic output / stable diffs.
+    assert list(record["fields"]["tone"].keys()) == ["alice@example.com", "bob@example.com"]
+    assert "is_authoritative" not in record
+    assert "annotation" not in record
+
+
+@pytest.mark.django_db()
+def test_export_jsonl_preserves_raw_types_and_nulls_missing_fields(client, team_with_users):
+    """Values keep their JSON types (int stays int); a field an annotator didn't answer is null."""
+    queue = AnnotationQueueFactory.create(
+        team=team_with_users,
+        num_reviews_required=2,
+        schema={
+            "quality_score": {"type": "int", "description": "Quality"},
+            "notes": {"type": "string", "description": "Notes"},
+        },
+    )
+    item = AnnotationItemFactory.create(queue=queue, team=team_with_users)
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    bob = UserFactory.create(username="bob@example.com", email="bob@example.com")
+    Annotation.objects.create(
+        item=item,
+        team=team_with_users,
+        reviewer=alice,
+        data={"quality_score": 5, "notes": "great"},
+        status=AnnotationStatus.SUBMITTED,
+    )
+    Annotation.objects.create(
+        item=item,
+        team=team_with_users,
+        reviewer=bob,
+        data={"quality_score": 3},
+        status=AnnotationStatus.SUBMITTED,
+    )
+
+    url = reverse("human_annotations:queue_export", args=[team_with_users.slug, queue.pk])
+    record = json.loads(client.get(url, {"format": "jsonl"}).content.decode().strip())
+
+    assert record["fields"]["quality_score"] == {"alice@example.com": 5, "bob@example.com": 3}
+    assert isinstance(record["fields"]["quality_score"]["alice@example.com"], int)
+    assert record["fields"]["notes"] == {"alice@example.com": "great", "bob@example.com": None}
+
+
+@pytest.mark.django_db()
+def test_export_jsonl_flagged_item_with_annotations_produces_single_record(client, team_with_users):
+    """A flagged item that also has annotations gets one record marked flagged, not a duplicate blank."""
+    queue = AnnotationQueueFactory.create(
+        team=team_with_users,
+        num_reviews_required=2,
+        schema={"quality_score": {"type": "int", "description": "Quality"}},
+    )
+    item = AnnotationItemFactory.create(queue=queue, team=team_with_users)
+    alice = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    Annotation.objects.create(
+        item=item,
+        team=team_with_users,
+        reviewer=alice,
+        data={"quality_score": 4},
+        status=AnnotationStatus.SUBMITTED,
+    )
+    AnnotationItem.objects.filter(pk=item.pk).update(status=AnnotationItemStatus.FLAGGED)
+
+    url = reverse("human_annotations:queue_export", args=[team_with_users.slug, queue.pk])
+    lines = client.get(url, {"format": "jsonl"}).content.decode().strip().split("\n")
+
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["flagged"] is True
+    assert record["fields"]["quality_score"] == {"alice@example.com": 4}
 
 
 # ===== Multi-Review =====
@@ -2006,7 +2149,7 @@ def test_export_csv_includes_authoritative_annotator(client, team_with_users, us
 
 
 @pytest.mark.django_db()
-def test_export_jsonl_includes_is_authoritative(client, team_with_users, user):
+def test_export_jsonl_includes_authoritative_annotator(client, team_with_users, user):
     queue = AnnotationQueueFactory.create(team=team_with_users, created_by=user, num_reviews_required=1)
     item = AnnotationItemFactory.create(queue=queue, team=team_with_users)
     Annotation.objects.create(
@@ -2019,5 +2162,5 @@ def test_export_jsonl_includes_is_authoritative(client, team_with_users, user):
     assert response.status_code == 200
     lines = response.content.decode().strip().splitlines()
     record = json.loads(lines[0])
-    assert "is_authoritative" in record
-    assert record["is_authoritative"] is True
+    assert record["authoritative_annotator"] == user.email
+    assert "is_authoritative" not in record

--- a/apps/human_annotations/tests/test_views.py
+++ b/apps/human_annotations/tests/test_views.py
@@ -1328,6 +1328,29 @@ def test_export_jsonl_preserves_raw_types_and_nulls_missing_fields(client, team_
 
 
 @pytest.mark.django_db()
+def test_export_jsonl_does_not_neutralize_formula_like_values(client, team_with_users):
+    """CSV formula neutralization must never reach JSONL: a `=`-prefixed value survives verbatim."""
+    queue = AnnotationQueueFactory.create(
+        team=team_with_users,
+        schema={"notes": {"type": "string", "description": "Notes"}},
+    )
+    item = AnnotationItemFactory.create(queue=queue, team=team_with_users)
+    reviewer = UserFactory.create(username="alice@example.com", email="alice@example.com")
+    Annotation.objects.create(
+        item=item,
+        team=team_with_users,
+        reviewer=reviewer,
+        data={"notes": "=1+1"},
+        status=AnnotationStatus.SUBMITTED,
+    )
+
+    url = reverse("human_annotations:queue_export", args=[team_with_users.slug, queue.pk])
+    record = json.loads(client.get(url, {"format": "jsonl"}).content.decode().strip())
+
+    assert record["fields"]["notes"]["alice@example.com"] == "=1+1"
+
+
+@pytest.mark.django_db()
 def test_export_jsonl_flagged_item_with_annotations_produces_single_record(client, team_with_users):
     """A flagged item that also has annotations gets one record marked flagged, not a duplicate blank."""
     queue = AnnotationQueueFactory.create(

--- a/apps/human_annotations/views/export_views.py
+++ b/apps/human_annotations/views/export_views.py
@@ -63,15 +63,21 @@ class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View
             return str(item.message.chat.experiment_session.external_id)
         return ""
 
-    def _build_flagged_row(self, item):
+    def _group_annotations_by_item(self, annotations):
+        by_item = {}
+        for ann in annotations:
+            by_item.setdefault(ann.item_id, []).append(ann)
+        return by_item
+
+    def _item_metadata(self, item_annotations, flagged_item_ids):
+        """Per-item facts shared by both export formats: authoritative annotator, timestamp, flag state."""
+        item = item_annotations[0].item
+        authoritative = next((a for a in item_annotations if a.is_authoritative), None)
         return {
-            "item_id": item.pk,
-            "item_type": item.item_type,
-            "session_id": self._get_session_external_id(item),
-            "annotated_at": "",
-            "flagged": True,
-            "is_authoritative": False,
-            "flags": item.flags,
+            "item": item,
+            "authoritative_email": authoritative.reviewer.email if authoritative else "",
+            "annotated_at": max(a.created_at for a in item_annotations).isoformat(),
+            "is_flagged": item.pk in flagged_item_ids,
         }
 
     def _pivot_annotations(self, annotations, flagged_items, schema_fields):
@@ -82,10 +88,7 @@ class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View
         """
         flagged_items = list(flagged_items)
         flagged_item_ids = {item.pk for item in flagged_items}
-
-        by_item = {}
-        for ann in annotations:
-            by_item.setdefault(ann.item_id, []).append(ann)
+        by_item = self._group_annotations_by_item(annotations)
 
         annotator_emails = sorted({ann.reviewer.email for ann in annotations})
 
@@ -101,9 +104,8 @@ class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View
         ] + annotator_emails
 
         rows = []
-        for item_id, item_annotations in by_item.items():
-            is_flagged = item_id in flagged_item_ids
-            rows.extend(self._pivot_item_rows(item_annotations, schema_fields, annotator_emails, is_flagged))
+        for item_annotations in by_item.values():
+            rows.extend(self._pivot_item_rows(item_annotations, schema_fields, annotator_emails, flagged_item_ids))
         for item in flagged_items:
             if item.pk in by_item:
                 continue
@@ -111,22 +113,20 @@ class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View
 
         return fieldnames, rows
 
-    def _pivot_item_rows(self, item_annotations, schema_fields, annotator_emails, is_flagged):
-        """Build one export row per schema field for a single item's annotations."""
-        item = item_annotations[0].item
-        authoritative = next((a for a in item_annotations if a.is_authoritative), None)
-        authoritative_email = authoritative.reviewer.email if authoritative else ""
-        annotated_at = max(a.created_at for a in item_annotations).isoformat()
+    def _pivot_item_rows(self, item_annotations, schema_fields, annotator_emails, flagged_item_ids):
+        """Build one CSV row per schema field for a single item's annotations."""
+        meta = self._item_metadata(item_annotations, flagged_item_ids)
+        item = meta["item"]
         data_by_email = {ann.reviewer.email: ann.data for ann in item_annotations}
 
         base = {
             "item_id": item.pk,
             "item_type": item.item_type,
             "session_id": self._get_session_external_id(item),
-            "flagged": is_flagged,
+            "flagged": meta["is_flagged"],
             "flags": json.dumps(item.flags),
-            "authoritative_annotator": authoritative_email,
-            "annotated_at": annotated_at,
+            "authoritative_annotator": meta["authoritative_email"],
+            "annotated_at": meta["annotated_at"],
         }
         rows = []
         for field in schema_fields:
@@ -167,27 +167,49 @@ class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View
         return response
 
     def _export_jsonl(self, queue, annotations, flagged_items):
-        lines = []
-        for ann in annotations:
-            record = {
-                "item_id": ann.item_id,
-                "item_type": ann.item.item_type,
-                "session_id": self._get_session_external_id(ann.item),
-                "annotated_at": ann.created_at.isoformat(),
-                "flagged": False,
-                "is_authoritative": ann.is_authoritative,
-                "flags": ann.item.flags,
-                "annotation": ann.data,
-            }
-            lines.append(json.dumps(record))
+        schema_fields = list(queue.schema.keys())
+        flagged_items = list(flagged_items)
+        flagged_item_ids = {item.pk for item in flagged_items}
+        by_item = self._group_annotations_by_item(annotations)
 
-        for item in flagged_items:
-            record = self._build_flagged_row(item)
-            # Flagged items have no annotation data; emit an empty dict so every record has the same shape.
-            record["annotation"] = {}
-            lines.append(json.dumps(record))
+        lines = [
+            json.dumps(self._jsonl_item_record(item_annotations, schema_fields, flagged_item_ids))
+            for item_annotations in by_item.values()
+        ]
+        lines.extend(json.dumps(self._jsonl_flagged_record(item)) for item in flagged_items if item.pk not in by_item)
 
         content = "\n".join(lines)
         response = HttpResponse(content, content_type="application/jsonl")
         response["Content-Disposition"] = f'attachment; filename="{_safe_filename(queue.name)}_annotations.jsonl"'
         return response
+
+    def _jsonl_item_record(self, item_annotations, schema_fields, flagged_item_ids):
+        """One JSONL record per item: item-level facts once, per-field values keyed by annotator email."""
+        meta = self._item_metadata(item_annotations, flagged_item_ids)
+        item = meta["item"]
+        annotators = sorted(item_annotations, key=lambda a: a.reviewer.email)
+        return {
+            "item_id": item.pk,
+            "item_type": item.item_type,
+            "session_id": self._get_session_external_id(item),
+            "flagged": meta["is_flagged"],
+            "flags": item.flags,
+            "authoritative_annotator": meta["authoritative_email"],
+            "annotated_at": meta["annotated_at"],
+            "fields": {
+                field: {ann.reviewer.email: ann.data.get(field) for ann in annotators} for field in schema_fields
+            },
+        }
+
+    def _jsonl_flagged_record(self, item):
+        """A flagged item with no annotations: item-level facts with empty fields."""
+        return {
+            "item_id": item.pk,
+            "item_type": item.item_type,
+            "session_id": self._get_session_external_id(item),
+            "flagged": True,
+            "flags": item.flags,
+            "authoritative_annotator": "",
+            "annotated_at": "",
+            "fields": {},
+        }


### PR DESCRIPTION
### Product Description

The annotation queue **JSONL export** now uses the same pivoted, per-reviewer structure as the CSV export. Previously it emitted one flat record per annotation with no reviewer attribution, so you could not tell which reviewer gave which answer, or compare reviewers on the same item.

It now emits **one record per item**, with each reviewer's answers nested per schema field (`fields: {field: {reviewer_email: value}}`), plus the item's `authoritative_annotator` and latest `annotated_at`. Side-by-side comparison and attribution are now immediate from the exported file alone.

Follow-up to #3832 (which pivoted the CSV export). Closes #3837.

> [!WARNING]
> This is a **breaking change** to the JSONL export shape. Consumers parsing the old per-annotation format (`is_authoritative`, `annotation`) must update. The CSV export is unchanged.

### Technical Description

- Rewrote `ExportAnnotations._export_jsonl` to group annotations by item and emit one record per item. Per-field values are nested under `fields`, keyed by reviewer email (sorted for deterministic output). A field a reviewer did not answer is `null`; value types are preserved (no stringifying).
- `authoritative_annotator` (reviewer email, blank if none picked) replaces the old boolean `is_authoritative`. `annotated_at` is the max `created_at` across the item's annotations. Flagged items with no annotations emit one record with empty `fields`; a flagged item that also has annotations produces a single record marked `flagged: true` (no duplicate contradictory record).
- Extracted the shared per-item logic (`_group_annotations_by_item`, `_item_metadata`) used by both the CSV and JSONL renderers. Formula neutralization (`_neutralize_csv_formula`) stays CSV-only by construction: it is never applied to JSONL, where prefixing an apostrophe would corrupt values. Removed the now-dead `_build_flagged_row`.
- CSV output is unchanged (verified byte-identical against `main` for the same data; all CSV tests pass).
- Added JSONL tests (per-item shape, raw types / null, flagged with and without annotations, authoritative annotator, query-count N+1 guard) and rewrote the two existing JSONL tests to the new shape. Verified test effectiveness with mutation testing (8/8 mutants killed after adding a sorted-keys assertion).

### Migrations
- [x] The migrations are backwards compatible (N/A - no migrations in this PR)

### Demo

Before (flat, one record per annotation, no reviewer attribution):

```json
{"item_id": 67, "item_type": "session", "annotated_at": "...", "flagged": false, "is_authoritative": false, "flags": [], "annotation": {"tone": "friendly", "accuracy": "accurate"}}
{"item_id": 67, "item_type": "session", "annotated_at": "...", "flagged": false, "is_authoritative": true, "flags": [], "annotation": {"tone": "too casual", "accuracy": "missed grammar"}}
```

After (one record per item, values nested per field by reviewer):

```json
{"item_id": 67, "item_type": "session", "session_id": "d99c...", "flagged": false, "flags": [], "authoritative_annotator": "marcus@example.com", "annotated_at": "2026-07-15T13:17:02Z", "fields": {"tone": {"fatima@example.com": "friendly", "marcus@example.com": "too casual"}, "accuracy": {"fatima@example.com": "accurate", "marcus@example.com": "missed grammar"}}}
```

### Docs and Changelog
- [x] This PR requires docs/changelog update

Docs: user-doc update in dimagi/open-chat-studio-docs#572, which rewrites the "Exporting Results" section for both the CSV pivot and this JSONL change (closes dimagi/open-chat-studio-docs#571).

Changelog note for the automation: *Annotation JSONL export now mirrors the CSV's per-reviewer pivoted shape - one record per item, values nested per field by reviewer, with the authoritative annotator. Breaking change to the JSONL format.*

Note: the docs/changelog dispatch automation does not run from a fork, so a maintainer will need to trigger the docs-repo action ("Update Changelog and Docs from OCS PR") with this PR number. The linked docs PR covers the user-facing docs manually.
