### PR TITLE
Include team metadata in provider usage report

### DIFF
--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -83,7 +83,7 @@ def get_token_usage_by_team(start: datetime, end: datetime):
         Trace.objects.filter(timestamp__gte=start, timestamp__lt=end)
         .exclude(status=TraceStatus.PENDING)
         .exclude(session__platform=ChannelPlatform.EVALUATIONS)
-        .values("team_id", "team__name", "team__slug")
+        .values("team_id", "team__name", "team__slug", "team__metadata")
         .annotate(
             run_count=Count("id"),
             total_tokens=Coalesce(Sum("n_total_tokens"), Value(0)),
@@ -111,25 +111,33 @@ def build_usage_report(start: datetime, end: datetime) -> dict:
 
     `total_cost` is a `{currency: amount}` map, not a scalar: a team can have
     records in more than one currency and summing them would be meaningless.
+
+    Each team carries a `metadata` object with the configured staff-only team
+    metadata fields (`TEAM_METADATA_FIELDS`); their definitions are echoed at the
+    top level as `metadata_fields` so a consumer can build labelled columns.
     """
+    metadata_fields = get_team_metadata_fields()
     token_rows = list(get_token_usage_by_team(start, end))
     cost_rows = list(get_cost_usage_by_team(start, end))
 
-    team_meta = {row["team_id"]: (row["team__name"], row["team__slug"]) for row in token_rows}
+    team_meta = {
+        row["team_id"]: (row["team__name"], row["team__slug"], row["team__metadata"] or {}) for row in token_rows
+    }
     missing_ids = {row["team_id"] for row in cost_rows} - team_meta.keys()
     if missing_ids:
-        missing = Team.objects.filter(id__in=missing_ids).values_list("id", "name", "slug")
-        team_meta.update({tid: (name, slug) for tid, name, slug in missing})
+        missing = Team.objects.filter(id__in=missing_ids).values_list("id", "name", "slug", "metadata")
+        team_meta.update({tid: (name, slug, metadata or {}) for tid, name, slug, metadata in missing})
 
     teams: dict[int, dict] = {}
 
     def _entry(team_id: int) -> dict:
         if team_id not in teams:
-            name, slug = team_meta.get(team_id, (None, None))
+            name, slug, metadata = team_meta.get(team_id, (None, None, {}))
             teams[team_id] = {
                 "team_id": team_id,
                 "team_name": name,
                 "team_slug": slug,
+                "metadata": {field["key"]: metadata.get(field["key"], "") for field in metadata_fields},
                 "run_count": 0,
                 "total_tokens": 0,
                 "total_cost": defaultdict(Decimal),  # currency -> amount
@@ -159,7 +167,12 @@ def build_usage_report(start: datetime, end: datetime) -> dict:
     for entry in result:
         entry["total_cost"] = {currency: str(amount) for currency, amount in entry["total_cost"].items()}
 
-    return {"start": start.isoformat(), "end": end.isoformat(), "teams": result}
+    return {
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "metadata_fields": metadata_fields,
+        "teams": result,
+    }
 
 
 def get_whatsapp_numbers():

--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -83,7 +83,7 @@ def get_token_usage_by_team(start: datetime, end: datetime):
         Trace.objects.filter(timestamp__gte=start, timestamp__lt=end)
         .exclude(status=TraceStatus.PENDING)
         .exclude(session__platform=ChannelPlatform.EVALUATIONS)
-        .values("team_id", "team__name", "team__slug", "team__metadata")
+        .values("team_id", "team__name", "team__slug")
         .annotate(
             run_count=Count("id"),
             total_tokens=Coalesce(Sum("n_total_tokens"), Value(0)),
@@ -120,19 +120,23 @@ def build_usage_report(start: datetime, end: datetime) -> dict:
     token_rows = list(get_token_usage_by_team(start, end))
     cost_rows = list(get_cost_usage_by_team(start, end))
 
-    team_meta = {
-        row["team_id"]: (row["team__name"], row["team__slug"], row["team__metadata"] or {}) for row in token_rows
-    }
+    team_meta = {row["team_id"]: (row["team__name"], row["team__slug"]) for row in token_rows}
     missing_ids = {row["team_id"] for row in cost_rows} - team_meta.keys()
     if missing_ids:
-        missing = Team.objects.filter(id__in=missing_ids).values_list("id", "name", "slug", "metadata")
-        team_meta.update({tid: (name, slug, metadata or {}) for tid, name, slug, metadata in missing})
+        missing = Team.objects.filter(id__in=missing_ids).values_list("id", "name", "slug")
+        team_meta.update({tid: (name, slug) for tid, name, slug in missing})
+
+    # Fetch metadata separately (keyed by PK): grouping the aggregate query by
+    # the JSON `metadata` column would be needlessly expensive, and metadata is
+    # per-team so it never affects the grouping anyway.
+    metadata_by_team = dict(Team.objects.filter(id__in=list(team_meta)).values_list("id", "metadata"))
 
     teams: dict[int, dict] = {}
 
     def _entry(team_id: int) -> dict:
         if team_id not in teams:
-            name, slug, metadata = team_meta.get(team_id, (None, None, {}))
+            name, slug = team_meta.get(team_id, (None, None))
+            metadata = metadata_by_team.get(team_id) or {}
             teams[team_id] = {
                 "team_id": team_id,
                 "team_name": name,

--- a/apps/admin/tests/test_provider_usage_api.py
+++ b/apps/admin/tests/test_provider_usage_api.py
@@ -94,6 +94,23 @@ def test_merges_token_totals_and_cost_detail(superuser_client):
 
 
 @pytest.mark.django_db()
+def test_includes_team_metadata(superuser_client, settings):
+    settings.TEAM_METADATA_FIELDS = [
+        {"key": "team_owner", "label": "Team Owner"},
+        {"key": "region", "label": "Region"},
+    ]
+    team = TeamFactory(name="Alpha", metadata={"team_owner": "Jia", "internal_only": "hidden"})
+    _trace(team, 100)
+
+    payload = superuser_client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE).json()
+
+    assert payload["metadata_fields"] == settings.TEAM_METADATA_FIELDS
+    alpha = {t["team_name"]: t for t in payload["teams"]}["Alpha"]
+    # Only configured fields are exposed; unconfigured keys stay hidden, missing ones blank.
+    assert alpha["metadata"] == {"team_owner": "Jia", "region": ""}
+
+
+@pytest.mark.django_db()
 def test_total_cost_keeps_currencies_separate(superuser_client):
     team = TeamFactory(name="Alpha")
     _trace(team, 100)


### PR DESCRIPTION
### Product Description
no change (superuser-only admin endpoint)

### Technical Description
Adds team metadata to the `/admin/api/provider-usage/` payload so external reporting (the spend-reconciliation sheet) can group/label teams by the same staff-only fields the CSV export already exposes.

Each team entry gains a `metadata` object containing the configured `TEAM_METADATA_FIELDS` (key → value, blank when unset); only configured fields are exposed, so unrelated keys in a team's raw metadata stay hidden. The field definitions are echoed once at the top level as `metadata_fields` so a consumer can build labelled columns without hardcoding them.

### Migrations
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update