### PR TITLE
Read trace token counts from UsageRecord

### DIFF
--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -15,6 +15,7 @@ from django.db.models.functions import Coalesce, TruncDate, TruncMonth, TruncWee
 from apps.cost_tracking.models import Confidence, ServiceKind, UsageRecord, UsageSource
 from apps.experiments.models import ExperimentSession
 from apps.teams.models import Team
+from apps.trace.models import Trace
 
 logger = logging.getLogger("ocs.cost_tracking")
 
@@ -86,6 +87,40 @@ class SessionUsage:
 
     total_cost: Decimal
     by_model: list[ModelSpend]
+
+
+@dataclass(frozen=True)
+class ModelTokens:
+    """One (provider, model) row of a trace's token breakdown. `input_tokens` is fresh input only —
+    `cached_input_tokens` and `cache_write_tokens` are the sub-buckets the recorder peels off it, so
+    the row's input side is the sum of all three."""
+
+    provider_type: str
+    model_name: str
+    input_tokens: int
+    cached_input_tokens: int
+    cache_write_tokens: int
+    output_tokens: int
+
+    @property
+    def total_input_tokens(self) -> int:
+        return self.input_tokens + self.cached_input_tokens + self.cache_write_tokens
+
+
+@dataclass(frozen=True)
+class TraceTokenUsage:
+    """A single trace's token usage: the input/output headline plus a per-model breakdown.
+    An empty `by_model` means no usage was recorded for the trace at all, which the trace
+    detail page renders as "no data" rather than as zero.
+
+    The headline is a two-way split, so unlike the usage API's `TokenCounts` it folds cache-write
+    into `input_tokens`: every kind lands on one side or the other, which keeps
+    `input_tokens + output_tokens == total` and reproduces the provider's headline input count."""
+
+    input_tokens: int
+    output_tokens: int
+    total: int
+    by_model: list[ModelTokens]
 
 
 @dataclass(frozen=True)
@@ -304,6 +339,49 @@ def session_usage(session: ExperimentSession) -> SessionUsage:
     return SessionUsage(total_cost=total_cost, by_model=by_model)
 
 
+def trace_token_usage(trace: Trace) -> TraceTokenUsage:
+    """Token usage for a single trace, grouped by (provider, model).
+
+    This is the source the trace detail page reads now that the counts no longer live on the
+    `Trace` row. It covers more than those counters did — estimated calls are recorded here too
+    — and splits by model, which a per-trace total could not.
+
+    Scoped by `trace` alone (a trace id is unique, and the FK is indexed); the caller has already
+    team-scoped the trace, and `Trace.team` is nullable while `UsageRecord.team` is not, so
+    re-filtering on it would drop rows for a trace whose team was deleted.
+    """
+    rows = (
+        UsageRecord.objects.filter(trace=trace)
+        .values("provider_type", "model_name")
+        .annotate(
+            input_tokens=_kind_quantity(ServiceKind.LLM_INPUT),
+            cached_input_tokens=_kind_quantity(ServiceKind.LLM_CACHED_INPUT),
+            cache_write_tokens=_kind_quantity(ServiceKind.LLM_CACHE_WRITE),
+            output_tokens=_kind_quantity(ServiceKind.LLM_OUTPUT),
+        )
+        .order_by("provider_type", "model_name")
+    )
+    by_model = [
+        ModelTokens(
+            provider_type=row["provider_type"],
+            model_name=row["model_name"],
+            input_tokens=int(row["input_tokens"]),
+            cached_input_tokens=int(row["cached_input_tokens"]),
+            cache_write_tokens=int(row["cache_write_tokens"]),
+            output_tokens=int(row["output_tokens"]),
+        )
+        for row in rows
+    ]
+    input_tokens = sum(row.total_input_tokens for row in by_model)
+    output_tokens = sum(row.output_tokens for row in by_model)
+    return TraceTokenUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total=input_tokens + output_tokens,
+        by_model=by_model,
+    )
+
+
 def coverage_gaps(team: Team, *, start: datetime, end: datetime, filters: CostFilters | None = None) -> CoverageGaps:
     """The models behind the period's unpriced / no-usage warnings, so the
     panel can list which models are responsible. Single grouped query over the
@@ -464,6 +542,11 @@ def _single_currency(scoped) -> str:
     a mix — the same single-currency assumption ``cost_total`` makes."""
     currencies = list(scoped.values_list("currency", flat=True).distinct())
     return currencies[0] if len(currencies) == 1 else "USD"
+
+
+def _kind_quantity(kind: ServiceKind):
+    """Summed `quantity` for one service kind, zero when the group has no such rows."""
+    return Coalesce(Sum("quantity", filter=Q(service_kind=kind)), _ZERO, output_field=_QUANTITY_FIELD)
 
 
 def _coverage_gap_from_row(row: dict, call_count: int) -> ModelCoverageGap:

--- a/apps/cost_tracking/tests/test_reporting.py
+++ b/apps/cost_tracking/tests/test_reporting.py
@@ -19,12 +19,14 @@ from apps.cost_tracking.services.reporting import (
     coverage_gaps,
     session_usage,
     token_counts,
+    trace_token_usage,
     usage_by_group,
     usage_timeseries,
 )
 from apps.utils.factories.cost_tracking import UsageRecordFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.team import TeamFactory
+from apps.utils.factories.traces import TraceFactory
 
 _NOW = datetime(2026, 6, 15, 12, 0, tzinfo=UTC)
 # The 30-day window most tests read over, named where a test needs it inside a lambda.
@@ -230,6 +232,106 @@ class TestSessionUsage:
         usage = session_usage(session)
 
         assert usage.total_cost == Decimal("1.00000000")
+        assert len(usage.by_model) == 1
+
+
+@pytest.mark.django_db()
+class TestTraceTokenUsage:
+    """Per-trace token breakdown — the trace detail page's token card."""
+
+    def test_empty_when_no_records(self):
+        team = TeamFactory.create()
+        trace = TraceFactory.create(team=team)
+
+        usage = trace_token_usage(trace)
+
+        assert usage.by_model == []
+        assert usage.total == 0
+
+    def test_splits_input_and_output(self):
+        team = TeamFactory.create()
+        trace = TraceFactory.create(team=team)
+        _usage(team, cost="0", when=_NOW, trace=trace, quantity=1000, service_kind=ServiceKind.LLM_INPUT)
+        _usage(team, cost="0", when=_NOW, trace=trace, quantity=500, service_kind=ServiceKind.LLM_OUTPUT)
+
+        usage = trace_token_usage(trace)
+
+        assert usage.input_tokens == 1000
+        assert usage.output_tokens == 500
+        assert usage.total == 1500
+
+    def test_cache_kinds_count_as_input(self):
+        """The card's two-way split folds both cache buckets into input, so the headline
+        total matches what the provider reported for the call."""
+        team = TeamFactory.create()
+        trace = TraceFactory.create(team=team)
+        _usage(team, cost="0", when=_NOW, trace=trace, quantity=500, service_kind=ServiceKind.LLM_INPUT)
+        _usage(team, cost="0", when=_NOW, trace=trace, quantity=300, service_kind=ServiceKind.LLM_CACHED_INPUT)
+        _usage(team, cost="0", when=_NOW, trace=trace, quantity=200, service_kind=ServiceKind.LLM_CACHE_WRITE)
+        _usage(team, cost="0", when=_NOW, trace=trace, quantity=400, service_kind=ServiceKind.LLM_OUTPUT)
+
+        usage = trace_token_usage(trace)
+
+        assert usage.input_tokens == 1000
+        assert usage.output_tokens == 400
+        assert usage.total == 1400
+        row = usage.by_model[0]
+        assert (row.input_tokens, row.cached_input_tokens, row.cache_write_tokens) == (500, 300, 200)
+
+    def test_groups_by_provider_and_model(self):
+        team = TeamFactory.create()
+        trace = TraceFactory.create(team=team)
+        for provider, model, kind, qty in [
+            ("openai", "gpt-4o", ServiceKind.LLM_INPUT, 100),
+            ("openai", "gpt-4o", ServiceKind.LLM_OUTPUT, 40),
+            ("anthropic", "claude-haiku-4-5", ServiceKind.LLM_INPUT, 70),
+        ]:
+            _usage(
+                team,
+                cost="0",
+                when=_NOW,
+                trace=trace,
+                provider_type=provider,
+                model_name=model,
+                service_kind=kind,
+                quantity=qty,
+            )
+
+        usage = trace_token_usage(trace)
+
+        assert [(m.provider_type, m.model_name, m.total_input_tokens, m.output_tokens) for m in usage.by_model] == [
+            ("anthropic", "claude-haiku-4-5", 70, 0),
+            ("openai", "gpt-4o", 100, 40),
+        ]
+
+    def test_scoped_to_trace(self):
+        team = TeamFactory.create()
+        trace = TraceFactory.create(team=team)
+        other = TraceFactory.create(team=team)
+        _usage(team, cost="0", when=_NOW, trace=trace, quantity=100, service_kind=ServiceKind.LLM_INPUT)
+        _usage(team, cost="0", when=_NOW, trace=other, quantity=900, service_kind=ServiceKind.LLM_INPUT)
+        _usage(team, cost="0", when=_NOW, quantity=900, service_kind=ServiceKind.LLM_INPUT)  # untraced
+
+        assert trace_token_usage(trace).total == 100
+
+    def test_unknown_confidence_rows_count_as_zero(self):
+        """A call with no usage data is recorded with `quantity=None`; it must not
+        blow up the sum or make the card claim tokens it doesn't have."""
+        team = TeamFactory.create()
+        trace = TraceFactory.create(team=team)
+        _usage(
+            team,
+            cost="0",
+            when=_NOW,
+            trace=trace,
+            quantity=None,
+            confidence=Confidence.UNKNOWN,
+            service_kind=ServiceKind.LLM_INPUT,
+        )
+
+        usage = trace_token_usage(trace)
+
+        assert usage.total == 0
         assert len(usage.by_model) == 1
 
 

--- a/apps/service_providers/tracing/metrics.py
+++ b/apps/service_providers/tracing/metrics.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
-from langchain_core.callbacks import UsageMetadataCallbackHandler
+from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.messages.utils import count_tokens_approximately
 
 from apps.cost_tracking.models import Confidence, ServiceKind
@@ -31,31 +31,29 @@ class TraceMetrics:
 
     n_turns: int | None = None
     n_toolcalls: int | None = None
-    n_total_tokens: int | None = None
-    n_prompt_tokens: int | None = None
-    n_completion_tokens: int | None = None
 
 
-class MetricsCollector(UsageMetadataCallbackHandler):
+class MetricsCollector(BaseCallbackHandler):
     """Thread-safe accumulator for pipeline execution metrics.
 
-    Collects turn counts, tool call counts, and token usage across all LLM
-    calls in a pipeline execution. Token usage is inherited from
-    UsageMetadataCallbackHandler, which reads AIMessage.usage_metadata — the
-    standard location populated by modern LangChain chat-model integrations
-    (including OpenAI's Responses API, where LLMResult.llm_output is None).
+    Counts turns and tool calls for the `Trace` row, and accumulates token
+    usage for `UsageRecord`. Those are the only two destinations: the trace
+    carries no token counters of its own, since per-(provider, model) rows
+    cover more calls and answer more questions than one summed integer could.
 
     Counter access is protected by a threading lock because LangGraph
     executes nodes in threads via DjangoSafeContextThreadPoolExecutor.
 
-    Cost tracking extension: holds per-call pending state keyed by `run_id`
-    so `on_llm_end` can attribute each response to its originating
-    (provider, model). EXACT usage routes to `_exact_usage`; missing usage
-    routes to `_fallback_usage` with ESTIMATED confidence (tiktoken for
-    OPENAI_FAMILY, count_tokens_approximately for everything else) — only
-    falls back to UNKNOWN when prompts are also empty. Both buckets are
-    keyed by (provider, model) so the same model name routed through two
-    different providers in one trace gets billed separately.
+    Token usage is read from AIMessage.usage_metadata — the standard location
+    populated by modern LangChain chat-model integrations (including OpenAI's
+    Responses API, where LLMResult.llm_output is None). Per-call pending state
+    is keyed by `run_id` so `on_llm_end` can attribute each response to its
+    originating (provider, model). EXACT usage routes to `_exact_usage`;
+    missing usage routes to `_fallback_usage` with ESTIMATED confidence
+    (tiktoken for OPENAI_FAMILY, count_tokens_approximately for everything
+    else) — only falls back to UNKNOWN when prompts are also empty. Both
+    buckets are keyed by (provider, model) so the same model name routed
+    through two different providers in one trace gets billed separately.
     `iter_cost_events()` drains both into `UsageEvent`s.
     """
 
@@ -64,8 +62,7 @@ class MetricsCollector(UsageMetadataCallbackHandler):
         self._counter_lock = threading.Lock()
         self._turns = 0
         self._toolcalls = 0
-        # Cost-tracking state. All access guarded by `_counter_lock`; the
-        # parent's `_lock` covers `self.usage_metadata` separately.
+        # Cost-tracking state. All access guarded by `_counter_lock`.
         self._pending_calls: dict[UUID, dict[str, Any]] = {}
         self._exact_usage: dict[tuple[str, str], dict[str, Any]] = {}
         self._fallback_usage: dict[tuple[str, str, Confidence], dict[str, int]] = {}
@@ -102,9 +99,6 @@ class MetricsCollector(UsageMetadataCallbackHandler):
             }
 
     def on_llm_end(self, response, *, run_id: UUID | None = None, **kwargs: Any) -> None:
-        # Parent still tracks self.usage_metadata for get_metrics()'s
-        # token totals; the cost path uses our own (provider, model) buckets.
-        super().on_llm_end(response, run_id=run_id, **kwargs)
         if run_id is None:
             return
         with self._counter_lock:
@@ -174,21 +168,7 @@ class MetricsCollector(UsageMetadataCallbackHandler):
         with self._counter_lock:
             turns = self._turns
             toolcalls = self._toolcalls
-        prompt_tokens, completion_tokens, total_tokens = self._sum_token_counts()
-        return TraceMetrics(
-            n_turns=turns or None,
-            n_toolcalls=toolcalls or None,
-            n_total_tokens=total_tokens or None,
-            n_prompt_tokens=prompt_tokens or None,
-            n_completion_tokens=completion_tokens or None,
-        )
-
-    def _sum_token_counts(self) -> tuple[int, int, int]:
-        with self._lock:
-            prompt = sum(u.get("input_tokens", 0) for u in self.usage_metadata.values())
-            completion = sum(u.get("output_tokens", 0) for u in self.usage_metadata.values())
-            total = sum(u.get("total_tokens", 0) for u in self.usage_metadata.values())
-        return prompt, completion, total
+        return TraceMetrics(n_turns=turns or None, n_toolcalls=toolcalls or None)
 
 
 def _estimate_tokens(provider: str, model: str, prompts: list[str], response) -> tuple[int, int]:

--- a/apps/service_providers/tracing/ocs_tracer.py
+++ b/apps/service_providers/tracing/ocs_tracer.py
@@ -149,9 +149,6 @@ class OCSTracer(Tracer):
         metrics = self.metrics_collector.get_metrics()
         self.trace_record.n_turns = metrics.n_turns
         self.trace_record.n_toolcalls = metrics.n_toolcalls
-        self.trace_record.n_total_tokens = metrics.n_total_tokens
-        self.trace_record.n_prompt_tokens = metrics.n_prompt_tokens
-        self.trace_record.n_completion_tokens = metrics.n_completion_tokens
 
     def _record_costs(self) -> None:
         """Drain the collector's accumulated usage into UsageRecord rows.

--- a/apps/service_providers/tracing/tests/test_metrics_collector.py
+++ b/apps/service_providers/tracing/tests/test_metrics_collector.py
@@ -66,43 +66,6 @@ class TestMetricsCollectorToolCalls:
         assert metrics.n_toolcalls is None
 
 
-class TestMetricsCollectorTokens:
-    def test_accumulates_tokens_across_calls(self):
-        collector = MetricsCollector(start_time=time.time())
-        collector.on_llm_end(_make_llm_result(100, 50))
-        collector.on_llm_end(_make_llm_result(200, 100))
-
-        metrics = collector.get_metrics()
-        assert metrics.n_prompt_tokens == 300
-        assert metrics.n_completion_tokens == 150
-        assert metrics.n_total_tokens == 450
-
-    def test_accumulates_tokens_across_models(self):
-        collector = MetricsCollector(start_time=time.time())
-        collector.on_llm_end(_make_llm_result(100, 50, model_name="gpt-4.1-mini"))
-        collector.on_llm_end(_make_llm_result(80, 40, model_name="claude-haiku-4-5"))
-
-        metrics = collector.get_metrics()
-        assert metrics.n_prompt_tokens == 180
-        assert metrics.n_completion_tokens == 90
-        assert metrics.n_total_tokens == 270
-
-    def test_missing_usage_metadata_handled(self):
-        collector = MetricsCollector(start_time=time.time())
-        collector.on_llm_start({}, ["prompt"])
-        message = AIMessage(content="response", response_metadata={"model_name": "gpt-4.1-mini"})
-        collector.on_llm_end(LLMResult(generations=[[ChatGeneration(message=message)]]))
-
-        metrics = collector.get_metrics()
-        assert metrics.n_turns == 1
-        assert metrics.n_total_tokens is None
-
-    def test_no_llm_calls_tokens_none(self):
-        collector = MetricsCollector(start_time=time.time())
-        metrics = collector.get_metrics()
-        assert metrics.n_total_tokens is None
-
-
 class TestMetricsCollectorThreadSafety:
     def test_concurrent_increments(self):
         collector = MetricsCollector(start_time=time.time())
@@ -129,25 +92,22 @@ class TestMetricsCollectorThreadSafety:
 
 class TestMetricsCollectorZeroToNone:
     """Verify that zero counts are converted to None to distinguish
-    'no LLM calls' from '0 tokens used'."""
+    'no LLM calls' from 'calls that counted nothing'."""
 
     def test_all_zeros_become_none(self):
         collector = MetricsCollector(start_time=time.time())
         metrics = collector.get_metrics()
         assert metrics.n_turns is None
         assert metrics.n_toolcalls is None
-        assert metrics.n_total_tokens is None
 
-    def test_turns_present_but_no_tokens(self):
-        """LLM called but no usage_metadata reported — n_turns is set, n_total_tokens is None."""
+    def test_turn_counted_even_without_usage_metadata(self):
+        """A call the provider reported no usage for is still a turn."""
         collector = MetricsCollector(start_time=time.time())
         collector.on_llm_start({}, ["prompt"])
         message = AIMessage(content="response", response_metadata={"model_name": "gpt-4.1-mini"})
         collector.on_llm_end(LLMResult(generations=[[ChatGeneration(message=message)]]))
 
-        metrics = collector.get_metrics()
-        assert metrics.n_turns == 1
-        assert metrics.n_total_tokens is None
+        assert collector.get_metrics().n_turns == 1
 
 
 # Cost-tracking extension: provider capture, on_llm_end fallback, iter_cost_events
@@ -212,8 +172,7 @@ class TestOnLlmEndFallback:
         collector.on_llm_start({}, **args)
         collector.on_llm_end(_result_with_usage("gpt-4o-mini", 100, 50), run_id=args["run_id"])
         assert collector._fallback_usage == {}
-        # Parent class accumulated usage_metadata.
-        assert sum(u["input_tokens"] for u in collector.usage_metadata.values()) == 100
+        assert collector._exact_usage[("openai", "gpt-4o-mini")]["input_tokens"] == 100
 
     def test_pending_call_cleared_on_end(self):
         collector = MetricsCollector(start_time=time.time())
@@ -278,7 +237,7 @@ class TestOnLlmEndFallback:
 
 
 class TestIterCostEvents:
-    """`iter_cost_events` drains usage_metadata + fallback buckets into UsageEvents."""
+    """`iter_cost_events` drains the exact + fallback buckets into UsageEvents."""
 
     def test_empty_collector_yields_nothing(self):
         collector = MetricsCollector(start_time=time.time())

--- a/apps/service_providers/tracing/tests/test_ocs_tracer_cost.py
+++ b/apps/service_providers/tracing/tests/test_ocs_tracer_cost.py
@@ -129,11 +129,11 @@ class TestCostRecordingEndToEnd:
         assert all(r.trace_id is not None for r in rows)
         assert all(r.session_id == session.id for r in rows)
 
-    def test_usage_record_quantity_matches_trace_token_count(self, experiment):
-        """Both counts come from the same `usage_metadata`, so they agree even with the
-        cache sub-buckets split out: `_split_buckets` subtracts cache_read/cache_creation
-        from the headline input and gives them their own rows, which sum back to it.
-        This is why the admin report can read tokens off UsageRecord.
+    def test_usage_record_quantity_matches_reported_usage(self, experiment):
+        """The recorded rows sum back to the provider's reported total even with the cache
+        sub-buckets split out: `_split_buckets` subtracts cache_read/cache_creation from the
+        headline input and gives them their own rows. This is why UsageRecord is the only
+        token source the reports and the trace detail page need.
         """
         tracer = OCSTracer(experiment, experiment.team_id)
         session = ExperimentSessionFactory.create(experiment=experiment, team=experiment.team)
@@ -155,13 +155,11 @@ class TestCostRecordingEndToEnd:
 
         trace_row = Trace.objects.get(team_id=experiment.team_id, trace_id=ctx.id)
         recorded = sum(row.quantity for row in UsageRecord.objects.filter(trace=trace_row))
-        assert trace_row.n_total_tokens == 1500
-        assert recorded == trace_row.n_total_tokens
+        assert recorded == 1500
 
-    def test_estimated_tokens_are_recorded_but_absent_from_the_trace(self, experiment):
-        """A call with no `usage_metadata` is estimated into UsageRecord, while the trace
-        counter only sums reported usage — the report reads the source that covers a call
-        the trace counter has no number for at all.
+    def test_estimated_tokens_are_recorded(self, experiment):
+        """A call with no `usage_metadata` still lands on UsageRecord, estimated — coverage
+        the trace counters never had, since they only summed reported usage.
         """
         tracer = OCSTracer(experiment, experiment.team_id)
         session = ExperimentSessionFactory.create(experiment=experiment, team=experiment.team)
@@ -180,7 +178,6 @@ class TestCostRecordingEndToEnd:
 
         trace_row = Trace.objects.get(team_id=experiment.team_id, trace_id=ctx.id)
         recorded = sum(row.quantity for row in UsageRecord.objects.filter(trace=trace_row))
-        assert trace_row.n_total_tokens is None
         assert recorded > 0
 
     def test_trace_finalisation_continues_when_recorder_fails(self, experiment):

--- a/apps/service_providers/tracing/tests/test_ocs_tracer_metrics.py
+++ b/apps/service_providers/tracing/tests/test_ocs_tracer_metrics.py
@@ -56,7 +56,6 @@ class TestOCSTracerMetrics:
         trace = Trace.objects.get(trace_id=trace_context.id)
         assert trace.n_turns == 1
         assert trace.n_toolcalls == 1
-        assert trace.n_total_tokens == 150
 
     def test_no_llm_calls_metrics_null(self, experiment):
         tracer = OCSTracer(experiment, experiment.team_id)
@@ -70,7 +69,6 @@ class TestOCSTracerMetrics:
         trace = Trace.objects.get(trace_id=trace_context.id)
         assert trace.n_turns is None
         assert trace.n_toolcalls is None
-        assert trace.n_total_tokens is None
 
     def test_metrics_persisted_on_error(self, experiment):
         tracer = OCSTracer(experiment, experiment.team_id)
@@ -89,7 +87,6 @@ class TestOCSTracerMetrics:
         trace = Trace.objects.get(trace_id=trace_context.id)
         assert trace.status == "error"
         assert trace.n_turns == 1
-        assert trace.n_total_tokens == 70
 
 
 class TestOCSCallbackHandlerMetricsDelegation:
@@ -105,11 +102,19 @@ class TestOCSCallbackHandlerMetricsDelegation:
     def test_on_llm_end_delegates_to_collector(self):
         tracer = OCSTracer(Mock(id=1), team_id=1)
         tracer.metrics_collector = MetricsCollector(start_time=0.0)
+        run_id = uuid4()
 
         handler = OCSCallbackHandler(tracer=tracer)
-        handler.on_llm_end(_llm_result(10, 5))
+        handler.on_llm_start(
+            {},
+            ["prompt"],
+            run_id=run_id,
+            invocation_params={"model": "gpt-4.1-mini"},
+            metadata={"ocs_provider_type": "openai"},
+        )
+        handler.on_llm_end(_llm_result(10, 5), run_id=run_id)
 
-        assert tracer.metrics_collector.get_metrics().n_total_tokens == 15
+        assert tracer.metrics_collector._exact_usage[("openai", "gpt-4.1-mini")]["input_tokens"] == 10
 
     def test_on_tool_start_delegates_to_collector(self):
         tracer = OCSTracer(Mock(id=1), team_id=1)

--- a/apps/trace/models.py
+++ b/apps/trace/models.py
@@ -53,6 +53,8 @@ class Trace(models.Model):
     error = models.TextField(blank=True, help_text="Error message if the trace failed")
     n_turns = models.IntegerField(null=True, blank=True, help_text="Number of LLM calls during pipeline execution")
     n_toolcalls = models.IntegerField(null=True, blank=True, help_text="Number of tool invocations across all turns")
+    # Dormant: nothing reads or writes these any more — token counts come off `UsageRecord`, which
+    # covers estimated calls too and splits by model. Columns dropped in a following release (#3986).
     n_total_tokens = models.IntegerField(null=True, blank=True, help_text="Total tokens (prompt + completion) consumed")
     n_prompt_tokens = models.IntegerField(null=True, blank=True, help_text="Total input/prompt tokens consumed")
     n_completion_tokens = models.IntegerField(

--- a/apps/trace/tests/test_views.py
+++ b/apps/trace/tests/test_views.py
@@ -5,7 +5,9 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from django.urls import reverse
 
+from apps.cost_tracking.models import ServiceKind
 from apps.trace.models import TraceStatus
+from apps.utils.factories.cost_tracking import UsageRecordFactory
 from apps.utils.factories.experiment import ExperimentSessionFactory
 from apps.utils.factories.team import TeamFactory
 from apps.utils.factories.traces import TraceFactory
@@ -56,6 +58,49 @@ def test_trace_detail_view_renders_filter_links(client, team_with_users):
     participant_link = links["participant"]
     assert participant_link["op_participant"] == ["equals"]
     assert participant_link["f_participant"] == [trace.participant.identifier]
+
+
+@pytest.mark.django_db()
+def test_trace_detail_view_reads_tokens_from_usage_records(client, team_with_users):
+    """The token card is fed by UsageRecord rows for the trace, not by counters on the row."""
+    team = team_with_users
+    user = team.members.first()
+    trace = _make_trace(team)
+    UsageRecordFactory.create(
+        team=team, trace=trace, service_kind=ServiceKind.LLM_INPUT, model_name="gpt-4o", quantity=1000
+    )
+    UsageRecordFactory.create(
+        team=team, trace=trace, service_kind=ServiceKind.LLM_CACHED_INPUT, model_name="gpt-4o", quantity=200
+    )
+    UsageRecordFactory.create(
+        team=team, trace=trace, service_kind=ServiceKind.LLM_OUTPUT, model_name="gpt-4o", quantity=500
+    )
+    UsageRecordFactory.create(team=team, trace=_make_trace(team), service_kind=ServiceKind.LLM_INPUT, quantity=999)
+
+    client.force_login(user)
+    response = client.get(reverse("trace:trace_detail", args=[team.slug, trace.pk]))
+
+    assert response.status_code == 200
+    usage = response.context_data["token_usage"]
+    assert (usage.input_tokens, usage.output_tokens, usage.total) == (1200, 500, 1700)
+    content = response.content.decode()
+    assert "1,700" in content
+    assert "gpt-4o" in content
+    assert "200 cached" in content
+
+
+@pytest.mark.django_db()
+def test_trace_detail_view_without_usage_records(client, team_with_users):
+    """No recorded usage renders the card's em dash rather than a zero total."""
+    team = team_with_users
+    user = team.members.first()
+    trace = _make_trace(team)
+
+    client.force_login(user)
+    response = client.get(reverse("trace:trace_detail", args=[team.slug, trace.pk]))
+
+    assert response.status_code == 200
+    assert response.context_data["token_usage"].by_model == []
 
 
 @pytest.mark.django_db()

--- a/apps/trace/views.py
+++ b/apps/trace/views.py
@@ -8,6 +8,7 @@ from django.views.generic import DetailView, TemplateView
 from django_tables2 import SingleTableView
 
 from apps.annotations.models import CustomTaggedItem
+from apps.cost_tracking.services.reporting import trace_token_usage
 from apps.service_providers.tracing.langfuse import get_langfuse_api_client
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 from apps.trace.filters import TraceFilter, get_trace_filter_context_data
@@ -72,6 +73,11 @@ class TraceDetailView(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Detail
             )
             .filter(team=self.request.team)
         )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["token_usage"] = trace_token_usage(self.object)
+        return context
 
 
 class TraceLangfuseSpansView(LoginAndTeamRequiredMixin, PermissionRequiredMixin, DetailView):

--- a/apps/web/management/commands/bootstrap_data.py
+++ b/apps/web/management/commands/bootstrap_data.py
@@ -408,33 +408,7 @@ class Command(BaseCommand):
         priced_model = priced_rule.model_name
         now = timezone.now()
 
-        created = 0
-        # Priced, exact spend: each session bills a little every day, with a
-        # per-session multiplier so bots differ in the Bot Performance table.
-        # Input and output are separate rows, as the recorder writes them.
-        for day in range(_USAGE_DAYS):
-            timestamp = now - timedelta(days=day, hours=3)
-            for idx, session in enumerate(sessions):
-                cost = Decimal("0.02") * (idx + 1) * (1 + day % 3)
-                # Only the latest day belongs to the seeded trace — a trace is one request.
-                trace = None if day else traces.get(session.id)
-                for service_kind, quantity, share in (
-                    (ServiceKind.LLM_INPUT, 400 + 50 * idx, Decimal("0.8")),
-                    (ServiceKind.LLM_OUTPUT, 100 + 20 * idx, Decimal("0.2")),
-                ):
-                    created += self._create_usage_record(
-                        team,
-                        session,
-                        provider_type,
-                        priced_model,
-                        service_kind=service_kind,
-                        quantity=quantity,
-                        cost=cost * share,
-                        confidence=Confidence.EXACT,
-                        pricing_rule=priced_rule,
-                        timestamp=timestamp,
-                        trace=trace,
-                    )
+        created = self._seed_daily_priced_usage(team, sessions, traces, provider_type, priced_rule, now)
 
         # A couple of estimated rows so the Exact/Estimated split shows.
         for session in sessions[:2]:
@@ -479,6 +453,46 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS(f"  Created {created} usage record(s)"))
         self._enable_cost_tracking_flag(team)
+
+    def _seed_daily_priced_usage(
+        self,
+        team,
+        sessions: list[ExperimentSession],
+        traces: dict[int, Trace],
+        provider_type,
+        priced_rule: PricingRule,
+        now,
+    ) -> int:
+        """Priced, exact spend: each session bills a little every day, with a
+        per-session multiplier so bots differ in the Bot Performance table. Input
+        and output are separate rows, as the recorder writes them. Returns the
+        number of records created.
+        """
+        created = 0
+        for day in range(_USAGE_DAYS):
+            timestamp = now - timedelta(days=day, hours=3)
+            for idx, session in enumerate(sessions):
+                cost = Decimal("0.02") * (idx + 1) * (1 + day % 3)
+                # Only the latest day belongs to the seeded trace — a trace is one request.
+                trace = None if day else traces.get(session.id)
+                for service_kind, quantity, share in (
+                    (ServiceKind.LLM_INPUT, 400 + 50 * idx, Decimal("0.8")),
+                    (ServiceKind.LLM_OUTPUT, 100 + 20 * idx, Decimal("0.2")),
+                ):
+                    created += self._create_usage_record(
+                        team,
+                        session,
+                        provider_type,
+                        priced_rule.model_name,
+                        service_kind=service_kind,
+                        quantity=quantity,
+                        cost=cost * share,
+                        confidence=Confidence.EXACT,
+                        pricing_rule=priced_rule,
+                        timestamp=timestamp,
+                        trace=trace,
+                    )
+        return created
 
     def _create_usage_record(
         self,

--- a/apps/web/management/commands/bootstrap_data.py
+++ b/apps/web/management/commands/bootstrap_data.py
@@ -204,8 +204,8 @@ class Command(BaseCommand):
         experiments = self._seed_experiments(user, team, pipelines)
         tags = self._seed_tags(user, team)
         sessions = self._seed_participants_and_sessions(user, team, experiments, tags)
-        self._seed_traces(team, sessions)
-        self._seed_usage_records(team, sessions, llm_provider)
+        traces = self._seed_traces(team, sessions)
+        self._seed_usage_records(team, sessions, llm_provider, traces)
         files = self._seed_files(team)
         self._seed_collection(team, files)
         self._seed_evaluation(team, llm_provider, llm_model)
@@ -346,16 +346,20 @@ class Command(BaseCommand):
         session.chat.add_tag(tag, team=team, added_by=user)
         return session
 
-    def _seed_traces(self, team, sessions: list[ExperimentSession]) -> None:
+    def _seed_traces(self, team, sessions: list[ExperimentSession]) -> dict[int, Trace]:
+        """Seed one trace per session, returned keyed by session id so the usage
+        records can hang off them — the trace detail page reads its token counts
+        from `UsageRecord`, so an unlinked record leaves that card empty."""
         if not sessions:
-            return
+            return {}
         self.stdout.write("")
         self.stdout.write("--- Creating Traces ---")
+        traces = {}
         for session in sessions:
             messages = list(session.chat.messages.order_by("created_at"))
             input_msg = next((m for m in messages if m.message_type == ChatMessageType.HUMAN), None)
             output_msg = next((m for m in messages if m.message_type == ChatMessageType.AI), None)
-            Trace.objects.create(
+            traces[session.id] = Trace.objects.create(
                 team=team,
                 experiment=session.experiment,
                 session=session,
@@ -366,17 +370,20 @@ class Command(BaseCommand):
                 duration=1234,
                 n_turns=1,
                 n_toolcalls=0,
-                n_total_tokens=250,
-                n_prompt_tokens=200,
-                n_completion_tokens=50,
             )
         self.stdout.write(self.style.SUCCESS(f"  Created {len(sessions)} trace(s)"))
+        return traces
 
-    def _seed_usage_records(self, team, sessions: list[ExperimentSession], llm_provider) -> None:
+    def _seed_usage_records(
+        self, team, sessions: list[ExperimentSession], llm_provider, traces: dict[int, Trace]
+    ) -> None:
         """Seed cost-tracking UsageRecords so the dashboard's Cost Tracking panel
         has data: priced spend spread over the last two weeks (for the daily-spend
         chart and per-bot costs), plus a few estimated / unpriced / no-usage rows
         so the confidence split and coverage-gap warnings render.
+
+        The most recent day's rows are attached to the session's trace, which is what
+        the trace detail page's token card reads.
         """
         # Rerun-safe: an already-seeded team yields no new sessions upstream, so
         # rehydrate from the DB rather than skipping usage seeding and the flag.
@@ -386,6 +393,8 @@ class Command(BaseCommand):
             )
         if not sessions:
             return
+        if not traces:
+            traces = {trace.session_id: trace for trace in Trace.objects.filter(team=team)}
         self.stdout.write("")
         self.stdout.write("--- Creating Usage Records ---")
 
@@ -402,21 +411,30 @@ class Command(BaseCommand):
         created = 0
         # Priced, exact spend: each session bills a little every day, with a
         # per-session multiplier so bots differ in the Bot Performance table.
+        # Input and output are separate rows, as the recorder writes them.
         for day in range(_USAGE_DAYS):
             timestamp = now - timedelta(days=day, hours=3)
             for idx, session in enumerate(sessions):
                 cost = Decimal("0.02") * (idx + 1) * (1 + day % 3)
-                created += self._create_usage_record(
-                    team,
-                    session,
-                    provider_type,
-                    priced_model,
-                    quantity=400 + 50 * idx,
-                    cost=cost,
-                    confidence=Confidence.EXACT,
-                    pricing_rule=priced_rule,
-                    timestamp=timestamp,
-                )
+                # Only the latest day belongs to the seeded trace — a trace is one request.
+                trace = None if day else traces.get(session.id)
+                for service_kind, quantity, share in (
+                    (ServiceKind.LLM_INPUT, 400 + 50 * idx, Decimal("0.8")),
+                    (ServiceKind.LLM_OUTPUT, 100 + 20 * idx, Decimal("0.2")),
+                ):
+                    created += self._create_usage_record(
+                        team,
+                        session,
+                        provider_type,
+                        priced_model,
+                        service_kind=service_kind,
+                        quantity=quantity,
+                        cost=cost * share,
+                        confidence=Confidence.EXACT,
+                        pricing_rule=priced_rule,
+                        timestamp=timestamp,
+                        trace=trace,
+                    )
 
         # A couple of estimated rows so the Exact/Estimated split shows.
         for session in sessions[:2]:
@@ -463,7 +481,19 @@ class Command(BaseCommand):
         self._enable_cost_tracking_flag(team)
 
     def _create_usage_record(
-        self, team, session, provider_type, model_name, *, quantity, cost, confidence, pricing_rule, timestamp
+        self,
+        team,
+        session,
+        provider_type,
+        model_name,
+        *,
+        quantity,
+        cost,
+        confidence,
+        pricing_rule,
+        timestamp,
+        service_kind=ServiceKind.LLM_INPUT,
+        trace=None,
     ) -> int:
         """Create one UsageRecord and stamp its timestamp (auto_now_add can't be
         set on create). Returns 1 so callers can tally."""
@@ -472,7 +502,8 @@ class Command(BaseCommand):
             experiment=session.experiment,
             session=session,
             participant=session.participant,
-            service_kind=ServiceKind.LLM_INPUT,
+            trace=trace,
+            service_kind=service_kind,
             provider_type=provider_type,
             model_name=model_name,
             quantity=quantity,

--- a/templates/trace/trace_detail.html
+++ b/templates/trace/trace_detail.html
@@ -76,21 +76,38 @@
         <div class="card card-border bg-base-100">
           <div class="card-body p-4">
             <span class="text-xs uppercase tracking-wide text-base-content/60">Tokens</span>
-            {% if trace.n_total_tokens is not None %}
+            {% if token_usage.by_model %}
               <div class="mt-2">
-                <span class="text-3xl font-bold">{{ trace.n_total_tokens|intcomma }}</span>
+                <span class="text-3xl font-bold">{{ token_usage.total|intcomma }}</span>
                 <span class="text-sm text-base-content/60 ml-1">total</span>
               </div>
-              {% if trace.n_total_tokens %}
+              {% if token_usage.total %}
                 <div class="flex h-1.5 rounded-full overflow-hidden mt-3 bg-base-200" aria-hidden="true">
-                  <div class="bg-primary" style="flex: {{ trace.n_prompt_tokens|default:0 }};"></div>
-                  <div class="bg-primary/30" style="flex: {{ trace.n_completion_tokens|default:0 }};"></div>
+                  <div class="bg-primary" style="flex: {{ token_usage.input_tokens }};"></div>
+                  <div class="bg-primary/30" style="flex: {{ token_usage.output_tokens }};"></div>
                 </div>
                 <div class="flex justify-between text-xs text-base-content/60 mt-2">
-                  <span>{{ trace.n_prompt_tokens|default:0|intcomma }} in</span>
-                  <span>{{ trace.n_completion_tokens|default:0|intcomma }} out</span>
+                  <span>{{ token_usage.input_tokens|intcomma }} in</span>
+                  <span>{{ token_usage.output_tokens|intcomma }} out</span>
                 </div>
               {% endif %}
+              <div class="mt-3 pt-3 border-t border-base-200 space-y-1">
+                {% for model in token_usage.by_model %}
+                  <div class="flex justify-between gap-2 text-xs">
+                    <span class="truncate text-base-content/80"
+                          title="{{ model.provider_type }} / {{ model.model_name }}">{{ model.model_name }}</span>
+                    <span class="whitespace-nowrap text-base-content/60">
+                      {{ model.total_input_tokens|intcomma }} in / {{ model.output_tokens|intcomma }} out
+                      {% if model.cached_input_tokens %}
+                        <span class="text-base-content/40">· {{ model.cached_input_tokens|intcomma }} cached</span>
+                      {% endif %}
+                      {% if model.cache_write_tokens %}
+                        <span class="text-base-content/40">· {{ model.cache_write_tokens|intcomma }} cache write</span>
+                      {% endif %}
+                    </span>
+                  </div>
+                {% endfor %}
+              </div>
             {% else %}
               <div class="text-3xl font-bold mt-2">—</div>
             {% endif %}


### PR DESCRIPTION
Phase 1 of #3986. `UsageRecord` has been the canonical token source since #3984, so the three `Trace` counters are now redundant — and worse than the replacement: they only ever summed usage the provider reported, while `UsageRecord` also carries estimated calls and splits by (provider, model).

Split into two releases on purpose. This PR removes every reader and writer but leaves the columns in place; the `RemoveField` migration lands in a following release (#4016). Dropping them together would mean old workers hitting `Trace.objects.create()` on missing columns during the rolling deploy — that call isn't wrapped, so chat requests would error for the deploy window.

Worth a closer look:

- **The in/out definition on the card deliberately differs from the usage API's `TokenCounts`.** `trace_token_usage` folds `LLM_CACHE_WRITE` into the input side so `in + out == total` and the headline reproduces what the provider reported for the call. `TokenCounts` keeps cache-write in `total` only, which is right for that API but would make the card's bar not add up.
- **`MetricsCollector` no longer subclasses `UsageMetadataCallbackHandler`.** Its `usage_metadata` dict existed solely to feed the trace counters; the cost path keeps its own `(provider, model)` buckets and is unaffected.
- **Phase 2 also needs `api-schemas/export.yml` regenerated** — the fields are exposed through the auto-generated `TraceDetail` export serializer. The importer reads `model._meta.concrete_fields` and ignores extra keys, so older export payloads still import after the drop.

### Migrations
N/A — no schema change in this PR.

### Demo
Verified against seeded dev data (`bootstrap_data` now links usage rows to their trace, so the card isn't blank locally):

The card keeps its previous shape and gains a per-model row underneath, with cached / cache-write tokens called out where present. Traces with no recorded usage render the em dash rather than a zero.

<img width="302" height="207" alt="tokens-card" src="https://github.com/user-attachments/assets/aa792664-dce1-42fd-b446-ebb0dc9eb18e" />


### Docs and Changelog
- [ ] This PR requires docs/changelog update
