### PR TITLE
feat: freeze target team during sync_team migration

### DIFF
--- a/api-schemas/export.yml
+++ b/api-schemas/export.yml
@@ -4320,18 +4320,14 @@ components:
       - results
     Manifest:
       type: object
-      description: 'The sync manifest: the call order and per-model config, plus a
-        checksum of the applied schema.'
+      description: 'The sync manifest: the call order and per-model config.'
       properties:
-        schema_checksum:
-          type: string
         entries:
           type: array
           items:
             $ref: '#/components/schemas/ManifestEntry'
       required:
       - entries
-      - schema_checksum
     ManifestEntry:
       type: object
       description: 'One row of the manifest: which model to pull and the config the

--- a/apps/api/export/serializers.py
+++ b/apps/api/export/serializers.py
@@ -144,9 +144,8 @@ class ManifestEntrySerializer(serializers.Serializer):
 
 
 class ManifestSerializer(serializers.Serializer):
-    """The sync manifest: the call order and per-model config, plus a checksum of the applied schema."""
+    """The sync manifest: the call order and per-model config."""
 
-    schema_checksum = serializers.CharField()
     entries = ManifestEntrySerializer(many=True)
 
 

--- a/apps/api/export/tests/test_views.py
+++ b/apps/api/export/tests/test_views.py
@@ -60,7 +60,6 @@ def test_manifest_is_public_and_returns_entries():
     response = APIClient().get(reverse("api:export:manifest"))
     assert response.status_code == 200
     body = response.json()
-    assert "schema_checksum" in body
     resources = {e["resource"] for e in body["entries"]}
     assert "chatbots" in resources
     assert "teams" not in resources  # the team is served on its own, not as a manifest resource

--- a/apps/teams/export/manifest.py
+++ b/apps/teams/export/manifest.py
@@ -1,16 +1,12 @@
 """The single maintenance surface for the team data sync: which models to pull, in what order,
 and the per-model config (secrets, team scoping, global matching) the endpoint and importer need."""
 
-import hashlib
-import json
 from collections.abc import Callable
 from dataclasses import dataclass
 
 from django.apps import apps
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.core.exceptions import FieldDoesNotExist
-from django.db import connection
-from django.db.migrations.recorder import MigrationRecorder
 from django.db.models import ForeignKey, Model, Prefetch, Q, QuerySet
 
 from apps.files.models import FilePurpose
@@ -261,23 +257,8 @@ def team_scoped_queryset(entry: ManifestEntry, team) -> QuerySet:
     return queryset.prefetch_related(*prefetch_factory(team)) if prefetch_factory else queryset
 
 
-def schema_checksum() -> str:
-    """Hash of the set of applied migrations, identified by ``(app, name)`` -- the same key
-    ``MigrationRecorder`` uses, so schemas that share a filename like ``0001_initial`` across apps
-    don't collide. Unaffected by apply order. Returns the hash of an empty set when the migrations
-    table is absent (e.g. tests run with --no-migrations); that's consistent as long as the source
-    and target both lack it."""
-    recorder = MigrationRecorder(connection)
-    applied = []
-    if recorder.has_table():
-        applied = list(recorder.migration_qs.order_by("app", "name").values_list("app", "name"))
-    data = json.dumps(applied, separators=(",", ":"))
-    return hashlib.sha256(data.encode("utf-8")).hexdigest()
-
-
 def build_manifest() -> dict:
     return {
-        "schema_checksum": schema_checksum(),
         "entries": [
             {
                 "model": e.model,

--- a/apps/teams/export/tests/test_command.py
+++ b/apps/teams/export/tests/test_command.py
@@ -328,6 +328,35 @@ def test_first_time_import_creates_team(tmp_path, keypair):
     assert Team.objects.filter(slug="imported-team-z").exists()
 
 
+def test_first_time_import_enables_migration_mode_on_target(tmp_path, keypair):
+    """The target team is frozen (migration mode on) the moment it's created, so this server doesn't
+    start firing the team's events and scheduled messages while the still-live source is migrating.
+    Migration mode isn't exported, so the sync sets it explicitly."""
+    manifest, rows = _scenario(keypair[0])
+    store = FKTranslationStore(tmp_path / "t.sqlite")
+
+    run_sync(FakeClient(manifest, rows), store, keypair[1])
+
+    assert Team.objects.get(slug="imported-team-z").is_migrating is True
+
+
+def test_rerun_does_not_re_enable_migration_mode(tmp_path, keypair):
+    """Migration mode is set only when the team is first created. If an operator turns it off (e.g. at
+    cutover), a later rerun of the sync must not silently turn it back on."""
+    manifest, rows = _scenario(keypair[0])
+    store = FKTranslationStore(tmp_path / "t.sqlite")
+    run_sync(FakeClient(manifest, rows), store, keypair[1])
+
+    team = Team.objects.get(slug="imported-team-z")
+    team.is_migrating = False
+    team.save(update_fields=["is_migrating"])
+
+    run_sync(FakeClient(manifest, rows), store, keypair[1])
+
+    team.refresh_from_db()
+    assert team.is_migrating is False
+
+
 class _FakeHTTPResponse:
     def __init__(self, status_code, detail):
         self.status_code = status_code

--- a/apps/teams/export/tests/test_command.py
+++ b/apps/teams/export/tests/test_command.py
@@ -9,7 +9,6 @@ from apps.api.export.serializers import build_resource_serializer
 from apps.service_providers.models import LlmProvider
 from apps.teams.export import seal as seal_mod
 from apps.teams.export.importer import Importer
-from apps.teams.export.manifest import schema_checksum
 from apps.teams.export.translation import FKTranslationStore
 from apps.teams.management.commands import sync_team
 from apps.teams.management.commands.sync_team import (
@@ -61,8 +60,8 @@ class FakeClient:
         return b""
 
 
-def _manifest(entries, checksum=None):
-    return {"schema_checksum": checksum if checksum is not None else schema_checksum(), "entries": entries}
+def _manifest(entries):
+    return {"entries": entries}
 
 
 def _scenario(public_key):
@@ -146,14 +145,6 @@ def test_load_private_key_returns_none_when_unset(monkeypatch):
     assert _load_private_key(None) is None
 
 
-def test_schema_checksum_mismatch_aborts(tmp_path, keypair):
-    manifest, rows = _scenario(keypair[0])
-    manifest["schema_checksum"] = manifest["schema_checksum"] + "-mismatch"
-    store = FKTranslationStore(tmp_path / "t.sqlite")
-    with pytest.raises(CommandError, match="schema"):
-        run_sync(FakeClient(manifest, rows), store, keypair[1])
-
-
 def test_aborts_when_secrets_present_but_no_private_key(tmp_path, keypair):
     """Without the private key the sealed secret fields would be imported as unreadable tokens, so
     the sync must refuse up front rather than silently corrupt provider configs / participant data."""
@@ -163,16 +154,6 @@ def test_aborts_when_secrets_present_but_no_private_key(tmp_path, keypair):
         run_sync(FakeClient(manifest, rows), store, None)
 
     assert not Team.objects.filter(slug="imported-team-z").exists()  # aborted before importing anything
-
-
-def test_skip_schema_check_bypasses_mismatch(tmp_path, keypair):
-    manifest, rows = _scenario(keypair[0])
-    manifest["schema_checksum"] = manifest["schema_checksum"] + "-mismatch"
-    store = FKTranslationStore(tmp_path / "t.sqlite")
-
-    run_sync(FakeClient(manifest, rows), store, keypair[1], enforce_schema=False)
-
-    assert Team.objects.filter(slug="imported-team-z").exists()
 
 
 def test_files_confirmation_is_asked_once_and_remembered(tmp_path, keypair, monkeypatch):
@@ -197,12 +178,13 @@ def test_files_confirmation_is_asked_once_and_remembered(tmp_path, keypair, monk
 def test_files_confirmation_is_not_remembered_when_preconditions_fail(tmp_path, keypair, monkeypatch):
     """A "yes" is only recorded once every other check passes, so an aborted run asks again."""
     manifest, rows = _scenario(keypair[0])
-    manifest["schema_checksum"] += "-mismatch"
     store = FKTranslationStore(tmp_path / "t.sqlite")
     monkeypatch.setattr("builtins.input", lambda *a, **k: "yes")
 
-    with pytest.raises(CommandError, match="schema"):
-        check_sync_preconditions(FakeClient(manifest, rows), keypair[1], store=store)
+    # No private key while the manifest exports sealed secrets -- a precondition that fails before the
+    # files prompt is reached.
+    with pytest.raises(CommandError, match="private key"):
+        check_sync_preconditions(FakeClient(manifest, rows), None, store=store)
 
     assert not store.has_flag(sync_team.FILES_CONFIRMED_FLAG)
 
@@ -461,7 +443,6 @@ def _force_delete_options(tmp_path, **overrides):
         "private_key_path": None,
         "state_dir": str(tmp_path),
         "limit": 100,
-        "skip_schema_check": False,
         "force_delete": True,
     }
     options.update(overrides)

--- a/apps/teams/export/tests/test_manifest.py
+++ b/apps/teams/export/tests/test_manifest.py
@@ -157,13 +157,6 @@ def test_get_manifest_entry_returns_matching_entry():
 
 
 @pytest.mark.django_db()
-def test_schema_checksum_is_reproducible():
-    first = manifest.schema_checksum()
-    assert isinstance(first, str)
-    assert first == manifest.schema_checksum()
-
-
-@pytest.mark.django_db()
 def test_team_scoped_queryset_isolates_teams_and_includes_globals():
     """team_scoped_queryset returns the team's own rows plus shared global rows, never another team's."""
     team = TeamFactory()
@@ -261,7 +254,6 @@ def test_queryset_includes_soft_deleted_channels():
 @pytest.mark.django_db()
 def test_build_manifest_payload_shape():
     payload = manifest.build_manifest()
-    assert isinstance(payload["schema_checksum"], str)
     assert {e["resource"] for e in payload["entries"]} == {e.resource for e in manifest.MANIFEST_ENTRIES}
     first = payload["entries"][0]
     assert set(first) >= {"model", "resource", "cursor", "secret"}

--- a/apps/teams/management/commands/sync_team.py
+++ b/apps/teams/management/commands/sync_team.py
@@ -194,7 +194,9 @@ def load_team(importer, client, store, write):
     - Present in the target DB under the same slug but not in the store: a team this sync doesn't track
       (created by hand, or its state DB was lost). Refuse to import over it and tell the operator to
       re-run with --force-delete, rather than silently overwriting a team we didn't create.
-    - Neither: a first-time import; fetch and create the team from the source."""
+    - Neither: a first-time import; fetch and create the team from the source, then put the new team
+      into migration mode so this server freezes its outbound firing too (see
+      ``_enable_target_migration_mode``)."""
     team = _committed_team(store)
     if team is not None:
         importer.set_target_team(team)
@@ -207,7 +209,18 @@ def load_team(importer, client, store, write):
             "sync's state. Re-run with --force-delete to delete it and re-import from scratch."
         )
     importer.import_rows(TEAM_MODEL, [team_row])
+    _enable_target_migration_mode(importer.target_team)
     write("synced team")
+
+
+def _enable_target_migration_mode(team: Team) -> None:
+    """Freeze the freshly imported team on this server by turning on migration mode. The source team is
+    already migrating; without this the target would start firing the team's events and scheduled
+    messages the moment it's imported, duplicating what the still-live source sends. Migration mode is
+    a per-server operational flag (not exported), so it's set here on creation and stays on until an
+    operator turns it off at cutover -- reruns load the team from the sync state and leave it alone."""
+    team.is_migrating = True
+    team.save(update_fields=["is_migrating"])
 
 
 def run_sync(

--- a/apps/teams/management/commands/sync_team.py
+++ b/apps/teams/management/commands/sync_team.py
@@ -4,6 +4,11 @@
 
 The command is a thin shell: it wires the resource fetcher to the import engine and the local FK
 translation store. Each run makes one pass over the manifest and exits; rerun to pick up new data.
+
+Run this against the latest code on both the source and target servers. The sync assumes their
+schemas are the same shape rather than checking it: matching code is what guarantees that, whereas
+migration history is a poor proxy (a squash or rename changes the recorded migrations without
+changing the schema), so a runtime check on migration state gave false mismatches.
 """
 
 import os
@@ -18,7 +23,7 @@ from django.core.management.base import BaseCommand, CommandError
 from apps.teams.export.client import ResourceFetcher
 from apps.teams.export.emails import send_password_reset_email
 from apps.teams.export.importer import Importer, mute_signals
-from apps.teams.export.manifest import TEAM_MODEL, entry_model, schema_checksum
+from apps.teams.export.manifest import TEAM_MODEL, entry_model
 from apps.teams.export.seal import MISSING_PUBLIC_KEY_DETAIL, load_private_key
 from apps.teams.export.translation import (
     FKTranslationStore,
@@ -115,22 +120,16 @@ def _prompt(message: str) -> str:
         raise CommandError("This command must be run interactively; stdin is closed.") from None
 
 
-def check_sync_preconditions(client, private_key, enforce_schema=True, store=None) -> dict:
+def check_sync_preconditions(client, private_key, store=None) -> dict:
     """Fetch the source manifest and confirm the sync can actually proceed: the source is reachable,
-    its schema matches, we hold a key for any sealed secrets, and the source team is ready to export
-    (migration mode on, public key set). When a ``store`` is given, also ask the operator to confirm
-    the team's files were moved to this server's storage backend -- that happens outside this command
-    and the sync fails without it. The answer is recorded in the store only once every check passes,
-    so an aborted run asks again while a rerun after a clean preflight doesn't. Returns the manifest.
-    Raises CommandError on any failure, before any rows are imported."""
+    we hold a key for any sealed secrets, and the source team is ready to export (migration mode on,
+    public key set). When a ``store`` is given, also ask the operator to confirm the team's files were
+    moved to this server's storage backend -- that happens outside this command and the sync fails
+    without it. The answer is recorded in the store only once every check passes, so an aborted run
+    asks again while a rerun after a clean preflight doesn't. Returns the manifest. Raises
+    CommandError on any failure, before any rows are imported."""
 
     manifest = client.get_manifest()
-    if enforce_schema and manifest.get("schema_checksum") != schema_checksum():
-        raise CommandError(
-            "Source and target schema checksums differ; bring both to the same migration state "
-            "before syncing, or pass --skip-schema-check to override."
-        )
-
     if private_key is None and any(entry.get("secret") for entry in manifest["entries"]):
         raise CommandError(
             "The source exports sealed secret fields but no private key was provided; the secrets "
@@ -217,11 +216,10 @@ def run_sync(
     private_key,
     write=lambda _m: None,
     page_limit=100,
-    enforce_schema=True,
     on_user_created=send_password_reset_email,
     style=None,
 ):
-    manifest = check_sync_preconditions(client, private_key, enforce_schema)
+    manifest = check_sync_preconditions(client, private_key)
 
     importer = Importer(
         store,
@@ -286,11 +284,6 @@ class Command(BaseCommand):
         parser.add_argument("--state-dir", default=".", help="Directory for the per-team SQLite state DB.")
         parser.add_argument("--limit", type=int, default=100, help="Page size for resource requests.")
         parser.add_argument(
-            "--skip-schema-check",
-            action="store_true",
-            help="Sync even if the source and target schema checksums differ.",
-        )
-        parser.add_argument(
             "--force-delete",
             action="store_true",
             help="Delete the local team and its sync state before syncing, for a clean re-import.",
@@ -301,14 +294,13 @@ class Command(BaseCommand):
         private_key = _load_private_key(options["private_key_path"])
 
         client = ResourceFetcher(options["source_url"], options["api_key"])
-        enforce_schema = not options["skip_schema_check"]
 
         if options["force_delete"]:
             self._run_force_delete(options)
 
         store = FKTranslationStore(Path(options["state_dir"]) / f"{options['team_slug']}.sqlite")
 
-        check_sync_preconditions(client, private_key, enforce_schema, store=store)
+        check_sync_preconditions(client, private_key, store=store)
 
         importer = run_sync(
             client,
@@ -316,7 +308,6 @@ class Command(BaseCommand):
             private_key,
             write=self.stdout.write,
             page_limit=options["limit"],
-            enforce_schema=enforce_schema,
             style=self.style,
         )
 


### PR DESCRIPTION
### Product Description
No user-facing change. Operational improvement to the `sync_team` command used to migrate a team's data between OCS servers.

### Technical Description
Two related changes to team sync:

**Enable migration mode on the target team during `sync_team`.** When `sync_team` creates the target team, it now also turns on migration mode (`is_migrating=True`) on the newly created team. Migration mode freezes a team's outbound firing — events and scheduled messages are skipped for migrating teams (`migrating_team_ids()` filtering in `apps/events/tasks.py`). The source team is already required to be in migration mode as a sync precondition, but `is_migrating` is deliberately excluded from the export (`EXCLUDE_REGISTRY`), so the imported team was previously created with the flag off. That meant the target could start firing the team's messages the moment it was imported — while the source is still live — duplicating what the source sends.

The flag is now set explicitly in `load_team()` on the first-time-import path only. Reruns load the team from the sync state and leave it untouched, so if an operator turns it off at cutover, a later rerun won't silently re-enable it. It stays on until an operator disables it manually at cutover.

**Remove `schema_checksum` from team sync** (prior commit). Migration history is a poor proxy for schema compatibility: a squash or rename changes the recorded migrations without changing the schema, so the runtime check rejected syncs between servers whose schemas were actually identical. Running the same code is what guarantees a compatible schema, so this drops the checksum helper, its manifest field, the source/target comparison, and the `--skip-schema-check` flag / `enforce_schema` parameter that existed only to override it, documenting the "run latest code on both servers" requirement instead.

### Demo
Run `sync_team` against a source server whose team is in migration mode; the newly created team on the target now shows migration mode enabled.

### Docs and Changelog
- [ ] This PR requires docs/changelog update
