### PR TITLE
Bump taskbadger to 2.3.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2654,18 +2654,6 @@ wheels = [
 ]
 
 [[package]]
-name = "markdown-it-py"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
-]
-
-[[package]]
 name = "markdownify"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2747,15 +2735,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -4357,19 +4336,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rich"
-version = "13.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/0e/e5aa3ab6857a16dadac7a970b2e1af21ddf23f03c99248db2c01082090a3/rich-13.6.0.tar.gz", hash = "sha256:5c14d22737e6d5084ef4771b62d5d4363165b403455a30a1c8ca39dc7b644bef", size = 220315, upload-time = "2023-09-30T14:10:38.639Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/2a/4e62ff633612f746f88618852a626bbe24226eba5e7ac90e91dcfd6a414e/rich-13.6.0-py3-none-any.whl", hash = "sha256:2b38e2fe9ca72c9a00170a1a2d20c63c790d0e10ef1fe35eba76e1e7b1d7d245", size = 239777, upload-time = "2023-09-30T14:10:36.484Z" },
-]
-
-[[package]]
 name = "rpds-py"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4466,15 +4432,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
-]
-
-[[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -4593,18 +4550,17 @@ wheels = [
 
 [[package]]
 name = "taskbadger"
-version = "1.6.3"
+version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "httpx" },
     { name = "python-dateutil" },
     { name = "tomlkit" },
-    { name = "typer", extra = ["all"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/e6/5337e7e68960d9937ca09f122c542a621b60df1f9696f47c04d6b7efa083/taskbadger-1.6.3.tar.gz", hash = "sha256:70cc4dac147b2dcb7f7885101f04f7fd3555fa0cfcc47e5cbfc7dbf274494ff7", size = 31682, upload-time = "2026-02-05T10:48:04.04Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/60/f903c3ea33896ff50c00eacb6794d8256188d5b0184e56f7b7d0bc2f871e/taskbadger-2.3.1.tar.gz", hash = "sha256:3c7a282581e5b254797f0351a5f7b48b1170cf5f28cc0080d74881bf1e1648f3", size = 38271, upload-time = "2026-07-27T13:51:47.062Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/1a/1a76622f146459bb4b02b48a028ba1294171b9a6f63311373d39cda66968/taskbadger-1.6.3-py3-none-any.whl", hash = "sha256:38a2ec9216962eaec395de91c6f0e542afbf29f7181368a537fb27e0a4d74d90", size = 60123, upload-time = "2026-02-05T10:48:02.993Z" },
+    { url = "https://files.pythonhosted.org/packages/17/c5/a93ff416131a36d5b7a7786cae1e545269cdb7ef9fed8c2694cd1fdc8c31/taskbadger-2.3.1-py3-none-any.whl", hash = "sha256:b0e297e3512a393b6bf18074a2c900ff8b3c6a2fb245e43d913076529f7a18f6", size = 70163, upload-time = "2026-07-27T13:51:46.146Z" },
 ]
 
 [[package]]
@@ -4881,13 +4837,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/49/39f10d0f75886439ab3dac889f14f8ad511982a754e382c9b6ca895b29e9/typer-0.9.0.tar.gz", hash = "sha256:50922fd79aea2f4751a8e0408ff10d2662bd0c8bbfa84755a699f3bada2978b2", size = 273985, upload-time = "2023-05-02T05:20:57.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/0e/c68adf10adda05f28a6ed7b9f4cd7b8e07f641b44af88ba72d9c89e4de7a/typer-0.9.0-py3-none-any.whl", hash = "sha256:5d96d986a21493606a358cae4461bd8cdf83cbf33a5aa950ae629ca3b51467ee", size = 45861, upload-time = "2023-05-02T05:20:55.675Z" },
-]
-
-[package.optional-dependencies]
-all = [
-    { name = "colorama" },
-    { name = "rich" },
-    { name = "shellingham" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Product Description
No change (internal dependency, not user-facing).

### Technical Description
Upgrades `taskbadger` from 1.6.3 to 2.3.1. Checked the changelog across the intervening versions; the only breaking change was removal of the already-deprecated `update_progress`/`increment_progress` methods (2.0.0), which aren't used anywhere in this codebase (we use `safe_update`, `create_task_safe`, `update_task_safe`). `taskbadger.init`, `CelerySystemIntegration`, and `current_scope()` usage are unaffected.

Lockfile also drops `rich`, `typer[all]`, `shellingham`, `markdown-it-py`, `mdurl` — these were only pulled in as taskbadger's CLI extras, which moved out of the default install in 2.0.0 and we don't use the CLI.

One thing to flag for whoever picks this up next: taskbadger now emits `DeprecationWarning: Legacy API keys are deprecated. Please switch to a project API key` on init. Migrating `TASKBADGER_API_KEY` to a project-scoped key is an ops change outside the scope of this bump.

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Dependency bump, no behavior change — a one-line changelog entry noting the taskbadger version bump is sufficient.