### PR TITLE
fix: apply every filter on a column instead of only the last

### DIFF
--- a/apps/chatbots/tests/test_chatbot_views.py
+++ b/apps/chatbots/tests/test_chatbot_views.py
@@ -364,6 +364,45 @@ def test_chatbot_sessions_table_view(team_with_users):
 
 
 @pytest.mark.django_db()
+def test_chatbot_sessions_table_view_applies_both_filters_on_one_column(client, team_with_users):
+    """A date range built from two filters on the same column must exclude out-of-range sessions.
+
+    Regression test for filters on the same column overwriting each other, which let
+    sessions from outside the requested range through.
+    """
+    team = team_with_users
+    user = team.members.first()
+    client.force_login(user)
+    experiment = ExperimentFactory.create(team=team)
+    in_range, out_of_range = (
+        ExperimentSessionFactory.create(
+            team=team,
+            experiment=experiment,
+            participant__team=team,
+            first_activity_at=datetime(2026, month, 15, tzinfo=UTC),
+        )
+        for month in (5, 1)
+    )
+
+    url = reverse("chatbots:sessions-list", kwargs={"team_slug": team.slug, "experiment_id": experiment.id})
+    response = client.get(
+        url,
+        {
+            "filter_0_column": "first_message",
+            "filter_0_operator": "after",
+            "filter_0_value": "2026-04-30",
+            "filter_1_column": "first_message",
+            "filter_1_operator": "before",
+            "filter_1_value": "2026-06-01",
+        },
+    )
+
+    assert response.status_code == 200
+    assert list(response.context_data["table"].data.data) == [in_range]
+    assert str(out_of_range.external_id) not in response.content.decode()
+
+
+@pytest.mark.django_db()
 @pytest.mark.parametrize("flag_active", [True, False])
 def test_continue_chat_action_respects_widget_flag(flag_active, client, team_with_users):
     """With ``flag_chat_widget`` active the Continue Chat action opens the embedded widget;

--- a/apps/experiments/tests/test_filters.py
+++ b/apps/experiments/tests/test_filters.py
@@ -287,6 +287,53 @@ class TestExperimentSessionFilters:
         assert filtered.count() == 1
         assert filtered.first() == session2
 
+    def test_two_filters_on_the_same_column_are_both_applied(self):
+        """Regression test: a date range expressed as two filters on one column.
+
+        The UI allows `First Message after X` AND `First Message before Y`. Both must be
+        applied — previously the second silently replaced the first, so sessions outside
+        the range (e.g. January) were still returned.
+        """
+        session_jan = ExperimentSessionFactory.create()
+        session_may = ExperimentSessionFactory.create(experiment=session_jan.experiment)
+        session_jul = ExperimentSessionFactory.create(experiment=session_jan.experiment)
+        for session, first_activity_at in [
+            (session_jan, "2026-01-15"),
+            (session_may, "2026-05-15"),
+            (session_jul, "2026-07-15"),
+        ]:
+            session.first_activity_at = timezone.datetime.fromisoformat(f"{first_activity_at}T10:00:00+00:00")
+            session.save()
+
+        params = {
+            "filter_0_column": "first_message",
+            "filter_0_operator": Operators.AFTER,
+            "filter_0_value": "2026-04-30",
+            "filter_1_column": "first_message",
+            "filter_1_operator": Operators.BEFORE,
+            "filter_1_value": "2026-06-01",
+        }
+        filtered = ExperimentSessionFilter().apply(
+            session_jan.experiment.sessions.all(), FilterParams(_get_querydict(params))
+        )
+        assert list(filtered) == [session_may]
+
+    def test_two_tag_filters_on_the_same_column_are_both_applied(self, sessions_with_tags):
+        """Two `any of` tag filters on the same column combine with AND."""
+        sessions, _ = sessions_with_tags
+        params = {
+            "filter_0_column": "tags",
+            "filter_0_operator": Operators.ANY_OF,
+            "filter_0_value": json.dumps(["important"]),
+            "filter_1_column": "tags",
+            "filter_1_operator": Operators.ANY_OF,
+            "filter_1_value": json.dumps(["follow-up"]),
+        }
+        filtered = ExperimentSessionFilter().apply(
+            sessions[0].experiment.sessions.all(), FilterParams(_get_querydict(params))
+        )
+        assert list(filtered) == [sessions[1]]
+
     def test_tag_filters(self, sessions_with_tags):
         """Test tag filtering with ANY_OF and ALL_OF operators"""
         sessions, tags = sessions_with_tags

--- a/apps/web/dynamic_filters/base.py
+++ b/apps/web/dynamic_filters/base.py
@@ -9,7 +9,7 @@ from typing import Any, ClassVar, Literal
 from django.db.models import Q, QuerySet
 from pydantic import BaseModel, Field, computed_field
 
-from .datastructures import FilterParams
+from .datastructures import ColumnFilterData, FilterParams
 
 logger = logging.getLogger("ocs.filters")
 
@@ -161,10 +161,18 @@ class ColumnFilter(BaseModel):
         return query_value
 
     def apply(self, queryset: QuerySet, filter_params: FilterParams, timezone=None) -> QuerySet:
-        column_filter = filter_params.get(self.query_param)
-        if not column_filter:
-            return queryset
+        """Apply every filter targeting this column, combining them with AND.
 
+        A column may appear more than once — the UI expresses a date range as
+        ``after X`` plus ``before Y`` on the same column — so each one narrows the
+        queryset further.
+        """
+        for column_filter in filter_params.get_all(self.query_param):
+            if column_filter:
+                queryset = self._apply_one(queryset, column_filter, timezone)
+        return queryset
+
+    def _apply_one(self, queryset: QuerySet, column_filter: ColumnFilterData, timezone=None) -> QuerySet:
         operator = column_filter.operator.replace(" ", "_").lower()
         if method := getattr(self, f"apply_{operator}", None):
             parsed_value = self.parse_query_value(column_filter.value)

--- a/apps/web/dynamic_filters/datastructures.py
+++ b/apps/web/dynamic_filters/datastructures.py
@@ -33,10 +33,15 @@ class ColumnFilterData(BaseModel):
 
 
 class FilterParams:
-    """A container for filter parameters extracted from a request's query parameters."""
+    """A container for filter parameters extracted from a request's query parameters.
+
+    Filters are held as a flat, ordered list rather than keyed by column: the UI allows
+    several filters on the same column (e.g. ``First Message after X`` AND
+    ``First Message before Y`` to express a date range), and each one must be applied.
+    """
 
     def __init__(self, query_params: QueryDict | None = None, column_filters: list[ColumnFilterData] | None = None):
-        self.filters: dict[str, ColumnFilterData] = {}
+        self.filters: list[ColumnFilterData] = []
 
         if query_params:
             for i in range(settings.MAX_FILTER_PARAMS):
@@ -44,13 +49,12 @@ class FilterParams:
                 filter_operator = query_params.get(f"filter_{i}_operator")
                 filter_value = query_params.get(f"filter_{i}_value")
                 if filter_column and filter_operator and filter_value:
-                    self.filters[filter_column] = ColumnFilterData(
-                        column=filter_column, operator=filter_operator, value=filter_value
+                    self.filters.append(
+                        ColumnFilterData(column=filter_column, operator=filter_operator, value=filter_value)
                     )
 
         if column_filters:
-            for item in column_filters:
-                self.filters[item.column] = item
+            self.filters.extend(column_filters)
 
     @classmethod
     def from_request(cls, request) -> Self:
@@ -66,12 +70,13 @@ class FilterParams:
             return cls(QueryDict(parsed_url.query))
         return cls()
 
-    def get(self, column: str) -> ColumnFilterData | None:
-        return self.filters.get(column)
+    def get_all(self, column: str) -> list[ColumnFilterData]:
+        """All filters targeting ``column``, in the order they were supplied."""
+        return [filter_data for filter_data in self.filters if filter_data.column == column]
 
     def to_query(self) -> str:
         query_data = {}
-        for i, filter_data in enumerate(self.filters.values()):
+        for i, filter_data in enumerate(self.filters):
             query_data.update(
                 {
                     f"filter_{i}_column": filter_data.column,

--- a/apps/web/dynamic_filters/tests/test_datastructures.py
+++ b/apps/web/dynamic_filters/tests/test_datastructures.py
@@ -1,0 +1,67 @@
+from urllib.parse import parse_qs
+
+import pytest
+from django.http import QueryDict
+
+from apps.web.dynamic_filters.datastructures import ColumnFilterData, FilterParams
+
+
+def _querydict(params: dict) -> QueryDict:
+    query_dict = QueryDict("", mutable=True)
+    query_dict.update(params)
+    return query_dict
+
+
+def test_multiple_filters_on_the_same_column_are_all_retained():
+    """Two filters on one column (e.g. a date range built from `after` + `before`) must both survive."""
+    params = _querydict(
+        {
+            "filter_0_column": "first_message",
+            "filter_0_operator": "after",
+            "filter_0_value": "2026-04-30",
+            "filter_1_column": "first_message",
+            "filter_1_operator": "before",
+            "filter_1_value": "2026-06-01",
+        }
+    )
+    filter_params = FilterParams(params)
+
+    assert [(f.operator, f.value) for f in filter_params.get_all("first_message")] == [
+        ("after", "2026-04-30"),
+        ("before", "2026-06-01"),
+    ]
+
+
+def test_get_all_returns_empty_list_for_unknown_column():
+    assert FilterParams().get_all("first_message") == []
+
+
+def test_to_query_round_trips_duplicate_columns():
+    column_filters = [
+        ColumnFilterData(column="first_message", operator="after", value="2026-04-30"),
+        ColumnFilterData(column="first_message", operator="before", value="2026-06-01"),
+        ColumnFilterData(column="participant", operator="equals", value="bob"),
+    ]
+    query = FilterParams(column_filters=column_filters).to_query()
+
+    round_tripped = FilterParams(QueryDict(query))
+    assert [(f.column, f.operator, f.value) for f in round_tripped.filters] == [
+        (f.column, f.operator, f.value) for f in column_filters
+    ]
+    # each filter gets its own index so nothing is silently dropped
+    assert sorted(parse_qs(query)["filter_0_column"] + parse_qs(query)["filter_1_column"]) == [
+        "first_message",
+        "first_message",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("operator", "value", "expected"),
+    [
+        pytest.param("any of", '["a", "b"]', '["a", "b"]', id="json-list-untouched"),
+        pytest.param("any of", "a", '["a"]', id="bare-string-wrapped"),
+        pytest.param("equals", "a", "a", id="non-list-operator-untouched"),
+    ],
+)
+def test_column_filter_data_normalises_list_values(operator, value, expected):
+    assert ColumnFilterData(column="tags", operator=operator, value=value).value == expected

--- a/docs/developer_guides/code_systems/dynamic_filters.md
+++ b/docs/developer_guides/code_systems/dynamic_filters.md
@@ -41,13 +41,15 @@ The `{i}` represents the filter index (0 to `MAX_FILTER_PARAMS-1`), allowing mul
 ### FilterParams and ColumnFilterData
 The `FilterParams` class extracts filter parameters from request query parameters and organizes them into `ColumnFilterData` objects. Each `ColumnFilterData` contains the column name, operator, and value for a single filter.
 
+The same column may appear more than once — a date range is expressed as `after X` plus `before Y` on the same column — so `FilterParams` keeps a flat, ordered list of filters rather than one entry per column. Use `FilterParams.get_all(column)` to retrieve every filter for a column.
+
 ### Column Filter
 The `ColumnFilter` class acts as a bridge between query parameters and ORM filters. Each filter defines a `query_param` attribute that corresponds to the column name in the query parameters. When a request contains `filter_{i}_column` matching this `query_param`, the filter processes the associated operator and value to generate the appropriate database query.
 
 The `ColumnFilter.apply()` method:
-1. Retrieves the `ColumnFilterData` for its `query_param` from `FilterParams`
-2. Converts the operator to a method name (e.g., "starts with" → `apply_starts_with`)
-3. Calls the appropriate `apply_*` method with the parsed value
+1. Retrieves every `ColumnFilterData` for its `query_param` from `FilterParams`
+2. For each one, converts the operator to a method name (e.g., "starts with" → `apply_starts_with`)
+3. Calls the appropriate `apply_*` method with the parsed value, narrowing the queryset further each time (filters on the same column combine with AND)
 
 ### Available Filter Types
 


### PR DESCRIPTION
### Product Description
Filters on the same column were not respected. Because a date range is expressed as two filters on one column (e.g. `First Message after 04/30/2026` AND `First Message before 06/01/2026`), only the second was applied and out-of-range rows (e.g. January sessions) were still returned. This affected every table using dynamic filters.

### Technical Description
`FilterParams` stored filters in a dict keyed by column name, so a second filter on the same column overwrote the first. It now keeps a flat, ordered `list[ColumnFilterData]` and exposes `get_all(column)` in place of `get(column)`. `ColumnFilter.apply()` iterates over every filter for its column and combines them with AND (single-filter logic extracted into `_apply_one`). `to_query()` re-indexes each filter so saved filters and dataset auto-population rules round-trip both halves of a range.

Added regression tests at three levels: queryset (`apps/experiments/tests/test_filters.py`), HTTP view (`apps/chatbots/tests/test_chatbot_views.py`), and unit (`apps/web/dynamic_filters/tests/test_datastructures.py`). Developer docs updated.

Fixes #3921


### Demo
N/A — covered by the view-level regression test.

### Docs and Changelog
- [x] This PR requires docs/changelog update (docs updated in this PR)

Generated with [Claude Code](https://claude.ai/code)