### PR TITLE
Revert accidental direct-to-main bootstrap fix

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -184,9 +184,7 @@ ensure_pnpm() {
 
     error "pnpm is required for this project. Corepack ships with Node.js; ensure Node 24+ is installed and run 'corepack enable'."
     [ "$CHECK_ONLY" != true ] && exit 1
-    # In --check mode, report the problem but keep going (matches the other check_* functions).
-    # A bare `return 1` here is not exempt from `set -e` and would abort the whole --check run.
-    return 0
+    return 1
 }
 
 # Check Node.js and npm


### PR DESCRIPTION
### Product Description
Reverts commit c5d6fee2c, which was pushed directly to `main` by mistake. The fix it contained (bootstrap `--check` abort) is being re-landed via a normal reviewed PR.

### Technical Description
Straight `git revert` of the accidental commit. Once merged, the fix returns through its own PR.

### Migrations
- [ ] The migrations are backwards compatible

### Demo
### Docs and Changelog
- [ ] This PR requires docs/changelog update