### PR TITLE
chore: upgrade open-chat-studio-widget to 0.11.0

### DIFF
--- a/apps/channels/migrations/0031_notify_widget_version_release_0_11_0.py
+++ b/apps/channels/migrations/0031_notify_widget_version_release_0_11_0.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+from apps.data_migrations.utils.migrations import RunDataMigration
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bot_channels", "0030_widget_auth_level_ratchet_fields"),
+        ("data_migrations", "0001_initial"),
+        ("teams", "0012_team_metadata"),
+    ]
+
+    operations = [
+        # Announce the 0.11.0 widget release to every team with an embedded-widget
+        # channel. force=True because the command's run-once slug is fixed; Django
+        # tracks this migration's single run. See docs/developer_guides/widget_versioning.md
+        RunDataMigration(
+            "notify_widget_version_release",
+            command_options={
+                "force": True,
+                "widget_version": "0.11.0",
+                "notes": (
+                    "Maintenance release: removes the deprecated use_session_token request field. "
+                    "Session token behaviour is now fully governed by the channel's auth level — no widget changes required."
+                ),
+            },
+        ),
+    ]

--- a/apps/channels/migrations/0031_notify_widget_version_release_0_11_0.py
+++ b/apps/channels/migrations/0031_notify_widget_version_release_0_11_0.py
@@ -19,9 +19,12 @@ class Migration(migrations.Migration):
             command_options={
                 "force": True,
                 "widget_version": "0.11.0",
+                "changelog_url": "https://docs.openchatstudio.com/chat_widget/changelog/#v0110-2026-07-23",
                 "notes": (
-                    "Maintenance release: removes the deprecated use_session_token request field. "
-                    "Session token behaviour is now fully governed by the channel's auth level — no widget changes required."
+                    "New: disabled mode puts the widget into read-only — history stays visible but the "
+                    "composer, send controls, and starter questions are hidden. "
+                    "New: configurable banner (banner-message, banner-style, banner-position) for "
+                    "always-visible notices, usable on its own or alongside disabled."
                 ),
             },
         ),

--- a/apps/channels/widget_versions.py
+++ b/apps/channels/widget_versions.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.utils.http import http_date
 from packaging.version import InvalidVersion, Version
 
-LATEST_VERSION = "0.10.0"
+LATEST_VERSION = "0.11.0"
 
 # Widgets older than 0.5.1 (Sept 2025) do not send the x-ocs-widget-version
 # header, so a missing/unparseable version is treated as older than everything.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "js-cookie": "^3.0.8",
         "js-tiktoken": "^1.0.21",
         "lodash": "^4.17.23",
-        "open-chat-studio-widget": "^0.10.0",
+        "open-chat-studio-widget": "^0.11.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-error-boundary": "^6.1.2",
@@ -3260,9 +3260,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3278,9 +3275,6 @@
       "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3298,9 +3292,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3316,9 +3307,6 @@
       "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8399,9 +8387,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8421,9 +8406,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -8445,9 +8427,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8467,9 +8446,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -9074,9 +9050,9 @@
       }
     },
     "node_modules/open-chat-studio-widget": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/open-chat-studio-widget/-/open-chat-studio-widget-0.10.0.tgz",
-      "integrity": "sha512-BVPxwH39aQULpH170CQdI2B97a/RyVScNNT12twvtDKquyvdoFB8UcoF8Ib9FwXJjjC2njdEuanC8BLMtHxjPg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/open-chat-studio-widget/-/open-chat-studio-widget-0.11.0.tgz",
+      "integrity": "sha512-eifYu/Hyinup5Zk0oSn2x+Fx4/ZWvICDKtyQH3aLKe1lK4MVD8s2xd0M+I15TlsyfBuarvNeOxpEAgssmZM4zA==",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.27.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "js-cookie": "^3.0.8",
     "js-tiktoken": "^1.0.21",
     "lodash": "^4.17.23",
-    "open-chat-studio-widget": "^0.10.0",
+    "open-chat-studio-widget": "^0.11.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-error-boundary": "^6.1.2",


### PR DESCRIPTION
Upgrades the `open-chat-studio-widget` npm package from `0.10.0` → `0.11.0`, following the process in `docs/developer_guides/widget_versioning.md`.

## Changes

**Widget source** (already published to npm by Simon in fc63925):

- **Read-only / disabled mode** — new `disabled` attribute puts the widget into read-only mode: chat history stays visible and scrollable, but the message composer and send controls are disabled, sending is blocked, and starter questions are hidden.
- **Configurable banner** — new `banner-message` attribute shows an always-visible notice. Style it with `banner-style` (`default` / `info` / `warning` / `error`) and position it with `banner-position` (`top` / `bottom`). Works on its own or alongside `disabled`.

**This PR:**
- `package.json` / `package-lock.json`: consume the published 0.11.0 from npm
- `apps/channels/widget_versions.py`: bump `LATEST_VERSION` to `0.11.0` (update-available badges follow automatically)
- `apps/channels/migrations/0031_notify_widget_version_release_0_11_0.py`: notify teams with embedded-widget channels of the new release on deploy

## Testing
```
python manage.py notify_widget_version_release --dry-run --widget-version 0.11.0
```