### PR TITLE
Stop chunks of unindexed files reaching collection retrieval

### DIFF
--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -23,7 +23,7 @@ from apps.chat.agent import schemas
 from apps.chat.agent.calculator import calculate
 from apps.chat.agent.openapi_tool import openapi_spec_op_to_function_def
 from apps.chat.models import ChatAttachment
-from apps.documents.models import Collection
+from apps.documents.models import Collection, chunk_from_indexed_file
 from apps.events.forms import ScheduledMessageConfigForm
 from apps.events.models import ScheduledMessage, TimePeriod
 from apps.experiments.models import AgentTools, Experiment, ExperimentSession
@@ -172,6 +172,7 @@ def _perform_collection_search(
     embeddings = list(
         FileChunkEmbedding.objects.annotate(distance=CosineDistance("embedding", query_vector))
         .filter(collection_id=collection.id)
+        .filter(chunk_from_indexed_file())
         .order_by("distance")
         .select_related("file")
         .only("text", "file__name", "file__metadata")[:max_results]

--- a/apps/documents/models.py
+++ b/apps/documents/models.py
@@ -256,9 +256,20 @@ class Collection(BaseTeamModel, VersionsMixin):
                     index_collection_files(collection_files)
             else:
                 # Create versions of file chunk embeddings and add them to the new collection
+                unindexed_file_ids = set(
+                    CollectionFile.objects.filter(collection=self, status__in=UNINDEXED_FILE_STATUSES).values_list(
+                        "file_id", flat=True
+                    )
+                )
                 for embedding in self.filechunkembedding_set.iterator(chunk_size=50):
                     # Skip embeddings for files that are no longer in the collection
                     if embedding.file_id not in file_versions:
+                        continue
+
+                    # A version's CollectionFile rows carry a blank status, so anything copied
+                    # here is trusted forever. Chunks belonging to a file that never finished
+                    # indexing must not be laundered into the version that way.
+                    if embedding.file_id in unindexed_file_ids:
                         continue
 
                     embedding_version = embedding.create_new_version(save=False)

--- a/apps/documents/models.py
+++ b/apps/documents/models.py
@@ -255,21 +255,14 @@ class Collection(BaseTeamModel, VersionsMixin):
                 if collection_files := CollectionFile.objects.filter(collection_id=new_version.id):
                     index_collection_files(collection_files)
             else:
-                # Create versions of file chunk embeddings and add them to the new collection
-                unindexed_file_ids = set(
-                    CollectionFile.objects.filter(collection=self, status__in=UNINDEXED_FILE_STATUSES).values_list(
-                        "file_id", flat=True
-                    )
-                )
-                for embedding in self.filechunkembedding_set.iterator(chunk_size=50):
+                # Create versions of file chunk embeddings and add them to the new collection.
+                # A version's CollectionFile rows carry a blank status, so anything copied here is
+                # trusted forever: chunks of a file that never indexed cleanly must not be laundered
+                # into the version that way.
+                embeddings = self.filechunkembedding_set.filter(chunk_from_indexed_file())
+                for embedding in embeddings.iterator(chunk_size=50):
                     # Skip embeddings for files that are no longer in the collection
                     if embedding.file_id not in file_versions:
-                        continue
-
-                    # A version's CollectionFile rows carry a blank status, so anything copied
-                    # here is trusted forever. Chunks belonging to a file that never finished
-                    # indexing must not be laundered into the version that way.
-                    if embedding.file_id in unindexed_file_ids:
                         continue
 
                     embedding_version = embedding.create_new_version(save=False)

--- a/apps/documents/models.py
+++ b/apps/documents/models.py
@@ -2,6 +2,7 @@ from collections.abc import Iterator
 from datetime import timedelta
 
 from django.db import models, transaction
+from django.db.models.expressions import Combinable
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.text import slugify
@@ -35,6 +36,11 @@ class FileStatus(models.TextChoices):
     IN_PROGRESS = ("in_progress", _("In Progress"))
     COMPLETED = "completed", _("Completed")
     FAILED = "failed", _("Failed")
+
+
+# Statuses whose chunks cannot be trusted: either indexing never finished, or it is about to
+# start again. In every case any chunks currently stored for the file are stale or partial.
+UNINDEXED_FILE_STATUSES = [FileStatus.PENDING, FileStatus.IN_PROGRESS, FileStatus.FAILED]
 
 
 class CollectionFileQuerySet(models.QuerySet):
@@ -75,6 +81,23 @@ class CollectionFile(models.Model):
     @property
     def status_enum(self):
         return FileStatus(self.status)
+
+
+def chunk_from_indexed_file() -> Combinable:
+    """Filter expression dropping `FileChunkEmbedding` rows whose file has not indexed cleanly.
+
+    Excludes `UNINDEXED_FILE_STATUSES` rather than requiring COMPLETED because
+    `create_new_version` adds files via `files.add(...)`, leaving `status` blank, so requiring
+    COMPLETED would return no chunks at all for published collections. Correlates on collection
+    as well as file, since a file can fail in one collection while indexing cleanly in another.
+    """
+    return ~models.Exists(
+        CollectionFile.objects.filter(
+            file_id=models.OuterRef("file_id"),
+            collection_id=models.OuterRef("collection_id"),
+            status__in=UNINDEXED_FILE_STATUSES,
+        )
+    )
 
 
 @audit_fields(

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -693,6 +693,14 @@ class DeleteCollection(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View)
 def retry_failed_uploads(request, team_slug: str, pk: int):
     queryset = CollectionFile.objects.filter(collection_id=pk, status=FileStatus.FAILED)
     collection_file_ids = list(queryset.values_list("id", flat=True))
+    failed_file_ids = list(queryset.values_list("file_id", flat=True))
+
+    # A file that failed partway through leaves the chunks it managed to embed behind, so
+    # discard them before re-indexing or the retry stacks fresh chunks on top of stale ones.
+    # Scoped to failed files deliberately: `FileChunkEmbedding.working_version` cascades, so
+    # deleting a healthy file's chunks would take a published version's copies with it.
+    FileChunkEmbedding.objects.filter(collection_id=pk, file_id__in=failed_file_ids).delete()
+
     queryset.update(status=FileStatus.PENDING)
     tasks.index_collection_files_task.delay(collection_file_ids)
     return redirect("documents:single_collection_home", team_slug=team_slug, pk=pk)

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -691,6 +691,7 @@ class DeleteCollection(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View)
 @login_and_team_required
 @permission_required("documents.change_collection", raise_exception=True)
 def retry_failed_uploads(request, team_slug: str, pk: int):
+    """Re-index every failed file in a collection, discarding what the failed attempt left behind."""
     queryset = CollectionFile.objects.filter(collection_id=pk, status=FileStatus.FAILED)
     collection_file_ids = list(queryset.values_list("id", flat=True))
     failed_file_ids = list(queryset.values_list("file_id", flat=True))

--- a/apps/service_providers/llm_service/index_managers.py
+++ b/apps/service_providers/llm_service/index_managers.py
@@ -12,7 +12,7 @@ from pgvector.django import CosineDistance
 
 from apps.assistants.utils import chunk_list
 from apps.documents.exceptions import FileUploadError
-from apps.documents.models import CollectionFile, FileStatus
+from apps.documents.models import CollectionFile, FileStatus, chunk_from_indexed_file
 from apps.files.models import File, FileChunkEmbedding
 from apps.service_providers.exceptions import UnableToLinkFileException
 
@@ -364,6 +364,7 @@ class LocalIndexManager(IndexManager, metaclass=ABCMeta):
         return (
             FileChunkEmbedding.objects.annotate(distance=CosineDistance("embedding", embedding_vector))
             .filter(collection_id=index_id)
+            .filter(chunk_from_indexed_file())
             .order_by("distance")
             .select_related("file")
             .only("text", "file__name")[:top_k]

--- a/apps/service_providers/llm_service/index_managers.py
+++ b/apps/service_providers/llm_service/index_managers.py
@@ -305,6 +305,10 @@ class LocalIndexManager(IndexManager, metaclass=ABCMeta):
             except Exception as e:
                 logger.exception("Failed to index file", extra={"file_id": file.id, "error": str(e)})
                 collection_file.status = FileStatus.FAILED
+                # A partial index leaves nothing behind: the chunks written before the provider
+                # failed are not a usable representation of the file and must not reach retrieval.
+                FileChunkEmbedding.objects.filter(id__in=[embedding.id for embedding in embeddings]).delete()
+                embeddings = []
             try:
                 collection_file.save(update_fields=["status"])
             except DatabaseError:

--- a/apps/service_providers/llm_service/index_managers.py
+++ b/apps/service_providers/llm_service/index_managers.py
@@ -272,6 +272,11 @@ class LocalIndexManager(IndexManager, metaclass=ABCMeta):
         chunk_size: int | None = None,
         chunk_overlap: int | None = None,
     ):
+        """Chunk and embed each file, marking its CollectionFile COMPLETED or FAILED.
+
+        Files are independent: one failing does not stop the rest. A file that fails leaves
+        no embeddings behind, since a partial index is not a usable representation of it.
+        """
         for collection_file in collection_files:
             file = collection_file.file
             embeddings = []

--- a/apps/service_providers/tests/test_failed_file_retrieval.py
+++ b/apps/service_providers/tests/test_failed_file_retrieval.py
@@ -1,0 +1,249 @@
+"""Regression tests for #3433 - chunks from FAILED files must not surface in retrieval.
+
+Two distinct scenarios are covered, and they guard different halves of the fix:
+
+* A file that fails partway through indexing now. The write-side cleanup removes the
+  chunks it managed to persist, so nothing reaches retrieval in the first place.
+* A collection corrupted *before* this fix shipped, where orphaned chunks are already
+  sitting in the database under a FAILED file. Write-side cleanup cannot reach those, so
+  the read filter and the discard step in the retry view are all that protect against
+  them. These are seeded directly rather than produced through `add_files`, because
+  `add_files` no longer leaves orphans behind and would mask the very code under test.
+"""
+
+from unittest import mock
+
+import pytest
+from django.conf import settings
+from django.urls import reverse
+
+from apps.chat.agent.tools import _perform_collection_search
+from apps.documents.models import CollectionFile, FileStatus
+from apps.files.models import FileChunkEmbedding
+from apps.service_providers.llm_service.index_managers import LocalIndexManager
+from apps.utils.factories.documents import CollectionFactory
+from apps.utils.factories.files import FileFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+
+CHUNKS = ["alpha chunk", "beta chunk", "gamma chunk"]
+
+
+class LocalIndexManagerMock(LocalIndexManager):
+    def chunk_file(self, file, chunk_size=None, chunk_overlap=None):
+        return CHUNKS
+
+    def get_embedding_vector(self, text, *, input_type):  # ty: ignore[invalid-method-override]
+        return [0.1] * settings.EMBEDDING_VECTOR_SIZE
+
+
+@pytest.fixture()
+def collection(db):
+    return CollectionFactory.create(team=TeamWithUsersFactory.create(), is_index=True, is_remote_index=False)
+
+
+@pytest.fixture()
+def index_manager():
+    with mock.patch("apps.service_providers.models.LlmProvider.get_local_index_manager") as get_manager:
+        manager = LocalIndexManagerMock(api_key="api-123", embedding_model_name="embedding-model")
+        get_manager.return_value = manager
+        yield manager
+
+
+def _index_file_failing_on_last_chunk(collection, index_manager):
+    """Index a file where embedding succeeds for chunks 1-2 and fails on chunk 3."""
+    file = FileFactory.create(team=collection.team)
+    collection.files.add(file)
+    collection_file = CollectionFile.objects.get(collection=collection, file=file)
+    collection_file.status = FileStatus.PENDING
+    collection_file.save()
+
+    good_vector = [0.1] * settings.EMBEDDING_VECTOR_SIZE
+    side_effect = [good_vector, good_vector, Exception("provider blew up on chunk 3")]
+
+    with mock.patch.object(index_manager, "get_embedding_vector", side_effect=side_effect):
+        index_manager.add_files(CollectionFile.objects.filter(id=collection_file.id).iterator(1))
+
+    collection_file.refresh_from_db()
+    return file, collection_file
+
+
+def _seed_orphans_from_a_pre_fix_failure(collection, texts, status=FileStatus.FAILED):
+    """Put chunks in the database under a file with the given status, bypassing add_files.
+
+    This is what a collection corrupted by the old code looks like: the file is marked
+    FAILED but the chunks written before the provider gave up are still there. Seeding
+    directly matters, because add_files now cleans up after itself and would leave nothing
+    for the read filter or the delete-before-indexing step to act on.
+    """
+    file = FileFactory.create(team=collection.team)
+    collection.files.add(file, through_defaults={"status": status})
+    collection_file = CollectionFile.objects.get(collection=collection, file=file)
+
+    for chunk_number, text in enumerate(texts, start=1):
+        FileChunkEmbedding.objects.create(
+            team_id=collection.team_id,
+            file=file,
+            collection=collection,
+            chunk_number=chunk_number,
+            text=text,
+            embedding=[0.1] * settings.EMBEDDING_VECTOR_SIZE,
+            page_number=0,
+        )
+
+    return file, collection_file
+
+
+@pytest.mark.django_db()
+class TestFailedFileRetrieval:
+    def test_partial_failure_cleans_up_persisted_chunks(self, collection, index_manager):
+        """A file that fails partway must not leave half its chunks in the database."""
+        file, collection_file = _index_file_failing_on_last_chunk(collection, index_manager)
+
+        assert collection_file.status == FileStatus.FAILED
+        assert FileChunkEmbedding.objects.filter(file=file, collection=collection).count() == 0
+
+    def test_index_manager_query_excludes_failed_file_chunks(self, collection, index_manager):
+        """The Query Collection preview must not return chunks from a FAILED file."""
+        _index_file_failing_on_last_chunk(collection, index_manager)
+
+        results = index_manager.query(index_id=collection.id, query="anything", top_k=5)
+
+        assert list(results) == []
+
+    def test_chat_search_excludes_failed_file_chunks(self, collection, index_manager):
+        """The path a chatbot retrieves through must not return chunks from a FAILED file."""
+        _index_file_failing_on_last_chunk(collection, index_manager)
+
+        output = _perform_collection_search(collection, query="anything", max_results=5)
+
+        assert "alpha chunk" not in output
+        assert "beta chunk" not in output
+
+    def test_retry_after_failure_does_not_duplicate_chunks(self, collection, index_manager):
+        """Re-indexing a previously failed file must replace its chunks, not add to them."""
+        file, collection_file = _index_file_failing_on_last_chunk(collection, index_manager)
+
+        # Simulate documents.views.retry_failed_uploads: FAILED -> PENDING, then re-index.
+        collection_file.status = FileStatus.PENDING
+        collection_file.save()
+        index_manager.add_files(CollectionFile.objects.filter(id=collection_file.id).iterator(1))
+
+        collection_file.refresh_from_db()
+        assert collection_file.status == FileStatus.COMPLETED
+
+        texts = sorted(e.text for e in FileChunkEmbedding.objects.filter(file=file, collection=collection))
+        assert texts == sorted(CHUNKS)
+
+    def test_publishing_does_not_copy_failed_file_chunks(self, collection, index_manager):
+        """A published version must not inherit chunks from a file that failed to index."""
+        _index_file_failing_on_last_chunk(collection, index_manager)
+
+        new_version = collection.create_new_version()
+
+        assert FileChunkEmbedding.objects.filter(collection=new_version).count() == 0
+
+
+@pytest.mark.django_db()
+class TestOrphansFromBeforeTheFix:
+    """Collections already carrying orphaned chunks when this fix ships.
+
+    Write-side cleanup cannot help here, so these are the only tests holding the read
+    filter and the retry-time discard honest.
+    """
+
+    def test_retrieval_hides_orphans_left_by_the_old_code(self, collection, index_manager):
+        """Neither retrieval path may return orphans that predate this fix."""
+        _seed_orphans_from_a_pre_fix_failure(collection, ["alpha chunk", "beta chunk"])
+
+        results = index_manager.query(index_id=collection.id, query="anything", top_k=5)
+        output = _perform_collection_search(collection, query="anything", max_results=5)
+
+        assert list(results) == []
+        assert "alpha chunk" not in output
+        assert "beta chunk" not in output
+
+    @pytest.mark.parametrize(
+        ("status", "expected_visible"),
+        [
+            pytest.param(FileStatus.COMPLETED, True, id="completed-is-served"),
+            pytest.param("", True, id="blank-status-from-versioning-is-served"),
+            pytest.param(FileStatus.FAILED, False, id="failed-is-hidden"),
+            pytest.param(FileStatus.IN_PROGRESS, False, id="killed-mid-index-is-hidden"),
+            pytest.param(FileStatus.PENDING, False, id="queued-for-retry-is-hidden"),
+        ],
+    )
+    def test_retrieval_visibility_by_file_status(self, collection, index_manager, status, expected_visible):
+        """Only a file that has finished indexing may be retrieved from.
+
+        Blank must stay visible: `create_new_version` leaves it blank, so hiding it would
+        black out retrieval for every published collection. PENDING and IN_PROGRESS must be
+        hidden because a file queued for retry, or one whose worker was killed mid-index,
+        still has stale chunks sitting under it.
+        """
+        _seed_orphans_from_a_pre_fix_failure(collection, ["alpha chunk"], status=status)
+
+        results = index_manager.query(index_id=collection.id, query="anything", top_k=5)
+
+        assert bool(list(results)) is expected_visible
+
+    def test_publishing_a_pre_fix_collection_drops_the_orphans(self, collection, index_manager):
+        """Publishing must not launder orphans past the filter.
+
+        A version's CollectionFile rows carry a blank status, so any orphan copied into a
+        version becomes permanently visible. They must not be copied in the first place.
+        """
+        _seed_orphans_from_a_pre_fix_failure(collection, ["alpha chunk", "beta chunk"])
+
+        new_version = collection.create_new_version()
+
+        assert FileChunkEmbedding.objects.filter(collection=new_version).count() == 0
+
+    def test_retrying_discards_orphans_before_reindexing(self, collection, index_manager, client):
+        """Retrying a failed upload must clear its stale chunks, so the retry cannot stack on them.
+
+        The discard happens in the retry view rather than in `add_files`, because
+        `FileChunkEmbedding.working_version` cascades: deleting a working chunk destroys the
+        copies held by published versions. Only failed files are discarded here, so no
+        successfully indexed content is ever at risk.
+        """
+        file, collection_file = _seed_orphans_from_a_pre_fix_failure(collection, ["alpha chunk", "beta chunk"])
+        client.force_login(collection.team.members.first())
+
+        url = reverse("documents:retry_failed_uploads", args=[collection.team.slug, collection.id])
+        with mock.patch("apps.documents.tasks.index_collection_files_task.delay") as index_task:
+            response = client.post(url)
+
+        assert response.status_code == 302
+        index_task.assert_called_once_with([collection_file.id])
+
+        collection_file.refresh_from_db()
+        assert collection_file.status == FileStatus.PENDING
+        assert FileChunkEmbedding.objects.filter(file=file, collection=collection).count() == 0
+
+    def test_retrying_leaves_published_version_chunks_alone(self, collection, index_manager, client):
+        """Discarding a failed file's chunks must not reach into a published version.
+
+        `working_version` is a CASCADE self-FK, so this guards against the discard taking a
+        published collection's content with it.
+        """
+        good_file = FileFactory.create(team=collection.team)
+        collection.files.add(good_file, through_defaults={"status": FileStatus.COMPLETED})
+        FileChunkEmbedding.objects.create(
+            team_id=collection.team_id,
+            file=good_file,
+            collection=collection,
+            chunk_number=1,
+            text="healthy chunk",
+            embedding=[0.1] * settings.EMBEDDING_VECTOR_SIZE,
+            page_number=0,
+        )
+        _seed_orphans_from_a_pre_fix_failure(collection, ["alpha chunk"])
+        new_version = collection.create_new_version()
+        client.force_login(collection.team.members.first())
+
+        url = reverse("documents:retry_failed_uploads", args=[collection.team.slug, collection.id])
+        with mock.patch("apps.documents.tasks.index_collection_files_task.delay"):
+            client.post(url)
+
+        published = FileChunkEmbedding.objects.filter(collection=new_version)
+        assert [chunk.text for chunk in published] == ["healthy chunk"]

--- a/apps/service_providers/tests/test_failed_file_retrieval.py
+++ b/apps/service_providers/tests/test_failed_file_retrieval.py
@@ -29,20 +29,26 @@ CHUNKS = ["alpha chunk", "beta chunk", "gamma chunk"]
 
 
 class LocalIndexManagerMock(LocalIndexManager):
+    """A local index manager that chunks and embeds without calling a provider."""
+
     def chunk_file(self, file, chunk_size=None, chunk_overlap=None):
+        """Return a fixed set of chunks, so tests control exactly how many embeddings are attempted."""
         return CHUNKS
 
     def get_embedding_vector(self, text, *, input_type):  # ty: ignore[invalid-method-override]
+        """Return a constant vector. Distance is irrelevant here; presence in the results is what matters."""
         return [0.1] * settings.EMBEDDING_VECTOR_SIZE
 
 
 @pytest.fixture()
 def collection(db):
+    """A local (not remote) indexed collection whose team has a member, for the view tests."""
     return CollectionFactory.create(team=TeamWithUsersFactory.create(), is_index=True, is_remote_index=False)
 
 
 @pytest.fixture()
 def index_manager():
+    """Patch the provider lookup so the collection resolves to the mock manager."""
     with mock.patch("apps.service_providers.models.LlmProvider.get_local_index_manager") as get_manager:
         manager = LocalIndexManagerMock(api_key="api-123", embedding_model_name="embedding-model")
         get_manager.return_value = manager
@@ -95,6 +101,8 @@ def _seed_orphans_from_a_pre_fix_failure(collection, texts, status=FileStatus.FA
 
 @pytest.mark.django_db()
 class TestFailedFileRetrieval:
+    """A file failing to index now, where the write-side cleanup should leave nothing behind."""
+
     def test_partial_failure_cleans_up_persisted_chunks(self, collection, index_manager):
         """A file that fails partway must not leave half its chunks in the database."""
         file, collection_file = _index_file_failing_on_last_chunk(collection, index_manager)


### PR DESCRIPTION
### Product Description

A file that fails partway through indexing into a local collection leaves the chunks it already embedded in the database, and nothing filtered them out on the way back. Chatbots retrieved fragments of documents that never finished indexing and cited them as sourced from that file. Retrying the upload stacked duplicates on top, publishing copied the orphans into the published version permanently, and a worker killed mid-index left partial chunks served as though complete.

### Technical Description

`chunk_from_indexed_file()` (`documents/models.py`) excludes chunks whose `CollectionFile` has not indexed cleanly, and both retrieval queries now use it. On the write side, `add_files` discards its own chunks when indexing fails, `create_new_version` no longer copies chunks of unindexed files, and `retry_failed_uploads` clears stale chunks before re-indexing.

Two decisions where the obvious alternative is wrong:

* **Excluding `PENDING`/`IN_PROGRESS`/`FAILED` rather than requiring `COMPLETED`.** `create_new_version` adds files via `files.add(...)`, leaving `status` blank, so requiring `COMPLETED` returns zero chunks for every published local collection.
* **The retry discard sits in the view, scoped to failed files, not in `add_files`.** `FileChunkEmbedding.working_version` is a CASCADE self-FK, so deleting a working chunk destroys the copies held by published versions.

Both are pinned by tests. Each of the four changes is mutation tested: reverting any one turns exactly one group red.

The two search tool fixtures in `test_tools.py` create chunks with no `CollectionFile` at all, a state production cannot reach. Left alone here, since making them realistic changes no outcome under this filter and the file is already over its length threshold.

Scope note: the issue names `LocalIndexManager.query`, which serves only the Query Collection preview. Chat retrieval uses a near-identical query in `_perform_collection_search`, so both are fixed.

Not addressed here: `CollectionFile` has no uniqueness constraint on `(file, collection)`. Duplicates are not reachable through any current path, but a stale `FAILED` row beside a good one would hide that file's chunks. Fixing it needs a constraint plus deduplicating existing rows.

### Migrations
- [x] The migrations are backwards compatible

No migrations. `makemigrations --check` reports no changes.

### Demo

Query Collection on a collection with a failed file: chunks returned before, none after.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Closes #3433
