### PR TITLE
Replace custom history-name combobox with CreatableSelect (#2490)

### DIFF
--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -1023,7 +1023,7 @@ export function HistoryTypeWidget(props: WidgetParams) {
                 onChange={reportSelection}
                 isDisabled={props.readOnly}
                 isClearable
-                className="react-select-container nodrag"
+                className="react-select-container react-select-join nodrag"
                 classNamePrefix="react-select"
                 placeholder="Type to search or create..."
               />

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -1,5 +1,6 @@
 import React, {ChangeEvent, ChangeEventHandler, ReactNode, useCallback, useId, useState, useMemo} from "react";
-import Select from 'react-select';
+import Select, {SingleValue} from 'react-select';
+import CreatableSelect from 'react-select/creatable';
 import {LlmProviderModel, Option, TypedOption} from "../types/nodeParameterValues";
 import usePipelineStore from "../stores/pipelineStore";
 import {classNames, concatenate, getCachedData, getDocumentationLink, getSelectOptions} from "../utils";
@@ -967,8 +968,6 @@ export function HistoryTypeWidget(props: WidgetParams) {
   const historyNameError = props.getNodeFieldError(props.nodeId, "history_name");
 
   const nodes = usePipelineStore((state) => state.nodes);
-  const [searchTerm, setSearchTerm] = useState("");
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const historyNameOptions = useMemo(() => {
     const historyNames = new Set<string>();
@@ -983,63 +982,16 @@ export function HistoryTypeWidget(props: WidgetParams) {
     return Array.from(historyNames).sort();
   }, [nodes]);
 
-  const filteredOptions = useMemo(() => {
-    if (!searchTerm || !isDropdownOpen) return historyNameOptions;
-    return historyNameOptions.filter(name =>
-      name.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-  }, [historyNameOptions, searchTerm, isDropdownOpen]);
+  const historyNameSelectOptions = useMemo(
+    () => historyNameOptions.map((name) => ({value: name, label: name})),
+    [historyNameOptions]
+  );
+  const selectedOption = historyName ? {value: historyName, label: historyName} : null;
 
-  const showCreateOption = searchTerm.trim() &&
-    !historyNameOptions.some(name => name.toLowerCase() === searchTerm.toLowerCase());
-
-  const displayValue = (isDropdownOpen && searchTerm !== "") ? searchTerm : (historyName || "");
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTerm(e.target.value);
-    if (!isDropdownOpen) {
-      setIsDropdownOpen(true);
-    }
-    if (e.target.value === "") {
-      handleOptionSelect("")
-    }
-  };
-
-  const handleOptionSelect = (value: string) => {
-    const syntheticEvent = {
-      target: {
-        name: "history_name",
-        value,
-      },
-    };
-    props.updateParamValue?.(syntheticEvent as React.ChangeEvent<HTMLInputElement>);
-    setSearchTerm("");
-    setIsDropdownOpen(false);
-  };
-
-  const handleCreateNew = () => {
-    const newName = searchTerm.trim();
-    if (newName) {
-      handleOptionSelect(newName);
-    }
-  };
-
-  const handleInputClick = () => {
-    setIsDropdownOpen(true);
-    setSearchTerm("");
-  };
-
-  const handleClearClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    handleOptionSelect("");
-  };
-
-  const handleDropdownToggle = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setIsDropdownOpen(!isDropdownOpen);
-    if (!isDropdownOpen) {
-      setSearchTerm("");
-    }
+  const reportSelection = (option: SingleValue<Option>) => {
+    props.updateParamValue?.({
+      target: {name: "history_name", value: option?.value ?? ""},
+    } as React.ChangeEvent<HTMLInputElement>);
   };
 
   return (
@@ -1064,68 +1016,17 @@ export function HistoryTypeWidget(props: WidgetParams) {
         </InputField>
         {historyType == "named" && (
           <InputField label="History Name" help_text={props.helpText}>
-            <div className="w-64 relative">
-              <input
-                type="text"
-                className="input w-full pr-8 nodrag"
-                value={displayValue}
-                onChange={handleInputChange}
-                onClick={handleInputClick}
+            <div className="w-64">
+              <CreatableSelect
+                options={historyNameSelectOptions}
+                value={selectedOption}
+                onChange={reportSelection}
+                isDisabled={props.readOnly}
+                isClearable
+                className="react-select-container nodrag"
+                classNamePrefix="react-select"
                 placeholder="Type to search or create..."
               />
-
-              {/* Icons container */}
-              <div className="absolute inset-y-0 right-0 flex items-center pr-2">
-                {/* Clear icon */}
-                {(historyName || searchTerm) && (
-                  <button
-                    type="button"
-                    className="p-1 hover:bg-gray-200 rounded"
-                    onClick={handleClearClick}
-                  >
-                    <i className="fa fa-times text-gray-400 hover:text-gray-600" />
-                  </button>
-                )}
-
-                {/* Dropdown icon */}
-                <button
-                  type="button"
-                  className="p-1 ml-1"
-                  onClick={handleDropdownToggle}
-                >
-                  <i className={`fa fa-chevron-down text-gray-400 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`} />
-                </button>
-              </div>
-
-              {isDropdownOpen && (
-                <div className="absolute z-10 w-full bg-white border border-gray-300 rounded-md shadow-lg max-h-40 overflow-y-auto normal-case">
-                  {!searchTerm && historyNameOptions.length == 0 && (
-                    <div
-                      className="px-3 py-2 text-gray-500 cursor-pointer hover:bg-gray-100"
-                      onClick={() => handleOptionSelect("")}>
-                      -- Select --
-                    </div>
-                  )}
-                  {filteredOptions.map((name) => (
-                    <div
-                      key={name}
-                      className="px-3 py-2 cursor-pointer hover:bg-gray-100"
-                      onClick={() => handleOptionSelect(name)}
-                    >
-                      {name}
-                    </div>
-                  ))}
-
-                  {showCreateOption && (
-                    <div
-                      className="px-3 py-2 cursor-pointer hover:bg-gray-100 text-blue-600 font-medium"
-                      onClick={handleCreateNew}
-                    >
-                      + Create "{searchTerm}"
-                    </div>
-                  )}
-                </div>
-              )}
             </div>
           </InputField>
         )}

--- a/assets/styles/app/react-select.css
+++ b/assets/styles/app/react-select.css
@@ -1,0 +1,83 @@
+/*
+  react-select is used for several pipeline-builder widgets (see
+  assets/javascript/apps/pipeline/nodes/widgets.tsx). The library ships a
+  hard-coded light palette that ignores the active daisyUI theme, so in dark
+  mode the control and menu rendered white-on-dark. These rules drive
+  react-select from the same daisyUI theme variables the native `select`/`input`
+  controls use, so it follows the light and dark themes automatically.
+
+  NOTE: react-select injects its styles via emotion into an *unlayered* origin,
+  so this file must stay unlayered too (imported without `layer(...)`); the
+  descendant selectors below then win on specificity.
+*/
+.react-select-container .react-select__control {
+  background-color: var(--color-base-100);
+  border-color: color-mix(in oklab, var(--color-base-content) 20%, transparent);
+}
+
+.react-select-container .react-select__control--is-focused {
+  border-color: var(--color-primary);
+  box-shadow: none;
+}
+
+.react-select-container .react-select__control--is-disabled {
+  background-color: var(--color-base-200);
+}
+
+.react-select-container .react-select__single-value,
+.react-select-container .react-select__input-container,
+.react-select-container .react-select__multi-value__label {
+  color: var(--color-base-content);
+}
+
+.react-select-container .react-select__placeholder {
+  color: color-mix(in oklab, var(--color-base-content) 60%, transparent);
+}
+
+.react-select-container .react-select__indicator {
+  color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
+}
+
+.react-select-container .react-select__indicator-separator {
+  background-color: color-mix(in oklab, var(--color-base-content) 20%, transparent);
+}
+
+.react-select-container .react-select__menu {
+  background-color: var(--color-base-100);
+  color: var(--color-base-content);
+  border: 1px solid color-mix(in oklab, var(--color-base-content) 20%, transparent);
+}
+
+.react-select-container .react-select__option {
+  background-color: transparent;
+  color: var(--color-base-content);
+}
+
+.react-select-container .react-select__option--is-focused {
+  background-color: var(--color-base-200);
+}
+
+.react-select-container .react-select__option--is-selected {
+  background-color: var(--color-primary);
+  color: var(--color-primary-content);
+}
+
+.react-select-container .react-select__multi-value {
+  background-color: var(--color-base-200);
+}
+
+/*
+  History-name select sits in a joined row next to the history-type <select>.
+  Match the daisyUI select height (var(--size-field) * 10) and square the shared
+  (left) edge — the type <select> is the join first-item (rounded-left,
+  square-right) — so the two controls align cleanly instead of leaving a
+  short, rounded-corner notch at the seam.
+*/
+.react-select-join .react-select__control {
+  min-height: calc(var(--size-field, 0.25rem) * 10);
+  border-start-start-radius: 0;
+  border-end-start-radius: 0;
+  border-start-end-radius: var(--radius-field);
+  border-end-end-radius: var(--radius-field);
+  margin-inline-start: calc(var(--border, 1px) * -1);
+}

--- a/assets/styles/site-tailwind.css
+++ b/assets/styles/site-tailwind.css
@@ -2,6 +2,7 @@
 @import './app/chat.css';
 @import './app/table.css' layer(components);
 @import './app/alertify.css';
+@import './app/react-select.css';
 @import './app/pg-components.css';
 @import './app/prompt-builder.css' layer(components);
 @import './app/dashboard.css' layer(components);


### PR DESCRIPTION
Swap the hand-rolled history-name combobox in HistoryTypeWidget for CreatableSelect from react-select, the create-enabled variant already used elsewhere in this file. The library now owns open/close state, filtering, the create affordance, clearing, and outside-click-to-close (fixing the defect where the old dropdown stayed open until the chevron was clicked or an option chosen).

A thin adapter keeps the existing updateParamValue contract intact: onChange maps the selected/created/cleared option to a synthetic change event with name "history_name", byte-identical to what the combobox wrote. Options are mapped into react-select's { value, label } shape, and the current selection is derived from the saved historyName so a freshly created name always displays. Styling reuses the react-select-container / react-select classNamePrefix pattern from MultiSelectWidget, with nodrag preserved on the container. All combobox-only state, handlers, and markup are deleted.

No schema, API, or stored-data change.


### Docs and Changelog
- [ ] This PR requires docs/changelog update