### PR TITLE
Add type and options to team metadata fields

### DIFF
--- a/apps/admin/imports.py
+++ b/apps/admin/imports.py
@@ -2,6 +2,9 @@ import csv
 import io
 from dataclasses import dataclass, field
 
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+
 from apps.teams.metadata import get_team_metadata_fields
 from apps.teams.models import Team
 
@@ -40,13 +43,13 @@ def import_team_metadata_from_csv(uploaded_file) -> TeamMetadataImportResult:
     return result
 
 
-def _resolve_columns(fieldnames) -> tuple[dict[str, str], str | None]:
-    """Map present CSV headers to field keys, or return an error describing why we can't."""
+def _resolve_columns(fieldnames) -> tuple[dict[str, dict], str | None]:
+    """Map present CSV headers to their field definitions, or return an error describing why we can't."""
     if SLUG_COLUMN not in fieldnames:
         return {}, f"CSV must include a '{SLUG_COLUMN}' column."
 
-    label_to_key = {f["label"]: f["key"] for f in get_team_metadata_fields()}
-    present_fields = {header: label_to_key[header] for header in fieldnames if header in label_to_key}
+    fields_by_label = {f["label"]: f for f in get_team_metadata_fields()}
+    present_fields = {header: fields_by_label[header] for header in fieldnames if header in fields_by_label}
     if not present_fields:
         return {}, "CSV has no columns matching configured metadata fields."
     return present_fields, None
@@ -66,9 +69,37 @@ def _apply_row(line_number, row, present_fields, teams_by_slug) -> tuple[str | N
     if team is None:
         return None, f"Row {line_number}: no team with slug '{slug}'."
 
+    values = {}
+    for header, field_def in present_fields.items():
+        value = (row.get(header) or "").strip()
+        error = _validate_value(line_number, field_def, value)
+        if error:
+            return None, error
+        values[field_def["key"]] = value
+
     metadata = dict(team.metadata or {})
-    for header, key in present_fields.items():
-        metadata[key] = (row.get(header) or "").strip()
+    metadata.update(values)
     team.metadata = metadata
     team.save(update_fields=["metadata"])
     return slug, None
+
+
+def _validate_value(line_number, field_def, value) -> str | None:
+    """Return an error string for an invalid cell value, or None if it's acceptable.
+
+    Blank values are always allowed (they clear the field); non-blank values must satisfy
+    the field's ``type`` constraints.
+    """
+    if not value:
+        return None
+    field_type = field_def["type"]
+    label = field_def["label"]
+    if field_type == "select" and value not in field_def["options"]:
+        allowed = ", ".join(field_def["options"])
+        return f"Row {line_number}: '{value}' is not a valid option for '{label}' (expected one of: {allowed})."
+    if field_type == "email":
+        try:
+            validate_email(value)
+        except ValidationError:
+            return f"Row {line_number}: '{value}' is not a valid email for '{label}'."
+    return None

--- a/apps/admin/tests/test_provider_usage_api.py
+++ b/apps/admin/tests/test_provider_usage_api.py
@@ -104,7 +104,10 @@ def test_includes_team_metadata(superuser_client, settings):
 
     payload = superuser_client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE).json()
 
-    assert payload["metadata_fields"] == settings.TEAM_METADATA_FIELDS
+    assert payload["metadata_fields"] == [
+        {"key": "team_owner", "label": "Team Owner", "type": "text"},
+        {"key": "region", "label": "Region", "type": "text"},
+    ]
     alpha = {t["team_name"]: t for t in payload["teams"]}["Alpha"]
     # Only configured fields are exposed; unconfigured keys stay hidden, missing ones blank.
     assert alpha["metadata"] == {"team_owner": "Jia", "region": ""}

--- a/apps/admin/tests/test_team_metadata_import.py
+++ b/apps/admin/tests/test_team_metadata_import.py
@@ -64,14 +64,31 @@ class TestImportTeamMetadataFromCsv:
         assert result.updated == []
         assert "no columns matching" in result.errors[0]
 
-    def test_select_value_outside_options_is_rejected(self, settings):
-        settings.TEAM_METADATA_FIELDS = TIER_FIELDS
+    @pytest.mark.parametrize(
+        ("fields", "csv_content", "expected_error"),
+        [
+            pytest.param(
+                TIER_FIELDS,
+                "Slug,Tier\nteam-a,Enterprise\n",
+                "not a valid option for 'Tier'",
+                id="select-value-outside-options",
+            ),
+            pytest.param(
+                [{"key": "contact", "label": "Contact", "type": "email"}],
+                "Slug,Contact\nteam-a,not-an-email\n",
+                "not a valid email for 'Contact'",
+                id="invalid-email",
+            ),
+        ],
+    )
+    def test_invalid_value_is_rejected(self, settings, fields, csv_content, expected_error):
+        settings.TEAM_METADATA_FIELDS = fields
         team = TeamFactory.create(slug="team-a", metadata={})
 
-        result = import_team_metadata_from_csv(_csv("Slug,Tier\nteam-a,Enterprise\n"))
+        result = import_team_metadata_from_csv(_csv(csv_content))
 
         assert result.updated == []
-        assert "not a valid option for 'Tier'" in result.errors[0]
+        assert expected_error in result.errors[0]
         team.refresh_from_db()
         assert team.metadata == {}
 
@@ -84,17 +101,6 @@ class TestImportTeamMetadataFromCsv:
         assert result.updated == ["team-a"]
         team.refresh_from_db()
         assert team.metadata == {"tier": "Paid"}
-
-    def test_invalid_email_is_rejected(self, settings):
-        settings.TEAM_METADATA_FIELDS = [{"key": "contact", "label": "Contact", "type": "email"}]
-        team = TeamFactory.create(slug="team-a", metadata={})
-
-        result = import_team_metadata_from_csv(_csv("Slug,Contact\nteam-a,not-an-email\n"))
-
-        assert result.updated == []
-        assert "not a valid email for 'Contact'" in result.errors[0]
-        team.refresh_from_db()
-        assert team.metadata == {}
 
     def test_blank_value_clears_without_validation(self, settings):
         settings.TEAM_METADATA_FIELDS = TIER_FIELDS

--- a/apps/admin/tests/test_team_metadata_import.py
+++ b/apps/admin/tests/test_team_metadata_import.py
@@ -9,6 +9,7 @@ from apps.users.models import CustomUser
 from apps.utils.factories.team import TeamFactory
 
 METADATA_FIELDS = [{"key": "team_owner", "label": "Team Owner"}]
+TIER_FIELDS = [{"key": "tier", "label": "Tier", "type": "select", "options": ["Free", "Paid"]}]
 
 
 def _csv(content: str):
@@ -62,6 +63,48 @@ class TestImportTeamMetadataFromCsv:
 
         assert result.updated == []
         assert "no columns matching" in result.errors[0]
+
+    def test_select_value_outside_options_is_rejected(self, settings):
+        settings.TEAM_METADATA_FIELDS = TIER_FIELDS
+        team = TeamFactory.create(slug="team-a", metadata={})
+
+        result = import_team_metadata_from_csv(_csv("Slug,Tier\nteam-a,Enterprise\n"))
+
+        assert result.updated == []
+        assert "not a valid option for 'Tier'" in result.errors[0]
+        team.refresh_from_db()
+        assert team.metadata == {}
+
+    def test_valid_select_value_is_accepted(self, settings):
+        settings.TEAM_METADATA_FIELDS = TIER_FIELDS
+        team = TeamFactory.create(slug="team-a", metadata={})
+
+        result = import_team_metadata_from_csv(_csv("Slug,Tier\nteam-a,Paid\n"))
+
+        assert result.updated == ["team-a"]
+        team.refresh_from_db()
+        assert team.metadata == {"tier": "Paid"}
+
+    def test_invalid_email_is_rejected(self, settings):
+        settings.TEAM_METADATA_FIELDS = [{"key": "contact", "label": "Contact", "type": "email"}]
+        team = TeamFactory.create(slug="team-a", metadata={})
+
+        result = import_team_metadata_from_csv(_csv("Slug,Contact\nteam-a,not-an-email\n"))
+
+        assert result.updated == []
+        assert "not a valid email for 'Contact'" in result.errors[0]
+        team.refresh_from_db()
+        assert team.metadata == {}
+
+    def test_blank_value_clears_without_validation(self, settings):
+        settings.TEAM_METADATA_FIELDS = TIER_FIELDS
+        team = TeamFactory.create(slug="team-a", metadata={"tier": "Paid"})
+
+        result = import_team_metadata_from_csv(_csv("Slug,Tier\nteam-a,\n"))
+
+        assert result.updated == ["team-a"]
+        team.refresh_from_db()
+        assert team.metadata == {"tier": ""}
 
 
 @pytest.mark.django_db()

--- a/apps/teams/metadata.py
+++ b/apps/teams/metadata.py
@@ -1,13 +1,17 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
+FIELD_TYPES = ("text", "email", "select")
 
-def get_team_metadata_fields() -> list[dict[str, str]]:
+
+def get_team_metadata_fields() -> list[dict]:
     """Return the configured internal (staff-only) team metadata field definitions.
 
-    Each definition is a dict with non-empty ``key`` and ``label`` entries, configured via
-    the ``TEAM_METADATA_FIELDS`` setting. Raises ``ImproperlyConfigured`` for a malformed
-    setting so the failure surfaces on first use rather than deep in a request.
+    Each definition is a dict with non-empty ``key`` and ``label`` entries plus a ``type``
+    (one of ``text``, ``email`` or ``select``, defaulting to ``text``). ``select`` fields
+    additionally carry a non-empty ``options`` list of strings. Configured via the
+    ``TEAM_METADATA_FIELDS`` setting; raises ``ImproperlyConfigured`` for a malformed setting
+    so the failure surfaces on first use rather than deep in a request.
     """
     raw = settings.TEAM_METADATA_FIELDS
     if not isinstance(raw, list):
@@ -15,7 +19,7 @@ def get_team_metadata_fields() -> list[dict[str, str]]:
     return [_validated_field(index, item) for index, item in enumerate(raw)]
 
 
-def _validated_field(index: int, item) -> dict[str, str]:
+def _validated_field(index: int, item) -> dict:
     if not isinstance(item, dict):
         raise ImproperlyConfigured(f"TEAM_METADATA_FIELDS[{index}] must be an object with 'key' and 'label'.")
     field = {}
@@ -24,4 +28,21 @@ def _validated_field(index: int, item) -> dict[str, str]:
         if not isinstance(value, str) or not value:
             raise ImproperlyConfigured(f"TEAM_METADATA_FIELDS[{index}].{name} must be a non-empty string.")
         field[name] = value
+
+    field_type = item.get("type", "text")
+    if field_type not in FIELD_TYPES:
+        raise ImproperlyConfigured(f"TEAM_METADATA_FIELDS[{index}].type must be one of {', '.join(FIELD_TYPES)}.")
+    field["type"] = field_type
+
+    if field_type == "select":
+        field["options"] = _validated_options(index, item.get("options"))
     return field
+
+
+def _validated_options(index: int, options) -> list[str]:
+    if not isinstance(options, list) or not options:
+        raise ImproperlyConfigured(f"TEAM_METADATA_FIELDS[{index}].options must be a non-empty list for select fields.")
+    for option in options:
+        if not isinstance(option, str) or not option:
+            raise ImproperlyConfigured(f"TEAM_METADATA_FIELDS[{index}].options must contain non-empty strings.")
+    return options

--- a/apps/teams/tests/test_internal_metadata.py
+++ b/apps/teams/tests/test_internal_metadata.py
@@ -63,6 +63,33 @@ def test_staff_can_save_metadata(team, staff_member, settings):
 
 
 @pytest.mark.django_db()
+def test_email_field_rejects_invalid_address(team, staff_member, settings):
+    settings.TEAM_METADATA_FIELDS = [{"key": "contact", "label": "Contact", "type": "email"}]
+    client = Client()
+    client.force_login(staff_member)
+    response = client.post(_url(team), {"contact": "not-an-email"})
+    assert response.status_code == 200  # redisplays the form with errors
+    team.refresh_from_db()
+    assert team.metadata == {}
+
+
+@pytest.mark.django_db()
+def test_select_field_rejects_value_outside_options(team, staff_member, settings):
+    settings.TEAM_METADATA_FIELDS = [{"key": "tier", "label": "Tier", "type": "select", "options": ["Free", "Paid"]}]
+    client = Client()
+    client.force_login(staff_member)
+
+    response = client.post(_url(team), {"tier": "Enterprise"})
+    assert response.status_code == 200  # invalid choice redisplays the form
+    team.refresh_from_db()
+    assert team.metadata == {}
+
+    client.post(_url(team), {"tier": "Paid"}, follow=True)
+    team.refresh_from_db()
+    assert team.metadata == {"tier": "Paid"}
+
+
+@pytest.mark.django_db()
 def test_save_preserves_unconfigured_metadata(team, staff_member, settings):
     """Editing the configured fields must not drop metadata keys that aren't in settings."""
     settings.TEAM_METADATA_FIELDS = METADATA_FIELDS

--- a/apps/teams/tests/test_metadata.py
+++ b/apps/teams/tests/test_metadata.py
@@ -6,7 +6,19 @@ from apps.teams.metadata import get_team_metadata_fields
 
 def test_returns_normalized_fields(settings):
     settings.TEAM_METADATA_FIELDS = [{"key": "team_owner", "label": "Team Owner", "extra": "ignored"}]
-    assert get_team_metadata_fields() == [{"key": "team_owner", "label": "Team Owner"}]
+    assert get_team_metadata_fields() == [{"key": "team_owner", "label": "Team Owner", "type": "text"}]
+
+
+def test_email_field(settings):
+    settings.TEAM_METADATA_FIELDS = [{"key": "contact", "label": "Contact", "type": "email"}]
+    assert get_team_metadata_fields() == [{"key": "contact", "label": "Contact", "type": "email"}]
+
+
+def test_select_field(settings):
+    settings.TEAM_METADATA_FIELDS = [{"key": "tier", "label": "Tier", "type": "select", "options": ["Free", "Paid"]}]
+    assert get_team_metadata_fields() == [
+        {"key": "tier", "label": "Tier", "type": "select", "options": ["Free", "Paid"]}
+    ]
 
 
 @pytest.mark.parametrize(
@@ -16,6 +28,11 @@ def test_returns_normalized_fields(settings):
         pytest.param([{"key": "team_owner"}], id="missing-label"),
         pytest.param([{"key": "", "label": "Team Owner"}], id="empty-key"),
         pytest.param(["not-a-dict"], id="not-a-dict"),
+        pytest.param([{"key": "k", "label": "L", "type": "number"}], id="unknown-type"),
+        pytest.param([{"key": "k", "label": "L", "type": "select"}], id="select-missing-options"),
+        pytest.param([{"key": "k", "label": "L", "type": "select", "options": []}], id="select-empty-options"),
+        pytest.param([{"key": "k", "label": "L", "type": "select", "options": ["", "b"]}], id="select-empty-option"),
+        pytest.param([{"key": "k", "label": "L", "type": "select", "options": "abc"}], id="select-options-not-list"),
     ],
 )
 def test_rejects_malformed_setting(settings, bad_setting):

--- a/apps/teams/views/internal_metadata.py
+++ b/apps/teams/views/internal_metadata.py
@@ -8,6 +8,16 @@ from apps.teams.decorators import login_and_team_required
 from apps.teams.metadata import get_team_metadata_fields
 
 
+def _build_field(field: dict, initial: str) -> forms.Field:
+    field_type = field["type"]
+    if field_type == "select":
+        choices = [("", "---------")] + [(option, option) for option in field["options"]]
+        return forms.ChoiceField(label=field["label"], required=False, initial=initial, choices=choices)
+    if field_type == "email":
+        return forms.EmailField(label=field["label"], required=False, initial=initial)
+    return forms.CharField(label=field["label"], required=False, initial=initial)
+
+
 class TeamMetadataForm(forms.Form):
     """Form for editing a team's internal (staff-only) metadata."""
 
@@ -18,11 +28,7 @@ class TeamMetadataForm(forms.Form):
         metadata = self.team.metadata or {}
         for field in get_team_metadata_fields():
             key = field["key"]
-            self.fields[key] = forms.CharField(
-                label=field["label"],
-                required=False,
-                initial=metadata.get(key, ""),
-            )
+            self.fields[key] = _build_field(field, initial=metadata.get(key, ""))
 
     def save(self):
         metadata = dict(self.team.metadata or {})


### PR DESCRIPTION
### Product Description
Internal (staff-only) team metadata fields can now be configured as dropdowns (`select` with a fixed option list) or email fields, in addition to plain text. Values are validated both in the edit form and on CSV import.

### Technical Description
`TEAM_METADATA_FIELDS` entries gain an optional `type` (`text` default / `email` / `select`) and, for `select`, a required non-empty `options` list. Malformed config raises `ImproperlyConfigured` at first use, as before.

The edit form maps each type to the matching Django field (`EmailField` / `ChoiceField`), so validation is standard form validation. On CSV import, non-blank cells are checked against the field type — an out-of-range select value or bad email skips that row with a descriptive error rather than writing it; blank cells still clear the field without validation.

### Migrations
N/A — no schema change.

### Docs and Changelog
- [ ] This PR requires docs/changelog update