### PR TITLE
Notify admins of upcoming OpenAI Assistants removal

### DIFF
--- a/apps/assistants/migrations/0015_notify_openai_assistant_removal.py
+++ b/apps/assistants/migrations/0015_notify_openai_assistant_removal.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+from apps.data_migrations.utils.migrations import RunDataMigration
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("assistants", "0014_alter_toolresources_extra"),
+        ("data_migrations", "0001_initial"),
+        ("teams", "0014_team_is_migrating"),
+    ]
+
+    operations = [
+        # Email team admins about the upcoming OpenAI Assistants API removal.
+        # force=True because the command's run-once slug is fixed; Django tracks this migration's single run.
+        RunDataMigration(
+            "notify_openai_assistant_removal",
+            command_options={"force": True},
+        ),
+    ]

--- a/apps/data_migrations/management/commands/notify_openai_assistant_removal.py
+++ b/apps/data_migrations/management/commands/notify_openai_assistant_removal.py
@@ -1,0 +1,77 @@
+from collections import defaultdict
+
+from apps.assistants.models import OpenAiAssistant
+from apps.data_migrations.management.commands.base import IdempotentCommand
+from apps.teams.email import collect_team_admin_emails, send_bulk_team_admin_emails
+from apps.teams.models import Team
+
+REMOVAL_DATE = "26 August 2026"
+
+
+class Command(IdempotentCommand):
+    help = "Notify team admins about the upcoming removal of OpenAI Assistants"
+    migration_name = "notify_openai_assistant_removal_2026_07_23"
+    disable_audit = True
+
+    def perform_migration(self, dry_run=False):
+        # Only working, non-archived assistants count as "in use" (working_versions_queryset filters both).
+        # A list (not a set) so that distinct assistants sharing a name are each counted and listed.
+        teams_data = defaultdict(list)
+        for assistant in OpenAiAssistant.objects.working_versions_queryset():
+            teams_data[assistant.team_id].append(assistant.name)
+
+        if not teams_data:
+            self.stdout.write(self.style.SUCCESS("No OpenAI Assistants found"))
+            return
+
+        teams_context = {}
+        for team_id, names in teams_data.items():
+            assistant_names = sorted(names)
+            teams_context[team_id] = {
+                "assistant_names": assistant_names,
+                "assistant_count": len(assistant_names),
+                "removal_date": REMOVAL_DATE,
+            }
+
+        total_teams = len(teams_context)
+        total_assistants = sum(len(names) for names in teams_data.values())
+
+        if self.verbosity > 1:
+            teams = {t.id: t for t in Team.objects.filter(id__in=teams_context.keys())}
+            self.stdout.write(f"\nFound {total_assistants} OpenAI Assistants affecting {total_teams} teams:")
+            for team_id, context in teams_context.items():
+                team = teams[team_id]
+                admin_emails = collect_team_admin_emails(team)
+                self.stdout.write(f"\n  Team: {team.name} (slug: {team.slug})")
+                self.stdout.write(f"    Affected assistants ({context['assistant_count']}):")
+                for name in context["assistant_names"]:
+                    self.stdout.write(f"      - {name}")
+                self.stdout.write(f"    Will notify {len(admin_emails)} admin(s): {', '.join(admin_emails)}")
+        else:
+            self.stdout.write(f"Found {total_assistants} OpenAI Assistants affecting {total_teams} teams")
+
+        if dry_run:
+            return f"Would notify {total_teams} team(s)"
+
+        results = send_bulk_team_admin_emails(
+            teams_context=teams_context,
+            subject_template="Open Chat Studio: OpenAI Assistants removal for {{ team.name }}",
+            body_template_path="events/email/openai_assistant_removal.txt",
+            fail_silently=False,
+        )
+
+        if self.verbosity > 1:
+            self.stdout.write("\nEmail results:")
+            self.stdout.write(f"  Sent: {results['sent']}")
+            self.stdout.write(f"  No admins: {results['no_admins']}")
+            self.stdout.write(f"  Failed: {results['failed']}")
+            for error in results["errors"]:
+                self.stdout.write(self.style.ERROR(f"  Error: {error}"))
+        else:
+            self.stdout.write(f"Sent {results['sent']} email(s)")
+            if results["failed"] > 0:
+                self.stdout.write(self.style.WARNING(f"{results['failed']} email(s) failed"))
+            for error in results["errors"]:
+                self.stdout.write(self.style.ERROR(f"  {error}"))
+
+        return f"Notified {results['sent']} team(s)"

--- a/apps/data_migrations/management/commands/notify_openai_assistant_removal.py
+++ b/apps/data_migrations/management/commands/notify_openai_assistant_removal.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+from django.core.management.base import CommandError
+
 from apps.assistants.models import OpenAiAssistant
 from apps.data_migrations.management.commands.base import IdempotentCommand
 from apps.teams.email import collect_team_admin_emails, send_bulk_team_admin_emails
@@ -14,41 +16,14 @@ class Command(IdempotentCommand):
     disable_audit = True
 
     def perform_migration(self, dry_run=False):
-        # Only working, non-archived assistants count as "in use" (working_versions_queryset filters both).
-        # A list (not a set) so that distinct assistants sharing a name are each counted and listed.
-        teams_data = defaultdict(list)
-        for assistant in OpenAiAssistant.objects.working_versions_queryset():
-            teams_data[assistant.team_id].append(assistant.name)
-
-        if not teams_data:
+        teams_context = self._build_teams_context()
+        if not teams_context:
             self.stdout.write(self.style.SUCCESS("No OpenAI Assistants found"))
             return
 
-        teams_context = {}
-        for team_id, names in teams_data.items():
-            assistant_names = sorted(names)
-            teams_context[team_id] = {
-                "assistant_names": assistant_names,
-                "assistant_count": len(assistant_names),
-                "removal_date": REMOVAL_DATE,
-            }
-
         total_teams = len(teams_context)
-        total_assistants = sum(len(names) for names in teams_data.values())
-
-        if self.verbosity > 1:
-            teams = {t.id: t for t in Team.objects.filter(id__in=teams_context.keys())}
-            self.stdout.write(f"\nFound {total_assistants} OpenAI Assistants affecting {total_teams} teams:")
-            for team_id, context in teams_context.items():
-                team = teams[team_id]
-                admin_emails = collect_team_admin_emails(team)
-                self.stdout.write(f"\n  Team: {team.name} (slug: {team.slug})")
-                self.stdout.write(f"    Affected assistants ({context['assistant_count']}):")
-                for name in context["assistant_names"]:
-                    self.stdout.write(f"      - {name}")
-                self.stdout.write(f"    Will notify {len(admin_emails)} admin(s): {', '.join(admin_emails)}")
-        else:
-            self.stdout.write(f"Found {total_assistants} OpenAI Assistants affecting {total_teams} teams")
+        total_assistants = sum(context["assistant_count"] for context in teams_context.values())
+        self._report_preview(teams_context, total_teams, total_assistants)
 
         if dry_run:
             return f"Would notify {total_teams} team(s)"
@@ -59,19 +34,56 @@ class Command(IdempotentCommand):
             body_template_path="events/email/openai_assistant_removal.txt",
             fail_silently=False,
         )
+        self._report_results(results)
 
+        if results["failed"]:
+            # Fail loudly so IdempotentCommand does not mark this run applied; otherwise the
+            # teams whose emails failed would never be notified. A re-run resends to all teams.
+            raise CommandError(f"{results['failed']} notification email(s) failed")
+
+        return f"Notified {results['sent']} team(s)"
+
+    def _build_teams_context(self):
+        # Only working, non-archived assistants count as "in use" (working_versions_queryset filters both).
+        # A list (not a set) so that distinct assistants sharing a name are each counted and listed.
+        teams_data = defaultdict(list)
+        for assistant in OpenAiAssistant.objects.working_versions_queryset():
+            teams_data[assistant.team_id].append(assistant.name)
+
+        return {
+            team_id: {
+                "assistant_names": sorted(names),
+                "assistant_count": len(names),
+                "removal_date": REMOVAL_DATE,
+            }
+            for team_id, names in teams_data.items()
+        }
+
+    def _report_preview(self, teams_context, total_teams, total_assistants):
+        if self.verbosity <= 1:
+            self.stdout.write(f"Found {total_assistants} OpenAI Assistants affecting {total_teams} teams")
+            return
+
+        teams = {t.id: t for t in Team.objects.filter(id__in=teams_context.keys())}
+        self.stdout.write(f"\nFound {total_assistants} OpenAI Assistants affecting {total_teams} teams:")
+        for team_id, context in teams_context.items():
+            team = teams[team_id]
+            admin_count = len(collect_team_admin_emails(team))
+            self.stdout.write(f"\n  Team: {team.name} (slug: {team.slug})")
+            self.stdout.write(f"    Affected assistants ({context['assistant_count']}):")
+            for name in context["assistant_names"]:
+                self.stdout.write(f"      - {name}")
+            self.stdout.write(f"    Will notify {admin_count} admin(s)")
+
+    def _report_results(self, results):
         if self.verbosity > 1:
             self.stdout.write("\nEmail results:")
             self.stdout.write(f"  Sent: {results['sent']}")
             self.stdout.write(f"  No admins: {results['no_admins']}")
             self.stdout.write(f"  Failed: {results['failed']}")
-            for error in results["errors"]:
-                self.stdout.write(self.style.ERROR(f"  Error: {error}"))
         else:
             self.stdout.write(f"Sent {results['sent']} email(s)")
             if results["failed"] > 0:
                 self.stdout.write(self.style.WARNING(f"{results['failed']} email(s) failed"))
-            for error in results["errors"]:
-                self.stdout.write(self.style.ERROR(f"  {error}"))
-
-        return f"Notified {results['sent']} team(s)"
+        for error in results["errors"]:
+            self.stdout.write(self.style.ERROR(f"  {error}"))

--- a/apps/data_migrations/tests/test_notify_openai_assistant_removal.py
+++ b/apps/data_migrations/tests/test_notify_openai_assistant_removal.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 import pytest
 from django.core import mail
 from django.core.management import call_command
+from django.core.management.base import CommandError
 
 from apps.utils.factories.assistants import OpenAiAssistantFactory
 
@@ -49,10 +52,23 @@ class TestNotifyOpenAiAssistantRemovalCommand:
 
     def test_archived_and_versioned_assistants_excluded(self, team_with_users):
         """Archived assistants and published version snapshots do not trigger a notification."""
-        OpenAiAssistantFactory(team=team_with_users, is_archived=True)
-        working = OpenAiAssistantFactory(team=team_with_users)
-        OpenAiAssistantFactory(team=team_with_users, working_version=working)
+        OpenAiAssistantFactory(team=team_with_users, name="Archived Bot", is_archived=True)
+        working = OpenAiAssistantFactory(team=team_with_users, name="Working Bot")
+        OpenAiAssistantFactory(team=team_with_users, name="Versioned Bot", working_version=working)
 
         call_command("notify_openai_assistant_removal", force=True)
 
         assert len(mail.outbox) == 1
+        body = mail.outbox[0].body
+        assert "Working Bot" in body
+        assert "Archived Bot" not in body
+        assert "Versioned Bot" not in body
+
+    @patch("apps.data_migrations.management.commands.notify_openai_assistant_removal.send_bulk_team_admin_emails")
+    def test_failed_delivery_raises(self, mock_send, team_with_users):
+        """A delivery failure raises so run_once does not record the migration as applied."""
+        mock_send.return_value = {"sent": 0, "failed": 1, "no_admins": 0, "errors": ["boom"]}
+        OpenAiAssistantFactory(team=team_with_users)
+
+        with pytest.raises(CommandError):
+            call_command("notify_openai_assistant_removal", force=True)

--- a/apps/data_migrations/tests/test_notify_openai_assistant_removal.py
+++ b/apps/data_migrations/tests/test_notify_openai_assistant_removal.py
@@ -1,0 +1,58 @@
+import pytest
+from django.core import mail
+from django.core.management import call_command
+
+from apps.utils.factories.assistants import OpenAiAssistantFactory
+
+
+def _team_admin_email(team):
+    return next(m.user.email for m in team.membership_set.all() if m.is_team_admin())
+
+
+@pytest.mark.django_db()
+class TestNotifyOpenAiAssistantRemovalCommand:
+    def test_no_assistants(self, capsys):
+        """If no assistants exist, nothing is sent."""
+        call_command("notify_openai_assistant_removal", force=True)
+        assert "No OpenAI Assistants found" in capsys.readouterr().out
+        assert len(mail.outbox) == 0
+
+    def test_notifies_team_admins(self, team_with_users):
+        """Admins of teams with a working assistant receive an email listing it."""
+        assistant = OpenAiAssistantFactory(team=team_with_users, name="My Assistant")
+
+        call_command("notify_openai_assistant_removal", force=True)
+
+        assert len(mail.outbox) == 1
+        email = mail.outbox[0]
+        assert email.to == [_team_admin_email(team_with_users)]
+        assert team_with_users.name in email.subject
+        assert assistant.name in email.body
+        assert "26 August 2026" in email.body
+
+    def test_assistant_names_not_html_escaped(self, team_with_users):
+        """Plain-text email must render special characters literally, not as HTML entities."""
+        OpenAiAssistantFactory(team=team_with_users, name="Bob's & Co <Bot>")
+
+        call_command("notify_openai_assistant_removal", force=True)
+
+        assert len(mail.outbox) == 1
+        assert "Bob's & Co <Bot>" in mail.outbox[0].body
+
+    def test_dry_run_does_not_send(self, team_with_users):
+        """Dry run previews without sending email."""
+        OpenAiAssistantFactory(team=team_with_users)
+
+        call_command("notify_openai_assistant_removal", dry_run=True)
+
+        assert len(mail.outbox) == 0
+
+    def test_archived_and_versioned_assistants_excluded(self, team_with_users):
+        """Archived assistants and published version snapshots do not trigger a notification."""
+        OpenAiAssistantFactory(team=team_with_users, is_archived=True)
+        working = OpenAiAssistantFactory(team=team_with_users)
+        OpenAiAssistantFactory(team=team_with_users, working_version=working)
+
+        call_command("notify_openai_assistant_removal", force=True)
+
+        assert len(mail.outbox) == 1

--- a/templates/events/email/openai_assistant_removal.txt
+++ b/templates/events/email/openai_assistant_removal.txt
@@ -7,7 +7,7 @@ The following {{ assistant_count }} assistant{% if assistant_count != 1 %}s{% en
 - {{ assistant_name }}
 {% endfor %}
 
-Please migrate these to a pipeline-based chatbot before {{ removal_date }} to avoid disruption.
+Please migrate these to a pipeline-based chatbot before {{ removal_date }} to avoid disruption. See our migration guide: https://docs.openchatstudio.com/how-to/assistants_migration/
 
 If you have any questions, please contact support.
 

--- a/templates/events/email/openai_assistant_removal.txt
+++ b/templates/events/email/openai_assistant_removal.txt
@@ -1,0 +1,16 @@
+{% autoescape off %}Hello {{ team.name }} Admin,
+
+OpenAI is retiring their Assistants API, so support for OpenAI Assistants in Open Chat Studio will be removed on {{ removal_date }}. See OpenAI's announcement: https://developers.openai.com/api/docs/deprecations#2025-08-20-assistants-api
+
+The following {{ assistant_count }} assistant{% if assistant_count != 1 %}s{% endif %} in your team will stop working after this date:
+{% for assistant_name in assistant_names %}
+- {{ assistant_name }}
+{% endfor %}
+
+Please migrate these to a pipeline-based chatbot before {{ removal_date }} to avoid disruption.
+
+If you have any questions, please contact support.
+
+Best regards,
+The Open Chat Studio Team
+{% endautoescape %}


### PR DESCRIPTION
### Product Description
Team admins with active OpenAI Assistants get an email warning that the Assistants API is being retired (removal date 26 August 2026) and pointing them at the migration guide to move onto a pipeline-based chatbot.

### Technical Description
`IdempotentCommand` (`notify_openai_assistant_removal`), following the existing `notify_deprecated_models` pattern — supports `--dry-run` and re-run guarding via `migration_name`. Only working, non-archived assistants are counted; same-named assistants in a team are each listed individually. The plain-text template uses `{% autoescape off %}` so names with `&`, `<`, `'` render literally rather than as HTML entities.

The command is wired to run on deploy via a `RunDataMigration` operation (`assistants/0015`), the same mechanism used for the widget-release notifications.

### Migrations
- [x] The migrations are backwards compatible

`assistants/0015` runs the notification command once on deploy. It only reads assistant/team rows and sends email — no schema or data changes.

### Docs and Changelog
- [ ] This PR requires docs/changelog update