### PR TITLE
Drop use_session_token field from chat widget

### DIFF
--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -582,7 +582,6 @@ export class OcsChat {
 
       const requestBody: Record<string, unknown> = {
         chatbot_id: this.chatbotId,
-        use_session_token: true,
         session_data: {
           source: 'widget',
           page_url: window.location.href,

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat_session_handling.spec.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat_session_handling.spec.tsx
@@ -840,7 +840,6 @@ describe('ocs-chat session tokens', () => {
 
     const startCall = (global.fetch as jest.Mock).mock.calls.find(call => call[0].includes('/api/chat/start/'));
     expect(startCall).toBeDefined();
-    expect(JSON.parse(startCall[1].body)).toEqual(expect.objectContaining({ use_session_token: true }));
     expect(setSessionTokenSpy).toHaveBeenCalledWith('tok-1');
     expect(window.localStorage.setItem).toHaveBeenCalledWith('ocs-chat-token-test-bot', 'tok-1');
   });


### PR DESCRIPTION
### Product Description
### Technical Description
Widget no longer sends `use_session_token` in the `/api/chat/start/` request. Server-side default behavior applies when the field is absent — confirm that matches the intended `true` behavior before merging.

### Migrations
N/A

### Demo
### Docs and Changelog
- [ ] This PR requires docs/changelog update