### PR TITLE
Fix start/end node migration util crashing on layout-only pipeline data

### DIFF
--- a/apps/pipelines/migrations/utils/migrate_start_end_nodes.py
+++ b/apps/pipelines/migrations/utils/migrate_start_end_nodes.py
@@ -122,6 +122,9 @@ def _set_new_nodes(pipeline, Node):
     to_delete = current_ids - new_ids
     Node.objects.filter(pipeline=pipeline, flow_id__in=to_delete).delete()
     for node in nodes:
+        if node.data is None:
+            # Layout-only node (ADR-0046): the Node row owns the content, so there is nothing to sync.
+            continue
         Node.objects.update_or_create(
             pipeline=pipeline,
             flow_id=node.id,

--- a/apps/pipelines/tests/test_add_start_end_nodes.py
+++ b/apps/pipelines/tests/test_add_start_end_nodes.py
@@ -11,6 +11,7 @@ from apps.pipelines.migrations.utils.migrate_start_end_nodes import (
 from apps.pipelines.models import Node, Pipeline
 from apps.pipelines.nodes.nodes import EndNode, StartNode
 from apps.pipelines.tests.utils import end_node, passthrough_node, start_node
+from apps.utils.factories.pipelines import PipelineFactory
 
 
 @pytest.mark.django_db()
@@ -268,6 +269,20 @@ def test_remove_start_end_nodes(team):
         "sourceHandle": "output",
         "targetHandle": "input",
     }
+
+
+@pytest.mark.django_db()
+def test_remove_start_end_nodes_with_layout_only_pipeline(team):
+    """``remove_all_start_end_nodes`` sweeps every pipeline in the DB, so it has to cope with
+    layout-only ``Pipeline.data`` (ADR-0046) where nodes carry no embedded ``data``."""
+    pipeline = PipelineFactory.create(team=team)
+    assert all("data" not in node for node in pipeline.data["nodes"])
+
+    remove_all_start_end_nodes(Node)
+    pipeline.refresh_from_db()
+
+    assert not pipeline.node_set.filter(type__in=[StartNode.__name__, EndNode.__name__]).exists()
+    assert pipeline.data["nodes"] == []
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
`test_remove_start_end_nodes` started failing on main at 62bc5b21c ([run 30437501333](https://github.com/dimagi/open-chat-studio/actions/runs/30437501333)) — green at the commit before, and #3978 is the only thing between them. #3978 didn't break anything; it reshuffled xdist scheduling so a module-scoped fixture that commits a pipeline (`inspect_bot`, `source_team`) shared a worker DB with this test.

The actual bug predates it. `remove_all_start_end_nodes` sweeps every pipeline in the DB, and `_set_new_nodes` reads `node.data.type` — but `Pipeline.data` has been layout-only since ADR-0046, so `FlowNode.data` is `None` for every stored pipeline. One `PipelineFactory.create()` anywhere in the same worker DB is enough to blow it up; no xdist needed to reproduce.

Skipping layout-only nodes is correct rather than merely defensive: the `Node` row owns type/label/params, so there's nothing to sync. The id-only `to_delete` set is unaffected, which is the part of the sweep that matters.

I fixed the util rather than scoping the test — scoping would mean threading a pipeline filter through a migration util's signature, and would leave the crash waiting for the next scheduling reshuffle.

### Migrations
No new migrations. Migration `0010` is the only caller and runs against an empty DB, so no production behaviour change.

### Docs and Changelog
- [ ] This PR requires docs/changelog update
