### PR TITLE
Stamp finished_at on failed evaluation runs

### DIFF
--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -676,6 +676,18 @@ class EvaluationRun(BaseTeamModel):
         if save:
             self.save(update_fields=["finished_at", "status"])
 
+    def mark_failed(self, error_message: str, save=True):
+        """Terminate the run with an error, stamping ``finished_at`` like ``mark_complete``.
+
+        Without the timestamp a failed run renders no finish time and no duration
+        (see ``evaluation_result_home.html`` and the run detail view).
+        """
+        self.finished_at = timezone.now()
+        self.status = EvaluationRunStatus.FAILED
+        self.error_message = error_message
+        if save:
+            self.save(update_fields=["finished_at", "status", "error_message"])
+
     def get_table_data(self, include_ids: bool = False):
         results_qs = (
             self.results.select_related("message__session__experiment", "evaluator", "session")

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -319,12 +319,12 @@ def _redispatch_unfinished(run: EvaluationRun, remaining: set[int]) -> tuple[lis
         run.stall_count = (run.stall_count or 0) + 1
 
     if run.stall_count >= MAX_STALLS and not made_progress:
-        run.status = EvaluationRunStatus.FAILED
-        run.error_message = (
+        run.mark_failed(
             f"Evaluation stalled: {len(unfinished)} message(s) made no progress after "
-            f"{MAX_STALLS} re-dispatch attempts."
+            f"{MAX_STALLS} re-dispatch attempts.",
+            save=False,
         )
-        run.save(update_fields=["status", "error_message", "stall_count"])
+        run.save(update_fields=["finished_at", "status", "error_message", "stall_count"])
         return [], True
 
     run.in_flight = unfinished

--- a/apps/evaluations/tests/test_evaluation_coordination.py
+++ b/apps/evaluations/tests/test_evaluation_coordination.py
@@ -399,6 +399,8 @@ def test_sweep_fails_after_max_stalls_without_progress(delay_mock, _publish):
     run.refresh_from_db()
     assert run.status == EvaluationRunStatus.FAILED
     assert run.error_message
+    assert run.finished_at is not None  # or the run renders no finish time and no duration
+    assert run.stall_count == 3  # mark_failed must not clobber the counter it is saved alongside
     delay_mock.assert_not_called()
 
 


### PR DESCRIPTION
### Product Description
A failed evaluation run now shows a finish time and a duration, the way a completed one already does.

### Technical Description
`EvaluationRun.mark_failed()` mirrors `mark_complete()`, stamping `finished_at` alongside the status and error message. The stall path in `_redispatch_unfinished` was the only place setting `FAILED`, and it saves `stall_count` in the same write, so it calls `mark_failed(..., save=False)` and keeps its explicit save.

Independent of the evaluator LLM-provider work; split out so it can land on its own.

### Migrations
None.

- [x] The migrations are backwards compatible

### Demo
The run detail page and the runs table pick up the timestamp automatically — no template changes.

### Docs and Changelog
- [ ] This PR requires docs/changelog update
