### PR TITLE
Validate the evaluator's LLM provider selection

### DIFF
--- a/apps/evaluations/forms.py
+++ b/apps/evaluations/forms.py
@@ -35,6 +35,8 @@ from apps.evaluations.utils import parse_history_text
 from apps.experiments.models import Experiment, ExperimentSession
 from apps.files.models import File
 from apps.human_annotations.models import AnnotationQueue, QueueStatus
+from apps.service_providers.models import LlmProvider, LlmProviderModel, LlmProviderTypes
+from apps.utils.fields import as_int
 from apps.web.dynamic_filters.datastructures import FilterParams
 
 
@@ -314,7 +316,47 @@ class EvaluatorForm(forms.ModelForm):
                 error_messages.append(f"{field_name.replace('_', ' ').title()}: {message}")
             raise forms.ValidationError(f"{', '.join(error_messages)}") from err
 
+        self._validate_llm_provider_selection(params)
+
         return cleaned_data
+
+    def _validate_llm_provider_selection(self, params: dict):
+        """Reject provider ids the team can't use, and pairings the provider can't serve.
+
+        The ids arrive inside the ``params`` JSON blob, so they never went through a
+        ModelChoiceField queryset, and an id from another team would run this team's
+        evaluations on someone else's credentials.
+        """
+        provider = None
+        provider_id = as_int(params.get("llm_provider_id"))
+        if provider_id is not None:
+            provider = LlmProvider.objects.filter(team=self.team, id=provider_id).first()
+            if provider is None:
+                raise forms.ValidationError("The selected LLM provider is not available to this team")
+
+        provider_model = None
+        provider_model_id = as_int(params.get("llm_provider_model_id"))
+        if provider_model_id is not None:
+            provider_model = LlmProviderModel.objects.for_team(self.team).filter(id=provider_model_id).first()
+            if provider_model is None:
+                raise forms.ValidationError("The selected LLM model is not available to this team")
+
+        # The picker only offers models matching the chosen provider's type (see
+        # ``_evaluator_parameter_values``), so a mismatch means the ids were not submitted
+        # through the UI. Left unchecked it fails at run time inside get_llm_service.
+        if provider is not None and provider_model is not None and provider.type != provider_model.type:
+            raise forms.ValidationError(
+                f"The selected LLM model is for {_provider_type_label(provider_model.type)} providers, "
+                f"but the selected provider is {_provider_type_label(provider.type)}"
+            )
+
+
+def _provider_type_label(provider_type: str) -> str:
+    """Human label for an LLM provider type slug, falling back to the slug itself."""
+    try:
+        return str(LlmProviderTypes[provider_type].label)
+    except KeyError:
+        return provider_type
 
 
 class EvaluatorTagRuleForm(forms.ModelForm):

--- a/apps/evaluations/tests/test_evaluator_views.py
+++ b/apps/evaluations/tests/test_evaluator_views.py
@@ -8,7 +8,13 @@ from django.test import Client
 from django.urls import reverse
 
 from apps.evaluations.models import ConditionType
-from apps.utils.factories.evaluations import EvaluatorFactory, EvaluatorTagRuleFactory
+from apps.service_providers.models import LlmProvider, LlmProviderTypes
+from apps.utils.factories.evaluations import (
+    EvaluatorFactory,
+    EvaluatorTagRuleFactory,
+    configure_evaluator_llm_provider,
+)
+from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 from apps.utils.factories.team import TeamWithUsersFactory
 
 
@@ -26,27 +32,28 @@ def client_with_user(team):
 
 @pytest.fixture()
 def evaluator(team):
-    return EvaluatorFactory.create(team=team)
+    """An LLM evaluator pointing at providers this team is actually allowed to use."""
+    return configure_evaluator_llm_provider(EvaluatorFactory.create(team=team))
 
 
 def _edit_url(team, evaluator):
     return reverse("evaluations:evaluator_edit", args=[team.slug, evaluator.pk])
 
 
-def _params(output_schema):
+def _params(output_schema, evaluator):
     return {
         "llm_prompt": "prompt",
-        "llm_provider_id": 1,
-        "llm_provider_model_id": 1,
+        "llm_provider_id": evaluator.params["llm_provider_id"],
+        "llm_provider_model_id": evaluator.params["llm_provider_model_id"],
         "output_schema": output_schema,
     }
 
 
-def _post_data(evaluator, output_schema, rule_rows):
+def _post_data(evaluator, output_schema, rule_rows, params=None):
     data = {
         "name": evaluator.name,
         "type": "LlmEvaluator",
-        "params": json.dumps(_params(output_schema)),
+        "params": json.dumps(params if params is not None else _params(output_schema, evaluator)),
         "evaluation_mode": evaluator.evaluation_mode,
         "tag_rules-TOTAL_FORMS": str(len(rule_rows)),
         "tag_rules-INITIAL_FORMS": str(len([r for r in rule_rows if r.get("id")])),
@@ -141,3 +148,51 @@ class TestEditEvaluatorSchemaDrift:
         evaluator.refresh_from_db()
         assert evaluator.params["output_schema"] == new_schema
         assert not evaluator.tag_rules.filter(pk=rule.pk).exists()
+
+
+@pytest.mark.django_db()
+class TestEvaluatorLlmProviderSelection:
+    def test_a_valid_selection_saves(self, client_with_user, team, evaluator):
+        new_provider = LlmProviderFactory.create(team=team)
+        new_model = LlmProviderModelFactory.create(team=team, type=new_provider.type)
+        params = _params(evaluator.params["output_schema"], evaluator) | {
+            "llm_provider_id": new_provider.id,
+            "llm_provider_model_id": new_model.id,
+        }
+
+        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
+            response = client_with_user.post(_edit_url(team, evaluator), _post_data(evaluator, {}, [], params=params))
+
+        assert response.status_code == 302, getattr(response, "context_data", None)
+        evaluator.refresh_from_db()
+        assert evaluator.params["llm_provider_id"] == new_provider.id
+        assert evaluator.params["llm_provider_model_id"] == new_model.id
+
+    def test_a_model_from_another_provider_type_is_rejected(self, client_with_user, team, evaluator):
+        """The picker only offers matching types, so a mismatch means a hand-crafted post."""
+        provider = LlmProvider.objects.get(id=evaluator.params["llm_provider_id"])
+        mismatched_type = next(t for t in LlmProviderTypes if str(t) != provider.type)
+        mismatched_model = LlmProviderModelFactory.create(team=team, type=str(mismatched_type))
+        params = _params(evaluator.params["output_schema"], evaluator) | {"llm_provider_model_id": mismatched_model.id}
+        original_model_id = evaluator.params["llm_provider_model_id"]
+
+        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
+            response = client_with_user.post(_edit_url(team, evaluator), _post_data(evaluator, {}, [], params=params))
+
+        assert response.status_code == 200
+        assert "providers, but the selected provider is" in response.content.decode()
+        evaluator.refresh_from_db()
+        assert evaluator.params["llm_provider_model_id"] == original_model_id
+
+    def test_another_teams_provider_is_rejected(self, client_with_user, team, evaluator):
+        other_teams_provider = LlmProviderFactory.create()
+        params = _params(evaluator.params["output_schema"], evaluator) | {"llm_provider_id": other_teams_provider.id}
+        original_provider_id = evaluator.params["llm_provider_id"]
+
+        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
+            response = client_with_user.post(_edit_url(team, evaluator), _post_data(evaluator, {}, [], params=params))
+
+        assert response.status_code == 200
+        assert "not available to this team" in response.content.decode()
+        evaluator.refresh_from_db()
+        assert evaluator.params["llm_provider_id"] == original_provider_id

--- a/apps/utils/factories/evaluations.py
+++ b/apps/utils/factories/evaluations.py
@@ -18,6 +18,7 @@ from apps.evaluations.models import (
     EvaluatorTagRule,
 )
 from apps.utils.factories.experiment import ChatFactory, ChatMessageFactory, ExperimentFactory
+from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 from apps.utils.factories.team import TeamFactory
 
 
@@ -49,6 +50,21 @@ class EvaluatorFactory(DjangoModelFactory):
             },
         }
     )
+
+
+def configure_evaluator_llm_provider(evaluator: Evaluator) -> Evaluator:
+    """Point an LLM evaluator at real providers in its own team, making it runnable.
+
+    ``EvaluatorFactory`` leaves the provider ids out of ``params``, so by default an
+    ``LlmEvaluator`` it builds names no provider — which the form now rejects on save.
+    Tests that post the evaluator form need this; most tests do not.
+    """
+    evaluator.params |= {
+        "llm_provider_id": LlmProviderFactory.create(team=evaluator.team).id,
+        "llm_provider_model_id": LlmProviderModelFactory.create(team=evaluator.team).id,
+    }
+    evaluator.save(update_fields=["params"])
+    return evaluator
 
 
 class EvaluationTagFactory(DjangoModelFactory):


### PR DESCRIPTION
### Product Description
Picking an LLM provider or model the team doesn't have access to, or a model that doesn't belong to the selected provider's type, is now rejected on save with a message naming the problem — instead of saving and failing later when the evaluator runs.

### Technical Description
`Evaluator.params` is a JSON blob, so `llm_provider_id` and `llm_provider_model_id` never passed through a `ModelChoiceField` queryset. Nothing checked team ownership, and nothing checked that the model's provider type matched the provider. Both checks now run in `EvaluatorForm.clean`.

The team check is the one that matters: an id from another team would have run this team's evaluations against another team's credentials.

Also adds `configure_evaluator_llm_provider` next to `EvaluatorFactory`, which leaves the provider ids out of `params` and so builds an evaluator this validation rejects.

### Migrations
None.

- [x] The migrations are backwards compatible

### Demo
The picker only ever offers models matching the chosen provider's type, so the type error is reachable only by a hand-crafted post.

### Docs and Changelog
- [ ] This PR requires docs/changelog update
