### PR TITLE
Fail a run up front when an evaluator has no LLM provider

### DIFF
--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -340,6 +340,33 @@ def _redispatch_unfinished(run: EvaluationRun, remaining: set[int]) -> tuple[lis
     return _chunk(unfinished, BATCH_SIZE), False
 
 
+def _unconfigured_evaluator_names(evaluator_ids: list[int]) -> list[str]:
+    """Names of LLM-backed evaluators in the plan that have no provider to run against.
+
+    ``Evaluator.get_evaluator_params`` raises per message, so without a pre-flight a single
+    unconfigured evaluator writes one error result per message in the dataset instead of
+    failing the run once.
+    """
+    names = []
+    for evaluator in Evaluator.objects.filter(id__in=evaluator_ids):
+        try:
+            requires_provider = evaluator.requires_llm_provider()
+        except AttributeError:
+            # Unknown evaluator type — ``type`` is free-text, so this is possible. Leave it
+            # to the per-message path, which already reports it as a result error.
+            continue
+        if requires_provider and (evaluator.llm_provider_id is None or evaluator.llm_provider_model_id is None):
+            names.append(evaluator.name)
+    return sorted(names)
+
+
+def _fail_run_for_unconfigured_evaluators(run: EvaluationRun, names: list[str]) -> None:
+    run.mark_failed(
+        f"No LLM provider configured for: {', '.join(names)}. "
+        "Edit each evaluator to select a provider and model, then start a new run."
+    )
+
+
 def _finalize_complete(run: EvaluationRun) -> None:
     """Mark the run complete and run the completion side effects (aggregates, tag reversal)."""
     run.mark_complete()
@@ -361,6 +388,14 @@ def _coordinate_locked_run(run: EvaluationRun) -> _TickResult:
     if total == 0 or not evaluator_ids:
         _finalize_complete(run)
         return _TickResult(batches=[], done=0, total=total, terminal="success")
+
+    # First tick only, to keep the steady-state tick free of this query. A provider deleted
+    # mid-run still nulls the FK, and those messages fall back to the per-message error path.
+    if run.status == EvaluationRunStatus.PENDING:
+        unconfigured = _unconfigured_evaluator_names(evaluator_ids)
+        if unconfigured:
+            _fail_run_for_unconfigured_evaluators(run, unconfigured)
+            return _TickResult(batches=[], done=0, total=total, terminal="error")
 
     remaining = set(plan_ids) - _done_message_ids(run, plan_ids, evaluator_ids)
     done = total - len(remaining)

--- a/apps/evaluations/tests/test_delta_evaluation_run.py
+++ b/apps/evaluations/tests/test_delta_evaluation_run.py
@@ -8,6 +8,7 @@ from apps.utils.factories.evaluations import (
     EvaluationConfigFactory,
     EvaluationMessageFactory,
     EvaluatorFactory,
+    configure_evaluator_llm_provider,
 )
 
 
@@ -37,7 +38,8 @@ def test_full_run_freezes_all_dataset_messages():
 @patch("apps.evaluations.tasks.evaluate_message_batch.delay")
 def test_coordinator_dispatches_only_scoped_messages_for_delta(delay_mock, _publish):
     config = EvaluationConfigFactory.create()
-    evaluator = EvaluatorFactory.create(team=config.team)
+    # Configured providers, or the run fails its pre-flight instead of dispatching.
+    evaluator = configure_evaluator_llm_provider(EvaluatorFactory.create(team=config.team))
     config.evaluators.set([evaluator])
     in_scope = EvaluationMessageFactory.create()
     out_of_scope = EvaluationMessageFactory.create()

--- a/apps/evaluations/tests/test_evaluation_coordination.py
+++ b/apps/evaluations/tests/test_evaluation_coordination.py
@@ -27,6 +27,7 @@ from apps.utils.factories.evaluations import (
     EvaluationResultFactory,
     EvaluationRunFactory,
     EvaluatorFactory,
+    configure_evaluator_llm_provider,
 )
 from apps.utils.factories.team import MembershipFactory, TeamWithUsersFactory
 from apps.utils.factories.user import GroupFactory
@@ -204,7 +205,8 @@ def _make_run(evaluator_count=1, message_count=5, status=EvaluationRunStatus.PEN
     """Build a run with a frozen plan of `message_count` messages and `evaluator_count` evaluators."""
     team = TeamWithUsersFactory.create()
     config = EvaluationConfigFactory.create(team=team)
-    evaluators = [EvaluatorFactory.create(team=team) for _ in range(evaluator_count)]
+    # Configured providers, or the run fails its pre-flight instead of dispatching.
+    evaluators = [configure_evaluator_llm_provider(EvaluatorFactory.create(team=team)) for _ in range(evaluator_count)]
     config.evaluators.set(evaluators)
     messages = [EvaluationMessageFactory.create() for _ in range(message_count)]
     config.dataset.messages.add(*messages)
@@ -219,6 +221,49 @@ def _complete_messages(run, evaluators, messages):
             EvaluationResultFactory.create(
                 team=run.team, run=run, evaluator=evaluator, message=message, output={"result": {"ok": 1}}
             )
+
+
+@pytest.mark.django_db()
+@patch("apps.evaluations.tasks._publish_tick")
+@patch("apps.evaluations.tasks.evaluate_message_batch.delay")
+def test_pending_run_with_an_unconfigured_evaluator_fails_before_dispatching(delay_mock, _publish):
+    """One error, not one per message: the pre-flight fails the run instead of dispatching."""
+    run, evaluators, _messages = _make_run(message_count=5, status=EvaluationRunStatus.PENDING)
+    evaluators[0].params |= {"llm_provider_id": None}
+    evaluators[0].save(update_fields=["params"])
+
+    coordinate_evaluation_runs()
+
+    run.refresh_from_db()
+    assert run.status == EvaluationRunStatus.FAILED
+    assert evaluators[0].name in run.error_message
+    assert "select a provider and model" in run.error_message
+    assert run.finished_at is not None  # or the run renders no finish time and no duration
+    assert delay_mock.call_count == 0
+    assert EvaluationResult.objects.filter(run=run).count() == 0
+
+
+@pytest.mark.django_db()
+@patch("apps.evaluations.tasks._publish_tick")
+@patch("apps.evaluations.tasks.evaluate_message_batch.delay")
+def test_pending_run_with_a_python_evaluator_needs_no_provider(delay_mock, _publish):
+    """PythonEvaluator has no LLM dependency, so the pre-flight must not fail it."""
+    team = TeamWithUsersFactory.create()
+    config = EvaluationConfigFactory.create(team=team)
+    evaluator = EvaluatorFactory.create(team=team, type="PythonEvaluator", params={"code": "def main(**kwargs): pass"})
+    config.evaluators.set([evaluator])
+    message = EvaluationMessageFactory.create()
+    config.dataset.messages.add(message)
+    run = EvaluationRunFactory.create(
+        config=config, team=team, status=EvaluationRunStatus.PENDING, evaluator_ids=[evaluator.id]
+    )
+    run.scoped_messages.add(message)
+
+    coordinate_evaluation_runs()
+
+    run.refresh_from_db()
+    assert run.status == EvaluationRunStatus.PROCESSING
+    assert delay_mock.call_count == 1
 
 
 @pytest.mark.django_db()
@@ -399,7 +444,7 @@ def test_sweep_fails_after_max_stalls_without_progress(delay_mock, _publish):
     run.refresh_from_db()
     assert run.status == EvaluationRunStatus.FAILED
     assert run.error_message
-    assert run.finished_at is not None  # or the run renders no finish time and no duration
+    assert run.finished_at is not None
     assert run.stall_count == 3  # mark_failed must not clobber the counter it is saved alongside
     delay_mock.assert_not_called()
 

--- a/apps/utils/factories/evaluations.py
+++ b/apps/utils/factories/evaluations.py
@@ -56,8 +56,9 @@ def configure_evaluator_llm_provider(evaluator: Evaluator) -> Evaluator:
     """Point an LLM evaluator at real providers in its own team, making it runnable.
 
     ``EvaluatorFactory`` leaves the provider ids out of ``params``, so by default an
-    ``LlmEvaluator`` it builds names no provider — which the form now rejects on save.
-    Tests that post the evaluator form need this; most tests do not.
+    ``LlmEvaluator`` it builds names no provider — which the form rejects on save and an
+    evaluation run rejects pre-flight. Tests that post the evaluator form, or drive a run
+    through the coordinator, need this; most tests do not.
     """
     evaluator.params |= {
         "llm_provider_id": LlmProviderFactory.create(team=evaluator.team).id,


### PR DESCRIPTION
Stacked on #3999 (base is `sk/evaluator-provider-fks`). Also needs #3997, which is merged into this branch and will drop out of the diff once it lands.

### Product Description
An evaluation run containing an evaluator with no LLM provider now fails once, up front, naming the evaluators to fix — rather than recording that same error against every message in the dataset.

### Technical Description
`get_evaluator_params()` raises per message, and `_run_evaluator_on_message` catches it and writes an error result, so a 5,000-message dataset produced 5,000 identical rows and as many logged exceptions for a condition knowable once before dispatch.

The coordinator now checks on the `PENDING` tick only, so steady-state ticks stay free of the query. `PythonEvaluator` is unaffected. An unknown evaluator `type` — `type` is free text — falls through to the per-message path rather than crashing the coordinator.

The per-message path stays: a provider deleted *after* dispatch is the one window the pre-flight can't close.

### Migrations
None.

- [x] The migrations are backwards compatible

### Demo
### Docs and Changelog
- [ ] This PR requires docs/changelog update
