### PR TITLE
Add team_slug to usage report

### DIFF
--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -83,7 +83,7 @@ def get_token_usage_by_team(start: datetime, end: datetime):
         Trace.objects.filter(timestamp__gte=start, timestamp__lt=end)
         .exclude(status=TraceStatus.PENDING)
         .exclude(session__platform=ChannelPlatform.EVALUATIONS)
-        .values("team_id", "team__name")
+        .values("team_id", "team__name", "team__slug")
         .annotate(
             run_count=Count("id"),
             total_tokens=Coalesce(Sum("n_total_tokens"), Value(0)),
@@ -93,11 +93,7 @@ def get_token_usage_by_team(start: datetime, end: datetime):
 
 
 def get_cost_usage_by_team(start: datetime, end: datetime):
-    """Per (team, provider, model, currency) cost + tokens from UsageRecord.
-
-    Only teams with `flag_ai_cost_monitoring` enabled record UsageRecords, so
-    this covers a subset of the teams returned by `get_token_usage_by_team`.
-    """
+    """Per (team, provider, model, currency) cost + tokens from UsageRecord."""
     return (
         UsageRecord.objects.filter(timestamp__gte=start, timestamp__lt=end)
         .values("team_id", "provider_type", "model_name", "currency")
@@ -119,18 +115,21 @@ def build_usage_report(start: datetime, end: datetime) -> dict:
     token_rows = list(get_token_usage_by_team(start, end))
     cost_rows = list(get_cost_usage_by_team(start, end))
 
-    team_names = {row["team_id"]: row["team__name"] for row in token_rows}
-    missing_ids = {row["team_id"] for row in cost_rows} - team_names.keys()
+    team_meta = {row["team_id"]: (row["team__name"], row["team__slug"]) for row in token_rows}
+    missing_ids = {row["team_id"] for row in cost_rows} - team_meta.keys()
     if missing_ids:
-        team_names.update(dict(Team.objects.filter(id__in=missing_ids).values_list("id", "name")))
+        missing = Team.objects.filter(id__in=missing_ids).values_list("id", "name", "slug")
+        team_meta.update({tid: (name, slug) for tid, name, slug in missing})
 
     teams: dict[int, dict] = {}
 
     def _entry(team_id: int) -> dict:
         if team_id not in teams:
+            name, slug = team_meta.get(team_id, (None, None))
             teams[team_id] = {
                 "team_id": team_id,
-                "team_name": team_names.get(team_id),
+                "team_name": name,
+                "team_slug": slug,
                 "run_count": 0,
                 "total_tokens": 0,
                 "total_cost": defaultdict(Decimal),  # currency -> amount

--- a/apps/admin/tests/test_provider_usage_api.py
+++ b/apps/admin/tests/test_provider_usage_api.py
@@ -65,6 +65,7 @@ def test_merges_token_totals_and_cost_detail(superuser_client):
     alpha = teams["Alpha"]
     assert alpha["run_count"] == 2
     assert alpha["total_tokens"] == 800
+    assert alpha["team_slug"] == team_a.slug
     assert Decimal(alpha["total_cost"]["USD"]) == Decimal("2.00")
     models = {m["model_name"]: m for m in alpha["models"]}
     assert Decimal(models["gpt-4o"]["cost"]) == Decimal("1.25")


### PR DESCRIPTION
### Product Description
no change (superuser-only admin API)

### Technical Description
Adds `team_slug` to each team entry in the `/admin/api/provider-usage/` payload so external reporting can key on the stable slug (and display it) rather than the mutable team name.

### Migrations
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update