### PR TITLE
fix: JSON collection — capture 'topics' metadata + sync summary log

### DIFF
--- a/apps/documents/source_loaders/json_collection.py
+++ b/apps/documents/source_loaders/json_collection.py
@@ -34,8 +34,22 @@ class JSONCollectionLoader(BaseDocumentLoader[JSONCollectionSourceConfig]):
     def load_documents(self) -> Iterator[Document]:
         """Load documents from a JSON indexed-collections feed."""
         items = self._fetch_json_list()
+        total = len(items)
+        skipped = 0
+        loaded = 0
         for item in items:
-            yield from self._process_item(item)
+            before = loaded
+            for doc in self._process_item(item):
+                loaded += 1
+                yield doc
+            if loaded == before:
+                skipped += 1
+        logger.info(
+            "JSON collection sync complete: %d item(s) in feed, %d document(s) loaded, %d item(s) produced no documents",
+            total,
+            loaded,
+            skipped,
+        )
 
     def _fetch_json_list(self) -> list[dict[str, Any]]:
         try:
@@ -64,7 +78,7 @@ class JSONCollectionLoader(BaseDocumentLoader[JSONCollectionSourceConfig]):
 
         fetchable = self._fetchable_attachments(item)
         if not fetchable:
-            logger.debug(
+            logger.warning(
                 "Skipping item %s: no attachments with a document link",
                 uri or title,
             )
@@ -105,6 +119,7 @@ class JSONCollectionLoader(BaseDocumentLoader[JSONCollectionSourceConfig]):
             "countries",
             "diseases",
             "tags",
+            "topics",
             "regions",
         ):
             if key in item:

--- a/apps/documents/tests/test_json_collection_loader.py
+++ b/apps/documents/tests/test_json_collection_loader.py
@@ -166,7 +166,7 @@ class TestLoadDocumentsNoFetchableLink:
         httpx_mock.add_response(url="https://example.com/feed.json", json=feed)
 
         loader = _make_loader(json_config)
-        with caplog.at_level(logging.DEBUG, logger="apps.documents.source_loaders.json_collection"):
+        with caplog.at_level(logging.WARNING, logger="apps.documents.source_loaders.json_collection"):
             docs = list(loader.load_documents())
 
         assert docs == []
@@ -200,6 +200,7 @@ class TestItemMetadataPropagation:
                 countries=["US", "CA"],
                 diseases=["malaria"],
                 tags=["health"],
+                topics=["Elimination", "M&E"],
                 regions=["AFRO"],
             )
         ]
@@ -218,9 +219,23 @@ class TestItemMetadataPropagation:
             ("countries", ["US", "CA"]),
             ("diseases", ["malaria"]),
             ("tags", ["health"]),
+            ("topics", ["Elimination", "M&E"]),
             ("regions", ["AFRO"]),
         ]:
             assert meta[k] == v
+
+    def test_topics_field_propagates_to_metadata(self, json_config, httpx_mock):
+        """Regression: 'topics' was omitted from _build_item_metadata (issue #3816)."""
+        feed = [_single_attachment_item(topics=["MDA / PC", "Gender"])]
+        httpx_mock.add_response(url="https://example.com/feed.json", json=feed)
+        httpx_mock.add_response(url="https://example.com/file.pdf", content=b"PDF")
+        loader = _make_loader(json_config)
+        with mock.patch(
+            "apps.documents.source_loaders.json_collection.markitdown_read",
+            return_value=_stub_doc("body"),
+        ):
+            meta = list(loader.load_documents())[0].metadata
+        assert meta["topics"] == ["MDA / PC", "Gender"]
 
     def test_optional_metadata_fields_absent_when_missing(self, json_config, httpx_mock):
         feed = [_single_attachment_item()]
@@ -232,7 +247,7 @@ class TestItemMetadataPropagation:
             return_value=_stub_doc("body"),
         ):
             meta = list(loader.load_documents())[0].metadata
-        for k in ("authors", "publisher", "countries", "diseases", "tags", "regions"):
+        for k in ("authors", "publisher", "countries", "diseases", "tags", "topics", "regions"):
             assert k not in meta
 
     def test_item_missing_title_and_uri_is_skipped(self, json_config, httpx_mock, caplog):
@@ -602,3 +617,61 @@ class TestAuthHeadersPropagation:
             docs = list(loader.load_documents())
         assert len(docs) == 1
         assert docs[0].page_content == "body"
+
+
+class TestLoadDocumentsSummaryLog:
+    """load_documents() emits an INFO summary at the end so operators can spot gaps."""
+
+    def test_summary_logged_for_mixed_feed(self, json_config, httpx_mock, caplog):
+        """A feed with some items that have no attachments produces an INFO summary
+        showing total items, documents loaded, and skipped item count.
+        """
+        feed = [
+            _single_attachment_item(title="Has attachment"),
+            {"title": "No attachment", "URI": "https://example.com/empty", "attachments": []},
+        ]
+        httpx_mock.add_response(url="https://example.com/feed.json", json=feed)
+        httpx_mock.add_response(url="https://example.com/file.pdf", content=b"PDF")
+        loader = _make_loader(json_config)
+        with (
+            caplog.at_level(logging.INFO, logger="apps.documents.source_loaders.json_collection"),
+            mock.patch(
+                "apps.documents.source_loaders.json_collection.markitdown_read",
+                return_value=_stub_doc("body"),
+            ),
+        ):
+            docs = list(loader.load_documents())
+
+        assert len(docs) == 1
+        summary = next(
+            (r for r in caplog.records if "sync complete" in r.message),
+            None,
+        )
+        assert summary is not None, "expected a sync-complete INFO log"
+        assert "2 item(s) in feed" in summary.message
+        assert "1 document(s) loaded" in summary.message
+        assert "1 item(s) produced no documents" in summary.message
+
+    def test_summary_logged_when_all_loaded(self, json_config, httpx_mock, caplog):
+        feed = [_single_attachment_item()]
+        httpx_mock.add_response(url="https://example.com/feed.json", json=feed)
+        httpx_mock.add_response(url="https://example.com/file.pdf", content=b"PDF")
+        loader = _make_loader(json_config)
+        with (
+            caplog.at_level(logging.INFO, logger="apps.documents.source_loaders.json_collection"),
+            mock.patch(
+                "apps.documents.source_loaders.json_collection.markitdown_read",
+                return_value=_stub_doc("body"),
+            ),
+        ):
+            docs = list(loader.load_documents())
+
+        assert len(docs) == 1
+        summary = next(
+            (r for r in caplog.records if "sync complete" in r.message),
+            None,
+        )
+        assert summary is not None
+        assert "1 item(s) in feed" in summary.message
+        assert "1 document(s) loaded" in summary.message
+        assert "0 item(s) produced no documents" in summary.message


### PR DESCRIPTION
## Summary

Investigated issue #3816 (JSON document source not loading all documents) using the ESPEN staging feed at https://espen.remora-staging.co.uk/documents.json.

### Findings from feed analysis (248 items)

| Category | Count |
|---|---|
| Items in feed | 248 |
| Items with fetchable attachments | 245 |
| Items with **empty** attachment arrays (silently skipped) | 3 |
| Items with `topics` field (data lost before this fix) | 110/248 |

The 3 items with empty attachment arrays are: *Taenia solium control and management course now available on OpenWHO*, *Nigeria NTD Master Plan 2023–2027 – EN*, and *Test* (id 489). These items exist in the feed but have no downloadable files, so the loader correctly skips them — but operators had no visibility into this.

### Changes

**1. Add `topics` to captured metadata (`_build_item_metadata`)**
`topics` is a first-class field in the ESPEN indexed-collections format (see issue #3176 spec) but was omitted from the list, so it was silently dropped from every loaded document. 110 out of 248 ESPEN documents carry this field.

**2. Promote the empty-attachment skip log from `DEBUG` → `WARNING`**
In production, DEBUG logs are often suppressed. Items with no attachment links were silently dropped with no operator-visible message. WARNING ensures it appears in the default log stream.

**3. Emit an INFO summary at the end of `load_documents()`**
The loader now emits a line like:
```
JSON collection sync complete: 248 item(s) in feed, 245 document(s) loaded, 3 item(s) produced no documents
```
This directly addresses the observability gap in #3816: operators can now see *why* the loaded count differs from the feed count.

### Tests added
- `test_topics_field_propagates_to_metadata` — regression test for the `topics` omission
- Updated `test_optional_metadata_fields_propagate_when_present` to include `topics`
- Updated `test_optional_metadata_fields_absent_when_missing` to assert `topics` absent when not present
- Updated `test_no_attachments_field_yields_nothing` to expect WARNING level (was DEBUG)
- `TestLoadDocumentsSummaryLog` — two new tests verifying the INFO summary with correct counts