### PR TITLE
Fix: transaction-atomic-db-exceptions): Fixes transaction.atomic excep…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,3 +73,12 @@ repos:
         pass_filenames: false
         always_run: true
         fail_fast: true
+      - id: atomic-exception-handling
+        name: database exceptions must not be caught inside transaction.atomic()
+        # Stdlib-only AST check, so it needs no virtualenv of its own. The repo-wide
+        # gate lives in scripts/test_check_atomic_exception_handling.py; this hook is
+        # the fast signal on the files a commit or PR actually touches.
+        entry: python3 scripts/check_atomic_exception_handling.py apps --files
+        language: system
+        files: ^apps/.*\.py$
+        exclude: /migrations/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ Tests and typecheck are necessary but not sufficient. For any change with a runt
 * For regressions: add a failing test that reproduces the bug, then fix to green
 * Prefer `pytest.mark.parametrize` for tests over enumerated data (same assertion, varying inputs); give each case a readable ID with `pytest.param(..., id="...")` rather than an inline comment
 * Always use @.github/pull_request_template.md as the template for pull request descriptions
+* Catch database exceptions *outside* `transaction.atomic()`, or wrap the failing code in a nested `atomic()` savepoint — a DB error caught inside the block leaves an aborted transaction that raises on the next query or on block exit. Enforced by `scripts/check_atomic_exception_handling.py` (pre-commit hook `atomic-exception-handling`)
 
 ## Ask first
 Confirm with a human before these — they are hard to reverse or change a shared contract:

--- a/apps/annotations/models.py
+++ b/apps/annotations/models.py
@@ -174,8 +174,8 @@ class UserComment(BaseTeamModel):
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey("content_type", "object_id")
 
-    @transaction.atomic()
     @staticmethod
+    @transaction.atomic()
     def add_for_model(model, comment: str, added_by: CustomUser, team: Team) -> "UserComment | None":
         try:
             model._meta.get_field("comments")

--- a/apps/annotations/tests/test_comments.py
+++ b/apps/annotations/tests/test_comments.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from django.urls import reverse
 
+from apps.annotations.models import UserComment
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.utils.factories.experiment import ExperimentSessionFactory
 from apps.utils.factories.team import TeamWithUsersFactory
@@ -51,6 +52,30 @@ def test_unlink_comment_view(chat, client):
     client.post(url, data=data)
 
     assert message.comments.count() == 0
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "accessor",
+    [
+        pytest.param(lambda: UserComment, id="via-class"),
+        pytest.param(lambda: UserComment(), id="via-instance"),
+    ],
+)
+def test_add_for_model_is_a_real_staticmethod(chat, accessor):
+    """`add_for_model` must not bind an instance to its `model` argument.
+
+    Stacking `@transaction.atomic()` above `@staticmethod` wraps the descriptor rather than
+    the function, leaving a plain function on the class — instance access then passes the
+    instance as `model` and the call fails with a TypeError.
+    """
+    message = ChatMessage.objects.create(chat=chat, message_type=ChatMessageType.HUMAN, content="Sqeezy")
+    user = chat.team.members.first()
+
+    comment = accessor().add_for_model(message, comment="a comment", added_by=user, team=chat.team)
+
+    assert comment is not None
+    assert comment.content_object == message
 
 
 @pytest.mark.django_db()

--- a/apps/assistants/views.py
+++ b/apps/assistants/views.py
@@ -126,7 +126,8 @@ class CreateOpenAiAssistant(BaseOpenAiAssistantView, CreateView):
         self.object = form.save()
         resource_formsets.save(self.request, self.object)
         try:
-            push_assistant_to_openai(self.object, internal_tools=get_assistant_tools(self.object))
+            with transaction.atomic():
+                push_assistant_to_openai(self.object, internal_tools=get_assistant_tools(self.object))
         except OpenAiSyncError as e:
             messages.error(self.request, f"Error syncing assistant to OpenAI: {e}")
             return self.form_invalid(form)
@@ -149,7 +150,8 @@ class EditOpenAiAssistant(BaseOpenAiAssistantView, UpdateView):
         if "file_search" in self.object.builtin_tools:
             ToolResources.objects.get_or_create(assistant=self.object, tool_type="file_search")
         try:
-            push_assistant_to_openai(self.object, internal_tools=get_assistant_tools(self.object))
+            with transaction.atomic():
+                push_assistant_to_openai(self.object, internal_tools=get_assistant_tools(self.object))
         except OpenAiSyncError as e:
             messages.error(self.request, f"Error syncing changes to OpenAI: {e}")
             form.add_error(None, str(e))

--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -484,11 +484,12 @@ class AttachMediaTool(CustomBaseTool):
 
         response = []
         include_links = self.experiment_session.experiment_channel.platform == ChannelPlatform.WEB
+        chat_attachment = self.chat_attachment
         for file_id in file_ids:
             try:
                 with transaction.atomic():
                     file = File.objects.get(id=file_id)
-                    self.chat_attachment.files.add(file_id)
+                    chat_attachment.files.add(file_id)
                     self.tool_callbacks.attach_file(file_id)
                     file_response = SUCCESSFUL_ATTACHMENT_MESSAGE.format(file_id=file_id, name=file.name)
 

--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -477,16 +477,23 @@ class AttachMediaTool(CustomBaseTool):
         )
         return chat_attachment
 
-    @transaction.atomic
     def action(self, file_ids: list[int]) -> str:
         if len(file_ids) > 5:
             return "A maximum of 5 files can be attached."
 
         response = []
         include_links = self.experiment_session.experiment_channel.platform == ChannelPlatform.WEB
+        # Resolve the parent row here, outside the per-file blocks below. `chat_attachment` is a
+        # cached_property, so leaving it to be evaluated on the first loop iteration puts its
+        # get_or_create inside that file's transaction: if the file fails, the rollback drops the row
+        # while the cached object keeps its id, and the m2m table's deferred foreign key then fails
+        # at COMMIT — after every later file has been reported attached.
         chat_attachment = self.chat_attachment
         for file_id in file_ids:
             try:
+                # One transaction per file, so a failed attachment rolls back on its own and the
+                # loop can keep going. Catching a DB error without leaving the block would abort
+                # the transaction and break every remaining iteration.
                 with transaction.atomic():
                     file = File.objects.get(id=file_id)
                     chat_attachment.files.add(file_id)

--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -486,28 +486,29 @@ class AttachMediaTool(CustomBaseTool):
         include_links = self.experiment_session.experiment_channel.platform == ChannelPlatform.WEB
         for file_id in file_ids:
             try:
-                file = File.objects.get(id=file_id)
-                self.chat_attachment.files.add(file_id)
-                self.tool_callbacks.attach_file(file_id)
-                file_response = SUCCESSFUL_ATTACHMENT_MESSAGE.format(file_id=file_id, name=file.name)
+                with transaction.atomic():
+                    file = File.objects.get(id=file_id)
+                    self.chat_attachment.files.add(file_id)
+                    self.tool_callbacks.attach_file(file_id)
+                    file_response = SUCCESSFUL_ATTACHMENT_MESSAGE.format(file_id=file_id, name=file.name)
 
-                if include_links:
-                    # Only the web platform is able to render these links
-                    if file.is_image:
-                        link_text = IMAGE_LINK_TEXT.format(
-                            file_id=file_id,
-                            session_id=self.experiment_session.id,
-                            team_slug=get_slug_for_team(file.team_id),
-                        )
-                    else:
-                        link_text = FILE_LINK_TEXT.format(
-                            name=file.name,
-                            file_id=file_id,
-                            session_id=self.experiment_session.id,
-                            team_slug=get_slug_for_team(file.team_id),
-                        )
-                    file_response = f"{file_response} {link_text}"
-                response.append(file_response)
+                    if include_links:
+                        # Only the web platform is able to render these links
+                        if file.is_image:
+                            link_text = IMAGE_LINK_TEXT.format(
+                                file_id=file_id,
+                                session_id=self.experiment_session.id,
+                                team_slug=get_slug_for_team(file.team_id),
+                            )
+                        else:
+                            link_text = FILE_LINK_TEXT.format(
+                                name=file.name,
+                                file_id=file_id,
+                                session_id=self.experiment_session.id,
+                                team_slug=get_slug_for_team(file.team_id),
+                            )
+                        file_response = f"{file_response} {link_text}"
+                    response.append(file_response)
             except File.DoesNotExist:
                 response.append(f"* {file_id}: File not found.")
             except utils.IntegrityError:
@@ -531,7 +532,6 @@ class SearchIndexTool(CustomBaseTool):
     args_schema: type[schemas.SearchIndexSchema] = schemas.SearchIndexSchema
     search_config: SearchToolConfig
 
-    @transaction.atomic
     def action(self, query: str) -> str:
         """
         Do a simple search for the top most relevant file chunks based on the query provided by the user. A little query
@@ -561,7 +561,6 @@ class SearchCollectionByIdTool(CustomBaseTool):
     generate_citations: bool = True
     allowed_collection_ids: list[int]
 
-    @transaction.atomic
     def action(self, collection_index_id: int, query: str) -> str:
         """
         Search a specific collection index for the most relevant file chunks based on the query.

--- a/apps/chat/tests/test_tools.py
+++ b/apps/chat/tests/test_tools.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 import pytz
-from django.db import connection
+from django.db import IntegrityError, connection
 from django.utils import timezone
 from langchain.tools import InjectedState
 from langchain_core.tools import InjectedToolCallId, StructuredTool
@@ -836,6 +836,31 @@ class TestAttachMediaTool(BaseTestAgentTool):
         assert f"* {failing_file.id}: Error fetching file." in response
         assert ok_file.name in response
         # The failed attachment rolled back to its savepoint; the following one still committed.
+        assert list(chat_attachment.files.values_list("id", flat=True)) == [ok_file.id]
+
+    @pytest.mark.django_db(transaction=True)
+    def test_first_file_failing_does_not_orphan_the_attachment_row(self, session):
+        """The ChatAttachment row must survive a rollback of the first file's savepoint.
+
+        `chat_attachment` is a cached_property, so it used to be created lazily inside the first
+        file's savepoint. Rolling that back removed the row while the cached object kept its id,
+        and the m2m table's deferred foreign key then failed at COMMIT — after the tool had
+        already reported the later files as attached.
+
+        Needs a real commit (`transaction=True`): the deferred constraint is only checked there.
+        """
+        assert not ChatAttachment.objects.filter(chat=session.chat).exists()
+        failing_file, ok_file = FileFactory.create_batch(2)
+
+        def fail_for_first_file(file_id):
+            if file_id == failing_file.id:
+                raise IntegrityError("simulated failure attaching the first file")
+
+        with mock.patch.object(ToolCallbacks, "attach_file", side_effect=fail_for_first_file):
+            response = self._invoke_tool(session, file_ids=[failing_file.id, ok_file.id])
+
+        assert f"* {failing_file.id}: Error fetching file." in response
+        chat_attachment = ChatAttachment.objects.get(chat=session.chat, tool_type="ocs_attachments")
         assert list(chat_attachment.files.values_list("id", flat=True)) == [ok_file.id]
 
 

--- a/apps/chat/tests/test_tools.py
+++ b/apps/chat/tests/test_tools.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 import pytz
+from django.db import connection
 from django.utils import timezone
 from langchain.tools import InjectedState
 from langchain_core.tools import InjectedToolCallId, StructuredTool
@@ -797,6 +798,45 @@ class TestAttachMediaTool(BaseTestAgentTool):
         assert chat_attachment.files.count() == 3
         assert all(str(file.id) in response for file in files)
         print(response)
+
+    def test_integrity_error_on_one_file_does_not_break_the_others(self, session):
+        """A DB error attaching one file must leave the loop able to attach the rest.
+
+        Regression test: `action()` is wrapped in `transaction.atomic`, and the
+        `except IntegrityError` used to sit inside that block. Postgres aborts the
+        transaction on the failed insert, so the next iteration's `File.objects.get()`
+        raised "An error occurred in the current transaction. You can't execute queries
+        until the end of the 'atomic' block" instead of attaching the remaining files.
+        """
+        chat_attachment, _ = ChatAttachment.objects.get_or_create(chat=session.chat, tool_type="ocs_attachments")
+        failing_file, ok_file = FileFactory.create_batch(2)
+
+        through = ChatAttachment.files.through
+        table = through._meta.db_table
+        attachment_column = through._meta.get_field("chatattachment").column
+        file_column = through._meta.get_field("file").column
+
+        def duplicate_the_attachment_row(file_id):
+            """Re-insert the row `files.add()` just created, for one file only.
+
+            Raw SQL so Postgres really aborts the transaction, the way it does for paths
+            Django doesn't wrap in `mark_for_rollback_on_error`.
+            """
+            if file_id != failing_file.id:
+                return
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"INSERT INTO {table} ({attachment_column}, {file_column}) VALUES (%s, %s)",  # noqa: S608
+                    [chat_attachment.id, file_id],
+                )
+
+        with mock.patch.object(ToolCallbacks, "attach_file", side_effect=duplicate_the_attachment_row):
+            response = self._invoke_tool(session, file_ids=[failing_file.id, ok_file.id])
+
+        assert f"* {failing_file.id}: Error fetching file." in response
+        assert ok_file.name in response
+        # The failed attachment rolled back to its savepoint; the following one still committed.
+        assert list(chat_attachment.files.values_list("id", flat=True)) == [ok_file.id]
 
 
 @pytest.mark.django_db()

--- a/apps/chat/tests/test_tools.py
+++ b/apps/chat/tests/test_tools.py
@@ -802,11 +802,11 @@ class TestAttachMediaTool(BaseTestAgentTool):
     def test_integrity_error_on_one_file_does_not_break_the_others(self, session):
         """A DB error attaching one file must leave the loop able to attach the rest.
 
-        Regression test: `action()` is wrapped in `transaction.atomic`, and the
-        `except IntegrityError` used to sit inside that block. Postgres aborts the
-        transaction on the failed insert, so the next iteration's `File.objects.get()`
-        raised "An error occurred in the current transaction. You can't execute queries
-        until the end of the 'atomic' block" instead of attaching the remaining files.
+        Regression test: `action()` used to be wrapped in a single `transaction.atomic`, with the
+        `except IntegrityError` inside it. Postgres aborts the transaction on the failed insert, so
+        the next iteration's `File.objects.get()` raised "An error occurred in the current
+        transaction. You can't execute queries until the end of the 'atomic' block" instead of
+        attaching the remaining files. Each file now gets its own transaction.
         """
         chat_attachment, _ = ChatAttachment.objects.get_or_create(chat=session.chat, tool_type="ocs_attachments")
         failing_file, ok_file = FileFactory.create_batch(2)
@@ -840,11 +840,11 @@ class TestAttachMediaTool(BaseTestAgentTool):
 
     @pytest.mark.django_db(transaction=True)
     def test_first_file_failing_does_not_orphan_the_attachment_row(self, session):
-        """The ChatAttachment row must survive a rollback of the first file's savepoint.
+        """The ChatAttachment row must survive a rollback of the first file's transaction.
 
-        `chat_attachment` is a cached_property, so it used to be created lazily inside the first
-        file's savepoint. Rolling that back removed the row while the cached object kept its id,
-        and the m2m table's deferred foreign key then failed at COMMIT — after the tool had
+        `chat_attachment` is a cached_property, so it would otherwise be created lazily inside the
+        first file's transaction. Rolling that back removes the row while the cached object keeps
+        its id, and the m2m table's deferred foreign key then fails at COMMIT — after the tool has
         already reported the later files as attached.
 
         Needs a real commit (`transaction=True`): the deferred constraint is only checked there.

--- a/apps/experiments/management/commands/fix_vector_store_duplication.py
+++ b/apps/experiments/management/commands/fix_vector_store_duplication.py
@@ -32,8 +32,8 @@ class Command(BaseCommand):
 
         with current_team(team):
             for assistant in assistants:
-                with transaction.atomic():
-                    try:
+                try:
+                    with transaction.atomic():
                         self.stdout.write(f"\n\nEvaluating {assistant} (id={assistant.id})")
                         original_resource = assistant.tool_resources.get(tool_type="file_search")
                         original_vector_store_id = original_resource.extra.get("vector_store_id")
@@ -62,8 +62,8 @@ class Command(BaseCommand):
 
                             diff = set(tool_resource.files.values_list("external_id", flat=True))
                             self.stdout.write(f"Diff between original and new file ids: {original_file_ids - diff}")
-                    except Exception as e:
-                        traceback.print_exception(type(e), e, e.__traceback__)
+                except Exception as e:
+                    traceback.print_exception(type(e), e, e.__traceback__)
 
         self.stdout.write("\nDone")
 

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1551,7 +1551,6 @@ class ExperimentSession(BaseTeamModel):
         if commit and trigger_type:
             enqueue_static_triggers.delay(self.id, trigger_type)
 
-    @transaction.atomic()
     def ad_hoc_bot_message(
         self,
         instruction_prompt: str | None,
@@ -1579,7 +1578,7 @@ class ExperimentSession(BaseTeamModel):
 
         trace_service = None
         try:
-            with current_team(self.team):
+            with transaction.atomic(), current_team(self.team):
                 experiment = use_experiment or self.experiment
                 trace_service = TracingService.create_for_experiment(experiment)
                 with trace_service.trace_or_span(

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -21,7 +21,7 @@ from apps.experiments.models import (
 )
 from apps.pipelines.models import Pipeline
 from apps.service_providers.llm_service.prompt_context import ParticipantDataProxy
-from apps.service_providers.tracing import TraceInfo
+from apps.service_providers.tracing import TraceInfo, TracingService
 from apps.teams.utils import get_slug_for_team
 from apps.trace.models import Trace, TraceStatus
 from apps.utils.factories.assistants import OpenAiAssistantFactory
@@ -406,7 +406,7 @@ class TestExperimentSession:
     @patch("apps.channels.registry.from_experiment_session")
     @patch.object(ExperimentSession, "_bot_prompt_for_user")
     def test_ad_hoc_message_transaction_rollback(self, mock_bot_prompt, from_experiment_session, experiment_session):
-        """Test that the @transaction.atomic() decorator on ad_hoc_bot_message
+        """Test that the transaction.atomic() block in ad_hoc_bot_message
         rolls back database changes when an exception occurs."""
         # Set up initial state
         initial_message_count = ChatMessage.objects.filter(chat=experiment_session.chat).count()
@@ -438,6 +438,44 @@ class TestExperimentSession:
         # Verify that the database changes were rolled back
         final_message_count = ChatMessage.objects.filter(chat=experiment_session.chat).count()
         assert final_message_count == initial_message_count, "Transaction should have rolled back the message creation"
+
+    @patch("apps.channels.registry.from_experiment_session")
+    @patch.object(ExperimentSession, "_bot_prompt_for_user")
+    def test_ad_hoc_message_db_error_is_swallowed_when_failing_silently(
+        self, mock_bot_prompt, from_experiment_session, experiment_session
+    ):
+        """`fail_silently=True` must also hold for database errors.
+
+        Regression test: the atomic block used to wrap the `except Exception` handler
+        (`@transaction.atomic()` on the method), so a swallowed DB error left the block to
+        commit a transaction Postgres had already aborted — raising `InternalError: current
+        transaction is aborted` out of a call that promised to fail silently.
+
+        The tracing service is stubbed out with one that has no tracers: with the OCS tracer
+        active, its own (also failing) trace-metadata write happens to mark the connection for
+        rollback and masks this, so the assertion here is about this method's transaction
+        handling rather than that accident.
+        """
+        mock_bot_prompt.return_value = "Test message"
+        mock_channel = Mock()
+        from_experiment_session.return_value = mock_channel
+
+        def send_and_break_the_transaction(message):
+            # Raw SQL so Postgres really aborts the transaction (division by zero), the way it
+            # does for paths Django doesn't wrap in `mark_for_rollback_on_error`.
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 1 / 0")
+
+        mock_channel.send_message_to_user = send_and_break_the_transaction
+        untraced = TracingService(
+            [], experiment_id=experiment_session.experiment_id, team_id=experiment_session.team_id
+        )
+
+        with patch.object(TracingService, "create_for_experiment", return_value=untraced):
+            assert experiment_session.ad_hoc_bot_message("Testing", TraceInfo(name="test"), fail_silently=True) is None
+
+        # The connection is still usable, i.e. the failed send was rolled back cleanly.
+        assert ChatMessage.objects.filter(chat=experiment_session.chat).exists() is False
 
     @patch("apps.channels.registry.from_experiment_session")
     @patch("apps.service_providers.models.LlmProvider.get_llm_service")

--- a/apps/filters/tests/test_views.py
+++ b/apps/filters/tests/test_views.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+
+import pytest
+from django.db import connection
+from django.urls import reverse
+
+from apps.filters.models import FilterSet
+
+
+@pytest.mark.django_db()
+class TestCreateFilterSet:
+    def _url(self, team, table_type=FilterSet.TableType.SESSIONS):
+        return reverse("filters:create_filter_set", args=[team.slug, table_type])
+
+    def test_create_filter_set(self, client, team_with_users):
+        user = team_with_users.members.first()
+        client.force_login(user)
+
+        response = client.post(
+            self._url(team_with_users),
+            data={"name": "My filter", "filter_query_string": "filter_0_column=status"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        assert FilterSet.objects.filter(team=team_with_users, name="My filter").exists()
+
+    def test_integrity_error_returns_400_and_leaves_transaction_usable(self, client, team_with_users):
+        """A DB error while saving must return a 400, not blow up on the way out of the atomic block.
+
+        Regression test: the save used to sit inside `transaction.atomic()` with the
+        `except IntegrityError` *inside* the block, so the atomic block exited "cleanly" on a
+        transaction Postgres had already aborted. Committing / releasing the savepoint then failed
+        with "current transaction is aborted" (or, if anything else queried first, with
+        "An error occurred in the current transaction. You can't execute queries until the end of
+        the 'atomic' block").
+        """
+        user = team_with_users.members.first()
+        client.force_login(user)
+        existing = FilterSet.objects.create(
+            team=team_with_users,
+            user=user,
+            table_type=FilterSet.TableType.SESSIONS,
+            name="Existing",
+            filter_query_string="filter_0_column=status",
+        )
+
+        def duplicate_key_insert(*args, **kwargs):
+            # Raw SQL so the failure is a plain aborted transaction, the way it arrives from
+            # paths Django doesn't wrap in `mark_for_rollback_on_error` (raw SQL, deferred
+            # constraints, multi-query saves).
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "INSERT INTO filters_filterset (id, name, table_type, filter_query_string, is_shared,"
+                    " is_starred, is_default_for_user, is_default_for_team, team_id, user_id, created_at,"
+                    " updated_at) VALUES (%s, 'dup', 'sessions', 'a=1', false, false, false, false, %s, %s,"
+                    " now(), now())",
+                    [existing.id, team_with_users.id, user.id],
+                )
+
+        with patch("apps.filters.serializers.FilterSetSerializer.save", side_effect=duplicate_key_insert):
+            response = client.post(
+                self._url(team_with_users),
+                data={"name": "My filter", "filter_query_string": "filter_0_column=status"},
+            )
+
+        assert response.status_code == 400
+        assert response.json() == {"error": "Unable to create filter set"}
+        # The failed save was rolled back cleanly, so the connection is still usable.
+        assert FilterSet.objects.filter(team=team_with_users).count() == 1

--- a/apps/filters/views.py
+++ b/apps/filters/views.py
@@ -41,12 +41,13 @@ def create_filter_set(request, team_slug: str, table_type: str):
     if not serializer.is_valid():
         return JsonResponse(serializer.errors, status=400)
 
-    with transaction.atomic():
-        try:
+    try:
+        with transaction.atomic():
             serializer.save(team=request.team, user=request.user)
-            return JsonResponse({"success": True, "filter_set": serializer.data})
-        except IntegrityError:
-            return JsonResponse({"error": "Unable to create filter set"}, status=400)
+    except IntegrityError:
+        return JsonResponse({"error": "Unable to create filter set"}, status=400)
+
+    return JsonResponse({"success": True, "filter_set": serializer.data})
 
 
 class FilterSetView(LoginAndTeamRequiredMixin, View):

--- a/apps/service_providers/models.py
+++ b/apps/service_providers/models.py
@@ -436,7 +436,8 @@ class VoiceProvider(BaseTeamModel, ProviderMixin):
         warnings: list[str] = []
         if self.type == VoiceProviderType.elevenlabs.value:
             try:
-                self.sync_voices()
+                with transaction.atomic(savepoint=True):
+                    self.sync_voices()
             except Exception:
                 log.exception("Failed to sync voices for ElevenLabs provider %s", self.pk)
                 warnings.append("Provider saved, but voice sync failed. You can retry via the sync button.")

--- a/scripts/check_atomic_exception_handling.py
+++ b/scripts/check_atomic_exception_handling.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+Flag database exceptions caught *inside* a ``transaction.atomic()`` block.
+
+When a query fails inside an atomic block, PostgreSQL aborts the transaction and
+Django sets ``connection.needs_rollback``. Catching that exception without
+leaving the block means the rollback never happens at the right level, so:
+
+* any later query in the block raises ``TransactionManagementError:
+  An error occurred in the current transaction. You can't execute queries until
+  the end of the 'atomic' block``; and
+* if the failure came from a path Django does not wrap in
+  ``mark_for_rollback_on_error`` (raw SQL, deferred constraints), the block's own
+  exit raises ``InternalError: current transaction is aborted``.
+
+Broken::
+
+    with transaction.atomic():
+        try:
+            do_stuff()
+        except IntegrityError:
+            handle()
+
+Fixed — try outside the atomic block::
+
+    try:
+        with transaction.atomic():
+            do_stuff()
+    except IntegrityError:
+        handle()
+
+Fixed — nested atomic as a savepoint, when the outer block must continue::
+
+    with transaction.atomic():
+        try:
+            with transaction.atomic():
+                do_stuff()
+        except IntegrityError:
+            handle()
+
+A handler is also accepted when it cannot leave a broken transaction behind:
+it re-raises unconditionally, or it calls ``transaction.set_rollback(True)``.
+
+Escape hatch for the rare genuine exception (nothing in the ``try`` body touches
+the database, for instance) — put a marker comment on the ``try:`` line or on the
+``except`` clause::
+
+    try:  # atomic-catch-ok: no DB access, parses an API response
+        ...
+
+Usage:
+    uv run python scripts/check_atomic_exception_handling.py apps
+    uv run python scripts/check_atomic_exception_handling.py apps --files apps/foo/views.py
+"""
+
+import argparse
+import ast
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Exception types whose presence means the transaction may already be broken.
+# `Error` is psycopg's/Django's base DB error; the bare-except and broad
+# `Exception`/`BaseException` cases are handled separately.
+DB_EXCEPTIONS = frozenset(
+    {
+        "DatabaseError",
+        "DataError",
+        "Error",
+        "IntegrityError",
+        "InterfaceError",
+        "InternalError",
+        "NotSupportedError",
+        "OperationalError",
+        "ProgrammingError",
+        "TransactionManagementError",
+    }
+)
+BROAD_EXCEPTIONS = frozenset({"Exception", "BaseException"})
+MARKER = re.compile(r"#\s*atomic-catch-ok:\s*(?P<reason>.+?)\s*$")
+
+
+@dataclass
+class Finding:
+    path: Path
+    lineno: int
+    atomic_lineno: int
+    caught: str  # what the handler catches, e.g. "IntegrityError" or "bare except"
+    function: str  # enclosing function, for the message
+
+
+def _attr_name(node: ast.AST) -> str:
+    """Rightmost name of a (possibly dotted) expression: ``db.IntegrityError`` -> ``IntegrityError``."""
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return ""
+
+
+def _is_atomic_call(node: ast.AST) -> bool:
+    """Whether an expression is ``transaction.atomic``/``atomic``, called or not.
+
+    Matches both ``atomic`` and ``atomic()`` so it works for decorators
+    (``@transaction.atomic`` and ``@transaction.atomic()``) and ``with`` items.
+    """
+    target = node.func if isinstance(node, ast.Call) else node
+    return _attr_name(target) == "atomic"
+
+
+def _opens_atomic(node: ast.AST) -> bool:
+    """Whether a ``with``/``async with`` statement opens an atomic block."""
+    return isinstance(node, (ast.With, ast.AsyncWith)) and any(
+        _is_atomic_call(item.context_expr) for item in node.items
+    )
+
+
+def _is_atomic_decorated(node: ast.AST) -> bool:
+    return isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and any(
+        _is_atomic_call(d) for d in node.decorator_list
+    )
+
+
+def _caught_names(handler: ast.ExceptHandler) -> list[str]:
+    """Exception names a handler catches; ``[]`` for a bare ``except:``."""
+    if handler.type is None:
+        return []
+    if isinstance(handler.type, ast.Tuple):
+        return [_attr_name(elt) for elt in handler.type.elts]
+    return [_attr_name(handler.type)]
+
+
+def _catches_db_error(handler: ast.ExceptHandler) -> str | None:
+    """What makes this handler risky inside an atomic block, or None if it isn't."""
+    names = _caught_names(handler)
+    if not names:
+        return "bare except"
+    for name in names:
+        if name in DB_EXCEPTIONS or name in BROAD_EXCEPTIONS:
+            return name
+    return None
+
+
+def _always_reraises(handler: ast.ExceptHandler) -> bool:
+    """Whether the handler unconditionally re-raises, letting the atomic block roll back.
+
+    Only a ``raise`` at the top level of the handler counts: a ``raise`` nested in
+    an ``if`` (``if not fail_silently: raise``) leaves the swallowing path intact.
+    """
+    return any(isinstance(stmt, ast.Raise) for stmt in handler.body)
+
+
+def _marks_rollback(handler: ast.ExceptHandler) -> bool:
+    """Whether the handler calls ``transaction.set_rollback(...)``, which is the
+    documented way to force the enclosing block to roll back after swallowing."""
+    return any(
+        _attr_name(node.func) == "set_rollback"
+        for node in ast.walk(ast.Module(body=handler.body, type_ignores=[]))
+        if isinstance(node, ast.Call)
+    )
+
+
+def _body_is_savepointed(try_node: ast.Try) -> bool:
+    """Whether every statement in the ``try`` body sits inside a nested atomic block.
+
+    This is the savepoint pattern (option B): the inner block rolls back to its
+    savepoint on the way out, so the outer transaction stays usable.
+    """
+    return bool(try_node.body) and all(_opens_atomic(stmt) for stmt in try_node.body)
+
+
+def _has_marker(lines: list[str], *nodes: ast.AST) -> bool:
+    """Whether an ``atomic-catch-ok:`` marker sits on any of the given nodes' first lines."""
+    return any(MARKER.search(lines[node.lineno - 1]) for node in nodes if node.lineno - 1 < len(lines))
+
+
+def find_violations(source: str, path: Path) -> list[Finding]:
+    """Return every DB-exception handler nested inside an atomic block."""
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    findings: list[Finding] = []
+
+    def visit(node: ast.AST, atomic_lineno: int | None, function: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            child_function = function
+            child_atomic = atomic_lineno
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                child_function = child.name
+                # A nested function body runs wherever it is called, not here, so it
+                # only inherits an atomic scope from its own decorator.
+                child_atomic = child.lineno if _is_atomic_decorated(child) else None
+            elif _opens_atomic(child):
+                child_atomic = child.lineno
+            elif isinstance(child, ast.Try) and atomic_lineno is not None:
+                findings.extend(_check_try(child, atomic_lineno, function, lines, path))
+                # The try body is still visited below: a nested atomic inside it
+                # opens a new scope that its own handlers are measured against.
+            visit(child, child_atomic, child_function)
+
+    visit(tree, None, "<module>")
+    return sorted(findings, key=lambda f: f.lineno)
+
+
+def _check_try(try_node: ast.Try, atomic_lineno: int, function: str, lines: list[str], path: Path) -> list[Finding]:
+    if _body_is_savepointed(try_node):
+        return []
+    findings = []
+    for handler in try_node.handlers:
+        caught = _catches_db_error(handler)
+        if caught is None or _always_reraises(handler) or _marks_rollback(handler):
+            continue
+        if _has_marker(lines, try_node, handler):
+            continue
+        findings.append(
+            Finding(
+                path=path,
+                lineno=handler.lineno,
+                atomic_lineno=atomic_lineno,
+                caught=caught,
+                function=function,
+            )
+        )
+    return findings
+
+
+def _scan_paths(root: Path, files: tuple[Path, ...] | None) -> list[Path]:
+    """Return the files to scan: everything under ``root``, or just ``files``.
+
+    Missing/non-Python paths are skipped (CI may pass deleted or renamed files),
+    as are migrations, which run inside their own transaction management.
+    """
+    candidates = sorted(root.rglob("*.py")) if files is None else sorted(files)
+    paths = []
+    for path in candidates:
+        if path.suffix != ".py" or not path.exists() or "migrations" in path.parts:
+            continue
+        paths.append(path)
+    return paths
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("root", type=Path, nargs="?", default=Path("apps"), help="Directory to scan")
+    parser.add_argument(
+        "--files",
+        nargs="*",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help="Only check these files (e.g. the files changed in a PR)",
+    )
+    args = parser.parse_args(argv)
+
+    findings = []
+    for path in _scan_paths(args.root, tuple(args.files) if args.files is not None else None):
+        # utf-8-sig: tolerate files saved with a UTF-8 BOM
+        try:
+            findings += find_violations(path.read_text(encoding="utf-8-sig"), path)
+        except SyntaxError as exc:
+            print(f"SKIP {path}: could not parse ({exc})", file=sys.stderr)
+
+    for f in findings:
+        print(
+            f"FAIL {f.path}:{f.lineno}: `except {f.caught}` inside the atomic block opened at "
+            f"line {f.atomic_lineno} ({f.function})"
+        )
+    if findings:
+        print(
+            f"\n{len(findings)} database exception(s) caught inside an atomic block."
+            "\nMove the try/except outside the atomic block, or wrap the failing code in a nested"
+            "\n`transaction.atomic()` savepoint. See scripts/check_atomic_exception_handling.py for details."
+        )
+        return 1
+    print("No database exceptions caught inside atomic blocks.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_atomic_exception_handling.py
+++ b/scripts/check_atomic_exception_handling.py
@@ -153,11 +153,17 @@ def _always_reraises(handler: ast.ExceptHandler) -> bool:
 
 def _marks_rollback(handler: ast.ExceptHandler) -> bool:
     """Whether the handler calls ``transaction.set_rollback(...)``, which is the
-    documented way to force the enclosing block to roll back after swallowing."""
+    documented way to force the enclosing block to roll back after swallowing.
+
+    Scoped like ``_always_reraises``: only a call at the top level of the handler
+    counts. One nested in an ``if`` leaves the branches that skip it swallowing the
+    error with the transaction still broken.
+    """
     return any(
-        _attr_name(node.func) == "set_rollback"
-        for node in ast.walk(ast.Module(body=handler.body, type_ignores=[]))
-        if isinstance(node, ast.Call)
+        isinstance(stmt, ast.Expr)
+        and isinstance(stmt.value, ast.Call)
+        and _attr_name(stmt.value.func) == "set_rollback"
+        for stmt in handler.body
     )
 
 
@@ -202,15 +208,29 @@ def find_violations(source: str, path: Path) -> list[Finding]:
     return sorted(findings, key=lambda f: f.lineno)
 
 
+def _unsafe_catch(handler: ast.ExceptHandler) -> str | None:
+    """What makes this handler unsafe inside an atomic block, or None if it is safe.
+
+    Safe means one of: it doesn't catch a database error at all; it re-raises, so the
+    block rolls back on the way out; or it forces the rollback itself.
+    """
+    caught = _catches_db_error(handler)
+    if caught is None:
+        return None
+    if _always_reraises(handler):
+        return None
+    if _marks_rollback(handler):
+        return None
+    return caught
+
+
 def _check_try(try_node: ast.Try, atomic_lineno: int, function: str, lines: list[str], path: Path) -> list[Finding]:
     if _body_is_savepointed(try_node):
         return []
     findings = []
     for handler in try_node.handlers:
-        caught = _catches_db_error(handler)
-        if caught is None or _always_reraises(handler) or _marks_rollback(handler):
-            continue
-        if _has_marker(lines, try_node, handler):
+        caught = _unsafe_catch(handler)
+        if caught is None or _has_marker(lines, try_node, handler):
             continue
         findings.append(
             Finding(

--- a/scripts/test_check_atomic_exception_handling.py
+++ b/scripts/test_check_atomic_exception_handling.py
@@ -54,51 +54,60 @@ class TestBrokenPattern:
         assert len(found) == 1
         assert found[0].function == "f"
 
-    def test_bare_atomic_decorator(self):
-        found = violations("""
-            @transaction.atomic
-            def f():
-                try:
-                    save()
-                except IntegrityError:
-                    handle()
-        """)
-        assert len(found) == 1
-
-    def test_async_with(self):
-        found = violations("""
-            async def f():
-                async with transaction.atomic():
-                    try:
-                        await save()
-                    except IntegrityError:
-                        handle()
-        """)
-        assert len(found) == 1
-
-    def test_atomic_as_one_of_several_context_managers(self):
-        found = violations("""
-            def f():
-                with transaction.atomic(), current_team(team):
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param(
+                """
+                @transaction.atomic
+                def f():
                     try:
                         save()
                     except IntegrityError:
                         handle()
-        """)
-        assert len(found) == 1
-
-    def test_deeply_nested_try(self):
-        found = violations("""
-            def f():
-                with transaction.atomic():
-                    for item in items:
-                        if item:
-                            try:
-                                save(item)
-                            except IntegrityError:
-                                handle()
-        """)
-        assert len(found) == 1
+                """,
+                id="bare-atomic-decorator",
+            ),
+            pytest.param(
+                """
+                async def f():
+                    async with transaction.atomic():
+                        try:
+                            await save()
+                        except IntegrityError:
+                            handle()
+                """,
+                id="async-with",
+            ),
+            pytest.param(
+                """
+                def f():
+                    with transaction.atomic(), current_team(team):
+                        try:
+                            save()
+                        except IntegrityError:
+                            handle()
+                """,
+                id="multiple-context-managers",
+            ),
+            pytest.param(
+                """
+                def f():
+                    with transaction.atomic():
+                        for item in items:
+                            if item:
+                                try:
+                                    save(item)
+                                except IntegrityError:
+                                    handle()
+                """,
+                id="deeply-nested-try",
+            ),
+        ],
+    )
+    def test_atomic_scope_is_detected(self, source):
+        """Every way of opening an atomic block, and a `try` at any depth inside it."""
+        assert len(violations(source)) == 1
 
     def test_reports_both_the_handler_and_the_atomic_line(self):
         found = violations("""
@@ -126,106 +135,150 @@ class TestBrokenPattern:
 
 
 class TestAcceptedPatterns:
-    def test_try_outside_atomic(self):
-        assert not violations("""
-            def f():
-                try:
-                    with transaction.atomic():
-                        save()
-                except IntegrityError:
-                    handle()
-        """)
-
-    def test_nested_atomic_savepoint(self):
-        assert not violations("""
-            def f():
-                with transaction.atomic():
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param(
+                """
+                def f():
                     try:
                         with transaction.atomic():
                             save()
                     except IntegrityError:
                         handle()
-        """)
-
-    def test_savepoint_with_keyword_argument(self):
-        assert not violations("""
-            def f():
-                with transaction.atomic():
-                    try:
-                        with transaction.atomic(savepoint=True):
+                """,
+                id="try-outside-atomic",
+            ),
+            pytest.param(
+                """
+                def f():
+                    with transaction.atomic():
+                        try:
+                            with transaction.atomic():
+                                save()
+                        except IntegrityError:
+                            handle()
+                """,
+                id="nested-savepoint",
+            ),
+            pytest.param(
+                """
+                def f():
+                    with transaction.atomic():
+                        try:
+                            with transaction.atomic(savepoint=True):
+                                save()
+                        except IntegrityError:
+                            handle()
+                """,
+                id="nested-savepoint-keyword-arg",
+            ),
+            pytest.param(
+                """
+                def f():
+                    with transaction.atomic():
+                        try:
                             save()
+                        except IntegrityError:
+                            log.exception("boom")
+                            raise
+                """,
+                id="handler-reraises",
+            ),
+            pytest.param(
+                """
+                def f():
+                    with transaction.atomic():
+                        try:
+                            save()
+                        except IntegrityError:
+                            transaction.set_rollback(True)
+                            handle()
+                """,
+                id="handler-sets-rollback",
+            ),
+            pytest.param(
+                """
+                def f():
+                    with transaction.atomic():
+                        try:
+                            parse(payload)
+                        except (KeyError, ValueError):
+                            handle()
+                """,
+                id="non-database-exception",
+            ),
+            pytest.param(
+                """
+                def f():
+                    try:
+                        save()
                     except IntegrityError:
                         handle()
-        """)
+                """,
+                id="no-atomic-block-at-all",
+            ),
+            pytest.param(
+                """
+                def f():
+                    with open(path) as fh:
+                        try:
+                            save(fh)
+                        except IntegrityError:
+                            handle()
+                """,
+                id="non-atomic-context-manager",
+            ),
+            pytest.param(
+                """
+                def f():
+                    with transaction.atomic():
+                        try:  # atomic-catch-ok: no DB access, parses an API response
+                            parse(payload)
+                        except Exception:
+                            handle()
+                """,
+                id="marker-on-try",
+            ),
+            pytest.param(
+                """
+                def f():
+                    with transaction.atomic():
+                        try:
+                            parse(payload)
+                        except Exception:  # atomic-catch-ok: no DB access
+                            handle()
+                """,
+                id="marker-on-handler",
+            ),
+        ],
+    )
+    def test_no_violation_reported(self, source):
+        """Patterns that leave the block, force a rollback, or can't break the transaction."""
+        assert not violations(source)
 
-    def test_handler_that_reraises(self):
-        assert not violations("""
+    @pytest.mark.parametrize(
+        "handler_body",
+        [
+            pytest.param("if flaky:\n                            raise", id="conditional-raise"),
+            pytest.param(
+                "if flaky:\n                            transaction.set_rollback(True)", id="conditional-set-rollback"
+            ),
+        ],
+    )
+    def test_escape_hatches_must_be_unconditional(self, handler_body):
+        """A `raise`/`set_rollback` nested in an `if` leaves the other branches swallowing.
+
+        Both helpers scope to the top level of the handler for this reason; they must stay
+        consistent, or the conditional-swallow case slips through as a false negative.
+        """
+        assert violations(f"""
             def f():
                 with transaction.atomic():
                     try:
                         save()
                     except IntegrityError:
-                        log.exception("boom")
-                        raise
-        """)
-
-    def test_handler_that_sets_rollback(self):
-        assert not violations("""
-            def f():
-                with transaction.atomic():
-                    try:
-                        save()
-                    except IntegrityError:
-                        transaction.set_rollback(True)
-                        handle()
-        """)
-
-    def test_non_database_exception(self):
-        assert not violations("""
-            def f():
-                with transaction.atomic():
-                    try:
-                        parse(payload)
-                    except (KeyError, ValueError):
-                        handle()
-        """)
-
-    def test_try_outside_any_atomic_block(self):
-        assert not violations("""
-            def f():
-                try:
-                    save()
-                except IntegrityError:
-                    handle()
-        """)
-
-    def test_non_atomic_context_manager(self):
-        assert not violations("""
-            def f():
-                with open(path) as fh:
-                    try:
-                        save(fh)
-                    except IntegrityError:
-                        handle()
-        """)
-
-    def test_marker_comment_on_try(self):
-        assert not violations("""
-            def f():
-                with transaction.atomic():
-                    try:  # atomic-catch-ok: no DB access, parses an API response
-                        parse(payload)
-                    except Exception:
-                        handle()
-        """)
-
-    def test_marker_comment_on_handler(self):
-        assert not violations("""
-            def f():
-                with transaction.atomic():
-                    try:
-                        parse(payload)
-                    except Exception:  # atomic-catch-ok: no DB access
+                        {handler_body}
                         handle()
         """)
 

--- a/scripts/test_check_atomic_exception_handling.py
+++ b/scripts/test_check_atomic_exception_handling.py
@@ -1,0 +1,373 @@
+"""Tests for check_atomic_exception_handling.py.
+
+Run with: uv run pytest scripts/test_check_atomic_exception_handling.py -v
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from check_atomic_exception_handling import find_violations, main  # noqa: E402
+
+
+def violations(source: str) -> list:
+    return find_violations(textwrap.dedent(source), Path("example.py"))
+
+
+class TestBrokenPattern:
+    @pytest.mark.parametrize(
+        "handler",
+        [
+            pytest.param("except IntegrityError:", id="integrity-error"),
+            pytest.param("except DatabaseError:", id="database-error"),
+            pytest.param("except db.IntegrityError:", id="dotted"),
+            pytest.param("except (ValueError, IntegrityError):", id="tuple"),
+            pytest.param("except Exception:", id="broad"),
+            pytest.param("except:", id="bare"),
+            pytest.param("except IntegrityError as exc:", id="aliased"),
+        ],
+    )
+    def test_catch_inside_with_block(self, handler):
+        found = violations(f"""
+            def f():
+                with transaction.atomic():
+                    try:
+                        save()
+                    {handler}
+                        handle()
+        """)
+        assert len(found) == 1
+
+    def test_catch_inside_decorated_function(self):
+        found = violations("""
+            @transaction.atomic()
+            def f():
+                try:
+                    save()
+                except IntegrityError:
+                    handle()
+        """)
+        assert len(found) == 1
+        assert found[0].function == "f"
+
+    def test_bare_atomic_decorator(self):
+        found = violations("""
+            @transaction.atomic
+            def f():
+                try:
+                    save()
+                except IntegrityError:
+                    handle()
+        """)
+        assert len(found) == 1
+
+    def test_async_with(self):
+        found = violations("""
+            async def f():
+                async with transaction.atomic():
+                    try:
+                        await save()
+                    except IntegrityError:
+                        handle()
+        """)
+        assert len(found) == 1
+
+    def test_atomic_as_one_of_several_context_managers(self):
+        found = violations("""
+            def f():
+                with transaction.atomic(), current_team(team):
+                    try:
+                        save()
+                    except IntegrityError:
+                        handle()
+        """)
+        assert len(found) == 1
+
+    def test_deeply_nested_try(self):
+        found = violations("""
+            def f():
+                with transaction.atomic():
+                    for item in items:
+                        if item:
+                            try:
+                                save(item)
+                            except IntegrityError:
+                                handle()
+        """)
+        assert len(found) == 1
+
+    def test_reports_both_the_handler_and_the_atomic_line(self):
+        found = violations("""
+            def f():
+                with transaction.atomic():
+                    try:
+                        save()
+                    except IntegrityError:
+                        handle()
+        """)
+        assert (found[0].lineno, found[0].atomic_lineno) == (6, 3)
+
+    def test_each_risky_handler_is_reported(self):
+        found = violations("""
+            def f():
+                with transaction.atomic():
+                    try:
+                        save()
+                    except IntegrityError:
+                        handle()
+                    except Exception:
+                        handle()
+        """)
+        assert [f.caught for f in found] == ["IntegrityError", "Exception"]
+
+
+class TestAcceptedPatterns:
+    def test_try_outside_atomic(self):
+        assert not violations("""
+            def f():
+                try:
+                    with transaction.atomic():
+                        save()
+                except IntegrityError:
+                    handle()
+        """)
+
+    def test_nested_atomic_savepoint(self):
+        assert not violations("""
+            def f():
+                with transaction.atomic():
+                    try:
+                        with transaction.atomic():
+                            save()
+                    except IntegrityError:
+                        handle()
+        """)
+
+    def test_savepoint_with_keyword_argument(self):
+        assert not violations("""
+            def f():
+                with transaction.atomic():
+                    try:
+                        with transaction.atomic(savepoint=True):
+                            save()
+                    except IntegrityError:
+                        handle()
+        """)
+
+    def test_handler_that_reraises(self):
+        assert not violations("""
+            def f():
+                with transaction.atomic():
+                    try:
+                        save()
+                    except IntegrityError:
+                        log.exception("boom")
+                        raise
+        """)
+
+    def test_handler_that_sets_rollback(self):
+        assert not violations("""
+            def f():
+                with transaction.atomic():
+                    try:
+                        save()
+                    except IntegrityError:
+                        transaction.set_rollback(True)
+                        handle()
+        """)
+
+    def test_non_database_exception(self):
+        assert not violations("""
+            def f():
+                with transaction.atomic():
+                    try:
+                        parse(payload)
+                    except (KeyError, ValueError):
+                        handle()
+        """)
+
+    def test_try_outside_any_atomic_block(self):
+        assert not violations("""
+            def f():
+                try:
+                    save()
+                except IntegrityError:
+                    handle()
+        """)
+
+    def test_non_atomic_context_manager(self):
+        assert not violations("""
+            def f():
+                with open(path) as fh:
+                    try:
+                        save(fh)
+                    except IntegrityError:
+                        handle()
+        """)
+
+    def test_marker_comment_on_try(self):
+        assert not violations("""
+            def f():
+                with transaction.atomic():
+                    try:  # atomic-catch-ok: no DB access, parses an API response
+                        parse(payload)
+                    except Exception:
+                        handle()
+        """)
+
+    def test_marker_comment_on_handler(self):
+        assert not violations("""
+            def f():
+                with transaction.atomic():
+                    try:
+                        parse(payload)
+                    except Exception:  # atomic-catch-ok: no DB access
+                        handle()
+        """)
+
+    def test_marker_without_reason_does_not_count(self):
+        assert violations("""
+            def f():
+                with transaction.atomic():
+                    try:
+                        save()
+                    except Exception:  # atomic-catch-ok
+                        handle()
+        """)
+
+
+class TestScopeTracking:
+    def test_nested_function_does_not_inherit_the_atomic_scope(self):
+        """A closure defined inside an atomic block runs wherever it is called."""
+        assert not violations("""
+            def f():
+                with transaction.atomic():
+                    def callback():
+                        try:
+                            save()
+                        except IntegrityError:
+                            handle()
+                    register(callback)
+        """)
+
+    def test_sibling_method_does_not_inherit_the_decorator(self):
+        assert not violations("""
+            class C:
+                @transaction.atomic()
+                def a(self):
+                    save()
+
+                def b(self):
+                    try:
+                        save()
+                    except IntegrityError:
+                        handle()
+        """)
+
+    def test_catch_after_the_atomic_block_closes(self):
+        assert not violations("""
+            def f():
+                with transaction.atomic():
+                    save()
+                try:
+                    save_more()
+                except IntegrityError:
+                    handle()
+        """)
+
+    def test_handler_inside_a_nested_atomic_is_measured_against_it(self):
+        """The inner block is its own scope, so a catch inside *it* is still a violation."""
+        found = violations("""
+            def f():
+                with transaction.atomic():
+                    try:
+                        with transaction.atomic():
+                            try:
+                                save()
+                            except IntegrityError:
+                                handle()
+                    except IntegrityError:
+                        handle()
+        """)
+        assert len(found) == 1
+        assert found[0].atomic_lineno == 5
+
+
+class TestMain:
+    def _write(self, tmp_path: Path, source: str) -> Path:
+        path = tmp_path / "mod.py"
+        path.write_text(textwrap.dedent(source))
+        return path
+
+    def test_exit_code_and_output_on_violation(self, tmp_path, capsys):
+        self._write(
+            tmp_path,
+            """
+            def f():
+                with transaction.atomic():
+                    try:
+                        save()
+                    except IntegrityError:
+                        handle()
+            """,
+        )
+        assert main([str(tmp_path)]) == 1
+        assert "except IntegrityError" in capsys.readouterr().out
+
+    def test_exit_code_when_clean(self, tmp_path, capsys):
+        self._write(tmp_path, "def f():\n    save()\n")
+        assert main([str(tmp_path)]) == 0
+        assert "No database exceptions" in capsys.readouterr().out
+
+    def test_files_argument_limits_the_scan(self, tmp_path, capsys):
+        bad = self._write(
+            tmp_path,
+            """
+            def f():
+                with transaction.atomic():
+                    try:
+                        save()
+                    except IntegrityError:
+                        handle()
+            """,
+        )
+        clean = tmp_path / "clean.py"
+        clean.write_text("def g():\n    pass\n")
+        assert main([str(tmp_path), "--files", str(clean)]) == 0
+        assert main([str(tmp_path), "--files", str(bad)]) == 1
+
+    def test_missing_and_non_python_files_are_skipped(self, tmp_path):
+        assert main([str(tmp_path), "--files", str(tmp_path / "gone.py"), str(tmp_path / "notes.txt")]) == 0
+
+    def test_migrations_are_skipped(self, tmp_path, capsys):
+        migrations = tmp_path / "migrations"
+        migrations.mkdir()
+        (migrations / "0001_initial.py").write_text(
+            textwrap.dedent("""
+                def f():
+                    with transaction.atomic():
+                        try:
+                            save()
+                        except IntegrityError:
+                            handle()
+            """)
+        )
+        assert main([str(tmp_path)]) == 0
+
+    def test_unparseable_file_is_reported_but_not_fatal(self, tmp_path, capsys):
+        self._write(tmp_path, "def f(:\n")
+        assert main([str(tmp_path)]) == 0
+        assert "SKIP" in capsys.readouterr().err
+
+
+def test_the_repo_is_clean():
+    """Repo-wide gate: `apps/` must stay free of this pattern.
+
+    The pre-commit hook only sees the files a commit touches, so this test is what keeps the
+    whole tree clean (e.g. when a violation arrives via a merge or a file rename).
+    """
+    assert main([str(Path(__file__).resolve().parent.parent / "apps")]) == 0


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->
Fixes a class of production errors where users would see a failed request or a silently discarded save instead of the intended outcome. The visible symptom was a spike in TransactionManagementError: An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.


### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->

Root cause. A DB error inside transaction.atomic() leaves the transaction aborted. Catching it without leaving the block means the next query or the block's own exit raises. Verified against a real database.

What to look at:

1. Pattern choice per site. Nested atomic() savepoint where the outer transaction must still commit (AttachMediaTool, both assistant form_valids, run_post_save_hook); try hoisted outside where the work should be discarded (create_filter_set, ad_hoc_bot_message, the vector-store command). The savepoint form preserves current behaviour. Hoisting in the assistant views would also roll back the local save on a sync failure, a product change I avoided.

2. Tests use real aborted transactions. A mocked IntegrityError doesn't reproduce this bug; the three regression tests use duplicate-key/raw-SQL failures and were verified to fail before the fix.

3. New AST check (scripts/check_atomic_exception_handling.py) runs as a pre-commit hook plus a repo-wide test. It's intra-file, so it can't catch the cross-function variant (run_post_save_hook).

4. Also included: four other narrow catches reviewed and left alone (can't break the transaction), plus two adjacent fixes:
    -  a @transaction.atomic()/@staticmethod ordering bug
    - two redundant atomic blocks on read-only paths.


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->

Fixes #3185 
