### PR TITLE
test: fix two flaky tests that fail intermittently in CI

### DIFF
--- a/apps/pipelines/tests/test_add_start_end_nodes.py
+++ b/apps/pipelines/tests/test_add_start_end_nodes.py
@@ -258,9 +258,7 @@ def test_remove_start_end_nodes(team):
     remove_all_start_end_nodes(Node)
     pipeline.refresh_from_db()
 
-    assert pipeline.node_set.all().count() == 2
-    assert pipeline.node_set.all()[0].flow_id == passthrough_1["id"]
-    assert pipeline.node_set.all()[1].flow_id == passthrough_2["id"]
+    assert set(pipeline.node_set.values_list("flow_id", flat=True)) == {passthrough_1["id"], passthrough_2["id"]}
     assert len(pipeline.data["edges"]) == 1
     assert pipeline.data["edges"][0] == {
         "id": "1->2",

--- a/apps/service_providers/tests/test_langfuse_client_manager.py
+++ b/apps/service_providers/tests/test_langfuse_client_manager.py
@@ -99,12 +99,12 @@ def test_prune_stale_clients(client_manager, config, langfuse_mock):
     # Arrange
     other_config = {"public_key": "other_key", "secret_key": "other_secret"}
     first_client = client_manager.get(config)
-
-    time.sleep(0.4)
     client_manager.get(other_config)  # Get second client
     assert len(client_manager.key_timestamps) == 2
 
-    time.sleep(0.1)  # Sleep longer than the stale timeout
+    # Backdate the first client so only it is past the stale timeout
+    client_manager.key_timestamps[config["public_key"]] -= client_manager.stale_timeout + 1
+
     client_manager._prune_stale()
 
     assert len(client_manager.key_timestamps) == 1


### PR DESCRIPTION
### Product Description
No change — test-only fixes.

### Technical Description
Two tests fail intermittently in CI:

- `test_remove_start_end_nodes` asserted on `pipeline.node_set.all()[0]` / `[1]`, but `Node` has no `Meta.ordering`, so Postgres returns rows in arbitrary heap order after `remove_all_start_end_nodes` deletes and rewrites rows. Replaced the positional asserts with a set comparison of `flow_id`s, which is what the test actually meant to check.
- `test_prune_stale_clients` slept real wall-clock time (0.4s + 0.1s) against a 0.5s stale timeout, so on a slow runner both clients went stale and got pruned (`assert 0 == 1`). The sleeps are gone; the test now backdates the first client's timestamp past the timeout, making it deterministic.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)