### PR TITLE
teach djlint about waffle block tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,8 @@ format_attribute_template_tags=true
 use_gitignore=true
 indent=2
 ignore="H030,H031,H021,H006,H013,H014,T003"
+# django-waffle block tags, unknown to djLint's parser
+custom_blocks="flag,switch"
 
 [tool.ty]
 


### PR DESCRIPTION
### Technical Description
Tell djlint to ignore the 'flag' and 'switch' blocks. This should fix the `Warning: T038 End tag has no matching block tag.` errors.