### PR TITLE
Expose widget build version on the element

### DIFF
--- a/components/chat_widget/src/components.d.ts
+++ b/components/chat_widget/src/components.d.ts
@@ -59,6 +59,10 @@ export namespace Components {
          */
         "embedKey"?: string;
         /**
+          * The widget's build version. Read this to identify which release is deployed on a page, e.g. `await el.getVersion()`. Also mirrored to the `data-widget-version` attribute on the host element for inspection.
+         */
+        "getVersion": () => Promise<string>;
+        /**
           * The text to place in the header.
          */
         "headerText": '';

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.spec.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.spec.tsx
@@ -1,8 +1,31 @@
 import { newSpecPage } from '@stencil/core/testing';
+import { Env } from '@stencil/core';
 import { OcsChat } from './ocs-chat';
 import { TranslationManager } from '../../utils/translations';
 
 describe('ocs-chat', () => {
+  describe('Widget version', () => {
+    it('mirrors the build version to the data-widget-version attribute', async () => {
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget chatbot-id="test-bot"></open-chat-studio-widget>`,
+      });
+
+      expect(page.root?.getAttribute('data-widget-version')).toBe(Env.version);
+    });
+
+    it('exposes the build version via getVersion() even without a chatbot id', async () => {
+      const page = await newSpecPage({
+        components: [OcsChat],
+        html: `<open-chat-studio-widget></open-chat-studio-widget>`,
+      });
+
+      const component = page.rootInstance as OcsChat;
+      expect(await component.getVersion()).toBe(Env.version);
+      expect(page.root?.getAttribute('data-widget-version')).toBe(Env.version);
+    });
+  });
+
   describe('Welcome Messages Display', () => {
     it('should display welcome messages when provided via translation files', async () => {
       const page = await newSpecPage({

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { Component, Host, h, Prop, State, Element, Watch, Env } from '@stencil/core';
+import { Component, Host, h, Prop, State, Element, Watch, Method, Env } from '@stencil/core';
 import {
   XMarkIcon,
   GripDotsVerticalIcon,
@@ -306,7 +306,20 @@ export class OcsChat {
   private currentSessionToken?: string;
   @Element() host: HTMLElement;
 
+  /**
+   * The widget's build version. Read this to identify which release is deployed
+   * on a page, e.g. `await el.getVersion()`. Also mirrored to the
+   * `data-widget-version` attribute on the host element for inspection.
+   */
+  @Method()
+  async getVersion(): Promise<string> {
+    return Env.version;
+  }
+
   async componentWillLoad() {
+    // Always expose the build version, even when chatbotId is missing.
+    this.host.setAttribute('data-widget-version', Env.version);
+
     if (!this.chatbotId) {
       this.error = 'Chatbot ID is required';
       return;

--- a/components/chat_widget/src/components/ocs-chat/readme.md
+++ b/components/chat_widget/src/components/ocs-chat/readme.md
@@ -43,6 +43,21 @@ For more information, see the [Open Chat Studio documentation](https://docs.open
 | `welcomeMessages`            | `welcome-messages`              | Welcome messages to display above starter questions (JSON array of strings)                                                                                                                                                                                                                                        | `string`                                      | `undefined`                        |
 
 
+## Methods
+
+### `getVersion() => Promise<string>`
+
+The widget's build version. Read this to identify which release is deployed
+on a page, e.g. `await el.getVersion()`. Also mirrored to the
+`data-widget-version` attribute on the host element for inspection.
+
+#### Returns
+
+Type: `Promise<string>`
+
+
+
+
 ## CSS Custom Properties
 
 | Name                                           | Description                                                                      |


### PR DESCRIPTION
### Product Description
Lets you tell which widget release is running on a deployed page without guessing from the CDN URL.

### Technical Description
`Env.version` (the build-time npm version) is now surfaced on the `<open-chat-studio-widget>` host element two ways:
- `data-widget-version` attribute — visible in DevTools, read via `getAttribute`. Stamped before the `chatbotId` guard so it's always present.
- `getVersion()` `@Method()` — programmatic access.

Reaches deployed embeds only after a widget npm release + a matching `LATEST_VERSION` bump in `apps/channels/widget_versions.py` (the app serves the widget from the CDN at that version, not from this source).

### Migrations
N/A

### Demo
`document.querySelector('open-chat-studio-widget').getAttribute('data-widget-version')` → `"0.11.0"`

### Docs and Changelog
- [x] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)