### PR TITLE
Update gpt-5.6-terra and gpt-5.6-luna pricing

### DIFF
--- a/apps/cost_tracking/migrations/0007_rate_update_20260731.py
+++ b/apps/cost_tracking/migrations/0007_rate_update_20260731.py
@@ -1,0 +1,8 @@
+from django.db import migrations
+
+from apps.cost_tracking.migration_utils import load_pricing_data
+
+
+class Migration(migrations.Migration):
+    dependencies = [("cost_tracking", "0006_usagerecord_evaluation_config_usagerecord_source_and_more")]
+    operations = [load_pricing_data()]

--- a/apps/cost_tracking/seed_data/llm_pricing.json
+++ b/apps/cost_tracking/seed_data/llm_pricing.json
@@ -983,19 +983,19 @@
     "rules": [
       {
         "service_kind": "llm_input",
-        "unit_price": "0.0025"
+        "unit_price": "0.002"
       },
       {
         "service_kind": "llm_output",
-        "unit_price": "0.015"
+        "unit_price": "0.012"
       },
       {
         "service_kind": "llm_cached_input",
-        "unit_price": "0.00025"
+        "unit_price": "0.0002"
       },
       {
         "service_kind": "llm_cache_write",
-        "unit_price": "0.003125"
+        "unit_price": "0.0025"
       }
     ]
   },
@@ -1027,19 +1027,19 @@
     "rules": [
       {
         "service_kind": "llm_input",
-        "unit_price": "0.001"
+        "unit_price": "0.0002"
       },
       {
         "service_kind": "llm_output",
-        "unit_price": "0.006"
+        "unit_price": "0.0012"
       },
       {
         "service_kind": "llm_cached_input",
-        "unit_price": "0.0001"
+        "unit_price": "0.00002"
       },
       {
         "service_kind": "llm_cache_write",
-        "unit_price": "0.00125"
+        "unit_price": "0.00025"
       }
     ]
   },


### PR DESCRIPTION
### Product Description
Cost tracking for GPT-5.6 Terra and Luna was overstating spend. OpenAI cut Terra 20% and Luna 80% on 2026-07-30 ([announcement](https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/)); Sol stayed at its launch rate.

| Model | Input /1M | Output /1M |
|---|---|---|
| gpt-5.6-terra | $2.50 → $2.00 | $15.00 → $12.00 |
| gpt-5.6-luna | $1.00 → $0.20 | $6.00 → $1.20 |

Cached reads are 10% of input and cache writes 1.25x, so those moved proportionally.

### Technical Description
The daily `auto-update-models` reconcile hasn't picked this up — it ran successfully today and found no price changes, because llm-stats.com/zeroeval hasn't reflected the new rates yet. The detection logic is fine (`_price_differs` is an exact `Decimal` compare, no threshold), it just lags the announcement. Doing it by hand now; when upstream catches up the seed will already match, so no duplicate PR.

The OpenAI page 403s automated fetches, so the figures come from three sources that independently agree on every input/cached/output/cache-write value and on the date: [VentureBeat](https://venturebeat.com/technology/ai-price-wars-openai-cuts-gpt-5-6-luna-prices-by-80-as-model-competition-shifts-toward-cost), [aipricing.guru](https://www.aipricing.guru/openai-pricing/), [BenchLM](https://benchlm.ai/openai/api-pricing). Worth a sanity-check on the magnitudes by a second pair of eyes given that provenance.

> Checked manually by @snopoke 

All three tiers are registered under `openai` only, so there are no `azure` seed entries to mirror. The announcement also mentions a premium "Fast mode" for Sol — not added, since it isn't a registered model in OCS.

### Migrations
- [x] The migrations are backwards compatible

`0007_rate_update_20260731` just calls `load_pricing_data()`, same as the generated rate-update migrations. `load_ai_pricing` supersedes rather than mutates — it closes the old row with `effective_to=now()` and inserts a new active one — so historical `UsageRecord` costs resolve against the rate that was active when they were recorded.

Verified against a local dev DB rather than inferring from the seed edit: after migrating, Terra and Luna each show the old row closed plus a new active row for all four service kinds, and Sol still has a single untouched active row. `apps/cost_tracking/` tests pass (123).

### Docs and Changelog
- [ ] This PR requires docs/changelog update
