### PR TITLE
Add bearer-token auth to provider reporting endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,12 @@ CRYPTOGRAPHY_SALT=
 # Tokens used to secure the /status endpoint. These should be kept secret
 HEALTH_CHECK_TOKENS=
 
+## Provider usage/key reporting
+# Bearer token for the admin provider-usage / provider-keys endpoints, so a
+# headless reporting script can call them. Generate with:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+PROVIDER_REPORTING_API_TOKEN=
+
 ## Oauth
 OIDC_RSA_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nexample key\n-----END PRIVATE KEY-----"
 OAUTH_PKCE_REQUIRED=True

--- a/apps/admin/tests/test_provider_usage_api.py
+++ b/apps/admin/tests/test_provider_usage_api.py
@@ -44,6 +44,27 @@ def test_invalid_range_returns_400(superuser_client):
 
 
 @pytest.mark.django_db()
+def test_valid_reporting_token_grants_access(client, settings):
+    settings.PROVIDER_REPORTING_API_TOKEN = "s3cret-token"
+    response = client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE, HTTP_AUTHORIZATION="Bearer s3cret-token")
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db()
+def test_invalid_reporting_token_falls_back_to_session(client, settings):
+    settings.PROVIDER_REPORTING_API_TOKEN = "s3cret-token"
+    response = client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE, HTTP_AUTHORIZATION="Bearer wrong")
+    assert response.status_code == 302  # no valid token, no superuser session
+
+
+@pytest.mark.django_db()
+def test_reporting_token_ignored_when_unset(client, settings):
+    settings.PROVIDER_REPORTING_API_TOKEN = None
+    response = client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE, HTTP_AUTHORIZATION="Bearer anything")
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db()
 def test_merges_token_totals_and_cost_detail(superuser_client):
     team_a = TeamFactory(name="Alpha")
     team_b = TeamFactory(name="Bravo")

--- a/apps/admin/tests/test_provider_usage_api.py
+++ b/apps/admin/tests/test_provider_usage_api.py
@@ -44,24 +44,19 @@ def test_invalid_range_returns_400(superuser_client):
 
 
 @pytest.mark.django_db()
-def test_valid_reporting_token_grants_access(client, settings):
-    settings.PROVIDER_REPORTING_API_TOKEN = "s3cret-token"
-    response = client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE, HTTP_AUTHORIZATION="Bearer s3cret-token")
-    assert response.status_code == 200
-
-
-@pytest.mark.django_db()
-def test_invalid_reporting_token_falls_back_to_session(client, settings):
-    settings.PROVIDER_REPORTING_API_TOKEN = "s3cret-token"
-    response = client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE, HTTP_AUTHORIZATION="Bearer wrong")
-    assert response.status_code == 302  # no valid token, no superuser session
-
-
-@pytest.mark.django_db()
-def test_reporting_token_ignored_when_unset(client, settings):
-    settings.PROVIDER_REPORTING_API_TOKEN = None
-    response = client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE, HTTP_AUTHORIZATION="Bearer anything")
-    assert response.status_code == 302
+@pytest.mark.parametrize(
+    ("configured_token", "auth_header", "expected_status"),
+    [
+        pytest.param("s3cret-token", "Bearer s3cret-token", 200, id="valid-token-grants-access"),
+        pytest.param("s3cret-token", "Bearer wrong", 302, id="invalid-token-falls-back-to-session"),
+        pytest.param(None, "Bearer anything", 302, id="token-ignored-when-unset"),
+        pytest.param("s3cret-token", "Bearer nön-ascii", 302, id="non-ascii-header-rejected"),
+    ],
+)
+def test_reporting_token_auth(client, settings, configured_token, auth_header, expected_status):
+    settings.PROVIDER_REPORTING_API_TOKEN = configured_token
+    response = client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE, HTTP_AUTHORIZATION=auth_header)
+    assert response.status_code == expected_status
 
 
 @pytest.mark.django_db()

--- a/apps/admin/views.py
+++ b/apps/admin/views.py
@@ -69,7 +69,9 @@ def _has_valid_reporting_token(request):
         return False
     prefix = "Bearer "
     header = request.headers.get("Authorization", "")
-    return header.startswith(prefix) and hmac.compare_digest(header.removeprefix(prefix), token)
+    if not header.startswith(prefix):
+        return False
+    return hmac.compare_digest(header.removeprefix(prefix).encode("utf-8"), token.encode("utf-8"))
 
 
 def superuser_or_reporting_token(view_func):

--- a/apps/admin/views.py
+++ b/apps/admin/views.py
@@ -1,7 +1,10 @@
+import functools
+import hmac
 import logging
 from datetime import datetime, time, timedelta
 from urllib.parse import urlencode
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import user_passes_test
 from django.core.exceptions import ValidationError
@@ -57,6 +60,32 @@ User = get_user_model()
 
 is_staff = user_passes_test(lambda u: u.is_staff, login_url="/404")
 is_superuser = user_passes_test(lambda u: u.is_superuser, login_url="/404")
+
+
+def _has_valid_reporting_token(request):
+    """True if the request carries the configured provider-reporting bearer token."""
+    token = settings.PROVIDER_REPORTING_API_TOKEN
+    if not token:
+        return False
+    prefix = "Bearer "
+    header = request.headers.get("Authorization", "")
+    return header.startswith(prefix) and hmac.compare_digest(header.removeprefix(prefix), token)
+
+
+def superuser_or_reporting_token(view_func):
+    """Allow a valid reporting token, else fall back to the superuser-session check.
+
+    Lets headless consumers authenticate with the shared token while the browser
+    admin UI keeps working via the session (same 302-to-/404 for everyone else).
+    """
+
+    @functools.wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        if _has_valid_reporting_token(request):
+            return view_func(request, *args, **kwargs)
+        return is_superuser(view_func)(request, *args, **kwargs)
+
+    return _wrapped
 
 
 @is_staff
@@ -462,7 +491,7 @@ def users_api(request):
     return JsonResponse(data, safe=False)
 
 
-@is_superuser
+@superuser_or_reporting_token
 def provider_usage_api(request):
     """Cross-team LLM usage over a date range: per-team token totals merged with
     per-model cost detail where cost tracking is enabled. Requires `range_type`,
@@ -475,7 +504,7 @@ def provider_usage_api(request):
     return JsonResponse(build_usage_report(start_timestamp, end_timestamp))
 
 
-@is_superuser
+@superuser_or_reporting_token
 def provider_keys_api(request):
     """Masked API-key fingerprint → team mapping across all LLM providers, so a
     report can attribute provider-side cost (keyed by the provider's redacted

--- a/config/settings.py
+++ b/config/settings.py
@@ -33,6 +33,11 @@ env.read_env(os.path.join(BASE_DIR, ".env"))
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env("SECRET_KEY")
 
+# Shared bearer token for the cross-team provider usage/key reporting admin
+# endpoints, so headless consumers (e.g. a reporting script) can call them
+# without a superuser browser session. Unset disables token auth.
+PROVIDER_REPORTING_API_TOKEN = env("PROVIDER_REPORTING_API_TOKEN", default=None)
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("DEBUG", default=True)
 IS_TESTING = "pytest" in sys.modules


### PR DESCRIPTION
### Product Description
no change (superuser-only admin endpoints)

### Technical Description
Follow-up to the provider reporting endpoints (#3817). Adds an optional shared bearer token so a headless consumer (a spend-reconciliation script) can call `/admin/api/provider-usage/` and `/admin/api/provider-keys/` without a superuser browser session.

`superuser_or_reporting_token` allows a valid `Authorization: Bearer <token>` (constant-time compared against `PROVIDER_REPORTING_API_TOKEN`), otherwise falls back to the existing superuser-session check — so the browser UI and the 302-to-/404 behaviour for everyone else are unchanged. When the setting is unset, token auth is disabled entirely.

The token is a single env secret (no DB model / rotation UI); revocable per-consumer credentials would mean OAuth client-credentials instead.

### Migrations
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update