### PR TITLE
fix: stream session-mode dataset population, correct trace sourcing

### DIFF
--- a/apps/evaluations/auto_population.py
+++ b/apps/evaluations/auto_population.py
@@ -14,11 +14,10 @@ from apps.evaluations.models import (
     DatasetAutoPopulationRule,
     EvaluationConfig,
     EvaluationDataset,
-    EvaluationMessage,
     EvaluationRunType,
 )
 from apps.evaluations.notifications import auto_population_rule_disabled_notification
-from apps.evaluations.utils import make_session_evaluation_messages
+from apps.evaluations.utils import iter_session_evaluation_messages
 from apps.experiments.filters import ExperimentSessionFilter
 from apps.experiments.models import ExperimentSession
 from apps.web.dynamic_filters.datastructures import FilterParams
@@ -26,11 +25,11 @@ from apps.web.dynamic_filters.datastructures import FilterParams
 logger = get_task_logger("ocs.evaluations")
 
 
-def _trigger_delta_runs_for_dataset(dataset: EvaluationDataset, appended: list[EvaluationMessage]) -> None:
+def _trigger_delta_runs_for_dataset(dataset: EvaluationDataset, appended_ids: list[int]) -> None:
     """Enqueue a DELTA evaluation run for each opted-in config on this dataset."""
     configs = EvaluationConfig.objects.filter(dataset=dataset, auto_run_on_append=True)
     for config in configs:
-        config.run(run_type=EvaluationRunType.DELTA, scoped_messages=appended)
+        config.run(run_type=EvaluationRunType.DELTA, scoped_message_ids=appended_ids)
 
 
 def _handle_rule_failure(rule: DatasetAutoPopulationRule, exception: Exception) -> None:
@@ -58,8 +57,17 @@ def _handle_rule_failure(rule: DatasetAutoPopulationRule, exception: Exception) 
         )
 
 
-def _scan_for_new_sessions(rule: DatasetAutoPopulationRule, created_floor) -> list[EvaluationMessage]:
-    """Find new sessions matching the rule's filter and build session-mode EvaluationMessages."""
+def _scan_for_new_sessions(rule: DatasetAutoPopulationRule, created_floor) -> list[int]:
+    """Find new sessions matching the rule's filter and append them to the dataset.
+
+    Returns the ids of the newly created EvaluationMessage rows. Messages are streamed rather
+    than materialised: a rule's first tick spans EVALUATIONS_AUTO_POPULATION_LOOKBACK_DAYS and
+    can therefore match as many sessions as a bulk clone would.
+
+    Note this runs inside the per-rule transaction opened by auto_populate_eval_datasets, so
+    add_messages_stream's per-batch commits degrade to savepoints here and the whole tick stays
+    one transaction. That is fine for incremental ticks, and memory stays bounded regardless.
+    """
     qs = ExperimentSession.objects.filter(
         team=rule.team,
         experiment=rule.source_experiment,
@@ -74,21 +82,20 @@ def _scan_for_new_sessions(rule: DatasetAutoPopulationRule, created_floor) -> li
     if not session_external_ids:
         return []
 
-    eval_messages = make_session_evaluation_messages(session_external_ids, team=rule.team)
-    if not eval_messages:
-        return []
-    created, _ = rule.dataset.add_messages(eval_messages)
-    return created
+    created_ids, _ = rule.dataset.add_messages_stream(
+        iter_session_evaluation_messages(session_external_ids, team=rule.team)
+    )
+    return created_ids
 
 
-def _ingest_rule(rule: DatasetAutoPopulationRule) -> list[EvaluationMessage]:
+def _ingest_rule(rule: DatasetAutoPopulationRule) -> list[int]:
     """Scan the rule's source experiment for new sessions, append matches to the dataset.
 
     Rules are only valid against session-mode datasets (enforced by
     `DatasetAutoPopulationRule.clean()`), so the scan always builds
     session-mode `EvaluationMessage` rows.
 
-    Returns the list of newly appended EvaluationMessage rows.
+    Returns the ids of the newly appended EvaluationMessage rows.
     """
     dataset = rule.dataset
     lookback_floor = timezone.now() - timedelta(days=settings.EVALUATIONS_AUTO_POPULATION_LOOKBACK_DAYS)

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -412,17 +412,8 @@ class EvaluationDataset(BaseTeamModel):
             keyed_batch = [(message, self._dedup_key(message)) for message in batch]
             with transaction.atomic():
                 EvaluationDataset.objects.select_for_update().get(pk=self.pk)
-                candidates = {key for _, key in keyed_batch if key is not None}
-                seen = self._existing_dedup_keys(candidates)
-                to_create = []
-                for message, key in keyed_batch:
-                    if key is not None:
-                        if key in seen:
-                            skipped += 1
-                            continue
-                        seen.add(key)
-                    to_create.append(message)
-
+                to_create, batch_skipped = self._partition_new_in_batch(keyed_batch)
+                skipped += batch_skipped
                 if to_create:
                     created = EvaluationMessage.objects.bulk_create(to_create, batch_size=batch_size)
                     self.messages.add(*created)
@@ -430,6 +421,29 @@ class EvaluationDataset(BaseTeamModel):
             if progress_callback:
                 progress_callback(len(created_ids), skipped)
         return created_ids, skipped
+
+    def _partition_new_in_batch(
+        self, keyed_batch: list[tuple[EvaluationMessage, tuple | None]]
+    ) -> tuple[list[EvaluationMessage], int]:
+        """Split one keyed batch into (messages_to_create, skipped_count), applying dedup.
+
+        Must run under the dataset row lock so the existing-key lookup stays consistent with the
+        insert. Messages with a null key can't be duplicates and are always kept.
+        """
+        candidates = {key for _, key in keyed_batch if key is not None}
+        seen = self._existing_dedup_keys(candidates)
+        to_create = []
+        skipped = 0
+        for message, key in keyed_batch:
+            if key is None:
+                to_create.append(message)
+                continue
+            if key in seen:
+                skipped += 1
+                continue
+            seen.add(key)
+            to_create.append(message)
+        return to_create, skipped
 
     class Meta:
         unique_together = ("name", "team")

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import importlib
+import itertools
 import uuid
 from collections import defaultdict
+from collections.abc import Callable, Iterable
 from functools import cached_property
 from typing import TYPE_CHECKING, Literal
 
@@ -36,6 +38,10 @@ from apps.utils.models import BaseModel
 
 if TYPE_CHECKING:
     from apps.evaluations.evaluators import EvaluatorResult
+
+# Messages written per transaction by EvaluationDataset.add_messages_stream. Bounds both the
+# INSERT size and how long the dataset row lock is held on any one batch.
+DATASET_ADD_BATCH_SIZE = 500
 
 
 class EvaluationRunStatus(models.TextChoices):
@@ -352,16 +358,78 @@ class EvaluationDataset(BaseTeamModel):
             return None
         return ("pair", message.input_chat_message_id, message.expected_output_chat_message_id)
 
-    def _existing_dedup_keys(self) -> set[tuple]:
-        """Build the set of dedup keys already present in this dataset."""
+    def _existing_dedup_keys(self, candidates: set[tuple] | None = None) -> set[tuple]:
+        """Build the set of dedup keys already present in this dataset.
+
+        When *candidates* is given, only those keys are looked up. This keeps a streaming add
+        to one index-assisted query per batch, instead of re-scanning every message in the
+        dataset for each batch.
+        """
         if self.evaluation_mode == EvaluationMode.SESSION:
-            session_ids = self.messages.filter(session__isnull=False).values_list("session_id", flat=True)
+            queryset = self.messages.filter(session__isnull=False)
+            if candidates is not None:
+                queryset = queryset.filter(session_id__in=[key[1] for key in candidates])
+            session_ids = queryset.values_list("session_id", flat=True)
             return {("session", session_id) for session_id in session_ids}
-        pairs = self.messages.filter(
+        queryset = self.messages.filter(
             input_chat_message_id__isnull=False,
             expected_output_chat_message_id__isnull=False,
-        ).values_list("input_chat_message_id", "expected_output_chat_message_id")
-        return {("pair", input_id, output_id) for input_id, output_id in pairs}
+        )
+        if candidates is not None:
+            # Narrowing on the (indexed) input id alone can over-select, so the pair equality
+            # is enforced by intersecting with `candidates` below.
+            queryset = queryset.filter(input_chat_message_id__in=[key[1] for key in candidates])
+        pairs = queryset.values_list("input_chat_message_id", "expected_output_chat_message_id")
+        existing = {("pair", input_id, output_id) for input_id, output_id in pairs}
+        return existing & candidates if candidates is not None else existing
+
+    def add_messages_stream(
+        self,
+        messages: Iterable[EvaluationMessage],
+        *,
+        batch_size: int = DATASET_ADD_BATCH_SIZE,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> tuple[list[int], int]:
+        """Persist and link messages from an iterable, committing one batch at a time.
+
+        Unlike add_messages, this never holds the whole message list or a single transaction for
+        the duration of the job, so it stays memory- and lock-bounded for very large datasets.
+        Each batch takes the same row lock add_messages does, which is all the dedup invariant
+        needs: mutual exclusion only has to cover one read-check-insert cycle, not the whole
+        stream. Two concurrent streams therefore interleave between batches without either
+        inserting a duplicate.
+
+        Returns (created_ids, skipped_count) — ids rather than instances, since holding 10k
+        EvaluationMessage objects is the memory problem this method exists to avoid.
+
+        Note: callers already inside an atomic block (e.g. the auto-population rule tick) turn
+        these per-batch commits into savepoints, and so keep single-transaction semantics.
+        """
+        created_ids: list[int] = []
+        skipped = 0
+        # strict=False: the final batch is expected to be short.
+        for batch in itertools.batched(messages, batch_size, strict=False):
+            keyed_batch = [(message, self._dedup_key(message)) for message in batch]
+            with transaction.atomic():
+                EvaluationDataset.objects.select_for_update().get(pk=self.pk)
+                candidates = {key for _, key in keyed_batch if key is not None}
+                seen = self._existing_dedup_keys(candidates)
+                to_create = []
+                for message, key in keyed_batch:
+                    if key is not None:
+                        if key in seen:
+                            skipped += 1
+                            continue
+                        seen.add(key)
+                    to_create.append(message)
+
+                if to_create:
+                    created = EvaluationMessage.objects.bulk_create(to_create, batch_size=batch_size)
+                    self.messages.add(*created)
+                    created_ids.extend(message.id for message in created)
+            if progress_callback:
+                progress_callback(len(created_ids), skipped)
+        return created_ids, skipped
 
     class Meta:
         unique_together = ("name", "team")
@@ -490,16 +558,19 @@ class EvaluationConfig(BaseTeamModel):
     def run(
         self,
         run_type: EvaluationRunType = EvaluationRunType.FULL,
-        scoped_messages: list[EvaluationMessage] | None = None,
+        scoped_message_ids: list[int] | None = None,
     ) -> EvaluationRun:
         """Runs the evaluation asynchronously using Celery.
 
         The run's plan is frozen at creation: `scoped_messages` is populated for
         every run type (all dataset ids for FULL, the PREVIEW sample, or the
-        explicit DELTA list) and `evaluator_ids` snapshots the config's evaluators.
-        The beat coordinator only ever reads this frozen plan, never the live
-        dataset, so a dataset that grows mid-run cannot prevent the run finishing.
+        explicit DELTA list in `scoped_message_ids`) and `evaluator_ids` snapshots the
+        config's evaluators. The beat coordinator only ever reads this frozen plan, never
+        the live dataset, so a dataset that grows mid-run cannot prevent the run finishing.
         `job_id` is a uuid used as the progress-publishing key for the run's life.
+
+        DELTA scoping takes ids rather than instances so large appends never have to hold
+        the message objects in memory.
         """
         generation_experiment = self.get_generation_experiment_version()
 
@@ -517,7 +588,7 @@ class EvaluationConfig(BaseTeamModel):
             if run_type == EvaluationRunType.PREVIEW:
                 message_ids = list(self.dataset.messages.values_list("id", flat=True)[:PREVIEW_SAMPLE_SIZE])
             elif run_type == EvaluationRunType.DELTA:
-                message_ids = [message.id for message in (scoped_messages or [])]
+                message_ids = list(scoped_message_ids or [])
             else:  # FULL
                 message_ids = list(self.dataset.messages.values_list("id", flat=True))
 

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -11,7 +11,7 @@ from celery.utils.log import get_task_logger
 from celery_progress.backend import PROGRESS_STATE, ProgressRecorder
 from django.core.files.base import ContentFile
 from django.db import IntegrityError, transaction
-from django.db.models import Count, Max, Prefetch, QuerySet
+from django.db.models import Count, Exists, Max, OuterRef, Prefetch, QuerySet
 from django.http import QueryDict
 from django.utils import timezone
 from taskbadger import StatusEnum
@@ -42,7 +42,7 @@ from apps.evaluations.models import (
     EvaluatorTagRule,
 )
 from apps.evaluations.tagging import apply_rules_to_result, reverse_stale_tags
-from apps.evaluations.utils import make_session_evaluation_messages, parse_csv_value_as_json, parse_history_text
+from apps.evaluations.utils import iter_session_evaluation_messages, parse_csv_value_as_json, parse_history_text
 from apps.experiments.models import Experiment, ExperimentSession, Participant
 from apps.files.models import File, FilePurpose
 from apps.teams.models import Team
@@ -1251,17 +1251,37 @@ def create_dataset_from_sessions_task(self, dataset_id: int, team_id: int, sessi
     dataset.status = DatasetCreationStatus.PROCESSING
     dataset.save(update_fields=["status"])
 
+    progress = {"created": 0, "skipped": 0}
+    total_sessions = 0
+
     try:
         progress_recorder.set_progress(0, 100, "Starting session-mode clone...")
 
         with current_team(dataset.team):
-            evaluation_messages = make_session_evaluation_messages(session_ids, team=dataset.team)
-
-            progress_recorder.set_progress(
-                40, 100, f"Found {len(evaluation_messages)} sessions, checking for duplicates..."
+            # Counted up front: the message source is a generator, so it has no len(), and the
+            # count is needed as the progress denominator. Empty sessions are excluded because
+            # they yield no EvaluationMessage, so counting them would leave the bar (and the
+            # "cloned X of Y" failure message) permanently short of its own total.
+            total_sessions = (
+                ExperimentSession.objects.filter(team=dataset.team, external_id__in=session_ids)
+                .filter(Exists(ChatMessage.objects.filter(chat_id=OuterRef("chat_id"))))
+                .count()
+                if session_ids
+                else 0
             )
 
-            created_messages, duplicates_skipped = dataset.add_messages(evaluation_messages)
+            def report(created: int, skipped: int) -> None:
+                """Publish per-batch progress so the bar advances instead of parking at 40%."""
+                progress["created"] = created
+                progress["skipped"] = skipped
+                done = created + skipped
+                percent = int(done / total_sessions * 100) if total_sessions else 100
+                progress_recorder.set_progress(percent, 100, f"Cloned {done} of {total_sessions} sessions")
+
+            created_ids, duplicates_skipped = dataset.add_messages_stream(
+                iter_session_evaluation_messages(session_ids, team=dataset.team),
+                progress_callback=report,
+            )
 
             dataset.status = DatasetCreationStatus.COMPLETED
             dataset.job_id = ""
@@ -1271,14 +1291,23 @@ def create_dataset_from_sessions_task(self, dataset_id: int, team_id: int, sessi
 
             return {
                 "success": True,
-                "created_count": len(created_messages),
+                "created_count": len(created_ids),
                 "duplicates_skipped": duplicates_skipped,
             }
 
-    except Exception as e:
+    # BaseException, not Exception: a gevent.Timeout (raised when a hard task time limit fires)
+    # derives from BaseException and would otherwise leave the dataset stuck in PROCESSING.
+    except BaseException as e:
         logger.exception(f"Error in session-mode clone task for dataset {dataset_id}: {e}")
-        message = "An error occurred while creating session-mode messages"
+        done = progress["created"] + progress["skipped"]
+        message = (
+            f"Failed after cloning {done} of {total_sessions} session(s): {e}. "
+            "Re-running will resume from where it stopped."
+        )
         _save_dataset_error(dataset, message)
+        if not isinstance(e, Exception):
+            # Record the failure, but never swallow SystemExit/KeyboardInterrupt/gevent.Timeout.
+            raise
         return {"success": False, "error": message}
 
 

--- a/apps/evaluations/tests/test_delta_evaluation_run.py
+++ b/apps/evaluations/tests/test_delta_evaluation_run.py
@@ -18,7 +18,7 @@ def test_run_with_scoped_messages_persists_scope():
     msg2 = EvaluationMessageFactory.create()
 
     with patch("apps.evaluations.tasks.run_evaluation_task.delay") as mock_delay:
-        run = config.run(run_type=EvaluationRunType.DELTA, scoped_messages=[msg1, msg2])
+        run = config.run(run_type=EvaluationRunType.DELTA, scoped_message_ids=[msg1.id, msg2.id])
 
     assert run.type == EvaluationRunType.DELTA
     assert set(run.scoped_messages.all()) == {msg1, msg2}

--- a/apps/evaluations/tests/test_evaluation_coordination.py
+++ b/apps/evaluations/tests/test_evaluation_coordination.py
@@ -88,7 +88,7 @@ def test_run_freezes_delta_explicit_list():
     msg2 = EvaluationMessageFactory.create()
 
     with patch("apps.evaluations.tasks.run_evaluation_task.delay"):
-        run = config.run(run_type=EvaluationRunType.DELTA, scoped_messages=[msg1, msg2])
+        run = config.run(run_type=EvaluationRunType.DELTA, scoped_message_ids=[msg1.id, msg2.id])
 
     assert set(run.scoped_messages.all()) == {msg1, msg2}
 

--- a/apps/evaluations/tests/test_session_mode.py
+++ b/apps/evaluations/tests/test_session_mode.py
@@ -8,6 +8,7 @@ from apps.evaluations.forms import EvaluationConfigForm, EvaluationDatasetEditFo
 from apps.evaluations.models import DatasetCreationStatus, EvaluationDataset, EvaluationMessage, EvaluationMode
 from apps.evaluations.tasks import create_dataset_from_sessions_task
 from apps.evaluations.utils import make_session_evaluation_messages
+from apps.trace.models import TraceStatus
 from apps.utils.factories.evaluations import EvaluationDatasetFactory, EvaluatorFactory
 from apps.utils.factories.experiment import ChatMessageFactory, ExperimentSessionFactory
 from apps.utils.factories.team import TeamFactory, TeamWithUsersFactory
@@ -65,19 +66,21 @@ class TestMakeSessionEvaluationMessages:
     def test_happy_path_multi_turn_session(self):
         """Session with N turns produces one EvaluationMessage with full history."""
         team = TeamFactory.create()
-        session = ExperimentSessionFactory.create(team=team)
+        session = ExperimentSessionFactory.create(team=team, state={"step": 3})
         chat = session.chat
 
-        ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.HUMAN, content="Hello")
+        human_1 = ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.HUMAN, content="Hello")
         ai_1 = ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.AI, content="Hi there!")
-        ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.HUMAN, content="How are you?")
+        human_2 = ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.HUMAN, content="How are you?")
 
         TraceFactory.create(
             team=team,
             experiment=session.experiment,
             session=session,
             participant=session.participant,
-            input_message=ai_1,
+            input_message=human_1,
+            output_message=ai_1,
+            status=TraceStatus.SUCCESS,
             duration=100,
             participant_data={"name": "Alice"},
             session_state={"step": 2},
@@ -89,7 +92,9 @@ class TestMakeSessionEvaluationMessages:
             experiment=session.experiment,
             session=session,
             participant=session.participant,
-            input_message=ai_2,
+            input_message=human_2,
+            output_message=ai_2,
+            status=TraceStatus.SUCCESS,
             duration=100,
             participant_data={"name": "Alice", "visits": 3},
             session_state={"step": 3},
@@ -177,33 +182,44 @@ class TestMakeSessionEvaluationMessages:
 
         assert len(result) == 0
 
-    def test_participant_data_from_last_ai_trace(self):
-        """Verify participant_data and session_state come from last AI message's trace."""
+    def test_participant_data_from_production_shaped_trace(self):
+        """participant_data comes from the trace of the last completed turn.
+
+        Production wires Trace.input_message to the *human* message
+        (apps/channels/stages/core.py) and Trace.output_message to the AI message
+        (apps/chat/bots.py). A trace shaped that way must still supply
+        participant_data. session_state comes from the session itself, since
+        Trace.session_state is only the start-of-turn snapshot.
+        """
         team = TeamFactory.create()
-        session = ExperimentSessionFactory.create(team=team)
+        session = ExperimentSessionFactory.create(team=team, state={"final": True})
         chat = session.chat
 
-        ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.HUMAN, content="Hello")
+        human_1 = ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.HUMAN, content="Hello")
         ai_1 = ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.AI, content="Hi!")
         TraceFactory.create(
             team=team,
             experiment=session.experiment,
             session=session,
             participant=session.participant,
-            input_message=ai_1,
+            input_message=human_1,
+            output_message=ai_1,
+            status=TraceStatus.SUCCESS,
             duration=100,
             participant_data={"version": 1},
             session_state={"first": True},
         )
 
-        ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.HUMAN, content="More")
+        human_2 = ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.HUMAN, content="More")
         ai_2 = ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.AI, content="Sure!")
         TraceFactory.create(
             team=team,
             experiment=session.experiment,
             session=session,
             participant=session.participant,
-            input_message=ai_2,
+            input_message=human_2,
+            output_message=ai_2,
+            status=TraceStatus.SUCCESS,
             duration=100,
             participant_data={"version": 2},
             session_state={"first": False},
@@ -211,8 +227,110 @@ class TestMakeSessionEvaluationMessages:
 
         result = make_session_evaluation_messages([session.external_id])
 
+        assert len(result) == 1
+        assert len(result[0].history) == 4
         assert result[0].participant_data == {"version": 2}
-        assert result[0].session_state == {"first": False}
+        # From ExperimentSession.state, not the trace snapshot.
+        assert result[0].session_state == {"final": True}
+
+    @pytest.mark.parametrize(
+        ("newest_trace_kwargs", "case_description"),
+        [
+            pytest.param(
+                {"status": TraceStatus.PENDING, "with_output_message": True},
+                "a trace still marked PENDING even though its reply row exists",
+                id="pending_with_output_message",
+            ),
+            pytest.param(
+                {"status": TraceStatus.SUCCESS, "with_output_message": False},
+                "a turn that never produced a reply",
+                id="no_output_message",
+            ),
+        ],
+    )
+    def test_incomplete_newest_trace_is_ignored(self, newest_trace_kwargs, case_description):
+        """An in-flight turn must not supply participant_data; the last completed turn wins.
+
+        Both discriminators are exercised independently: `status != PENDING` and
+        `output_message IS NOT NULL`. Dropping either filter has to fail one of these cases.
+        """
+        team = TeamFactory.create()
+        session = ExperimentSessionFactory.create(team=team)
+        chat = session.chat
+
+        human_1 = ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.HUMAN, content="Hello")
+        ai_1 = ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.AI, content="Hi!")
+        TraceFactory.create(
+            team=team,
+            experiment=session.experiment,
+            session=session,
+            participant=session.participant,
+            input_message=human_1,
+            output_message=ai_1,
+            status=TraceStatus.SUCCESS,
+            duration=100,
+            participant_data={"version": 1},
+            session_state={"first": True},
+        )
+        # A newer turn that is still running.
+        human_2 = ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.HUMAN, content="More")
+        in_flight_output = None
+        if newest_trace_kwargs["with_output_message"]:
+            in_flight_output = ChatMessageFactory.create(
+                chat=chat, message_type=ChatMessageType.AI, content="Working on it"
+            )
+        TraceFactory.create(
+            team=team,
+            experiment=session.experiment,
+            session=session,
+            participant=session.participant,
+            input_message=human_2,
+            output_message=in_flight_output,
+            status=newest_trace_kwargs["status"],
+            duration=0,
+            participant_data={"version": "in-flight"},
+            session_state={"first": "in-flight"},
+        )
+
+        result = make_session_evaluation_messages([session.external_id])
+
+        assert len(result) == 1
+        assert result[0].participant_data == {"version": 1}
+
+    def test_multiple_traces_on_one_message_do_not_duplicate_history(self):
+        """Two traces referencing the same ChatMessage must not duplicate it in history.
+
+        Trace.input_message is a reverse FK (related_name="input_message_trace"), so
+        joining through it emits one row per Trace and inflates the conversation.
+        """
+        team = TeamFactory.create()
+        session = ExperimentSessionFactory.create(team=team)
+        chat = session.chat
+
+        human_1 = ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.HUMAN, content="Hello")
+        ai_1 = ChatMessageFactory.create(chat=chat, message_type=ChatMessageType.AI, content="Hi!")
+        # The same turn traced twice (e.g. a retried generation).
+        for version in (1, 2):
+            TraceFactory.create(
+                team=team,
+                experiment=session.experiment,
+                session=session,
+                participant=session.participant,
+                input_message=human_1,
+                output_message=ai_1,
+                status=TraceStatus.SUCCESS,
+                duration=100,
+                participant_data={"version": version},
+                session_state={"attempt": version},
+            )
+
+        result = make_session_evaluation_messages([session.external_id])
+
+        assert len(result) == 1
+        assert len(result[0].history) == 2
+        assert [entry["content"] for entry in result[0].history] == ["Hello", "Hi!"]
+        # Tie-break is the most recent trace (-timestamp, -id).
+        assert result[0].participant_data == {"version": 2}
 
     def test_multiple_sessions(self):
         """Multiple sessions produce one EvaluationMessage each."""

--- a/apps/evaluations/tests/test_session_mode_streaming.py
+++ b/apps/evaluations/tests/test_session_mode_streaming.py
@@ -1,0 +1,203 @@
+"""Bounded-memory contract for session-mode dataset population (issue #3963).
+
+These tests pin the *streaming* behaviour rather than the output: sessions are read in
+keyset-paginated chunks, query count tracks chunk count rather than session count, and a
+partially-completed run resumes instead of duplicating work.
+
+Following apps/experiments/tests/test_export.py, these shrink the chunk size rather than
+growing the data — ExperimentSessionFactory builds an Experiment, Chat, Participant and
+ExperimentChannel per call, so asserting on 10k sessions directly is not viable.
+"""
+
+import itertools
+from unittest.mock import patch
+
+import pytest
+from django.db import connection
+from django.test import override_settings
+from django.test.utils import CaptureQueriesContext
+
+from apps.chat.models import ChatMessage, ChatMessageType
+from apps.evaluations.models import DatasetCreationStatus, EvaluationDataset, EvaluationMode
+from apps.evaluations.tasks import create_dataset_from_sessions_task
+from apps.evaluations.utils import iter_session_evaluation_messages
+from apps.utils.factories.channels import ExperimentChannelFactory
+from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
+
+# Resolving the selected external ids to primary keys, done once up front.
+PK_RESOLUTION_QUERIES = 1
+# One chunk costs: the chunk's sessions, their messages, and their traces.
+QUERIES_PER_CHUNK = 3
+
+
+def _make_sessions(count, experiment, channel, messages_per_session=2):
+    """Create `count` sessions sharing one experiment/channel, each with a short conversation."""
+    sessions = []
+    chat_messages = []
+    for session_index in range(count):
+        session = ExperimentSessionFactory.create(experiment=experiment, experiment_channel=channel)
+        for turn in range(messages_per_session):
+            chat_messages.append(
+                ChatMessage(
+                    chat=session.chat,
+                    message_type=ChatMessageType.HUMAN if turn % 2 == 0 else ChatMessageType.AI,
+                    content=f"session-{session_index} turn-{turn}",
+                )
+            )
+        sessions.append(session)
+    ChatMessage.objects.bulk_create(chat_messages)
+    return sessions
+
+
+@pytest.fixture()
+def experiment_and_channel():
+    experiment = ExperimentFactory.create()
+    return experiment, ExperimentChannelFactory.create(team=experiment.team)
+
+
+@pytest.mark.django_db()
+def test_every_session_is_yielded_across_chunk_boundaries(experiment_and_channel):
+    """A chunk size that doesn't divide the session count must not drop or repeat sessions."""
+    experiment, channel = experiment_and_channel
+    sessions = _make_sessions(5, experiment, channel)
+
+    result = list(
+        iter_session_evaluation_messages([session.external_id for session in sessions], chunk_size=2),
+    )
+
+    assert [message.session_id for message in result] == sorted(session.id for session in sessions)
+    assert all(len(message.history) == 2 for message in result)
+
+
+@pytest.mark.django_db()
+def test_default_chunk_size_is_patchable(experiment_and_channel):
+    """The module constant is read at call time, so tests can shrink it (as test_export.py does)."""
+    experiment, channel = experiment_and_channel
+    sessions = _make_sessions(3, experiment, channel)
+    external_ids = [session.external_id for session in sessions]
+
+    with patch("apps.evaluations.utils.SESSION_CHUNK_SIZE", 1), CaptureQueriesContext(connection) as ctx:
+        result = list(iter_session_evaluation_messages(external_ids))
+
+    assert len(result) == 3
+    # Chunks of 1 over 3 sessions, on top of the single pk-resolution query.
+    assert len(ctx.captured_queries) == PK_RESOLUTION_QUERIES + QUERIES_PER_CHUNK * 3
+
+
+@pytest.mark.django_db()
+def test_query_count_is_independent_of_session_count(experiment_and_channel):
+    """Doubling the sessions inside one chunk must not change the number of queries.
+
+    This is the regression guard for the original bug: the old implementation issued a fixed
+    number of queries but loaded every message into memory. Chunking trades that for a query
+    count driven by chunk count, so the per-chunk cost must stay flat as sessions grow.
+    """
+    experiment, channel = experiment_and_channel
+    sessions = _make_sessions(2, experiment, channel)
+
+    with CaptureQueriesContext(connection) as ctx_small:
+        list(iter_session_evaluation_messages([s.external_id for s in sessions], chunk_size=50))
+
+    sessions += _make_sessions(2, experiment, channel)
+
+    with CaptureQueriesContext(connection) as ctx_large:
+        list(iter_session_evaluation_messages([s.external_id for s in sessions], chunk_size=50))
+
+    assert (
+        len(ctx_small.captured_queries) == len(ctx_large.captured_queries) == PK_RESOLUTION_QUERIES + QUERIES_PER_CHUNK
+    )
+
+
+@pytest.mark.django_db()
+def test_sessions_without_messages_are_skipped(experiment_and_channel):
+    """An empty session mid-chunk is skipped without disturbing its neighbours."""
+    experiment, channel = experiment_and_channel
+    sessions = _make_sessions(2, experiment, channel)
+    empty = ExperimentSessionFactory.create(experiment=experiment, experiment_channel=channel)
+
+    result = list(
+        iter_session_evaluation_messages(
+            [sessions[0].external_id, empty.external_id, sessions[1].external_id], chunk_size=2
+        )
+    )
+
+    assert [message.session_id for message in result] == sorted(session.id for session in sessions)
+
+
+@pytest.mark.django_db()
+def test_add_messages_stream_commits_each_batch(experiment_and_channel):
+    """Progress is reported per batch, and every message lands exactly once."""
+    experiment, channel = experiment_and_channel
+    sessions = _make_sessions(5, experiment, channel)
+    dataset = EvaluationDataset.objects.create(
+        team=experiment.team, name="streamed", evaluation_mode=EvaluationMode.SESSION
+    )
+    progress = []
+
+    created_ids, skipped = dataset.add_messages_stream(
+        iter_session_evaluation_messages([s.external_id for s in sessions], chunk_size=2),
+        batch_size=2,
+        progress_callback=lambda created, skipped_count: progress.append((created, skipped_count)),
+    )
+
+    assert len(created_ids) == 5
+    assert skipped == 0
+    # Batches of 2 over 5 messages: 2, 4, then the short final batch.
+    assert progress == [(2, 0), (4, 0), (5, 0)]
+    assert dataset.messages.count() == 5
+
+
+@pytest.mark.django_db()
+def test_add_messages_stream_is_idempotent(experiment_and_channel):
+    """Re-streaming the same sessions skips them all, so a failed run can simply be retried."""
+    experiment, channel = experiment_and_channel
+    sessions = _make_sessions(4, experiment, channel)
+    external_ids = [session.external_id for session in sessions]
+    dataset = EvaluationDataset.objects.create(
+        team=experiment.team, name="streamed", evaluation_mode=EvaluationMode.SESSION
+    )
+
+    dataset.add_messages_stream(iter_session_evaluation_messages(external_ids, chunk_size=2), batch_size=2)
+    created_ids, skipped = dataset.add_messages_stream(
+        iter_session_evaluation_messages(external_ids, chunk_size=2), batch_size=2
+    )
+
+    assert created_ids == []
+    assert skipped == 4
+    assert dataset.messages.count() == 4
+
+
+@pytest.mark.django_db()
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+def test_task_resumes_after_partial_failure(experiment_and_channel):
+    """A run that dies mid-stream leaves a FAILED dataset that a re-run completes."""
+    experiment, channel = experiment_and_channel
+    sessions = _make_sessions(4, experiment, channel)
+    external_ids = [session.external_id for session in sessions]
+    dataset = EvaluationDataset.objects.create(
+        team=experiment.team, name="partial", evaluation_mode=EvaluationMode.SESSION
+    )
+
+    real_add = EvaluationDataset.add_messages_stream
+
+    def die_halfway(self, messages, *, batch_size=None, progress_callback=None):
+        """Commit the first two sessions, then blow up as an OOM-killed worker would."""
+        real_add(self, itertools.islice(messages, 2), batch_size=2, progress_callback=progress_callback)
+        raise RuntimeError("worker died")
+
+    with patch.object(EvaluationDataset, "add_messages_stream", die_halfway):
+        create_dataset_from_sessions_task.delay(dataset.id, experiment.team.id, external_ids).get()
+
+    dataset.refresh_from_db()
+    assert dataset.status == DatasetCreationStatus.FAILED
+    assert dataset.messages.count() == 2
+    # The error names how far it got, so a human knows a retry will pick up the rest.
+    assert "2 of 4 session(s)" in dataset.error_message
+
+    result = create_dataset_from_sessions_task.delay(dataset.id, experiment.team.id, external_ids).get()
+
+    dataset.refresh_from_db()
+    assert dataset.status == DatasetCreationStatus.COMPLETED
+    assert result["created_count"] == 2
+    assert result["duplicates_skipped"] == 2
+    assert dataset.messages.count() == 4

--- a/apps/evaluations/tests/test_session_mode_task.py
+++ b/apps/evaluations/tests/test_session_mode_task.py
@@ -105,7 +105,7 @@ def test_create_dataset_from_sessions_task_error_path():
         team=team, name="Test Session Dataset 3", evaluation_mode=EvaluationMode.SESSION
     )
 
-    with patch("apps.evaluations.tasks.make_session_evaluation_messages", side_effect=Exception("DB error")):
+    with patch("apps.evaluations.tasks.iter_session_evaluation_messages", side_effect=Exception("DB error")):
         task_result = create_dataset_from_sessions_task.delay(dataset.id, team.id, [session.external_id])
         result = task_result.get()
 
@@ -113,3 +113,6 @@ def test_create_dataset_from_sessions_task_error_path():
 
     dataset.refresh_from_db()
     assert dataset.status == DatasetCreationStatus.FAILED
+    # The real exception reaches the user, not a fixed string, and names what was committed.
+    assert "DB error" in dataset.error_message
+    assert "0 of 1 session(s)" in dataset.error_message

--- a/apps/evaluations/utils.py
+++ b/apps/evaluations/utils.py
@@ -1,9 +1,13 @@
 import inspect
+import itertools
 import json
+import logging
 import re
 from collections import Counter, defaultdict
+from collections.abc import Generator
 from typing import TYPE_CHECKING, Any, cast
 
+import dictdiffer
 from django.db.models import F
 from pydantic import BaseModel, Field, create_model
 
@@ -11,7 +15,14 @@ from apps.chat.models import ChatMessage, ChatMessageType
 from apps.evaluations.exceptions import HistoryParseException
 from apps.evaluations.field_definitions import FieldDefinition
 from apps.experiments.models import ExperimentSession
+from apps.trace.models import Trace, TraceStatus
 from apps.utils.fields import sanitize_json_data as fields_sanitize_json_data
+
+logger = logging.getLogger("ocs.evaluations")
+
+# Sessions loaded per chunk when building session-mode evaluation messages. Mirrors
+# EXPORT_CHUNK_SIZE in apps.experiments.export — the same bounded-memory pattern.
+SESSION_CHUNK_SIZE = 200
 
 if TYPE_CHECKING:
     from apps.evaluations.models import EvaluationMessage
@@ -205,76 +216,127 @@ def _clean_field_name(field_name):
     return field_name or "context_variable"
 
 
-def make_session_evaluation_messages(session_external_ids: list[str], team=None) -> list["EvaluationMessage"]:
-    """Create one EvaluationMessage per session, with the full conversation as history.
+def _latest_participant_data_by_session(session_ids: list[int]) -> dict[int, dict]:
+    """Map session id -> participant_data as of each session's last completed turn.
 
-    Unlike make_evaluation_messages_from_sessions (which creates one message per human-AI pair),
-    this creates a single message per session for holistic session evaluation.
+    Queries Trace directly rather than joining through ChatMessage.input_message_trace: that
+    is a reverse FK, so joining it emits one row per Trace and duplicates messages. DISTINCT ON
+    returns a single row per session, and requiring both a non-PENDING status and an
+    output_message skips turns that are still running or never produced a reply. The
+    participant_data diff is applied to get the end-of-turn snapshot, matching
+    apps.experiments.export._get_participant_data_for_message.
     """
+    rows = (
+        Trace.objects.filter(session_id__in=session_ids, output_message__isnull=False)
+        .exclude(status=TraceStatus.PENDING)
+        .order_by("session_id", "-timestamp", "-id")
+        .distinct("session_id")
+        .values_list("session_id", "participant_data", "participant_data_diff")
+    )
+    participant_data_by_session = {}
+    for session_id, participant_data, participant_data_diff in rows:
+        participant_data = participant_data or {}
+        if participant_data_diff:
+            try:
+                participant_data = dictdiffer.patch(participant_data_diff, participant_data)
+            except (KeyError, IndexError, TypeError, ValueError):
+                # A diff that no longer applies to its snapshot must not abort the whole stream:
+                # the caller may be part-way through a multi-thousand-session clone, and every
+                # retry would fail on this same session. Fall back to the start-of-turn snapshot.
+                logger.warning("Ignoring unapplicable participant_data_diff on latest trace for session %s", session_id)
+        participant_data_by_session[session_id] = participant_data
+    return participant_data_by_session
+
+
+def _build_session_evaluation_messages(sessions: list[ExperimentSession]) -> Generator["EvaluationMessage"]:
+    """Build one EvaluationMessage per session in *sessions*, using two queries for the batch."""
     from apps.evaluations.models import (  # noqa: PLC0415 - circular: evaluations.models imports evaluations.utils
         EvaluationMessage,
     )
 
-    if not session_external_ids:
-        return []
-
-    filters = {"chat__experiment_session__external_id__in": session_external_ids}
-    if team is not None:
-        filters["chat__experiment_session__team"] = team
-    all_messages = list(
-        ChatMessage.objects.filter(**filters)
-        .annotate(
-            session_external_id=F("chat__experiment_session__external_id"),
-            experiment_public_id=F("chat__experiment_session__experiment__public_id"),
-            trace_participant_data=F("input_message_trace__participant_data"),
-            trace_session_state=F("input_message_trace__session_state"),
-        )
-        .order_by("created_at")
+    session_ids = [session.id for session in sessions]
+    history_by_chat: dict[int, list[dict]] = defaultdict(list)
+    # Grouped by chat_id (a forward field on ExperimentSession) so no join is needed, and
+    # read as values_list rather than model instances: only these three fields reach
+    # `history`, and instantiating a ChatMessage per message is what made this unbounded.
+    message_rows = (
+        ChatMessage.objects.filter(chat_id__in=[session.chat_id for session in sessions])
+        .order_by("chat_id", "created_at", "id")
+        .values_list("chat_id", "message_type", "content", "summary")
     )
+    for chat_id, message_type, content, summary in message_rows:
+        history_by_chat[chat_id].append({"message_type": message_type, "content": content, "summary": summary})
 
-    sessions: dict[str, list] = {}
-    for msg in all_messages:
-        sessions.setdefault(msg.session_external_id, []).append(msg)
+    participant_data_by_session = _latest_participant_data_by_session(session_ids)
 
-    session_map = {str(s.external_id): s for s in ExperimentSession.objects.filter(external_id__in=sessions.keys())}
-
-    result = []
-    for session_id, messages in sessions.items():
-        history = [
-            {
-                "message_type": msg.message_type,
-                "content": msg.content,
-                "summary": msg.summary,
-            }
-            for msg in messages
-        ]
-
-        participant_data = {}
-        session_state = {}
-        for msg in reversed(messages):
-            if msg.message_type == ChatMessageType.AI:
-                participant_data = msg.trace_participant_data or {}
-                session_state = msg.trace_session_state or {}
-                break
-
-        eval_message = EvaluationMessage(
-            session=session_map.get(str(session_id)),
+    for session in sessions:
+        history = history_by_chat.get(session.chat_id)
+        if not history:
+            continue  # a session with no messages produces no EvaluationMessage
+        yield EvaluationMessage(
+            session=session,
             input={},
             output={},
             history=history,
-            participant_data=participant_data,
-            session_state=session_state,
+            participant_data=participant_data_by_session.get(session.id, {}),
+            # Sourced from the session, not the trace: Trace.session_state is the snapshot taken
+            # when the trace *opened*, while post-turn state is written back to
+            # ExperimentSession.state (apps/chat/bots.py). Using the session keeps this
+            # end-of-conversation, consistent with the end-of-turn participant_data above and
+            # with how exports report session state (apps/experiments/export.py).
+            session_state=session.state or {},
             metadata={
-                "session_id": str(session_id),
-                "experiment_id": str(messages[0].experiment_public_id),
+                "session_id": str(session.external_id),
+                "experiment_id": str(session.experiment.public_id),
                 "created_mode": "clone",
             },
             input_chat_message=None,
             expected_output_chat_message=None,
         )
-        result.append(eval_message)
 
-    return result
+
+def iter_session_evaluation_messages(
+    session_external_ids: list[str], team=None, chunk_size: int | None = None
+) -> Generator["EvaluationMessage"]:
+    """Yield one EvaluationMessage per session, with the full conversation as history.
+
+    Unlike make_evaluation_messages_from_sessions (which creates one message per human-AI pair),
+    this creates a single message per session for holistic session evaluation.
+
+    Sessions are loaded one chunk at a time so memory stays flat regardless of how many were
+    selected — only one chunk's messages are resident at a time. Materialising every ChatMessage
+    across all sessions at once previously OOM-killed the worker (see #3963).
+    """
+    if not session_external_ids:
+        return
+
+    # Resolved here rather than as a default argument so the module constant stays patchable
+    # in tests, matching apps.experiments.export's use of EXPORT_CHUNK_SIZE.
+    chunk_size = chunk_size or SESSION_CHUNK_SIZE
+
+    base_qs = ExperimentSession.objects.filter(external_id__in=session_external_ids)
+    if team is not None:
+        base_qs = base_qs.filter(team=team)
+
+    # Resolve the external ids to pks once. Keyset-paginating the external_id queryset instead
+    # would re-send the whole external_id IN-list on every page — 10k bind parameters per chunk,
+    # and a hard ceiling once the statement exceeds PostgreSQL's 65535-parameter limit. A list of
+    # ints is cheap to hold (~8 bytes each) compared to the message rows it lets us avoid.
+    # ExperimentSession.Meta.ordering is ["-created_at"], so pk ordering must be explicit.
+    session_pks = list(base_qs.order_by("pk").values_list("pk", flat=True))
+
+    for pk_chunk in itertools.batched(session_pks, chunk_size, strict=False):
+        sessions = list(ExperimentSession.objects.filter(pk__in=pk_chunk).select_related("experiment").order_by("pk"))
+        yield from _build_session_evaluation_messages(sessions)
+
+
+def make_session_evaluation_messages(session_external_ids: list[str], team=None) -> list["EvaluationMessage"]:
+    """Eager wrapper around iter_session_evaluation_messages.
+
+    Only safe for small session counts; large jobs should consume the generator so memory
+    stays bounded.
+    """
+    return list(iter_session_evaluation_messages(session_external_ids, team=team))
 
 
 def make_evaluation_messages_from_sessions(message_ids_per_session: dict[str, list[str]]) -> list["EvaluationMessage"]:


### PR DESCRIPTION
Creating a session-mode evaluation dataset from more than a few thousand sessions OOM-killed the Celery worker (#3963). Because that is a SIGKILL, and `task_acks_late` is globally inert, the dataset was left stuck in `PROCESSING` forever with no error and the progress bar frozen at 40%.

### Product Description

Large session-mode datasets can now be created, and a failure reports what actually went wrong plus how far it got. Re-running resumes rather than restarting.

Session-mode datasets also now carry real `participant_data`/`session_state`; previously both were always empty.

### Technical Description

`make_session_evaluation_messages` materialised every `ChatMessage` across every selected session into one list. Measured per-object costs put peak RSS around 1.4 GB at a typical 20 messages/session — over a 1 GB worker. It is now a generator that loads one chunk of sessions at a time, and `add_messages_stream` commits per batch instead of holding one transaction (and one of only 35 pool connections) for the whole job.

Worth review attention:

- **`participant_data` was silently always `{}`.** The old code read it from the last AI message's `input_message_trace`, but production sets `Trace.input_message` to the *human* message (`apps/channels/stages/core.py`) and the AI message to `output_message`. The pre-existing test passed only because it wired traces the other way round; that test was corrected rather than kept. This changes what session-mode evaluators see.
- **`session_state` now comes from `ExperimentSession.state`, not the trace.** `Trace.session_state` is only the snapshot from when the trace *opened*; post-turn state is written back to the session. Sourcing it from the trace would have left it a turn behind the now-end-of-turn `participant_data`. This matches how exports report session state.
- **Per-batch commits replace one long lock.** Each batch still takes the same dataset row lock, which is all the dedup invariant needs — mutual exclusion only has to cover one read-check-insert cycle. Two concurrent adds interleave between batches without duplicating. `_existing_dedup_keys` gained a `candidates` argument so each batch does one index-assisted lookup instead of rescanning the dataset.
- **External ids are resolved to pks once**, then chunked. Keyset-paginating the `external_id` queryset would have re-sent the whole IN-list on every page (10k bind parameters per chunk, and a hard ceiling at PostgreSQL's 65535-parameter limit).
- `EvaluationConfig.run()` takes `scoped_message_ids` instead of instances, since it only ever needed ids.

Deliberately out of scope, tracked in #3963: users still cannot *select* 10k sessions in production (the WAF caps the POST body at ~215 ids — that needs a matching `export_waf_allow_list` regeneration in ocs-deploy), and message-mode has the same reverse-FK row multiplication in a different code path.

Chunking is the fix here, not a timeout — `soft_time_limit` is silently discarded by the gevent pool, which is worth its own issue.

### Migrations

None.

### Docs and Changelog

- [ ] This PR requires docs/changelog update