### PR TITLE
fix: don't abort bootstrap --check when pnpm/Corepack missing

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -184,7 +184,9 @@ ensure_pnpm() {
 
     error "pnpm is required for this project. Corepack ships with Node.js; ensure Node 24+ is installed and run 'corepack enable'."
     [ "$CHECK_ONLY" != true ] && exit 1
-    return 1
+    # In --check mode, report the problem but keep going (matches the other check_* functions).
+    # A bare `return 1` here is not exempt from `set -e` and would abort the whole --check run.
+    return 0
 }
 
 # Check Node.js and npm


### PR DESCRIPTION
### Product Description
`./bootstrap.sh --check` aborts early (skipping the remaining checks and the "Check complete!" summary) when both pnpm and Corepack are missing — the exact scenario `--check` exists to diagnose.

### Technical Description
`ensure_pnpm` ended with a bare `return 1`. Unlike the `[ ... ] && exit 1` guard (whose failing test is exempt from `set -e`), a bare `return 1` is **not** exempt: since `ensure_pnpm` is the last statement of `check_node`, and `check_node` is a bare call in `do_bootstrap`, the non-zero return propagates up and `set -e` aborts the whole run before the summary.

`return 1` is only ever reachable in `--check` mode (in normal mode the `exit 1` fires first), so it served no purpose other than triggering this bug. Changed to `return 0`, matching the report-and-continue behavior of the sibling `check_*` functions.

Verified by reproducing the abort and confirming `return 0` lets `--check` run to completion.

### Migrations
- [ ] The migrations are backwards compatible

### Demo
### Docs and Changelog
- [ ] This PR requires docs/changelog update