### PR TITLE
fix: use static names for eval tasks and include the run id in the data

### DIFF
--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -435,13 +435,22 @@ def _ensure_taskbadger_task(run: EvaluationRun, total: int) -> None:
     """
     if run.taskbadger_task_id:
         return
+    # Below the guard on purpose: one query per run, not one per tick per active run.
+    config = EvaluationConfig.objects.select_related("dataset").get(id=run.config_id)
     task = taskbadger.create_task_safe(
         name="Evaluation run",
         status=StatusEnum.PROCESSING,
         value=0,
         value_max=total,
         stale_timeout=TASKBADGER_STALE_TIMEOUT,
-        data={"run_id": run.id},
+        data={
+            "run_id": run.id,
+            "run_type": run.type,
+            "config_id": config.id,
+            "config_name": config.name,
+            "dataset_id": config.dataset_id,
+            "dataset_name": config.dataset.name,
+        },
     )
     if task is not None:
         run.taskbadger_task_id = task.id

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -436,11 +436,12 @@ def _ensure_taskbadger_task(run: EvaluationRun, total: int) -> None:
     if run.taskbadger_task_id:
         return
     task = taskbadger.create_task_safe(
-        name=f"Evaluation run {run.id}",
+        name="Evaluation run",
         status=StatusEnum.PROCESSING,
         value=0,
         value_max=total,
         stale_timeout=TASKBADGER_STALE_TIMEOUT,
+        data={"run_id": run.id},
     )
     if task is not None:
         run.taskbadger_task_id = task.id

--- a/apps/evaluations/tests/test_evaluation_coordination.py
+++ b/apps/evaluations/tests/test_evaluation_coordination.py
@@ -14,6 +14,7 @@ from taskbadger import StatusEnum
 from apps.evaluations.const import PREVIEW_SAMPLE_SIZE
 from apps.evaluations.models import EvaluationResult, EvaluationRun, EvaluationRunStatus, EvaluationRunType
 from apps.evaluations.tasks import (
+    _ensure_taskbadger_task,
     _mark_run_failed,
     _publish_tick,
     _TickResult,
@@ -442,6 +443,42 @@ def test_full_run_reaches_completion_over_multiple_ticks(evaluator_run_mock, _pu
     for message_id, evaluator_id in EvaluationResult.objects.filter(run=run).values_list("message_id", "evaluator_id"):
         assert (message_id, evaluator_id) not in seen
         seen.add((message_id, evaluator_id))
+
+
+@pytest.mark.django_db()
+def test_ensure_taskbadger_task_records_run_context():
+    config = EvaluationConfigFactory.create()
+    run = EvaluationRunFactory.create(config=config, team=config.team, type=EvaluationRunType.DELTA)
+
+    with patch("apps.evaluations.tasks.taskbadger.create_task_safe") as create_mock:
+        create_mock.return_value = Mock(id="tb-new")
+        _ensure_taskbadger_task(run, total=5)
+
+    assert create_mock.call_args.kwargs["name"] == "Evaluation run"
+    assert create_mock.call_args.kwargs["data"] == {
+        "run_id": run.id,
+        "run_type": "delta",
+        "config_id": config.id,
+        "config_name": config.name,
+        "dataset_id": config.dataset_id,
+        "dataset_name": config.dataset.name,
+    }
+    run.refresh_from_db()
+    assert run.taskbadger_task_id == "tb-new"
+
+
+@pytest.mark.django_db()
+def test_ensure_taskbadger_task_is_free_once_created(django_assert_num_queries):
+    """The config lookup must stay below the task-id guard: it runs once per run, not once per tick."""
+    run = EvaluationRunFactory.create(taskbadger_task_id="tb-1")
+
+    with (
+        patch("apps.evaluations.tasks.taskbadger.create_task_safe") as create_mock,
+        django_assert_num_queries(0),
+    ):
+        _ensure_taskbadger_task(run, total=5)
+
+    create_mock.assert_not_called()
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->
No user-facing change. Newly created evaluation runs now start on the next coordinator tick (up to ~30s) instead of immediately.

### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->
Improves the Taskbadger integration for evaluation runs and fixes duplicate Taskbadger tasks:

* Use a static name ("Evaluation run") for the per-run Taskbadger task and include the run id, run type, config and dataset in the task data, so Taskbadger groups these tasks by name instead of creating a distinct name per run.

### Migrations
- [ ] The migrations are backwards compatible

No migrations.

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
