### PR TITLE
Guard destructive evaluation deletes against in-flight runs

### DIFF
--- a/apps/evaluations/exceptions.py
+++ b/apps/evaluations/exceptions.py
@@ -1,6 +1,13 @@
+from django.core.exceptions import ValidationError
+
+
 class EvaluationRunException(Exception):
     pass
 
 
 class HistoryParseException(Exception):
     pass
+
+
+class InFlightRunsError(ValidationError):
+    """Raised when a delete is blocked because related EvaluationRuns are still in progress."""

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -152,6 +152,13 @@ class EvaluationMessage(BaseModel):
         output_content = self.output.get("content", "no content")
         return f"{input_role}: {input_content}, {output_role}: {output_content}"
 
+    def delete(self, *args, **kwargs):
+        related_runs = EvaluationRun.objects.filter(
+            models.Q(config__dataset__messages=self) | models.Q(scoped_messages=self)
+        )
+        raise_if_runs_in_flight(related_runs, "message")
+        return super().delete(*args, **kwargs)
+
     @classmethod
     def create_from_sessions(
         cls, team: Team, external_session_ids, filtered_session_ids=None, filter_params=None, timezone=None

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel as PydanticBaseModel
 
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.chatbots.version_resolver import VersionSelectionRule, resolve_chatbot_version
+from apps.evaluations.exceptions import InFlightRunsError
 from apps.evaluations.export import build_evaluation_table_data
 from apps.evaluations.rule_validation import (
     ConditionType,
@@ -39,6 +40,22 @@ class EvaluationRunStatus(models.TextChoices):
     PROCESSING = "processing", "Processing"
     COMPLETED = "completed", "Completed"
     FAILED = "failed", "Failed"
+
+
+NON_TERMINAL_RUN_STATUSES = (EvaluationRunStatus.PENDING, EvaluationRunStatus.PROCESSING)
+
+
+def raise_if_runs_in_flight(runs: models.QuerySet[EvaluationRun], resource_label: str) -> None:
+    """Raise InFlightRunsError if any run in `runs` is PENDING or PROCESSING.
+
+    `runs` is an EvaluationRun queryset; `resource_label` is the user-facing
+    noun for the object being deleted (e.g. "evaluation", "evaluator", "dataset").
+    """
+    if runs.filter(status__in=NON_TERMINAL_RUN_STATUSES).exists():
+        raise InFlightRunsError(
+            f"Cannot delete this {resource_label} while evaluation runs are in progress. "
+            "Wait for the runs to finish, then try again."
+        )
 
 
 class EvaluationRunType(models.TextChoices):
@@ -414,6 +431,10 @@ class EvaluationConfig(BaseTeamModel):
 
     def __str__(self):
         return f"EvaluationConfig ({self.name})"
+
+    def delete(self, *args, **kwargs):
+        raise_if_runs_in_flight(EvaluationRun.objects.filter(config=self), "evaluation")
+        return super().delete(*args, **kwargs)
 
     def get_generation_experiment_version(self):
         """Resolve the actual experiment version based on selection type.

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -50,6 +50,12 @@ def raise_if_runs_in_flight(runs: models.QuerySet[EvaluationRun], resource_label
 
     `runs` is an EvaluationRun queryset; `resource_label` is the user-facing
     noun for the object being deleted (e.g. "evaluation", "evaluator", "dataset").
+
+    This only guards instance `Model.delete()` calls. Bulk `QuerySet.delete()`
+    and parent-cascade deletes execute SQL-level deletes that bypass the model
+    override entirely, so this is best-effort UX protection, not a hard invariant;
+    the evaluation tasks are hardened to degrade to a logged no-op if a run or
+    message vanishes out from under them.
     """
     if runs.filter(status__in=NON_TERMINAL_RUN_STATUSES).exists():
         raise InFlightRunsError(
@@ -153,6 +159,9 @@ class EvaluationMessage(BaseModel):
         return f"{input_role}: {input_content}, {output_role}: {output_content}"
 
     def delete(self, *args, **kwargs):
+        # Blocks on any in-flight run whose dataset contains this message OR that scoped it directly.
+        # A PREVIEW/DELTA run that will not actually process this message is over-blocked here; that
+        # is the safe direction (never strand a run) and in-flight runs are short-lived.
         related_runs = EvaluationRun.objects.filter(
             models.Q(config__dataset__messages=self) | models.Q(scoped_messages=self)
         )

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -103,6 +103,7 @@ class Evaluator(BaseTeamModel):
         return f"{self.name} ({label})"
 
     def delete(self, *args, **kwargs):
+        """Block deletion while any config using this evaluator has an in-flight run."""
         raise_if_runs_in_flight(EvaluationRun.objects.filter(config__evaluators=self), "evaluator")
         return super().delete(*args, **kwargs)
 
@@ -159,9 +160,11 @@ class EvaluationMessage(BaseModel):
         return f"{input_role}: {input_content}, {output_role}: {output_content}"
 
     def delete(self, *args, **kwargs):
-        # Blocks on any in-flight run whose dataset contains this message OR that scoped it directly.
-        # A PREVIEW/DELTA run that will not actually process this message is over-blocked here; that
-        # is the safe direction (never strand a run) and in-flight runs are short-lived.
+        """Block deletion while an in-flight run references this message, via its dataset or DELTA scoping.
+
+        A PREVIEW/DELTA run that will not actually process this message is over-blocked here; that
+        is the safe direction (never strand a run) and in-flight runs are short-lived.
+        """
         related_runs = EvaluationRun.objects.filter(
             models.Q(config__dataset__messages=self) | models.Q(scoped_messages=self)
         )
@@ -278,6 +281,7 @@ class EvaluationDataset(BaseTeamModel):
         return f"{self.name} ({self.messages.count()} {mode}s)"
 
     def delete(self, *args, **kwargs):
+        """Block deletion while any config using this dataset has an in-flight run."""
         raise_if_runs_in_flight(EvaluationRun.objects.filter(config__dataset=self), "dataset")
         return super().delete(*args, **kwargs)
 
@@ -457,6 +461,7 @@ class EvaluationConfig(BaseTeamModel):
         return f"EvaluationConfig ({self.name})"
 
     def delete(self, *args, **kwargs):
+        """Block deletion while any of this config's runs is still in progress."""
         raise_if_runs_in_flight(EvaluationRun.objects.filter(config=self), "evaluation")
         return super().delete(*args, **kwargs)
 

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -96,6 +96,10 @@ class Evaluator(BaseTeamModel):
             label = self.type
         return f"{self.name} ({label})"
 
+    def delete(self, *args, **kwargs):
+        raise_if_runs_in_flight(EvaluationRun.objects.filter(config__evaluators=self), "evaluator")
+        return super().delete(*args, **kwargs)
+
     @cached_property
     def evaluator(self):
         module = importlib.import_module("apps.evaluations.evaluators")

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -261,6 +261,10 @@ class EvaluationDataset(BaseTeamModel):
         mode = EvaluationMode(self.evaluation_mode).label
         return f"{self.name} ({self.messages.count()} {mode}s)"
 
+    def delete(self, *args, **kwargs):
+        raise_if_runs_in_flight(EvaluationRun.objects.filter(config__dataset=self), "dataset")
+        return super().delete(*args, **kwargs)
+
     def get_absolute_url(self):
         return reverse("evaluations:dataset_edit", args=[get_slug_for_team(self.team_id), self.id])
 

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -68,12 +68,20 @@ def evaluate_single_message_task(evaluation_run_id, evaluator_ids, message_id):
     First runs the message through the bot, then runs the evaluator.
     ExperimentSessions created in this task are deleted periodically by cleanup_old_evaluation_data
     """
-    evaluation_run = EvaluationRun.objects.select_related("team").get(id=evaluation_run_id)
+    try:
+        evaluation_run = EvaluationRun.objects.select_related("team").get(id=evaluation_run_id)
+    except EvaluationRun.DoesNotExist:
+        logger.warning("EvaluationRun %s no longer exists; skipping message %s", evaluation_run_id, message_id)
+        return
 
     with current_team(evaluation_run.team):
-        message = EvaluationMessage.objects.select_related("session__chat", "expected_output_chat_message").get(
-            id=message_id
-        )
+        try:
+            message = EvaluationMessage.objects.select_related("session__chat", "expected_output_chat_message").get(
+                id=message_id
+            )
+        except EvaluationMessage.DoesNotExist:
+            logger.warning("EvaluationMessage %s no longer exists; skipping in run %s", message_id, evaluation_run_id)
+            return
         # Only run bot generation if an experiment version is configured
         generation_experiment = evaluation_run.generation_experiment
         session_id, bot_response = None, ""
@@ -280,7 +288,10 @@ def run_evaluation_task(evaluation_run_id):
             evaluation_run.save(update_fields=["job_id"])
     except Exception as e:
         logger.exception(f"Error starting evaluation run {evaluation_run_id}: {e}")
-        evaluation_run = EvaluationRun.objects.get(id=evaluation_run_id)
+        evaluation_run = EvaluationRun.objects.filter(id=evaluation_run_id).first()
+        if evaluation_run is None:
+            logger.warning("EvaluationRun %s vanished before it could be marked FAILED", evaluation_run_id)
+            return
         evaluation_run.status = EvaluationRunStatus.FAILED
         evaluation_run.error_message = str(e)
         evaluation_run.job_id = ""

--- a/apps/evaluations/tests/test_clear_eval_runs.py
+++ b/apps/evaluations/tests/test_clear_eval_runs.py
@@ -12,6 +12,7 @@ from apps.evaluations.models import (
     EvaluationMode,
     EvaluationResult,
     EvaluationRun,
+    EvaluationRunStatus,
 )
 from apps.evaluations.tagging import remove_applied_tags_for_runs
 from apps.utils.factories.evaluations import (
@@ -189,7 +190,7 @@ class TestClearEvaluationRunsView:
 
         dataset = EvaluationDatasetFactory.create(team=team, messages=[message])
         config = EvaluationConfigFactory.create(team=team, dataset=dataset, evaluators=[evaluator])
-        run = EvaluationRunFactory.create(team=team, config=config)
+        run = EvaluationRunFactory.create(team=team, config=config, status=EvaluationRunStatus.COMPLETED)
         result = EvaluationResultFactory.create(team=team, evaluator=evaluator, message=message, run=run, output={})
         AppliedTagFactory.create(team=team, evaluation_result=result, rule=rule, tag=tag)
         return config, chat_message, tag
@@ -286,3 +287,30 @@ class TestClearEvaluationRunsView:
 
         clear_url = reverse("evaluations:clear_evaluation_runs", args=[team_with_users.slug, config.id])
         assert clear_url not in response.content.decode()
+
+    @pytest.mark.django_db()
+    def test_clear_all_blocked_when_run_in_flight(self, client, team_with_users):
+        user = team_with_users.members.first()
+        config = EvaluationConfigFactory.create(team=team_with_users)
+        EvaluationRunFactory.create(team=team_with_users, config=config, status=EvaluationRunStatus.PROCESSING)
+
+        client.force_login(user)
+        url = reverse("evaluations:clear_evaluation_runs", args=[team_with_users.slug, config.id])
+        response = client.post(url)
+
+        assert response.status_code == 409
+        assert EvaluationRun.objects.filter(config=config).exists()
+
+    @pytest.mark.django_db()
+    def test_clear_all_blocked_leaves_applied_tags_untouched(self, client, team_with_users):
+        """A blocked clear must not run tag removal (guard precedes the atomic block)."""
+        user = team_with_users.members.first()
+        config, chat_message, tag = self._setup_config_with_applied_tag(team_with_users)
+        EvaluationRunFactory.create(team=team_with_users, config=config, status=EvaluationRunStatus.PROCESSING)
+
+        client.force_login(user)
+        url = reverse("evaluations:clear_evaluation_runs", args=[team_with_users.slug, config.id])
+        response = client.post(url)
+
+        assert response.status_code == 409
+        assert CustomTaggedItem.objects.filter(tag=tag).exists()

--- a/apps/evaluations/tests/test_delete_dataset.py
+++ b/apps/evaluations/tests/test_delete_dataset.py
@@ -3,8 +3,12 @@ from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
-from apps.evaluations.models import EvaluationDataset
-from apps.utils.factories.evaluations import EvaluationDatasetFactory
+from apps.evaluations.models import EvaluationConfig, EvaluationDataset, EvaluationRun, EvaluationRunStatus
+from apps.utils.factories.evaluations import (
+    EvaluationConfigFactory,
+    EvaluationDatasetFactory,
+    EvaluationRunFactory,
+)
 from apps.utils.factories.team import MembershipFactory, TeamFactory
 from apps.utils.factories.user import GroupFactory
 
@@ -39,6 +43,46 @@ def test_delete_dataset_without_delete_perm_is_forbidden(client, team_with_users
 
     assert response.status_code == 403
     assert EvaluationDataset.objects.filter(id=dataset.id).exists()
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "status",
+    [
+        pytest.param(EvaluationRunStatus.PENDING, id="pending"),
+        pytest.param(EvaluationRunStatus.PROCESSING, id="processing"),
+    ],
+)
+def test_delete_dataset_blocked_while_run_in_flight(status, client, team_with_users):
+    user = team_with_users.members.first()
+    dataset = EvaluationDatasetFactory.create(team=team_with_users)
+    config = EvaluationConfigFactory.create(team=team_with_users, dataset=dataset)
+    EvaluationRunFactory.create(team=team_with_users, config=config, status=status)
+
+    client.force_login(user)
+    url = reverse("evaluations:dataset_delete", args=[team_with_users.slug, dataset.id])
+    response = client.delete(url)
+
+    assert response.status_code == 409
+    assert EvaluationDataset.objects.filter(id=dataset.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_dataset_allowed_and_cascades_when_runs_terminal(client, team_with_users):
+    """Allowed delete proceeds AND the cascade actually removes config + runs."""
+    user = team_with_users.members.first()
+    dataset = EvaluationDatasetFactory.create(team=team_with_users)
+    config = EvaluationConfigFactory.create(team=team_with_users, dataset=dataset)
+    run = EvaluationRunFactory.create(team=team_with_users, config=config, status=EvaluationRunStatus.FAILED)
+
+    client.force_login(user)
+    url = reverse("evaluations:dataset_delete", args=[team_with_users.slug, dataset.id])
+    response = client.delete(url)
+
+    assert response.status_code == 200
+    assert not EvaluationDataset.objects.filter(id=dataset.id).exists()
+    assert not EvaluationConfig.objects.filter(id=config.id).exists()
+    assert not EvaluationRun.objects.filter(id=run.id).exists()
 
 
 @pytest.mark.django_db()

--- a/apps/evaluations/tests/test_delete_evaluation.py
+++ b/apps/evaluations/tests/test_delete_evaluation.py
@@ -3,8 +3,8 @@ from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
-from apps.evaluations.models import EvaluationConfig, EvaluationRun
-from apps.utils.factories.evaluations import EvaluationConfigFactory
+from apps.evaluations.models import EvaluationConfig, EvaluationRun, EvaluationRunStatus
+from apps.utils.factories.evaluations import EvaluationConfigFactory, EvaluationRunFactory
 from apps.utils.factories.team import MembershipFactory, TeamFactory
 from apps.utils.factories.user import GroupFactory
 
@@ -52,6 +52,79 @@ def test_delete_evaluation_redirect_param_zero_does_not_redirect(client, team_wi
     assert response.status_code == 200
     assert "HX-Redirect" not in response.headers
     assert not EvaluationConfig.objects.filter(id=evaluation.id).exists()
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "status",
+    [
+        pytest.param(EvaluationRunStatus.PENDING, id="pending"),
+        pytest.param(EvaluationRunStatus.PROCESSING, id="processing"),
+    ],
+)
+def test_delete_config_blocked_while_run_in_flight(status, client, team_with_users):
+    user = team_with_users.members.first()
+    evaluation = EvaluationConfigFactory.create(team=team_with_users)
+    EvaluationRunFactory.create(team=team_with_users, config=evaluation, status=status)
+
+    client.force_login(user)
+    url = reverse("evaluations:delete", args=[team_with_users.slug, evaluation.id])
+    response = client.delete(url)
+
+    assert response.status_code == 409
+    assert EvaluationConfig.objects.filter(id=evaluation.id).exists()
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "status",
+    [
+        pytest.param(EvaluationRunStatus.COMPLETED, id="completed"),
+        pytest.param(EvaluationRunStatus.FAILED, id="failed"),
+    ],
+)
+def test_delete_config_allowed_when_runs_terminal(status, client, team_with_users):
+    user = team_with_users.members.first()
+    evaluation = EvaluationConfigFactory.create(team=team_with_users)
+    EvaluationRunFactory.create(team=team_with_users, config=evaluation, status=status)
+
+    client.force_login(user)
+    url = reverse("evaluations:delete", args=[team_with_users.slug, evaluation.id])
+    response = client.delete(url)
+
+    assert response.status_code == 200
+    assert not EvaluationConfig.objects.filter(id=evaluation.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_config_blocked_with_one_in_flight_among_terminal(client, team_with_users):
+    user = team_with_users.members.first()
+    evaluation = EvaluationConfigFactory.create(team=team_with_users)
+    EvaluationRunFactory.create(team=team_with_users, config=evaluation, status=EvaluationRunStatus.COMPLETED)
+    EvaluationRunFactory.create(team=team_with_users, config=evaluation, status=EvaluationRunStatus.PROCESSING)
+
+    client.force_login(user)
+    url = reverse("evaluations:delete", args=[team_with_users.slug, evaluation.id])
+    response = client.delete(url)
+
+    assert response.status_code == 409
+    assert EvaluationConfig.objects.filter(id=evaluation.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_config_blocked_redirect_path_has_no_hx_redirect(client, team_with_users):
+    """A blocked detail-page delete (?redirect=1) returns 409 and must not leak HX-Redirect."""
+    user = team_with_users.members.first()
+    evaluation = EvaluationConfigFactory.create(team=team_with_users)
+    EvaluationRunFactory.create(team=team_with_users, config=evaluation, status=EvaluationRunStatus.PROCESSING)
+
+    client.force_login(user)
+    url = reverse("evaluations:delete", args=[team_with_users.slug, evaluation.id])
+    response = client.delete(f"{url}?redirect=1")
+
+    assert response.status_code == 409
+    assert "HX-Redirect" not in response.headers
+    assert EvaluationConfig.objects.filter(id=evaluation.id).exists()
 
 
 @pytest.mark.django_db()

--- a/apps/evaluations/tests/test_delete_evaluator.py
+++ b/apps/evaluations/tests/test_delete_evaluator.py
@@ -3,8 +3,12 @@ from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
-from apps.evaluations.models import Evaluator
-from apps.utils.factories.evaluations import EvaluatorFactory
+from apps.evaluations.models import EvaluationRunStatus, Evaluator
+from apps.utils.factories.evaluations import (
+    EvaluationConfigFactory,
+    EvaluationRunFactory,
+    EvaluatorFactory,
+)
 from apps.utils.factories.team import MembershipFactory, TeamFactory
 from apps.utils.factories.user import GroupFactory
 
@@ -38,6 +42,75 @@ def test_delete_evaluator_without_delete_perm_is_forbidden(client, team_with_use
     response = client.delete(url)
 
     assert response.status_code == 403
+    assert Evaluator.objects.filter(id=evaluator.id).exists()
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "status",
+    [
+        pytest.param(EvaluationRunStatus.PENDING, id="pending"),
+        pytest.param(EvaluationRunStatus.PROCESSING, id="processing"),
+    ],
+)
+def test_delete_evaluator_blocked_while_run_in_flight(status, client, team_with_users):
+    user = team_with_users.members.first()
+    evaluator = EvaluatorFactory.create(team=team_with_users)
+    config = EvaluationConfigFactory.create(team=team_with_users, evaluators=[evaluator])
+    EvaluationRunFactory.create(team=team_with_users, config=config, status=status)
+
+    client.force_login(user)
+    url = reverse("evaluations:evaluator_delete", args=[team_with_users.slug, evaluator.id])
+    response = client.delete(url)
+
+    assert response.status_code == 409
+    assert Evaluator.objects.filter(id=evaluator.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_evaluator_allowed_when_runs_terminal(client, team_with_users):
+    user = team_with_users.members.first()
+    evaluator = EvaluatorFactory.create(team=team_with_users)
+    config = EvaluationConfigFactory.create(team=team_with_users, evaluators=[evaluator])
+    EvaluationRunFactory.create(team=team_with_users, config=config, status=EvaluationRunStatus.COMPLETED)
+
+    client.force_login(user)
+    url = reverse("evaluations:evaluator_delete", args=[team_with_users.slug, evaluator.id])
+    response = client.delete(url)
+
+    assert response.status_code == 200
+    assert not Evaluator.objects.filter(id=evaluator.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_evaluator_allowed_when_on_no_config(client, team_with_users):
+    """An evaluator on no config has no related runs and deletes cleanly."""
+    user = team_with_users.members.first()
+    evaluator = EvaluatorFactory.create(team=team_with_users)
+
+    client.force_login(user)
+    url = reverse("evaluations:evaluator_delete", args=[team_with_users.slug, evaluator.id])
+    response = client.delete(url)
+
+    assert response.status_code == 200
+    assert not Evaluator.objects.filter(id=evaluator.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_evaluator_blocked_when_shared_config_in_flight(client, team_with_users):
+    """Evaluator on two configs: A in-flight, B terminal -> blocked (would corrupt A)."""
+    user = team_with_users.members.first()
+    evaluator = EvaluatorFactory.create(team=team_with_users)
+    config_a = EvaluationConfigFactory.create(team=team_with_users, evaluators=[evaluator])
+    config_b = EvaluationConfigFactory.create(team=team_with_users, evaluators=[evaluator])
+    EvaluationRunFactory.create(team=team_with_users, config=config_a, status=EvaluationRunStatus.PROCESSING)
+    EvaluationRunFactory.create(team=team_with_users, config=config_b, status=EvaluationRunStatus.COMPLETED)
+
+    client.force_login(user)
+    url = reverse("evaluations:evaluator_delete", args=[team_with_users.slug, evaluator.id])
+    response = client.delete(url)
+
+    assert response.status_code == 409
     assert Evaluator.objects.filter(id=evaluator.id).exists()
 
 

--- a/apps/evaluations/tests/test_delete_message.py
+++ b/apps/evaluations/tests/test_delete_message.py
@@ -8,6 +8,7 @@ from apps.utils.factories.evaluations import (
     EvaluationMessageFactory,
     EvaluationRunFactory,
 )
+from apps.utils.factories.team import TeamFactory
 
 
 @pytest.mark.django_db()
@@ -35,10 +36,15 @@ def test_delete_message_blocked_while_dataset_run_in_flight(status, client, team
 
 @pytest.mark.django_db()
 def test_delete_message_blocked_while_scoped_delta_run_in_flight(client, team_with_users):
+    """Isolates the scoped_messages OR-clause: the run's config uses a DIFFERENT dataset,
+    so only the scoped_messages relationship (not config__dataset__messages) can block."""
     user = team_with_users.members.first()
     message = EvaluationMessageFactory.create()
-    dataset = EvaluationDatasetFactory.create(team=team_with_users, messages=[message])
-    config = EvaluationConfigFactory.create(team=team_with_users, dataset=dataset)
+    # The dataset the message belongs to (needed for the team-scoped view lookup).
+    EvaluationDatasetFactory.create(team=team_with_users, messages=[message])
+    # In-flight DELTA run whose config points at a different dataset that does NOT contain the message.
+    other_dataset = EvaluationDatasetFactory.create(team=team_with_users)
+    config = EvaluationConfigFactory.create(team=team_with_users, dataset=other_dataset)
     run = EvaluationRunFactory.create(
         team=team_with_users,
         config=config,
@@ -56,12 +62,19 @@ def test_delete_message_blocked_while_scoped_delta_run_in_flight(client, team_wi
 
 
 @pytest.mark.django_db()
-def test_delete_message_allowed_when_runs_terminal(client, team_with_users):
+@pytest.mark.parametrize(
+    "status",
+    [
+        pytest.param(EvaluationRunStatus.COMPLETED, id="completed"),
+        pytest.param(EvaluationRunStatus.FAILED, id="failed"),
+    ],
+)
+def test_delete_message_allowed_when_runs_terminal(status, client, team_with_users):
     user = team_with_users.members.first()
     message = EvaluationMessageFactory.create()
     dataset = EvaluationDatasetFactory.create(team=team_with_users, messages=[message])
     config = EvaluationConfigFactory.create(team=team_with_users, dataset=dataset)
-    EvaluationRunFactory.create(team=team_with_users, config=config, status=EvaluationRunStatus.COMPLETED)
+    EvaluationRunFactory.create(team=team_with_users, config=config, status=status)
 
     client.force_login(user)
     url = reverse("evaluations:delete_message", args=[team_with_users.slug, message.id])
@@ -69,3 +82,18 @@ def test_delete_message_allowed_when_runs_terminal(client, team_with_users):
 
     assert response.status_code == 200
     assert not EvaluationMessage.objects.filter(id=message.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_message_for_other_team_returns_404(client, team_with_users):
+    user = team_with_users.members.first()
+    other_team = TeamFactory.create()
+    message = EvaluationMessageFactory.create()
+    EvaluationDatasetFactory.create(team=other_team, messages=[message])
+
+    client.force_login(user)
+    url = reverse("evaluations:delete_message", args=[team_with_users.slug, message.id])
+    response = client.delete(url)
+
+    assert response.status_code == 404
+    assert EvaluationMessage.objects.filter(id=message.id).exists()

--- a/apps/evaluations/tests/test_delete_message.py
+++ b/apps/evaluations/tests/test_delete_message.py
@@ -1,0 +1,71 @@
+import pytest
+from django.urls import reverse
+
+from apps.evaluations.models import EvaluationMessage, EvaluationRunStatus, EvaluationRunType
+from apps.utils.factories.evaluations import (
+    EvaluationConfigFactory,
+    EvaluationDatasetFactory,
+    EvaluationMessageFactory,
+    EvaluationRunFactory,
+)
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "status",
+    [
+        pytest.param(EvaluationRunStatus.PENDING, id="pending"),
+        pytest.param(EvaluationRunStatus.PROCESSING, id="processing"),
+    ],
+)
+def test_delete_message_blocked_while_dataset_run_in_flight(status, client, team_with_users):
+    user = team_with_users.members.first()
+    message = EvaluationMessageFactory.create()
+    dataset = EvaluationDatasetFactory.create(team=team_with_users, messages=[message])
+    config = EvaluationConfigFactory.create(team=team_with_users, dataset=dataset)
+    EvaluationRunFactory.create(team=team_with_users, config=config, status=status)
+
+    client.force_login(user)
+    url = reverse("evaluations:delete_message", args=[team_with_users.slug, message.id])
+    response = client.delete(url)
+
+    assert response.status_code == 409
+    assert EvaluationMessage.objects.filter(id=message.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_message_blocked_while_scoped_delta_run_in_flight(client, team_with_users):
+    user = team_with_users.members.first()
+    message = EvaluationMessageFactory.create()
+    dataset = EvaluationDatasetFactory.create(team=team_with_users, messages=[message])
+    config = EvaluationConfigFactory.create(team=team_with_users, dataset=dataset)
+    run = EvaluationRunFactory.create(
+        team=team_with_users,
+        config=config,
+        status=EvaluationRunStatus.PROCESSING,
+        type=EvaluationRunType.DELTA,
+    )
+    run.scoped_messages.add(message)
+
+    client.force_login(user)
+    url = reverse("evaluations:delete_message", args=[team_with_users.slug, message.id])
+    response = client.delete(url)
+
+    assert response.status_code == 409
+    assert EvaluationMessage.objects.filter(id=message.id).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_message_allowed_when_runs_terminal(client, team_with_users):
+    user = team_with_users.members.first()
+    message = EvaluationMessageFactory.create()
+    dataset = EvaluationDatasetFactory.create(team=team_with_users, messages=[message])
+    config = EvaluationConfigFactory.create(team=team_with_users, dataset=dataset)
+    EvaluationRunFactory.create(team=team_with_users, config=config, status=EvaluationRunStatus.COMPLETED)
+
+    client.force_login(user)
+    url = reverse("evaluations:delete_message", args=[team_with_users.slug, message.id])
+    response = client.delete(url)
+
+    assert response.status_code == 200
+    assert not EvaluationMessage.objects.filter(id=message.id).exists()

--- a/apps/evaluations/tests/test_evaluation_tasks.py
+++ b/apps/evaluations/tests/test_evaluation_tasks.py
@@ -12,6 +12,7 @@ from apps.evaluations.models import (
     AppliedTag,
     ConditionType,
     EvaluationResult,
+    EvaluationRun,
     EvaluationRunType,
 )
 from apps.evaluations.tasks import (
@@ -19,6 +20,7 @@ from apps.evaluations.tasks import (
     cleanup_old_evaluation_data,
     evaluate_single_message_task,
     run_bot_generation,
+    run_evaluation_task,
 )
 from apps.experiments.models import ExperimentSession, Participant
 from apps.pipelines.tests.utils import create_pipeline_model, end_node, render_template_node, start_node
@@ -327,3 +329,27 @@ def test_evaluate_single_message_skips_tagging_for_preview_run(
     assert EvaluationResult.objects.filter(message=evaluation_message, run=run, evaluator=evaluator).exists()
     assert not expected_output.tags.filter(pk=tag.pk).exists()
     assert AppliedTag.objects.count() == 0
+
+
+@pytest.mark.django_db()
+def test_evaluate_single_message_task_skips_deleted_run(evaluation_run, evaluation_message):
+    """Run row deleted before the task executes -> no result written, no exception."""
+    run, evaluator = evaluation_run
+    run_id = run.id
+    run.delete()
+
+    evaluate_single_message_task(run_id, [evaluator.id], evaluation_message.id)
+
+    assert not EvaluationResult.objects.filter(run_id=run_id).exists()
+
+
+@pytest.mark.django_db()
+def test_run_evaluation_task_handles_deleted_run(evaluation_run):
+    """Run deleted before dispatch -> handler does not raise a second DoesNotExist."""
+    run, _ = evaluation_run
+    run_id = run.id
+    run.delete()
+
+    run_evaluation_task(run_id)
+
+    assert not EvaluationRun.objects.filter(id=run_id).exists()

--- a/apps/evaluations/tests/test_evaluation_tasks.py
+++ b/apps/evaluations/tests/test_evaluation_tasks.py
@@ -11,6 +11,7 @@ from apps.chatbots.version_resolver import VersionSelectionRule
 from apps.evaluations.models import (
     AppliedTag,
     ConditionType,
+    EvaluationMessage,
     EvaluationResult,
     EvaluationRun,
     EvaluationRunType,
@@ -353,3 +354,18 @@ def test_run_evaluation_task_handles_deleted_run(evaluation_run):
     run_evaluation_task(run_id)
 
     assert not EvaluationRun.objects.filter(id=run_id).exists()
+
+
+@pytest.mark.django_db()
+def test_evaluate_single_message_task_skips_deleted_message(evaluation_run, evaluation_message):
+    """Message deleted out from under a surviving in-flight run -> no result written, no exception.
+
+    Uses a bulk queryset delete to mimic the cascade/race path that bypasses the model guard.
+    """
+    run, evaluator = evaluation_run
+    message_id = evaluation_message.id
+    EvaluationMessage.objects.filter(id=message_id).delete()
+
+    evaluate_single_message_task(run.id, [evaluator.id], message_id)
+
+    assert not EvaluationResult.objects.filter(run=run).exists()

--- a/apps/evaluations/views/dataset_views.py
+++ b/apps/evaluations/views/dataset_views.py
@@ -28,6 +28,7 @@ from apps.evaluations.dataset_clone import (
     mark_dataset_pending,
     resolve_add_sessions_external_ids,
 )
+from apps.evaluations.exceptions import InFlightRunsError
 from apps.evaluations.forms import (
     EvaluationDatasetEditForm,
     EvaluationDatasetForm,
@@ -161,8 +162,10 @@ class DeleteDataset(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
     def delete(self, request, team_slug: str, pk: int):
         """Handle AJAX delete requests."""
         dataset = get_object_or_404(EvaluationDataset, team=request.team, pk=pk)
-        dataset.delete()
-
+        try:
+            dataset.delete()
+        except InFlightRunsError as e:
+            return HttpResponse(", ".join(e.messages), status=409)
         return HttpResponse(status=200)
 
 

--- a/apps/evaluations/views/dataset_views.py
+++ b/apps/evaluations/views/dataset_views.py
@@ -524,7 +524,10 @@ def _get_message_form_data(request) -> dict:
 def delete_message(request, team_slug, message_id):
     """Delete a message from the dataset"""
     message = get_object_or_404(EvaluationMessage, id=message_id, evaluationdataset__team=request.team)
-    message.delete()
+    try:
+        message.delete()
+    except InFlightRunsError as e:
+        return HttpResponse(", ".join(e.messages), status=409)
     return HttpResponse("", status=200)
 
 

--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -22,6 +22,7 @@ from django.views.generic import CreateView, TemplateView, UpdateView, View
 from django_tables2 import SingleTableView, columns, tables
 
 from apps.evaluations.const import EVALUATION_RUN_FIXED_HEADERS
+from apps.evaluations.exceptions import InFlightRunsError
 from apps.evaluations.export import write_evaluation_csv
 from apps.evaluations.forms import EvaluationConfigForm, get_experiment_version_choices
 from apps.evaluations.models import EvaluationConfig, EvaluationRun, EvaluationRunStatus, EvaluationRunType
@@ -129,7 +130,10 @@ class DeleteEvaluation(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View)
 
     def delete(self, request, team_slug: str, pk: int):
         evaluation = get_object_or_404(EvaluationConfig, team=request.team, pk=pk)
-        evaluation.delete()
+        try:
+            evaluation.delete()
+        except InFlightRunsError as e:
+            return HttpResponse(", ".join(e.messages), status=409)
         response = HttpResponse(status=200)
         if request.GET.get("redirect") == "1":
             response["HX-Redirect"] = reverse("evaluations:home", args=[self.request.team.slug])

--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -25,7 +25,13 @@ from apps.evaluations.const import EVALUATION_RUN_FIXED_HEADERS
 from apps.evaluations.exceptions import InFlightRunsError
 from apps.evaluations.export import write_evaluation_csv
 from apps.evaluations.forms import EvaluationConfigForm, get_experiment_version_choices
-from apps.evaluations.models import EvaluationConfig, EvaluationRun, EvaluationRunStatus, EvaluationRunType
+from apps.evaluations.models import (
+    EvaluationConfig,
+    EvaluationRun,
+    EvaluationRunStatus,
+    EvaluationRunType,
+    raise_if_runs_in_flight,
+)
 from apps.evaluations.tables import EvaluationConfigTable, EvaluationRunTable
 from apps.evaluations.tagging import remove_applied_tags_for_runs
 from apps.evaluations.tasks import (
@@ -168,7 +174,12 @@ class ClearEvaluationRuns(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Vi
 
     def post(self, request, team_slug: str, evaluation_pk: int):
         config = get_object_or_404(EvaluationConfig, id=evaluation_pk, team=request.team)
-        runs = EvaluationRun.objects.filter(config=config)
+        run_ids = list(EvaluationRun.objects.filter(config=config).values_list("id", flat=True))
+        runs = EvaluationRun.objects.filter(id__in=run_ids)
+        try:
+            raise_if_runs_in_flight(runs, "evaluation")
+        except InFlightRunsError as e:
+            return HttpResponse(", ".join(e.messages), status=409)
         with transaction.atomic():
             remove_applied_tags_for_runs(runs)
             runs.delete()

--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -135,6 +135,7 @@ class DeleteEvaluation(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View)
     permission_required = "evaluations.delete_evaluationconfig"
 
     def delete(self, request, team_slug: str, pk: int):
+        """Delete the config, returning 409 if a related run is still in progress."""
         evaluation = get_object_or_404(EvaluationConfig, team=request.team, pk=pk)
         try:
             evaluation.delete()
@@ -173,6 +174,7 @@ class ClearEvaluationRuns(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Vi
     permission_required = "evaluations.delete_evaluationrun"
 
     def post(self, request, team_slug: str, evaluation_pk: int):
+        """Un-apply this config's eval tags and delete all its runs, returning 409 if any run is in progress."""
         config = get_object_or_404(EvaluationConfig, id=evaluation_pk, team=request.team)
         run_ids = list(EvaluationRun.objects.filter(config=config).values_list("id", flat=True))
         runs = EvaluationRun.objects.filter(id__in=run_ids)

--- a/apps/evaluations/views/evaluator_views.py
+++ b/apps/evaluations/views/evaluator_views.py
@@ -180,6 +180,7 @@ class DeleteEvaluator(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
     permission_required = "evaluations.delete_evaluator"
 
     def delete(self, request, team_slug: str, pk: int):
+        """Delete the evaluator, returning 409 if a related run is still in progress."""
         evaluator = get_object_or_404(Evaluator, team=request.team, pk=pk)
         try:
             evaluator.delete()

--- a/apps/evaluations/views/evaluator_views.py
+++ b/apps/evaluations/views/evaluator_views.py
@@ -13,6 +13,7 @@ from django_tables2 import SingleTableView
 from apps.annotations.models import Tag
 from apps.custom_actions.schema_utils import resolve_references
 from apps.evaluations import evaluators
+from apps.evaluations.exceptions import InFlightRunsError
 from apps.evaluations.forms import EvaluatorForm, EvaluatorTagRuleFormSet
 from apps.evaluations.models import Evaluator
 from apps.evaluations.tables import EvaluatorTable
@@ -180,7 +181,10 @@ class DeleteEvaluator(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
 
     def delete(self, request, team_slug: str, pk: int):
         evaluator = get_object_or_404(Evaluator, team=request.team, pk=pk)
-        evaluator.delete()
+        try:
+            evaluator.delete()
+        except InFlightRunsError as e:
+            return HttpResponse(", ".join(e.messages), status=409)
         return HttpResponse(status=200)
 
 


### PR DESCRIPTION
### Product Description

Deleting an evaluation, evaluator, dataset, or dataset message, or clearing an evaluation's run history, while an evaluation run is still in progress could strand or crash that background run. This PR blocks those destructive actions while a related run is `PENDING` or `PROCESSING`: the action is rejected with a clear message ("Cannot delete this evaluation while evaluation runs are in progress. Wait for the runs to finish, then try again.") shown in the standard error modal, and nothing is deleted. Once the runs finish (or fail), the same action succeeds normally.

Fixes #3385.

### Technical Description

A shared guard lives in `apps/evaluations/models.py`: `NON_TERMINAL_RUN_STATUSES` plus `raise_if_runs_in_flight(runs, resource_label)`, which raises a new `InFlightRunsError` (in `apps/evaluations/exceptions.py`, subclassing `ValidationError`) when any run in the given queryset is non-terminal.

- **Model `delete()` overrides** on `EvaluationConfig`, `Evaluator`, `EvaluationDataset`, and `EvaluationMessage` call the guard before `super().delete()`, each with the query that is exactly the set of runs the delete would cascade-destroy:
  - config: `config=self`
  - evaluator (M2M): `config__evaluators=self`
  - dataset (FK cascade): `config__dataset=self`
  - message: `Q(config__dataset__messages=self) | Q(scoped_messages=self)` (dataset membership for FULL/PREVIEW runs, and DELTA `scoped_messages`)
- **Views** (`DeleteEvaluation`, `DeleteEvaluator`, `DeleteDataset`, `delete_message`) catch `InFlightRunsError` and return `HttpResponse(", ".join(e.messages), status=409)`. 409 is required: the global htmx handler surfaces a 4xx body in a modal, and because htmx only swaps on 2xx, a table-row delete does not replace the row with error text.
- **`ClearEvaluationRuns`** deletes via `queryset.delete()` (which bypasses `Model.delete()`), so it calls the guard directly over a **pinned id set** (`run_ids = list(...values_list("id"))`, then `filter(id__in=run_ids)` for the guard, tag-removal, and delete) so all three operate on the identical frozen set.
- **Celery task hardening** (`apps/evaluations/tasks.py`): `evaluate_single_message_task` guards its run and message fetches, and `run_evaluation_task`'s failure handler re-fetches with `.filter().first()` instead of `.get()`, so the residual race/cascade paths the model guard cannot cover degrade to a logged no-op instead of an unhandled task failure (previously the failure handler could raise a second `DoesNotExist`, masking the original error).

**Divergence from the `LlmProviderModel` guarded-delete precedent** (`apps/service_providers/`): a dedicated `InFlightRunsError` subclass (vs plain `ValidationError`) so views catch precisely, and HTTP **409** (vs the precedent's 400) per @snopoke's decision on the issue.

Tests are behaviour tests through the view (`client.delete`/`client.post`, asserting status code + DB state), matching the existing delete-test files; task tests call the task directly and assert observable DB state. The two defensive task branches and the message `scoped_messages` guard clause are each mutation-verified (removing the guard fails the corresponding test).

### Migrations

No migrations. The change is model methods + a module-level constant + an exception class; no schema change (`makemigrations --check` reports "No changes detected").

- [x] The migrations are backwards compatible

### Known Limitations

1. **TOCTOU race (residual, mitigated).** The guard is check-then-delete with no lock, and run creation also takes no lock, so a run entering `PENDING` between the guard SELECT and the delete is not caught (millisecond window; most likely via `auto_run_on_append` or two users acting at once). The task hardening turns the worst case (a run cascade-deleted mid-flight) into a logged no-op. Fully closing it would need `select_for_update` on both the delete and run-creation paths; the cited `LlmProviderModel` precedent has the same gap.
2. **Admin single-object delete now 500s.** `ModelAdmin.delete_model` calls `obj.delete()`, which raises `InFlightRunsError` -> unhandled 500 in the Django admin. Blocking is safer than silently stranding a run, so this is accepted.
3. **Message/PREVIEW/DELTA over-block.** A message is blocked if any in-flight run's dataset contains it, even for a PREVIEW/DELTA run that will not actually process it. Conservative and safe (never strands a run); in-flight runs are short-lived.
4. **Completed-run history still cascades (out of scope).** Deleting a message or evaluator still removes `EvaluationResult`/aggregate rows belonging to *terminal* runs (those FKs are CASCADE). This guard only protects in-flight runs; the historical-data-loss behaviour is unchanged and tracked separately in #3861.

### Demo

Verified end-to-end in the running app: with a `PROCESSING` run attached, deleting the config, deleting the dataset, and clearing runs each return 409 and show the error modal with the object untouched; flipping the run to a terminal status lets the same actions succeed. Backend paths additionally verified via authenticated requests and a runtime demonstration of the task hardening degrading to a logged no-op.

### Docs and Changelog

- [ ] This PR requires docs/changelog update
