### PR TITLE
feat: add v2 trigger_bot endpoint with structured channel response

### DIFF
--- a/api-schemas/v2.yml
+++ b/api-schemas/v2.yml
@@ -113,6 +113,121 @@ paths:
               schema:
                 $ref: '#/components/schemas/Me'
           description: ''
+  /api/v2/trigger_bot/:
+    post:
+      operationId: trigger_bot_message
+      description: |-
+        Trigger the bot to send a message to the user, or deliver a message directly.
+
+        Provide either ``prompt_text`` (routes through the LLM/bot pipeline) or ``message_text``
+        (sends the exact text to the participant without any LLM processing). Exactly one is required.
+
+        The response ``channel`` is an object of ``{platform, data}``; for CommCare Connect, ``data``
+        carries the ``external_channel_id`` of the session's Connect channel.
+      summary: Trigger the bot to send a message to the user, or deliver a message
+        directly
+      tags:
+      - Channels
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TriggerBotMessageRequest'
+            examples:
+              GenerateBotMessageAndSend:
+                value:
+                  identifier: '+15556793'
+                  experiment: exp1
+                  platform: whatsapp
+                  prompt_text: Tell the user to do something
+                  session_data:
+                    key: value
+                  participant_data:
+                    key: value
+                summary: Generates a bot message and sends it to the user (auto-creates
+                  participant if needed).
+              SendMessageDirectly:
+                value:
+                  identifier: '+15556793'
+                  experiment: exp1
+                  platform: whatsapp
+                  message_text: Your appointment is confirmed for tomorrow at 10am.
+                  session_data:
+                    key: value
+                  participant_data:
+                    key: value
+                summary: Send a pre-written message directly to the participant, bypassing
+                  the bot/LLM.
+              ExperimentChannelNotFound:
+                value:
+                  detail: Experiment cannot send messages on the connect_messaging
+                    channel
+                summary: Experiment cannot send messages on the specified channel
+              ConsentNotGiven:
+                value:
+                  detail: User has not given consent
+                summary: User has not given consent
+        required: true
+      security:
+      - OAuth2:
+        - chatbots:interact
+      - apiKeyAuth: []
+      - tokenAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TriggerBotMessageResponse'
+              examples:
+                GenerateBotMessageAndSend:
+                  value:
+                    identifier: '+15556793'
+                    experiment: exp1
+                    platform: whatsapp
+                    prompt_text: Tell the user to do something
+                    session_data:
+                      key: value
+                    participant_data:
+                      key: value
+                  summary: Generates a bot message and sends it to the user (auto-creates
+                    participant if needed).
+                SendMessageDirectly:
+                  value:
+                    identifier: '+15556793'
+                    experiment: exp1
+                    platform: whatsapp
+                    message_text: Your appointment is confirmed for tomorrow at 10am.
+                    session_data:
+                      key: value
+                    participant_data:
+                      key: value
+                  summary: Send a pre-written message directly to the participant,
+                    bypassing the bot/LLM.
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                description: Bad Request
+              examples:
+                ConsentNotGiven:
+                  value:
+                    detail: User has not given consent
+                  summary: User has not given consent
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                description: Not Found
+              examples:
+                ExperimentChannelNotFound:
+                  value:
+                    detail: Experiment cannot send messages on the connect_messaging
+                      channel
+                  summary: Experiment cannot send messages on the specified channel
+          description: ''
   /api/v2/usage/:
     get:
       operationId: usage
@@ -1385,6 +1500,89 @@ components:
       required:
       - name
       - slug
+    TriggerBotChannel:
+      type: object
+      description: |-
+        The channel a trigger_bot session runs on, plus any platform-specific data.
+
+        Unlike v1 (where ``channel`` is just the platform slug), v2 nests the platform under a dict so
+        platform-specific fields can live alongside it in ``data`` without widening the top-level shape.
+      properties:
+        platform:
+          type: string
+          description: Channel platform slug, e.g. 'commcare_connect'.
+        data:
+          type: object
+          additionalProperties: {}
+          description: Platform-specific channel data. For CommCare Connect this includes
+            'external_channel_id'; empty for platforms without extra channel data.
+      required:
+      - data
+      - platform
+    TriggerBotMessageRequest:
+      type: object
+      properties:
+        identifier:
+          type: string
+          title: Participant Identifier
+        platform:
+          allOf:
+          - $ref: '#/components/schemas/PlatformEnum'
+          title: Participant Platform
+        experiment:
+          type: string
+          format: uuid
+          title: Experiment ID
+        prompt_text:
+          type: string
+          nullable: true
+          title: Prompt to go to bot
+        message_text:
+          type: string
+          nullable: true
+          title: Message to send directly to participant (bypasses bot/LLM)
+        start_new_session:
+          type: boolean
+          default: false
+          title: Starts a new session
+        session_data:
+          type: object
+          additionalProperties: {}
+          description: Update session data. This will be merged with existing session
+            data
+        participant_data:
+          type: object
+          additionalProperties: {}
+          description: Update Participant data. This will be merged with existing
+            participant data
+      required:
+      - experiment
+      - identifier
+      - platform
+    TriggerBotMessageResponse:
+      type: object
+      properties:
+        session_id:
+          type: string
+          readOnly: true
+        url:
+          type: string
+          format: uri
+          example: https://example.com/api/sessions/123e4567-e89b-12d3-a456-426614174000/
+          readOnly: true
+        team:
+          allOf:
+          - $ref: '#/components/schemas/Team'
+          readOnly: true
+        channel:
+          allOf:
+          - $ref: '#/components/schemas/TriggerBotChannel'
+          readOnly: true
+      required:
+      - channel
+      - session_id
+      - team
+      - url
     UsagePeriod:
       type: object
       properties:
@@ -1458,6 +1656,8 @@ components:
       type: http
       scheme: bearer
 tags:
+- name: Channels
+  description: Trigger bot messages or deliver messages directly to users on a channel.
 - name: Chatbots
   description: List, retrieve and inspect chatbots (v2; formerly 'experiments').
 - name: Me

--- a/apps/api/v2/channels.py
+++ b/apps/api/v2/channels.py
@@ -1,0 +1,75 @@
+from django.db import transaction
+from drf_spectacular.utils import OpenApiExample, extend_schema
+from rest_framework.views import APIView
+
+from apps.api.serializers import TriggerBotMessageRequest
+from apps.api.v2.serializers import TriggerBotMessageResponse
+from apps.api.views.channels import handle_trigger_bot_message
+
+
+class TriggerBotMessageView(APIView):
+    required_scopes = ("chatbots:interact",)
+
+    @extend_schema(
+        operation_id="trigger_bot_message",
+        summary="Trigger the bot to send a message to the user, or deliver a message directly",
+        tags=["Channels"],
+        request=TriggerBotMessageRequest(),
+        responses={
+            200: TriggerBotMessageResponse,
+            400: {"description": "Bad Request"},
+            404: {"description": "Not Found"},
+        },
+        examples=[
+            OpenApiExample(
+                name="GenerateBotMessageAndSend",
+                summary="Generates a bot message and sends it to the user (auto-creates participant if needed).",
+                value={
+                    "identifier": "+15556793",
+                    "experiment": "exp1",
+                    "platform": "whatsapp",
+                    "prompt_text": "Tell the user to do something",
+                    "session_data": {"key": "value"},
+                    "participant_data": {"key": "value"},
+                },
+                status_codes=[200],
+            ),
+            OpenApiExample(
+                name="SendMessageDirectly",
+                summary="Send a pre-written message directly to the participant, bypassing the bot/LLM.",
+                value={
+                    "identifier": "+15556793",
+                    "experiment": "exp1",
+                    "platform": "whatsapp",
+                    "message_text": "Your appointment is confirmed for tomorrow at 10am.",
+                    "session_data": {"key": "value"},
+                    "participant_data": {"key": "value"},
+                },
+                status_codes=[200],
+            ),
+            OpenApiExample(
+                name="ExperimentChannelNotFound",
+                summary="Experiment cannot send messages on the specified channel",
+                value={"detail": "Experiment cannot send messages on the connect_messaging channel"},
+                status_codes=[404],
+            ),
+            OpenApiExample(
+                name="ConsentNotGiven",
+                summary="User has not given consent",
+                value={"detail": "User has not given consent"},
+                status_codes=[400],
+            ),
+        ],
+    )
+    @transaction.atomic
+    def post(self, request):
+        """
+        Trigger the bot to send a message to the user, or deliver a message directly.
+
+        Provide either ``prompt_text`` (routes through the LLM/bot pipeline) or ``message_text``
+        (sends the exact text to the participant without any LLM processing). Exactly one is required.
+
+        The response ``channel`` is an object of ``{platform, data}``; for CommCare Connect, ``data``
+        carries the ``external_channel_id`` of the session's Connect channel.
+        """
+        return handle_trigger_bot_message(request, TriggerBotMessageResponse)

--- a/apps/api/v2/serializers.py
+++ b/apps/api/v2/serializers.py
@@ -2,7 +2,8 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from apps.api.serializers import ApiUrlField, TeamSerializer
-from apps.experiments.models import Experiment
+from apps.channels.models import ChannelPlatform
+from apps.experiments.models import Experiment, ExperimentSession
 from apps.users.helpers import user_has_confirmed_email_address
 from apps.users.models import CustomUser
 
@@ -51,3 +52,46 @@ class MeSerializer(serializers.ModelSerializer):
     @extend_schema_field(serializers.BooleanField())
     def get_email_verified(self, obj):
         return user_has_confirmed_email_address(obj, obj.email)
+
+
+class TriggerBotChannelSerializer(serializers.Serializer):
+    """The channel a trigger_bot session runs on, plus any platform-specific data.
+
+    Unlike v1 (where ``channel`` is just the platform slug), v2 nests the platform under a dict so
+    platform-specific fields can live alongside it in ``data`` without widening the top-level shape.
+    """
+
+    platform = serializers.CharField(help_text="Channel platform slug, e.g. 'commcare_connect'.")
+    data = serializers.DictField(
+        help_text=(
+            "Platform-specific channel data. For CommCare Connect this includes "
+            "'external_channel_id'; empty for platforms without extra channel data."
+        )
+    )
+
+
+class TriggerBotMessageResponse(serializers.ModelSerializer):
+    session_id = serializers.ReadOnlyField(source="external_id")
+    url = ApiUrlField(
+        openapi_example="https://example.com/api/sessions/123e4567-e89b-12d3-a456-426614174000/",
+        view_name="api:session-detail",
+        lookup_field="external_id",
+        lookup_url_kwarg="id",
+    )
+    team = TeamSerializer(read_only=True)
+    channel = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ExperimentSession
+        fields = ["session_id", "url", "team", "channel"]
+
+    @extend_schema_field(TriggerBotChannelSerializer)
+    def get_channel(self, obj) -> dict:
+        data = {}
+        if obj.platform == ChannelPlatform.COMMCARE_CONNECT:
+            participant_data = self.context.get("participant_data")
+            if participant_data is not None:
+                external_channel_id = participant_data.system_metadata.get("commcare_connect_channel_id")
+                if external_channel_id:
+                    data["external_channel_id"] = external_channel_id
+        return {"platform": obj.platform, "data": data}

--- a/apps/api/v2/tests/test_trigger_bot_api.py
+++ b/apps/api/v2/tests/test_trigger_bot_api.py
@@ -1,0 +1,155 @@
+import json
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+from django.test import override_settings
+from django.urls import resolve, reverse
+
+from apps.channels.models import ChannelPlatform
+from apps.experiments.models import ExperimentSession, ParticipantData
+from apps.utils.factories.channels import ExperimentChannelFactory
+from apps.utils.factories.experiment import ExperimentFactory, ParticipantFactory
+from apps.utils.factories.service_provider_factories import LlmProviderFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+from apps.utils.tests.clients import ApiTestClient
+from apps.utils.tests.langchain import mock_llm
+
+
+@pytest.fixture()
+def experiment(db):
+    exp = ExperimentFactory.create(team=TeamWithUsersFactory.create())
+    LlmProviderFactory.create(team=exp.team)
+    return exp
+
+
+def _setup_connect_participant_data(experiment, connect_id, system_metadata, encryption_key=None):
+    participant = ParticipantFactory.create(
+        team=experiment.team, identifier=connect_id, platform=ChannelPlatform.COMMCARE_CONNECT
+    )
+    return ParticipantData.objects.create(
+        team=experiment.team,
+        participant=participant,
+        experiment=experiment,
+        system_metadata=system_metadata,
+        encryption_key=encryption_key or "",
+    )
+
+
+def test_trigger_bot_url_reverses():
+    assert reverse("api:v2:trigger_bot") == "/api/v2/trigger_bot/"
+
+
+def test_trigger_bot_url_resolves():
+    assert resolve("/api/v2/trigger_bot/").url_name == "trigger_bot"
+
+
+@pytest.mark.django_db()
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+@patch("apps.channels.connect_channel.CommCareConnectClient")
+@pytest.mark.parametrize("auth_method", ["api_key", "oauth"])
+def test_trigger_bot_returns_connect_channel_data(
+    ConnectClient, experiment, auth_method, django_capture_on_commit_callbacks
+):
+    """For a CommCare Connect channel, ``channel.data`` carries the Connect ``external_channel_id``."""
+    connect_id = uuid.uuid4().hex
+    commcare_connect_channel_id = uuid.uuid4().hex
+    encryption_key = os.urandom(32).hex()
+    participant_data = _setup_connect_participant_data(
+        experiment,
+        connect_id=connect_id,
+        system_metadata={"commcare_connect_channel_id": commcare_connect_channel_id, "consent": True},
+        encryption_key=encryption_key,
+    )
+    ExperimentChannelFactory.create(
+        team=experiment.team, experiment=experiment, platform=ChannelPlatform.COMMCARE_CONNECT
+    )
+
+    api_user = experiment.team.members.first()
+    client = ApiTestClient(api_user, experiment.team, auth_method=auth_method)
+    data = {
+        "identifier": connect_id,
+        "platform": ChannelPlatform.COMMCARE_CONNECT,
+        "experiment": str(experiment.public_id),
+        "prompt_text": "Tell the user to take a break",
+    }
+    url = reverse("api:v2:trigger_bot")
+    with mock_llm(["Time to take a break"]):
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(url, json.dumps(data), content_type="application/json")
+
+    assert response.status_code == 200
+    session = ExperimentSession.objects.get(participant=participant_data.participant, experiment=experiment)
+    response_data = response.json()
+    assert response_data["session_id"] == str(session.external_id)
+    assert response_data["team"] == {"name": experiment.team.name, "slug": experiment.team.slug}
+    assert f"/api/sessions/{session.external_id}/" in response_data["url"]
+    assert response_data["channel"] == {
+        "platform": ChannelPlatform.COMMCARE_CONNECT,
+        "data": {"external_channel_id": commcare_connect_channel_id},
+    }
+
+
+@pytest.mark.django_db()
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+def test_trigger_bot_non_connect_channel_has_empty_data(experiment, django_capture_on_commit_callbacks):
+    """Non-Connect platforms report an empty ``channel.data``."""
+    ExperimentChannelFactory.create(
+        team=experiment.team,
+        experiment=experiment,
+        platform=ChannelPlatform.EMAIL,
+        extra_data={"email_address": "bot@chat.openchatstudio.com"},
+    )
+
+    api_user = experiment.team.members.first()
+    client = ApiTestClient(api_user, experiment.team)
+    data = {
+        "identifier": "user@example.com",
+        "platform": ChannelPlatform.EMAIL,
+        "experiment": str(experiment.public_id),
+        "prompt_text": "Say hello",
+    }
+    url = reverse("api:v2:trigger_bot")
+    with mock_llm(["Hello from the bot"]):
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(url, json.dumps(data), content_type="application/json")
+
+    assert response.status_code == 200
+    assert response.json()["channel"] == {"platform": ChannelPlatform.EMAIL, "data": {}}
+
+
+@pytest.mark.django_db()
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+def test_trigger_bot_ignores_connect_metadata_on_non_connect_platform(experiment, django_capture_on_commit_callbacks):
+    """A stray ``commcare_connect_channel_id`` on a non-Connect participant must not leak into ``data``."""
+    identifier = "user@example.com"
+    participant = ParticipantFactory.create(team=experiment.team, identifier=identifier, platform=ChannelPlatform.EMAIL)
+    ParticipantData.objects.create(
+        team=experiment.team,
+        participant=participant,
+        experiment=experiment,
+        system_metadata={"commcare_connect_channel_id": "should-not-leak"},
+    )
+    ExperimentChannelFactory.create(
+        team=experiment.team,
+        experiment=experiment,
+        platform=ChannelPlatform.EMAIL,
+        extra_data={"email_address": "bot@chat.openchatstudio.com"},
+    )
+
+    api_user = experiment.team.members.first()
+    client = ApiTestClient(api_user, experiment.team)
+    data = {
+        "identifier": identifier,
+        "platform": ChannelPlatform.EMAIL,
+        "experiment": str(experiment.public_id),
+        "prompt_text": "Say hello",
+    }
+    url = reverse("api:v2:trigger_bot")
+    with mock_llm(["Hello"]):
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(url, json.dumps(data), content_type="application/json")
+
+    assert response.status_code == 200
+    assert response.json()["channel"] == {"platform": ChannelPlatform.EMAIL, "data": {}}

--- a/apps/api/v2/urls.py
+++ b/apps/api/v2/urls.py
@@ -2,6 +2,7 @@ from django.urls import include, path
 from rest_framework import routers
 
 from apps.api.v2 import views
+from apps.api.v2.channels import TriggerBotMessageView
 from apps.api.v2.usage.views import UsageView
 
 app_name = "v2"
@@ -14,5 +15,6 @@ router.register(r"chatbots", views.ChatbotViewSet, basename="chatbot")
 urlpatterns = [
     path("me/", views.MeView.as_view(), name="me"),
     path("usage/", UsageView.as_view(), name="usage"),
+    path("trigger_bot/", TriggerBotMessageView.as_view(), name="trigger_bot"),
     path("", include(router.urls)),
 ]

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -141,6 +141,63 @@ def _ensure_commcare_connect_ready(channel, identifier, participant_data):
     return None
 
 
+def handle_trigger_bot_message(request, response_serializer_class):
+    """Run the trigger-bot flow shared by all API versions and build the response.
+
+    Validates the request, resolves the experiment/channel, ensures CommCare Connect enrollment and
+    consent where relevant, creates or reuses the session, and dispatches the async bot-message task.
+    The session is then serialised with ``response_serializer_class`` (which differs per API version).
+
+    Returns the final response to hand back from the view: a 200 ``Response`` on success, or an error
+    response (bad channel, failed enrollment, missing consent) to return as-is.
+    """
+    serializer = TriggerBotMessageRequest(data=request.data)
+    serializer.is_valid(raise_exception=True)
+
+    data = serializer.data
+    platform = data["platform"]
+    identifier = ChannelPlatform(platform).normalize_identifier(data["identifier"])
+    # Propagate the normalized identifier so the async task uses a consistent value
+    data = dict(data)
+    data["identifier"] = identifier
+    experiment = get_object_or_404(Experiment, public_id=data["experiment"], team=request.team)
+
+    channel = ExperimentChannel.objects.filter(platform=platform, experiment=experiment).first()
+    if not channel:
+        return JsonResponse(
+            {"detail": f"Experiment cannot send messages on the {platform} channel. Create the channel first."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    participant_data = _get_or_create_participant_data(
+        request, identifier, platform, experiment, data.get("participant_data")
+    )
+
+    if platform == ChannelPlatform.COMMCARE_CONNECT:
+        if error := _ensure_commcare_connect_ready(channel, identifier, participant_data):
+            return error
+
+    target_experiment = resolve_published_or_working(experiment)
+    ChannelClass = get_channel_class_for_platform(platform)
+    bot_channel = ChannelClass(experiment=target_experiment, experiment_channel=channel)
+    with current_team(experiment.team):
+        bot_channel.ensure_session_exists_for_participant(identifier, new_session=data["start_new_session"])
+        session = bot_channel.experiment_session
+        assert session is not None
+        if data.get("session_data"):
+            session.state = {**session.state, **data["session_data"]}
+            session.save(update_fields=["state"])
+
+    trigger_bot_message_task.delay_on_commit(
+        str(session.external_id), data.get("prompt_text"), data.get("message_text")
+    )
+
+    response_serializer = response_serializer_class(
+        instance=session, context={"request": request, "participant_data": participant_data}
+    )
+    return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+
 class TriggerBotMessageView(APIView):
     required_scopes = ("chatbots:interact",)
 
@@ -203,46 +260,4 @@ class TriggerBotMessageView(APIView):
         Provide either ``prompt_text`` (routes through the LLM/bot pipeline) or ``message_text``
         (sends the exact text to the participant without any LLM processing). Exactly one is required.
         """
-        serializer = TriggerBotMessageRequest(data=request.data)
-        serializer.is_valid(raise_exception=True)
-
-        data = serializer.data
-        platform = data["platform"]
-        identifier = ChannelPlatform(platform).normalize_identifier(data["identifier"])
-        # Propagate the normalized identifier so the async task uses a consistent value
-        data = dict(data)
-        data["identifier"] = identifier
-        experiment = get_object_or_404(Experiment, public_id=data["experiment"], team=request.team)
-
-        channel = ExperimentChannel.objects.filter(platform=platform, experiment=experiment).first()
-        if not channel:
-            return JsonResponse(
-                {"detail": f"Experiment cannot send messages on the {platform} channel. Create the channel first."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        participant_data = _get_or_create_participant_data(
-            request, identifier, platform, experiment, data.get("participant_data")
-        )
-
-        if platform == ChannelPlatform.COMMCARE_CONNECT:
-            if error := _ensure_commcare_connect_ready(channel, identifier, participant_data):
-                return error
-
-        target_experiment = resolve_published_or_working(experiment)
-        ChannelClass = get_channel_class_for_platform(platform)
-        bot_channel = ChannelClass(experiment=target_experiment, experiment_channel=channel)
-        with current_team(experiment.team):
-            bot_channel.ensure_session_exists_for_participant(identifier, new_session=data["start_new_session"])
-            session = bot_channel.experiment_session
-            assert session is not None
-            if data.get("session_data"):
-                session.state = {**session.state, **data["session_data"]}
-                session.save(update_fields=["state"])
-
-        trigger_bot_message_task.delay_on_commit(
-            str(session.external_id), data.get("prompt_text"), data.get("message_text")
-        )
-
-        response_serializer = TriggerBotMessageResponse(instance=session, context={"request": request})
-        return Response(response_serializer.data, status=status.HTTP_200_OK)
+        return handle_trigger_bot_message(request, TriggerBotMessageResponse)


### PR DESCRIPTION
### Product Description
Adds a **v2 trigger_bot endpoint** (`POST /api/v2/trigger_bot/`) whose response models the channel as a structured object rather than a bare platform slug. This lets CommCare Connect identify the specific Connect channel used for a given bot session — the Connect channel id is returned under `channel.data.external_channel_id` — while leaving room for other platforms to attach their own channel data in future without changing the top-level response shape.

### Technical Description
- **v2 `channel` shape.** v2 returns `channel` as `{platform, data}` instead of a plain string. For CommCare Connect, `data` contains `external_channel_id` (read from `participant_data.system_metadata["commcare_connect_channel_id"]`); for other platforms `data` is `{}`. The Connect lookup is gated on the session platform, so non-Connect responses never include it.
- **Shared flow, no duplication.** The trigger-bot request handling in `apps/api/views/channels.py` is extracted into `handle_trigger_bot_message(request, response_serializer_class)`. The v1 view delegates to it (v1 response byte-for-byte unchanged), and the new v2 view reuses it with the v2 serializer.
- **New v2 surface.** `apps/api/v2/channels.py` (view) and `apps/api/v2/serializers.py` (`TriggerBotMessageResponse` + `TriggerBotChannelSerializer`), wired at `POST /api/v2/trigger_bot/` in `apps/api/v2/urls.py`.
- Regenerated `api-schemas/v2.yml` via `inv schema` (v1 schema unchanged).
- Test coverage in `apps/api/v2/tests/test_trigger_bot_api.py` for the Connect, non-Connect, and stray-metadata-on-non-Connect cases.

v1 (`/api/trigger_bot`) is unchanged and remains frozen.

Closes #3878

### Migrations
- [ ] The migrations are backwards compatible

N/A — no migrations in this change.

### Demo
`POST /api/v2/trigger_bot/` for a CommCare Connect channel now returns e.g.:
```json
{
  "session_id": "...",
  "url": "...",
  "team": {...},
  "channel": {
    "platform": "commcare_connect",
    "data": {"external_channel_id": "7d6a-fdc93-4e9c"}
  }
}
```
For other platforms, `channel.data` is `{}`.

### Docs and Changelog
- [ ] This PR requires docs/changelog update
