### PR TITLE
Ensure pnpm via Corepack in bootstrap/tasks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     open-pull-requests-limit: 5
     schedule:
       interval: "monthly"
+  - package-ecosystem: "npm"
+    directory: "/components/chat_widget"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "uv"
     directory: "/"
     open-pull-requests-limit: 5

--- a/api-schemas/export.yml
+++ b/api-schemas/export.yml
@@ -3032,6 +3032,11 @@ components:
           type: string
           description: System ID of the sync task, if present.
           maxLength: 40
+        sync_started_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the current sync task acquired its lock.
         is_archived:
           type: boolean
         collection:

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -163,6 +163,30 @@ install_uv() {
     fi
 }
 
+# Ensure pnpm is available via Corepack (pnpm is pinned in package.json's packageManager field).
+# Enables Corepack when needed and fails clearly if pnpm cannot be made available.
+ensure_pnpm() {
+    if command_exists pnpm; then
+        info "pnpm is available ($(pnpm --version))"
+        return 0
+    fi
+
+    if command_exists corepack; then
+        info "pnpm not found; enabling it via 'corepack enable'..."
+        if corepack enable && command_exists pnpm; then
+            info "pnpm is now available ($(pnpm --version))"
+            return 0
+        fi
+        error "'corepack enable' did not make pnpm available."
+    else
+        error "Neither pnpm nor Corepack is available."
+    fi
+
+    error "pnpm is required for this project. Corepack ships with Node.js; ensure Node 24+ is installed and run 'corepack enable'."
+    [ "$CHECK_ONLY" != true ] && exit 1
+    return 1
+}
+
 # Check Node.js and npm
 check_node() {
     step "Checking Node.js installation..."
@@ -188,15 +212,8 @@ check_node() {
         [ "$CHECK_ONLY" != true ] && exit 1
     fi
 
-    # pnpm is the package manager for this project, provided via corepack (bundled with Node).
-    if command_exists corepack; then
-        corepack enable >/dev/null 2>&1 || true
-    fi
-    if command_exists pnpm; then
-        info "pnpm is installed ($(pnpm --version))"
-    else
-        warn "pnpm not found. Enable it with 'corepack enable' (corepack ships with Node.js 24)."
-    fi
+    # pnpm is the package manager for this project, provided via Corepack (bundled with Node).
+    ensure_pnpm
 }
 
 # Check Python version
@@ -275,8 +292,8 @@ install_python_deps() {
 install_node_deps() {
     step "Installing Node.js dependencies..."
     if confirm "Install/update Node.js dependencies with 'pnpm install'?" "y"; then
+        ensure_pnpm
         info "Running: pnpm install --frozen-lockfile"
-        corepack enable >/dev/null 2>&1 || true
         pnpm install --frozen-lockfile
         info "Node.js dependencies installed successfully"
     else

--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,6 @@
 import platform
 import re
+import shutil
 import sys
 import textwrap
 import time
@@ -259,6 +260,21 @@ def ruff(c: Context, no_fix=False, unsafe_fixes=False, paths=""):
     c.run(f"ruff format {target_paths}", echo=True, pty=True)
 
 
+def _ensure_pnpm(c: Context):
+    """Ensure pnpm is available via Corepack (pinned in package.json), failing clearly if it cannot be."""
+    if shutil.which("pnpm"):
+        return
+    if shutil.which("corepack"):
+        cprint("pnpm not found; enabling it via 'corepack enable'...", "yellow")
+        if c.run("corepack enable", echo=True, warn=True).ok and shutil.which("pnpm"):
+            return
+    raise Exit(
+        "pnpm is required but unavailable. Corepack ships with Node.js; "
+        "ensure Node 24+ is installed and run 'corepack enable'.",
+        -1,
+    )
+
+
 @task(
     aliases=["npm"],
     help={
@@ -268,6 +284,7 @@ def ruff(c: Context, no_fix=False, unsafe_fixes=False, paths=""):
 )
 def pnpm(c: Context, watch=False, install=False):
     """Build frontend assets with webpack. Use --watch for development."""
+    _ensure_pnpm(c)
     if install:
         c.run("pnpm install", echo=True)
     cmd = "dev-watch" if watch else "dev"


### PR DESCRIPTION
### Product Description
no change

### Technical Description
Follow-up to the npm→pnpm migration (#3917). The dev bootstrap script and the `inv pnpm` task previously ran `corepack enable || true` and then invoked pnpm regardless, so a missing/failed Corepack surfaced as a cryptic pnpm error. Both now go through a single `ensure_pnpm` helper that enables Corepack when pnpm is absent and aborts with an actionable message if it still can't be made available.

Also adds a Dependabot entry for `components/chat_widget`, which has its own `pnpm-lock.yaml` and wasn't being monitored (only `/` was configured). Dependabot's `npm` ecosystem covers pnpm lockfiles.

### Migrations
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update