### PR TITLE
feat: scope strip_node_data to a single team and report progress

### DIFF
--- a/apps/pipelines/management/commands/strip_node_data.py
+++ b/apps/pipelines/management/commands/strip_node_data.py
@@ -1,10 +1,11 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from apps.pipelines.migrations.utils.strip_node_data import (
     rebuild_node_data_in_pipelines,
     strip_node_data_from_pipelines,
 )
 from apps.pipelines.models import Node, Pipeline
+from apps.teams.models import Team
 
 
 class Command(BaseCommand):
@@ -21,11 +22,25 @@ class Command(BaseCommand):
             action="store_true",
             help="Reverse: rebuild the embedded node blobs from the Node rows (needed by pre-ADR-0046 code).",
         )
+        parser.add_argument(
+            "--team",
+            help="Limit to a single team, by slug.",
+        )
 
     def handle(self, *args, **options):
+        team = None
+        if options["team"]:
+            try:
+                team = Team.objects.get(slug=options["team"])
+            except Team.DoesNotExist:
+                raise CommandError(f"Team '{options['team']}' does not exist.") from None
+
         if options["rebuild"]:
-            rebuild_node_data_in_pipelines(Pipeline, Node)
+            rebuild_node_data_in_pipelines(Pipeline, Node, team=team)
             self.stdout.write(self.style.SUCCESS("Rebuilt node data in pipeline data."))
         else:
-            strip_node_data_from_pipelines(Pipeline, Node)
+            strip_node_data_from_pipelines(Pipeline, Node, team=team, progress_callback=self._report_progress)
             self.stdout.write(self.style.SUCCESS("Stripped node data from pipeline data."))
+
+    def _report_progress(self, processed, total):
+        self.stdout.write(f"Processed {processed}/{total} pipelines")

--- a/apps/pipelines/migrations/utils/strip_node_data.py
+++ b/apps/pipelines/migrations/utils/strip_node_data.py
@@ -18,15 +18,29 @@ LAYOUT_NODE_KEYS = ("id", "type", "position")
 BATCH_SIZE = 500
 
 
-def strip_node_data_from_pipelines(Pipeline, Node):
+def strip_node_data_from_pipelines(Pipeline, Node, team=None, progress_callback=None):
+    """`team`, if given, scopes the strip to that team's pipelines only.
+
+    `progress_callback(processed, total)` is invoked every ``BATCH_SIZE`` pipelines
+    and once more on the final pipeline, if given.
+    """
+    queryset = Pipeline._base_manager.exclude(data__isnull=True)
+    if team is not None:
+        queryset = queryset.filter(team=team)
+    total = queryset.count()
+
     pending = []
-    for pipeline in Pipeline._base_manager.exclude(data__isnull=True).iterator(chunk_size=BATCH_SIZE):
+    processed = 0
+    for pipeline in queryset.iterator(chunk_size=BATCH_SIZE):
         rows = []
         for row in Node._base_manager.filter(pipeline_id=pipeline.id).order_by("-is_archived"):
             rows.append(row)
 
         _backfill_positions(pipeline, Node, node_rows=rows)
         stripped_nodes = _strip_nodes(pipeline, Node, rows)
+        processed += 1
+        if progress_callback and (processed % BATCH_SIZE == 0 or processed == total):
+            progress_callback(processed, total)
         if stripped_nodes is None:
             continue
         pipeline.data = {**pipeline.data, "nodes": stripped_nodes}
@@ -93,15 +107,21 @@ def _strip_nodes(pipeline, Node, node_rows):
     return [{key: node[key] for key in LAYOUT_NODE_KEYS if key in node} for node in nodes]
 
 
-def rebuild_node_data_in_pipelines(Pipeline, Node):
+def rebuild_node_data_in_pipelines(Pipeline, Node, team=None):
     """Reverse of the strip: rebuild each node's embedded content blob from its Node row.
 
     Exists so the strip is genuinely reversible — pre-ADR-0046 code requires the
     blob (``FlowNode.data`` was a mandatory field), so a code rollback needs it restored.
     Nodes without a backing row are left untouched. Idempotent.
+
+    `team`, if given, scopes the rebuild to that team's pipelines only.
     """
+    queryset = Pipeline._base_manager.exclude(data__isnull=True)
+    if team is not None:
+        queryset = queryset.filter(team=team)
+
     pending = []
-    for pipeline in Pipeline._base_manager.exclude(data__isnull=True).iterator(chunk_size=BATCH_SIZE):
+    for pipeline in queryset.iterator(chunk_size=BATCH_SIZE):
         nodes = (pipeline.data or {}).get("nodes") or []
         if not nodes:
             continue

--- a/apps/pipelines/tests/test_strip_node_data.py
+++ b/apps/pipelines/tests/test_strip_node_data.py
@@ -1,7 +1,6 @@
 import pytest
 from django.core.management import CommandError, call_command
 
-from apps.pipelines.migrations.utils import strip_node_data as strip_node_data_module
 from apps.pipelines.migrations.utils.strip_node_data import (
     rebuild_node_data_in_pipelines,
     strip_node_data_from_pipelines,
@@ -120,18 +119,6 @@ class TestStripNodeData:
         other_pipeline.refresh_from_db()
         assert all("data" not in node for node in pipeline.data["nodes"])
         assert all("data" in node for node in other_pipeline.data["nodes"])
-
-    def test_reports_progress_periodically(self, team, monkeypatch):
-        monkeypatch.setattr(strip_node_data_module, "BATCH_SIZE", 1)
-        for _ in range(3):
-            _create_old_format_pipeline(team)
-        calls = []
-
-        strip_node_data_from_pipelines(
-            Pipeline, Node, progress_callback=lambda processed, total: calls.append((processed, total))
-        )
-
-        assert calls == [(1, 3), (2, 3), (3, 3)]
 
     def test_progress_callback_is_optional(self, team):
         _create_old_format_pipeline(team)

--- a/apps/pipelines/tests/test_strip_node_data.py
+++ b/apps/pipelines/tests/test_strip_node_data.py
@@ -1,11 +1,13 @@
 import pytest
-from django.core.management import call_command
+from django.core.management import CommandError, call_command
 
+from apps.pipelines.migrations.utils import strip_node_data as strip_node_data_module
 from apps.pipelines.migrations.utils.strip_node_data import (
     rebuild_node_data_in_pipelines,
     strip_node_data_from_pipelines,
 )
 from apps.pipelines.models import Node, Pipeline
+from apps.utils.factories.team import TeamFactory
 
 
 def _old_format_data():
@@ -106,6 +108,35 @@ class TestStripNodeData:
 
         pipeline.refresh_from_db()
         assert pipeline.data == data
+
+    def test_scopes_to_single_team(self, team):
+        other_team = TeamFactory.create()
+        pipeline = _create_old_format_pipeline(team)
+        other_pipeline = _create_old_format_pipeline(other_team)
+
+        strip_node_data_from_pipelines(Pipeline, Node, team=team)
+
+        pipeline.refresh_from_db()
+        other_pipeline.refresh_from_db()
+        assert all("data" not in node for node in pipeline.data["nodes"])
+        assert all("data" in node for node in other_pipeline.data["nodes"])
+
+    def test_reports_progress_periodically(self, team, monkeypatch):
+        monkeypatch.setattr(strip_node_data_module, "BATCH_SIZE", 1)
+        for _ in range(3):
+            _create_old_format_pipeline(team)
+        calls = []
+
+        strip_node_data_from_pipelines(
+            Pipeline, Node, progress_callback=lambda processed, total: calls.append((processed, total))
+        )
+
+        assert calls == [(1, 3), (2, 3), (3, 3)]
+
+    def test_progress_callback_is_optional(self, team):
+        _create_old_format_pipeline(team)
+
+        strip_node_data_from_pipelines(Pipeline, Node)
 
 
 @pytest.mark.django_db()
@@ -232,3 +263,19 @@ class TestStripNodeDataCommand:
         pipeline.refresh_from_db()
         nodes_by_id = {node["id"]: node for node in pipeline.data["nodes"]}
         assert nodes_by_id["start-1"]["data"]["type"] == "StartNode"
+
+    def test_team_option_scopes_to_single_team(self, team):
+        other_team = TeamFactory.create()
+        pipeline = _create_old_format_pipeline(team)
+        other_pipeline = _create_old_format_pipeline(other_team)
+
+        call_command("strip_node_data", "--team", team.slug)
+
+        pipeline.refresh_from_db()
+        other_pipeline.refresh_from_db()
+        assert all("data" not in node for node in pipeline.data["nodes"])
+        assert all("data" in node for node in other_pipeline.data["nodes"])
+
+    def test_team_option_raises_for_unknown_slug(self, team):
+        with pytest.raises(CommandError):
+            call_command("strip_node_data", "--team", "does-not-exist")


### PR DESCRIPTION
Adds a --team option to the strip_node_data command (applies to both the strip and --rebuild paths) and a periodic progress callback for strip_node_data_from_pipelines.

<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->


### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update
N/A

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
