### PR TITLE
Usage API: group_by dimensions, pagination, and chatbot/platform filters

### DIFF
--- a/api-schemas/v2.yml
+++ b/api-schemas/v2.yml
@@ -220,9 +220,17 @@ paths:
         (human/AI/total counts), ''sessions'' (count), ''participants'' (distinct
         count), ''cost'' (total spend and currency), and ''tokens'' (prompt/completion/total).
         With ''granularity'' finer than ''total'', results are one row per time bucket.
-        Optionally narrowed to a single participant.'
+        With ''group_by'' set, results are cursor-paginated breakdown rows — one per
+        group, or one per (group, bucket) when combined with a finer granularity.
+        Optionally narrowed by participant, chatbot, or platform.'
       summary: Usage
       parameters:
+      - in: query
+        name: chatbot
+        schema:
+          type: string
+          format: uuid
+        description: Restrict to a single chatbot by its ``public_id``.
       - in: query
         name: end
         schema:
@@ -248,6 +256,21 @@ paths:
           * `daily` - daily
           * `weekly` - weekly
           * `monthly` - monthly
+      - in: query
+        name: group_by
+        schema:
+          enum:
+          - participant
+          - chatbot
+          - platform
+          type: string
+          minLength: 1
+        description: |-
+          Break the results down by this dimension: one row per group, cursor-paginated. Combines with 'granularity' to give one row per (group, time bucket).
+
+          * `participant` - participant
+          * `chatbot` - chatbot
+          * `platform` - platform
       - in: query
         name: metric
         schema:
@@ -295,6 +318,35 @@ paths:
           * `current_month` - current_month
           * `previous_month` - previous_month
       - in: query
+        name: platform
+        schema:
+          enum:
+          - telegram
+          - web
+          - whatsapp
+          - facebook
+          - sureadhere
+          - api
+          - slack
+          - commcare_connect
+          - embedded_widget
+          - email
+          type: string
+          minLength: 1
+        description: |-
+          Restrict to a single channel platform by its slug (e.g. 'web', 'whatsapp').
+
+          * `telegram` - telegram
+          * `web` - web
+          * `whatsapp` - whatsapp
+          * `facebook` - facebook
+          * `sureadhere` - sureadhere
+          * `api` - api
+          * `slack` - slack
+          * `commcare_connect` - commcare_connect
+          * `embedded_widget` - embedded_widget
+          * `email` - email
+      - in: query
         name: start
         schema:
           type: string
@@ -321,7 +373,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UsageResponse'
+                $ref: '#/components/schemas/UsageResponseOrGrouped'
           description: ''
 components:
   schemas:
@@ -482,6 +534,19 @@ components:
       - name
       - url
       - versions
+    ChatbotIdentity:
+      type: object
+      properties:
+        public_id:
+          type: string
+          format: uuid
+          description: Stable chatbot identifier.
+        name:
+          type: string
+          description: Chatbot name.
+      required:
+      - name
+      - public_id
     ChatbotInspect:
       type: object
       description: |-
@@ -774,6 +839,70 @@ components:
           nullable: true
           description: Use the provider's neural (higher-quality) voice engine, where
             supported.
+    GroupedUsageResponse:
+      type: object
+      description: |-
+        The grouped, cursor-paginated response envelope. Documents the shape the view assembles from the
+        shared ``CursorPagination`` plus the ``period``/``group_by`` context.
+      properties:
+        period:
+          $ref: '#/components/schemas/UsagePeriod'
+        group_by:
+          type: string
+          description: Dimension the rows are grouped by.
+        count:
+          type: integer
+          description: Total number of groups matching the query. Only present on
+            the first page.
+        next:
+          type: string
+          nullable: true
+          description: Cursor URL for the next page, or null.
+        previous:
+          type: string
+          nullable: true
+          description: Cursor URL for the previous page, or null.
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupedUsageRow'
+      required:
+      - group_by
+      - next
+      - period
+      - previous
+      - results
+    GroupedUsageRow:
+      type: object
+      description: |-
+        One breakdown row: the group's identity plus a block per requested metric. Exactly one of
+        ``participant``/``chatbot``/``platform`` is present (matching ``group_by``); ``bucket_start`` is
+        present only when a finer granularity expands each group into per-bucket rows.
+      properties:
+        messages:
+          $ref: '#/components/schemas/MessageCounts'
+        sessions:
+          type: integer
+          description: Sessions started in the window, excluding evaluation-harness
+            and never-engaged sessions.
+        participants:
+          type: integer
+          description: Distinct participants active in the window.
+        cost:
+          $ref: '#/components/schemas/Cost'
+        tokens:
+          $ref: '#/components/schemas/Tokens'
+        participant:
+          $ref: '#/components/schemas/ParticipantIdentity'
+        chatbot:
+          $ref: '#/components/schemas/ChatbotIdentity'
+        platform:
+          type: string
+          description: Channel platform slug (platform grouping).
+        bucket_start:
+          type: string
+          format: date-time
+          description: Inclusive start of this bucket, in the request timezone.
     IdentifierTypeEnum:
       enum:
       - email
@@ -1361,6 +1490,23 @@ components:
           description: Total number of items matching the query. Only present on the
             first page (requests without a cursor).
           example: 123
+    ParticipantIdentity:
+      type: object
+      properties:
+        public_id:
+          type: string
+          format: uuid
+          description: Stable participant identifier.
+        identifier:
+          type: string
+          description: Human-readable handle (email/phone/anon id).
+        platform:
+          type: string
+          description: Channel platform the participant belongs to.
+      required:
+      - identifier
+      - platform
+      - public_id
     PlatformEnum:
       enum:
       - telegram
@@ -1703,6 +1849,10 @@ components:
       - group_by
       - period
       - results
+    UsageResponseOrGrouped:
+      oneOf:
+      - $ref: '#/components/schemas/UsageResponse'
+      - $ref: '#/components/schemas/GroupedUsageResponse'
     UsageResults:
       type: object
       description: |-

--- a/apps/api/pagination.py
+++ b/apps/api/pagination.py
@@ -2,7 +2,11 @@ from rest_framework.pagination import CursorPagination as RestCursorPagination
 
 
 class CursorPagination(RestCursorPagination):
-    ordering = "-created_at"
+    # ``created_at`` is not unique, so pair it with the primary key as a tiebreaker: this gives a stable
+    # total order across requests, so rows sharing a ``created_at`` at a page boundary aren't skipped or
+    # duplicated. ``-pk`` (not ``-id``) works for models with a non-``id`` primary key. The cursor
+    # position is still keyed on the first field (``created_at``); the tiebreaker only stabilises order.
+    ordering = ("-created_at", "-pk")
     page_size_query_param = "page_size"
     max_page_size = 1500
 

--- a/apps/api/v2/usage/param_serializers.py
+++ b/apps/api/v2/usage/param_serializers.py
@@ -16,11 +16,15 @@ from rest_framework import serializers
 from apps.api.v2.usage.services import (
     GRANULARITY_CHOICES,
     GRANULARITY_TOTAL,
+    GROUP_BY_CHOICES,
+    GROUP_PARTICIPANT,
+    METRIC_PARTICIPANTS,
     PERIOD_CHOICES,
     PERIOD_CURRENT_MONTH,
     SUPPORTED_METRICS,
     _month_bounds,
 )
+from apps.channels.models import ChannelPlatform
 
 # Cap on how many buckets a single response may span, applied per granularity. It bounds both the
 # response size and the aggregation cost, and is what rejects e.g. ``daily`` over a multi-year range.
@@ -78,6 +82,14 @@ class UsageQuerySerializer(serializers.Serializer):
             "one row per bucket, each carrying 'bucket_start'."
         ),
     )
+    group_by = serializers.ChoiceField(
+        choices=list(GROUP_BY_CHOICES),
+        required=False,
+        help_text=(
+            "Break the results down by this dimension: one row per group, cursor-paginated. Combines "
+            "with 'granularity' to give one row per (group, time bucket)."
+        ),
+    )
     participant = serializers.UUIDField(
         required=False,
         help_text="Restrict to a single participant by their ``public_id``.",
@@ -86,6 +98,17 @@ class UsageQuerySerializer(serializers.Serializer):
         required=False,
         max_length=320,
         help_text="Restrict to a single participant by their raw identifier (email/phone).",
+    )
+    chatbot = serializers.UUIDField(
+        required=False,
+        help_text="Restrict to a single chatbot by its ``public_id``.",
+    )
+    platform = serializers.ChoiceField(
+        # ``evaluations`` is excluded: the usage API drops evaluation-harness sessions, so filtering or
+        # grouping by that platform would report messages while ``sessions`` stayed structurally zero.
+        choices=[value for value in ChannelPlatform.values if value != ChannelPlatform.EVALUATIONS],
+        required=False,
+        help_text="Restrict to a single channel platform by its slug (e.g. 'web', 'whatsapp').",
     )
     tz = serializers.CharField(
         default="UTC",
@@ -102,6 +125,11 @@ class UsageQuerySerializer(serializers.Serializer):
         if attrs.get("participant") and attrs.get("participant_identifier"):
             raise serializers.ValidationError(
                 "Provide only one of 'participant' or 'participant_identifier', not both."
+            )
+        if attrs.get("group_by") == GROUP_PARTICIPANT and METRIC_PARTICIPANTS in attrs["metric"]:
+            # A per-participant breakdown makes the distinct-participant count trivially 1 per row.
+            raise serializers.ValidationError(
+                "The 'participants' metric is redundant with group_by=participant; drop one of them."
             )
         tz = attrs["tz"]
         start, end = self._resolve_window(attrs, tz)

--- a/apps/api/v2/usage/serializers.py
+++ b/apps/api/v2/usage/serializers.py
@@ -51,6 +51,45 @@ class UsageBucketResultSerializer(UsageResultsSerializer):
     bucket_start = serializers.DateTimeField(help_text="Inclusive start of this bucket, in the request timezone.")
 
 
+class ParticipantIdentitySerializer(serializers.Serializer):
+    public_id = serializers.UUIDField(help_text="Stable participant identifier.")
+    identifier = serializers.CharField(help_text="Human-readable handle (email/phone/anon id).")
+    platform = serializers.CharField(help_text="Channel platform the participant belongs to.")
+
+
+class ChatbotIdentitySerializer(serializers.Serializer):
+    public_id = serializers.UUIDField(help_text="Stable chatbot identifier.")
+    name = serializers.CharField(help_text="Chatbot name.")
+
+
+class GroupedUsageRowSerializer(UsageResultsSerializer):
+    """One breakdown row: the group's identity plus a block per requested metric. Exactly one of
+    ``participant``/``chatbot``/``platform`` is present (matching ``group_by``); ``bucket_start`` is
+    present only when a finer granularity expands each group into per-bucket rows."""
+
+    participant = ParticipantIdentitySerializer(required=False)
+    chatbot = ChatbotIdentitySerializer(required=False)
+    platform = serializers.CharField(required=False, help_text="Channel platform slug (platform grouping).")
+    bucket_start = serializers.DateTimeField(
+        required=False, help_text="Inclusive start of this bucket, in the request timezone."
+    )
+
+
+class GroupedUsageResponseSerializer(serializers.Serializer):
+    """The grouped, cursor-paginated response envelope. Documents the shape the view assembles from the
+    shared ``CursorPagination`` plus the ``period``/``group_by`` context."""
+
+    period = UsagePeriodSerializer(source="*")
+    group_by = serializers.CharField(help_text="Dimension the rows are grouped by.")
+    count = serializers.IntegerField(
+        help_text="Total number of groups matching the query. Only present on the first page.",
+        required=False,
+    )
+    next = serializers.CharField(help_text="Cursor URL for the next page, or null.", allow_null=True)
+    previous = serializers.CharField(help_text="Cursor URL for the previous page, or null.", allow_null=True)
+    results = GroupedUsageRowSerializer(many=True)
+
+
 class UsageResponseSerializer(serializers.Serializer):
     period = UsagePeriodSerializer(source="*")
     granularity = serializers.CharField(help_text="Time-bucketing applied to the results.")
@@ -67,7 +106,8 @@ class UsageResponseSerializer(serializers.Serializer):
 
     @extend_schema_field(serializers.CharField(allow_null=True))
     def get_group_by(self, obj) -> None:
-        # Grouping arrives in a later slice; this slice is always ungrouped.
+        # This serializer renders the ungrouped response only; grouped requests use
+        # GroupedUsageResponseSerializer, so group_by is always null here.
         return None
 
     @extend_schema_field(

--- a/apps/api/v2/usage/services.py
+++ b/apps/api/v2/usage/services.py
@@ -10,7 +10,7 @@ and :func:`group_rows`. See ``docs/design/usage-api.md``.
 """
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import TypedDict
@@ -122,7 +122,13 @@ class UsageResult:
 @dataclass(frozen=True)
 class UsageQuery:
     """Validated, team-scoped inputs for a single usage request. Bundling them keeps the many
-    aggregation helpers to one parameter and lets the window/filters travel together unchanged."""
+    aggregation helpers to one parameter and lets the window/filters travel together unchanged.
+
+    The ``participant``/``participant_identifier``/``chatbot`` fields are the raw request handles;
+    :func:`resolve_query_filters` turns them into the ``*_ids`` below **once** per request. The
+    queryset builders filter on those FK-id fields (never the handles), so no metric joins the
+    ``experiment``/``participant`` tables and the archived-inclusive id resolution lives in one place.
+    Build a query, then resolve it before running any aggregation."""
 
     team: Team
     metrics: set[str]
@@ -135,6 +141,12 @@ class UsageQuery:
     chatbot: str | None = None
     platform: str | None = None
     group_by: str | None = None
+    # Populated by resolve_query_filters. ``None`` means "no such filter requested"; an empty list means
+    # "requested but matched nobody" (with filter_is_empty set), which the ``__in`` filters turn into an
+    # empty result and the cost path short-circuits to zeros.
+    participant_ids: list[int] | None = None
+    experiment_ids: list[int] | None = None
+    filter_is_empty: bool = False
 
 
 @dataclass(frozen=True)
@@ -223,6 +235,34 @@ _GROUP_SPECS = {
         identity=lambda item: item["platform"],
     ),
 }
+
+
+def resolve_query_filters(query: UsageQuery) -> UsageQuery:
+    """Resolve the participant/chatbot request handles to DB ids **once**, returning a new query that
+    carries them. Every metric then filters on the FK-id columns (``participant_id``/``experiment_id``)
+    instead of joining ``participant``/``experiment`` to match a ``public_id``/``identifier``, and the
+    archived-inclusive resolution (``get_all()``) happens in exactly one place. Call this before running
+    any aggregation; ``filter_is_empty`` marks a requested filter that matched nobody so the reader
+    returns zeros. Idempotent enough to skip when nothing needs resolving."""
+    if not (query.participant or query.participant_identifier or query.chatbot):
+        return query
+    participant_ids = query.participant_ids
+    experiment_ids = query.experiment_ids
+    is_empty = query.filter_is_empty
+    if query.participant or query.participant_identifier:
+        # An identifier can match several participants (one per platform), so this resolves to a list.
+        lookup = {"public_id": query.participant} if query.participant else {"identifier": query.participant_identifier}
+        participant_ids = list(Participant.objects.filter(team=query.team, **lookup).values_list("id", flat=True))
+        is_empty = is_empty or not participant_ids
+    if query.chatbot:
+        # ``get_all()`` so an archived chatbot still resolves to its id (its activity is reached elsewhere
+        # by manager-agnostic relation traversal); each version owns its own ``public_id``, so this is at
+        # most one id, but keep it a list for a uniform ``__in`` filter.
+        experiment_ids = list(
+            Experiment.objects.get_all().filter(team=query.team, public_id=query.chatbot).values_list("id", flat=True)
+        )
+        is_empty = is_empty or not experiment_ids
+    return replace(query, participant_ids=participant_ids, experiment_ids=experiment_ids, filter_is_empty=is_empty)
 
 
 def usage_query(query: UsageQuery) -> UsageResult:
@@ -528,32 +568,18 @@ def _token_counts(query: UsageQuery, cost_filter: _CostFilter) -> TokenCounts:
 
 
 def _cost_filter(query: UsageQuery) -> _CostFilter:
-    """Resolve the participant/chatbot/platform filters to the ``CostFilters`` the reporting read path
-    honours. ``is_empty`` is True when a participant *or* chatbot filter was requested but resolved to
-    no rows, so the caller short-circuits to zeros — ``CostFilters`` treats an empty id list as "no
-    filter", not "match none", so an unmatched id filter would otherwise widen the result to everything.
-    A platform filter needs no id resolution (it is a slug matched directly) and never sets ``is_empty``.
-    """
+    """Build the ``CostFilters`` the reporting read path honours from the query's already-resolved ids
+    (see :func:`resolve_query_filters`). ``is_empty`` carries through ``filter_is_empty`` so the caller
+    short-circuits to zeros — ``CostFilters`` treats an empty id list as "no filter", not "match none",
+    so an unmatched id filter would otherwise widen the result to everything."""
     kwargs: dict = {}
-    is_empty = False
-    if query.participant or query.participant_identifier:
-        # An identifier can match several participants (one per platform), so this returns a list.
-        lookup = {"public_id": query.participant} if query.participant else {"identifier": query.participant_identifier}
-        participant_ids = list(Participant.objects.filter(team=query.team, **lookup).values_list("id", flat=True))
-        kwargs["participant_ids"] = participant_ids
-        is_empty = is_empty or not participant_ids
-    if query.chatbot:
-        # ``get_all()`` so an archived chatbot resolves to its id: the message/session paths reach it by
-        # relation traversal (archived-inclusive), so cost/tokens must too or they would zero out while
-        # the other metrics report real activity for the same ``chatbot`` filter.
-        experiment_ids = list(
-            Experiment.objects.get_all().filter(team=query.team, public_id=query.chatbot).values_list("id", flat=True)
-        )
-        kwargs["experiment_ids"] = experiment_ids
-        is_empty = is_empty or not experiment_ids
+    if query.participant_ids is not None:
+        kwargs["participant_ids"] = query.participant_ids
+    if query.experiment_ids is not None:
+        kwargs["experiment_ids"] = query.experiment_ids
     if query.platform:
         kwargs["platform_names"] = [query.platform]
-    return _CostFilter(filters=reporting.CostFilters(**kwargs), is_empty=is_empty)
+    return _CostFilter(filters=reporting.CostFilters(**kwargs), is_empty=query.filter_is_empty)
 
 
 def _session_queryset(query: UsageQuery) -> QuerySet[ExperimentSession]:
@@ -565,12 +591,11 @@ def _session_queryset(query: UsageQuery) -> QuerySet[ExperimentSession]:
         .exclude(platform=ChannelPlatform.EVALUATIONS)
         .exclude(status=SessionStatus.SETUP)
     )
-    if query.participant:
-        queryset = queryset.filter(participant__public_id=query.participant)
-    if query.participant_identifier:
-        queryset = queryset.filter(participant__identifier=query.participant_identifier)
-    if query.chatbot:
-        queryset = queryset.filter(experiment__public_id=query.chatbot)
+    # Filter on the session's own FK columns (resolved ids), so no join to experiment/participant.
+    if query.participant_ids is not None:
+        queryset = queryset.filter(participant_id__in=query.participant_ids)
+    if query.experiment_ids is not None:
+        queryset = queryset.filter(experiment_id__in=query.experiment_ids)
     if query.platform:
         queryset = queryset.filter(platform=query.platform)
     return queryset
@@ -603,12 +628,12 @@ def _message_queryset(query: UsageQuery) -> QuerySet[ChatMessage]:
     ``chat__experiment_session__participant``. Backed by the ``(chat, message_type, created_at)`` index.
     """
     queryset = ChatMessage.objects.filter(chat__team=query.team, created_at__gte=query.start, created_at__lt=query.end)
-    if query.participant:
-        queryset = queryset.filter(chat__experiment_session__participant__public_id=query.participant)
-    if query.participant_identifier:
-        queryset = queryset.filter(chat__experiment_session__participant__identifier=query.participant_identifier)
-    if query.chatbot:
-        queryset = queryset.filter(chat__experiment_session__experiment__public_id=query.chatbot)
+    # Filter on the session's FK-id columns (resolved ids), so the message query joins through the chat
+    # and session it needs anyway but not the experiment/participant tables.
+    if query.participant_ids is not None:
+        queryset = queryset.filter(chat__experiment_session__participant_id__in=query.participant_ids)
+    if query.experiment_ids is not None:
+        queryset = queryset.filter(chat__experiment_session__experiment_id__in=query.experiment_ids)
     if query.platform:
         queryset = queryset.filter(chat__experiment_session__platform=query.platform)
     return queryset

--- a/apps/api/v2/usage/services.py
+++ b/apps/api/v2/usage/services.py
@@ -3,8 +3,10 @@
 This is the single place that turns a validated ``UsageQuery`` into team-scoped aggregates. It
 supports the ``messages``, ``sessions``, ``participants``, ``cost``, and ``tokens`` metrics over an
 explicit ``[start, end)`` window (resolved from ``period`` or ``start``/``end`` by the param
-serializer) at ``total``/``daily``/``weekly``/``monthly`` granularity. Later slices add grouping
-without changing this contract. See ``docs/design/usage-api.md``.
+serializer) at ``total``/``daily``/``weekly``/``monthly`` granularity, optionally broken down by a
+``group_by`` dimension (participant/chatbot/platform). Ungrouped requests go through
+:func:`usage_query`; grouped requests are cursor-paginated by the view over :func:`group_entities`
+and :func:`group_rows`. See ``docs/design/usage-api.md``.
 """
 
 from dataclasses import dataclass
@@ -14,14 +16,14 @@ from typing import TypedDict
 from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
-from django.db.models import Count, Q, QuerySet
+from django.db.models import Count, F, Q, QuerySet
 from django.db.models.functions import TruncDate, TruncMonth, TruncWeek
 from django.utils import timezone
 
 from apps.channels.models import ChannelPlatform
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.cost_tracking.services import reporting
-from apps.experiments.models import ExperimentSession, Participant, SessionStatus
+from apps.experiments.models import Experiment, ExperimentSession, Participant, SessionStatus
 from apps.teams.models import Team
 
 # Metric identifiers. Later slices extend SUPPORTED_METRICS; the param serializer validates against it.
@@ -44,6 +46,36 @@ GRANULARITY_DAILY = "daily"
 GRANULARITY_WEEKLY = "weekly"
 GRANULARITY_MONTHLY = "monthly"
 GRANULARITY_CHOICES = (GRANULARITY_TOTAL, GRANULARITY_DAILY, GRANULARITY_WEEKLY, GRANULARITY_MONTHLY)
+
+# Dimensions the results may be broken down by. When set, the response is one row per group (or per
+# (group, bucket) at a finer granularity), cursor-paginated. v2 vocabulary says ``chatbot``, not
+# ``experiment`` (ADR-0023); the underlying model is still ``Experiment``.
+GROUP_PARTICIPANT = "participant"
+GROUP_CHATBOT = "chatbot"
+GROUP_PLATFORM = "platform"
+GROUP_BY_CHOICES = (GROUP_PARTICIPANT, GROUP_CHATBOT, GROUP_PLATFORM)
+
+# Ceiling on the rows a single grouped page may materialise (``groups × buckets``); see
+# :func:`grouped_page_size_cap`.
+MAX_GROUPED_ROWS = 10_000
+
+# The relation from each source to the grouped dimension. ``ChatMessage`` reaches the dimension two
+# relations away (via its chat's session); ``ExperimentSession`` and ``UsageRecord`` hold it locally.
+_MESSAGE_GROUP_FIELD = {
+    GROUP_PARTICIPANT: "chat__experiment_session__participant",
+    GROUP_CHATBOT: "chat__experiment_session__experiment",
+    GROUP_PLATFORM: "chat__experiment_session__platform",
+}
+_SESSION_GROUP_FIELD = {
+    GROUP_PARTICIPANT: "participant",
+    GROUP_CHATBOT: "experiment",
+    GROUP_PLATFORM: "platform",
+}
+_USAGE_GROUP_FIELD = {
+    GROUP_PARTICIPANT: "participant_id",
+    GROUP_CHATBOT: "experiment_id",
+    GROUP_PLATFORM: "session__platform",
+}
 
 # DB truncation per bucketed granularity (Django's TruncWeek starts weeks on Monday, matching the
 # Python-side bucket boundaries below).
@@ -76,13 +108,26 @@ class TokenCounts(TypedDict):
     total: int
 
 
+# Zeroed block per metric, for buckets/(group, bucket) cells with no activity. Factories (not shared
+# instances) so each empty slot gets its own object rather than aliasing one. Single source so the
+# grouped and ungrouped zero-fills can't drift apart.
+_EMPTY_METRIC = {
+    METRIC_MESSAGES: lambda: MessageCounts(human=0, ai=0, total=0),
+    METRIC_SESSIONS: lambda: 0,
+    METRIC_PARTICIPANTS: lambda: 0,
+    METRIC_COST: lambda: CostBlock(total=Decimal(0), currency="USD"),
+    METRIC_TOKENS: lambda: TokenCounts(prompt=0, completion=0, total=0),
+}
+
+
 @dataclass(frozen=True)
 class UsageResult:
     """The endpoint response, pre-serialisation.
 
     ``results`` is either a single object mapping each requested metric name to its aggregate block
     (``granularity=total``), or a list of such objects — one per time bucket, each carrying a
-    ``bucket_start`` — when a finer granularity is requested. Grouping arrives in a later slice."""
+    ``bucket_start`` — when a finer granularity is requested. This is the ungrouped response only;
+    grouped requests are paginated by the view and never build a ``UsageResult``."""
 
     period_start: datetime
     period_end: datetime
@@ -104,6 +149,9 @@ class UsageQuery:
     granularity: str = GRANULARITY_TOTAL
     participant: str | None = None
     participant_identifier: str | None = None
+    chatbot: str | None = None
+    platform: str | None = None
+    group_by: str | None = None
 
 
 @dataclass(frozen=True)
@@ -125,6 +173,217 @@ def usage_query(query: UsageQuery) -> UsageResult:
         granularity=query.granularity,
         results=results,
     )
+
+
+def group_entities(query: UsageQuery) -> QuerySet:
+    """The paginatable base for a grouped request: one entry per group *active in the window* (a group
+    with at least one message), so breakdown rows never carry all-zero noise for idle groups. The view
+    cursor-paginates this and passes the page to :func:`group_rows`.
+
+    ``participant``/``chatbot`` return the entity querysets (``Participant``/``Experiment``), ordered by
+    the paginator's ``-created_at``. ``platform`` has no backing model, so it returns the distinct
+    platform slugs present, ordered on the ``platform`` alias (which also clears ``ChatMessage``'s
+    default ``created_at`` ordering, so the ``.distinct()`` stays one row per slug).
+
+    ``chatbot`` resolves through ``Experiment.objects.get_all()`` so archived chatbots that were active
+    in the window still appear — the message/session paths reach chatbots by relation traversal, which
+    is manager-agnostic and includes archived rows, so grouping must match them or the breakdown would
+    silently drop archived activity that the ungrouped totals still count.
+    """
+    if query.group_by == GROUP_PARTICIPANT:
+        return Participant.objects.filter(team=query.team, id__in=_active_group_ids(query))
+    if query.group_by == GROUP_CHATBOT:
+        return Experiment.objects.get_all().filter(team=query.team, id__in=_active_group_ids(query))
+    return (
+        _message_queryset(query)
+        .exclude(chat__experiment_session__platform__isnull=True)
+        .exclude(chat__experiment_session__platform="")
+        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
+        .values(platform=F("chat__experiment_session__platform"))
+        .distinct()
+        .order_by("chat__experiment_session__platform")
+    )
+
+
+def group_rows(query: UsageQuery, page: list) -> list[dict]:
+    """Serialisable breakdown rows for one page of :func:`group_entities`. At ``total`` granularity each
+    group yields one row; at a finer granularity each group is expanded to one flat row per time bucket
+    in the window (each carrying ``bucket_start``), so the whole page's rows are ``groups × buckets``.
+    Metrics absent for a (group, bucket) are zero-filled."""
+    keys = [_page_key(query.group_by, item) for item in page]
+    buckets = _group_buckets(query)
+    index = _grouped_metric_index(query, keys, buckets)
+    rows: list[dict] = []
+    for item in page:
+        key = _page_key(query.group_by, item)
+        identity = _group_identity(query.group_by, item)
+        for bucket in buckets:
+            row: dict = {query.group_by: identity}
+            if bucket is not None:
+                row["bucket_start"] = bucket
+            row.update(index[(key, _bucket_key(bucket, query.tz))])
+            rows.append(row)
+    return rows
+
+
+def _active_group_ids(query: UsageQuery) -> QuerySet:
+    """Distinct ids of the ``participant``/``chatbot`` entities with a message in the window."""
+    return _message_queryset(query).values_list(_MESSAGE_GROUP_FIELD[query.group_by], flat=True).distinct()
+
+
+def _page_key(group_by: str, item):
+    """The value that joins a paginated group to its aggregated metrics — the entity id for
+    ``participant``/``chatbot``, the slug for ``platform`` (a ``.values`` dict)."""
+    return item["platform"] if group_by == GROUP_PLATFORM else item.id
+
+
+def _group_identity(group_by: str, item):
+    """The group's identity block for the response row. Participant rows carry both handles a client
+    might hold (``public_id`` and ``identifier``); platform is just its slug."""
+    if group_by == GROUP_PARTICIPANT:
+        return {"public_id": str(item.public_id), "identifier": item.identifier, "platform": item.platform}
+    if group_by == GROUP_CHATBOT:
+        return {"public_id": str(item.public_id), "name": item.name}
+    return item["platform"]
+
+
+def _group_buckets(query: UsageQuery) -> list:
+    """The bucket dimension of the grouped rows: ``[None]`` at ``total`` (one row per group), else the
+    tz-aware bucket-start datetimes covering the window (one row per group per bucket)."""
+    if query.granularity == GRANULARITY_TOTAL:
+        return [None]
+    return list(_iter_bucket_starts(query.start, query.end, query.granularity, query.tz))
+
+
+def grouped_page_size_cap(query: UsageQuery) -> int:
+    """Max groups per page so a grouped page materialises at most :data:`MAX_GROUPED_ROWS` rows. A page
+    expands to ``groups × buckets`` rows, and the window guard bounds buckets but not their product with
+    ``page_size``; this caps that product so a fine granularity over a wide window can't be combined with
+    a large ``page_size`` into a huge single response. Cursor pagination still walks every group."""
+    return max(1, MAX_GROUPED_ROWS // len(_group_buckets(query)))
+
+
+def _bucket_key(bucket: datetime | None, tz: ZoneInfo):
+    """The local calendar date keying a bucket in the metric index; ``None`` at ``total`` granularity.
+    Delegates to :func:`_bucket_date` so the Python-generated bucket starts and the DB truncation results
+    normalise to their local date the same way (they must agree for the index and rows to join)."""
+    return None if bucket is None else _bucket_date(bucket, tz)
+
+
+def _grouped_metric_index(query: UsageQuery, keys: list, buckets: list) -> dict:
+    """``{(group_key, bucket_key): {metric: block}}`` for every (group, bucket) on the page, zero-filled.
+    Each metric runs a single query grouped by the dimension (and, at a finer granularity, the time
+    bucket) restricted to ``keys``; results are keyed back onto the page's (group, bucket) cells."""
+    bucket_keys = [_bucket_key(bucket, query.tz) for bucket in buckets]
+    index = {(key, bucket_key): {} for key in keys for bucket_key in bucket_keys}
+
+    trunc = None if query.granularity == GRANULARITY_TOTAL else _TRUNC[query.granularity]
+    msg_field = _MESSAGE_GROUP_FIELD[query.group_by]
+    ses_field = _SESSION_GROUP_FIELD[query.group_by]
+
+    # (metric, row iterator) per requested non-cost metric; built conditionally so a metric's query only
+    # runs when asked for. Cost/tokens share one UsageRecord read and are filled separately below.
+    metric_rows = []
+    if METRIC_MESSAGES in query.metrics:
+        metric_rows.append((METRIC_MESSAGES, _grouped_message_counts(query, keys, msg_field, trunc)))
+    if METRIC_SESSIONS in query.metrics:
+        metric_rows.append(
+            (METRIC_SESSIONS, _grouped_scalar(_session_queryset(query), keys, ses_field, trunc, query.tz, Count("id")))
+        )
+    if METRIC_PARTICIPANTS in query.metrics:
+        # group_by=participant is rejected upstream, so this only runs for chatbot/platform.
+        metric_rows.append(
+            (
+                METRIC_PARTICIPANTS,
+                _grouped_scalar(
+                    _active_participant_queryset(query),
+                    keys,
+                    msg_field,
+                    trunc,
+                    query.tz,
+                    Count("chat__experiment_session__participant", distinct=True),
+                ),
+            )
+        )
+    for metric, rows in metric_rows:
+        for group_key, bucket_key, value in rows:
+            index[(group_key, bucket_key)][metric] = value
+    if METRIC_COST in query.metrics or METRIC_TOKENS in query.metrics:
+        _fill_grouped_cost_tokens(query, keys, index)
+
+    _zero_fill_grouped(query, index)
+    return index
+
+
+def _grouped_message_counts(query: UsageQuery, keys: list, group_field: str, trunc):
+    """Yield ``(group_key, bucket_key, MessageCounts)`` for the human/AI split per group (and bucket)."""
+    queryset = _message_queryset(query).filter(**{f"{group_field}__in": keys})
+    value_fields = [group_field]
+    if trunc is not None:
+        queryset = queryset.annotate(bucket=trunc("created_at", tzinfo=query.tz))
+        value_fields.append("bucket")
+    rows = queryset.values(*value_fields).annotate(
+        human=Count("id", filter=Q(message_type=ChatMessageType.HUMAN)),
+        ai=Count("id", filter=Q(message_type=ChatMessageType.AI)),
+    )
+    for row in rows:
+        bucket_key = None if trunc is None else _bucket_date(row["bucket"], query.tz)
+        yield (
+            row[group_field],
+            bucket_key,
+            MessageCounts(human=row["human"], ai=row["ai"], total=row["human"] + row["ai"]),
+        )
+
+
+def _grouped_scalar(queryset: QuerySet, keys: list, group_field: str, trunc, tz: ZoneInfo, aggregate):
+    """Yield ``(group_key, bucket_key, int)`` for a single-integer metric grouped by ``group_field``
+    (and, when ``trunc`` is set, the tz-truncated time bucket), restricted to ``keys``."""
+    queryset = queryset.filter(**{f"{group_field}__in": keys})
+    value_fields = [group_field]
+    if trunc is not None:
+        queryset = queryset.annotate(bucket=trunc("created_at", tzinfo=tz))
+        value_fields.append("bucket")
+    for row in queryset.values(*value_fields).annotate(n=aggregate):
+        bucket_key = None if trunc is None else _bucket_date(row["bucket"], tz)
+        yield row[group_field], bucket_key, row["n"]
+
+
+def _fill_grouped_cost_tokens(query: UsageQuery, keys: list, index: dict) -> None:
+    """Add the ``cost``/``tokens`` blocks to the (group, bucket) cells from one grouped ``UsageRecord``
+    read (via the cost read path) so cost and tokens reconcile with each other and with the totals."""
+    cost_filter = _cost_filter(query)
+    granularity = None if query.granularity == GRANULARITY_TOTAL else query.granularity
+    rows = (
+        []
+        if cost_filter.is_empty
+        else reporting.usage_by_group(
+            query.team,
+            start=query.start,
+            end=query.end,
+            group_field=_USAGE_GROUP_FIELD[query.group_by],
+            keys=keys,
+            granularity=granularity,
+            tz=query.tz,
+            filters=cost_filter.filters,
+        )
+    )
+    for row in rows:
+        bucket_key = None if granularity is None else _bucket_date(row["bucket"], query.tz)
+        cell = index.get((row["key"], bucket_key))
+        if cell is None:
+            continue
+        if METRIC_COST in query.metrics:
+            cell[METRIC_COST] = CostBlock(total=row["cost"], currency=row["currency"])
+        if METRIC_TOKENS in query.metrics:
+            cell[METRIC_TOKENS] = TokenCounts(prompt=row["prompt"], completion=row["completion"], total=row["total"])
+
+
+def _zero_fill_grouped(query: UsageQuery, index: dict) -> None:
+    """Give every (group, bucket) cell a zeroed block for each requested metric it is missing, so the
+    response is dense over the page even where a group had no activity in a bucket."""
+    for cell in index.values():
+        for metric in query.metrics:
+            cell.setdefault(metric, _EMPTY_METRIC[metric]())
 
 
 def _aggregate(query: UsageQuery) -> dict:
@@ -154,19 +413,18 @@ def _bucketed(query: UsageQuery) -> list[dict]:
     starts = list(_iter_bucket_starts(query.start, query.end, query.granularity, query.tz))
     rows: list[dict] = [{"bucket_start": bucket} for bucket in starts]
 
-    # (grouped-query fn, empty-bucket value factory) per metric. The factory (not a shared value) so
-    # each empty bucket gets its own object rather than aliasing one instance.
     metric_specs = (
-        (METRIC_MESSAGES, _message_counts_by_bucket, lambda: MessageCounts(human=0, ai=0, total=0)),
-        (METRIC_SESSIONS, _session_counts_by_bucket, lambda: 0),
-        (METRIC_PARTICIPANTS, _participant_counts_by_bucket, lambda: 0),
+        (METRIC_MESSAGES, _message_counts_by_bucket),
+        (METRIC_SESSIONS, _session_counts_by_bucket),
+        (METRIC_PARTICIPANTS, _participant_counts_by_bucket),
     )
-    for metric, counts_by_bucket, empty in metric_specs:
+    for metric, counts_by_bucket in metric_specs:
         if metric not in query.metrics:
             continue
         by_date = counts_by_bucket(query, trunc)
         for row in rows:
-            row[metric] = by_date.get(row["bucket_start"].date(), empty())
+            # _EMPTY_METRIC factory (not a shared value) so each empty bucket gets its own object.
+            row[metric] = by_date.get(row["bucket_start"].date(), _EMPTY_METRIC[metric]())
 
     _fill_cost_tokens_buckets(query, rows)
     return rows
@@ -182,9 +440,9 @@ def _fill_cost_tokens_buckets(query: UsageQuery, rows: list[dict]) -> None:
     for row in rows:
         block = by_date.get(row["bucket_start"].date())
         if METRIC_COST in query.metrics:
-            row[METRIC_COST] = block["cost"] if block else CostBlock(total=Decimal(0), currency="USD")
+            row[METRIC_COST] = block["cost"] if block else _EMPTY_METRIC[METRIC_COST]()
         if METRIC_TOKENS in query.metrics:
-            row[METRIC_TOKENS] = block["tokens"] if block else TokenCounts(prompt=0, completion=0, total=0)
+            row[METRIC_TOKENS] = block["tokens"] if block else _EMPTY_METRIC[METRIC_TOKENS]()
 
 
 def _cost_tokens_by_bucket(query: UsageQuery) -> dict:
@@ -230,14 +488,32 @@ def _token_counts(query: UsageQuery, cost_filter: _CostFilter) -> TokenCounts:
 
 
 def _cost_filter(query: UsageQuery) -> _CostFilter:
-    """Resolve the participant filter to ``UsageRecord`` participant ids. An identifier can match several
-    participants (one per platform), so this returns a list. Returns an unfiltered ``CostFilters`` when
-    no participant filter was requested."""
-    if not query.participant and not query.participant_identifier:
-        return _CostFilter(filters=reporting.CostFilters(), is_empty=False)
-    lookup = {"public_id": query.participant} if query.participant else {"identifier": query.participant_identifier}
-    participant_ids = list(Participant.objects.filter(team=query.team, **lookup).values_list("id", flat=True))
-    return _CostFilter(filters=reporting.CostFilters(participant_ids=participant_ids), is_empty=not participant_ids)
+    """Resolve the participant/chatbot/platform filters to the ``CostFilters`` the reporting read path
+    honours. ``is_empty`` is True when a participant *or* chatbot filter was requested but resolved to
+    no rows, so the caller short-circuits to zeros — ``CostFilters`` treats an empty id list as "no
+    filter", not "match none", so an unmatched id filter would otherwise widen the result to everything.
+    A platform filter needs no id resolution (it is a slug matched directly) and never sets ``is_empty``.
+    """
+    kwargs: dict = {}
+    is_empty = False
+    if query.participant or query.participant_identifier:
+        # An identifier can match several participants (one per platform), so this returns a list.
+        lookup = {"public_id": query.participant} if query.participant else {"identifier": query.participant_identifier}
+        participant_ids = list(Participant.objects.filter(team=query.team, **lookup).values_list("id", flat=True))
+        kwargs["participant_ids"] = participant_ids
+        is_empty = is_empty or not participant_ids
+    if query.chatbot:
+        # ``get_all()`` so an archived chatbot resolves to its id: the message/session paths reach it by
+        # relation traversal (archived-inclusive), so cost/tokens must too or they would zero out while
+        # the other metrics report real activity for the same ``chatbot`` filter.
+        experiment_ids = list(
+            Experiment.objects.get_all().filter(team=query.team, public_id=query.chatbot).values_list("id", flat=True)
+        )
+        kwargs["experiment_ids"] = experiment_ids
+        is_empty = is_empty or not experiment_ids
+    if query.platform:
+        kwargs["platform_names"] = [query.platform]
+    return _CostFilter(filters=reporting.CostFilters(**kwargs), is_empty=is_empty)
 
 
 def _session_queryset(query: UsageQuery) -> QuerySet[ExperimentSession]:
@@ -253,6 +529,10 @@ def _session_queryset(query: UsageQuery) -> QuerySet[ExperimentSession]:
         queryset = queryset.filter(participant__public_id=query.participant)
     if query.participant_identifier:
         queryset = queryset.filter(participant__identifier=query.participant_identifier)
+    if query.chatbot:
+        queryset = queryset.filter(experiment__public_id=query.chatbot)
+    if query.platform:
+        queryset = queryset.filter(platform=query.platform)
     return queryset
 
 
@@ -293,6 +573,10 @@ def _message_queryset(query: UsageQuery) -> QuerySet[ChatMessage]:
         queryset = queryset.filter(chat__experiment_session__participant__public_id=query.participant)
     if query.participant_identifier:
         queryset = queryset.filter(chat__experiment_session__participant__identifier=query.participant_identifier)
+    if query.chatbot:
+        queryset = queryset.filter(chat__experiment_session__experiment__public_id=query.chatbot)
+    if query.platform:
+        queryset = queryset.filter(chat__experiment_session__platform=query.platform)
     return queryset
 
 

--- a/apps/api/v2/usage/services.py
+++ b/apps/api/v2/usage/services.py
@@ -396,10 +396,12 @@ def _fill_grouped_cost_tokens(query: UsageQuery, keys: list, index: dict) -> Non
             query.team,
             start=query.start,
             end=query.end,
-            group_field=_GROUP_SPECS[query.group_by].usage_field,
-            keys=keys,
-            granularity=granularity,
-            tz=query.tz,
+            breakdown=reporting.GroupBreakdown(
+                field=_GROUP_SPECS[query.group_by].usage_field,
+                keys=keys,
+                granularity=granularity,
+                tz=query.tz,
+            ),
             # Currency is only read for the cost block, so a tokens-only request skips the extra scan.
             resolve_currency=METRIC_COST in query.metrics,
             filters=cost_filter.filters,

--- a/apps/api/v2/usage/services.py
+++ b/apps/api/v2/usage/services.py
@@ -340,10 +340,22 @@ def _grouped_metric_index(query: UsageQuery, keys: list, buckets: list) -> dict:
     bucket_keys = [_bucket_key(bucket, query.tz) for bucket in buckets]
     index = {(key, bucket_key): {} for key in keys for bucket_key in bucket_keys}
 
+    for metric, rows in _grouped_non_cost_metric_rows(query, keys):
+        for group_key, bucket_key, value in rows:
+            index[(group_key, bucket_key)][metric] = value
+    if METRIC_COST in query.metrics or METRIC_TOKENS in query.metrics:
+        _fill_grouped_cost_tokens(query, keys, index)
+
+    _zero_fill_grouped(query, index)
+    return index
+
+
+def _grouped_non_cost_metric_rows(query: UsageQuery, keys: list) -> list:
+    """``(metric, (group_key, bucket_key, value) iterator)`` for each requested non-cost metric, built
+    conditionally so a metric's query only runs when asked for. Cost/tokens share one UsageRecord read
+    and are filled separately by the caller."""
     trunc = None if query.granularity == GRANULARITY_TOTAL else _TRUNC[query.granularity]
     spec = _GROUP_SPECS[query.group_by]
-    msg_field = spec.message_field
-    ses_field = spec.session_field
 
     def by_group(queryset, group_field, **annotations):
         return _grouped_rows(
@@ -354,32 +366,22 @@ def _grouped_metric_index(query: UsageQuery, keys: list, buckets: list) -> dict:
             **annotations,
         )
 
-    # (metric, (group_key, bucket_key, value) iterator) per requested non-cost metric, built
-    # conditionally so a metric's query only runs when asked for. Cost/tokens share one UsageRecord read
-    # and are filled separately below.
     metric_rows = []
     if METRIC_MESSAGES in query.metrics:
-        rows = by_group(_message_queryset(query), msg_field, **_MESSAGE_ANNOTATIONS)
+        rows = by_group(_message_queryset(query), spec.message_field, **_MESSAGE_ANNOTATIONS)
         metric_rows.append((METRIC_MESSAGES, ((gk, bk, _message_counts_from_row(row)) for gk, bk, row in rows)))
     if METRIC_SESSIONS in query.metrics:
-        rows = by_group(_session_queryset(query), ses_field, n=Count("id"))
+        rows = by_group(_session_queryset(query), spec.session_field, n=Count("id"))
         metric_rows.append((METRIC_SESSIONS, ((gk, bk, row["n"]) for gk, bk, row in rows)))
     if METRIC_PARTICIPANTS in query.metrics:
         # group_by=participant is rejected upstream, so this only runs for chatbot/platform.
         rows = by_group(
             _active_participant_queryset(query),
-            msg_field,
+            spec.message_field,
             n=Count("chat__experiment_session__participant", distinct=True),
         )
         metric_rows.append((METRIC_PARTICIPANTS, ((gk, bk, row["n"]) for gk, bk, row in rows)))
-    for metric, rows in metric_rows:
-        for group_key, bucket_key, value in rows:
-            index[(group_key, bucket_key)][metric] = value
-    if METRIC_COST in query.metrics or METRIC_TOKENS in query.metrics:
-        _fill_grouped_cost_tokens(query, keys, index)
-
-    _zero_fill_grouped(query, index)
-    return index
+    return metric_rows
 
 
 def _fill_grouped_cost_tokens(query: UsageQuery, keys: list, index: dict) -> None:

--- a/apps/api/v2/usage/services.py
+++ b/apps/api/v2/usage/services.py
@@ -270,6 +270,34 @@ def _bucket_key(bucket: datetime | None, tz: ZoneInfo):
     return None if bucket is None else _bucket_date(bucket, tz)
 
 
+# Human/AI message-count annotations, shared by the total, bucketed, and grouped message reads so the
+# split is defined in one place.
+_MESSAGE_ANNOTATIONS = {
+    "human": Count("id", filter=Q(message_type=ChatMessageType.HUMAN)),
+    "ai": Count("id", filter=Q(message_type=ChatMessageType.AI)),
+}
+
+
+def _message_counts_from_row(row: dict) -> MessageCounts:
+    """Build a :class:`MessageCounts` from a row/aggregate carrying ``human``/``ai`` counts."""
+    return MessageCounts(human=row["human"], ai=row["ai"], total=row["human"] + row["ai"])
+
+
+def _grouped_rows(queryset: QuerySet, *, group_field: str | None, trunc, tz: ZoneInfo, **annotations):
+    """Aggregate ``queryset`` by an optional dimension ``group_field`` and an optional tz time bucket
+    (``trunc``), applying ``annotations``. Yields ``(group_key, bucket_key, row)`` where each key is
+    ``None`` when that axis isn't requested. The single home of the ``.values(...).annotate(...)`` +
+    bucket-date boilerplate, shared by the grouped breakdown and the ungrouped timeseries."""
+    value_fields = [group_field] if group_field else []
+    if trunc is not None:
+        queryset = queryset.annotate(bucket=trunc("created_at", tzinfo=tz))
+        value_fields.append("bucket")
+    for row in queryset.values(*value_fields).annotate(**annotations):
+        group_key = row[group_field] if group_field else None
+        bucket_key = _bucket_date(row["bucket"], tz) if trunc is not None else None
+        yield group_key, bucket_key, row
+
+
 def _grouped_metric_index(query: UsageQuery, keys: list, buckets: list) -> dict:
     """``{(group_key, bucket_key): {metric: block}}`` for every (group, bucket) on the page, zero-filled.
     Each metric runs a single query grouped by the dimension (and, at a finer granularity, the time
@@ -281,30 +309,33 @@ def _grouped_metric_index(query: UsageQuery, keys: list, buckets: list) -> dict:
     msg_field = _MESSAGE_GROUP_FIELD[query.group_by]
     ses_field = _SESSION_GROUP_FIELD[query.group_by]
 
-    # (metric, row iterator) per requested non-cost metric; built conditionally so a metric's query only
-    # runs when asked for. Cost/tokens share one UsageRecord read and are filled separately below.
+    def by_group(queryset, group_field, **annotations):
+        return _grouped_rows(
+            queryset.filter(**{f"{group_field}__in": keys}),
+            group_field=group_field,
+            trunc=trunc,
+            tz=query.tz,
+            **annotations,
+        )
+
+    # (metric, (group_key, bucket_key, value) iterator) per requested non-cost metric, built
+    # conditionally so a metric's query only runs when asked for. Cost/tokens share one UsageRecord read
+    # and are filled separately below.
     metric_rows = []
     if METRIC_MESSAGES in query.metrics:
-        metric_rows.append((METRIC_MESSAGES, _grouped_message_counts(query, keys, msg_field, trunc)))
+        rows = by_group(_message_queryset(query), msg_field, **_MESSAGE_ANNOTATIONS)
+        metric_rows.append((METRIC_MESSAGES, ((gk, bk, _message_counts_from_row(row)) for gk, bk, row in rows)))
     if METRIC_SESSIONS in query.metrics:
-        metric_rows.append(
-            (METRIC_SESSIONS, _grouped_scalar(_session_queryset(query), keys, ses_field, trunc, query.tz, Count("id")))
-        )
+        rows = by_group(_session_queryset(query), ses_field, n=Count("id"))
+        metric_rows.append((METRIC_SESSIONS, ((gk, bk, row["n"]) for gk, bk, row in rows)))
     if METRIC_PARTICIPANTS in query.metrics:
         # group_by=participant is rejected upstream, so this only runs for chatbot/platform.
-        metric_rows.append(
-            (
-                METRIC_PARTICIPANTS,
-                _grouped_scalar(
-                    _active_participant_queryset(query),
-                    keys,
-                    msg_field,
-                    trunc,
-                    query.tz,
-                    Count("chat__experiment_session__participant", distinct=True),
-                ),
-            )
+        rows = by_group(
+            _active_participant_queryset(query),
+            msg_field,
+            n=Count("chat__experiment_session__participant", distinct=True),
         )
+        metric_rows.append((METRIC_PARTICIPANTS, ((gk, bk, row["n"]) for gk, bk, row in rows)))
     for metric, rows in metric_rows:
         for group_key, bucket_key, value in rows:
             index[(group_key, bucket_key)][metric] = value
@@ -313,39 +344,6 @@ def _grouped_metric_index(query: UsageQuery, keys: list, buckets: list) -> dict:
 
     _zero_fill_grouped(query, index)
     return index
-
-
-def _grouped_message_counts(query: UsageQuery, keys: list, group_field: str, trunc):
-    """Yield ``(group_key, bucket_key, MessageCounts)`` for the human/AI split per group (and bucket)."""
-    queryset = _message_queryset(query).filter(**{f"{group_field}__in": keys})
-    value_fields = [group_field]
-    if trunc is not None:
-        queryset = queryset.annotate(bucket=trunc("created_at", tzinfo=query.tz))
-        value_fields.append("bucket")
-    rows = queryset.values(*value_fields).annotate(
-        human=Count("id", filter=Q(message_type=ChatMessageType.HUMAN)),
-        ai=Count("id", filter=Q(message_type=ChatMessageType.AI)),
-    )
-    for row in rows:
-        bucket_key = None if trunc is None else _bucket_date(row["bucket"], query.tz)
-        yield (
-            row[group_field],
-            bucket_key,
-            MessageCounts(human=row["human"], ai=row["ai"], total=row["human"] + row["ai"]),
-        )
-
-
-def _grouped_scalar(queryset: QuerySet, keys: list, group_field: str, trunc, tz: ZoneInfo, aggregate):
-    """Yield ``(group_key, bucket_key, int)`` for a single-integer metric grouped by ``group_field``
-    (and, when ``trunc`` is set, the tz-truncated time bucket), restricted to ``keys``."""
-    queryset = queryset.filter(**{f"{group_field}__in": keys})
-    value_fields = [group_field]
-    if trunc is not None:
-        queryset = queryset.annotate(bucket=trunc("created_at", tzinfo=tz))
-        value_fields.append("bucket")
-    for row in queryset.values(*value_fields).annotate(n=aggregate):
-        bucket_key = None if trunc is None else _bucket_date(row["bucket"], tz)
-        yield row[group_field], bucket_key, row["n"]
 
 
 def _fill_grouped_cost_tokens(query: UsageQuery, keys: list, index: dict) -> None:
@@ -554,13 +552,7 @@ def _message_counts(query: UsageQuery) -> MessageCounts:
     """Human/AI/total message counts for the window. ``total`` is ``human + ai`` (the two surfaced
     categories); system messages are internal and excluded so the parts always sum to the total."""
     # Filtered Count aggregates return 0 for no matches, never None.
-    counts = _message_queryset(query).aggregate(
-        human=Count("id", filter=Q(message_type=ChatMessageType.HUMAN)),
-        ai=Count("id", filter=Q(message_type=ChatMessageType.AI)),
-    )
-    human = counts["human"]
-    ai = counts["ai"]
-    return MessageCounts(human=human, ai=ai, total=human + ai)
+    return _message_counts_from_row(_message_queryset(query).aggregate(**_MESSAGE_ANNOTATIONS))
 
 
 def _message_queryset(query: UsageQuery) -> QuerySet[ChatMessage]:
@@ -585,20 +577,11 @@ def _active_participant_queryset(query: UsageQuery) -> QuerySet[ChatMessage]:
 
 
 def _message_counts_by_bucket(query: UsageQuery, trunc) -> dict:
-    rows = (
-        _message_queryset(query)
-        .annotate(bucket=trunc("created_at", tzinfo=query.tz))
-        .values("bucket")
-        .annotate(
-            human=Count("id", filter=Q(message_type=ChatMessageType.HUMAN)),
-            ai=Count("id", filter=Q(message_type=ChatMessageType.AI)),
-        )
-    )
     return {
-        _bucket_date(row["bucket"], query.tz): MessageCounts(
-            human=row["human"], ai=row["ai"], total=row["human"] + row["ai"]
+        bucket_key: _message_counts_from_row(row)
+        for _, bucket_key, row in _grouped_rows(
+            _message_queryset(query), group_field=None, trunc=trunc, tz=query.tz, **_MESSAGE_ANNOTATIONS
         )
-        for row in rows
     }
 
 
@@ -618,8 +601,10 @@ def _participant_counts_by_bucket(query: UsageQuery, trunc) -> dict:
 def _scalar_by_bucket(queryset: QuerySet, trunc, tz: ZoneInfo, aggregate) -> dict:
     """Group ``queryset`` into ``tz``-truncated buckets and reduce each to a single integer via
     ``aggregate``, keyed by local calendar date. Shared by the session and participant metrics."""
-    rows = queryset.annotate(bucket=trunc("created_at", tzinfo=tz)).values("bucket").annotate(n=aggregate)
-    return {_bucket_date(row["bucket"], tz): row["n"] for row in rows}
+    return {
+        bucket_key: row["n"]
+        for _, bucket_key, row in _grouped_rows(queryset, group_field=None, trunc=trunc, tz=tz, n=aggregate)
+    }
 
 
 def _iter_bucket_starts(start: datetime, end: datetime, granularity: str, tz: ZoneInfo):

--- a/apps/api/v2/usage/services.py
+++ b/apps/api/v2/usage/services.py
@@ -9,6 +9,7 @@ serializer) at ``total``/``daily``/``weekly``/``monthly`` granularity, optionall
 and :func:`group_rows`. See ``docs/design/usage-api.md``.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
@@ -58,24 +59,6 @@ GROUP_BY_CHOICES = (GROUP_PARTICIPANT, GROUP_CHATBOT, GROUP_PLATFORM)
 # Ceiling on the rows a single grouped page may materialise (``groups × buckets``); see
 # :func:`grouped_page_size_cap`.
 MAX_GROUPED_ROWS = 10_000
-
-# The relation from each source to the grouped dimension. ``ChatMessage`` reaches the dimension two
-# relations away (via its chat's session); ``ExperimentSession`` and ``UsageRecord`` hold it locally.
-_MESSAGE_GROUP_FIELD = {
-    GROUP_PARTICIPANT: "chat__experiment_session__participant",
-    GROUP_CHATBOT: "chat__experiment_session__experiment",
-    GROUP_PLATFORM: "chat__experiment_session__platform",
-}
-_SESSION_GROUP_FIELD = {
-    GROUP_PARTICIPANT: "participant",
-    GROUP_CHATBOT: "experiment",
-    GROUP_PLATFORM: "platform",
-}
-_USAGE_GROUP_FIELD = {
-    GROUP_PARTICIPANT: "participant_id",
-    GROUP_CHATBOT: "experiment_id",
-    GROUP_PLATFORM: "session__platform",
-}
 
 # DB truncation per bucketed granularity (Django's TruncWeek starts weeks on Monday, matching the
 # Python-side bucket boundaries below).
@@ -164,6 +147,84 @@ class _CostFilter:
     is_empty: bool
 
 
+@dataclass(frozen=True)
+class _GroupSpec:
+    """Everything the grouped path needs for one ``group_by`` dimension, in a single record so adding a
+    dimension is one registry entry and a missing piece is a construction-time error, not a request-time
+    ``KeyError``. The ``*_field`` names are the relation from each source to the dimension: ``ChatMessage``
+    reaches it two relations away (via its chat's session); ``ExperimentSession``/``UsageRecord`` hold it
+    locally."""
+
+    message_field: str
+    session_field: str
+    usage_field: str
+    # A validated UsageQuery -> the paginatable base queryset of groups active in the window.
+    entities: Callable[["UsageQuery"], QuerySet]
+    # A paginated item -> the value joining it to its aggregated metrics (entity id, or platform slug).
+    # A model instance for participant/chatbot, a ``.values`` dict for platform, so params stay untyped.
+    page_key: Callable[..., object]
+    # A paginated item -> the group's identity block for the response row.
+    identity: Callable[..., object]
+
+
+def _participant_entities(query: "UsageQuery") -> QuerySet:
+    return Participant.objects.filter(team=query.team, id__in=_active_group_ids(query))
+
+
+def _chatbot_entities(query: "UsageQuery") -> QuerySet:
+    # ``get_all()`` so archived chatbots active in the window still appear: the message/session paths
+    # reach chatbots by relation traversal (archived-inclusive), so grouping must match them or the
+    # breakdown would silently drop archived activity that the ungrouped totals still count.
+    return Experiment.objects.get_all().filter(team=query.team, id__in=_active_group_ids(query))
+
+
+def _platform_entities(query: "UsageQuery") -> QuerySet:
+    # Platform has no backing model, so return the distinct slugs present, ordered on the ``platform``
+    # alias (which also clears ``ChatMessage``'s default ``created_at`` ordering, keeping ``.distinct()``
+    # one row per slug). ``evaluations`` is excluded to match the session metric's exclusion.
+    return (
+        _message_queryset(query)
+        .exclude(chat__experiment_session__platform__isnull=True)
+        .exclude(chat__experiment_session__platform="")
+        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
+        .values(platform=F("chat__experiment_session__platform"))
+        .distinct()
+        .order_by("chat__experiment_session__platform")
+    )
+
+
+_GROUP_SPECS = {
+    GROUP_PARTICIPANT: _GroupSpec(
+        message_field="chat__experiment_session__participant",
+        session_field="participant",
+        usage_field="participant_id",
+        entities=_participant_entities,
+        page_key=lambda item: item.id,
+        identity=lambda item: {
+            "public_id": str(item.public_id),
+            "identifier": item.identifier,
+            "platform": item.platform,
+        },
+    ),
+    GROUP_CHATBOT: _GroupSpec(
+        message_field="chat__experiment_session__experiment",
+        session_field="experiment",
+        usage_field="experiment_id",
+        entities=_chatbot_entities,
+        page_key=lambda item: item.id,
+        identity=lambda item: {"public_id": str(item.public_id), "name": item.name},
+    ),
+    GROUP_PLATFORM: _GroupSpec(
+        message_field="chat__experiment_session__platform",
+        session_field="platform",
+        usage_field="session__platform",
+        entities=_platform_entities,
+        page_key=lambda item: item["platform"],
+        identity=lambda item: item["platform"],
+    ),
+}
+
+
 def usage_query(query: UsageQuery) -> UsageResult:
     results = _aggregate(query) if query.granularity == GRANULARITY_TOTAL else _bucketed(query)
     return UsageResult(
@@ -178,31 +239,9 @@ def usage_query(query: UsageQuery) -> UsageResult:
 def group_entities(query: UsageQuery) -> QuerySet:
     """The paginatable base for a grouped request: one entry per group *active in the window* (a group
     with at least one message), so breakdown rows never carry all-zero noise for idle groups. The view
-    cursor-paginates this and passes the page to :func:`group_rows`.
-
-    ``participant``/``chatbot`` return the entity querysets (``Participant``/``Experiment``), ordered by
-    the paginator's ``-created_at``. ``platform`` has no backing model, so it returns the distinct
-    platform slugs present, ordered on the ``platform`` alias (which also clears ``ChatMessage``'s
-    default ``created_at`` ordering, so the ``.distinct()`` stays one row per slug).
-
-    ``chatbot`` resolves through ``Experiment.objects.get_all()`` so archived chatbots that were active
-    in the window still appear — the message/session paths reach chatbots by relation traversal, which
-    is manager-agnostic and includes archived rows, so grouping must match them or the breakdown would
-    silently drop archived activity that the ungrouped totals still count.
-    """
-    if query.group_by == GROUP_PARTICIPANT:
-        return Participant.objects.filter(team=query.team, id__in=_active_group_ids(query))
-    if query.group_by == GROUP_CHATBOT:
-        return Experiment.objects.get_all().filter(team=query.team, id__in=_active_group_ids(query))
-    return (
-        _message_queryset(query)
-        .exclude(chat__experiment_session__platform__isnull=True)
-        .exclude(chat__experiment_session__platform="")
-        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
-        .values(platform=F("chat__experiment_session__platform"))
-        .distinct()
-        .order_by("chat__experiment_session__platform")
-    )
+    cursor-paginates this and passes the page to :func:`group_rows`. The per-dimension queryset comes
+    from the :class:`_GroupSpec` registry."""
+    return _GROUP_SPECS[query.group_by].entities(query)
 
 
 def group_rows(query: UsageQuery, page: list) -> list[dict]:
@@ -228,23 +267,19 @@ def group_rows(query: UsageQuery, page: list) -> list[dict]:
 
 def _active_group_ids(query: UsageQuery) -> QuerySet:
     """Distinct ids of the ``participant``/``chatbot`` entities with a message in the window."""
-    return _message_queryset(query).values_list(_MESSAGE_GROUP_FIELD[query.group_by], flat=True).distinct()
+    return _message_queryset(query).values_list(_GROUP_SPECS[query.group_by].message_field, flat=True).distinct()
 
 
 def _page_key(group_by: str, item):
     """The value that joins a paginated group to its aggregated metrics — the entity id for
     ``participant``/``chatbot``, the slug for ``platform`` (a ``.values`` dict)."""
-    return item["platform"] if group_by == GROUP_PLATFORM else item.id
+    return _GROUP_SPECS[group_by].page_key(item)
 
 
 def _group_identity(group_by: str, item):
     """The group's identity block for the response row. Participant rows carry both handles a client
     might hold (``public_id`` and ``identifier``); platform is just its slug."""
-    if group_by == GROUP_PARTICIPANT:
-        return {"public_id": str(item.public_id), "identifier": item.identifier, "platform": item.platform}
-    if group_by == GROUP_CHATBOT:
-        return {"public_id": str(item.public_id), "name": item.name}
-    return item["platform"]
+    return _GROUP_SPECS[group_by].identity(item)
 
 
 def _group_buckets(query: UsageQuery) -> list:
@@ -306,8 +341,9 @@ def _grouped_metric_index(query: UsageQuery, keys: list, buckets: list) -> dict:
     index = {(key, bucket_key): {} for key in keys for bucket_key in bucket_keys}
 
     trunc = None if query.granularity == GRANULARITY_TOTAL else _TRUNC[query.granularity]
-    msg_field = _MESSAGE_GROUP_FIELD[query.group_by]
-    ses_field = _SESSION_GROUP_FIELD[query.group_by]
+    spec = _GROUP_SPECS[query.group_by]
+    msg_field = spec.message_field
+    ses_field = spec.session_field
 
     def by_group(queryset, group_field, **annotations):
         return _grouped_rows(
@@ -358,7 +394,7 @@ def _fill_grouped_cost_tokens(query: UsageQuery, keys: list, index: dict) -> Non
             query.team,
             start=query.start,
             end=query.end,
-            group_field=_USAGE_GROUP_FIELD[query.group_by],
+            group_field=_GROUP_SPECS[query.group_by].usage_field,
             keys=keys,
             granularity=granularity,
             tz=query.tz,

--- a/apps/api/v2/usage/services.py
+++ b/apps/api/v2/usage/services.py
@@ -398,6 +398,8 @@ def _fill_grouped_cost_tokens(query: UsageQuery, keys: list, index: dict) -> Non
             keys=keys,
             granularity=granularity,
             tz=query.tz,
+            # Currency is only read for the cost block, so a tokens-only request skips the extra scan.
+            resolve_currency=METRIC_COST in query.metrics,
             filters=cost_filter.filters,
         )
     )

--- a/apps/api/v2/usage/tests/test_usage_grouping.py
+++ b/apps/api/v2/usage/tests/test_usage_grouping.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from zoneinfo import ZoneInfo
 
 import pytest
+import time_machine
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
@@ -244,6 +245,32 @@ def test_group_by_combined_with_granularity_gives_flat_bucket_rows():
         assert "bucket_start" in row
     by_bucket = {row["bucket_start"][:10]: row["messages"]["human"] for row in results}
     assert by_bucket == {"2026-07-01": 1, "2026-07-02": 2}
+
+
+@pytest.mark.django_db()
+def test_grouped_pagination_stable_when_created_at_ties():
+    """Participants created at the same instant must each appear exactly once when paged one at a time —
+    the (-created_at, -pk) tiebreaker gives a stable total order so the boundary can't skip/duplicate."""
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    with time_machine.travel("2026-05-01T00:00:00+00:00"):  # all participants share a created_at
+        participants = [
+            ParticipantFactory.create(team=team, identifier=f"p{i}@example.com", platform="web") for i in range(5)
+        ]
+    for participant in participants:
+        _add_messages(ExperimentSessionFactory.create(team=team, participant=participant, platform="web"), human=1)
+
+    client = ApiTestClient(user, team)
+    seen: list[str] = []
+    response = client.get(reverse(USAGE_URL), {"metric": "messages", "group_by": "participant", "page_size": 1}).json()
+    for _ in range(10):  # cap iterations so a pagination bug fails instead of looping forever
+        seen.extend(row["participant"]["identifier"] for row in response["results"])
+        if not response["next"]:
+            break
+        response = client.get(response["next"]).json()
+
+    assert sorted(seen) == [f"p{i}@example.com" for i in range(5)]
+    assert len(seen) == len(set(seen))  # each group exactly once, no boundary skip/duplicate
 
 
 @pytest.mark.django_db()

--- a/apps/api/v2/usage/tests/test_usage_grouping.py
+++ b/apps/api/v2/usage/tests/test_usage_grouping.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 from zoneinfo import ZoneInfo
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
 from apps.api.v2.usage.services import MAX_GROUPED_ROWS, UsageQuery, grouped_page_size_cap
@@ -351,6 +353,27 @@ def test_participants_metric_with_group_by_participant_is_rejected():
 
     assert response.status_code == 400
     assert "redundant" in str(response.json()).lower()
+
+
+@pytest.mark.django_db()
+def test_tokens_only_grouped_skips_currency_scan():
+    """A grouped tokens-only request must not run the extra DISTINCT-currency scan; a cost request does."""
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    alice = ParticipantFactory.create(team=team, identifier="alice@example.com", platform="web")
+    session = ExperimentSessionFactory.create(team=team, participant=alice, platform="web")
+    _add_messages(session, human=1)
+    UsageRecordFactory.create(team=team, participant=alice, session=session, quantity=100, cost=Decimal("1"))
+    client = ApiTestClient(user, team)
+
+    def currency_scans(metric):
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(reverse(USAGE_URL), {"metric": metric, "group_by": "participant"})
+        assert response.status_code == 200
+        return sum("distinct" in q["sql"].lower() and "currency" in q["sql"].lower() for q in ctx.captured_queries)
+
+    assert currency_scans("tokens") == 0
+    assert currency_scans("cost") >= 1
 
 
 @pytest.mark.django_db()

--- a/apps/api/v2/usage/tests/test_usage_grouping.py
+++ b/apps/api/v2/usage/tests/test_usage_grouping.py
@@ -11,7 +11,14 @@ from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
-from apps.api.v2.usage.services import MAX_GROUPED_ROWS, UsageQuery, grouped_page_size_cap
+from apps.api.v2.usage.services import (
+    MAX_GROUPED_ROWS,
+    UsageQuery,
+    _message_queryset,
+    _session_queryset,
+    grouped_page_size_cap,
+    resolve_query_filters,
+)
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.cost_tracking.models import ServiceKind
 from apps.utils.factories.cost_tracking import UsageRecordFactory
@@ -401,6 +408,31 @@ def test_participants_metric_with_group_by_participant_is_rejected():
 
     assert response.status_code == 400
     assert "redundant" in str(response.json()).lower()
+
+
+@pytest.mark.django_db()
+def test_id_filters_avoid_joining_experiment_and_participant_tables():
+    """chatbot/participant filters resolve to FK ids, so the message/session queries filter on the FK
+    columns and never join the experiment/participant tables."""
+    team = TeamWithUsersFactory.create()
+    chatbot = ExperimentFactory.create(team=team)
+    session = ExperimentSessionFactory.create(team=team, experiment=chatbot)
+    window = {
+        "metrics": {"messages"},
+        "tz": ZoneInfo("UTC"),
+        "start": datetime.datetime(2000, 1, 1, tzinfo=datetime.UTC),
+        "end": datetime.datetime(2100, 1, 1, tzinfo=datetime.UTC),
+    }
+
+    chatbot_q = resolve_query_filters(UsageQuery(team=team, chatbot=chatbot.public_id, **window))
+    msg_sql = str(_message_queryset(chatbot_q).query).lower()
+    assert "experiments_experimentsession" in msg_sql  # still joins the session it needs
+    assert '"experiments_experiment" on' not in msg_sql  # but not the experiment table
+    assert '"experiments_experiment" on' not in str(_session_queryset(chatbot_q).query).lower()
+
+    participant_q = resolve_query_filters(UsageQuery(team=team, participant=session.participant.public_id, **window))
+    assert '"experiments_participant" on' not in str(_message_queryset(participant_q).query).lower()
+    assert '"experiments_participant" on' not in str(_session_queryset(participant_q).query).lower()
 
 
 @pytest.mark.django_db()

--- a/apps/api/v2/usage/tests/test_usage_grouping.py
+++ b/apps/api/v2/usage/tests/test_usage_grouping.py
@@ -1,0 +1,386 @@
+"""Tests for ``group_by`` breakdowns, cursor pagination, the ``chatbot``/``platform`` filters, and the
+combo guards (issue #3852)."""
+
+import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+from django.urls import reverse
+
+from apps.api.v2.usage.services import MAX_GROUPED_ROWS, UsageQuery, grouped_page_size_cap
+from apps.chat.models import ChatMessage, ChatMessageType
+from apps.cost_tracking.models import ServiceKind
+from apps.utils.factories.cost_tracking import UsageRecordFactory
+from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory, ParticipantFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+from apps.utils.tests.clients import ApiTestClient
+
+USAGE_URL = "api:v2:usage"
+
+
+def _add_messages(session, *, human=0, ai=0, when=None):
+    kwargs = {"created_at": when} if when else {}
+    for message_type, count in ((ChatMessageType.HUMAN, human), (ChatMessageType.AI, ai)):
+        for _ in range(count):
+            ChatMessage.objects.create(chat=session.chat, message_type=message_type, content="x", **kwargs)
+
+
+@pytest.mark.django_db()
+def test_group_by_participant_one_row_each_with_both_handles():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    alice = ParticipantFactory.create(team=team, identifier="alice@example.com", platform="web")
+    bob = ParticipantFactory.create(team=team, identifier="bob@example.com", platform="web")
+    _add_messages(ExperimentSessionFactory.create(team=team, participant=alice, platform="web"), human=3, ai=2)
+    _add_messages(ExperimentSessionFactory.create(team=team, participant=bob, platform="web"), human=1)
+    # An idle participant (no messages) is excluded from the breakdown.
+    ParticipantFactory.create(team=team, identifier="idle@example.com", platform="web")
+
+    client = ApiTestClient(user, team)
+    response = client.get(reverse(USAGE_URL), {"metric": "messages", "group_by": "participant"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["group_by"] == "participant"
+    assert data["count"] == 2
+    by_identifier = {row["participant"]["identifier"]: row for row in data["results"]}
+    assert set(by_identifier) == {"alice@example.com", "bob@example.com"}
+    assert by_identifier["alice@example.com"]["participant"]["public_id"] == str(alice.public_id)
+    assert by_identifier["alice@example.com"]["messages"] == {"human": 3, "ai": 2, "total": 5}
+    assert by_identifier["bob@example.com"]["messages"] == {"human": 1, "ai": 0, "total": 1}
+
+
+@pytest.mark.django_db()
+def test_group_by_chatbot_rows_carry_public_id_and_name():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    support = ExperimentFactory.create(team=team, name="Support")
+    sales = ExperimentFactory.create(team=team, name="Sales")
+    _add_messages(ExperimentSessionFactory.create(team=team, experiment=support), human=4)
+    _add_messages(ExperimentSessionFactory.create(team=team, experiment=sales), human=2)
+
+    client = ApiTestClient(user, team)
+    response = client.get(reverse(USAGE_URL), {"metric": "messages", "group_by": "chatbot"})
+
+    assert response.status_code == 200
+    data = response.json()
+    by_name = {row["chatbot"]["name"]: row for row in data["results"]}
+    assert set(by_name) == {"Support", "Sales"}
+    assert by_name["Support"]["chatbot"]["public_id"] == str(support.public_id)
+    assert by_name["Support"]["messages"]["human"] == 4
+
+
+@pytest.mark.django_db()
+def test_group_by_platform_rows_are_slugs():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    _add_messages(ExperimentSessionFactory.create(team=team, platform="web"), human=5)
+    _add_messages(ExperimentSessionFactory.create(team=team, platform="whatsapp"), human=3)
+
+    client = ApiTestClient(user, team)
+    response = client.get(reverse(USAGE_URL), {"metric": "messages", "group_by": "platform"})
+
+    assert response.status_code == 200
+    data = response.json()
+    by_platform = {row["platform"]: row["messages"]["human"] for row in data["results"]}
+    assert by_platform == {"web": 5, "whatsapp": 3}
+
+
+@pytest.mark.django_db()
+def test_grouped_results_are_cursor_paginated():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    for i in range(3):
+        participant = ParticipantFactory.create(team=team, identifier=f"p{i}@example.com", platform="web")
+        _add_messages(ExperimentSessionFactory.create(team=team, participant=participant, platform="web"), human=1)
+
+    client = ApiTestClient(user, team)
+    first = client.get(reverse(USAGE_URL), {"metric": "messages", "group_by": "participant", "page_size": 2}).json()
+
+    assert first["count"] == 3  # total only on the first page
+    assert len(first["results"]) == 2
+    assert first["next"] is not None
+
+    second = client.get(first["next"]).json()
+    assert len(second["results"]) == 1
+    seen = {row["participant"]["identifier"] for row in first["results"] + second["results"]}
+    assert seen == {"p0@example.com", "p1@example.com", "p2@example.com"}
+
+
+@pytest.mark.django_db()
+def test_platform_grouping_is_cursor_paginated():
+    """Platform has no backing model, so it paginates a distinct-slug queryset ordered by the slug."""
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    for platform in ("web", "whatsapp", "telegram"):
+        _add_messages(ExperimentSessionFactory.create(team=team, platform=platform), human=1)
+
+    client = ApiTestClient(user, team)
+    first = client.get(reverse(USAGE_URL), {"metric": "messages", "group_by": "platform", "page_size": 2}).json()
+
+    assert first["count"] == 3
+    assert len(first["results"]) == 2
+    assert first["next"] is not None
+    second = client.get(first["next"]).json()
+    seen = {row["platform"] for row in first["results"] + second["results"]}
+    assert seen == {"web", "whatsapp", "telegram"}
+
+
+@pytest.mark.django_db()
+def test_chatbot_filter_narrows_all_metrics():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    target = ExperimentFactory.create(team=team)
+    session = ExperimentSessionFactory.create(team=team, experiment=target)
+    _add_messages(session, human=6)
+    UsageRecordFactory.create(team=team, experiment=target, session=session, quantity=500, cost=Decimal("1.50"))
+    # A different chatbot's activity that must be excluded.
+    other_session = ExperimentSessionFactory.create(team=team)
+    _add_messages(other_session, human=9)
+    UsageRecordFactory.create(team=team, experiment=other_session.experiment, session=other_session, cost=Decimal("9"))
+
+    client = ApiTestClient(user, team)
+    response = client.get(
+        reverse(USAGE_URL),
+        {"metric": ["messages", "cost"], "chatbot": str(target.public_id)},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["results"]["messages"]["human"] == 6
+    assert data["results"]["cost"]["total"] == "1.50000000"
+
+
+@pytest.mark.django_db()
+def test_platform_filter_narrows_all_metrics():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    web_session = ExperimentSessionFactory.create(team=team, platform="web")
+    _add_messages(web_session, human=7)
+    UsageRecordFactory.create(team=team, session=web_session, quantity=300, cost=Decimal("2"))
+    wa_session = ExperimentSessionFactory.create(team=team, platform="whatsapp")
+    _add_messages(wa_session, human=4)
+    UsageRecordFactory.create(team=team, session=wa_session, cost=Decimal("5"))
+
+    client = ApiTestClient(user, team)
+    response = client.get(
+        reverse(USAGE_URL),
+        {"metric": ["messages", "cost"], "platform": "web"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["results"]["messages"]["human"] == 7
+    assert data["results"]["cost"]["total"] == "2.00000000"
+
+
+@pytest.mark.django_db()
+def test_grouped_cost_and_tokens_per_group():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    alice = ParticipantFactory.create(team=team, identifier="alice@example.com", platform="web")
+    session = ExperimentSessionFactory.create(team=team, participant=alice, platform="web")
+    _add_messages(session, human=1)
+    UsageRecordFactory.create(
+        team=team,
+        participant=alice,
+        session=session,
+        service_kind=ServiceKind.LLM_INPUT,
+        quantity=1000,
+        cost=Decimal("1"),
+    )
+    UsageRecordFactory.create(
+        team=team,
+        participant=alice,
+        session=session,
+        service_kind=ServiceKind.LLM_OUTPUT,
+        quantity=400,
+        cost=Decimal("2"),
+    )
+
+    client = ApiTestClient(user, team)
+    response = client.get(
+        reverse(USAGE_URL),
+        {"metric": ["cost", "tokens"], "group_by": "participant"},
+    )
+
+    assert response.status_code == 200
+    row = response.json()["results"][0]
+    assert row["participant"]["identifier"] == "alice@example.com"
+    assert row["cost"]["total"] == "3.00000000"
+    assert row["tokens"] == {"prompt": 1000, "completion": 400, "total": 1400}
+
+
+@pytest.mark.django_db()
+def test_group_by_combined_with_granularity_gives_flat_bucket_rows():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    chatbot = ExperimentFactory.create(team=team, name="Daily")
+    session = ExperimentSessionFactory.create(team=team, experiment=chatbot)
+    _add_messages(session, human=1, when=datetime.datetime(2026, 7, 1, 12, tzinfo=datetime.UTC))
+    _add_messages(session, human=2, when=datetime.datetime(2026, 7, 2, 12, tzinfo=datetime.UTC))
+
+    client = ApiTestClient(user, team)
+    response = client.get(
+        reverse(USAGE_URL),
+        {
+            "metric": "messages",
+            "group_by": "chatbot",
+            "granularity": "daily",
+            "start": "2026-07-01",
+            "end": "2026-07-03",
+        },
+    )
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    # one chatbot × two daily buckets = two flat rows, each carrying its bucket_start.
+    assert len(results) == 2
+    for row in results:
+        assert row["chatbot"]["name"] == "Daily"
+        assert "bucket_start" in row
+    by_bucket = {row["bucket_start"][:10]: row["messages"]["human"] for row in results}
+    assert by_bucket == {"2026-07-01": 1, "2026-07-02": 2}
+
+
+@pytest.mark.django_db()
+def test_chatbot_filter_includes_archived_chatbot():
+    """An archived chatbot's messages AND cost must both report — the message path reaches archived
+    experiments by relation, so cost/tokens must resolve them too (not zero out asymmetrically)."""
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    chatbot = ExperimentFactory.create(team=team)
+    session = ExperimentSessionFactory.create(team=team, experiment=chatbot)
+    _add_messages(session, human=4)
+    UsageRecordFactory.create(team=team, experiment=chatbot, session=session, cost=Decimal("7"))
+    chatbot.is_archived = True
+    chatbot.save(update_fields=["is_archived"])
+
+    client = ApiTestClient(user, team)
+    response = client.get(
+        reverse(USAGE_URL),
+        {"metric": ["messages", "cost"], "chatbot": str(chatbot.public_id)},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["results"]["messages"]["human"] == 4
+    assert data["results"]["cost"]["total"] == "7.00000000"
+
+
+@pytest.mark.django_db()
+def test_group_by_chatbot_includes_archived_chatbot():
+    """A chatbot archived after it was active in the window must still appear as a breakdown row, or the
+    grouped rows silently fail to sum to the ungrouped totals (which count archived activity)."""
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    chatbot = ExperimentFactory.create(team=team, name="Archived")
+    _add_messages(ExperimentSessionFactory.create(team=team, experiment=chatbot), human=3)
+    chatbot.is_archived = True
+    chatbot.save(update_fields=["is_archived"])
+
+    client = ApiTestClient(user, team)
+    response = client.get(reverse(USAGE_URL), {"metric": "messages", "group_by": "chatbot"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 1
+    assert data["results"][0]["chatbot"]["name"] == "Archived"
+    assert data["results"][0]["messages"]["human"] == 3
+
+
+def test_grouped_page_size_cap_shrinks_with_bucket_count():
+    """The groups-per-page cap tightens as the bucket count grows, bounding groups × buckets rows."""
+    base = {
+        "team": None,
+        "metrics": {"messages"},
+        "tz": ZoneInfo("UTC"),
+        "start": datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
+        "end": datetime.datetime(2026, 4, 11, tzinfo=datetime.UTC),  # 100 days
+    }
+    assert grouped_page_size_cap(UsageQuery(**base, granularity="total")) == MAX_GROUPED_ROWS
+    assert grouped_page_size_cap(UsageQuery(**base, granularity="daily")) == MAX_GROUPED_ROWS // 100
+
+
+@pytest.mark.django_db()
+def test_platform_evaluations_filter_is_rejected():
+    """`evaluations` is not a real usage platform (its sessions are excluded), so filtering by it is 400."""
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    client = ApiTestClient(user, team)
+
+    response = client.get(reverse(USAGE_URL), {"metric": "messages", "platform": "evaluations"})
+
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db()
+def test_participants_metric_grouped_by_chatbot_counts_distinct():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    chatbot = ExperimentFactory.create(team=team, name="Shared")
+    alice = ParticipantFactory.create(team=team, identifier="alice@example.com", platform="web")
+    bob = ParticipantFactory.create(team=team, identifier="bob@example.com", platform="web")
+    # Two participants, two sessions each on the same chatbot → distinct count is 2, not 4.
+    for participant in (alice, alice, bob):
+        _add_messages(
+            ExperimentSessionFactory.create(team=team, experiment=chatbot, participant=participant, platform="web"),
+            human=1,
+        )
+
+    client = ApiTestClient(user, team)
+    response = client.get(reverse(USAGE_URL), {"metric": "participants", "group_by": "chatbot"})
+
+    assert response.status_code == 200
+    row = response.json()["results"][0]
+    assert row["chatbot"]["name"] == "Shared"
+    assert row["participants"] == 2
+
+
+@pytest.mark.django_db()
+def test_participants_metric_with_group_by_participant_is_rejected():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    client = ApiTestClient(user, team)
+
+    response = client.get(
+        reverse(USAGE_URL),
+        {"metric": "participants", "group_by": "participant"},
+    )
+
+    assert response.status_code == 400
+    assert "redundant" in str(response.json()).lower()
+
+
+@pytest.mark.django_db()
+def test_grouped_team_isolation():
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    other_team = TeamWithUsersFactory.create()
+    _add_messages(ExperimentSessionFactory.create(team=other_team), human=5)
+
+    client = ApiTestClient(user, team)
+    response = client.get(reverse(USAGE_URL), {"metric": "messages", "group_by": "participant"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 0
+    assert data["results"] == []
+
+
+@pytest.mark.django_db()
+def test_unknown_chatbot_filter_returns_zeroed_cost():
+    """A chatbot filter matching no experiment must zero cost, not silently widen to the whole team."""
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    UsageRecordFactory.create(team=team, cost=Decimal("9"))
+
+    client = ApiTestClient(user, team)
+    response = client.get(
+        reverse(USAGE_URL),
+        {"metric": "cost", "chatbot": "00000000-0000-0000-0000-000000000000"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["results"]["cost"] == {"total": "0.00000000", "currency": "USD"}

--- a/apps/api/v2/usage/tests/test_usage_grouping.py
+++ b/apps/api/v2/usage/tests/test_usage_grouping.py
@@ -112,6 +112,27 @@ def test_grouped_results_are_cursor_paginated():
 
 
 @pytest.mark.django_db()
+def test_grouped_default_page_is_bounded_by_cap(monkeypatch):
+    """A grouped request that omits ``page_size`` is still clamped to the cap, not the unclamped project
+    default. Regression: only ``max_page_size`` was lowered, which DRF ignores without a ``page_size``
+    query param, so the default page fell through to ``PAGE_SIZE`` and defeated the cap."""
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    for i in range(3):
+        participant = ParticipantFactory.create(team=team, identifier=f"p{i}@example.com", platform="web")
+        _add_messages(ExperimentSessionFactory.create(team=team, participant=participant, platform="web"), human=1)
+
+    monkeypatch.setattr("apps.api.v2.usage.services.grouped_page_size_cap", lambda query: 2)
+
+    client = ApiTestClient(user, team)
+    # No page_size param: before the fix this returned all 3 (default 100); now bounded to the cap of 2.
+    first = client.get(reverse(USAGE_URL), {"metric": "messages", "group_by": "participant"}).json()
+
+    assert len(first["results"]) == 2
+    assert first["next"] is not None
+
+
+@pytest.mark.django_db()
 def test_platform_grouping_is_cursor_paginated():
     """Platform has no backing model, so it paginates a distinct-slug queryset ordered by the slug."""
     team = TeamWithUsersFactory.create()

--- a/apps/api/v2/usage/views.py
+++ b/apps/api/v2/usage/views.py
@@ -1,21 +1,34 @@
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import PolymorphicProxySerializer, extend_schema
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.api.pagination import CursorPagination
+from apps.api.v2.usage import services
 from apps.api.v2.usage.param_serializers import UsageQuerySerializer
 from apps.api.v2.usage.permissions import CanViewUsage
-from apps.api.v2.usage.serializers import UsageResponseSerializer
-from apps.api.v2.usage.services import UsageQuery, usage_query
+from apps.api.v2.usage.serializers import (
+    GroupedUsageResponseSerializer,
+    GroupedUsageRowSerializer,
+    UsagePeriodSerializer,
+    UsageResponseSerializer,
+)
+from apps.api.v2.usage.services import GROUP_PLATFORM, UsageQuery, usage_query
 from apps.oauth.permissions import TokenHasOAuthResourceScope
+
+
+class PlatformCursorPagination(CursorPagination):
+    # The platform breakdown has no backing model (so no ``created_at``); it paginates the distinct
+    # platform slugs, which are unique and orderable, so cursor over the ``platform`` field instead.
+    ordering = "platform"
 
 
 class UsageView(APIView):
     # A comment, not a docstring: drf-spectacular would publish a docstring as the operation
     # description, and the per-operation description below is the client-facing one.
     # Team-scoped usage inspection. Returns message counts, session counts, distinct participant
-    # counts, cost, and token counts over a time window, optionally bucketed and narrowed to a
-    # single participant.
+    # counts, cost, and token counts over a time window, optionally bucketed, grouped by a dimension,
+    # and narrowed by participant/chatbot/platform.
     # See docs/design/usage-api.md.
 
     permission_classes = [IsAuthenticated, CanViewUsage, TokenHasOAuthResourceScope]
@@ -29,28 +42,54 @@ class UsageView(APIView):
             "(current/previous month) or an explicit half-open 'start'/'end'. Each requested metric "
             "gets its own block: 'messages' (human/AI/total counts), 'sessions' (count), 'participants' "
             "(distinct count), 'cost' (total spend and currency), and 'tokens' (prompt/completion/total). "
-            "With 'granularity' finer than 'total', results are one row per time bucket. Optionally "
-            "narrowed to a single participant."
+            "With 'granularity' finer than 'total', results are one row per time bucket. With 'group_by' "
+            "set, results are cursor-paginated breakdown rows — one per group, or one per (group, bucket) "
+            "when combined with a finer granularity. Optionally narrowed by participant, chatbot, or "
+            "platform."
         ),
         tags=["Usage"],
         # Query parameters are derived from the request serializer so the docs can't drift from validation.
         parameters=[UsageQuerySerializer],
-        responses=UsageResponseSerializer,
+        responses=PolymorphicProxySerializer(
+            component_name="UsageResponseOrGrouped",
+            serializers=[UsageResponseSerializer, GroupedUsageResponseSerializer],
+            resource_type_field_name=None,
+        ),
     )
     def get(self, request):
         params = UsageQuerySerializer(data=request.query_params)
         params.is_valid(raise_exception=True)
         validated = params.validated_data
-        result = usage_query(
-            UsageQuery(
-                team=request.team,
-                metrics=validated["metric"],
-                start=validated["start"],
-                end=validated["end"],
-                granularity=validated["granularity"],
-                tz=validated["tz"],
-                participant=validated.get("participant"),
-                participant_identifier=validated.get("participant_identifier"),
-            )
+        query = UsageQuery(
+            team=request.team,
+            metrics=validated["metric"],
+            start=validated["start"],
+            end=validated["end"],
+            granularity=validated["granularity"],
+            tz=validated["tz"],
+            participant=validated.get("participant"),
+            participant_identifier=validated.get("participant_identifier"),
+            chatbot=validated.get("chatbot"),
+            platform=validated.get("platform"),
+            group_by=validated.get("group_by"),
         )
+        if query.group_by:
+            return self._grouped_response(request, query)
+        result = usage_query(query)
         return Response(UsageResponseSerializer(result).data)
+
+    def _grouped_response(self, request, query: UsageQuery) -> Response:
+        """Cursor-paginate the groups, compute each page's metrics, and wrap the rows in the shared
+        pagination envelope augmented with the request's ``period`` and ``group_by``."""
+        paginator = PlatformCursorPagination() if query.group_by == GROUP_PLATFORM else CursorPagination()
+        # Each group expands to one row per time bucket, so bound groups-per-page by the bucket count to
+        # keep the materialised page (groups × buckets) from ballooning at a fine granularity.
+        paginator.max_page_size = min(paginator.max_page_size, services.grouped_page_size_cap(query))
+        page = paginator.paginate_queryset(services.group_entities(query), request, view=self)
+        rows = services.group_rows(query, page)
+        response = paginator.get_paginated_response(GroupedUsageRowSerializer(rows, many=True).data)
+        response.data["period"] = UsagePeriodSerializer(
+            {"period_start": query.start, "period_end": query.end, "timezone": str(query.tz)}
+        ).data
+        response.data["group_by"] = query.group_by
+        return response

--- a/apps/api/v2/usage/views.py
+++ b/apps/api/v2/usage/views.py
@@ -73,6 +73,8 @@ class UsageView(APIView):
             platform=validated.get("platform"),
             group_by=validated.get("group_by"),
         )
+        # Resolve the participant/chatbot handles to FK ids once, so every metric filters on ids.
+        query = services.resolve_query_filters(query)
         if query.group_by:
             return self._grouped_response(request, query)
         result = usage_query(query)

--- a/apps/api/v2/usage/views.py
+++ b/apps/api/v2/usage/views.py
@@ -83,8 +83,13 @@ class UsageView(APIView):
         pagination envelope augmented with the request's ``period`` and ``group_by``."""
         paginator = PlatformCursorPagination() if query.group_by == GROUP_PLATFORM else CursorPagination()
         # Each group expands to one row per time bucket, so bound groups-per-page by the bucket count to
-        # keep the materialised page (groups × buckets) from ballooning at a fine granularity.
-        paginator.max_page_size = min(paginator.max_page_size, services.grouped_page_size_cap(query))
+        # keep the materialised page (groups × buckets) from ballooning at a fine granularity. Clamp both
+        # the client cutoff (max_page_size) and the default (page_size): DRF only applies max_page_size
+        # when the client sends ?page_size, so a request that omits it would otherwise fall through to the
+        # unclamped project default and defeat the cap.
+        cap = services.grouped_page_size_cap(query)
+        paginator.max_page_size = min(paginator.max_page_size, cap)
+        paginator.page_size = min(paginator.page_size, cap)
         page = paginator.paginate_queryset(services.group_entities(query), request, view=self)
         rows = services.group_rows(query, page)
         response = paginator.get_paginated_response(GroupedUsageRowSerializer(rows, many=True).data)

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -358,6 +358,7 @@ def usage_by_group(
     keys: list,
     granularity: str | None = None,
     tz: ZoneInfo | None = None,
+    resolve_currency: bool = True,
     filters: CostFilters | None = None,
 ) -> list[dict]:
     """Cost + token counts in [start, end) grouped by ``group_field`` (``participant_id`` /
@@ -368,13 +369,16 @@ def usage_by_group(
     caller zero-fills groups/buckets absent from the result. Note the per-group rows need not sum to the
     ungrouped window total: records whose ``group_field`` is NULL (e.g. a session-less record under
     platform grouping) or falls outside ``keys`` are excluded from the breakdown.
+
+    ``resolve_currency=False`` skips the extra ``SELECT DISTINCT currency`` scan when the caller only
+    wants token counts; ``currency`` then defaults to ``"USD"`` (unused by a tokens-only caller).
     """
     scoped = (
         _scoped_records(team, filters)
         .filter(timestamp__gte=start, timestamp__lt=end, **{f"{group_field}__in": keys})
         .annotate(key=F(group_field))
     )
-    currency = _single_currency(scoped)
+    currency = _single_currency(scoped) if resolve_currency else "USD"
     group_cols = ["key"]
     if granularity:
         trunc = _GRANULARITY_TRUNC.get(granularity, TruncDate)

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -117,6 +117,18 @@ class CostFilters:
     participant_ids: list[int] | None = None
 
 
+@dataclass(frozen=True)
+class GroupBreakdown:
+    """How ``usage_by_group`` slices records into rows, bundled so the function takes one argument
+    instead of four parallel ones: the ``field`` to group by and the ``keys`` to keep, plus an optional
+    tz-aware time bucketing (``granularity``/``tz``) that expands each group into one row per bucket."""
+
+    field: str
+    keys: list
+    granularity: str | None = None
+    tz: ZoneInfo | None = None
+
+
 def _scoped_records(team: Team, filters: CostFilters | None = None):
     """Team-scoped UsageRecords with the dashboard's chatbot / participant /
     platform filters applied (mirrors the cost panel's other charts). Platform
@@ -354,16 +366,13 @@ def usage_by_group(
     *,
     start: datetime,
     end: datetime,
-    group_field: str,
-    keys: list,
-    granularity: str | None = None,
-    tz: ZoneInfo | None = None,
+    breakdown: GroupBreakdown,
     resolve_currency: bool = True,
     filters: CostFilters | None = None,
 ) -> list[dict]:
-    """Cost + token counts in [start, end) grouped by ``group_field`` (``participant_id`` /
-    ``experiment_id`` / ``session__platform``), restricted to ``keys``. One row per group — or per
-    (group, bucket) when ``granularity`` is set, truncated in ``tz``. Each row is
+    """Cost + token counts in [start, end) grouped by ``breakdown.field`` (``participant_id`` /
+    ``experiment_id`` / ``session__platform``), restricted to ``breakdown.keys``. One row per group — or
+    per (group, bucket) when ``breakdown.granularity`` is set, truncated in ``breakdown.tz``. Each row is
     ``{'key', ['bucket'], 'cost' (Decimal), 'currency', 'prompt', 'completion', 'total'}``. Shares the
     scoped-record path with ``cost_total``/``token_counts`` (same team + ``CostFilters`` scoping); the
     caller zero-fills groups/buckets absent from the result. Note the per-group rows need not sum to the
@@ -375,14 +384,14 @@ def usage_by_group(
     """
     scoped = (
         _scoped_records(team, filters)
-        .filter(timestamp__gte=start, timestamp__lt=end, **{f"{group_field}__in": keys})
-        .annotate(key=F(group_field))
+        .filter(timestamp__gte=start, timestamp__lt=end, **{f"{breakdown.field}__in": breakdown.keys})
+        .annotate(key=F(breakdown.field))
     )
     currency = _single_currency(scoped) if resolve_currency else "USD"
     group_cols = ["key"]
-    if granularity:
-        trunc = _GRANULARITY_TRUNC.get(granularity, TruncDate)
-        scoped = scoped.annotate(bucket=trunc("timestamp", tzinfo=tz))
+    if breakdown.granularity:
+        trunc = _GRANULARITY_TRUNC.get(breakdown.granularity, TruncDate)
+        scoped = scoped.annotate(bucket=trunc("timestamp", tzinfo=breakdown.tz))
         group_cols.append("bucket")
     rows = (
         scoped.values(*group_cols)

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from decimal import Decimal
 from zoneinfo import ZoneInfo
 
-from django.db.models import Count, DecimalField, Q, Sum
+from django.db.models import Count, DecimalField, F, Q, Sum
 from django.db.models.functions import Coalesce, TruncDate, TruncMonth, TruncWeek
 
 from apps.cost_tracking.models import Confidence, ServiceKind, UsageRecord
@@ -339,6 +339,65 @@ def usage_timeseries(
     return [
         {
             "bucket": row["bucket"],
+            "cost": row["cost"],
+            "currency": currency,
+            "prompt": int(row["prompt"]),
+            "completion": int(row["completion"]),
+            "total": int(row["total"]),
+        }
+        for row in rows
+    ]
+
+
+def usage_by_group(
+    team: Team,
+    *,
+    start: datetime,
+    end: datetime,
+    group_field: str,
+    keys: list,
+    granularity: str | None = None,
+    tz: ZoneInfo | None = None,
+    filters: CostFilters | None = None,
+) -> list[dict]:
+    """Cost + token counts in [start, end) grouped by ``group_field`` (``participant_id`` /
+    ``experiment_id`` / ``session__platform``), restricted to ``keys``. One row per group — or per
+    (group, bucket) when ``granularity`` is set, truncated in ``tz``. Each row is
+    ``{'key', ['bucket'], 'cost' (Decimal), 'currency', 'prompt', 'completion', 'total'}``. Shares the
+    scoped-record path with ``cost_total``/``token_counts`` (same team + ``CostFilters`` scoping); the
+    caller zero-fills groups/buckets absent from the result. Note the per-group rows need not sum to the
+    ungrouped window total: records whose ``group_field`` is NULL (e.g. a session-less record under
+    platform grouping) or falls outside ``keys`` are excluded from the breakdown.
+    """
+    scoped = (
+        _scoped_records(team, filters)
+        .filter(timestamp__gte=start, timestamp__lt=end, **{f"{group_field}__in": keys})
+        .annotate(key=F(group_field))
+    )
+    currency = _single_currency(scoped)
+    group_cols = ["key"]
+    if granularity:
+        trunc = _GRANULARITY_TRUNC.get(granularity, TruncDate)
+        scoped = scoped.annotate(bucket=trunc("timestamp", tzinfo=tz))
+        group_cols.append("bucket")
+    rows = (
+        scoped.values(*group_cols)
+        .annotate(
+            cost=Coalesce(Sum("cost"), _ZERO, output_field=_COST_FIELD),
+            prompt=Coalesce(
+                Sum("quantity", filter=Q(service_kind__in=_PROMPT_KINDS)), _ZERO, output_field=_QUANTITY_FIELD
+            ),
+            completion=Coalesce(
+                Sum("quantity", filter=Q(service_kind=ServiceKind.LLM_OUTPUT)), _ZERO, output_field=_QUANTITY_FIELD
+            ),
+            total=Coalesce(Sum("quantity"), _ZERO, output_field=_QUANTITY_FIELD),
+        )
+        .order_by()
+    )
+    return [
+        {
+            "key": row["key"],
+            "bucket": row.get("bucket"),
             "cost": row["cost"],
             "currency": currency,
             "prompt": int(row["prompt"]),

--- a/docs/design/usage-api.md
+++ b/docs/design/usage-api.md
@@ -144,7 +144,13 @@ Ungrouped, `total` granularity — a single totals object under `results`. With 
 and no `group_by`, `results` is one row per time bucket (each row carries `bucket_start`).
 
 Grouping by participant emits **both** `public_id` and `identifier` per row so clients can map by
-either handle.
+either handle. Chatbot rows carry `{public_id, name}`; platform rows carry the slug directly.
+
+`group_by` combined with a finer `granularity` produces **flat rows**: one row per `(group, bucket)`,
+each carrying the group identity and a `bucket_start`. Pagination is over the groups (the shared
+`CursorPagination`), and each page's groups are expanded to their buckets; the max-window guard bounds
+the bucket count. The group universe is the groups **active in the window** (those with at least one
+message), so idle groups don't produce all-zero rows.
 
 ## Decisions
 


### PR DESCRIPTION
Closes #3852. Adds breakdown (`group_by`) and filter (`chatbot`, `platform`) support to `GET /api/v2/usage/`, on top of the metrics/window/granularity foundation from the earlier slices. Design: `docs/design/usage-api.md`.

### Product Description
Clients can now break usage down by `participant`, `chatbot`, or `platform` (one cursor-paginated row per group) and narrow any metric to a single `chatbot` (public_id) or `platform` (slug).

### Technical Description
A few decisions worth the reviewer's attention:

- **`group_by` + `granularity` shape** was left open by the design doc; it emits **flat `(group × bucket)` rows** (each row carries the group identity and a `bucket_start`). Pagination is over groups, expanded to buckets, bounded by both the existing window guard and a new per-page row cap.
- **`platform` is not a model**, so it paginates a distinct-slug `.values()` queryset via a small `PlatformCursorPagination` (ordered by slug) rather than the entity-queryset path used for participant/chatbot.
- **Archived chatbots**: the `chatbot` filter and `group_by=chatbot` resolve through `Experiment.objects.get_all()`. The message/session paths reach experiments by relation traversal (archived-inclusive), so without this cost/tokens would zero out — and grouped rows would drop archived activity — asymmetrically from the other metrics.
- **Shared `CursorPagination` change (cross-cutting)**: ordering is now `("-created_at", "-pk")`. `-created_at` alone isn't unique and could skip/duplicate rows at a page boundary. This affects every cursor-paginated endpoint, not just usage — the main reason to look beyond the usage app.
- The last four commits are the follow-ups from a self-review; the two `refactor:` commits are behavior-preserving (no response/schema change).

### Migrations
N/A — no schema changes.

### Docs and Changelog
- [x] This PR requires docs/changelog update

New query params (`group_by`, `chatbot`, `platform`) and the grouped/paginated response shape on `GET /api/v2/usage/`.