### PR TITLE
refactor: base the team sync schema check on the export API schema

### DIFF
--- a/api-schemas/export.yml
+++ b/api-schemas/export.yml
@@ -4321,10 +4321,12 @@ components:
     Manifest:
       type: object
       description: 'The sync manifest: the call order and per-model config, plus a
-        checksum of the applied schema.'
+        checksum of the export schema.'
       properties:
         schema_checksum:
           type: string
+          description: SHA-256 of this server's export OpenAPI schema; clients compare
+            it against their own to detect an incompatible export surface.
         entries:
           type: array
           items:

--- a/apps/api/export/serializers.py
+++ b/apps/api/export/serializers.py
@@ -144,9 +144,8 @@ class ManifestEntrySerializer(serializers.Serializer):
 
 
 class ManifestSerializer(serializers.Serializer):
-    """The sync manifest: the call order and per-model config, plus a checksum of the applied schema."""
+    """The sync manifest: the call order and per-model config."""
 
-    schema_checksum = serializers.CharField()
     entries = ManifestEntrySerializer(many=True)
 
 

--- a/apps/api/export/serializers.py
+++ b/apps/api/export/serializers.py
@@ -144,8 +144,12 @@ class ManifestEntrySerializer(serializers.Serializer):
 
 
 class ManifestSerializer(serializers.Serializer):
-    """The sync manifest: the call order and per-model config."""
+    """The sync manifest: the call order and per-model config, plus a checksum of the export schema."""
 
+    schema_checksum = serializers.CharField(
+        help_text="SHA-256 of this server's export OpenAPI schema; clients compare it against their "
+        "own to detect an incompatible export surface."
+    )
     entries = ManifestEntrySerializer(many=True)
 
 

--- a/apps/api/export/tests/test_views.py
+++ b/apps/api/export/tests/test_views.py
@@ -60,7 +60,6 @@ def test_manifest_is_public_and_returns_entries():
     response = APIClient().get(reverse("api:export:manifest"))
     assert response.status_code == 200
     body = response.json()
-    assert "schema_checksum" in body
     resources = {e["resource"] for e in body["entries"]}
     assert "chatbots" in resources
     assert "teams" not in resources  # the team is served on its own, not as a manifest resource

--- a/apps/api/export/tests/test_views.py
+++ b/apps/api/export/tests/test_views.py
@@ -60,6 +60,7 @@ def test_manifest_is_public_and_returns_entries():
     response = APIClient().get(reverse("api:export:manifest"))
     assert response.status_code == 200
     body = response.json()
+    assert "schema_checksum" in body
     resources = {e["resource"] for e in body["entries"]}
     assert "chatbots" in resources
     assert "teams" not in resources  # the team is served on its own, not as a manifest resource

--- a/apps/teams/export/manifest.py
+++ b/apps/teams/export/manifest.py
@@ -1,13 +1,17 @@
 """The single maintenance surface for the team data sync: which models to pull, in what order,
 and the per-model config (secrets, team scoping, global matching) the endpoint and importer need."""
 
+import hashlib
+import json
 from collections.abc import Callable
 from dataclasses import dataclass
+from functools import cache
 
 from django.apps import apps
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import ForeignKey, Model, Prefetch, Q, QuerySet
+from drf_spectacular.generators import SchemaGenerator
 
 from apps.files.models import FilePurpose
 
@@ -257,8 +261,22 @@ def team_scoped_queryset(entry: ManifestEntry, team) -> QuerySet:
     return queryset.prefetch_related(*prefetch_factory(team)) if prefetch_factory else queryset
 
 
+@cache
+def schema_checksum() -> str:
+    """Hash of the export API's OpenAPI schema -- the exact shape of the data the sync transfers
+    (endpoints, fields, types), generated from the running code. Two servers produce the same
+    checksum exactly when their export surfaces match, making it a code-compatibility check that,
+    unlike migration history, ignores squashes and renames. Generated without a request so
+    host-dependent example URLs stay at their fixed placeholder; keys are sorted so the hash doesn't
+    depend on dict ordering. Cached: the schema can't change within a process."""
+    schema = SchemaGenerator(api_version="export").get_schema(request=None, public=True)
+    data = json.dumps(schema, separators=(",", ":"), sort_keys=True, default=str)
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
 def build_manifest() -> dict:
     return {
+        "schema_checksum": schema_checksum(),
         "entries": [
             {
                 "model": e.model,

--- a/apps/teams/export/manifest.py
+++ b/apps/teams/export/manifest.py
@@ -1,16 +1,12 @@
 """The single maintenance surface for the team data sync: which models to pull, in what order,
 and the per-model config (secrets, team scoping, global matching) the endpoint and importer need."""
 
-import hashlib
-import json
 from collections.abc import Callable
 from dataclasses import dataclass
 
 from django.apps import apps
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.core.exceptions import FieldDoesNotExist
-from django.db import connection
-from django.db.migrations.recorder import MigrationRecorder
 from django.db.models import ForeignKey, Model, Prefetch, Q, QuerySet
 
 from apps.files.models import FilePurpose
@@ -261,23 +257,8 @@ def team_scoped_queryset(entry: ManifestEntry, team) -> QuerySet:
     return queryset.prefetch_related(*prefetch_factory(team)) if prefetch_factory else queryset
 
 
-def schema_checksum() -> str:
-    """Hash of the set of applied migrations, identified by ``(app, name)`` -- the same key
-    ``MigrationRecorder`` uses, so schemas that share a filename like ``0001_initial`` across apps
-    don't collide. Unaffected by apply order. Returns the hash of an empty set when the migrations
-    table is absent (e.g. tests run with --no-migrations); that's consistent as long as the source
-    and target both lack it."""
-    recorder = MigrationRecorder(connection)
-    applied = []
-    if recorder.has_table():
-        applied = list(recorder.migration_qs.order_by("app", "name").values_list("app", "name"))
-    data = json.dumps(applied, separators=(",", ":"))
-    return hashlib.sha256(data.encode("utf-8")).hexdigest()
-
-
 def build_manifest() -> dict:
     return {
-        "schema_checksum": schema_checksum(),
         "entries": [
             {
                 "model": e.model,

--- a/apps/teams/export/tests/test_command.py
+++ b/apps/teams/export/tests/test_command.py
@@ -9,6 +9,7 @@ from apps.api.export.serializers import build_resource_serializer
 from apps.service_providers.models import LlmProvider
 from apps.teams.export import seal as seal_mod
 from apps.teams.export.importer import Importer
+from apps.teams.export.manifest import schema_checksum
 from apps.teams.export.translation import FKTranslationStore
 from apps.teams.management.commands import sync_team
 from apps.teams.management.commands.sync_team import (
@@ -60,8 +61,8 @@ class FakeClient:
         return b""
 
 
-def _manifest(entries):
-    return {"entries": entries}
+def _manifest(entries, checksum=None):
+    return {"schema_checksum": checksum if checksum is not None else schema_checksum(), "entries": entries}
 
 
 def _scenario(public_key):
@@ -145,6 +146,24 @@ def test_load_private_key_returns_none_when_unset(monkeypatch):
     assert _load_private_key(None) is None
 
 
+def test_schema_checksum_mismatch_aborts(tmp_path, keypair):
+    manifest, rows = _scenario(keypair[0])
+    manifest["schema_checksum"] = manifest["schema_checksum"] + "-mismatch"
+    store = FKTranslationStore(tmp_path / "t.sqlite")
+    with pytest.raises(CommandError, match="schema"):
+        run_sync(FakeClient(manifest, rows), store, keypair[1])
+
+
+def test_skip_schema_check_bypasses_mismatch(tmp_path, keypair):
+    manifest, rows = _scenario(keypair[0])
+    manifest["schema_checksum"] = manifest["schema_checksum"] + "-mismatch"
+    store = FKTranslationStore(tmp_path / "t.sqlite")
+
+    run_sync(FakeClient(manifest, rows), store, keypair[1], enforce_schema=False)
+
+    assert Team.objects.filter(slug="imported-team-z").exists()
+
+
 def test_aborts_when_secrets_present_but_no_private_key(tmp_path, keypair):
     """Without the private key the sealed secret fields would be imported as unreadable tokens, so
     the sync must refuse up front rather than silently corrupt provider configs / participant data."""
@@ -178,13 +197,12 @@ def test_files_confirmation_is_asked_once_and_remembered(tmp_path, keypair, monk
 def test_files_confirmation_is_not_remembered_when_preconditions_fail(tmp_path, keypair, monkeypatch):
     """A "yes" is only recorded once every other check passes, so an aborted run asks again."""
     manifest, rows = _scenario(keypair[0])
+    manifest["schema_checksum"] += "-mismatch"
     store = FKTranslationStore(tmp_path / "t.sqlite")
     monkeypatch.setattr("builtins.input", lambda *a, **k: "yes")
 
-    # No private key while the manifest exports sealed secrets -- a precondition that fails before the
-    # files prompt is reached.
-    with pytest.raises(CommandError, match="private key"):
-        check_sync_preconditions(FakeClient(manifest, rows), None, store=store)
+    with pytest.raises(CommandError, match="schema"):
+        check_sync_preconditions(FakeClient(manifest, rows), keypair[1], store=store)
 
     assert not store.has_flag(sync_team.FILES_CONFIRMED_FLAG)
 
@@ -443,6 +461,7 @@ def _force_delete_options(tmp_path, **overrides):
         "private_key_path": None,
         "state_dir": str(tmp_path),
         "limit": 100,
+        "skip_schema_check": False,
         "force_delete": True,
     }
     options.update(overrides)

--- a/apps/teams/export/tests/test_command.py
+++ b/apps/teams/export/tests/test_command.py
@@ -9,7 +9,6 @@ from apps.api.export.serializers import build_resource_serializer
 from apps.service_providers.models import LlmProvider
 from apps.teams.export import seal as seal_mod
 from apps.teams.export.importer import Importer
-from apps.teams.export.manifest import schema_checksum
 from apps.teams.export.translation import FKTranslationStore
 from apps.teams.management.commands import sync_team
 from apps.teams.management.commands.sync_team import (
@@ -61,8 +60,8 @@ class FakeClient:
         return b""
 
 
-def _manifest(entries, checksum=None):
-    return {"schema_checksum": checksum if checksum is not None else schema_checksum(), "entries": entries}
+def _manifest(entries):
+    return {"entries": entries}
 
 
 def _scenario(public_key):
@@ -146,14 +145,6 @@ def test_load_private_key_returns_none_when_unset(monkeypatch):
     assert _load_private_key(None) is None
 
 
-def test_schema_checksum_mismatch_aborts(tmp_path, keypair):
-    manifest, rows = _scenario(keypair[0])
-    manifest["schema_checksum"] = manifest["schema_checksum"] + "-mismatch"
-    store = FKTranslationStore(tmp_path / "t.sqlite")
-    with pytest.raises(CommandError, match="schema"):
-        run_sync(FakeClient(manifest, rows), store, keypair[1])
-
-
 def test_aborts_when_secrets_present_but_no_private_key(tmp_path, keypair):
     """Without the private key the sealed secret fields would be imported as unreadable tokens, so
     the sync must refuse up front rather than silently corrupt provider configs / participant data."""
@@ -163,16 +154,6 @@ def test_aborts_when_secrets_present_but_no_private_key(tmp_path, keypair):
         run_sync(FakeClient(manifest, rows), store, None)
 
     assert not Team.objects.filter(slug="imported-team-z").exists()  # aborted before importing anything
-
-
-def test_skip_schema_check_bypasses_mismatch(tmp_path, keypair):
-    manifest, rows = _scenario(keypair[0])
-    manifest["schema_checksum"] = manifest["schema_checksum"] + "-mismatch"
-    store = FKTranslationStore(tmp_path / "t.sqlite")
-
-    run_sync(FakeClient(manifest, rows), store, keypair[1], enforce_schema=False)
-
-    assert Team.objects.filter(slug="imported-team-z").exists()
 
 
 def test_files_confirmation_is_asked_once_and_remembered(tmp_path, keypair, monkeypatch):
@@ -197,12 +178,13 @@ def test_files_confirmation_is_asked_once_and_remembered(tmp_path, keypair, monk
 def test_files_confirmation_is_not_remembered_when_preconditions_fail(tmp_path, keypair, monkeypatch):
     """A "yes" is only recorded once every other check passes, so an aborted run asks again."""
     manifest, rows = _scenario(keypair[0])
-    manifest["schema_checksum"] += "-mismatch"
     store = FKTranslationStore(tmp_path / "t.sqlite")
     monkeypatch.setattr("builtins.input", lambda *a, **k: "yes")
 
-    with pytest.raises(CommandError, match="schema"):
-        check_sync_preconditions(FakeClient(manifest, rows), keypair[1], store=store)
+    # No private key while the manifest exports sealed secrets -- a precondition that fails before the
+    # files prompt is reached.
+    with pytest.raises(CommandError, match="private key"):
+        check_sync_preconditions(FakeClient(manifest, rows), None, store=store)
 
     assert not store.has_flag(sync_team.FILES_CONFIRMED_FLAG)
 
@@ -461,7 +443,6 @@ def _force_delete_options(tmp_path, **overrides):
         "private_key_path": None,
         "state_dir": str(tmp_path),
         "limit": 100,
-        "skip_schema_check": False,
         "force_delete": True,
     }
     options.update(overrides)

--- a/apps/teams/export/tests/test_manifest.py
+++ b/apps/teams/export/tests/test_manifest.py
@@ -156,6 +156,13 @@ def test_get_manifest_entry_returns_matching_entry():
     assert manifest.get_manifest_entry("not_a_resource") is None
 
 
+def test_schema_checksum_is_reproducible():
+    first = manifest.schema_checksum()
+    assert isinstance(first, str)
+    manifest.schema_checksum.cache_clear()
+    assert first == manifest.schema_checksum()
+
+
 @pytest.mark.django_db()
 def test_team_scoped_queryset_isolates_teams_and_includes_globals():
     """team_scoped_queryset returns the team's own rows plus shared global rows, never another team's."""
@@ -254,6 +261,7 @@ def test_queryset_includes_soft_deleted_channels():
 @pytest.mark.django_db()
 def test_build_manifest_payload_shape():
     payload = manifest.build_manifest()
+    assert isinstance(payload["schema_checksum"], str)
     assert {e["resource"] for e in payload["entries"]} == {e.resource for e in manifest.MANIFEST_ENTRIES}
     first = payload["entries"][0]
     assert set(first) >= {"model", "resource", "cursor", "secret"}

--- a/apps/teams/export/tests/test_manifest.py
+++ b/apps/teams/export/tests/test_manifest.py
@@ -157,13 +157,6 @@ def test_get_manifest_entry_returns_matching_entry():
 
 
 @pytest.mark.django_db()
-def test_schema_checksum_is_reproducible():
-    first = manifest.schema_checksum()
-    assert isinstance(first, str)
-    assert first == manifest.schema_checksum()
-
-
-@pytest.mark.django_db()
 def test_team_scoped_queryset_isolates_teams_and_includes_globals():
     """team_scoped_queryset returns the team's own rows plus shared global rows, never another team's."""
     team = TeamFactory()
@@ -261,7 +254,6 @@ def test_queryset_includes_soft_deleted_channels():
 @pytest.mark.django_db()
 def test_build_manifest_payload_shape():
     payload = manifest.build_manifest()
-    assert isinstance(payload["schema_checksum"], str)
     assert {e["resource"] for e in payload["entries"]} == {e.resource for e in manifest.MANIFEST_ENTRIES}
     first = payload["entries"][0]
     assert set(first) >= {"model", "resource", "cursor", "secret"}

--- a/apps/teams/management/commands/sync_team.py
+++ b/apps/teams/management/commands/sync_team.py
@@ -4,6 +4,11 @@
 
 The command is a thin shell: it wires the resource fetcher to the import engine and the local FK
 translation store. Each run makes one pass over the manifest and exits; rerun to pick up new data.
+
+Run this against the latest code on both the source and target servers. The sync assumes their
+schemas are the same shape rather than checking it: matching code is what guarantees that, whereas
+migration history is a poor proxy (a squash or rename changes the recorded migrations without
+changing the schema), so a runtime check on migration state gave false mismatches.
 """
 
 import os
@@ -18,7 +23,7 @@ from django.core.management.base import BaseCommand, CommandError
 from apps.teams.export.client import ResourceFetcher
 from apps.teams.export.emails import send_password_reset_email
 from apps.teams.export.importer import Importer, mute_signals
-from apps.teams.export.manifest import TEAM_MODEL, entry_model, schema_checksum
+from apps.teams.export.manifest import TEAM_MODEL, entry_model
 from apps.teams.export.seal import MISSING_PUBLIC_KEY_DETAIL, load_private_key
 from apps.teams.export.translation import (
     FKTranslationStore,
@@ -115,22 +120,16 @@ def _prompt(message: str) -> str:
         raise CommandError("This command must be run interactively; stdin is closed.") from None
 
 
-def check_sync_preconditions(client, private_key, enforce_schema=True, store=None) -> dict:
+def check_sync_preconditions(client, private_key, store=None) -> dict:
     """Fetch the source manifest and confirm the sync can actually proceed: the source is reachable,
-    its schema matches, we hold a key for any sealed secrets, and the source team is ready to export
-    (migration mode on, public key set). When a ``store`` is given, also ask the operator to confirm
-    the team's files were moved to this server's storage backend -- that happens outside this command
-    and the sync fails without it. The answer is recorded in the store only once every check passes,
-    so an aborted run asks again while a rerun after a clean preflight doesn't. Returns the manifest.
-    Raises CommandError on any failure, before any rows are imported."""
+    we hold a key for any sealed secrets, and the source team is ready to export (migration mode on,
+    public key set). When a ``store`` is given, also ask the operator to confirm the team's files were
+    moved to this server's storage backend -- that happens outside this command and the sync fails
+    without it. The answer is recorded in the store only once every check passes, so an aborted run
+    asks again while a rerun after a clean preflight doesn't. Returns the manifest. Raises
+    CommandError on any failure, before any rows are imported."""
 
     manifest = client.get_manifest()
-    if enforce_schema and manifest.get("schema_checksum") != schema_checksum():
-        raise CommandError(
-            "Source and target schema checksums differ; bring both to the same migration state "
-            "before syncing, or pass --skip-schema-check to override."
-        )
-
     if private_key is None and any(entry.get("secret") for entry in manifest["entries"]):
         raise CommandError(
             "The source exports sealed secret fields but no private key was provided; the secrets "
@@ -217,11 +216,10 @@ def run_sync(
     private_key,
     write=lambda _m: None,
     page_limit=100,
-    enforce_schema=True,
     on_user_created=send_password_reset_email,
     style=None,
 ):
-    manifest = check_sync_preconditions(client, private_key, enforce_schema)
+    manifest = check_sync_preconditions(client, private_key)
 
     importer = Importer(
         store,
@@ -286,11 +284,6 @@ class Command(BaseCommand):
         parser.add_argument("--state-dir", default=".", help="Directory for the per-team SQLite state DB.")
         parser.add_argument("--limit", type=int, default=100, help="Page size for resource requests.")
         parser.add_argument(
-            "--skip-schema-check",
-            action="store_true",
-            help="Sync even if the source and target schema checksums differ.",
-        )
-        parser.add_argument(
             "--force-delete",
             action="store_true",
             help="Delete the local team and its sync state before syncing, for a clean re-import.",
@@ -301,14 +294,13 @@ class Command(BaseCommand):
         private_key = _load_private_key(options["private_key_path"])
 
         client = ResourceFetcher(options["source_url"], options["api_key"])
-        enforce_schema = not options["skip_schema_check"]
 
         if options["force_delete"]:
             self._run_force_delete(options)
 
         store = FKTranslationStore(Path(options["state_dir"]) / f"{options['team_slug']}.sqlite")
 
-        check_sync_preconditions(client, private_key, enforce_schema, store=store)
+        check_sync_preconditions(client, private_key, store=store)
 
         importer = run_sync(
             client,
@@ -316,7 +308,6 @@ class Command(BaseCommand):
             private_key,
             write=self.stdout.write,
             page_limit=options["limit"],
-            enforce_schema=enforce_schema,
             style=self.style,
         )
 

--- a/apps/teams/management/commands/sync_team.py
+++ b/apps/teams/management/commands/sync_team.py
@@ -5,10 +5,11 @@
 The command is a thin shell: it wires the resource fetcher to the import engine and the local FK
 translation store. Each run makes one pass over the manifest and exits; rerun to pick up new data.
 
-Run this against the latest code on both the source and target servers. The sync assumes their
-schemas are the same shape rather than checking it: matching code is what guarantees that, whereas
-migration history is a poor proxy (a squash or rename changes the recorded migrations without
-changing the schema), so a runtime check on migration state gave false mismatches.
+Run this against the latest code on both the source and target servers. Compatibility is verified
+by comparing checksums of the two servers' export OpenAPI schemas -- the exact shape of the data
+being transferred -- rather than their migration history, which is a poor proxy (a squash or rename
+changes the recorded migrations without changing the schema). A mismatch means the servers run
+different export code; deploy the latest code on both, or pass --skip-schema-check to override.
 """
 
 import os
@@ -23,7 +24,7 @@ from django.core.management.base import BaseCommand, CommandError
 from apps.teams.export.client import ResourceFetcher
 from apps.teams.export.emails import send_password_reset_email
 from apps.teams.export.importer import Importer, mute_signals
-from apps.teams.export.manifest import TEAM_MODEL, entry_model
+from apps.teams.export.manifest import TEAM_MODEL, entry_model, schema_checksum
 from apps.teams.export.seal import MISSING_PUBLIC_KEY_DETAIL, load_private_key
 from apps.teams.export.translation import (
     FKTranslationStore,
@@ -120,16 +121,23 @@ def _prompt(message: str) -> str:
         raise CommandError("This command must be run interactively; stdin is closed.") from None
 
 
-def check_sync_preconditions(client, private_key, store=None) -> dict:
+def check_sync_preconditions(client, private_key, enforce_schema=True, store=None) -> dict:
     """Fetch the source manifest and confirm the sync can actually proceed: the source is reachable,
-    we hold a key for any sealed secrets, and the source team is ready to export (migration mode on,
-    public key set). When a ``store`` is given, also ask the operator to confirm the team's files were
-    moved to this server's storage backend -- that happens outside this command and the sync fails
-    without it. The answer is recorded in the store only once every check passes, so an aborted run
-    asks again while a rerun after a clean preflight doesn't. Returns the manifest. Raises
-    CommandError on any failure, before any rows are imported."""
+    its export schema matches ours, we hold a key for any sealed secrets, and the source team is
+    ready to export (migration mode on, public key set). When a ``store`` is given, also ask the
+    operator to confirm the team's files were moved to this server's storage backend -- that happens
+    outside this command and the sync fails without it. The answer is recorded in the store only once
+    every check passes, so an aborted run asks again while a rerun after a clean preflight doesn't.
+    Returns the manifest. Raises CommandError on any failure, before any rows are imported."""
 
     manifest = client.get_manifest()
+    if enforce_schema and manifest.get("schema_checksum") != schema_checksum():
+        raise CommandError(
+            "Source and target export schema checksums differ, so the servers are running different "
+            "export code. Deploy the same (latest) code on both servers before syncing, or pass "
+            "--skip-schema-check to override."
+        )
+
     if private_key is None and any(entry.get("secret") for entry in manifest["entries"]):
         raise CommandError(
             "The source exports sealed secret fields but no private key was provided; the secrets "
@@ -216,10 +224,11 @@ def run_sync(
     private_key,
     write=lambda _m: None,
     page_limit=100,
+    enforce_schema=True,
     on_user_created=send_password_reset_email,
     style=None,
 ):
-    manifest = check_sync_preconditions(client, private_key)
+    manifest = check_sync_preconditions(client, private_key, enforce_schema)
 
     importer = Importer(
         store,
@@ -284,6 +293,11 @@ class Command(BaseCommand):
         parser.add_argument("--state-dir", default=".", help="Directory for the per-team SQLite state DB.")
         parser.add_argument("--limit", type=int, default=100, help="Page size for resource requests.")
         parser.add_argument(
+            "--skip-schema-check",
+            action="store_true",
+            help="Sync even if the source and target export schema checksums differ.",
+        )
+        parser.add_argument(
             "--force-delete",
             action="store_true",
             help="Delete the local team and its sync state before syncing, for a clean re-import.",
@@ -294,13 +308,14 @@ class Command(BaseCommand):
         private_key = _load_private_key(options["private_key_path"])
 
         client = ResourceFetcher(options["source_url"], options["api_key"])
+        enforce_schema = not options["skip_schema_check"]
 
         if options["force_delete"]:
             self._run_force_delete(options)
 
         store = FKTranslationStore(Path(options["state_dir"]) / f"{options['team_slug']}.sqlite")
 
-        check_sync_preconditions(client, private_key, store=store)
+        check_sync_preconditions(client, private_key, enforce_schema, store=store)
 
         importer = run_sync(
             client,
@@ -308,6 +323,7 @@ class Command(BaseCommand):
             private_key,
             write=self.stdout.write,
             page_limit=options["limit"],
+            enforce_schema=enforce_schema,
             style=self.style,
         )
 


### PR DESCRIPTION
### Product Description
No user-facing change. Internal cleanup of the team data sync (`sync_team`).

### Technical Description
Replaces the migration-state checksum that gated the team sync with a checksum of the export API's OpenAPI schema.

**Why:** migration history is a poor proxy for schema compatibility. A squash or a rename changes a server's recorded migrations without changing its schema, so the old check rejected syncs between servers whose schemas were actually identical. The export OpenAPI schema is the opposite: it is generated from the running code and describes the exact shape of the data the sync transfers (endpoints, fields, types), so the source and target agree on the checksum exactly when their export surfaces match — a direct check that both servers run compatible code.

Concretely:

- `schema_checksum()` in `apps/teams/export/manifest.py` now hashes the export API's OpenAPI document (`SchemaGenerator(api_version="export")`, no request so host placeholders stay fixed, sorted keys). Verified byte-identical across processes and `PYTHONHASHSEED` values.
- The manifest keeps its `schema_checksum` field, and `check_sync_preconditions` keeps the source/target comparison and the `--skip-schema-check` override; only the basis of the checksum changes.
- The checksum is cached per process (the schema can't change while the code is running).
- Regenerates `api-schemas/export.yml` (field description).

### Migrations
- [x] The migrations are backwards compatible

No migrations in this change.

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
