### PR TITLE
Speed up and add loading feedback to the provider usages page

### DIFF
--- a/apps/service_providers/tests/test_usages.py
+++ b/apps/service_providers/tests/test_usages.py
@@ -112,7 +112,7 @@ def test_document_sources_roll_up_to_collections(team_with_users, client):
     client.force_login(user)
     response = client.get(
         reverse(
-            "service_providers:usages",
+            "service_providers:usages_content",
             kwargs={"team_slug": team_with_users.slug, "provider_type": "auth", "pk": auth_provider.pk},
         )
     )
@@ -359,7 +359,7 @@ def test_usages_view_renders_version_tags(team_with_users, client):
     user = team_with_users.members.first()
     client.force_login(user)
     url = reverse(
-        "service_providers:usages",
+        "service_providers:usages_content",
         kwargs={"team_slug": team_with_users.slug, "provider_type": "voice", "pk": voice.pk},
     )
     response = client.get(url)
@@ -375,7 +375,8 @@ def test_usages_view_renders_version_tags(team_with_users, client):
 
 
 @pytest.mark.django_db()
-def test_usages_view_renders(team_with_users, client, anthropic_provider):
+def test_usages_view_renders_shell_with_loading_state(team_with_users, client, anthropic_provider):
+    """The shell must not resolve usages itself; it defers to the content view."""
     user = team_with_users.members.first()
     client.force_login(user)
     url = reverse(
@@ -384,4 +385,24 @@ def test_usages_view_renders(team_with_users, client, anthropic_provider):
     )
     response = client.get(url)
     assert response.status_code == 200
-    assert b"Where is" in response.content
+    body = response.content.decode()
+    assert "Where is" in body
+    assert "loading-spinner" in body
+    content_url = reverse(
+        "service_providers:usages_content",
+        kwargs={"team_slug": team_with_users.slug, "provider_type": "llm", "pk": anthropic_provider.pk},
+    )
+    assert f'hx-get="{content_url}"' in body
+
+
+@pytest.mark.django_db()
+def test_usages_content_view_renders(team_with_users, client, anthropic_provider):
+    user = team_with_users.members.first()
+    client.force_login(user)
+    url = reverse(
+        "service_providers:usages_content",
+        kwargs={"team_slug": team_with_users.slug, "provider_type": "llm", "pk": anthropic_provider.pk},
+    )
+    response = client.get(url)
+    assert response.status_code == 200
+    assert b"not currently referenced" in response.content

--- a/apps/service_providers/tests/test_usages.py
+++ b/apps/service_providers/tests/test_usages.py
@@ -1,4 +1,7 @@
 import pytest
+from django.db import connection
+from django.template.loader import render_to_string
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
 from apps.analysis.models import TranscriptAnalysis
@@ -372,6 +375,75 @@ def test_usages_view_renders_version_tags(team_with_users, client):
     working_url = working.get_absolute_url()
     assert f'href="{working_url}"' in body, "working version row should link directly to the working URL"
     assert f'href="{working_url}#versions"' in body, "older-version row should link with the #versions hash"
+
+
+def _add_pipeline_usage(provider, count: int) -> None:
+    """Attach ``count`` more pipeline-node references (each with its own chatbot)."""
+    for _ in range(count):
+        pipeline = PipelineFactory(team=provider.team)
+        NodeFactory(pipeline=pipeline, type="LLMResponseWithPrompt", params={"llm_provider_id": provider.id})
+        ExperimentFactory(team=provider.team, pipeline=pipeline)
+
+
+@pytest.mark.django_db()
+def test_archived_pipelines_are_still_reported(anthropic_provider):
+    """A provider referenced only by an archived pipeline must not look unreferenced."""
+    team = anthropic_provider.team
+    pipeline = PipelineFactory(team=team, name="Archived", is_archived=True)
+    NodeFactory(pipeline=pipeline, type="LLMResponseWithPrompt", params={"llm_provider_id": anthropic_provider.id})
+
+    usages = get_provider_usages(anthropic_provider)
+
+    items_by_label = {c.label: [obj.id for obj in c.items] for c in usages.categories}
+    assert items_by_label == {"Unlinked Pipelines": [pipeline.id]}
+
+
+@pytest.mark.django_db()
+def test_resolving_usages_does_not_scale_with_pipeline_count(anthropic_provider):
+    """N+1 guard: query count must be flat in the number of referencing pipelines."""
+    _add_pipeline_usage(anthropic_provider, 1)
+    with CaptureQueriesContext(connection) as few:
+        usages_few = get_provider_usages(anthropic_provider)
+
+    _add_pipeline_usage(anthropic_provider, 4)
+    with CaptureQueriesContext(connection) as many:
+        usages_many = get_provider_usages(anthropic_provider)
+
+    assert usages_few.total == 1, "sanity: the single pipeline resolves to one chatbot"
+    assert usages_many.total == 5, "sanity: all five pipelines resolve to chatbots"
+    assert len(many.captured_queries) == len(few.captured_queries), (
+        f"query count grew from {len(few.captured_queries)} to {len(many.captured_queries)} "
+        f"when pipeline references went from 1 to 5"
+    )
+
+
+@pytest.mark.django_db()
+def test_rendering_usages_does_not_scale_with_version_count(team_with_users):
+    """N+1 guard: the item partial resolves working versions without a query per row."""
+    voice = VoiceProviderFactory(team=team_with_users)
+
+    def render_for(provider):
+        return render_to_string(
+            "service_providers/components/usages_content.html",
+            {"provider": provider, "usages": get_provider_usages(provider)},
+        )
+
+    working = ExperimentFactory(team=team_with_users, voice_provider=voice)
+    working.create_new_version()
+    render_for(voice)  # warm any process-level caches (e.g. team slug lookups)
+    with CaptureQueriesContext(connection) as few:
+        render_for(voice)
+
+    for _ in range(3):
+        extra = ExperimentFactory(team=team_with_users, voice_provider=voice)
+        extra.create_new_version()
+    with CaptureQueriesContext(connection) as many:
+        render_for(voice)
+
+    assert len(many.captured_queries) == len(few.captured_queries), (
+        f"query count grew from {len(few.captured_queries)} to {len(many.captured_queries)} "
+        f"when versioned chatbot references went from 2 to 8"
+    )
 
 
 @pytest.mark.django_db()

--- a/apps/service_providers/urls.py
+++ b/apps/service_providers/urls.py
@@ -30,6 +30,11 @@ urlpatterns = [
     path("<slug:provider_type>/create/<str:subtype>/", views.CreateServiceProvider.as_view(), name="new"),
     path("<slug:provider_type>/<int:pk>/", views.CreateServiceProvider.as_view(), name="edit"),
     path("<slug:provider_type>/<int:pk>/usages/", views.ServiceProviderUsagesView.as_view(), name="usages"),
+    path(
+        "<slug:provider_type>/<int:pk>/usages/content/",
+        views.ServiceProviderUsagesContentView.as_view(),
+        name="usages_content",
+    ),
     path("<slug:provider_type>/<int:pk>/delete/", views.delete_service_provider, name="delete"),
     path("<slug:provider_type>/<int:pk>/remove-file/<int:file_id>", views.remove_file, name="delete_file"),
     path("<slug:provider_type>/<int:pk>/upload-file/", views.AddFileToProvider.as_view(), name="add_file"),

--- a/apps/service_providers/usages.py
+++ b/apps/service_providers/usages.py
@@ -165,7 +165,10 @@ def _resolve_channel_chatbots(channels: list) -> tuple[list[Experiment], list]:
     unique_channels = _dedupe_by_id(channels)
     experiment_ids = {ch.experiment_id for ch in unique_channels if ch.experiment_id}
     experiments_by_id = (
-        {exp.id: exp for exp in Experiment.objects.filter(id__in=experiment_ids).select_related("team")}
+        {
+            exp.id: exp
+            for exp in Experiment.objects.filter(id__in=experiment_ids).select_related("team", "working_version")
+        }
         if experiment_ids
         else {}
     )
@@ -192,7 +195,9 @@ def _build_document_source_categories(document_sources: list) -> list[UsageCateg
     collection_ids = {ds.collection_id for ds in document_sources if ds.collection_id}
     if not collection_ids:
         return []
-    collections = list(Collection.objects.filter(id__in=collection_ids).select_related("team").order_by("name"))
+    collections = list(
+        Collection.objects.filter(id__in=collection_ids).select_related("team", "working_version").order_by("name")
+    )
     return [UsageCategory(label="Collections", items=collections)]
 
 
@@ -209,7 +214,7 @@ def _dedupe_by_id(items: list) -> list:
 
 def _experiments_for_pipelines(pipeline_ids: set[int]) -> dict[int, list]:
     by_pipeline: dict[int, dict[int, object]] = defaultdict(dict)
-    for exp in Experiment.objects.filter(pipeline_id__in=pipeline_ids).select_related("team"):
+    for exp in Experiment.objects.filter(pipeline_id__in=pipeline_ids).select_related("team", "working_version"):
         by_pipeline[exp.pipeline_id][exp.id] = exp
 
     # Indirect link: an EventAction of type "pipeline_start" stores the
@@ -219,9 +224,10 @@ def _experiments_for_pipelines(pipeline_ids: set[int]) -> dict[int, list]:
         "action__action_type": EventActionType.PIPELINE_START,
         "action__params__pipeline_id__in": pipeline_id_values,
     }
+    trigger_select_related = ("action", "experiment", "experiment__team", "experiment__working_version")
     for trigger_qs in (
-        StaticTrigger.objects.filter(**trigger_filter).select_related("action", "experiment", "experiment__team"),
-        TimeoutTrigger.objects.filter(**trigger_filter).select_related("action", "experiment", "experiment__team"),
+        StaticTrigger.objects.filter(**trigger_filter).select_related(*trigger_select_related),
+        TimeoutTrigger.objects.filter(**trigger_filter).select_related(*trigger_select_related),
     ):
         for trigger in trigger_qs:
             raw_pipeline_id = trigger.action.params.get("pipeline_id")

--- a/apps/service_providers/views.py
+++ b/apps/service_providers/views.py
@@ -66,26 +66,50 @@ class ServiceProviderMixin:
         return ServiceProvider[type_]
 
 
-class ServiceProviderUsagesView(
-    LoginAndTeamRequiredMixin, ServiceProviderMixin, PermissionRequiredMixin, django_views.View
-):
-    template_name = "service_providers/usages.html"
-
+class ServiceProviderUsagesMixin(LoginAndTeamRequiredMixin, ServiceProviderMixin, PermissionRequiredMixin):
     def get_permission_required(self):
         return (self.provider_type.get_permission("view"),)
 
+    def get_provider(self):
+        return get_object_or_404(self.provider_type.model, team=self.request.team, pk=self.kwargs["pk"])
+
+
+class ServiceProviderUsagesView(ServiceProviderUsagesMixin, django_views.View):
+    """Page shell only.
+
+    Resolving usages fans out over many tables and can take several seconds,
+    so the list itself is fetched by ``ServiceProviderUsagesContentView`` via
+    HTMX and the shell shows a spinner in the meantime.
+    """
+
+    template_name = "service_providers/usages.html"
+
     def get(self, request, *args, **kwargs):
-        provider = get_object_or_404(self.provider_type.model, team=request.team, pk=self.kwargs["pk"])
-        usages = get_provider_usages(provider)
+        provider = self.get_provider()
         return render(
             request,
             self.template_name,
             {
                 "provider": provider,
                 "provider_type": self.provider_type,
-                "usages": usages,
                 "title": f"Usages of {provider.name}",
                 "active_tab": "manage-team",
+            },
+        )
+
+
+class ServiceProviderUsagesContentView(ServiceProviderUsagesMixin, django_views.View):
+    template_name = "service_providers/components/usages_content.html"
+
+    def get(self, request, *args, **kwargs):
+        provider = self.get_provider()
+        return render(
+            request,
+            self.template_name,
+            {
+                "provider": provider,
+                "provider_type": self.provider_type,
+                "usages": get_provider_usages(provider),
             },
         )
 

--- a/apps/utils/deletion.py
+++ b/apps/utils/deletion.py
@@ -240,17 +240,40 @@ def _get_m2m_related_models(model):
 
 
 def get_related_objects(instance, pipeline_param_key: str | None = None) -> list:
-    from apps.pipelines.models import Node  # noqa: PLC0415 - circular: pipelines.models→experiments.models→deletion
+    from apps.pipelines.models import (  # noqa: PLC0415 - circular: pipelines.models→experiments.models→deletion
+        Node,
+        Pipeline,
+    )
 
     related_objects = []
 
     for queryset in _get_related_objects_querysets(instance, pipeline_param_key):
         if queryset.model == Node:
-            related_objects.extend([node.pipeline for node in queryset.only("pipeline").all()])
-        else:
-            related_objects.extend(queryset.all())
+            # Report the owning pipelines rather than the nodes themselves. Resolving them
+            # through a subquery on the node ids keeps this to a single query (walking
+            # ``node.pipeline`` per row costs one each) and dedupes, so a pipeline with
+            # several referencing nodes is reported once.
+            #
+            # ``get_all()`` rather than ``objects``: the default manager hides archived
+            # rows, but the ``node.pipeline`` fetch this replaces went through the base
+            # manager, so archived pipelines were — and stay — visible to callers.
+            queryset = Pipeline.objects.get_all().filter(id__in=queryset.values("pipeline_id"))
+        # ``.all()`` normalises the related managers yielded above into querysets.
+        related_objects.extend(_with_working_version(queryset.all()))
 
     return related_objects
+
+
+def _with_working_version(queryset):
+    """``select_related`` the version parent when the model is versioned.
+
+    Callers render each object through its working version, which owns the edit UI
+    (see ``service_providers/components/usage_item.html``). Without this, every row
+    that is not itself a working version costs an extra query.
+    """
+    if any(field.name == "working_version" for field in queryset.model._meta.concrete_fields):
+        return queryset.select_related("working_version")
+    return queryset
 
 
 def has_related_objects(instance, pipeline_param_key: str | None = None) -> bool:

--- a/templates/service_providers/components/usages_content.html
+++ b/templates/service_providers/components/usages_content.html
@@ -1,0 +1,21 @@
+{% if usages.is_empty %}
+  <div class="alert alert-info">
+    <span>This provider is not currently referenced by any objects.</span>
+  </div>
+{% else %}
+  <p class="mb-4">This provider is referenced by {{ usages.total }} object{{ usages.total|pluralize }}:</p>
+  {% for category in usages.categories %}
+    <h2 class="font-semibold my-2">{{ category.label }} ({{ category.items|length }})</h2>
+    <ul class="list-disc list-inside ml-2">
+      {% for obj in category.items %}
+        <li>
+          {% if category.label == "Chatbots" %}
+            {% include "service_providers/components/usage_item.html" with obj=obj link_to_versions_anchor=True %}
+          {% else %}
+            {% include "service_providers/components/usage_item.html" with obj=obj %}
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  {% endfor %}
+{% endif %}

--- a/templates/service_providers/usages.html
+++ b/templates/service_providers/usages.html
@@ -18,27 +18,14 @@
       {{ provider_type.label }}{% if provider.type %} — {{ provider.type_enum.label }}{% endif %}
     </p>
 
-    {% if usages.is_empty %}
-      <div class="alert alert-info">
-        <span>This provider is not currently referenced by any objects.</span>
+    <div id="provider-usages"
+         hx-get="{% url 'service_providers:usages_content' request.team.slug provider_type.slug provider.pk %}"
+         hx-trigger="load">
+      <div class="flex items-center gap-2 text-base-content/60">
+        <span class="loading loading-spinner loading-md"></span>
+        <span>Searching for usages…</span>
       </div>
-    {% else %}
-      <p class="mb-4">This provider is referenced by {{ usages.total }} object{{ usages.total|pluralize }}:</p>
-      {% for category in usages.categories %}
-        <h2 class="font-semibold my-2">{{ category.label }} ({{ category.items|length }})</h2>
-        <ul class="list-disc list-inside ml-2">
-          {% for obj in category.items %}
-            <li>
-              {% if category.label == "Chatbots" %}
-                {% include "service_providers/components/usage_item.html" with obj=obj link_to_versions_anchor=True %}
-              {% else %}
-                {% include "service_providers/components/usage_item.html" with obj=obj %}
-              {% endif %}
-            </li>
-          {% endfor %}
-        </ul>
-      {% endfor %}
-    {% endif %}
+    </div>
 
     <div class="mt-6">
       <a href="{% url 'service_providers:edit' request.team.slug provider_type.slug provider.pk %}" class="btn btn-outline">Back to provider</a>


### PR DESCRIPTION
### Product Description

The "Where is X used?" page for a service provider used to sit blank for seconds with no indication it was working. It now paints immediately with a spinner, the underlying lookup is faster, and it reports evaluators, which it previously missed entirely.

### Technical Description

One commit per part.

**Loading feedback.** The page shell and the usage list are now separate views, with the list fetched over HTMX (`usages_content`). Time-to-first-paint no longer depends on how long resolution takes.

**The slowness.** Two N+1 loops:

- `get_related_objects` walked `node.pipeline` per row — and `.only("pipeline")` made it worse, deferring `llm_provider_id` so the reverse-manager's known-related-object bookkeeping reloaded it per node too.
- `usage_item.html` renders each row through its working version, which was a query per non-working-version row.

Both collapse to single queries. 21 → 9 queries on dev data, and flat from 4 to 204 usage rows.

**Missing evaluators.** `LlmEvaluator` gets `llm_provider_id` from `LLMResponseMixin` into `Evaluator.params` as JSON, with no FK, so `get_related_objects` could never see it — the page reported nothing for a provider used only by evaluators. Pipeline nodes and evaluators are the only two models that hide ids in `params` (confirmed against `clone_team`'s remap logic and `importer._node_param_models`). Adds one constant query.

### Where to focus review

`get_related_objects` also serves the provider and LLM-provider-model delete paths, so the N+1 change isn't local to this page:

- Pipelines are now deduped — a pipeline with several nodes referencing the provider is reported once instead of once per node.
- `Pipeline.objects` hides archived rows via `VersionsObjectManagerMixin`, but the `node.pipeline` fetch it replaces went through the base manager. Plain `objects` would have silently dropped archived pipelines from usage lists and unblocked provider deletes that previously were blocked, so it uses `get_all()`. Pinned by `test_archived_pipelines_are_still_reported`, which I confirmed fails without it.

The evaluator lookup is deliberately **not** wired into `_get_related_objects_querysets`, so deletion behaviour is unchanged. `_replace_custom_model_with_global` repoints pipeline-node params before calling `custom_model.delete()` but never touches evaluator params, so including evaluators there would make `LlmProviderModel.delete()` raise and break the default-models sync instead of reporting anything. `test_evaluator_params_do_not_block_provider_model_deletion` pins that.

**Follow-up, tracked in #3974:** that asymmetry is a real gap — replacing a custom provider model, or deleting one, silently leaves evaluator params pointing at a row that no longer exists. Fixing it means repointing evaluator params in `_replace_custom_model_with_global` and `remove_deprecated_models`, which is row-mutating migration code and has to land before the lookup is shared, so it wanted its own change.

### Migrations

N/A

### Demo

Shell renders instantly with "Searching for usages…" + spinner, then HTMX swaps in the list. Reproduce by opening any provider's *Show usages* link; to see the spinner on fast local data, throttle the `usages/content/` request.

### Verification

Beyond the suite: rendered HTML is byte-identical before vs. after the N+1 fix on real dev data (captured through the view, with the change stashed for the baseline). The guard tests assert equal query counts across 1→5 references and 2→8 versioned rows rather than pinning absolute numbers — both fail on the old code (10→14 and 3→6). Driving the evaluator path against the dev DB surfaced a pre-existing evaluator the page had been silently omitting.

### Docs and Changelog
- [x] This PR requires docs/changelog update

Changelog note: the service provider usages page now shows a loading indicator, resolves faster, and lists evaluators that use the provider.
