### PR TITLE
Verify Turn.io webhook signatures with an optional per-provider HMAC secret

### DIFF
--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -248,10 +248,23 @@ def is_non_conversational_whatsapp_message(message_data: dict) -> bool:
     malformed "messages" value - it returns False and lets the request fall through
     to the signature guard instead.
     """
-    messages = message_data.get("messages") or []
-    if not isinstance(messages, list) or not messages or not isinstance(messages[0], dict):
+    first_message = _first_whatsapp_message(message_data)
+    if first_message is None:
         return False
-    return messages[0].get("type") in _NON_CONVERSATIONAL_WA_MESSAGE_TYPES
+    return first_message.get("type") in _NON_CONVERSATIONAL_WA_MESSAGE_TYPES
+
+
+def _first_whatsapp_message(message_data: dict) -> dict | None:
+    """The first entry of a WhatsApp "messages" array, or None if it is absent or malformed.
+
+    Callers reach this with unauthenticated input, so every unexpected shape resolves to
+    None rather than raising.
+    """
+    messages = message_data.get("messages")
+    if not isinstance(messages, list) or not messages:
+        return None
+    first_message = messages[0]
+    return first_message if isinstance(first_message, dict) else None
 
 
 class WhatsAppMessage(BaseMessage):

--- a/apps/channels/datamodels.py
+++ b/apps/channels/datamodels.py
@@ -242,9 +242,14 @@ def is_non_conversational_whatsapp_message(message_data: dict) -> bool:
     "system" payloads have a "messages" array but no "contacts" key, so the webhook
     views use this to skip them before dispatching a task that would KeyError while
     parsing. "unsupported"/"unknown" payloads are skipped as there is nothing to process.
+
+    This runs on unauthenticated input on the Turn.io webhook (verification happens
+    after the ignore-filters, see new_turn_message), so it must not raise on a
+    malformed "messages" value - it returns False and lets the request fall through
+    to the signature guard instead.
     """
     messages = message_data.get("messages") or []
-    if not messages:
+    if not isinstance(messages, list) or not messages or not isinstance(messages[0], dict):
         return False
     return messages[0].get("type") in _NON_CONVERSATIONAL_WA_MESSAGE_TYPES
 

--- a/apps/channels/tests/test_datamodels.py
+++ b/apps/channels/tests/test_datamodels.py
@@ -63,6 +63,20 @@ class TestIsNonConversationalWhatsAppMessage:
         assert is_non_conversational_whatsapp_message({}) is False
         assert is_non_conversational_whatsapp_message({"messages": []}) is False
 
+    @pytest.mark.parametrize(
+        "message_data",
+        [
+            pytest.param({"messages": [1]}, id="messages_list_of_int"),
+            pytest.param({"messages": "abc"}, id="messages_is_string"),
+            pytest.param({"messages": {"a": "b"}}, id="messages_is_dict"),
+            pytest.param({"messages": [[]]}, id="messages_list_of_list"),
+        ],
+    )
+    def test_false_for_malformed_messages(self, message_data):
+        """Runs on unauthenticated input (verification happens after this filter on the
+        Turn.io webhook), so malformed shapes must return False rather than raise."""
+        assert is_non_conversational_whatsapp_message(message_data) is False
+
 
 @pytest.mark.parametrize(
     ("value", "expected"),

--- a/apps/channels/tests/test_turn_webhook.py
+++ b/apps/channels/tests/test_turn_webhook.py
@@ -1,0 +1,53 @@
+import base64
+import hashlib
+import hmac
+import json
+
+import pytest
+
+from apps.channels import turn_webhook
+
+HMAC_SECRET = "turn_test_hmac_secret"
+
+
+def _sign(payload: bytes, secret: str = HMAC_SECRET) -> str:
+    return base64.b64encode(hmac.new(secret.encode(), payload, hashlib.sha256).digest()).decode()
+
+
+class TestVerifySignature:
+    def test_valid_signature(self):
+        payload = b'{"messages": [{"id": "abc"}]}'
+        assert turn_webhook.verify_signature(payload, _sign(payload), HMAC_SECRET) is True
+
+    def test_signature_from_a_different_secret(self):
+        payload = b'{"messages": [{"id": "abc"}]}'
+        assert turn_webhook.verify_signature(payload, _sign(payload, "other_secret"), HMAC_SECRET) is False
+
+    def test_tampered_body(self):
+        signature = _sign(b'{"messages": [{"id": "abc"}]}')
+        assert turn_webhook.verify_signature(b'{"messages": [{"id": "xyz"}]}', signature, HMAC_SECRET) is False
+
+    def test_reserialized_body_does_not_verify(self):
+        """Raw-body discipline: re-serializing reorders keys, so only request.body may be signed."""
+        raw = b'{"b": 2, "a": 1}'
+        reserialized = json.dumps(json.loads(raw), sort_keys=True).encode()
+        assert turn_webhook.verify_signature(reserialized, _sign(raw), HMAC_SECRET) is False
+
+    @pytest.mark.parametrize(
+        "signature_header",
+        [
+            pytest.param("", id="empty_header"),
+            pytest.param("not-base64-at-all", id="garbage_header"),
+            pytest.param("sha256=" + _sign(b'{"messages": []}'), id="prefixed_header"),
+            pytest.param("sïgnature-with-non-ascii", id="non_ascii_header"),
+        ],
+    )
+    def test_unusable_header_returns_false_without_raising(self, signature_header):
+        assert turn_webhook.verify_signature(b'{"messages": []}', signature_header, HMAC_SECRET) is False
+
+    def test_empty_secret(self):
+        payload = b'{"messages": []}'
+        assert turn_webhook.verify_signature(payload, _sign(payload), "") is False
+
+    def test_empty_payload_with_matching_signature(self):
+        assert turn_webhook.verify_signature(b"", _sign(b""), HMAC_SECRET) is True

--- a/apps/channels/tests/test_turn_webhook.py
+++ b/apps/channels/tests/test_turn_webhook.py
@@ -14,10 +14,13 @@ HMAC_SECRET = "turn_test_hmac_secret"
 
 
 def _sign(payload: bytes, secret: str = HMAC_SECRET) -> str:
+    """Produce the header value Turn.io would send for this body: base64 HMAC-SHA256."""
     return base64.b64encode(hmac.new(secret.encode(), payload, hashlib.sha256).digest()).decode()
 
 
 class TestVerifySignature:
+    """Unit tests for the pure helper, covering the never-raise contract."""
+
     def test_valid_signature(self):
         payload = b'{"messages": [{"id": "abc"}]}'
         assert turn_webhook.verify_signature(payload, _sign(payload), HMAC_SECRET) is True
@@ -57,6 +60,7 @@ class TestVerifySignature:
 
 
 def _post(client, channel, payload: dict, signature: str | None = None):
+    """POST a JSON payload to a channel's Turn.io webhook, omitting the header when signature is None."""
     body = json.dumps(payload).encode()
     headers = {}
     if signature is not None:
@@ -71,6 +75,7 @@ def _post(client, channel, payload: dict, signature: str | None = None):
 
 @pytest.fixture()
 def signed_turn_channel(turnio_whatsapp_channel):
+    """A Turn.io channel whose provider has a secret configured, so verification is enforced."""
     provider = turnio_whatsapp_channel.messaging_provider
     provider.config = {"auth_token": "123", "hmac_secret": HMAC_SECRET}
     provider.save()
@@ -79,6 +84,8 @@ def signed_turn_channel(turnio_whatsapp_channel):
 
 @pytest.mark.django_db()
 class TestNewTurnMessageSignatureVerification:
+    """The signature guard as seen through the view, including the staged-rollout pass-through."""
+
     @patch("apps.channels.tasks.handle_turn_message")
     def test_unconfigured_provider_still_accepts_unsigned_webhooks(self, task, client, turnio_whatsapp_channel):
         """Staged rollout: providers that have not copied their secret across keep working."""
@@ -152,6 +159,8 @@ class TestNewTurnMessageSignatureVerification:
 
 @pytest.mark.django_db()
 class TestNewTurnMessageRequestHandling:
+    """Request shapes that must not reach the guard as a 500: wrong method, unparseable body."""
+
     def test_get_returns_405(self, client, turnio_whatsapp_channel):
         """Previously a GET reached json.loads on an empty body and returned a 500."""
         url = reverse(

--- a/apps/channels/tests/test_turn_webhook.py
+++ b/apps/channels/tests/test_turn_webhook.py
@@ -175,3 +175,12 @@ class TestNewTurnMessageRequestHandling:
         response = client.post(url, data=body, content_type="application/json")
         assert response.status_code == 400
         task.delay.assert_not_called()
+
+    @patch("apps.channels.tasks.handle_turn_message")
+    def test_malformed_messages_value_does_not_500(self, task, client, signed_turn_channel):
+        """is_non_conversational_whatsapp_message runs on unauthenticated input, before the
+        signature guard. A malformed "messages" entry must not crash it - it should fall
+        through to the (here, failing) signature check rather than raising a 500."""
+        response = _post(client, signed_turn_channel, {"messages": [1]})
+        assert response.status_code == 401
+        task.delay.assert_not_called()

--- a/apps/channels/tests/test_turn_webhook.py
+++ b/apps/channels/tests/test_turn_webhook.py
@@ -159,9 +159,19 @@ class TestNewTurnMessageRequestHandling:
         )
         assert client.get(url).status_code == 405
 
-    def test_malformed_body_returns_400(self, client, turnio_whatsapp_channel):
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param(b"not json", id="invalid_json"),
+            pytest.param(b"5", id="valid_json_scalar_not_an_object"),
+            pytest.param(b'"xxmessagesxx"', id="valid_json_string_containing_messages_substring"),
+        ],
+    )
+    @patch("apps.channels.tasks.handle_turn_message")
+    def test_malformed_body_returns_400(self, task, body, client, turnio_whatsapp_channel):
         url = reverse(
             "channels:new_turn_message", kwargs={"experiment_id": turnio_whatsapp_channel.experiment.public_id}
         )
-        response = client.post(url, data=b"not json", content_type="application/json")
+        response = client.post(url, data=body, content_type="application/json")
         assert response.status_code == 400
+        task.delay.assert_not_called()

--- a/apps/channels/tests/test_turn_webhook.py
+++ b/apps/channels/tests/test_turn_webhook.py
@@ -2,10 +2,13 @@ import base64
 import hashlib
 import hmac
 import json
+from unittest.mock import patch
 
 import pytest
+from django.urls import reverse
 
 from apps.channels import turn_webhook
+from apps.channels.tests.message_examples import turnio_messages
 
 HMAC_SECRET = "turn_test_hmac_secret"
 
@@ -51,3 +54,114 @@ class TestVerifySignature:
 
     def test_empty_payload_with_matching_signature(self):
         assert turn_webhook.verify_signature(b"", _sign(b""), HMAC_SECRET) is True
+
+
+def _post(client, channel, payload: dict, signature: str | None = None):
+    body = json.dumps(payload).encode()
+    headers = {}
+    if signature is not None:
+        headers["HTTP_X_TURN_HOOK_SIGNATURE"] = signature
+    return client.post(
+        reverse("channels:new_turn_message", kwargs={"experiment_id": channel.experiment.public_id}),
+        data=body,
+        content_type="application/json",
+        **headers,
+    )
+
+
+@pytest.fixture()
+def signed_turn_channel(turnio_whatsapp_channel):
+    provider = turnio_whatsapp_channel.messaging_provider
+    provider.config = {"auth_token": "123", "hmac_secret": HMAC_SECRET}
+    provider.save()
+    return turnio_whatsapp_channel
+
+
+@pytest.mark.django_db()
+class TestNewTurnMessageSignatureVerification:
+    @patch("apps.channels.tasks.handle_turn_message")
+    def test_unconfigured_provider_still_accepts_unsigned_webhooks(self, task, client, turnio_whatsapp_channel):
+        """Staged rollout: providers that have not copied their secret across keep working."""
+        response = _post(client, turnio_whatsapp_channel, turnio_messages.text_message())
+        assert response.status_code == 200
+        task.delay.assert_called_once()
+
+    @patch("apps.channels.tasks.handle_turn_message")
+    def test_valid_signature_is_accepted(self, task, client, signed_turn_channel):
+        payload = turnio_messages.text_message()
+        signature = _sign(json.dumps(payload).encode())
+        response = _post(client, signed_turn_channel, payload, signature)
+        assert response.status_code == 200
+        task.delay.assert_called_once()
+
+    @patch("apps.channels.tasks.handle_turn_message")
+    def test_invalid_signature_is_rejected(self, task, client, signed_turn_channel):
+        response = _post(client, signed_turn_channel, turnio_messages.text_message(), "bm90LWEtc2lnbmF0dXJl")
+        assert response.status_code == 401
+        task.delay.assert_not_called()
+
+    @patch("apps.channels.tasks.handle_turn_message")
+    def test_missing_signature_header_is_rejected(self, task, client, signed_turn_channel):
+        response = _post(client, signed_turn_channel, turnio_messages.text_message())
+        assert response.status_code == 401
+        task.delay.assert_not_called()
+
+    @patch("apps.channels.tasks.handle_turn_message")
+    def test_signature_over_a_different_body_is_rejected(self, task, client, signed_turn_channel):
+        signature = _sign(json.dumps(turnio_messages.text_message()).encode())
+        other_payload = turnio_messages.text_message()
+        other_payload["messages"][0]["text"]["body"] = "tampered"
+        response = _post(client, signed_turn_channel, other_payload, signature)
+        assert response.status_code == 401
+        task.delay.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "stored_secret",
+        [
+            pytest.param("   ", id="whitespace_only"),
+            pytest.param("", id="empty_string"),
+            pytest.param(None, id="none"),
+        ],
+    )
+    @patch("apps.channels.tasks.handle_turn_message")
+    def test_blank_stored_secret_counts_as_unconfigured(self, task, stored_secret, client, turnio_whatsapp_channel):
+        provider = turnio_whatsapp_channel.messaging_provider
+        provider.config = {"auth_token": "123", "hmac_secret": stored_secret}
+        provider.save()
+        response = _post(client, turnio_whatsapp_channel, turnio_messages.text_message())
+        assert response.status_code == 200
+        task.delay.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            pytest.param(turnio_messages.status_message(), id="status_callback_no_messages_key"),
+            pytest.param(turnio_messages.system_user_changed_number_message(), id="non_conversational"),
+        ],
+    )
+    @patch("apps.channels.tasks.handle_turn_message")
+    def test_ignored_payloads_are_filtered_before_verification(self, task, payload, client, signed_turn_channel):
+        """Turn's status callbacks and system messages are filtered out before the signature
+        check, so an unsigned one gets a 200 rather than a 401 in the customer's Turn dashboard.
+        `status_message` has no "messages" key; `system_user_changed_number_message` has one and
+        is caught by is_non_conversational_whatsapp_message, the two filters run in that order."""
+        response = _post(client, signed_turn_channel, payload)
+        assert response.status_code == 200
+        task.delay.assert_not_called()
+
+
+@pytest.mark.django_db()
+class TestNewTurnMessageRequestHandling:
+    def test_get_returns_405(self, client, turnio_whatsapp_channel):
+        """Previously a GET reached json.loads on an empty body and returned a 500."""
+        url = reverse(
+            "channels:new_turn_message", kwargs={"experiment_id": turnio_whatsapp_channel.experiment.public_id}
+        )
+        assert client.get(url).status_code == 405
+
+    def test_malformed_body_returns_400(self, client, turnio_whatsapp_channel):
+        url = reverse(
+            "channels:new_turn_message", kwargs={"experiment_id": turnio_whatsapp_channel.experiment.public_id}
+        )
+        response = client.post(url, data=b"not json", content_type="application/json")
+        assert response.status_code == 400

--- a/apps/channels/turn_webhook.py
+++ b/apps/channels/turn_webhook.py
@@ -1,0 +1,22 @@
+from django.utils.crypto import constant_time_compare
+
+from apps.api.permissions import get_hmac_digest
+
+SIGNATURE_HEADER = "X-Turn-Hook-Signature"
+
+
+def verify_signature(payload: bytes, signature_header: str, hmac_secret: str) -> bool:
+    """Verify the X-Turn-Hook-Signature header from a Turn.io webhook.
+
+    Turn signs the raw request body with HMAC-SHA256, keyed on the secret configured
+    for that webhook in the customer's Turn account, and sends the base64-encoded
+    digest. See https://whatsapp.turn.io/docs/api/webhooks
+
+    Returns False for any unusable input rather than raising: a malformed or absent
+    header is an authentication failure, not a server error.
+    """
+    if not signature_header or not hmac_secret:
+        return False
+
+    expected = get_hmac_digest(key=hmac_secret.encode(), data_bytes=payload).decode()
+    return constant_time_compare(expected, signature_header)

--- a/apps/channels/views.py
+++ b/apps/channels/views.py
@@ -145,6 +145,10 @@ def new_turn_message(request, experiment_id: uuid):
         log.debug("Turn.io webhook received invalid JSON")
         return HttpResponseBadRequest("Invalid JSON.")
 
+    if not isinstance(message_data, dict):
+        log.debug("Turn.io webhook received a non-object JSON body")
+        return HttpResponseBadRequest("Invalid JSON.")
+
     if "messages" not in message_data:
         # Normal inbound messages should have a "messages" key, so ignore everything else
         return HttpResponse()

--- a/apps/channels/views.py
+++ b/apps/channels/views.py
@@ -159,15 +159,19 @@ def new_turn_message(request, experiment_id: uuid):
 
     # Verification runs after the ignore-filters so that unsigned provider callbacks,
     # which are discarded either way, are not rejected in the customer's Turn dashboard.
-    if not _turn_signature_is_valid(request, channel):
+    # A failure here returns 401 (rather than Meta's 200-and-drop) because Turn surfaces
+    # the failure in the customer's own Turn dashboard and, unlike Meta, does not
+    # auto-disable a webhook after sustained non-2xx responses.
+    if not _turn_request_is_authorised(request, channel):
         return HttpResponse("Invalid signature.", status=401)
 
     tasks.handle_turn_message.delay(experiment_id=experiment_id, message_data=message_data)
     return HttpResponse()
 
 
-def _turn_signature_is_valid(request, channel: ExperimentChannel) -> bool:
-    """Verify the Turn.io webhook signature, if the provider has a secret configured.
+def _turn_request_is_authorised(request, channel: ExperimentChannel) -> bool:
+    """Check whether the Turn.io webhook request is authorised: True if the provider has
+    no secret configured (fail-open, see below) or if the request's signature matches.
 
     The secret is optional by design: a provider that has not yet copied it across from
     its own Turn account is left unverified rather than having its live traffic dropped.
@@ -175,7 +179,7 @@ def _turn_signature_is_valid(request, channel: ExperimentChannel) -> bool:
     """
     hmac_secret = (channel.messaging_provider.config.get("hmac_secret") or "").strip()
     if not hmac_secret:
-        log.debug(
+        log.info(
             "Turn.io webhook not verified: no HMAC secret configured for provider %s",
             channel.messaging_provider_id,
         )
@@ -185,11 +189,20 @@ def _turn_signature_is_valid(request, channel: ExperimentChannel) -> bool:
     if turn_webhook.verify_signature(request.body, signature, hmac_secret):
         return True
 
-    log.warning(
-        "Turn.io webhook signature verification failed for provider %s (team %s)",
-        channel.messaging_provider_id,
-        channel.team.slug,
-    )
+    if not signature:
+        log.warning(
+            "Turn.io webhook signature verification failed for provider %s (team %s): "
+            "no signature header present, Turn may not be configured to sign requests",
+            channel.messaging_provider_id,
+            channel.team.slug,
+        )
+    else:
+        log.warning(
+            "Turn.io webhook signature verification failed for provider %s (team %s): "
+            "signature did not match, the configured secret may be incorrect",
+            channel.messaging_provider_id,
+            channel.team.slug,
+        )
     return False
 
 

--- a/apps/channels/views.py
+++ b/apps/channels/views.py
@@ -29,7 +29,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.api.permissions import verify_hmac
-from apps.channels import meta_webhook, tasks
+from apps.channels import meta_webhook, tasks, turn_webhook
 from apps.channels.datamodels import TwilioMessage, is_non_conversational_whatsapp_message
 from apps.channels.exceptions import ExperimentChannelException
 from apps.channels.forms import ChannelFormWrapper
@@ -127,6 +127,7 @@ def new_sureadhere_message(request, sureadhere_tenant_id: int):
 
 
 @csrf_exempt
+@require_POST
 def new_turn_message(request, experiment_id: uuid):
     channel = tasks.get_experiment_channel(
         ChannelPlatform.WHATSAPP,
@@ -138,7 +139,12 @@ def new_turn_message(request, experiment_id: uuid):
 
     set_current_team(channel.team)
     request.experiment = channel.experiment  # used by RequestLoggingMiddleware
-    message_data = json.loads(request.body.decode("utf-8"))
+    try:
+        message_data = json.loads(request.body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        log.debug("Turn.io webhook received invalid JSON")
+        return HttpResponseBadRequest("Invalid JSON.")
+
     if "messages" not in message_data:
         # Normal inbound messages should have a "messages" key, so ignore everything else
         return HttpResponse()
@@ -147,8 +153,40 @@ def new_turn_message(request, experiment_id: uuid):
         log.info("Ignoring non-conversational Turn.io WhatsApp webhook")
         return HttpResponse()
 
+    # Verification runs after the ignore-filters so that unsigned provider callbacks,
+    # which are discarded either way, are not rejected in the customer's Turn dashboard.
+    if not _turn_signature_is_valid(request, channel):
+        return HttpResponse("Invalid signature.", status=401)
+
     tasks.handle_turn_message.delay(experiment_id=experiment_id, message_data=message_data)
     return HttpResponse()
+
+
+def _turn_signature_is_valid(request, channel: ExperimentChannel) -> bool:
+    """Verify the Turn.io webhook signature, if the provider has a secret configured.
+
+    The secret is optional by design: a provider that has not yet copied it across from
+    its own Turn account is left unverified rather than having its live traffic dropped.
+    See dimagi/open-chat-studio#2346.
+    """
+    hmac_secret = (channel.messaging_provider.config.get("hmac_secret") or "").strip()
+    if not hmac_secret:
+        log.debug(
+            "Turn.io webhook not verified: no HMAC secret configured for provider %s",
+            channel.messaging_provider_id,
+        )
+        return True
+
+    signature = request.headers.get(turn_webhook.SIGNATURE_HEADER, "")
+    if turn_webhook.verify_signature(request.body, signature, hmac_secret):
+        return True
+
+    log.warning(
+        "Turn.io webhook signature verification failed for provider %s (team %s)",
+        channel.messaging_provider_id,
+        channel.team.slug,
+    )
+    return False
 
 
 def new_api_message_schema(versioned: bool):

--- a/apps/service_providers/forms.py
+++ b/apps/service_providers/forms.py
@@ -296,8 +296,7 @@ class TurnIOMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
     )
 
     def clean(self):
-        """Normalise hmac_secret so the stored value is always a string.
-        """
+        """Normalise hmac_secret so the stored value is always a string."""
         cleaned_data = super().clean()
         cleaned_data["hmac_secret"] = (cleaned_data.get("hmac_secret") or "").strip()
         return cleaned_data

--- a/apps/service_providers/forms.py
+++ b/apps/service_providers/forms.py
@@ -283,9 +283,25 @@ class TwilioMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
 
 
 class TurnIOMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
-    obfuscate_fields = ["auth_token"]
+    obfuscate_fields = ["auth_token", "hmac_secret"]
 
     auth_token = forms.CharField(label=_("Auth Token"))
+    hmac_secret = forms.CharField(
+        label=_("Webhook HMAC Secret"),
+        required=False,
+        help_text=_(
+            "Optional. The HMAC secret from your Turn account's webhook settings. When set, incoming "
+            "webhooks must carry a matching X-Turn-Hook-Signature header or they are rejected."
+        ),
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        # ObfuscatingMixin restores the unmasked original for an unchanged field, which is
+        # None for a provider saved before this field existed. Normalise so config never
+        # holds None and a whitespace-only secret counts as unset.
+        cleaned_data["hmac_secret"] = (cleaned_data.get("hmac_secret") or "").strip()
+        return cleaned_data
 
 
 class SureAdhereMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):

--- a/apps/service_providers/forms.py
+++ b/apps/service_providers/forms.py
@@ -297,11 +297,6 @@ class TurnIOMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
 
     def clean(self):
         """Normalise hmac_secret so the stored value is always a string.
-
-        ObfuscatingMixin restores the unmasked original for an unchanged field, which is
-        None for a provider saved before this field existed. Without this, config could
-        hold None and slip past a `not hmac_secret` check. Stripping also makes a
-        whitespace-only secret count as unset.
         """
         cleaned_data = super().clean()
         cleaned_data["hmac_secret"] = (cleaned_data.get("hmac_secret") or "").strip()

--- a/apps/service_providers/forms.py
+++ b/apps/service_providers/forms.py
@@ -296,10 +296,14 @@ class TurnIOMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
     )
 
     def clean(self):
+        """Normalise hmac_secret so the stored value is always a string.
+
+        ObfuscatingMixin restores the unmasked original for an unchanged field, which is
+        None for a provider saved before this field existed. Without this, config could
+        hold None and slip past a `not hmac_secret` check. Stripping also makes a
+        whitespace-only secret count as unset.
+        """
         cleaned_data = super().clean()
-        # ObfuscatingMixin restores the unmasked original for an unchanged field, which is
-        # None for a provider saved before this field existed. Normalise so config never
-        # holds None and a whitespace-only secret counts as unset.
         cleaned_data["hmac_secret"] = (cleaned_data.get("hmac_secret") or "").strip()
         return cleaned_data
 

--- a/apps/service_providers/tests/test_messaging_providers.py
+++ b/apps/service_providers/tests/test_messaging_providers.py
@@ -14,7 +14,6 @@ from apps.channels.models import ChannelPlatform
 from apps.channels.tests.message_examples import turnio_messages
 from apps.chat.exceptions import ServiceWindowExpiredException
 from apps.service_providers.exceptions import MessageMediaError
-from apps.service_providers.forms import TurnIOMessagingConfigForm
 from apps.service_providers.messaging_service import MetaCloudAPIService, TwilioService
 from apps.service_providers.models import MessagingProvider, MessagingProviderType
 from apps.service_providers.speech_service import SynthesizedAudio
@@ -869,53 +868,3 @@ class TestMetaCloudAPIServiceBSUIDRecipient:
         assert sent["recipient"] == self.BSUID
         assert sent["recipient_type"] == "individual"
         assert "to" not in sent
-
-
-class TestTurnIOMessagingConfigForm:
-    """The hmac_secret is optional so that existing Turn providers keep working after deploy.
-
-    See dimagi/open-chat-studio#2346 - enforcing on deploy day would drop live webhook
-    traffic for every provider that has not yet copied its secret across from Turn.
-    """
-
-    def test_hmac_secret_is_optional(self):
-        form = TurnIOMessagingConfigForm(None, data={"auth_token": "token123"})
-        assert form.is_valid(), form.errors
-        assert form.cleaned_data["hmac_secret"] == ""
-
-    def test_hmac_secret_is_saved_when_supplied(self):
-        form = TurnIOMessagingConfigForm(None, data={"auth_token": "token123", "hmac_secret": "s3cr3t-value"})
-        assert form.is_valid(), form.errors
-        assert form.cleaned_data["hmac_secret"] == "s3cr3t-value"
-
-    def test_hmac_secret_is_stripped(self):
-        form = TurnIOMessagingConfigForm(None, data={"auth_token": "token123", "hmac_secret": "  s3cr3t-value  "})
-        assert form.is_valid(), form.errors
-        assert form.cleaned_data["hmac_secret"] == "s3cr3t-value"
-
-    def test_blank_secret_on_a_pre_existing_provider_normalises_to_empty_string(self):
-        """A provider saved before this field existed has no hmac_secret in its config.
-
-        ObfuscatingMixin restores the unmasked original for an unchanged field, which
-        would be None here. Storing None would defeat the `not hmac_secret` check.
-        """
-        form = TurnIOMessagingConfigForm(
-            None,
-            data={"auth_token": "token123", "hmac_secret": ""},
-            initial={"auth_token": "token123"},
-        )
-        assert form.is_valid(), form.errors
-        assert form.cleaned_data["hmac_secret"] == ""
-
-    def test_unchanged_masked_secret_keeps_the_original_value(self):
-        form = TurnIOMessagingConfigForm(
-            None,
-            data={"auth_token": "token123", "hmac_secret": "s3cr...ue"},
-            initial={"auth_token": "token123", "hmac_secret": "s3cr3t-value"},
-        )
-        assert form.is_valid(), form.errors
-        assert form.cleaned_data["hmac_secret"] == "s3cr3t-value"
-
-    def test_secret_is_obfuscated_for_display(self):
-        form = TurnIOMessagingConfigForm(None, initial={"auth_token": "token123", "hmac_secret": "s3cr3t-value"})
-        assert form["hmac_secret"].value() == "s3cr...ue"

--- a/apps/service_providers/tests/test_messaging_providers.py
+++ b/apps/service_providers/tests/test_messaging_providers.py
@@ -14,6 +14,7 @@ from apps.channels.models import ChannelPlatform
 from apps.channels.tests.message_examples import turnio_messages
 from apps.chat.exceptions import ServiceWindowExpiredException
 from apps.service_providers.exceptions import MessageMediaError
+from apps.service_providers.forms import TurnIOMessagingConfigForm
 from apps.service_providers.messaging_service import MetaCloudAPIService, TwilioService
 from apps.service_providers.models import MessagingProvider, MessagingProviderType
 from apps.service_providers.speech_service import SynthesizedAudio
@@ -868,3 +869,53 @@ class TestMetaCloudAPIServiceBSUIDRecipient:
         assert sent["recipient"] == self.BSUID
         assert sent["recipient_type"] == "individual"
         assert "to" not in sent
+
+
+class TestTurnIOMessagingConfigForm:
+    """The hmac_secret is optional so that existing Turn providers keep working after deploy.
+
+    See dimagi/open-chat-studio#2346 - enforcing on deploy day would drop live webhook
+    traffic for every provider that has not yet copied its secret across from Turn.
+    """
+
+    def test_hmac_secret_is_optional(self):
+        form = TurnIOMessagingConfigForm(None, data={"auth_token": "token123"})
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["hmac_secret"] == ""
+
+    def test_hmac_secret_is_saved_when_supplied(self):
+        form = TurnIOMessagingConfigForm(None, data={"auth_token": "token123", "hmac_secret": "s3cr3t-value"})
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["hmac_secret"] == "s3cr3t-value"
+
+    def test_hmac_secret_is_stripped(self):
+        form = TurnIOMessagingConfigForm(None, data={"auth_token": "token123", "hmac_secret": "  s3cr3t-value  "})
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["hmac_secret"] == "s3cr3t-value"
+
+    def test_blank_secret_on_a_pre_existing_provider_normalises_to_empty_string(self):
+        """A provider saved before this field existed has no hmac_secret in its config.
+
+        ObfuscatingMixin restores the unmasked original for an unchanged field, which
+        would be None here. Storing None would defeat the `not hmac_secret` check.
+        """
+        form = TurnIOMessagingConfigForm(
+            None,
+            data={"auth_token": "token123", "hmac_secret": ""},
+            initial={"auth_token": "token123"},
+        )
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["hmac_secret"] == ""
+
+    def test_unchanged_masked_secret_keeps_the_original_value(self):
+        form = TurnIOMessagingConfigForm(
+            None,
+            data={"auth_token": "token123", "hmac_secret": "s3cr...ue"},
+            initial={"auth_token": "token123", "hmac_secret": "s3cr3t-value"},
+        )
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["hmac_secret"] == "s3cr3t-value"
+
+    def test_secret_is_obfuscated_for_display(self):
+        form = TurnIOMessagingConfigForm(None, initial={"auth_token": "token123", "hmac_secret": "s3cr3t-value"})
+        assert form["hmac_secret"].value() == "s3cr...ue"

--- a/apps/service_providers/tests/test_turnio_config_form.py
+++ b/apps/service_providers/tests/test_turnio_config_form.py
@@ -1,0 +1,51 @@
+from apps.service_providers.forms import TurnIOMessagingConfigForm
+
+
+class TestTurnIOMessagingConfigForm:
+    """The hmac_secret is optional so that existing Turn providers keep working after deploy.
+
+    See dimagi/open-chat-studio#2346 - enforcing on deploy day would drop live webhook
+    traffic for every provider that has not yet copied its secret across from Turn.
+    """
+
+    def test_hmac_secret_is_optional(self):
+        form = TurnIOMessagingConfigForm(None, data={"auth_token": "token123"})
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["hmac_secret"] == ""
+
+    def test_hmac_secret_is_saved_when_supplied(self):
+        form = TurnIOMessagingConfigForm(None, data={"auth_token": "token123", "hmac_secret": "s3cr3t-value"})
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["hmac_secret"] == "s3cr3t-value"
+
+    def test_hmac_secret_is_stripped(self):
+        form = TurnIOMessagingConfigForm(None, data={"auth_token": "token123", "hmac_secret": "  s3cr3t-value  "})
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["hmac_secret"] == "s3cr3t-value"
+
+    def test_blank_secret_on_a_pre_existing_provider_normalises_to_empty_string(self):
+        """A provider saved before this field existed has no hmac_secret in its config.
+
+        ObfuscatingMixin restores the unmasked original for an unchanged field, which
+        would be None here. Storing None would defeat the `not hmac_secret` check.
+        """
+        form = TurnIOMessagingConfigForm(
+            None,
+            data={"auth_token": "token123", "hmac_secret": ""},
+            initial={"auth_token": "token123"},
+        )
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["hmac_secret"] == ""
+
+    def test_unchanged_masked_secret_keeps_the_original_value(self):
+        form = TurnIOMessagingConfigForm(
+            None,
+            data={"auth_token": "token123", "hmac_secret": "s3cr...ue"},
+            initial={"auth_token": "token123", "hmac_secret": "s3cr3t-value"},
+        )
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["hmac_secret"] == "s3cr3t-value"
+
+    def test_secret_is_obfuscated_for_display(self):
+        form = TurnIOMessagingConfigForm(None, initial={"auth_token": "token123", "hmac_secret": "s3cr3t-value"})
+        assert form["hmac_secret"].value() == "s3cr...ue"

--- a/docs/developer_guides/code_systems/turn_io_integration.md
+++ b/docs/developer_guides/code_systems/turn_io_integration.md
@@ -1,0 +1,57 @@
+# Turn.io Integration
+
+This guide covers the configuration parameters for a Turn.io messaging provider and how inbound webhooks are authenticated.
+
+## Provider Configuration
+
+| Parameter | Label | Required | Where it's used |
+|-----------|-------|----------|----------------|
+| `auth_token` | Auth Token | Yes | All outbound calls to the Turn API |
+| `hmac_secret` | Webhook HMAC Secret | No | Verifying incoming webhook payload signatures |
+
+Both are stored as encrypted fields and obfuscated in the UI.
+
+## `hmac_secret` - Webhook Signature Verification
+
+Turn signs every webhook delivery with an HMAC-SHA256 of the raw request body, keyed on the
+secret configured for that webhook in your Turn account, and sends the base64-encoded digest
+in the `X-Turn-Hook-Signature` header.
+
+When `hmac_secret` is set on the provider, OCS recomputes that digest over the raw body and
+compares it in constant time. A request whose signature is missing or does not match is
+rejected with a `401`, and no message is queued.
+
+When `hmac_secret` is blank, the signature is not checked and the webhook is accepted as
+before. This is deliberate: the secret can only be read from the customer's own Turn account,
+so requiring it on the day the feature deploys would drop live traffic for every provider
+that had not yet copied it across, including self-hosted OCS instances. See
+[issue #2346](https://github.com/dimagi/open-chat-studio/issues/2346).
+
+**Leaving it blank means the webhook endpoint is unauthenticated.** Anyone who knows the URL
+can forge messages as any participant. Set the secret as soon as your Turn account is
+configured to sign.
+
+### Setting it up
+
+1. In your Turn account, open the webhook configuration for the number connected to this chatbot.
+2. Copy the HMAC secret shown there. If the webhook has no secret yet, generate one in Turn first.
+3. In OCS, open **Service Providers - Messaging**, edit the Turn.io provider, paste the value into
+   **Webhook HMAC Secret**, and save.
+4. Send a test message through WhatsApp and confirm the bot replies.
+
+Verification takes effect on the very next request, so do step 4 immediately. Turn retries a
+failed delivery up to five times with incremental backoff, but a `4xx` cancels the retries, so
+a mismatched secret loses messages rather than delaying them.
+
+### If messages stop arriving
+
+Clear the **Webhook HMAC Secret** field and save. Delivery resumes immediately, and you can
+re-check the value in your Turn account without losing further messages. A `401` in your Turn
+dashboard's delivery log confirms the secret did not match what Turn is signing with.
+
+### Verification order
+
+Turn also delivers status callbacks and outbound-message echoes to the same URL. OCS filters
+those out before checking the signature, so they continue to receive a `200` rather than
+appearing as authentication failures in the Turn dashboard. Only payloads that would be
+dispatched to a chatbot are verified.

--- a/docs/developer_guides/code_systems/turn_io_integration.md
+++ b/docs/developer_guides/code_systems/turn_io_integration.md
@@ -35,7 +35,7 @@ configured to sign.
 
 1. In your Turn account, open the webhook configuration for the number connected to this chatbot.
 2. Copy the HMAC secret shown there. If the webhook has no secret yet, generate one in Turn first.
-3. In OCS, open **Service Providers - Messaging**, edit the Turn.io provider, paste the value into
+3. In OCS, open **Team Settings**, then in the **Messaging Providers** section edit the Turn.io provider, paste the value into
    **Webhook HMAC Secret**, and save.
 4. Send a test message through WhatsApp and confirm the bot replies.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
       - Dynamic Filters: developer_guides/code_systems/dynamic_filters.md
       - Slack Channel Integration: developer_guides/code_systems/slack_channel_integration.md
       - Meta Cloud API Integration: developer_guides/code_systems/meta_cloud_api_integration.md
+      - Turn.io Integration: developer_guides/code_systems/turn_io_integration.md
       - Index Managers: developer_guides/code_systems/index_managers.md
       - Citations: developer_guides/code_systems/citations.md
       - Notifications: developer_guides/code_systems/notifications.md


### PR DESCRIPTION
Closes #2346
Docs companion: dimagi/open-chat-studio-docs#624

### Product Description

Turn.io WhatsApp providers gain an optional **Webhook HMAC Secret**. When it is set, OCS verifies `X-Turn-Hook-Signature` on every inbound webhook and rejects a mismatch with a `401`. When it is blank, nothing changes.

Optional per your call on the issue: add the field, don't make it required, notify teams. Deploy is a no-op for every existing provider.

### Technical Description

`new_turn_message` was `@csrf_exempt` with no request authentication, so anyone with the URL could post messages as a participant.

- **`apps/channels/turn_webhook.py`** (new) - `verify_signature`, mirroring `meta_webhook.py`. Reuses `get_hmac_digest`, constant-time compare, signs the raw body, never raises.
- **`apps/service_providers/forms.py`** - optional obfuscated `hmac_secret`, normalised to `""`. `ObfuscatingMixin.clean()` restores `None` for a field absent from an older provider's config, which would slip past a `not hmac_secret` check.
- **`apps/channels/views.py`** - `@require_POST`, JSON decode and non-object guards, signature guard. Order: lookup, decode, filters, verify, dispatch.
- **`apps/channels/datamodels.py`** - `is_non_conversational_whatsapp_message` runs before authentication and returned a 500 on four malformed `messages` shapes. Shared with the Meta handler. Kept as its own commit (`c54ba5d31`) since it is the only change outside the Turn path.

Three decisions worth your eye:

- **Verify after the ignore-filters,** so unsigned status callbacks stay `200` rather than showing as auth failures in the customer's Turn dashboard.
- **`401`, not Meta's 200-and-drop.** Turn cancels retries on `4xx` and documents no auto-deactivation, so surfacing the failure beats hiding it behind a fake success.
- **The secret is per-provider; Turn's is per-webhook.** A provider backing two chatbots would verify only one. Fails closed, and clearing the field recovers. Not restructured because `ExperimentChannel.extra_data` is unencrypted and `MessagingProvider.config` is the only encrypted store - happy to revisit if you'd rather solve it now.

Required would not have worked, incidentally: a required form field does not backfill existing rows, so live providers would keep an empty secret until someone re-saved them.

### Migrations

None. `MessagingProvider.config` is a schemaless encrypted `JSONField` and pydantic ignores unknown keys.

- [x] The migrations are backwards compatible

### Demo

Dev server, real signatures, Celery queue depth asserted either side of each request so "rejected" means nothing was enqueued:

```
signed provider + valid signature     200  queue+1
signed provider + wrong signature     401  queue+0
signed provider + no signature hdr    401  queue+0
unconfigured provider, unsigned       200  queue+1
GET                                   405  queue+0
malformed body                        400  queue+0
valid JSON scalar body                400  queue+0
hostile {"messages":[1]}, unsigned    401  queue+0
status callback, unsigned             200  queue+0
unknown chatbot id                    404  queue+0
```

The secret never reaches the logs. One loose end: the fail-open path logs at `INFO`, and no `ocs.channels` `INFO` surfaces under `runserver` - including pre-existing calls unrelated to this PR - so that line may not be visible where you would expect.

For an unconfigured provider the only behaviour changes are two robustness fixes: GET returns `405` instead of `500`, malformed body returns `400` instead of `500`.

Out of scope: SureAdhere (punted on the issue), enforcing in code once every provider is provisioned, replay protection (matching the existing Meta posture), and rate limiting (#2349).

### Docs and Changelog

- [x] This PR requires docs/changelog update

Adds `docs/developer_guides/code_systems/turn_io_integration.md` and its nav entry. Team-facing setup steps are in the docs PR above.
