### PR TITLE
fix: allow git deps for widget publish on npm 12

### DIFF
--- a/components/chat_widget/.npmrc
+++ b/components/chat_widget/.npmrc
@@ -1,0 +1,4 @@
+# stencil-tailwind-plugin pulls postcss-combine-duplicated-selectors from a git
+# fork (transitive). npm >=12 defaults allow-git=none, which blocks this and
+# fails `npm ci`. Re-enable git dependency fetching.
+allow-git=all


### PR DESCRIPTION
### Product Description
N/A

### Technical Description
The `publish_widget` workflow upgrades to `npm@latest` (now npm 12), which changed a security default to `allow-git=none` — blocking *any* git-referenced dependency. `stencil-tailwind-plugin` transitively pulls `postcss-combine-duplicated-selectors` from a git fork, so `npm ci` fails with `EALLOWGIT` ("Refusing to fetch …").

Fix: commit a `.npmrc` in the widget dir with `allow-git=all`. Committing it (rather than passing a CLI flag in the workflow) also fixes local `npm ci` for anyone on npm 12 and documents the reason.

The `git+ssh://` in the error is a red herring — npm auto-falls-back to anonymous https for github-hosted deps, verified with ssh disabled. So no lockfile change is needed.

Not addressed here: the underlying reliance on the unversioned `poimen/…` fork, which comes from `stencil-tailwind-plugin` upstream.

### Migrations
- [x] The migrations are backwards compatible

N/A — no migrations.

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update