### PR TITLE
fix: remove run_evaluation_task fast-path kick

### DIFF
--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -492,7 +492,10 @@ class EvaluationConfig(BaseTeamModel):
         run_type: EvaluationRunType = EvaluationRunType.FULL,
         scoped_messages: list[EvaluationMessage] | None = None,
     ) -> EvaluationRun:
-        """Runs the evaluation asynchronously using Celery.
+        """Creates a PENDING run for the beat coordinator to pick up.
+
+        Dispatching work is solely `coordinate_evaluation_runs`' job: this method
+        only persists the plan, so the run starts on the next coordination tick.
 
         The run's plan is frozen at creation: `scoped_messages` is populated for
         every run type (all dataset ids for FULL, the PREVIEW sample, or the
@@ -524,11 +527,6 @@ class EvaluationConfig(BaseTeamModel):
             if message_ids:
                 run.scoped_messages.add(*message_ids)
 
-        from apps.evaluations.tasks import (  # noqa: PLC0415 - circular: evaluations.tasks imports evaluations.models
-            run_evaluation_task,
-        )
-
-        run_evaluation_task.delay(run.id)
         return run
 
     def run_preview(self) -> EvaluationRun:

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -387,6 +387,10 @@ def _drive_run(run_id: int) -> None:
 def coordinate_evaluation_runs() -> None:
     """Beat task (every 30s): drive every active evaluation run one tick.
 
+    The only thing that dispatches evaluation work. `EvaluationConfig.run` just creates
+    a PENDING run; this sweep's PENDING branch starts it, so a newly created run waits
+    up to one beat interval before its first batch goes out.
+
     Stateless between ticks — any work lost to a deploy is recomputed and repaired
     on the next tick. Overlapping sweeps partition runs via select_for_update(skip_locked).
     """
@@ -467,18 +471,6 @@ def _publish_tick(run: EvaluationRun, result: "_TickResult") -> None:
     else:
         _publish_progress(run.job_id, result.done, result.total)
         _update_taskbadger(run, value=result.done, value_max=result.total)
-
-
-def _mark_run_failed(run_id: int, message: str) -> None:
-    run = EvaluationRun.objects.filter(id=run_id).first()
-    if run is None:
-        logger.warning("EvaluationRun %s vanished before it could be marked FAILED", run_id)
-        return
-    run.status = EvaluationRunStatus.FAILED
-    run.error_message = message
-    run.save(update_fields=["status", "error_message"])
-    _publish_progress(run.job_id, 0, 0, stop=True)
-    _update_taskbadger(run, value=0, value_max=0, status=StatusEnum.ERROR)
 
 
 def _maybe_apply_tag_rules(
@@ -570,19 +562,6 @@ def _create_message_history(chat: Chat, history: list[dict]) -> None:
         for idx, history_entry in enumerate(history)
     ]
     ChatMessage.objects.bulk_create(history_messages)
-
-
-@shared_task
-def run_evaluation_task(evaluation_run_id: int) -> None:
-    """Fast-path kick for a freshly created run: run one coordination tick immediately
-    so the first batch dispatches without waiting for the next beat. The beat sweep's
-    PENDING branch is the backstop if this dispatcher is lost.
-    """
-    try:
-        _drive_run(evaluation_run_id)
-    except Exception as e:
-        logger.exception(f"Error starting evaluation run {evaluation_run_id}: {e}")
-        _mark_run_failed(evaluation_run_id, str(e))
 
 
 @shared_task(base=TaskbadgerTask)

--- a/apps/evaluations/tests/test_auto_population_task.py
+++ b/apps/evaluations/tests/test_auto_population_task.py
@@ -1,5 +1,4 @@
 from datetime import timedelta as _td
-from unittest.mock import patch
 
 import pytest
 
@@ -100,8 +99,7 @@ def test_ingest_rule_triggers_delta_runs_only_for_opted_in_configs():
     session.chat.messages.create(message_type="human", content="x")
     session.chat.messages.create(message_type="ai", content="y")
 
-    with patch("apps.evaluations.tasks.run_evaluation_task.delay"):
-        _ingest_rule(rule)
+    _ingest_rule(rule)
 
     runs_for_opted_in = opted_in.evaluationrun_set.filter(type=EvaluationRunType.DELTA)
     runs_for_opted_out = opted_out.evaluationrun_set.filter(type=EvaluationRunType.DELTA)
@@ -114,15 +112,18 @@ def test_ingest_rule_triggers_delta_runs_only_for_opted_in_configs():
 
 @pytest.mark.django_db()
 def test_ingest_rule_no_appends_no_runs():
+    """A tick that appends nothing triggers no delta run, even for an opted-in config.
+
+    The source experiment has no sessions, so `auto_run_on_append` has nothing to fire on.
+    """
     team = TeamFactory.create()
     dataset = EvaluationDataset.objects.create(team=team, name="Test Dataset 6", evaluation_mode=EvaluationMode.SESSION)
     rule = DatasetAutoPopulationRuleFactory.create(team=team, dataset=dataset)
-    EvaluationConfigFactory.create(team=team, dataset=dataset, auto_run_on_append=True)
+    config = EvaluationConfigFactory.create(team=team, dataset=dataset, auto_run_on_append=True)
 
-    with patch("apps.evaluations.tasks.run_evaluation_task.delay") as mock_delay:
-        _ingest_rule(rule)
+    _ingest_rule(rule)
 
-    mock_delay.assert_not_called()
+    assert not config.evaluationrun_set.exists()
 
 
 @pytest.mark.django_db()

--- a/apps/evaluations/tests/test_delta_evaluation_run.py
+++ b/apps/evaluations/tests/test_delta_evaluation_run.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from apps.evaluations.models import EvaluationResult, EvaluationRun, EvaluationRunStatus, EvaluationRunType
-from apps.evaluations.tasks import run_evaluation_task
+from apps.evaluations.tasks import coordinate_evaluation_runs
 from apps.utils.factories.evaluations import (
     EvaluationConfigFactory,
     EvaluationMessageFactory,
@@ -17,29 +17,25 @@ def test_run_with_scoped_messages_persists_scope():
     msg1 = EvaluationMessageFactory.create()
     msg2 = EvaluationMessageFactory.create()
 
-    with patch("apps.evaluations.tasks.run_evaluation_task.delay") as mock_delay:
-        run = config.run(run_type=EvaluationRunType.DELTA, scoped_messages=[msg1, msg2])
+    run = config.run(run_type=EvaluationRunType.DELTA, scoped_messages=[msg1, msg2])
 
     assert run.type == EvaluationRunType.DELTA
     assert set(run.scoped_messages.all()) == {msg1, msg2}
-    mock_delay.assert_called_once_with(run.id)
 
 
 @pytest.mark.django_db()
 def test_full_run_freezes_all_dataset_messages():
     config = EvaluationConfigFactory.create()
     dataset_ids = set(config.dataset.messages.values_list("id", flat=True))
-    with patch("apps.evaluations.tasks.run_evaluation_task.delay") as mock_delay:
-        run = config.run()
+    run = config.run()
     assert run.type == EvaluationRunType.FULL
     assert set(run.scoped_messages.values_list("id", flat=True)) == dataset_ids
-    mock_delay.assert_called_once_with(run.id)
 
 
 @pytest.mark.django_db()
 @patch("apps.evaluations.tasks._publish_tick")
 @patch("apps.evaluations.tasks.evaluate_message_batch.delay")
-def test_run_evaluation_task_dispatches_only_scoped_messages_for_delta(delay_mock, _publish):
+def test_coordinator_dispatches_only_scoped_messages_for_delta(delay_mock, _publish):
     config = EvaluationConfigFactory.create()
     evaluator = EvaluatorFactory.create(team=config.team)
     config.evaluators.set([evaluator])
@@ -56,7 +52,7 @@ def test_run_evaluation_task_dispatches_only_scoped_messages_for_delta(delay_moc
     )
     run.scoped_messages.add(in_scope)
 
-    run_evaluation_task(run.id)
+    coordinate_evaluation_runs()
 
     dispatched = [message_id for call in delay_mock.call_args_list for message_id in call.args[1]]
     assert dispatched == [in_scope.id]

--- a/apps/evaluations/tests/test_evaluation_coordination.py
+++ b/apps/evaluations/tests/test_evaluation_coordination.py
@@ -14,13 +14,11 @@ from taskbadger import StatusEnum
 from apps.evaluations.const import PREVIEW_SAMPLE_SIZE
 from apps.evaluations.models import EvaluationResult, EvaluationRun, EvaluationRunStatus, EvaluationRunType
 from apps.evaluations.tasks import (
-    _mark_run_failed,
     _publish_tick,
     _TickResult,
     coordinate_evaluation_runs,
     evaluate_message,
     evaluate_message_batch,
-    run_evaluation_task,
 )
 from apps.utils.factories.evaluations import (
     EvaluationConfigFactory,
@@ -61,12 +59,12 @@ def test_run_freezes_full_plan_and_evaluators():
     all_ids = set(config.dataset.messages.values_list("id", flat=True))
     evaluator_ids = list(config.evaluators.values_list("id", flat=True))
 
-    with patch("apps.evaluations.tasks.run_evaluation_task.delay"):
-        run = config.run(run_type=EvaluationRunType.FULL)
+    run = config.run(run_type=EvaluationRunType.FULL)
 
     assert set(run.scoped_messages.values_list("id", flat=True)) == all_ids
     assert run.evaluator_ids == evaluator_ids
     assert run.job_id  # a uuid was assigned
+    assert run.status == EvaluationRunStatus.PENDING  # left for the coordinator to start
 
 
 @pytest.mark.django_db()
@@ -75,8 +73,7 @@ def test_run_freezes_preview_sample():
     for _ in range(PREVIEW_SAMPLE_SIZE + 5):
         config.dataset.messages.add(EvaluationMessageFactory.create())
 
-    with patch("apps.evaluations.tasks.run_evaluation_task.delay"):
-        run = config.run(run_type=EvaluationRunType.PREVIEW)
+    run = config.run(run_type=EvaluationRunType.PREVIEW)
 
     assert run.scoped_messages.count() == PREVIEW_SAMPLE_SIZE
 
@@ -87,10 +84,23 @@ def test_run_freezes_delta_explicit_list():
     msg1 = EvaluationMessageFactory.create()
     msg2 = EvaluationMessageFactory.create()
 
-    with patch("apps.evaluations.tasks.run_evaluation_task.delay"):
-        run = config.run(run_type=EvaluationRunType.DELTA, scoped_messages=[msg1, msg2])
+    run = config.run(run_type=EvaluationRunType.DELTA, scoped_messages=[msg1, msg2])
 
     assert set(run.scoped_messages.all()) == {msg1, msg2}
+
+
+@pytest.mark.django_db()
+@patch("apps.evaluations.tasks.evaluate_message_batch.delay")
+def test_run_dispatches_nothing_and_waits_for_the_coordinator(delay_mock):
+    """Creating a run must not dispatch work; only coordinate_evaluation_runs does that."""
+    config = EvaluationConfigFactory.create()
+
+    run = config.run()
+
+    delay_mock.assert_not_called()
+    assert run.status == EvaluationRunStatus.PENDING
+    assert run.in_flight == []
+    assert run.batch_dispatched_at is None
 
 
 @pytest.fixture()
@@ -393,19 +403,6 @@ def test_sweep_fails_after_max_stalls_without_progress(delay_mock, _publish):
 
 @pytest.mark.django_db()
 @patch("apps.evaluations.tasks._publish_tick")
-@patch("apps.evaluations.tasks.evaluate_message_batch.delay")
-def test_run_evaluation_task_fast_path_dispatches_batch_one(delay_mock, _publish):
-    run, evaluators, messages = _make_run(message_count=5, status=EvaluationRunStatus.PENDING)
-
-    run_evaluation_task(run.id)
-
-    run.refresh_from_db()
-    assert run.status == EvaluationRunStatus.PROCESSING
-    assert delay_mock.call_count == 2  # 5 messages => 2 batches
-
-
-@pytest.mark.django_db()
-@patch("apps.evaluations.tasks._publish_tick")
 @patch("apps.evaluations.models.Evaluator.run")
 def test_full_run_reaches_completion_over_multiple_ticks(evaluator_run_mock, _publish):
     """A run larger than one batch completes across several ticks, with no duplicate results.
@@ -492,30 +489,6 @@ def test_publish_tick_terminal_success_publishes_stop_state():
         "SUCCESS",
     )
     taskbadger_mock.assert_called_once_with("tb-1", value=5, value_max=5, status=StatusEnum.SUCCESS)
-
-
-@pytest.mark.django_db()
-def test_mark_run_failed_sets_status_and_publishes_stop_state():
-    run = EvaluationRunFactory.create(
-        job_id="job-123", taskbadger_task_id="tb-1", status=EvaluationRunStatus.PROCESSING
-    )
-
-    with (
-        patch("apps.evaluations.tasks.current_app") as app_mock,
-        patch("apps.evaluations.tasks.taskbadger.update_task_safe") as taskbadger_mock,
-    ):
-        _mark_run_failed(run.id, "boom")
-
-    run.refresh_from_db()
-    assert run.status == EvaluationRunStatus.FAILED
-    assert run.error_message == "boom"
-    # The stop publish uses "SUCCESS" so the poller reloads; the page then shows FAILED.
-    app_mock.backend.store_result.assert_called_once_with(
-        "job-123",
-        {"pending": False, "current": 0, "total": 0, "percent": 100.0, "description": "0 of 0 evaluated"},
-        "SUCCESS",
-    )
-    taskbadger_mock.assert_called_once_with("tb-1", value=0, value_max=0, status=StatusEnum.ERROR)
 
 
 @pytest.mark.django_db()

--- a/apps/evaluations/tests/test_evaluation_tasks.py
+++ b/apps/evaluations/tests/test_evaluation_tasks.py
@@ -18,10 +18,10 @@ from apps.evaluations.models import (
 )
 from apps.evaluations.tasks import (
     EVAL_SESSIONS_TTL_DAYS,
+    _drive_run,
     cleanup_old_evaluation_data,
     evaluate_message,
     run_bot_generation,
-    run_evaluation_task,
 )
 from apps.experiments.models import ExperimentSession, Participant
 from apps.pipelines.tests.utils import create_pipeline_model, end_node, render_template_node, start_node
@@ -345,13 +345,13 @@ def test_evaluate_message_skips_deleted_run(evaluation_run, evaluation_message):
 
 
 @pytest.mark.django_db()
-def test_run_evaluation_task_handles_deleted_run(evaluation_run):
-    """Run deleted before dispatch -> handler does not raise a second DoesNotExist."""
+def test_drive_run_handles_deleted_run(evaluation_run):
+    """Run deleted before its tick -> the coordination driver returns without raising."""
     run, _ = evaluation_run
     run_id = run.id
     run.delete()
 
-    run_evaluation_task(run_id)
+    _drive_run(run_id)
 
     assert not EvaluationRun.objects.filter(id=run_id).exists()
 

--- a/apps/evaluations/tests/test_group_evaluation.py
+++ b/apps/evaluations/tests/test_group_evaluation.py
@@ -1,5 +1,5 @@
 from typing import cast
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -46,21 +46,15 @@ def test_group_evaluation_with_multiple_evaluators():
         EvaluationConfigFactory.create(evaluators=[evaluator1, evaluator2, evaluator3], dataset=dataset),
     )
 
-    # Mock the main task
-    with patch("apps.evaluations.tasks.run_evaluation_task.delay") as mock_task:
-        mock_result = Mock()
-        mock_result.id = "test-task-id"
-        mock_task.return_value = mock_result
+    evaluation_run = evaluation_config.run()
 
-        evaluation_run = evaluation_config.run()
+    # Check that the evaluation run was created properly
+    evaluation_run.refresh_from_db()
+    assert evaluation_run.status == EvaluationRunStatus.PENDING
 
-        # Check that the evaluation run was created properly
-        evaluation_run.refresh_from_db()
-        assert evaluation_run.status == EvaluationRunStatus.PENDING
-
-        # Verify config has expected number of evaluators and messages
-        assert evaluation_config.evaluators.count() == 3
-        assert evaluation_config.dataset.messages.count() == 1
+    # Verify config has expected number of evaluators and messages
+    assert evaluation_config.evaluators.count() == 3
+    assert evaluation_config.dataset.messages.count() == 1
 
 
 @pytest.mark.django_db()
@@ -69,20 +63,11 @@ def test_empty_evaluation_config():
     # Create config with no evaluators
     evaluation_config = cast(EvaluationConfig, EvaluationConfigFactory.create(evaluators=[]))
 
-    # Mock the main task to see what happens
-    with patch("apps.evaluations.tasks.run_evaluation_task.delay") as mock_task:
-        mock_result = Mock()
-        mock_result.id = "test-task-id"
-        mock_task.return_value = mock_result
+    evaluation_run = evaluation_config.run()
 
-        evaluation_run = evaluation_config.run()
-
-        # The task should still be called, even with no evaluators
-        evaluation_run.refresh_from_db()
-        assert evaluation_run.status == EvaluationRunStatus.PENDING
-
-        # Task should be called with the evaluation run id
-        mock_task.assert_called_once_with(evaluation_run.id)
+    # A run is still created; it stays PENDING until the coordinator picks it up.
+    evaluation_run.refresh_from_db()
+    assert evaluation_run.status == EvaluationRunStatus.PENDING
 
 
 @pytest.mark.django_db()

--- a/docs/design/unified-assessment.md
+++ b/docs/design/unified-assessment.md
@@ -144,7 +144,7 @@ Automated scorers run code or LLMs against session data to produce structured re
 
 **Existing code:**
 - `LlmEvaluator`, `PythonEvaluator`: [`apps/evaluations/evaluators.py`](../../apps/evaluations/evaluators.py)
-- Celery chord orchestration: [`apps/evaluations/tasks.py:run_evaluation_task`](../../apps/evaluations/tasks.py)
+- Run orchestration (beat coordinator): [`apps/evaluations/tasks.py:coordinate_evaluation_runs`](../../apps/evaluations/tasks.py)
 - Bot generation: [`apps/evaluations/tasks.py:run_bot_generation`](../../apps/evaluations/tasks.py)
 - Version resolution: [`apps/evaluations/models.py:EvaluationConfig.get_generation_experiment_version`](../../apps/evaluations/models.py)
 - **Tag emission from eval results** (FR-3.8, backlog #4): [`apps/evaluations/models.py:EvaluatorTagRule`](../../apps/evaluations/models.py) (rule shape) + [`apps/evaluations/tagging.py`](../../apps/evaluations/tagging.py) (matcher) + [`apps/evaluations/models.py:AppliedTag`](../../apps/evaluations/models.py) (audit row). Session-mode rules tag `session.chat`; message-mode rules tag `ChatMessage`. Generalised by `RoutingRule` / `AppliedRoutingRule` in the unified design — see D-14.


### PR DESCRIPTION
### Product Description

Every evaluation run created two Taskbadger tasks, and the duplicate went permanently stale — so Taskbadger's view of a run's progress was misleading.

### Technical Description

`run_evaluation_task` existed only to dispatch the first batch without waiting for the beat. It was never added to the Taskbadger integration's excludes list, so the integration auto-tracked it as a second task; it also raced the beat sweep inside `_ensure_taskbadger_task`'s create window, and whichever call lost orphaned an "Evaluation run" task that never got another update. Adding it to the excludes list would fix the first problem and leave the race, so I deleted the kick instead — `coordinate_evaluation_runs`' PENDING branch already existed as the backstop, so this is a deletion rather than a new code path, and it's what ADR-0047 already describes the coordinator as being.

Cost: a new run now waits up to one beat interval (30s) before its first batch, so the progress bar can sit at zero that long. Worth a look on whether that's acceptable or the interval should drop.

### Docs and Changelog

- [ ] This PR requires docs/changelog update