### PR TITLE
Report evaluators that reference an LLM provider

### DIFF
--- a/apps/service_providers/tests/test_models.py
+++ b/apps/service_providers/tests/test_models.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 
 from apps.service_providers.models import LlmProviderModel
 from apps.utils.factories.assistants import OpenAiAssistantFactory
+from apps.utils.factories.evaluations import EvaluatorFactory
 from apps.utils.factories.pipelines import PipelineFactory
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 
@@ -76,6 +77,22 @@ class TestServiceProviderModel:
         provider_model = LlmProviderModel.objects.get(id=node.params["llm_provider_model_id"])
         with pytest.raises(ValidationError, match=pipeline.name):
             provider_model.delete()
+
+    @pytest.mark.django_db()
+    def test_evaluator_params_do_not_block_provider_model_deletion(self):
+        """Deletion deliberately ignores evaluator params.
+
+        Nothing repoints evaluator params when a custom model is replaced by a global one
+        (see ``_replace_custom_model_with_global``), so blocking here would break that
+        sync instead of orphaning a reference. The usages page reports these separately.
+        """
+        provider_model = LlmProviderModelFactory.create()
+        EvaluatorFactory(
+            team=provider_model.team,
+            params={"llm_provider_model_id": provider_model.id},
+        )
+
+        provider_model.delete()
 
     @pytest.mark.django_db()
     def test_can_delete_unassociated_provider_models(self):

--- a/apps/service_providers/tests/test_usages.py
+++ b/apps/service_providers/tests/test_usages.py
@@ -12,6 +12,7 @@ from apps.service_providers.utils import ServiceProvider
 from apps.utils.factories.assistants import OpenAiAssistantFactory
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.documents import CollectionFactory, DocumentSourceFactory
+from apps.utils.factories.evaluations import EvaluatorFactory
 from apps.utils.factories.events import EventActionFactory, StaticTriggerFactory
 from apps.utils.factories.experiment import ExperimentFactory, SyntheticVoiceFactory
 from apps.utils.factories.pipelines import NodeFactory, PipelineFactory
@@ -377,12 +378,37 @@ def test_usages_view_renders_version_tags(team_with_users, client):
     assert f'href="{working_url}#versions"' in body, "older-version row should link with the #versions hash"
 
 
-def _add_pipeline_usage(provider, count: int) -> None:
-    """Attach ``count`` more pipeline-node references (each with its own chatbot)."""
+def _add_provider_usage(provider, count: int) -> None:
+    """Attach ``count`` more references: a pipeline node (with its chatbot) and an evaluator."""
     for _ in range(count):
         pipeline = PipelineFactory(team=provider.team)
         NodeFactory(pipeline=pipeline, type="LLMResponseWithPrompt", params={"llm_provider_id": provider.id})
         ExperimentFactory(team=provider.team, pipeline=pipeline)
+        EvaluatorFactory(team=provider.team, params={"llm_provider_id": provider.id})
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("stored_id", [pytest.param(int, id="int"), pytest.param(str, id="str")])
+def test_evaluators_referencing_the_provider_in_params_are_reported(anthropic_provider, stored_id):
+    """``Evaluator.params`` holds ``llm_provider_id`` as JSON, not an FK."""
+    evaluator = EvaluatorFactory(
+        team=anthropic_provider.team,
+        name="Sentiment",
+        params={"llm_provider_id": stored_id(anthropic_provider.id)},
+    )
+
+    usages = get_provider_usages(anthropic_provider)
+
+    items_by_label = {c.label: [obj.id for obj in c.items] for c in usages.categories}
+    assert items_by_label == {"Evaluators": [evaluator.id]}
+
+
+@pytest.mark.django_db()
+def test_evaluators_referencing_a_different_provider_are_not_reported(anthropic_provider):
+    other_provider = LlmProviderFactory(team=anthropic_provider.team)
+    EvaluatorFactory(team=anthropic_provider.team, params={"llm_provider_id": other_provider.id})
+
+    assert get_provider_usages(anthropic_provider).is_empty()
 
 
 @pytest.mark.django_db()
@@ -399,21 +425,21 @@ def test_archived_pipelines_are_still_reported(anthropic_provider):
 
 
 @pytest.mark.django_db()
-def test_resolving_usages_does_not_scale_with_pipeline_count(anthropic_provider):
-    """N+1 guard: query count must be flat in the number of referencing pipelines."""
-    _add_pipeline_usage(anthropic_provider, 1)
+def test_resolving_usages_does_not_scale_with_reference_count(anthropic_provider):
+    """N+1 guard: query count must be flat in the number of referencing objects."""
+    _add_provider_usage(anthropic_provider, 1)
     with CaptureQueriesContext(connection) as few:
         usages_few = get_provider_usages(anthropic_provider)
 
-    _add_pipeline_usage(anthropic_provider, 4)
+    _add_provider_usage(anthropic_provider, 4)
     with CaptureQueriesContext(connection) as many:
         usages_many = get_provider_usages(anthropic_provider)
 
-    assert usages_few.total == 1, "sanity: the single pipeline resolves to one chatbot"
-    assert usages_many.total == 5, "sanity: all five pipelines resolve to chatbots"
+    assert usages_few.total == 2, "sanity: one chatbot + one evaluator"
+    assert usages_many.total == 10, "sanity: five chatbots + five evaluators"
     assert len(many.captured_queries) == len(few.captured_queries), (
         f"query count grew from {len(few.captured_queries)} to {len(many.captured_queries)} "
-        f"when pipeline references went from 1 to 5"
+        f"when references went from 2 to 10"
     )
 
 

--- a/apps/service_providers/usages.py
+++ b/apps/service_providers/usages.py
@@ -25,7 +25,7 @@ from typing import Literal
 from apps.documents.models import Collection
 from apps.events.models import EventActionType, StaticTrigger, TimeoutTrigger
 from apps.experiments.models import Experiment
-from apps.utils.deletion import get_related_objects
+from apps.utils.deletion import get_related_evaluators_queryset, get_related_objects
 
 from .utils import ServiceProvider
 
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 MatchMode = Literal["exact", "suffix", "contains"]
 
-_PIPELINE_PARAM_KEY_BY_PROVIDER_SLUG = {
+_PARAM_KEY_BY_PROVIDER_SLUG = {
     ServiceProvider.llm.slug: "llm_provider_id",
 }
 
@@ -74,10 +74,15 @@ def get_provider_usages(provider) -> ProviderUsages:
     reached by any chatbot stay visible in "Unlinked Pipelines" /
     "Unlinked Channels" categories. Document sources roll up to their
     parent Collection.
+
+    Pipeline nodes and evaluators reference providers from a JSON ``params``
+    blob rather than a foreign key, so both are looked up by param key.
     """
     service_provider = _service_provider_for(provider)
-    pipeline_param_key = _PIPELINE_PARAM_KEY_BY_PROVIDER_SLUG.get(service_provider.slug)
-    related = get_related_objects(provider, pipeline_param_key=pipeline_param_key)
+    params_key = _PARAM_KEY_BY_PROVIDER_SLUG.get(service_provider.slug)
+    related = get_related_objects(provider, pipeline_param_key=params_key)
+    if params_key:
+        related.extend(get_related_evaluators_queryset(provider, params_key))
 
     # Per-category dicts dedupe rows that are reachable through more than one
     # reverse relation (e.g. TranscriptAnalysis has both llm_provider and

--- a/apps/utils/deletion.py
+++ b/apps/utils/deletion.py
@@ -290,13 +290,28 @@ def _get_related_objects_querysets(instance, pipeline_param_key: str | None = No
         yield get_related_pipelines_queryset(instance, pipeline_param_key)
 
 
+def _params_key_filter(params_key: str, instance) -> Q:
+    """Match ``params[params_key]`` against ``instance.id`` stored as either int or str."""
+    return Q(**{f"params__{params_key}": instance.id}) | Q(**{f"params__{params_key}": str(instance.id)})
+
+
 def get_related_pipelines_queryset(instance, pipeline_param_key: str | None = None):
     from apps.pipelines.models import Node  # noqa: PLC0415 - circular: pipelines.models→experiments.models→deletion
 
-    pipelines = Node.objects.filter(
-        Q(**{f"params__{pipeline_param_key}": instance.id}) | Q(**{f"params__{pipeline_param_key}": str(instance.id)})
-    )
-    return pipelines
+    return Node.objects.filter(_params_key_filter(pipeline_param_key, instance))
+
+
+def get_related_evaluators_queryset(instance, params_key: str):
+    """Evaluators referencing ``instance`` from their JSON ``params`` (no FK exists).
+
+    Deliberately not part of ``_get_related_objects_querysets``: the delete paths that
+    call it repoint pipeline-node params before deleting, but nothing repoints evaluator
+    params, so including this there would turn a silent orphan into a hard failure.
+    Callers that only want to *report* usages ask for it explicitly.
+    """
+    from apps.evaluations.models import Evaluator  # noqa: PLC0415 - circular: evaluations.models→…→deletion
+
+    return Evaluator.objects.filter(_params_key_filter(params_key, instance))
 
 
 def get_related_pipelines_queryset_for_list_param(instance, pipeline_param_key: str | None = None):


### PR DESCRIPTION
Split out of #3970, which merged before this commit landed.

`LlmEvaluator` gets `llm_provider_id` from `LLMResponseMixin` into `Evaluator.params` as JSON, with no FK, so `get_related_objects` could never see it — the provider usages page reported nothing for a provider used only by evaluators. Pipeline nodes and evaluators are the only two models that hide resource ids in `params` (checked against `clone_team`'s remap logic and `importer._node_param_models`).

The lookup is deliberately **not** wired into `_get_related_objects_querysets`, so deletion behaviour is unchanged. `_replace_custom_model_with_global` repoints pipeline-node params before calling `custom_model.delete()` but never touches evaluator params, so sharing the lookup would make `LlmProviderModel.delete()` raise and break the default-models sync rather than report anything. `test_evaluator_params_do_not_block_provider_model_deletion` pins that, and #3974 tracks doing it properly (repointing has to land first).

Adds one constant query; the existing N+1 guard now covers evaluators too, so resolution stays flat in the number of references.

### Migrations

N/A

### Verification

Both new tests fail on the old code (`{}` vs `{'Evaluators': [...]}`). The reported case is parametrized over the id being stored as int or str, since params hold either. Running this against the dev DB surfaced a pre-existing evaluator the page had been silently omitting.

### Docs and Changelog
- [x] This PR requires docs/changelog update

Changelog note: the service provider usages page now lists evaluators that use the provider.
