### PR TITLE
Read report tokens off UsageRecord, not Trace

### DIFF
--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from datetime import datetime
 from decimal import Decimal
 
-from django.db.models import Count, DecimalField, Q, Sum, Value
+from django.db.models import Count, DecimalField, Q, Sum
 from django.db.models.functions import Coalesce, TruncDate
 
 from apps.channels.models import ChannelPlatform, ExperimentChannel
@@ -16,7 +16,6 @@ from apps.evaluations.models import EvaluationConfig, EvaluationDataset, Evaluat
 from apps.experiments.models import Experiment, ExperimentSession, Participant
 from apps.teams.metadata import get_team_metadata_fields
 from apps.teams.models import Team
-from apps.trace.models import Trace, TraceStatus
 
 _ZERO = Decimal(0)
 _COST_FIELD = DecimalField(max_digits=14, decimal_places=8)
@@ -49,53 +48,38 @@ def get_participant_stats(start: datetime, end: datetime):
 
 def usage_to_csv(start: datetime, end: datetime):
     metadata_fields = get_team_metadata_fields()
-    headers = ["Team", "Run Count", "Total Tokens"] + [field["label"] for field in metadata_fields]
+    headers = ["Team", "Total Tokens"] + [field["label"] for field in metadata_fields]
     rows = (
-        (team_name, run_count, total_tokens, *(metadata.get(field["key"], "") for field in metadata_fields))
-        for team_name, run_count, total_tokens, metadata in get_usage_data(start, end)
+        (team_name, total_tokens, *(metadata.get(field["key"], "") for field in metadata_fields))
+        for team_name, total_tokens, metadata in get_usage_data(start, end)
     )
     return _write_data_to_csv(headers, rows)
 
 
 def get_usage_data(start: datetime, end: datetime):
-    """Per-team usage from completed trace token counts.
+    """Per-team token totals from UsageRecord, highest first.
 
-    Only includes traces with a settled status (excludes PENDING). No platform is
-    filtered out — spend costs the same money whatever produced it — but that alone
-    doesn't make this reconcile with `get_cost_usage_by_team`: tokens come from `Trace`
-    and cost from `UsageRecord`, and neither half of an evaluation run writes a `Trace`
-    (judge calls bypass tracing, and eval generation is billed by `UsageOnlyTracer`,
-    ADR-0050). So eval runs are cost-only here until token reporting moves onto
-    `UsageRecord`. Pre-tracing periods will report lower totals than the legacy
-    character-based proxy.
+    `UsageRecord` is the single source for both halves of the usage report, so tokens
+    and cost reconcile against the same rows. It also covers writers that have no
+    trace, which a trace-sourced count missed entirely: neither half of an evaluation
+    run writes a `Trace` (judge calls bypass tracing, and eval generation is billed by
+    `UsageOnlyTracer`, ADR-0050), so eval runs used to be cost-only here. Every source
+    counts (ADR-0048): a team-level total is what the team used. `UsageRecord` only
+    goes back to the cost-tracking rollout, so earlier periods report zero.
     """
-    usage_data = (
-        Trace.objects.filter(timestamp__gte=start, timestamp__lt=end)
-        .exclude(status=TraceStatus.PENDING)
-        .values("team_id", "team__name", "team__metadata")
-        .annotate(
-            run_count=Count("id"),
-            total_tokens=Coalesce(Sum("n_total_tokens"), Value(0)),
-        )
-        .order_by("-run_count", "team__name")
+    totals = (
+        UsageRecord.objects.filter(timestamp__gte=start, timestamp__lt=end)
+        .values("team_id")
+        .annotate(total_tokens=Coalesce(Sum("quantity"), _ZERO, output_field=_QUANTITY_FIELD))
     )
-    for data in usage_data:
-        yield data["team__name"], data["run_count"], data["total_tokens"], data["team__metadata"] or {}
-
-
-def get_token_usage_by_team(start: datetime, end: datetime):
-    """Per-team run count + total tokens from settled traces, unfiltered by platform
-    (see `get_usage_data` for how far these totals track `get_cost_usage_by_team`)."""
-    return (
-        Trace.objects.filter(timestamp__gte=start, timestamp__lt=end)
-        .exclude(status=TraceStatus.PENDING)
-        .values("team_id", "team__name", "team__slug")
-        .annotate(
-            run_count=Count("id"),
-            total_tokens=Coalesce(Sum("n_total_tokens"), Value(0)),
-        )
-        .order_by("-run_count", "team__name")
-    )
+    tokens_by_team = {row["team_id"]: int(row["total_tokens"]) for row in totals}
+    # Name and metadata are fetched by PK rather than grouped on, as in
+    # `get_cost_usage_by_team`: both are per-team so neither affects the grouping, and
+    # the JSON `metadata` column is expensive to GROUP BY. Keeping them out of the
+    # aggregate also keeps the team join off the high-volume UsageRecord scan.
+    teams = Team.objects.filter(id__in=list(tokens_by_team)).values_list("id", "name", "metadata")
+    for team_id, name, metadata in sorted(teams, key=lambda team: (-tokens_by_team[team[0]], team[1] or "")):
+        yield name, tokens_by_team[team_id], metadata or {}
 
 
 def get_cost_usage_by_team(start: datetime, end: datetime):
@@ -117,8 +101,11 @@ def get_cost_usage_by_team(start: datetime, end: datetime):
 
 
 def build_usage_report(start: datetime, end: datetime) -> dict:
-    """Cross-team usage: per-team token totals (always populated) merged with
-    per-model cost detail from recorded UsageRecords.
+    """Cross-team usage: per-team token + cost totals with per-model detail, all from
+    UsageRecord.
+
+    Both halves come from the same rows, so a team's `total_tokens` is exactly the sum
+    of its `models[].tokens` — that is the point of reading one table rather than two.
 
     `total_cost` is a `{currency: amount}` map, not a scalar: a team can have
     records in more than one currency and summing them would be meaningless.
@@ -128,57 +115,44 @@ def build_usage_report(start: datetime, end: datetime) -> dict:
     top level as `metadata_fields` so a consumer can build labelled columns.
     """
     metadata_fields = get_team_metadata_fields()
-    token_rows = list(get_token_usage_by_team(start, end))
     cost_rows = list(get_cost_usage_by_team(start, end))
 
-    team_meta = {row["team_id"]: (row["team__name"], row["team__slug"]) for row in token_rows}
-    missing_ids = {row["team_id"] for row in cost_rows} - team_meta.keys()
-    if missing_ids:
-        missing = Team.objects.filter(id__in=missing_ids).values_list("id", "name", "slug")
-        team_meta.update({tid: (name, slug) for tid, name, slug in missing})
-
-    # Fetch metadata separately (keyed by PK): grouping the aggregate query by
-    # the JSON `metadata` column would be needlessly expensive, and metadata is
-    # per-team so it never affects the grouping anyway.
-    metadata_by_team = dict(Team.objects.filter(id__in=list(team_meta)).values_list("id", "metadata"))
+    team_info = {
+        team_id: (name, slug, metadata or {})
+        for team_id, name, slug, metadata in Team.objects.filter(
+            id__in={row["team_id"] for row in cost_rows}
+        ).values_list("id", "name", "slug", "metadata")
+    }
 
     teams: dict[int, dict] = {}
-
-    def _entry(team_id: int) -> dict:
+    for row in cost_rows:
+        team_id = row["team_id"]
         if team_id not in teams:
-            name, slug = team_meta.get(team_id, (None, None))
-            metadata = metadata_by_team.get(team_id) or {}
+            name, slug, metadata = team_info.get(team_id, (None, None, {}))
             teams[team_id] = {
                 "team_id": team_id,
                 "team_name": name,
                 "team_slug": slug,
                 "metadata": {field["key"]: metadata.get(field["key"], "") for field in metadata_fields},
-                "run_count": 0,
                 "total_tokens": 0,
                 "total_cost": defaultdict(Decimal),  # currency -> amount
                 "models": [],
             }
-        return teams[team_id]
-
-    for row in token_rows:
-        entry = _entry(row["team_id"])
-        entry["run_count"] = row["run_count"]
-        entry["total_tokens"] = row["total_tokens"]
-
-    for row in cost_rows:
-        entry = _entry(row["team_id"])
+        entry = teams[team_id]
+        tokens = int(row["tokens"] or 0)
+        entry["total_tokens"] += tokens
         entry["total_cost"][row["currency"]] += row["cost"]
         entry["models"].append(
             {
                 "provider_type": row["provider_type"],
                 "model_name": row["model_name"],
                 "currency": row["currency"],
-                "tokens": int(row["tokens"] or 0),
+                "tokens": tokens,
                 "cost": str(row["cost"]),
             }
         )
 
-    result = sorted(teams.values(), key=lambda t: (-t["run_count"], t["team_name"] or ""))
+    result = sorted(teams.values(), key=lambda t: (-t["total_tokens"], t["team_name"] or ""))
     for entry in result:
         entry["total_cost"] = {currency: str(amount) for currency, amount in entry["total_cost"].items()}
 

--- a/apps/admin/tests/test_provider_usage_api.py
+++ b/apps/admin/tests/test_provider_usage_api.py
@@ -5,12 +5,10 @@ import pytest
 from django.urls import reverse
 from django.utils import timezone
 
-from apps.cost_tracking.models import UsageSource
-from apps.trace.models import Trace, TraceStatus
+from apps.cost_tracking.models import ServiceKind, UsageSource
 from apps.users.models import CustomUser
 from apps.utils.factories.cost_tracking import UsageRecordFactory
 from apps.utils.factories.team import TeamFactory
-from apps.utils.factories.traces import TraceFactory
 
 DATE_RANGE = {"range_type": "custom", "start": "2026-05-01", "end": "2026-05-31"}
 INVALID_RANGE = {"range_type": "custom", "start": "not-a-date", "end": "2026-05-31"}
@@ -24,11 +22,9 @@ def superuser_client(client):
     return client
 
 
-def _trace(team, tokens):
-    trace = TraceFactory(team=team, status=TraceStatus.SUCCESS, n_total_tokens=tokens)
-    # timestamp uses auto_now_add, so place it inside the window after creation.
-    Trace.objects.filter(pk=trace.pk).update(timestamp=WHEN)
-    return trace
+def _usage(team, **kwargs):
+    kwargs.setdefault("at", WHEN)
+    return UsageRecordFactory(team=team, **kwargs)
 
 
 @pytest.mark.django_db()
@@ -61,18 +57,14 @@ def test_reporting_token_auth(client, settings, configured_token, auth_header, e
 
 
 @pytest.mark.django_db()
-def test_merges_token_totals_and_cost_detail(superuser_client):
+def test_token_totals_reconcile_with_per_model_detail(superuser_client):
+    """The whole point of reading one table: `total_tokens` is exactly the sum of
+    `models[].tokens`, and `total_cost` the sum of their costs."""
     team_a = TeamFactory(name="Alpha")
     team_b = TeamFactory(name="Bravo")
-    _trace(team_a, 500)
-    _trace(team_a, 300)
-    _trace(team_b, 100)
-    UsageRecordFactory(
-        team=team_a, provider_type="openai", model_name="gpt-4o", quantity=500, cost=Decimal("1.25"), at=WHEN
-    )
-    UsageRecordFactory(
-        team=team_a, provider_type="anthropic", model_name="claude", quantity=200, cost=Decimal("0.75"), at=WHEN
-    )
+    _usage(team_a, provider_type="openai", model_name="gpt-4o", quantity=500, cost=Decimal("1.25"))
+    _usage(team_a, provider_type="anthropic", model_name="claude", quantity=300, cost=Decimal("0.75"))
+    _usage(team_b, provider_type="openai", model_name="gpt-4o", quantity=100, cost=Decimal("0.10"))
 
     response = superuser_client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE)
 
@@ -80,18 +72,25 @@ def test_merges_token_totals_and_cost_detail(superuser_client):
     teams = {t["team_name"]: t for t in response.json()["teams"]}
 
     alpha = teams["Alpha"]
-    assert alpha["run_count"] == 2
     assert alpha["total_tokens"] == 800
     assert alpha["team_slug"] == team_a.slug
     assert Decimal(alpha["total_cost"]["USD"]) == Decimal("2.00")
     models = {m["model_name"]: m for m in alpha["models"]}
     assert Decimal(models["gpt-4o"]["cost"]) == Decimal("1.25")
     assert models["gpt-4o"]["tokens"] == 500
+    assert alpha["total_tokens"] == sum(m["tokens"] for m in alpha["models"])
 
-    bravo = teams["Bravo"]
-    assert bravo["run_count"] == 1
-    assert bravo["models"] == []
-    assert bravo["total_cost"] == {}
+    assert teams["Bravo"]["total_tokens"] == 100
+
+
+@pytest.mark.django_db()
+def test_teams_ordered_by_token_total(superuser_client):
+    _usage(TeamFactory(name="Small"), quantity=10)
+    _usage(TeamFactory(name="Big"), quantity=900)
+
+    payload = superuser_client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE).json()
+
+    assert [t["team_name"] for t in payload["teams"]] == ["Big", "Small"]
 
 
 @pytest.mark.django_db()
@@ -101,7 +100,7 @@ def test_includes_team_metadata(superuser_client, settings):
         {"key": "region", "label": "Region"},
     ]
     team = TeamFactory(name="Alpha", metadata={"team_owner": "Jia", "internal_only": "hidden"})
-    _trace(team, 100)
+    _usage(team, quantity=100)
 
     payload = superuser_client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE).json()
 
@@ -115,27 +114,42 @@ def test_includes_team_metadata(superuser_client, settings):
 
 
 @pytest.mark.django_db()
-def test_total_cost_counts_evaluation_spend(superuser_client):
-    """Billing view: eval spend is the team's spend, counted in the total with no
-    per-source split (ADR-0048). Only the cost half sees judge spend — the token half
-    reads `Trace`, and judge calls have no trace."""
+def test_counts_untraced_evaluation_spend_in_both_halves(superuser_client):
+    """Billing view: eval spend is the team's spend, counted with no per-source split
+    (ADR-0048). Judge calls have no trace, so a trace-sourced token count saw the cost
+    but not the tokens — reading UsageRecord for both closes that."""
     team = TeamFactory(name="Alpha")
-    _trace(team, 100)
-    UsageRecordFactory(team=team, model_name="gpt-4o", cost=Decimal("1.00"), at=WHEN)
-    UsageRecordFactory(team=team, model_name="gpt-4o", cost=Decimal("0.25"), source=UsageSource.EVALUATION, at=WHEN)
+    _usage(team, model_name="gpt-4o", quantity=1000, cost=Decimal("1.00"))
+    _usage(team, model_name="gpt-4o", quantity=250, cost=Decimal("0.25"), source=UsageSource.EVALUATION, trace=None)
 
     payload = superuser_client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE).json()
 
     alpha = {t["team_name"]: t for t in payload["teams"]}["Alpha"]
+    assert alpha["total_tokens"] == 1250
     assert Decimal(alpha["total_cost"]["USD"]) == Decimal("1.25")
+
+
+@pytest.mark.django_db()
+def test_total_tokens_spans_service_kinds(superuser_client):
+    """One LLM call becomes several per-kind rows; the team total is every kind, so it
+    tracks the trace-sourced `usage_metadata` total it replaces."""
+    team = TeamFactory(name="Alpha")
+    _usage(team, model_name="gpt-4o", service_kind=ServiceKind.LLM_INPUT, quantity=700)
+    _usage(team, model_name="gpt-4o", service_kind=ServiceKind.LLM_CACHED_INPUT, quantity=200)
+    _usage(team, model_name="gpt-4o", service_kind=ServiceKind.LLM_CACHE_WRITE, quantity=100)
+    _usage(team, model_name="gpt-4o", service_kind=ServiceKind.LLM_OUTPUT, quantity=50)
+
+    payload = superuser_client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE).json()
+
+    alpha = {t["team_name"]: t for t in payload["teams"]}["Alpha"]
+    assert alpha["total_tokens"] == 1050
 
 
 @pytest.mark.django_db()
 def test_total_cost_keeps_currencies_separate(superuser_client):
     team = TeamFactory(name="Alpha")
-    _trace(team, 100)
-    UsageRecordFactory(team=team, model_name="gpt-4o", cost=Decimal("1.25"), currency="USD", at=WHEN)
-    UsageRecordFactory(team=team, model_name="claude", cost=Decimal("0.90"), currency="EUR", at=WHEN)
+    _usage(team, model_name="gpt-4o", cost=Decimal("1.25"), currency="USD")
+    _usage(team, model_name="claude", cost=Decimal("0.90"), currency="EUR")
 
     response = superuser_client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE)
 
@@ -146,14 +160,12 @@ def test_total_cost_keeps_currencies_separate(superuser_client):
 
 
 @pytest.mark.django_db()
-def test_excludes_pending_traces(superuser_client):
+def test_excludes_records_outside_the_range(superuser_client):
     team = TeamFactory(name="Alpha")
-    _trace(team, 500)
-    pending = TraceFactory(team=team, status=TraceStatus.PENDING, n_total_tokens=999)
-    Trace.objects.filter(pk=pending.pk).update(timestamp=WHEN)
+    _usage(team, quantity=500)
+    _usage(team, quantity=999, at=timezone.make_aware(datetime(2026, 4, 30, 23, 59)))
 
     response = superuser_client.get(reverse("ocs_admin:provider_usage_api"), DATE_RANGE)
 
     alpha = {t["team_name"]: t for t in response.json()["teams"]}["Alpha"]
-    assert alpha["run_count"] == 1
     assert alpha["total_tokens"] == 500

--- a/apps/admin/tests/test_queries.py
+++ b/apps/admin/tests/test_queries.py
@@ -19,8 +19,9 @@ from apps.admin.queries import (
 )
 from apps.admin.views import _compute_growth
 from apps.channels.models import ChannelPlatform
-from apps.trace.models import Trace, TraceStatus
+from apps.cost_tracking.models import ServiceKind, UsageSource
 from apps.utils.factories.channels import ExperimentChannelFactory
+from apps.utils.factories.cost_tracking import UsageRecordFactory
 from apps.utils.factories.documents import CollectionFactory
 from apps.utils.factories.evaluations import (
     EvaluationConfigFactory,
@@ -34,7 +35,6 @@ from apps.utils.factories.experiment import (
     ParticipantFactory,
 )
 from apps.utils.factories.team import MembershipFactory, TeamFactory
-from apps.utils.factories.traces import TraceFactory
 
 
 @pytest.fixture()
@@ -91,20 +91,12 @@ class TestTeamMetadataExports:
         settings.TEAM_METADATA_FIELDS = [{"key": "team_owner", "label": "Team Owner"}]
         start, end = date_range
         team = TeamFactory.create(name="Team A", metadata={"team_owner": "Jane Doe"})
-        session = ExperimentSessionFactory.create(team=team, experiment__team=team)
-        TraceFactory.create(
-            team=team,
-            experiment=session.experiment,
-            session=session,
-            participant=session.participant,
-            status=TraceStatus.SUCCESS,
-            n_total_tokens=100,
-        )
+        UsageRecordFactory.create(team=team, quantity=100)
 
         csv_output = usage_to_csv(start, end)
         lines = csv_output.strip().splitlines()
-        assert lines[0] == "Team,Run Count,Total Tokens,Team Owner"
-        assert lines[1] == "Team A,1,100,Jane Doe"
+        assert lines[0] == "Team,Total Tokens,Team Owner"
+        assert lines[1] == "Team A,100,Jane Doe"
 
     def test_team_metadata_csv_lists_all_teams(self, settings):
         settings.TEAM_METADATA_FIELDS = [{"key": "team_owner", "label": "Team Owner"}]
@@ -388,95 +380,53 @@ class TestGetWhatsappNumberData:
 
 @pytest.mark.django_db()
 class TestGetUsageData:
-    def _make_trace(self, *, session, status=TraceStatus.SUCCESS, tokens=0):
-        return TraceFactory.create(
-            team=session.team,
-            experiment=session.experiment,
-            session=session,
-            participant=session.participant,
-            status=status,
-            n_total_tokens=tokens,
-        )
-
-    def test_sums_tokens_and_counts_runs_per_team(self, date_range):
+    def test_sums_tokens_per_team(self, date_range):
         start, end = date_range
         team_a = TeamFactory.create(name="Team A")
         team_b = TeamFactory.create(name="Team B")
-        session_a = ExperimentSessionFactory.create(team=team_a, experiment__team=team_a)
-        session_b = ExperimentSessionFactory.create(team=team_b, experiment__team=team_b)
 
-        self._make_trace(session=session_a, tokens=100)
-        self._make_trace(session=session_a, tokens=50)
-        self._make_trace(session=session_b, tokens=200)
+        UsageRecordFactory.create(team=team_a, quantity=100)
+        UsageRecordFactory.create(team=team_a, quantity=50)
+        UsageRecordFactory.create(team=team_b, quantity=200)
 
-        rows = {team: (run_count, tokens) for team, run_count, tokens, _ in get_usage_data(start, end)}
-        assert rows["Team A"] == (2, 150)
-        assert rows["Team B"] == (1, 200)
+        rows = {team: tokens for team, tokens, _ in get_usage_data(start, end)}
+        assert rows == {"Team A": 150, "Team B": 200}
 
-    def test_orders_by_run_count_descending(self, date_range):
+    def test_sums_across_service_kinds(self, date_range):
+        """One LLM call is split into per-kind rows; the team total is every kind."""
+        start, end = date_range
+        team = TeamFactory.create(name="T")
+        UsageRecordFactory.create(team=team, service_kind=ServiceKind.LLM_INPUT, quantity=90)
+        UsageRecordFactory.create(team=team, service_kind=ServiceKind.LLM_CACHED_INPUT, quantity=10)
+        UsageRecordFactory.create(team=team, service_kind=ServiceKind.LLM_OUTPUT, quantity=25)
+
+        assert list(get_usage_data(start, end)) == [("T", 125, {})]
+
+    def test_orders_by_tokens_descending(self, date_range):
         start, end = date_range
         team_small = TeamFactory.create(name="Small")
         team_big = TeamFactory.create(name="Big")
-        small_session = ExperimentSessionFactory.create(team=team_small, experiment__team=team_small)
-        big_session = ExperimentSessionFactory.create(team=team_big, experiment__team=team_big)
+        UsageRecordFactory.create(team=team_small, quantity=10)
+        UsageRecordFactory.create(team=team_big, quantity=30)
 
-        self._make_trace(session=small_session, tokens=10)
-        for _ in range(3):
-            self._make_trace(session=big_session, tokens=10)
+        assert [row[0] for row in get_usage_data(start, end)] == ["Big", "Small"]
 
-        result = list(get_usage_data(start, end))
-        assert [row[0] for row in result] == ["Big", "Small"]
-
-    def test_includes_evaluations_platform(self, date_range):
-        # Eval traffic bills like any other traffic, and the cost half of the usage
-        # report counts it, so the token half must too.
+    def test_includes_untraced_evaluation_spend(self, date_range):
+        """Judge calls bypass the tracer, so they have no trace to be counted through —
+        reading UsageRecord is what puts their tokens in the report at all (ADR-0048)."""
         start, end = date_range
         team = TeamFactory.create(name="T")
-        web_channel = ExperimentChannelFactory.create(team=team, platform=ChannelPlatform.WEB)
-        eval_channel = ExperimentChannelFactory.create(team=team, platform=ChannelPlatform.EVALUATIONS)
-        web_session = ExperimentSessionFactory.create(
-            team=team,
-            experiment=web_channel.experiment,
-            experiment_channel=web_channel,
-            platform=ChannelPlatform.WEB,
-        )
-        eval_session = ExperimentSessionFactory.create(
-            team=team,
-            experiment=eval_channel.experiment,
-            experiment_channel=eval_channel,
-            platform=ChannelPlatform.EVALUATIONS,
-        )
-        self._make_trace(session=web_session, tokens=100)
-        self._make_trace(session=eval_session, tokens=400)
+        UsageRecordFactory.create(team=team, quantity=100)
+        UsageRecordFactory.create(team=team, quantity=400, source=UsageSource.EVALUATION, trace=None)
 
-        rows = list(get_usage_data(start, end))
-        assert rows == [("T", 2, 500, {})]
+        assert list(get_usage_data(start, end)) == [("T", 500, {})]
 
-    def test_excludes_pending_traces_but_includes_errors(self, date_range):
+    def test_handles_null_quantity(self, date_range):
         start, end = date_range
         team = TeamFactory.create(name="T")
-        session = ExperimentSessionFactory.create(team=team, experiment__team=team)
-        self._make_trace(session=session, status=TraceStatus.SUCCESS, tokens=10)
-        self._make_trace(session=session, status=TraceStatus.ERROR, tokens=5)
-        self._make_trace(session=session, status=TraceStatus.PENDING, tokens=99999)
+        UsageRecordFactory.create(team=team, quantity=None)
 
-        rows = list(get_usage_data(start, end))
-        assert rows == [("T", 2, 15, {})]
-
-    def test_handles_null_token_counts(self, date_range):
-        start, end = date_range
-        team = TeamFactory.create(name="T")
-        session = ExperimentSessionFactory.create(team=team, experiment__team=team)
-        TraceFactory.create(
-            team=team,
-            experiment=session.experiment,
-            session=session,
-            status=TraceStatus.SUCCESS,
-            n_total_tokens=None,
-        )
-
-        rows = list(get_usage_data(start, end))
-        assert rows == [("T", 1, 0, {})]
+        assert list(get_usage_data(start, end)) == [("T", 0, {})]
 
     def test_does_not_merge_teams_sharing_a_display_name(self, date_range):
         # Team.name has no uniqueness constraint, so grouping by name alone would
@@ -484,33 +434,21 @@ class TestGetUsageData:
         start, end = date_range
         team_one = TeamFactory.create(name="Duplicate")
         team_two = TeamFactory.create(name="Duplicate")
-        session_one = ExperimentSessionFactory.create(team=team_one, experiment__team=team_one)
-        session_two = ExperimentSessionFactory.create(team=team_two, experiment__team=team_two)
-
-        self._make_trace(session=session_one, tokens=10)
-        self._make_trace(session=session_two, tokens=20)
-        self._make_trace(session=session_two, tokens=30)
+        UsageRecordFactory.create(team=team_one, quantity=10)
+        UsageRecordFactory.create(team=team_two, quantity=20)
+        UsageRecordFactory.create(team=team_two, quantity=30)
 
         rows = list(get_usage_data(start, end))
-        assert len(rows) == 2
-        token_totals = sorted(row[2] for row in rows)
-        run_counts = sorted(row[1] for row in rows)
-        assert token_totals == [10, 50]
-        assert run_counts == [1, 2]
+        assert sorted(row[1] for row in rows) == [10, 50]
         assert all(row[0] == "Duplicate" for row in rows)
 
     def test_filters_by_date_range(self, date_range):
         start, end = date_range
         team = TeamFactory.create(name="T")
-        session = ExperimentSessionFactory.create(team=team, experiment__team=team)
-        in_window = self._make_trace(session=session, tokens=10)
-        out_of_window = self._make_trace(session=session, tokens=99999)
-        # Trace.timestamp uses auto_now_add; bypass via update()
-        Trace.objects.filter(id=out_of_window.id).update(timestamp=start - timedelta(seconds=1))
-        Trace.objects.filter(id=in_window.id).update(timestamp=start + timedelta(seconds=1))
+        UsageRecordFactory.create(team=team, quantity=10, at=start + timedelta(seconds=1))
+        UsageRecordFactory.create(team=team, quantity=99999, at=start - timedelta(seconds=1))
 
-        rows = list(get_usage_data(start, end))
-        assert rows == [("T", 1, 10, {})]
+        assert list(get_usage_data(start, end)) == [("T", 10, {})]
 
 
 class TestComputeGrowth:

--- a/apps/admin/views.py
+++ b/apps/admin/views.py
@@ -550,8 +550,8 @@ def users_api(request):
 
 @superuser_or_reporting_token
 def provider_usage_api(request):
-    """Cross-team LLM usage over a date range: per-team token totals merged with
-    per-model cost detail where cost tracking is enabled. Requires `range_type`,
+    """Cross-team LLM usage over a date range: per-team token + cost totals with
+    per-model detail, all read from recorded UsageRecords. Requires `range_type`,
     `start`, and `end` query params (as the dashboard date-range form).
     """
     result = _validated_range(request)

--- a/apps/service_providers/tracing/tests/conftest.py
+++ b/apps/service_providers/tracing/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+from django.core.cache import cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Redis state doesn't roll back with the test DB, so a PricingRule seeded by one
+    test stays in the resolver cache for the next one — which then writes a
+    UsageRecord pointing at a rolled-back rule id. Mirrors the cost_tracking fixture.
+    """
+    cache.clear()
+    yield
+    cache.clear()

--- a/apps/service_providers/tracing/tests/test_ocs_tracer_cost.py
+++ b/apps/service_providers/tracing/tests/test_ocs_tracer_cost.py
@@ -17,16 +17,23 @@ from apps.trace.models import Trace, TraceStatus
 from apps.utils.factories.experiment import ExperimentSessionFactory
 
 
-def _llm_result(input_tokens: int, output_tokens: int, model: str = "test-model") -> LLMResult:
-    message = AIMessage(
-        content="response",
-        usage_metadata={
-            "input_tokens": input_tokens,
-            "output_tokens": output_tokens,
-            "total_tokens": input_tokens + output_tokens,
-        },
-        response_metadata={"model_name": model},
-    )
+def _llm_result(
+    input_tokens: int, output_tokens: int, model: str = "test-model", input_token_details: dict | None = None
+) -> LLMResult:
+    usage_metadata = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+    }
+    if input_token_details:
+        usage_metadata["input_token_details"] = input_token_details
+    message = AIMessage(content="response", usage_metadata=usage_metadata, response_metadata={"model_name": model})
+    return LLMResult(generations=[[ChatGeneration(message=message, text="response")]], llm_output=None)
+
+
+def _bare_llm_result() -> LLMResult:
+    """A response with no `usage_metadata` — routes to the ESTIMATED fallback."""
+    message = AIMessage(content="response", response_metadata={"model_name": "test-model"})
     return LLMResult(generations=[[ChatGeneration(message=message, text="response")]], llm_output=None)
 
 
@@ -121,6 +128,60 @@ class TestCostRecordingEndToEnd:
         assert by_kind[ServiceKind.LLM_OUTPUT].cost == Decimal("0.00030000")
         assert all(r.trace_id is not None for r in rows)
         assert all(r.session_id == session.id for r in rows)
+
+    def test_usage_record_quantity_matches_trace_token_count(self, experiment):
+        """Both counts come from the same `usage_metadata`, so they agree even with the
+        cache sub-buckets split out: `_split_buckets` subtracts cache_read/cache_creation
+        from the headline input and gives them their own rows, which sum back to it.
+        This is why the admin report can read tokens off UsageRecord.
+        """
+        tracer = OCSTracer(experiment, experiment.team_id)
+        session = ExperimentSessionFactory.create(experiment=experiment, team=experiment.team)
+        ctx = TraceContext(id=uuid4(), name="t")
+        run_id = uuid4()
+
+        with tracer.trace(trace_context=ctx, session=session):
+            tracer.metrics_collector.on_llm_start(
+                {},
+                ["hello world"],
+                run_id=run_id,
+                invocation_params={"model": "test-model"},
+                metadata={"ocs_provider_type": "openai"},
+            )
+            tracer.metrics_collector.on_llm_end(
+                _llm_result(1000, 500, input_token_details={"cache_read": 300, "cache_creation": 200}),
+                run_id=run_id,
+            )
+
+        trace_row = Trace.objects.get(team_id=experiment.team_id, trace_id=ctx.id)
+        recorded = sum(row.quantity for row in UsageRecord.objects.filter(trace=trace_row))
+        assert trace_row.n_total_tokens == 1500
+        assert recorded == trace_row.n_total_tokens
+
+    def test_estimated_tokens_are_recorded_but_absent_from_the_trace(self, experiment):
+        """A call with no `usage_metadata` is estimated into UsageRecord, while the trace
+        counter only sums reported usage — the report reads the source that covers a call
+        the trace counter has no number for at all.
+        """
+        tracer = OCSTracer(experiment, experiment.team_id)
+        session = ExperimentSessionFactory.create(experiment=experiment, team=experiment.team)
+        ctx = TraceContext(id=uuid4(), name="t")
+        run_id = uuid4()
+
+        with tracer.trace(trace_context=ctx, session=session):
+            tracer.metrics_collector.on_llm_start(
+                {},
+                ["hello world"],
+                run_id=run_id,
+                invocation_params={"model": "test-model"},
+                metadata={"ocs_provider_type": "openai"},
+            )
+            tracer.metrics_collector.on_llm_end(_bare_llm_result(), run_id=run_id)
+
+        trace_row = Trace.objects.get(team_id=experiment.team_id, trace_id=ctx.id)
+        recorded = sum(row.quantity for row in UsageRecord.objects.filter(trace=trace_row))
+        assert trace_row.n_total_tokens is None
+        assert recorded > 0
 
     def test_trace_finalisation_continues_when_recorder_fails(self, experiment):
         """A cost-recording failure must not block trace_record.save() —

--- a/docs/adr/0050-eval-driven-generation-is-evaluation-spend.md
+++ b/docs/adr/0050-eval-driven-generation-is-evaluation-spend.md
@@ -31,7 +31,7 @@ We will bill eval-driven generation as evaluation spend, and record it without a
 - The read path is untouched: keying on `source` alone (ADR-0048) already answers correctly for every consumer.
 - An eval session's own cost page reports $0, since both halves of its spend are now `EVALUATION`; surfacing it is [#3981](https://github.com/dimagi/open-chat-studio/issues/3981).
 - "What did evaluating this cost?" now covers a whole run, not just the judging.
-- The admin report's halves diverge further: cost counts eval runs, tokens come from `Trace` and cannot, until [#3984](https://github.com/dimagi/open-chat-studio/issues/3984) moves token reporting onto `UsageRecord`.
+- The admin report's halves diverged further while its tokens came from `Trace`: cost counted eval runs and tokens could not. [#3984](https://github.com/dimagi/open-chat-studio/issues/3984) closed that by moving token reporting onto `UsageRecord`, so both halves now read the same rows.
 - Eval runs still write no trace, so debugging a failing one stays as hard as it was.
 - A tracer now exists that keeps no trace, so "tracer implies `Trace` row" is no longer true.
 


### PR DESCRIPTION
Closes #3984. Follow-up to #3978 (ADR-0048) and #3985 (ADR-0050).

The cross-team usage report summed tokens from `Trace` and cost from `UsageRecord`, so its two halves could not be reconciled. ADR-0050 made that worse: an eval run now writes no `Trace` at all — judge calls bypass the tracer and generation is billed by `UsageOnlyTracer` — so eval tokens landed nowhere while eval cost was counted.

### Product Description

Token totals in the cross-team usage report and CSV export now reconcile with the cost figures beside them, and include evaluation spend that previously went uncounted. `run_count` is gone from both surfaces.

### Technical Description

Everything reads `UsageRecord` now. `build_usage_report` derives each team's `total_tokens` by summing the per-model rows it already fetches, so `total_tokens == sum(models[].tokens)` holds by construction rather than by coincidence — that also drops a query and the dead "team in the cost half but not the token half" back-fill.

Two things worth reviewer attention:

**The reporting API response shape changes.** `run_count` is gone from `teams[]`, and the usage CSV header goes from `Team,Run Count,Total Tokens` to `Team,Total Tokens`. A run is a trace concept — `UsageRecord.trace_id` is null for untraced writers, so counting distinct traces would undercount activity rather than move cleanly. `PROVIDER_REPORTING_API_TOKEN` implies a headless consumer, so anything reading `run_count` breaks and a saved CSV import shifts columns. Both were sanctioned on the issue; flagging because AGENTS.md treats removing a public API field as ask-first.

**Pre-rollout periods now report zero tokens**, since `UsageRecord` only goes back to the cost-tracking rollout while `Trace` goes further back. Deliberate (issue: "no special action required") and there is precedent in the same docstring for this kind of step.

Where the totals land relative to the old ones, verified rather than assumed — two tests in `test_ocs_tracer_cost.py` pin it:

- Exact usage agrees to the token even with cache sub-buckets, because `_split_buckets` subtracts `cache_read`/`cache_creation` out of the headline input into their own rows and those sum back to it.
- A call with no `usage_metadata` is estimated into `UsageRecord` but absent from `n_total_tokens`, which only sums reported usage.

Those tests seed `PricingRule`s, so the tracing suite gets the same autouse cache-clearing fixture `apps/cost_tracking/tests` already has — Redis doesn't roll back with the test DB, so a cached rule outlives the row it points at.

Out of scope: `templates/trace/trace_detail.html` keeps showing one trace's own counts — legitimately per-trace.

Also touched one stale ADR-0050 consequence line that named this issue as the open fix.

### Migrations

None.

### Demo

Against seeded dev data, both surfaces return the reconciling numbers (`35600 + 0 + 400 == 36000`):

```
GET /admin/api/provider-usage/  ->  "total_tokens": 36000, models: gpt-4o 35600, legacy-model-y 0, experimental-model-x 400
GET /admin/export/usage/        ->  Team,Total Tokens,Team Owner
                                    Test Team,36000,
```

### Docs and Changelog
- [x] This PR requires docs/changelog update

`run_count` is removed from the provider usage API response and the usage CSV export; token totals now include evaluation spend and are only available from the cost-tracking rollout onward.
