### PR TITLE
Chunk team admin emails under SES recipient limit

### DIFF
--- a/apps/data_migrations/management/commands/notify_openai_assistant_removal.py
+++ b/apps/data_migrations/management/commands/notify_openai_assistant_removal.py
@@ -15,6 +15,20 @@ class Command(IdempotentCommand):
     migration_name = "notify_openai_assistant_removal_2026_07_23"
     disable_audit = True
 
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--team-ids",
+            nargs="+",
+            type=int,
+            default=None,
+            help="Only notify these team IDs (default: all teams with a working assistant)",
+        )
+
+    def handle(self, *args, **options):
+        self.team_ids = options.get("team_ids")
+        super().handle(*args, **options)
+
     def perform_migration(self, dry_run=False):
         teams_context = self._build_teams_context()
         if not teams_context:
@@ -47,7 +61,10 @@ class Command(IdempotentCommand):
         # Only working, non-archived assistants count as "in use" (working_versions_queryset filters both).
         # A list (not a set) so that distinct assistants sharing a name are each counted and listed.
         teams_data = defaultdict(list)
-        for assistant in OpenAiAssistant.objects.working_versions_queryset():
+        assistants = OpenAiAssistant.objects.working_versions_queryset()
+        if self.team_ids:
+            assistants = assistants.filter(team_id__in=self.team_ids)
+        for assistant in assistants:
             teams_data[assistant.team_id].append(assistant.name)
 
         return {

--- a/apps/data_migrations/tests/test_notify_openai_assistant_removal.py
+++ b/apps/data_migrations/tests/test_notify_openai_assistant_removal.py
@@ -6,6 +6,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 
 from apps.utils.factories.assistants import OpenAiAssistantFactory
+from apps.utils.factories.team import TeamWithUsersFactory
 
 
 def _team_admin_email(team):
@@ -63,6 +64,17 @@ class TestNotifyOpenAiAssistantRemovalCommand:
         assert "Working Bot" in body
         assert "Archived Bot" not in body
         assert "Versioned Bot" not in body
+
+    def test_team_ids_scopes_notification(self, team_with_users):
+        """--team-ids limits notifications to the given teams, leaving others un-notified."""
+        other_team = TeamWithUsersFactory()
+        OpenAiAssistantFactory(team=team_with_users, name="Included Bot")
+        OpenAiAssistantFactory(team=other_team, name="Excluded Bot")
+
+        call_command("notify_openai_assistant_removal", force=True, team_ids=[team_with_users.id])
+
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == [_team_admin_email(team_with_users)]
 
     @patch("apps.data_migrations.management.commands.notify_openai_assistant_removal.send_bulk_team_admin_emails")
     def test_failed_delivery_raises(self, mock_send, team_with_users):

--- a/apps/teams/email.py
+++ b/apps/teams/email.py
@@ -5,6 +5,14 @@ from django.template.loader import render_to_string
 
 from apps.teams.models import Team
 
+# AWS SES rejects a single SendEmail call with more than 50 recipients, so chunk larger admin lists.
+MAX_RECIPIENTS_PER_EMAIL = 50
+
+
+def _chunked(items, size):
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
 
 def send_bulk_team_admin_emails(
     teams_context: dict[int, dict], subject_template: str, body_template_path: str, fail_silently=False
@@ -60,15 +68,17 @@ def send_bulk_team_admin_emails(
         try:
             # Render subject from template string
             subject = Template(subject_template).render(Context(email_context))
+            message = render_to_string(body_template_path, context=email_context)
 
-            # Send email
-            send_mail(
-                subject=subject,
-                message=render_to_string(body_template_path, context=email_context),
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=admin_emails,
-                fail_silently=fail_silently,
-            )
+            # Send in chunks so no single SendEmail call exceeds the SES recipient limit.
+            for recipient_chunk in _chunked(admin_emails, MAX_RECIPIENTS_PER_EMAIL):
+                send_mail(
+                    subject=subject,
+                    message=message,
+                    from_email=settings.DEFAULT_FROM_EMAIL,
+                    recipient_list=recipient_chunk,
+                    fail_silently=fail_silently,
+                )
             results["sent"] += 1
 
         except Exception as e:

--- a/apps/teams/tests/test_email.py
+++ b/apps/teams/tests/test_email.py
@@ -1,0 +1,49 @@
+import pytest
+from django.core import mail
+
+from apps.teams.backends import get_team_owner_groups
+from apps.teams.email import MAX_RECIPIENTS_PER_EMAIL, send_bulk_team_admin_emails
+from apps.utils.factories.team import MembershipFactory, TeamFactory
+
+
+def _add_admins(team, count):
+    for _ in range(count):
+        MembershipFactory(team=team, groups=get_team_owner_groups)
+
+
+@pytest.mark.django_db()
+class TestSendBulkTeamAdminEmails:
+    def test_large_admin_list_split_into_chunks(self):
+        """A team with more admins than the SES limit is emailed in chunks of <= the limit."""
+        team = TeamFactory()
+        admin_count = MAX_RECIPIENTS_PER_EMAIL + 5
+        _add_admins(team, admin_count)
+
+        results = send_bulk_team_admin_emails(
+            teams_context={team.id: {}},
+            subject_template="Subject for {{ team.name }}",
+            body_template_path="events/email/openai_assistant_removal.txt",
+        )
+
+        assert results["sent"] == 1
+        assert results["failed"] == 0
+        assert len(mail.outbox) == 2
+        assert all(len(email.to) <= MAX_RECIPIENTS_PER_EMAIL for email in mail.outbox)
+        recipients = [addr for email in mail.outbox for addr in email.to]
+        assert len(recipients) == admin_count
+        assert len(set(recipients)) == admin_count
+
+    def test_small_admin_list_single_email(self):
+        """A team within the recipient limit is emailed once with all admins."""
+        team = TeamFactory()
+        _add_admins(team, 3)
+
+        results = send_bulk_team_admin_emails(
+            teams_context={team.id: {}},
+            subject_template="Subject for {{ team.name }}",
+            body_template_path="events/email/openai_assistant_removal.txt",
+        )
+
+        assert results["sent"] == 1
+        assert len(mail.outbox) == 1
+        assert len(mail.outbox[0].to) == 3


### PR DESCRIPTION
### Product Description
no change

### Technical Description
The `notify_openai_assistant_removal` migration failed in a deploy: it emailed 41 of 42 affected teams, then errored on Team 1, whose admin list exceeds AWS SES's 50-recipient-per-message limit. `send_mail` put every admin of a team into a single `SendEmail` call.

`send_bulk_team_admin_emails` now splits each team's recipients into chunks of ≤50, one send per chunk. Behaviour is unchanged for teams within the limit.

Also adds an optional `--team-ids` filter to the command so a re-run can be scoped to specific teams — useful for notifying only the team(s) that didn't get the email, rather than resending to all 42.

Worth a look on deploy: the migration operation still runs unscoped (`force=True`, all teams). Because `send_mail` is not transactional, the 41 emails from the failed run already went out even though the migration rolled back — so an unscoped re-run will duplicate them. Scoping the re-run (via `--team-ids`, or faking the migration and running the command manually) is a deploy-time decision, not baked into this PR.

### Migrations
- [x] The migrations are backwards compatible

### Docs and Changelog
- [ ] This PR requires docs/changelog update