### PR TITLE
Drop cost_tracking_enabled from usage report

### DIFF
--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -13,10 +13,8 @@ from apps.chat.models import ChatMessage
 from apps.cost_tracking.models import UsageRecord
 from apps.experiments.models import ExperimentSession, Participant
 from apps.teams.metadata import get_team_metadata_fields
-from apps.teams.models import Flag, Team
+from apps.teams.models import Team
 from apps.trace.models import Trace, TraceStatus
-
-COST_TRACKING_FLAG = "flag_ai_cost_monitoring"
 
 _ZERO = Decimal(0)
 _COST_FIELD = DecimalField(max_digits=14, decimal_places=8)
@@ -111,27 +109,15 @@ def get_cost_usage_by_team(start: datetime, end: datetime):
     )
 
 
-def get_cost_tracking_team_ids() -> set[int]:
-    """Team ids for which `flag_ai_cost_monitoring` is active."""
-    flag = Flag.objects.filter(name=COST_TRACKING_FLAG).prefetch_related("teams").first()
-    if flag is None or flag.everyone is False:
-        return set()
-    if flag.everyone is True:
-        return set(Team.objects.values_list("id", flat=True))
-    return set(flag.teams.values_list("id", flat=True))
-
-
 def build_usage_report(start: datetime, end: datetime) -> dict:
-    """Cross-team usage: token totals for every team (always populated) merged
-    with per-model cost detail where cost tracking is on. `cost_tracking_enabled`
-    flags which teams' cost detail is complete vs. token-only.
+    """Cross-team usage: per-team token totals (always populated) merged with
+    per-model cost detail from recorded UsageRecords.
 
     `total_cost` is a `{currency: amount}` map, not a scalar: a team can have
     records in more than one currency and summing them would be meaningless.
     """
     token_rows = list(get_token_usage_by_team(start, end))
     cost_rows = list(get_cost_usage_by_team(start, end))
-    enabled_team_ids = get_cost_tracking_team_ids()
 
     team_names = {row["team_id"]: row["team__name"] for row in token_rows}
     missing_ids = {row["team_id"] for row in cost_rows} - team_names.keys()
@@ -147,7 +133,6 @@ def build_usage_report(start: datetime, end: datetime) -> dict:
                 "team_name": team_names.get(team_id),
                 "run_count": 0,
                 "total_tokens": 0,
-                "cost_tracking_enabled": team_id in enabled_team_ids,
                 "total_cost": defaultdict(Decimal),  # currency -> amount
                 "models": [],
             }

--- a/apps/admin/tests/test_provider_usage_api.py
+++ b/apps/admin/tests/test_provider_usage_api.py
@@ -5,7 +5,6 @@ import pytest
 from django.urls import reverse
 from django.utils import timezone
 
-from apps.teams.models import Flag
 from apps.trace.models import Trace, TraceStatus
 from apps.users.models import CustomUser
 from apps.utils.factories.cost_tracking import UsageRecordFactory
@@ -29,13 +28,6 @@ def _trace(team, tokens):
     # timestamp uses auto_now_add, so place it inside the window after creation.
     Trace.objects.filter(pk=trace.pk).update(timestamp=WHEN)
     return trace
-
-
-def _enable_cost_tracking(team):
-    flag, _ = Flag.objects.get_or_create(name="flag_ai_cost_monitoring")
-    flag.everyone = None
-    flag.save()
-    flag.teams.add(team)
 
 
 @pytest.mark.django_db()
@@ -64,7 +56,6 @@ def test_merges_token_totals_and_cost_detail(superuser_client):
     UsageRecordFactory(
         team=team_a, provider_type="anthropic", model_name="claude", quantity=200, cost=Decimal("0.75"), at=WHEN
     )
-    _enable_cost_tracking(team_a)
 
     response = superuser_client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE)
 
@@ -74,7 +65,6 @@ def test_merges_token_totals_and_cost_detail(superuser_client):
     alpha = teams["Alpha"]
     assert alpha["run_count"] == 2
     assert alpha["total_tokens"] == 800
-    assert alpha["cost_tracking_enabled"] is True
     assert Decimal(alpha["total_cost"]["USD"]) == Decimal("2.00")
     models = {m["model_name"]: m for m in alpha["models"]}
     assert Decimal(models["gpt-4o"]["cost"]) == Decimal("1.25")
@@ -82,7 +72,6 @@ def test_merges_token_totals_and_cost_detail(superuser_client):
 
     bravo = teams["Bravo"]
     assert bravo["run_count"] == 1
-    assert bravo["cost_tracking_enabled"] is False
     assert bravo["models"] == []
     assert bravo["total_cost"] == {}
 
@@ -93,7 +82,6 @@ def test_total_cost_keeps_currencies_separate(superuser_client):
     _trace(team, 100)
     UsageRecordFactory(team=team, model_name="gpt-4o", cost=Decimal("1.25"), currency="USD", at=WHEN)
     UsageRecordFactory(team=team, model_name="claude", cost=Decimal("0.90"), currency="EUR", at=WHEN)
-    _enable_cost_tracking(team)
 
     response = superuser_client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE)
 


### PR DESCRIPTION
### Product Description
no change (superuser-only admin API)

### Technical Description
Follow-up to #3817. `flag_ai_cost_monitoring` is now enabled for all teams for data collection (it only gates the UI), so `cost_tracking_enabled` in the `/admin/api/provider-usage/` payload was always `true` and carried no signal. Removes the field and the now-dead `get_cost_tracking_team_ids` helper.

### Migrations
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update