### PR TITLE
Usage API: sessions and participants metrics

### DIFF
--- a/api-schemas/v2.yml
+++ b/api-schemas/v2.yml
@@ -116,9 +116,10 @@ paths:
   /api/v2/usage/:
     get:
       operationId: usage
-      description: Return team-scoped usage data. Currently reports human, AI, and
-        total message counts for a calendar month, optionally narrowed to a single
-        participant.
+      description: 'Return team-scoped usage data for a calendar month. Each requested
+        metric gets its own block: ''messages'' (human/AI/total counts), ''sessions''
+        (count), and ''participants'' (distinct count). Optionally narrowed to a single
+        participant.'
       summary: Usage
       parameters:
       - in: query
@@ -128,8 +129,13 @@ paths:
           items:
             enum:
             - messages
+            - participants
+            - sessions
             type: string
-            description: '* `messages` - messages'
+            description: |-
+              * `messages` - messages
+              * `participants` - participants
+              * `sessions` - sessions
         description: Metrics to return; repeat the parameter for several.
         required: true
       - in: query
@@ -1421,6 +1427,13 @@ components:
       properties:
         messages:
           $ref: '#/components/schemas/MessageCounts'
+        sessions:
+          type: integer
+          description: Sessions started in the window, excluding evaluation-harness
+            and never-engaged sessions.
+        participants:
+          type: integer
+          description: Distinct participants active in the window.
   securitySchemes:
     OAuth2:
       type: oauth2

--- a/apps/api/v2/usage/serializers.py
+++ b/apps/api/v2/usage/serializers.py
@@ -22,6 +22,11 @@ class UsageResultsSerializer(serializers.Serializer):
     metrics it asked for."""
 
     messages = MessageCountsSerializer(required=False)
+    sessions = serializers.IntegerField(
+        required=False,
+        help_text="Sessions started in the window, excluding evaluation-harness and never-engaged sessions.",
+    )
+    participants = serializers.IntegerField(required=False, help_text="Distinct participants active in the window.")
 
 
 class UsageResponseSerializer(serializers.Serializer):

--- a/apps/api/v2/usage/services.py
+++ b/apps/api/v2/usage/services.py
@@ -1,9 +1,9 @@
 """Query orchestration for the usage API (``GET /api/v2/usage/``).
 
-This is the single place that turns validated query params into team-scoped aggregates. The first
-slice (#3848) supports the ``messages`` metric over a calendar month; later slices add sessions,
-participants, cost/tokens, explicit windows, granularity, and grouping without changing this
-contract. See ``docs/design/usage-api.md``.
+This is the single place that turns validated query params into team-scoped aggregates. It supports
+the ``messages``, ``sessions``, and ``participants`` metrics over a calendar month; later slices add
+cost/tokens, explicit windows, granularity, and grouping without changing this contract. See
+``docs/design/usage-api.md``.
 """
 
 from dataclasses import dataclass
@@ -12,15 +12,19 @@ from typing import TypedDict
 from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
-from django.db.models import Count, Q
+from django.db.models import Count, Q, QuerySet
 from django.utils import timezone
 
+from apps.channels.models import ChannelPlatform
 from apps.chat.models import ChatMessage, ChatMessageType
+from apps.experiments.models import ExperimentSession, SessionStatus
 from apps.teams.models import Team
 
 # Metric identifiers. Later slices extend SUPPORTED_METRICS; the param serializer validates against it.
 METRIC_MESSAGES = "messages"
-SUPPORTED_METRICS = frozenset({METRIC_MESSAGES})
+METRIC_SESSIONS = "sessions"
+METRIC_PARTICIPANTS = "participants"
+SUPPORTED_METRICS = frozenset({METRIC_MESSAGES, METRIC_SESSIONS, METRIC_PARTICIPANTS})
 
 # Calendar-month period selectors.
 PERIOD_CURRENT_MONTH = "current_month"
@@ -59,7 +63,50 @@ def usage_query(
     results: dict = {}
     if METRIC_MESSAGES in metrics:
         results[METRIC_MESSAGES] = _message_counts(team, start, end, participant, participant_identifier)
+    if METRIC_SESSIONS in metrics:
+        results[METRIC_SESSIONS] = _session_count(team, start, end, participant, participant_identifier)
+    if METRIC_PARTICIPANTS in metrics:
+        results[METRIC_PARTICIPANTS] = _active_participant_count(team, start, end, participant, participant_identifier)
     return UsageResult(period_start=start, period_end=end, timezone=str(tz), results=results)
+
+
+def _session_count(
+    team: Team,
+    start: datetime,
+    end: datetime,
+    participant: str | None,
+    participant_identifier: str | None,
+) -> int:
+    """Team-scoped ``ExperimentSession`` *started* (``created_at``) within the window. Evaluation-harness
+    sessions and sessions still in ``SETUP`` (created but never engaged) are excluded so the count
+    reflects real participant usage, matching the dashboard's session definition."""
+    queryset = (
+        ExperimentSession.objects.filter(team=team, created_at__gte=start, created_at__lt=end)
+        .exclude(platform=ChannelPlatform.EVALUATIONS)
+        .exclude(status=SessionStatus.SETUP)
+    )
+    if participant:
+        queryset = queryset.filter(participant__public_id=participant)
+    if participant_identifier:
+        queryset = queryset.filter(participant__identifier=participant_identifier)
+    return queryset.count()
+
+
+def _active_participant_count(
+    team: Team,
+    start: datetime,
+    end: datetime,
+    participant: str | None,
+    participant_identifier: str | None,
+) -> int:
+    """Distinct participants *active* in the window — those with at least one human/AI message in it.
+    Keyed off message activity (not session creation) so a participant active in a session started
+    earlier is still counted, and restricted to the same human/AI categories the ``messages`` metric
+    surfaces so the two metrics agree on who counts as active (internal ``system`` messages excluded)."""
+    queryset = _message_queryset(team, start, end, participant, participant_identifier).filter(
+        message_type__in=(ChatMessageType.HUMAN, ChatMessageType.AI)
+    )
+    return queryset.aggregate(n=Count("chat__experiment_session__participant", distinct=True))["n"]
 
 
 def _message_counts(
@@ -70,26 +117,34 @@ def _message_counts(
     participant_identifier: str | None,
 ) -> MessageCounts:
     """Human/AI/total message counts for the window. ``total`` is ``human + ai`` (the two surfaced
-    categories); system messages are internal and excluded so the parts always sum to the total.
-
-    ``ChatMessage`` has no direct team FK, so scope via ``chat__team``; the participant lives two
-    relations away, at ``chat__experiment_session__participant``. Backed by the
-    ``(chat, message_type, created_at)`` index.
-    """
-    queryset = ChatMessage.objects.filter(chat__team=team, created_at__gte=start, created_at__lt=end)
-    if participant:
-        queryset = queryset.filter(chat__experiment_session__participant__public_id=participant)
-    if participant_identifier:
-        queryset = queryset.filter(chat__experiment_session__participant__identifier=participant_identifier)
-
+    categories); system messages are internal and excluded so the parts always sum to the total."""
     # Filtered Count aggregates return 0 for no matches, never None.
-    counts = queryset.aggregate(
+    counts = _message_queryset(team, start, end, participant, participant_identifier).aggregate(
         human=Count("id", filter=Q(message_type=ChatMessageType.HUMAN)),
         ai=Count("id", filter=Q(message_type=ChatMessageType.AI)),
     )
     human = counts["human"]
     ai = counts["ai"]
     return MessageCounts(human=human, ai=ai, total=human + ai)
+
+
+def _message_queryset(
+    team: Team,
+    start: datetime,
+    end: datetime,
+    participant: str | None,
+    participant_identifier: str | None,
+) -> QuerySet[ChatMessage]:
+    """Team-scoped ``ChatMessage`` in the window. ``ChatMessage`` has no direct team FK, so scope via
+    ``chat__team``; the participant lives two relations away, at
+    ``chat__experiment_session__participant``. Backed by the ``(chat, message_type, created_at)`` index.
+    """
+    queryset = ChatMessage.objects.filter(chat__team=team, created_at__gte=start, created_at__lt=end)
+    if participant:
+        queryset = queryset.filter(chat__experiment_session__participant__public_id=participant)
+    if participant_identifier:
+        queryset = queryset.filter(chat__experiment_session__participant__identifier=participant_identifier)
+    return queryset
 
 
 def _month_bounds(period: str, tz: ZoneInfo) -> tuple[datetime, datetime]:

--- a/apps/api/v2/usage/tests/test_usage_sessions_participants.py
+++ b/apps/api/v2/usage/tests/test_usage_sessions_participants.py
@@ -1,0 +1,183 @@
+import pytest
+import time_machine
+from dateutil.relativedelta import relativedelta
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.channels.models import ChannelPlatform
+from apps.chat.models import ChatMessage, ChatMessageType
+from apps.experiments.models import ExperimentSession, SessionStatus
+from apps.utils.factories.experiment import ExperimentSessionFactory, ParticipantFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+from apps.utils.tests.clients import ApiTestClient
+
+USAGE_URL = "api:v2:usage"
+
+
+def _add_messages(session, *, human=0, ai=0, when=None):
+    kwargs = {"created_at": when} if when else {}
+    for message_type, count in ((ChatMessageType.HUMAN, human), (ChatMessageType.AI, ai)):
+        for _ in range(count):
+            ChatMessage.objects.create(chat=session.chat, message_type=message_type, content="x", **kwargs)
+
+
+@pytest.mark.django_db()
+def test_sessions_metric_counts_current_month_excluding_eval_and_setup():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    ExperimentSessionFactory.create_batch(3, team=team, status=SessionStatus.ACTIVE)
+    ExperimentSessionFactory.create(team=team, status=SessionStatus.SETUP)  # never engaged, excluded
+    ExperimentSessionFactory.create(
+        team=team, status=SessionStatus.ACTIVE, platform=ChannelPlatform.EVALUATIONS
+    )  # eval-harness session, excluded
+
+    client = ApiTestClient(user, team)
+    response = client.get(reverse(USAGE_URL), {"metric": "sessions"})
+
+    assert response.status_code == 200
+    assert response.json()["results"]["sessions"] == 3
+
+
+@pytest.mark.django_db()
+def test_participants_metric_counts_distinct_active():
+    """Two sessions share one participant, a third has its own; all have messages: 3 sessions, 2
+    distinct active participants."""
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    shared = ParticipantFactory.create(team=team)
+    _add_messages(ExperimentSessionFactory.create(team=team, participant=shared, status=SessionStatus.ACTIVE), human=1)
+    _add_messages(ExperimentSessionFactory.create(team=team, participant=shared, status=SessionStatus.ACTIVE), human=1)
+    _add_messages(ExperimentSessionFactory.create(team=team, status=SessionStatus.ACTIVE), human=1)
+
+    client = ApiTestClient(user, team)
+    response = client.get(reverse(USAGE_URL), {"metric": ["sessions", "participants"]})
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert results["sessions"] == 3
+    assert results["participants"] == 2
+
+
+@pytest.mark.django_db()
+def test_sessions_and_participants_use_different_windows():
+    """``sessions`` windows on session creation, ``participants`` on message activity, so the two can
+    diverge: a participant active this month in a session started last month counts for
+    ``participants`` but not ``sessions``, and vice versa."""
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    last_month = timezone.now() - relativedelta(months=1)
+
+    # Session started last month, but its participant sends a message this month → active now.
+    old_session = ExperimentSessionFactory.create(team=team, status=SessionStatus.ACTIVE)
+    ExperimentSession.objects.filter(pk=old_session.pk).update(created_at=last_month)
+    _add_messages(old_session, human=1)  # message defaults to now (this month)
+
+    # Session started this month, but its only activity was last month → not active now.
+    new_session = ExperimentSessionFactory.create(team=team, status=SessionStatus.ACTIVE)
+    _add_messages(new_session, human=1, when=last_month)
+
+    client = ApiTestClient(user, team)
+    response = client.get(reverse(USAGE_URL), {"metric": ["sessions", "participants"]})
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert results["sessions"] == 1  # only new_session was created in the window
+    assert results["participants"] == 1  # only old_session's participant was active in the window
+
+
+@pytest.mark.django_db()
+def test_participants_excludes_system_only_activity():
+    """A participant whose only message is an internal ``system`` message is not "active": the
+    ``participants`` metric counts the same human/AI categories the ``messages`` metric surfaces."""
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    session = ExperimentSessionFactory.create(team=team)
+    ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.SYSTEM, content="x")
+
+    client = ApiTestClient(user, team)
+    response = client.get(reverse(USAGE_URL), {"metric": ["messages", "participants"]})
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert results["messages"] == {"human": 0, "ai": 0, "total": 0}
+    assert results["participants"] == 0
+
+
+@pytest.mark.django_db()
+def test_multi_metric_response_has_one_block_each():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    session = ExperimentSessionFactory.create(team=team, status=SessionStatus.ACTIVE)
+    _add_messages(session, human=2, ai=1)
+
+    client = ApiTestClient(user, team)
+    response = client.get(
+        reverse(USAGE_URL),
+        {"metric": ["messages", "sessions", "participants"]},
+    )
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert results["messages"] == {"human": 2, "ai": 1, "total": 3}
+    assert results["sessions"] == 1
+    assert results["participants"] == 1
+
+
+@pytest.mark.django_db()
+def test_participant_filter_applies_to_new_metrics():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    target = ExperimentSessionFactory.create(team=team, status=SessionStatus.ACTIVE)
+    _add_messages(target, human=1)
+    _add_messages(
+        ExperimentSessionFactory.create(team=team, participant=target.participant, status=SessionStatus.ACTIVE),
+        human=1,
+    )
+    # different participant, excluded by the filter
+    _add_messages(ExperimentSessionFactory.create(team=team, status=SessionStatus.ACTIVE), human=1)
+
+    client = ApiTestClient(user, team)
+    response = client.get(
+        reverse(USAGE_URL),
+        {"metric": ["sessions", "participants"], "participant": str(target.participant.public_id)},
+    )
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert results["sessions"] == 2  # both of the target participant's sessions
+    assert results["participants"] == 1  # a participant filter narrows to a single participant
+
+
+@pytest.mark.django_db()
+def test_team_isolation():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    other_team = TeamWithUsersFactory.create()
+    ExperimentSessionFactory.create_batch(4, team=other_team, status=SessionStatus.ACTIVE)
+
+    client = ApiTestClient(user, team)
+    response = client.get(reverse(USAGE_URL), {"metric": ["sessions", "participants"]})
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert results["sessions"] == 0
+    assert results["participants"] == 0
+
+
+@pytest.mark.django_db()
+@time_machine.travel("2026-03-15T12:00:00+00:00")
+def test_period_filter_applies_to_sessions():
+    """``created_at`` is ``auto_now_add`` on ExperimentSession, so travel to each month to place the
+    sessions, then query. The current window must not include last month's sessions."""
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    with time_machine.travel("2026-02-10T12:00:00+00:00"):
+        ExperimentSessionFactory.create_batch(2, team=team, status=SessionStatus.ACTIVE)  # previous month
+    ExperimentSessionFactory.create(team=team, status=SessionStatus.ACTIVE)  # current month (March)
+
+    client = ApiTestClient(user, team)
+    current = client.get(reverse(USAGE_URL), {"metric": "sessions", "period": "current_month"}).json()
+    previous = client.get(reverse(USAGE_URL), {"metric": "sessions", "period": "previous_month"}).json()
+
+    assert current["results"]["sessions"] == 1
+    assert previous["results"]["sessions"] == 2

--- a/apps/api/v2/usage/views.py
+++ b/apps/api/v2/usage/views.py
@@ -13,8 +13,9 @@ from apps.oauth.permissions import TokenHasOAuthResourceScope
 class UsageView(APIView):
     # A comment, not a docstring: drf-spectacular would publish a docstring as the operation
     # description, and the per-operation description below is the client-facing one.
-    # Team-scoped usage inspection. Returns human/AI/total message counts for a calendar month,
-    # optionally narrowed to a single participant. See docs/design/usage-api.md.
+    # Team-scoped usage inspection. Returns message counts, session counts, and distinct participant
+    # counts for a calendar month, optionally narrowed to a single participant.
+    # See docs/design/usage-api.md.
 
     permission_classes = [IsAuthenticated, CanViewUsage, TokenHasOAuthResourceScope]
     required_scopes = ["usage"]
@@ -23,8 +24,9 @@ class UsageView(APIView):
         operation_id="usage",
         summary="Usage",
         description=(
-            "Return team-scoped usage data. Currently reports human, AI, and total message counts "
-            "for a calendar month, optionally narrowed to a single participant."
+            "Return team-scoped usage data for a calendar month. Each requested metric gets its own "
+            "block: 'messages' (human/AI/total counts), 'sessions' (count), and 'participants' "
+            "(distinct count). Optionally narrowed to a single participant."
         ),
         tags=["Usage"],
         # Query parameters are derived from the request serializer so the docs can't drift from validation.


### PR DESCRIPTION
Closes #3849. Third slice of the usage API (`GET /api/v2/usage/`); design in `docs/design/usage-api.md`.

### Product Description
`GET /api/v2/usage/` now serves two more activity metrics alongside `messages`: `sessions` and `participants`. Clients request any combination (`?metric=messages&metric=sessions&metric=participants`) and get one block per metric in a single call, over the same calendar-month window and participant filters.

### Technical Description
Two definition choices worth a look, both diverging from a naive count:

- **`sessions`** windows on `ExperimentSession.created_at`, but excludes evaluation-harness sessions and sessions still in `SETUP` (created but never engaged), so the count matches the dashboard's notion of a real session rather than counting eval runs and abandoned setups.
- **`participants`** is keyed off *message activity*, not session creation: distinct participants with a human/AI message in the window. This means a participant active this month in a session started earlier still counts, and it uses the same human/AI categories the `messages` metric surfaces (internal `system` messages excluded) so the two metrics agree on who was active.

The `metric` param stays a repeated query param (`MultipleChoiceField`), per the design's D2 — not the comma-list the issue text mentioned — so the OpenAPI enum-array schema is preserved. `services.py` shares one `_message_queryset` helper between `messages` and `participants` for identical scoping/windowing.

### Migrations
N/A — no schema changes.

### Docs and Changelog
- [ ] This PR requires docs/changelog update