### PR TITLE
fix: give the inspect API a stable pipeline node order

### DIFF
--- a/apps/api/v2/inspect/nodes.py
+++ b/apps/api/v2/inspect/nodes.py
@@ -37,6 +37,17 @@ def node_render_order(node) -> int:
     return {"StartNode": 0, "EndNode": 2}.get(node.type, 1)
 
 
+def nodes_in_render_order(pipeline) -> list:
+    """The pipeline's nodes in a stable order: start node first, end node last, the rest by id.
+
+    ``Node`` declares no default ordering, so ``node_set.all()`` comes back in whatever order the
+    database happens to yield and the same pipeline can serialise its nodes differently between
+    requests. Sorting happens in Python rather than via ``order_by`` so it reads the prefetched rows
+    (see ``inspect_node_queryset``) instead of costing another query.
+    """
+    return sorted(pipeline.node_set.all(), key=lambda node: (node_render_order(node), node.id))
+
+
 def graph_digest(node_list, pipeline_data: dict | None) -> dict:
     """Build a lightweight view of the pipeline's shape.
 

--- a/apps/api/v2/inspect/serializers.py
+++ b/apps/api/v2/inspect/serializers.py
@@ -23,7 +23,7 @@ from apps.api.v2.inspect.channels import get_channels
 from apps.api.v2.inspect.nodes import (
     graph_digest,
     inspect_node_queryset,
-    node_render_order,
+    nodes_in_render_order,
 )
 from apps.api.v2.inspect.param_serializers import node_params_schema
 from apps.api.v2.utils import parse_custom_actions
@@ -580,16 +580,15 @@ class InspectPipelineSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(GraphSerializer())
     def get_graph(self, pipeline) -> dict:
-        # The graph digest is a topology keyed by flow_id/edges, so node order is immaterial here;
-        # the human-facing ``nodes`` list below is the one that is render-ordered. Rendered through
-        # GraphSerializer so the digest's ``flow_id`` is exposed as ``node_id`` (matching the graph
-        # node shape) rather than leaking the raw column name.
-        return GraphSerializer(graph_digest(list(pipeline.node_set.all()), pipeline.data)).data
+        # Render-ordered like ``nodes`` below so the two lists line up positionally and a given
+        # pipeline always serialises the same way. Rendered through GraphSerializer so the digest's
+        # ``flow_id`` is exposed as ``node_id`` (matching the graph node shape) rather than leaking
+        # the raw column name.
+        return GraphSerializer(graph_digest(nodes_in_render_order(pipeline), pipeline.data)).data
 
     @extend_schema_field(InspectNodeSerializer(many=True))
     def get_nodes(self, pipeline) -> list:
-        nodes = sorted(pipeline.node_set.all(), key=lambda n: (node_render_order(n), n.id))
-        return InspectNodeSerializer(nodes, many=True, context=self.context).data
+        return InspectNodeSerializer(nodes_in_render_order(pipeline), many=True, context=self.context).data
 
 
 # ── Events / triggers / actions (ADR-0025) ───────────────────────────────────────────────────────

--- a/apps/api/v2/inspect/tests/test_nodes.py
+++ b/apps/api/v2/inspect/tests/test_nodes.py
@@ -2,7 +2,7 @@
 
 from types import SimpleNamespace
 
-from apps.api.v2.inspect.nodes import graph_digest, node_render_order
+from apps.api.v2.inspect.nodes import graph_digest, node_render_order, nodes_in_render_order
 from apps.api.v2.inspect.serializers import InspectNodeSerializer
 from apps.pipelines.nodes import nodes as pipeline_nodes
 
@@ -24,6 +24,20 @@ def test_node_render_order_pins_start_first_end_last():
     end = SimpleNamespace(type="EndNode")
     middle = SimpleNamespace(type="LLMResponseWithPrompt")
     assert node_render_order(start) < node_render_order(middle) < node_render_order(end)
+
+
+def test_nodes_in_render_order_is_stable_whatever_order_the_db_returns():
+    """``Node`` has no default ordering, so the same pipeline can come back from the database in a
+    different row order each time. The helper has to impose the order, not inherit it."""
+    end = SimpleNamespace(type="EndNode", id=2)
+    start = SimpleNamespace(type="StartNode", id=9)
+    llm = SimpleNamespace(type="LLMResponseWithPrompt", id=7)
+    assistant = SimpleNamespace(type="AssistantNode", id=4)
+
+    expected = [start, assistant, llm, end]
+    for row_order in ([end, start, llm, assistant], [llm, assistant, end, start], expected):
+        pipeline = SimpleNamespace(node_set=SimpleNamespace(all=lambda rows=row_order: rows))
+        assert nodes_in_render_order(pipeline) == expected
 
 
 def test_graph_digest_strips_positions_and_normalises_handles():

--- a/apps/api/v2/tests/test_chatbots_inspect.py
+++ b/apps/api/v2/tests/test_chatbots_inspect.py
@@ -364,6 +364,13 @@ def test_shared_provider_inlined_identically(inspect_bot):
     assert _node(payload, "Route")["llm"] == _node(payload, "Answer")["llm"] == _expected_llm(inspect_bot)
 
 
+@pytest.mark.django_db()
+def test_graph_and_nodes_agree_on_order(inspect_bot):
+    pipeline = _get(inspect_bot)["pipeline"]
+    # both lists are render-ordered off the same helper, so a client can zip them positionally
+    assert [n["node_id"] for n in pipeline["graph"]["nodes"]] == [n["node_id"] for n in pipeline["nodes"]]
+
+
 # ── Versioning ───────────────────────────────────────────────────────────────────────────────────
 @pytest.mark.django_db()
 def test_version_default_and_specific(inspect_bot):


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->


### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->
`InspectPipelineSerializer.get_graph` built its node list straight from `pipeline.node_set.all()`, which has no ordering — `Node` declares no `Meta.ordering`, so Postgres returns rows in heap order and any UPDATE to a node rewrites its tuple to the end of the heap. The same pipeline could therefore serialise `graph.nodes` in a different order between requests, and `graph.nodes` could disagree with the render-ordered `nodes` list beside it.

Both lists now come from a shared `nodes_in_render_order` helper, so they are identically ordered and stable. Sorting stays in Python so it reads the prefetched rows rather than costing another query.

This is what made `test_full_response_body` fail under `pytest -n auto`: the node rows came back as [Assistant, Answer] instead of [Answer, Assistant].



### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
