### PR TITLE
bump timeout for restricted http client

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1046,7 +1046,7 @@ RESERVED_SESSION_STATE_KEYS = {"user_input", "outputs", "attachments", "remote_c
 # Restricted HTTP client settings (used by RestrictedHttpClient in the Python sandbox)
 RESTRICTED_HTTP_MAX_REQUESTS = 10
 RESTRICTED_HTTP_DEFAULT_TIMEOUT = 5  # seconds
-RESTRICTED_HTTP_MAX_TIMEOUT = 30  # seconds
+RESTRICTED_HTTP_MAX_TIMEOUT = 60  # seconds
 MB = 1_048_576  # 1 MB
 RESTRICTED_HTTP_MAX_RESPONSE_BYTES = 5 * MB
 RESTRICTED_HTTP_MAX_REQUEST_BYTES = MB


### PR DESCRIPTION
### Product Description
Increase the maximum allowed timeout for requests from the restricted http client from 30s to 60s.

### Technical Description
Small settings change.


### Docs and Changelog
- [x] This PR requires docs/changelog update
