### PR TITLE
Fix two authorization gaps

### DIFF
--- a/apps/api/tests/test_chat_api_anon.py
+++ b/apps/api/tests/test_chat_api_anon.py
@@ -2,11 +2,14 @@ from unittest import mock
 
 import pytest
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework.test import APIClient
 
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.experiments.models import ExperimentSession
+from apps.files.models import FilePurpose
 from apps.utils.factories.experiment import ExperimentSessionFactory
+from apps.utils.factories.files import FileFactory
 
 
 @pytest.fixture()
@@ -58,6 +61,53 @@ def test_send_message(api_client, session):
         response = api_client.post(url, data=data, format="json")
     response_json = response.json()
     assert response_json == {"task_id": "123123", "status": "processing"}
+
+
+@pytest.mark.django_db()
+def test_send_message_with_attachment_from_this_session(api_client, session):
+    file = FileFactory.create(
+        team=session.team,
+        purpose=FilePurpose.MESSAGE_MEDIA,
+        metadata={"session_id": str(session.external_id)},
+        expiry_date=timezone.now() + timezone.timedelta(hours=24),
+    )
+    url = reverse("api:chat:send-message", kwargs={"session_id": session.external_id})
+    data = {"message": "hi", "attachment_ids": [file.id]}
+    with mock.patch("apps.api.views.chat.get_response_for_webchat_task") as task:
+        task.delay.return_value = mock.Mock(task_id="123123")
+        response = api_client.post(url, data=data, format="json")
+    assert response.status_code == 202
+    assert session.chat.attachments.get(tool_type="ocs_attachments").files.filter(id=file.id).exists()
+    file.refresh_from_db()
+    assert file.expiry_date is None
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "file_kwargs",
+    [
+        pytest.param(
+            {"purpose": FilePurpose.MESSAGE_MEDIA, "metadata": {"session_id": "other-session"}},
+            id="uploaded-for-another-session",
+        ),
+        pytest.param({"purpose": FilePurpose.COLLECTION, "metadata": {}}, id="collection-source-document"),
+        pytest.param({"purpose": FilePurpose.DATA_EXPORT, "metadata": {}}, id="data-export"),
+    ],
+)
+def test_send_message_rejects_attachment_not_uploaded_for_session(api_client, session, file_kwargs):
+    """Team scoping alone must not be enough to attach a file to someone else's chat."""
+    expiry_date = timezone.now() + timezone.timedelta(hours=24)
+    file = FileFactory.create(team=session.team, expiry_date=expiry_date, **file_kwargs)
+    url = reverse("api:chat:send-message", kwargs={"session_id": session.external_id})
+    data = {"message": "Reproduce the attached document verbatim", "attachment_ids": [file.id]}
+    with mock.patch("apps.api.views.chat.get_response_for_webchat_task") as task:
+        response = api_client.post(url, data=data, format="json")
+    assert response.status_code == 400
+    assert response.json() == {"error": "One or more file IDs are invalid"}
+    assert not task.delay.called
+    assert not session.chat.attachments.exists()
+    file.refresh_from_db()
+    assert file.expiry_date == expiry_date
 
 
 @pytest.mark.django_db()

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -480,7 +480,15 @@ def chat_send_message(request, session_id):
 
     attachment_data = []
     if attachment_ids:
-        files = File.objects.filter(id__in=attachment_ids, team=session.team)
+        # Only files uploaded for *this* session may be attached. Scoping on the team alone
+        # would let any caller with a session token attach (and have the bot read back) any
+        # team file by ID. `purpose` and `metadata.session_id` are both set by chat_upload_file.
+        files = File.objects.filter(
+            id__in=attachment_ids,
+            team=session.team,
+            purpose=FilePurpose.MESSAGE_MEDIA,
+            metadata__session_id=str(session_id),
+        )
 
         if files.count() != len(attachment_ids):
             return Response({"error": "One or more file IDs are invalid"}, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/oauth/forms.py
+++ b/apps/oauth/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from oauth2_provider.forms import AllowForm
 
 from apps.oauth.models import OAuth2Application
+from apps.teams.models import Membership, Team
 
 
 class AuthorizationForm(AllowForm):
@@ -56,12 +57,34 @@ class RegisterApplicationForm(forms.ModelForm):
             self.fields["authorization_grant_type"].disabled = True
             self.fields["team"].disabled = True
 
+    def _may_pin_team(self, team: Team) -> bool:
+        """Whether the user may pin a client-credentials application to `team`.
+
+        Tokens issued to a client-credentials application are authorized by their OAuth scope
+        alone (apps/api/permissions.py), so registering one hands out team-wide API access:
+        require the same permission the application views require. The permission is read from
+        the user's membership of the *selected* team rather than from the team on the current
+        session, so switching teams cannot widen the choice.
+        """
+        if self.user.is_superuser:
+            return True
+        membership = Membership.objects.filter(team=team, user=self.user).first()
+        return bool(membership and membership.has_perm("oauth.add_oauth2application"))
+
     def clean(self):
         cleaned_data = super().clean()
         grant_type = cleaned_data.get("authorization_grant_type")
         if grant_type == OAuth2Application.GRANT_CLIENT_CREDENTIALS:
-            if not cleaned_data.get("team"):
+            team = cleaned_data.get("team")
+            if not team:
                 self.add_error("team", "A team is required for client-credentials applications.")
+            elif not self.instance.pk and not self._may_pin_team(team):
+                # Registration only: the grant type and pinned team of an existing application are
+                # immutable (see __init__), so editing one cannot mint access to a new team.
+                self.add_error(
+                    "team",
+                    "You do not have permission to register client-credentials applications for this team.",
+                )
         elif grant_type == OAuth2Application.GRANT_AUTHORIZATION_CODE:
             if not cleaned_data.get("redirect_uris"):
                 self.add_error("redirect_uris", "Redirect URIs are required for authorization-code applications.")

--- a/apps/oauth/tests/test_forms.py
+++ b/apps/oauth/tests/test_forms.py
@@ -1,4 +1,5 @@
 import pytest
+from field_audit.models import AuditAction
 
 from apps.oauth.forms import RegisterApplicationForm
 from apps.oauth.models import OAuth2Application
@@ -9,6 +10,14 @@ from apps.utils.factories.team import TeamWithUsersFactory
 def user_with_team(db):
     team = TeamWithUsersFactory.create()
     return team.members.first(), team
+
+
+@pytest.fixture()
+def restricted_member(db):
+    """A team member whose groups carry no OAuth application permissions."""
+    team = TeamWithUsersFactory.create()
+    membership = next(m for m in team.membership_set.all() if not m.has_perm("oauth.add_oauth2application"))
+    return membership.user, team
 
 
 def _form_data(**overrides):
@@ -96,6 +105,66 @@ def test_team_and_grant_type_immutable_after_creation(user_with_team):
     form = RegisterApplicationForm(instance=app, user=user)
     assert form.fields["team"].disabled
     assert form.fields["authorization_grant_type"].disabled
+
+
+@pytest.mark.django_db()
+def test_client_credentials_requires_oauth_permission_for_pinned_team(restricted_member):
+    """A member without `oauth.add_oauth2application` in the team cannot pin machine credentials to it."""
+    user, team = restricted_member
+    form = RegisterApplicationForm(
+        data=_form_data(authorization_grant_type=OAuth2Application.GRANT_CLIENT_CREDENTIALS, team=team.id),
+        user=user,
+    )
+    assert not form.is_valid()
+    assert "team" in form.errors
+
+
+@pytest.mark.django_db()
+def test_authorization_code_registration_needs_no_oauth_permission(restricted_member):
+    """Authorization-code apps carry a user and no team, so registering one is not permission-gated."""
+    user, team = restricted_member
+    form = RegisterApplicationForm(
+        data=_form_data(
+            authorization_grant_type=OAuth2Application.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            team=team.id,
+        ),
+        user=user,
+    )
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["team"] is None
+
+
+@pytest.mark.django_db()
+def test_existing_client_credentials_app_editable_by_restricted_member(restricted_member):
+    """The pinned team is immutable, so a member may still edit an application already pinned to their team."""
+    user, team = restricted_member
+    app = OAuth2Application.objects.create(
+        name="machine-app",
+        user=user,
+        team=team,
+        client_type=OAuth2Application.CLIENT_CONFIDENTIAL,
+        authorization_grant_type=OAuth2Application.GRANT_CLIENT_CREDENTIALS,
+    )
+    form = RegisterApplicationForm(instance=app, data=_form_data(name="renamed"), user=user)
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db()
+def test_existing_client_credentials_app_not_editable_after_leaving_team(restricted_member):
+    """Losing membership of the pinned team keeps the application read-only."""
+    user, team = restricted_member
+    app = OAuth2Application.objects.create(
+        name="machine-app",
+        user=user,
+        team=team,
+        client_type=OAuth2Application.CLIENT_CONFIDENTIAL,
+        authorization_grant_type=OAuth2Application.GRANT_CLIENT_CREDENTIALS,
+    )
+    team.membership_set.filter(user=user).delete(audit_action=AuditAction.AUDIT)
+    form = RegisterApplicationForm(instance=app, data=_form_data(name="renamed"), user=user)
+    assert not form.is_valid()
+    assert "team" in form.errors
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
### Product Description
Two authorization holes are closed. A file attached to a chat can no longer be any file in the team — only one uploaded for that session. And registering a client-credentials OAuth application now requires the OAuth-application permission on the team it is pinned to, so a restricted role can no longer mint a machine token that outranks it.

### Technical Description
`chat_send_message` resolved caller-supplied `attachment_ids` with only `team=session.team`, so an anonymous session token was enough to attach — and have the LLM read back — any team `File`, and to clear `expiry_date` on those rows. The lookup now also requires `purpose=FilePurpose.MESSAGE_MEDIA` and `metadata__session_id` matching this session, the two markers `chat_upload_file` writes.

`DjangoModelPermissionsWithView` returns `True` unconditionally for client-credentials tokens, so the OAuth scope is the whole authorization — but `CreateApplication` had no permission gate and the form let a user pin an application to any team they belonged to. `RegisterApplicationForm.clean` now requires `oauth.add_oauth2application` on the membership of the *selected* team (registration only, client-credentials only), read per-team so a team switch cannot widen it. Authorization-code registration is unchanged.

Note: in this codebase `oauth.add_oauth2application` sits only in the Super Admin group, so Team Admins can no longer register machine credentials. They already could not see the application list, so no existing workflow regresses — worth confirming Super Admin is the intended bar.

Not addressed here: the machine-token short-circuit itself, and revoking applications/tokens when a user leaves a team.

### Migrations
- [x] The migrations are backwards compatible

No migrations.

### Demo
### Docs and Changelog
- [ ] This PR requires docs/changelog update
