### PR TITLE
Evaluations: edit the evaluator LLM provider FKs directly

### DIFF
--- a/apps/data_migrations/management/commands/remove_deprecated_models.py
+++ b/apps/data_migrations/management/commands/remove_deprecated_models.py
@@ -117,13 +117,8 @@ class Command(IdempotentCommand):
         """Move every reference to ``db_model`` onto ``replacement_model`` (or clear it) before delete."""
         new_value = replacement_model.id if replacement_model else None
 
-        # Evaluators keep a copy of the model id in params for the form UI, so they are
-        # repointed through the model method that moves params and FK together. Has to
-        # happen before the generic FK pass, which would otherwise claim them first.
-        for evaluator in db_model.evaluators.all():
-            evaluator.set_llm_provider_model_id(new_value)
-
-        # Update FK references (assistants, analyses, etc.) to replacement, or let cascade handle them
+        # Update FK references (assistants, analyses, evaluators, etc.) to replacement, or let
+        # cascade handle them
         if replacement_model:
             for obj in get_related_objects(db_model):
                 fields_to_update = [

--- a/apps/data_migrations/tests/test_notify_deprecated_models.py
+++ b/apps/data_migrations/tests/test_notify_deprecated_models.py
@@ -89,7 +89,7 @@ class TestNotifyDeprecatedModelsCommand:
         deprecated_model = LlmProviderModelFactory(
             team=None, type="openai", name="test-deprecated-model", deprecated=True
         )
-        evaluator = EvaluatorFactory.create(params={"llm_provider_model_id": deprecated_model.id})
+        evaluator = EvaluatorFactory.create(llm_provider_model=deprecated_model)
 
         with patch(
             "apps.data_migrations.management.commands.notify_deprecated_models.DEFAULT_LLM_PROVIDER_MODELS",

--- a/apps/data_migrations/tests/test_remove_deprecated_models.py
+++ b/apps/data_migrations/tests/test_remove_deprecated_models.py
@@ -105,13 +105,12 @@ class TestRemoveDeprecatedModelsCommand:
     )
     @patch("apps.data_migrations.management.commands.remove_deprecated_models.deleted_model_notification")
     def test_repoints_evaluators(self, mock_notify, replacement_name):
-        """Evaluator params and FK move together, so the delete pre-check no longer blocks."""
+        """The evaluator FK moves off the model, so the delete pre-check no longer blocks."""
         old_model = LlmProviderModelFactory(team=None, type="openai", name="gpt-4-old")
         replacement_model = (
             LlmProviderModelFactory(team=None, type="openai", name=replacement_name) if replacement_name else None
         )
-        evaluator = EvaluatorFactory.create(params={"llm_provider_model_id": old_model.id})
-        assert evaluator.llm_provider_model_id == old_model.id
+        evaluator = EvaluatorFactory.create(llm_provider_model=old_model)
 
         deleted_models = [("openai", "gpt-4-old", replacement_name) if replacement_name else ("openai", "gpt-4-old")]
         with patch(
@@ -122,9 +121,7 @@ class TestRemoveDeprecatedModelsCommand:
 
         assert not LlmProviderModel.objects.filter(id=old_model.id).exists()
         evaluator.refresh_from_db()
-        expected_id = replacement_model.id if replacement_model else None
-        assert evaluator.llm_provider_model_id == expected_id
-        assert evaluator.params["llm_provider_model_id"] == expected_id
+        assert evaluator.llm_provider_model_id == (replacement_model.id if replacement_model else None)
 
     @patch("apps.data_migrations.management.commands.remove_deprecated_models.deleted_model_notification")
     def test_notifies_affected_team(self, mock_notify):
@@ -152,7 +149,7 @@ class TestRemoveDeprecatedModelsCommand:
     def test_notifies_the_team_about_affected_evaluators(self, mock_notify):
         """Collected before the repoint moves the FK, or the evaluator goes unreported."""
         old_model = LlmProviderModelFactory(team=None, type="openai", name="gpt-4-old")
-        evaluator = EvaluatorFactory.create(params={"llm_provider_model_id": old_model.id})
+        evaluator = EvaluatorFactory.create(llm_provider_model=old_model)
 
         deleted_models = [("openai", "gpt-4-old")]
         with patch(

--- a/apps/evaluations/evaluators.py
+++ b/apps/evaluations/evaluators.py
@@ -43,11 +43,12 @@ class BaseEvaluator(BaseModel):
 
 
 class LLMResponseMixin(BaseModel):
-    # These two ids drive the form UI (which is generated from this schema) but the stored
-    # reference lives on the ``Evaluator.llm_provider``/``llm_provider_model`` FKs.
-    # ``Evaluator.get_evaluator_params`` resolves them from there, not from the params JSON.
-    llm_provider_id: int = Field(..., title="LLM Model", json_schema_extra=UiSchema(widget=Widgets.llm_provider_model))
-    llm_provider_model_id: int = Field(..., json_schema_extra=UiSchema(widget=Widgets.none))
+    # Supplied by ``Evaluator.get_evaluator_params`` from the
+    # ``Evaluator.llm_provider``/``llm_provider_model`` FKs, which are where the selection is
+    # stored. They are not part of ``params`` and are not rendered from this schema — the
+    # evaluator form edits the FKs through its own fields (see ``LLM_PROVIDER_FIELDS``).
+    llm_provider_id: int
+    llm_provider_model_id: int
     llm_temperature: float = Field(
         default=0.7, ge=0.0, le=2.0, title="Temperature", json_schema_extra=UiSchema(widget=Widgets.range)
     )
@@ -71,6 +72,11 @@ class LLMResponseMixin(BaseModel):
         model_name = self.get_llm_provider_model().name
         params = get_model_parameters(model_name, temperature=self.llm_temperature)
         return self.get_llm_service().get_chat_model(model_name, **params)
+
+
+# The ``LLMResponseMixin`` fields that are stored as FK columns on ``Evaluator`` instead of in
+# ``params``. Kept out of the form-rendering schema and injected when the evaluator is built.
+LLM_PROVIDER_FIELDS = ("llm_provider_id", "llm_provider_model_id")
 
 
 class LlmEvaluator(LLMResponseMixin, BaseEvaluator):

--- a/apps/evaluations/forms.py
+++ b/apps/evaluations/forms.py
@@ -38,7 +38,6 @@ from apps.experiments.models import Experiment, ExperimentSession
 from apps.files.models import File
 from apps.human_annotations.models import AnnotationQueue, QueueStatus
 from apps.service_providers.models import LlmProvider, LlmProviderModel, LlmProviderTypes
-from apps.utils.fields import as_int
 from apps.web.dynamic_filters.datastructures import FilterParams
 
 
@@ -276,16 +275,25 @@ class EvaluationConfigForm(forms.ModelForm):
 class EvaluatorForm(forms.ModelForm):
     class Meta:
         model = Evaluator
-        fields = ("name", "type", "params", "evaluation_mode")
+        fields = ("name", "type", "params", "evaluation_mode", "llm_provider", "llm_provider_model")
         widgets = {
             "type": forms.HiddenInput(),
             "params": forms.HiddenInput(),
             "evaluation_mode": forms.RadioSelect(choices=EvaluationMode.choices),
         }
+        # The provider picker is rendered by the template rather than by these fields' widgets,
+        # so the team-scoped querysets set in __init__ are what reject another team's provider.
+        # These are the messages the user sees when they do.
+        error_messages = {
+            "llm_provider": {"invalid_choice": "The selected LLM provider is not available to this team"},
+            "llm_provider_model": {"invalid_choice": "The selected LLM model is not available to this team"},
+        }
 
     def __init__(self, team, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.team = team
+        self.fields["llm_provider"].queryset = LlmProvider.objects.filter(team=team)
+        self.fields["llm_provider_model"].queryset = LlmProviderModel.objects.for_team(team)
 
     def clean(self):
         cleaned_data = super().clean()
@@ -302,14 +310,30 @@ class EvaluatorForm(forms.ModelForm):
             except json.JSONDecodeError as err:
                 raise forms.ValidationError("Invalid JSON format for parameters") from err
 
+        evaluators_module = importlib.import_module("apps.evaluations.evaluators")
         try:
-            evaluators_module = importlib.import_module("apps.evaluations.evaluators")
             evaluator_class = getattr(evaluators_module, evaluator_type)
-
-            evaluator_class(**params)
-
         except AttributeError as err:
             raise forms.ValidationError(f"Unknown evaluator type: {evaluator_type}") from err
+
+        # A stale tab may still post the ids inside params; the FK fields are the record now,
+        # so drop them rather than storing a copy that nothing reads.
+        params = {key: value for key, value in params.items() if key not in evaluators_module.LLM_PROVIDER_FIELDS}
+        cleaned_data["params"] = params
+
+        if issubclass(evaluator_class, evaluators_module.LLMResponseMixin):
+            self._validate_llm_provider_selection()
+            if self.errors:
+                # The evaluator cannot be constructed without the ids it takes from the FKs,
+                # so there is nothing more to say until the selection is fixed.
+                return cleaned_data
+            params = params | {
+                "llm_provider_id": self.cleaned_data["llm_provider"].id,
+                "llm_provider_model_id": self.cleaned_data["llm_provider_model"].id,
+            }
+
+        try:
+            evaluator_class(**params)
         except PydanticValidationError as err:
             error_messages = []
             for error in err.errors():
@@ -318,38 +342,26 @@ class EvaluatorForm(forms.ModelForm):
                 error_messages.append(f"{field_name.replace('_', ' ').title()}: {message}")
             raise forms.ValidationError(f"{', '.join(error_messages)}") from err
 
-        self._validate_llm_provider_selection(params)
-
         return cleaned_data
 
-    def _validate_llm_provider_selection(self, params: dict):
-        """Reject provider ids the team can't use, and pairings the provider can't serve.
+    def _validate_llm_provider_selection(self):
+        """Require a provider and model for an LLM evaluator, and reject pairings it can't serve."""
+        provider = self.cleaned_data.get("llm_provider")
+        provider_model = self.cleaned_data.get("llm_provider_model")
 
-        The ids arrive inside the ``params`` JSON blob, so they never went through a
-        ModelChoiceField queryset, and an id from another team would run this team's
-        evaluations on someone else's credentials.
-        """
-        provider = None
-        provider_id = as_int(params.get("llm_provider_id"))
-        if provider_id is not None:
-            provider = LlmProvider.objects.filter(team=self.team, id=provider_id).first()
-            if provider is None:
-                raise forms.ValidationError("The selected LLM provider is not available to this team")
-
-        provider_model = None
-        provider_model_id = as_int(params.get("llm_provider_model_id"))
-        if provider_model_id is not None:
-            provider_model = LlmProviderModel.objects.for_team(self.team).filter(id=provider_model_id).first()
-            if provider_model is None:
-                raise forms.ValidationError("The selected LLM model is not available to this team")
+        if provider is None and "llm_provider" not in self.errors:
+            self.add_error("llm_provider", "Select an LLM provider for this evaluator")
+        if provider_model is None and "llm_provider_model" not in self.errors:
+            self.add_error("llm_provider_model", "Select an LLM model for this evaluator")
 
         # The picker only offers models matching the chosen provider's type (see
         # ``_evaluator_parameter_values``), so a mismatch means the ids were not submitted
         # through the UI. Left unchecked it fails at run time inside get_llm_service.
         if provider is not None and provider_model is not None and provider.type != provider_model.type:
-            raise forms.ValidationError(
+            self.add_error(
+                "llm_provider_model",
                 f"The selected LLM model is for {_provider_type_label(provider_model.type)} providers, "
-                f"but the selected provider is {_provider_type_label(provider.type)}"
+                f"but the selected provider is {_provider_type_label(provider.type)}",
             )
 
 

--- a/apps/evaluations/forms.py
+++ b/apps/evaluations/forms.py
@@ -298,27 +298,14 @@ class EvaluatorForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super().clean()
 
-        params = self.cleaned_data.get("params")
         evaluator_type = self.cleaned_data.get("type")
-
         if not evaluator_type:
             raise forms.ValidationError("Missing evaluator type")
 
-        if isinstance(params, str):
-            try:
-                params = json.loads(params) or {}
-            except json.JSONDecodeError as err:
-                raise forms.ValidationError("Invalid JSON format for parameters") from err
-
         evaluators_module = importlib.import_module("apps.evaluations.evaluators")
-        try:
-            evaluator_class = getattr(evaluators_module, evaluator_type)
-        except AttributeError as err:
-            raise forms.ValidationError(f"Unknown evaluator type: {evaluator_type}") from err
+        evaluator_class = _get_evaluator_class(evaluators_module, evaluator_type)
 
-        # A stale tab may still post the ids inside params; the FK fields are the record now,
-        # so drop them rather than storing a copy that nothing reads.
-        params = {key: value for key, value in params.items() if key not in evaluators_module.LLM_PROVIDER_FIELDS}
+        params = _clean_params(self.cleaned_data.get("params"), evaluators_module.LLM_PROVIDER_FIELDS)
         cleaned_data["params"] = params
 
         if issubclass(evaluator_class, evaluators_module.LLMResponseMixin):
@@ -332,16 +319,7 @@ class EvaluatorForm(forms.ModelForm):
                 "llm_provider_model_id": self.cleaned_data["llm_provider_model"].id,
             }
 
-        try:
-            evaluator_class(**params)
-        except PydanticValidationError as err:
-            error_messages = []
-            for error in err.errors():
-                field_name = error["loc"][0] if error["loc"] else "unknown"
-                message = error["msg"]
-                error_messages.append(f"{field_name.replace('_', ' ').title()}: {message}")
-            raise forms.ValidationError(f"{', '.join(error_messages)}") from err
-
+        _validate_evaluator_params(evaluator_class, params)
         return cleaned_data
 
     def _validate_llm_provider_selection(self):
@@ -363,6 +341,40 @@ class EvaluatorForm(forms.ModelForm):
                 f"The selected LLM model is for {_provider_type_label(provider_model.type)} providers, "
                 f"but the selected provider is {_provider_type_label(provider.type)}",
             )
+
+
+def _get_evaluator_class(evaluators_module, evaluator_type: str):
+    """The evaluator class named by the form's hidden ``type`` field."""
+    try:
+        return getattr(evaluators_module, evaluator_type)
+    except AttributeError as err:
+        raise forms.ValidationError(f"Unknown evaluator type: {evaluator_type}") from err
+
+
+def _clean_params(params, provider_field_names) -> dict:
+    """Parse the hidden params JSON.
+
+    A stale tab may still post the provider ids inside params; the FK fields are the record
+    now, so drop them rather than storing a copy that nothing reads.
+    """
+    if isinstance(params, str):
+        try:
+            params = json.loads(params) or {}
+        except json.JSONDecodeError as err:
+            raise forms.ValidationError("Invalid JSON format for parameters") from err
+    return {key: value for key, value in params.items() if key not in provider_field_names}
+
+
+def _validate_evaluator_params(evaluator_class, params: dict) -> None:
+    """Report pydantic's complaints about the params as a form error."""
+    try:
+        evaluator_class(**params)
+    except PydanticValidationError as err:
+        error_messages = []
+        for error in err.errors():
+            field_name = error["loc"][0] if error["loc"] else "unknown"
+            error_messages.append(f"{str(field_name).replace('_', ' ').title()}: {error['msg']}")
+        raise forms.ValidationError(", ".join(error_messages)) from err
 
 
 def _provider_type_label(provider_type: str) -> str:

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -33,7 +33,7 @@ from apps.experiments.filters import ChatMessageFilter
 from apps.experiments.models import ExperimentSession
 from apps.teams.models import BaseTeamModel, Team
 from apps.teams.utils import get_slug_for_team
-from apps.utils.fields import SanitizedJSONField, as_int
+from apps.utils.fields import SanitizedJSONField
 from apps.utils.models import BaseModel
 
 if TYPE_CHECKING:
@@ -104,10 +104,11 @@ class Evaluator(BaseTeamModel):
         default=EvaluationMode.MESSAGE,
         help_text="Message mode evaluates individual message pairs; Session mode evaluates entire conversations",
     )
-    # The LLM provider an LLM-backed evaluator runs against. Null for evaluators with no LLM
-    # dependency (PythonEvaluator), and nulled by SET_NULL when the provider is deleted —
-    # which is the point: the id used to live only in ``params``, where a deleted provider
-    # left a dangling integer behind. Kept in sync with params by ``sync_llm_provider_fks``.
+    # The LLM provider an LLM-backed evaluator runs against, and the only record of it that is
+    # read. Nothing writes the ids to ``params`` any more; rows last saved before that changed
+    # may still carry a copy, which is ignored (a follow-up migration strips it). Null for
+    # evaluators with no LLM dependency (PythonEvaluator), and nulled by SET_NULL when the
+    # provider is deleted, so a deleted provider can never leave a dangling id behind.
     llm_provider = models.ForeignKey(
         "service_providers.LlmProvider",
         on_delete=models.SET_NULL,
@@ -130,57 +131,6 @@ class Evaluator(BaseTeamModel):
             label = self.type
         return f"{self.name} ({label})"
 
-    def save(self, *args, **kwargs):
-        """Derive the LLM FK columns from ``params`` before every write.
-
-        Doing it here rather than in the form keeps every writer (the form, team cloning,
-        bootstrap data, factories) consistent without each having to remember.
-        """
-        update_fields = kwargs.get("update_fields")
-        if update_fields is None or "params" in update_fields:
-            changed = self.sync_llm_provider_fks()
-            if update_fields is not None:
-                kwargs["update_fields"] = [*update_fields, *changed]
-        return super().save(*args, **kwargs)
-
-    def sync_llm_provider_fks(self) -> list[str]:
-        """Point the LLM FK columns at the ids in ``params``, returning the columns changed.
-
-        A dangling id becomes null instead of being written straight through: nothing stops
-        an LlmProvider being deleted while an evaluator references it, and re-deriving the
-        stale id would trip the deferred DB constraint at commit. Mirrors
-        ``Node._sync_resource_fk_fields``.
-        """
-        changed = []
-        for field_name in ("llm_provider", "llm_provider_model"):
-            attname = f"{field_name}_id"
-            value = as_int((self.params or {}).get(attname))
-            current = getattr(self, attname)
-            if value == current:
-                # Already in sync, so there is nothing to validate: a non-null FK column is
-                # guaranteed to resolve by the constraint itself, and SET_NULL would have
-                # nulled it if the row had since been deleted. Skipping the existence query
-                # here keeps the common re-save free.
-                continue
-            if value is not None:
-                related_model = self._meta.get_field(field_name).related_model
-                if not related_model._base_manager.filter(pk=value).exists():
-                    value = None
-                if value == current:
-                    continue
-            setattr(self, attname, value)
-            changed.append(attname)
-        return changed
-
-    def set_llm_provider_model_id(self, provider_model_id: int | None):
-        """Repoint this evaluator at another LLM provider model (or at nothing).
-
-        ``params`` still carries a copy of the id for the schema-driven form UI, so both
-        move together: saving ``params`` re-derives the FK column.
-        """
-        self.params["llm_provider_model_id"] = provider_model_id
-        self.save(update_fields=["params"])
-
     def delete(self, *args, **kwargs):
         """Block deletion while any config using this evaluator has an in-flight run."""
         raise_if_runs_in_flight(EvaluationRun.objects.filter(config__evaluators=self), "evaluator")
@@ -197,11 +147,11 @@ class Evaluator(BaseTeamModel):
         return issubclass(self.evaluator, module.LLMResponseMixin)
 
     def get_evaluator_params(self) -> dict:
-        """``params`` with the LLM ids taken from the FK columns rather than the JSON blob.
+        """``params`` plus the LLM ids read off the FK columns.
 
-        The FK columns are the resolved reference. ``params`` only carries the raw ids the
-        form submitted — it is what the schema-driven UI edits — and may still name a
-        provider that has since been deleted.
+        ``LLMResponseMixin`` is a pydantic model that takes the ids as fields, so they have
+        to be supplied to construct it; the FK columns are where they are stored. Overlaid
+        rather than merged, so a legacy copy of the ids left in ``params`` cannot win.
         """
         params = dict(self.params or {})
         if not self.requires_llm_provider():

--- a/apps/evaluations/tests/test_delta_evaluation_run.py
+++ b/apps/evaluations/tests/test_delta_evaluation_run.py
@@ -8,7 +8,6 @@ from apps.utils.factories.evaluations import (
     EvaluationConfigFactory,
     EvaluationMessageFactory,
     EvaluatorFactory,
-    configure_evaluator_llm_provider,
 )
 
 
@@ -38,8 +37,7 @@ def test_full_run_freezes_all_dataset_messages():
 @patch("apps.evaluations.tasks.evaluate_message_batch.delay")
 def test_coordinator_dispatches_only_scoped_messages_for_delta(delay_mock, _publish):
     config = EvaluationConfigFactory.create()
-    # Configured providers, or the run fails its pre-flight instead of dispatching.
-    evaluator = configure_evaluator_llm_provider(EvaluatorFactory.create(team=config.team))
+    evaluator = EvaluatorFactory.create(team=config.team)
     config.evaluators.set([evaluator])
     in_scope = EvaluationMessageFactory.create()
     out_of_scope = EvaluationMessageFactory.create()

--- a/apps/evaluations/tests/test_evaluation_coordination.py
+++ b/apps/evaluations/tests/test_evaluation_coordination.py
@@ -36,7 +36,6 @@ from apps.utils.factories.evaluations import (
     EvaluationResultFactory,
     EvaluationRunFactory,
     EvaluatorFactory,
-    configure_evaluator_llm_provider,
 )
 from apps.utils.factories.team import MembershipFactory, TeamWithUsersFactory
 from apps.utils.factories.user import GroupFactory
@@ -214,8 +213,7 @@ def _make_run(evaluator_count=1, message_count=5, status=EvaluationRunStatus.PEN
     """Build a run with a frozen plan of `message_count` messages and `evaluator_count` evaluators."""
     team = TeamWithUsersFactory.create()
     config = EvaluationConfigFactory.create(team=team)
-    # Configured providers, or the run fails its pre-flight instead of dispatching.
-    evaluators = [configure_evaluator_llm_provider(EvaluatorFactory.create(team=team)) for _ in range(evaluator_count)]
+    evaluators = [EvaluatorFactory.create(team=team) for _ in range(evaluator_count)]
     config.evaluators.set(evaluators)
     messages = [EvaluationMessageFactory.create() for _ in range(message_count)]
     config.dataset.messages.add(*messages)
@@ -238,8 +236,8 @@ def _complete_messages(run, evaluators, messages):
 def test_pending_run_with_an_unconfigured_evaluator_fails_before_dispatching(delay_mock, _publish):
     """One error, not one per message: the pre-flight fails the run instead of dispatching."""
     run, evaluators, _messages = _make_run(message_count=5, status=EvaluationRunStatus.PENDING)
-    evaluators[0].params |= {"llm_provider_id": None}
-    evaluators[0].save(update_fields=["params"])
+    evaluators[0].llm_provider = None
+    evaluators[0].save(update_fields=["llm_provider"])
 
     sweep()
 

--- a/apps/evaluations/tests/test_evaluator_llm_provider_fks.py
+++ b/apps/evaluations/tests/test_evaluator_llm_provider_fks.py
@@ -1,9 +1,8 @@
-"""The Evaluator.llm_provider / llm_provider_model FK columns and how they track params."""
+"""The Evaluator.llm_provider / llm_provider_model FK columns, the only record of the selection."""
 
 import pytest
 
 from apps.evaluations.exceptions import EvaluationRunException
-from apps.evaluations.models import Evaluator
 from apps.utils.factories.evaluations import EvaluatorFactory
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 
@@ -18,128 +17,60 @@ def provider_model(provider):
     return LlmProviderModelFactory.create(team=provider.team)
 
 
-def _params(provider_id, provider_model_id) -> dict:
+@pytest.fixture()
+def evaluator(provider, provider_model):
+    return EvaluatorFactory.create(
+        team=provider.team, llm_provider=provider, llm_provider_model=provider_model, params=_params()
+    )
+
+
+def _params() -> dict:
     return {
-        "llm_provider_id": provider_id,
-        "llm_provider_model_id": provider_model_id,
         "prompt": "evaluate {input.content}",
         "output_schema": {"score": {"type": "int", "description": "score"}},
     }
 
 
 @pytest.mark.django_db()
-class TestFkSync:
-    @pytest.mark.parametrize("cast", [pytest.param(int, id="int-in-params"), pytest.param(str, id="str-in-params")])
-    def test_fks_populated_from_params_on_create(self, provider, provider_model, cast):
-        evaluator = EvaluatorFactory.create(
-            team=provider.team, params=_params(cast(provider.id), cast(provider_model.id))
-        )
-
+class TestProviderReference:
+    def test_params_carries_no_provider_ids(self, evaluator, provider, provider_model):
         evaluator.refresh_from_db()
+
+        assert evaluator.params == _params()
         assert evaluator.llm_provider_id == provider.id
         assert evaluator.llm_provider_model_id == provider_model.id
 
-    def test_fks_follow_params_on_update(self, provider, provider_model):
-        evaluator = EvaluatorFactory.create(team=provider.team, params=_params(provider.id, provider_model.id))
-        other_provider = LlmProviderFactory.create(team=provider.team)
-
-        evaluator.params["llm_provider_id"] = other_provider.id
-        evaluator.save(update_fields=["params"])
-
-        evaluator.refresh_from_db()
-        assert evaluator.llm_provider_id == other_provider.id
-
-    def test_dangling_ids_become_null(self, provider, provider_model):
-        """A deleted provider leaves a stale id in params; the FK must not resurrect it.
-
-        The stale id stays in ``params`` on purpose — the form still edits it, and #3995
-        removes the copy from ``params`` altogether.
-        """
-        evaluator = EvaluatorFactory.create(
-            team=provider.team, params=_params(provider.id + 1000, provider_model.id + 1000)
-        )
-
-        evaluator.refresh_from_db()
-        assert evaluator.llm_provider_id is None
-        assert evaluator.llm_provider_model_id is None
-
-    def test_python_evaluator_has_no_provider(self):
-        evaluator = EvaluatorFactory.create(type="PythonEvaluator", params={"code": "def main(**kwargs): pass"})
-
-        evaluator.refresh_from_db()
-        assert evaluator.llm_provider_id is None
-        assert evaluator.llm_provider_model_id is None
-
-    def test_provider_deletion_nulls_the_fk(self, provider, provider_model):
-        evaluator = EvaluatorFactory.create(team=provider.team, params=_params(provider.id, provider_model.id))
-
+    def test_provider_deletion_nulls_the_fk(self, evaluator, provider, provider_model):
         provider.delete()
 
         evaluator.refresh_from_db()
         assert evaluator.llm_provider_id is None
         assert evaluator.llm_provider_model_id == provider_model.id
 
-    def test_unrelated_update_does_not_touch_the_fks(self, provider, provider_model):
-        """A targeted save that doesn't include params leaves the FK columns alone."""
-        evaluator = EvaluatorFactory.create(team=provider.team, params=_params(provider.id, provider_model.id))
-        other_model = LlmProviderModelFactory.create(team=provider.team)
-        Evaluator.objects.filter(pk=evaluator.pk).update(llm_provider_model=other_model)
-
-        evaluator.refresh_from_db()
-        evaluator.name = "renamed"
-        evaluator.save(update_fields=["name"])
-
-        evaluator.refresh_from_db()
-        assert evaluator.name == "renamed"
-        assert evaluator.llm_provider_model_id == other_model.id
-
-    def test_an_unchanged_provider_costs_no_existence_queries(
-        self, provider, provider_model, django_assert_num_queries
-    ):
-        """Re-deriving an id the FK column already holds needs no validation.
-
-        A non-null FK is guaranteed to resolve by the constraint, and SET_NULL would have
-        nulled it if the row had gone away.
-        """
-        evaluator = EvaluatorFactory.create(team=provider.team, params=_params(provider.id, provider_model.id))
-        evaluator.refresh_from_db()
-
-        with django_assert_num_queries(1):  # the UPDATE only
-            evaluator.save(update_fields=["params"])
-
-    def test_a_changed_provider_is_still_validated(self, provider, provider_model):
-        """The check is skipped only when the value matches; a new id is still verified."""
-        evaluator = EvaluatorFactory.create(team=provider.team, params=_params(provider.id, provider_model.id))
-        evaluator.params["llm_provider_id"] = provider.id + 1000
-        evaluator.save(update_fields=["params"])
-
-        evaluator.refresh_from_db()
-        assert evaluator.llm_provider_id is None
-
-    def test_set_llm_provider_model_id_moves_params_and_fk(self, provider, provider_model):
-        evaluator = EvaluatorFactory.create(team=provider.team, params=_params(provider.id, provider_model.id))
-        replacement = LlmProviderModelFactory.create(team=provider.team)
-
-        evaluator.set_llm_provider_model_id(replacement.id)
-
-        evaluator.refresh_from_db()
-        assert evaluator.llm_provider_model_id == replacement.id
-        assert evaluator.params["llm_provider_model_id"] == replacement.id
-
 
 @pytest.mark.django_db()
 class TestRuntimeResolution:
-    def test_fk_wins_over_a_stale_params_id(self, provider, provider_model):
-        """The FK is the reference; params only feeds the form UI."""
-        evaluator = EvaluatorFactory.create(team=provider.team, params=_params(provider.id, provider_model.id))
+    def test_the_fk_ids_are_injected_into_the_params(self, evaluator, provider, provider_model):
+        """``LLMResponseMixin`` takes the ids as fields, so they are supplied from the FKs."""
+        assert evaluator.get_evaluator_params() == _params() | {
+            "llm_provider_id": provider.id,
+            "llm_provider_model_id": provider_model.id,
+        }
+
+    def test_a_legacy_params_copy_is_overridden_by_the_fks(self, provider, provider_model):
+        """Rows saved before the ids left ``params`` still carry them; the FK is what runs."""
         other_provider = LlmProviderFactory.create(team=provider.team)
-        Evaluator.objects.filter(pk=evaluator.pk).update(llm_provider=other_provider)
-        evaluator.refresh_from_db()
+        evaluator = EvaluatorFactory.create(
+            team=provider.team,
+            llm_provider=provider,
+            llm_provider_model=provider_model,
+            params=_params() | {"llm_provider_id": other_provider.id, "llm_provider_model_id": 0},
+        )
 
-        assert evaluator.get_evaluator_params()["llm_provider_id"] == other_provider.id
+        assert evaluator.get_evaluator_params()["llm_provider_id"] == provider.id
+        assert evaluator.get_evaluator_params()["llm_provider_model_id"] == provider_model.id
 
-    def test_missing_provider_raises_a_useful_error(self, provider, provider_model):
-        evaluator = EvaluatorFactory.create(team=provider.team, params=_params(provider.id, provider_model.id))
+    def test_missing_provider_raises_a_useful_error(self, evaluator, provider):
         provider.delete()
         evaluator.refresh_from_db()
 
@@ -148,6 +79,8 @@ class TestRuntimeResolution:
 
     def test_python_evaluator_params_pass_through(self):
         params = {"code": "def main(**kwargs): pass"}
-        evaluator = EvaluatorFactory.create(type="PythonEvaluator", params=params)
+        evaluator = EvaluatorFactory.create(
+            type="PythonEvaluator", llm_provider=None, llm_provider_model=None, params=params
+        )
 
         assert evaluator.get_evaluator_params() == params

--- a/apps/evaluations/tests/test_evaluator_views.py
+++ b/apps/evaluations/tests/test_evaluator_views.py
@@ -7,13 +7,11 @@ import pytest
 from django.test import Client
 from django.urls import reverse
 
+from apps.evaluations import evaluators
 from apps.evaluations.models import ConditionType
-from apps.service_providers.models import LlmProvider, LlmProviderTypes
-from apps.utils.factories.evaluations import (
-    EvaluatorFactory,
-    EvaluatorTagRuleFactory,
-    configure_evaluator_llm_provider,
-)
+from apps.evaluations.views.evaluator_views import _get_evaluator_schema
+from apps.service_providers.models import LlmProviderTypes
+from apps.utils.factories.evaluations import EvaluatorFactory, EvaluatorTagRuleFactory
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 from apps.utils.factories.team import TeamWithUsersFactory
 
@@ -33,28 +31,25 @@ def client_with_user(team):
 @pytest.fixture()
 def evaluator(team):
     """An LLM evaluator pointing at providers this team is actually allowed to use."""
-    return configure_evaluator_llm_provider(EvaluatorFactory.create(team=team))
+    return EvaluatorFactory.create(team=team)
 
 
 def _edit_url(team, evaluator):
     return reverse("evaluations:evaluator_edit", args=[team.slug, evaluator.pk])
 
 
-def _params(output_schema, evaluator):
-    return {
-        "llm_prompt": "prompt",
-        "llm_provider_id": evaluator.params["llm_provider_id"],
-        "llm_provider_model_id": evaluator.params["llm_provider_model_id"],
-        "output_schema": output_schema,
-    }
+def _params(output_schema):
+    return {"llm_prompt": "prompt", "output_schema": output_schema}
 
 
-def _post_data(evaluator, output_schema, rule_rows, params=None):
+def _post_data(evaluator, output_schema, rule_rows, params=None, **overrides):
     data = {
         "name": evaluator.name,
         "type": "LlmEvaluator",
-        "params": json.dumps(params if params is not None else _params(output_schema, evaluator)),
+        "params": json.dumps(params if params is not None else _params(output_schema)),
         "evaluation_mode": evaluator.evaluation_mode,
+        "llm_provider": evaluator.llm_provider_id,
+        "llm_provider_model": evaluator.llm_provider_model_id,
         "tag_rules-TOTAL_FORMS": str(len(rule_rows)),
         "tag_rules-INITIAL_FORMS": str(len([r for r in rule_rows if r.get("id")])),
         "tag_rules-MIN_NUM_FORMS": "0",
@@ -63,7 +58,7 @@ def _post_data(evaluator, output_schema, rule_rows, params=None):
     for i, row in enumerate(rule_rows):
         for key, value in row.items():
             data[f"tag_rules-{i}-{key}"] = value
-    return data
+    return data | overrides
 
 
 @pytest.mark.django_db()
@@ -150,52 +145,151 @@ class TestEditEvaluatorSchemaDrift:
         assert not evaluator.tag_rules.filter(pk=rule.pk).exists()
 
 
+@pytest.mark.parametrize(
+    ("evaluator_class", "requires_provider"),
+    [
+        pytest.param(evaluators.LlmEvaluator, True, id="llm-evaluator"),
+        pytest.param(evaluators.PythonEvaluator, False, id="python-evaluator"),
+    ],
+)
+def test_the_rendered_schema_flags_the_provider_instead_of_listing_its_ids(evaluator_class, requires_provider):
+    """The picker is driven by the flag; the ids are form fields, so they are not parameters."""
+    schema = _get_evaluator_schema(evaluator_class)
+
+    assert schema["requires_llm_provider"] is requires_provider
+    assert not set(evaluators.LLM_PROVIDER_FIELDS) & set(schema["properties"])
+    assert not set(evaluators.LLM_PROVIDER_FIELDS) & set(schema["required"])
+
+
+@pytest.mark.django_db()
+class TestEvaluatorPickerInitialState:
+    """What the provider picker starts on — it is seeded from the FKs, not from params."""
+
+    def test_editing_starts_on_the_saved_selection(self, client_with_user, team, evaluator):
+        response = client_with_user.get(_edit_url(team, evaluator))
+
+        assert response.context_data["llm_provider_selection"] == {
+            "llm_provider_id": evaluator.llm_provider_id,
+            "llm_provider_model_id": evaluator.llm_provider_model_id,
+        }
+
+    def test_creating_starts_on_the_teams_first_provider(self, client_with_user, team):
+        provider = LlmProviderFactory.create(team=team)
+        model = LlmProviderModelFactory.create(team=team, type=provider.type)
+
+        response = client_with_user.get(reverse("evaluations:evaluator_new", args=[team.slug]))
+
+        assert response.context_data["llm_provider_selection"] == {
+            "llm_provider_id": provider.id,
+            "llm_provider_model_id": model.id,
+        }
+
+    def test_editing_an_evaluator_whose_provider_was_deleted_starts_on_nothing(self, client_with_user, team, evaluator):
+        """Defaulting here would repoint the evaluator at an unchosen provider on the next Update."""
+        evaluator.llm_provider.delete()
+        LlmProviderFactory.create(team=team)  # a default is available, and must not be used
+
+        response = client_with_user.get(_edit_url(team, evaluator))
+
+        assert response.context_data["llm_provider_selection"]["llm_provider_id"] is None
+
+    def test_a_cleared_selection_stays_cleared_on_re_render(self, client_with_user, team, evaluator):
+        """Falling back to the default here would show a provider next to "select a provider"."""
+        response = client_with_user.post(
+            _edit_url(team, evaluator), _post_data(evaluator, {}, [], llm_provider="", llm_provider_model="")
+        )
+
+        assert response.context_data["llm_provider_selection"] == {
+            "llm_provider_id": "",
+            "llm_provider_model_id": "",
+        }
+
+
 @pytest.mark.django_db()
 class TestEvaluatorLlmProviderSelection:
-    def test_a_valid_selection_saves_and_repoints_the_fks(self, client_with_user, team, evaluator):
-        """The submitted ids land on the FK columns, not just in params."""
+    def test_a_valid_selection_repoints_the_fks(self, client_with_user, team, evaluator):
         new_provider = LlmProviderFactory.create(team=team)
         new_model = LlmProviderModelFactory.create(team=team, type=new_provider.type)
-        params = _params(evaluator.params["output_schema"], evaluator) | {
-            "llm_provider_id": new_provider.id,
-            "llm_provider_model_id": new_model.id,
-        }
+
+        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
+            response = client_with_user.post(
+                _edit_url(team, evaluator),
+                _post_data(evaluator, {}, [], llm_provider=new_provider.id, llm_provider_model=new_model.id),
+            )
+
+        assert response.status_code == 302, getattr(response, "context_data", None)
+        evaluator.refresh_from_db()
+        assert evaluator.llm_provider_id == new_provider.id
+        assert evaluator.llm_provider_model_id == new_model.id
+
+    def test_ids_posted_inside_params_are_discarded(self, client_with_user, team, evaluator):
+        """A stale tab may still submit them; the FK fields are the only record."""
+        other_provider = LlmProviderFactory.create(team=team)
+        params = _params({}) | {"llm_provider_id": other_provider.id, "llm_provider_model_id": 999}
 
         with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
             response = client_with_user.post(_edit_url(team, evaluator), _post_data(evaluator, {}, [], params=params))
 
         assert response.status_code == 302, getattr(response, "context_data", None)
         evaluator.refresh_from_db()
-        assert evaluator.params["llm_provider_id"] == new_provider.id
-        assert evaluator.params["llm_provider_model_id"] == new_model.id
-        assert evaluator.llm_provider_id == new_provider.id
-        assert evaluator.llm_provider_model_id == new_model.id
+        assert "llm_provider_id" not in evaluator.params
+        assert "llm_provider_model_id" not in evaluator.params
+        assert evaluator.llm_provider_id != other_provider.id
 
     def test_a_model_from_another_provider_type_is_rejected(self, client_with_user, team, evaluator):
         """The picker only offers matching types, so a mismatch means a hand-crafted post."""
-        provider = LlmProvider.objects.get(id=evaluator.params["llm_provider_id"])
-        mismatched_type = next(t for t in LlmProviderTypes if str(t) != provider.type)
+        mismatched_type = next(t for t in LlmProviderTypes if str(t) != evaluator.llm_provider.type)
         mismatched_model = LlmProviderModelFactory.create(team=team, type=str(mismatched_type))
-        params = _params(evaluator.params["output_schema"], evaluator) | {"llm_provider_model_id": mismatched_model.id}
-        original_model_id = evaluator.params["llm_provider_model_id"]
+        original_model_id = evaluator.llm_provider_model_id
 
         with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
-            response = client_with_user.post(_edit_url(team, evaluator), _post_data(evaluator, {}, [], params=params))
+            response = client_with_user.post(
+                _edit_url(team, evaluator), _post_data(evaluator, {}, [], llm_provider_model=mismatched_model.id)
+            )
 
         assert response.status_code == 200
         assert "providers, but the selected provider is" in response.content.decode()
         evaluator.refresh_from_db()
-        assert evaluator.params["llm_provider_model_id"] == original_model_id
+        assert evaluator.llm_provider_model_id == original_model_id
 
     def test_another_teams_provider_is_rejected(self, client_with_user, team, evaluator):
         other_teams_provider = LlmProviderFactory.create()
-        params = _params(evaluator.params["output_schema"], evaluator) | {"llm_provider_id": other_teams_provider.id}
-        original_provider_id = evaluator.params["llm_provider_id"]
+        original_provider_id = evaluator.llm_provider_id
 
         with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
-            response = client_with_user.post(_edit_url(team, evaluator), _post_data(evaluator, {}, [], params=params))
+            response = client_with_user.post(
+                _edit_url(team, evaluator), _post_data(evaluator, {}, [], llm_provider=other_teams_provider.id)
+            )
 
         assert response.status_code == 200
         assert "not available to this team" in response.content.decode()
         evaluator.refresh_from_db()
-        assert evaluator.params["llm_provider_id"] == original_provider_id
+        assert evaluator.llm_provider_id == original_provider_id
+
+    def test_an_llm_evaluator_without_a_provider_is_rejected(self, client_with_user, team, evaluator):
+        original_provider_id = evaluator.llm_provider_id
+
+        with patch("apps.evaluations.evaluators.LlmEvaluator.__init__", return_value=None):
+            response = client_with_user.post(
+                _edit_url(team, evaluator), _post_data(evaluator, {}, [], llm_provider="", llm_provider_model="")
+            )
+
+        assert response.status_code == 200
+        assert "Select an LLM provider for this evaluator" in response.content.decode()
+        evaluator.refresh_from_db()
+        assert evaluator.llm_provider_id == original_provider_id
+
+    def test_a_python_evaluator_clears_the_provider(self, client_with_user, team, evaluator):
+        """No provider is posted for an evaluator type with no LLM, so the FKs are nulled."""
+        code = "def main(input, output, context, full_history, generated_response, **kwargs):\n    return {}"
+        data = _post_data(evaluator, {}, [], params={"code": code})
+        data["type"] = "PythonEvaluator"
+        del data["llm_provider"]
+        del data["llm_provider_model"]
+
+        response = client_with_user.post(_edit_url(team, evaluator), data)
+
+        assert response.status_code == 302, getattr(response, "context_data", None)
+        evaluator.refresh_from_db()
+        assert evaluator.llm_provider_id is None
+        assert evaluator.llm_provider_model_id is None

--- a/apps/evaluations/views/evaluator_views.py
+++ b/apps/evaluations/views/evaluator_views.py
@@ -110,13 +110,13 @@ class EvaluatorFormsetMixin:
     def get_object_or_none(self):
         return None
 
-    def _get_evaluator_form_context(self):
+    def _get_evaluator_form_context(self, form):
         llm_providers = list(LlmProvider.objects.filter(team=self.request.team).values("id", "name", "type"))
         llm_provider_models = list(LlmProviderModel.objects.for_team(self.request.team))
         return {
             "evaluator_schemas": _evaluator_schemas(),
             "parameter_values": _evaluator_parameter_values(self.request.team, llm_providers, llm_provider_models),
-            "default_values": _evaluator_default_values(llm_providers, llm_provider_models),
+            "llm_provider_selection": _initial_llm_provider_selection(form, llm_providers, llm_provider_models),
         }
 
 
@@ -135,7 +135,7 @@ class CreateEvaluator(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Evalua
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update(self._get_evaluator_form_context())
+        context.update(self._get_evaluator_form_context(context["form"]))
         return context
 
     def get_form_kwargs(self):
@@ -160,7 +160,7 @@ class EditEvaluator(LoginAndTeamRequiredMixin, PermissionRequiredMixin, Evaluato
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update(self._get_evaluator_form_context())
+        context.update(self._get_evaluator_form_context(context["form"]))
         return context
 
     def get_queryset(self):
@@ -234,6 +234,13 @@ def _get_evaluator_schema(evaluator_class):
     schema = resolve_references(evaluator_class.model_json_schema())
     schema.pop("$defs", None)
 
+    # The provider ids are not params — they live on the Evaluator FK columns and the form edits
+    # them through its own fields. The flag is what tells the UI to render that picker.
+    schema["requires_llm_provider"] = issubclass(evaluator_class, evaluators.LLMResponseMixin)
+    for field_name in evaluators.LLM_PROVIDER_FIELDS:
+        schema["properties"].pop(field_name, None)
+    schema["required"] = [name for name in schema.get("required", []) if name not in evaluators.LLM_PROVIDER_FIELDS]
+
     # Remove type ambiguity for optional fields
     for _key, value in schema["properties"].items():
         if "anyOf" in value:
@@ -266,8 +273,25 @@ def _evaluator_parameter_values(team, llm_providers, llm_provider_models):
     }
 
 
-def _evaluator_default_values(llm_providers: list[dict], llm_provider_models):
-    """Returns the default values for evaluator parameters."""
+def _initial_llm_provider_selection(form, llm_providers: list[dict], llm_provider_models) -> dict:
+    """Which provider and model the picker starts on.
+
+    Only a brand new evaluator is given a default. An existing one shows exactly what it has,
+    even when that is nothing (its provider was deleted), and so does a re-rendered submit:
+    a default filled in there reads as answered, and one Update away from silently repointing
+    the evaluator at a provider the user never chose.
+    """
+    selection = {
+        "llm_provider_id": form["llm_provider"].value(),
+        "llm_provider_model_id": form["llm_provider_model"].value(),
+    }
+    if form.is_bound or form.instance.pk:
+        return selection
+    return _default_llm_provider_selection(llm_providers, llm_provider_models)
+
+
+def _default_llm_provider_selection(llm_providers: list[dict], llm_provider_models) -> dict:
+    """The team's first provider and a model it can serve, so the model list has something to filter by."""
     llm_provider_model_id = None
     provider_id = None
     if llm_providers:

--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -338,12 +338,12 @@ def _evaluator_provider_model_fk_in_db() -> bool:
 
 
 def _repoint_evaluators(custom_model, global_model) -> None:
-    """Move every evaluator on ``custom_model`` to ``global_model``, ``params`` and FK together.
+    """Move every evaluator on ``custom_model`` to ``global_model``.
 
-    Written out here rather than calling ``Evaluator.set_llm_provider_model_id`` because
-    this also runs from migrations (``migration_utils.llm_model_migration``), where these
-    are historical models: they carry no custom methods, and in states older than
-    ``evaluations.0018`` the ``evaluators`` accessor does not exist at all.
+    The caller's generic FK pass would repoint them too. This exists for the guard below:
+    it also runs from migrations (``migration_utils.llm_model_migration``), where in states
+    older than ``evaluations.0018`` the ``evaluators`` accessor does not exist at all, and
+    the generic pass cannot tell that apart from having nothing to repoint.
     """
     evaluators = getattr(custom_model, "evaluators", None)
     if evaluators is None:
@@ -361,16 +361,13 @@ def _repoint_evaluators(custom_model, global_model) -> None:
             )
         return
 
-    for evaluator in evaluators.all():
-        evaluator.params["llm_provider_model_id"] = global_model.id
-        evaluator.llm_provider_model_id = global_model.id
-        evaluator.save(update_fields=["params", "llm_provider_model_id"])
+    evaluators.update(llm_provider_model_id=global_model.id)
 
 
 def _replace_custom_model_with_global(custom_model, global_model, LlmProviderModel):
     """Repoint everything referencing ``custom_model`` at ``global_model``, then delete it."""
-    # Evaluators first: they keep a copy of the model id in ``params`` alongside the FK, so
-    # both have to move together. Once done they drop out of get_related_objects below.
+    # Evaluators first: the generic pass below cannot tell an absent relation (an old
+    # migration state) from one with nothing to repoint. Once done they drop out of it.
     _repoint_evaluators(custom_model, global_model)
 
     for obj in get_related_objects(custom_model):

--- a/apps/service_providers/tests/test_default_models.py
+++ b/apps/service_providers/tests/test_default_models.py
@@ -89,8 +89,7 @@ def test_converts_custom_models_to_global_models_pipelines():
 @pytest.mark.django_db()
 def test_converts_custom_models_to_global_models_evaluators():
     custom_model = LlmProviderModelFactory.create()
-    evaluator = EvaluatorFactory.create(team=custom_model.team, params={"llm_provider_model_id": custom_model.id})
-    assert evaluator.llm_provider_model_id == custom_model.id
+    evaluator = EvaluatorFactory.create(team=custom_model.team, llm_provider_model=custom_model)
 
     defaults = {custom_model.type: [Model(custom_model.name, custom_model.max_token_limit)]}
     with patch("apps.service_providers.llm_service.default_models.DEFAULT_LLM_PROVIDER_MODELS", defaults):
@@ -99,7 +98,6 @@ def test_converts_custom_models_to_global_models_evaluators():
     global_model = LlmProviderModel.objects.get(team=None, type=custom_model.type, name=custom_model.name)
     evaluator.refresh_from_db()
     assert evaluator.llm_provider_model_id == global_model.id
-    assert evaluator.params["llm_provider_model_id"] == global_model.id
 
 
 @pytest.mark.django_db()
@@ -107,10 +105,10 @@ def test_converts_custom_models_to_global_models_from_a_migration(requires_migra
     """``_update_llm_provider_models`` also runs from migrations, with historical models.
 
     Historical models carry no custom methods, so the evaluator repointing has to work
-    without ``Evaluator.set_llm_provider_model_id``.
+    against the reverse accessor alone.
     """
     custom_model = LlmProviderModelFactory.create()
-    evaluator = EvaluatorFactory.create(team=custom_model.team, params={"llm_provider_model_id": custom_model.id})
+    evaluator = EvaluatorFactory.create(team=custom_model.team, llm_provider_model=custom_model)
 
     historical_state = MigrationExecutor(connection).loader.project_state()
     HistoricalLlmProviderModel = historical_state.apps.get_model("service_providers", "LlmProviderModel")
@@ -122,7 +120,6 @@ def test_converts_custom_models_to_global_models_from_a_migration(requires_migra
     global_model = LlmProviderModel.objects.get(team=None, type=custom_model.type, name=custom_model.name)
     evaluator.refresh_from_db()
     assert evaluator.llm_provider_model_id == global_model.id
-    assert evaluator.params["llm_provider_model_id"] == global_model.id
 
 
 @pytest.mark.django_db()

--- a/apps/service_providers/tests/test_models.py
+++ b/apps/service_providers/tests/test_models.py
@@ -84,10 +84,7 @@ class TestServiceProviderModel:
         the remove_deprecated_models command) repoint evaluators first.
         """
         provider_model = LlmProviderModelFactory.create()
-        evaluator = EvaluatorFactory(
-            team=provider_model.team,
-            params={"llm_provider_model_id": provider_model.id},
-        )
+        evaluator = EvaluatorFactory(team=provider_model.team, llm_provider_model=provider_model)
 
         with pytest.raises(ValidationError, match=evaluator.name):
             provider_model.delete()

--- a/apps/service_providers/tests/test_usages.py
+++ b/apps/service_providers/tests/test_usages.py
@@ -468,18 +468,12 @@ def _add_provider_usage(provider, count: int) -> None:
         pipeline = PipelineFactory(team=provider.team)
         NodeFactory(pipeline=pipeline, type="LLMResponseWithPrompt", params={"llm_provider_id": provider.id})
         ExperimentFactory(team=provider.team, pipeline=pipeline)
-        EvaluatorFactory(team=provider.team, params={"llm_provider_id": provider.id})
+        EvaluatorFactory(team=provider.team, llm_provider=provider)
 
 
 @pytest.mark.django_db()
-@pytest.mark.parametrize("stored_id", [pytest.param(int, id="int"), pytest.param(str, id="str")])
-def test_evaluators_referencing_the_provider_in_params_are_reported(anthropic_provider, stored_id):
-    """The id is submitted inside ``Evaluator.params``; the reported reference is the derived FK."""
-    evaluator = EvaluatorFactory(
-        team=anthropic_provider.team,
-        name="Sentiment",
-        params={"llm_provider_id": stored_id(anthropic_provider.id)},
-    )
+def test_evaluators_referencing_the_provider_are_reported(anthropic_provider):
+    evaluator = EvaluatorFactory(team=anthropic_provider.team, name="Sentiment", llm_provider=anthropic_provider)
 
     usages = get_provider_usages(anthropic_provider)
 
@@ -490,7 +484,7 @@ def test_evaluators_referencing_the_provider_in_params_are_reported(anthropic_pr
 @pytest.mark.django_db()
 def test_evaluators_referencing_a_different_provider_are_not_reported(anthropic_provider):
     other_provider = LlmProviderFactory(team=anthropic_provider.team)
-    EvaluatorFactory(team=anthropic_provider.team, params={"llm_provider_id": other_provider.id})
+    EvaluatorFactory(team=anthropic_provider.team, llm_provider=other_provider)
 
     assert get_provider_usages(anthropic_provider).is_empty()
 

--- a/apps/service_providers/tests/test_views.py
+++ b/apps/service_providers/tests/test_views.py
@@ -164,11 +164,10 @@ def test_delete_llm_provider_blocked_by_an_evaluator(team_with_users, authed_cli
     """Evaluators reference the provider by FK, so deleting underneath one is blocked.
 
     Previously they were collected by get_related_objects but silently dropped, leaving the
-    evaluator with a nulled FK and a stale id in params — unrunnable, with no warning.
+    evaluator with a nulled FK and nothing to run against — with no warning.
     """
     provider = LlmProviderFactory(team=team_with_users)
-    evaluator = EvaluatorFactory.create(team=team_with_users, params={"llm_provider_id": provider.id})
-    assert evaluator.llm_provider_id == provider.id
+    evaluator = EvaluatorFactory.create(team=team_with_users, llm_provider=provider)
 
     response = authed_client.delete(
         reverse(

--- a/apps/teams/management/commands/clone_team.py
+++ b/apps/teams/management/commands/clone_team.py
@@ -461,17 +461,14 @@ class Command(BaseCommand):
 
     def _clone_evaluations(self, ctx: CloneContext):
         """Clone evaluators, datasets, and configs."""
-        # Evaluators - remap llm_provider_id and llm_provider_model_id in params; the matching
-        # FK columns are derived from those on save.
         for evaluator in Evaluator.objects.filter(team=ctx.source_team):
-            params = dict(evaluator.params)
-            self._remap_evaluator_params(ctx, evaluator.name, params)
-
             new_evaluator = Evaluator.objects.create(
                 team=ctx.target_team,
                 name=evaluator.name,
                 type=evaluator.type,
-                params=params,
+                params=dict(evaluator.params),
+                llm_provider_id=self._remap_evaluator_llm_id(ctx, evaluator, "llm_provider_id"),
+                llm_provider_model_id=self._remap_evaluator_llm_id(ctx, evaluator, "llm_provider_model_id"),
             )
             ctx.evaluators[evaluator.id] = new_evaluator
 
@@ -551,26 +548,19 @@ class Command(BaseCommand):
             if new_evaluator_ids:
                 new_config.evaluators.set(new_evaluator_ids)
 
-    def _remap_evaluator_params(self, ctx: CloneContext, name: str, params: dict):
-        """Remap FK IDs in evaluator params to new team's objects."""
-        # Remap llm_provider_id
-        if "llm_provider_id" in params and params["llm_provider_id"]:
-            old_id = int(params["llm_provider_id"])
-            if old_id in ctx.llm_providers:
-                params["llm_provider_id"] = ctx.llm_providers[old_id].id
-            elif not LlmProvider.objects.filter(id=old_id, team__isnull=True).exists():
-                raise CommandError(
-                    f"Evaluator '{name}' references llm_provider_id={old_id} which was not found in source team."
-                )
-            # else: global provider, leave as-is
-
-        # Remap llm_provider_model_id
-        if "llm_provider_model_id" in params and params["llm_provider_model_id"]:
-            old_id = int(params["llm_provider_model_id"])
-            if old_id in ctx.llm_provider_models:
-                params["llm_provider_model_id"] = ctx.llm_provider_models[old_id].id
-            elif not LlmProviderModel.objects.filter(id=old_id, team__isnull=True).exists():
-                raise CommandError(
-                    f"Evaluator '{name}' references llm_provider_model_id={old_id} which was not found in source team."
-                )
-            # else: global model, leave as-is
+    def _remap_evaluator_llm_id(self, ctx: CloneContext, evaluator: Evaluator, field: str) -> int | None:
+        """The target team's id for one of an evaluator's LLM FKs, or the same id if it is global."""
+        mapping, model = {
+            "llm_provider_id": (ctx.llm_providers, LlmProvider),
+            "llm_provider_model_id": (ctx.llm_provider_models, LlmProviderModel),
+        }[field]
+        old_id = getattr(evaluator, field)
+        if not old_id:
+            return None
+        if old_id in mapping:
+            return mapping[old_id].id
+        if model.objects.filter(id=old_id, team__isnull=True).exists():
+            return old_id  # global, shared by both teams
+        raise CommandError(
+            f"Evaluator '{evaluator.name}' references {field}={old_id} which was not found in source team."
+        )

--- a/apps/teams/management/commands/clone_team.py
+++ b/apps/teams/management/commands/clone_team.py
@@ -466,6 +466,7 @@ class Command(BaseCommand):
                 team=ctx.target_team,
                 name=evaluator.name,
                 type=evaluator.type,
+                evaluation_mode=evaluator.evaluation_mode,
                 params=dict(evaluator.params),
                 llm_provider_id=self._remap_evaluator_llm_id(ctx, evaluator, "llm_provider_id"),
                 llm_provider_model_id=self._remap_evaluator_llm_id(ctx, evaluator, "llm_provider_model_id"),

--- a/apps/teams/tests/test_clone_team.py
+++ b/apps/teams/tests/test_clone_team.py
@@ -251,6 +251,14 @@ def test_clone_team_clones_evaluations(source_team):
     target_eval_count = Evaluator.objects.filter(team=target).count()
     assert target_eval_count == source_eval_count
 
+    # The provider selection is FK-only, and must land on the target team's own copies
+    source_evaluator = Evaluator.objects.filter(team=source_team).first()
+    target_evaluator = Evaluator.objects.get(team=target, name=source_evaluator.name)
+    assert target_evaluator.llm_provider.team == target
+    assert target_evaluator.llm_provider.name == source_evaluator.llm_provider.name
+    assert target_evaluator.llm_provider_model.team == target
+    assert target_evaluator.llm_provider_model.name == source_evaluator.llm_provider_model.name
+
     # Verify datasets cloned
     source_ds_count = EvaluationDataset.objects.filter(team=source_team).count()
     target_ds_count = EvaluationDataset.objects.filter(team=target).count()

--- a/apps/teams/tests/test_clone_team.py
+++ b/apps/teams/tests/test_clone_team.py
@@ -64,7 +64,8 @@ def source_team(django_db_blocker):
         )
 
         # Evaluations
-        evaluator = EvaluatorFactory.create(team=team)
+        # Non-default evaluation_mode so the clone is checked to carry it over
+        evaluator = EvaluatorFactory.create(team=team, evaluation_mode="session")
         dataset = EvaluationDatasetFactory.create(team=team)
         EvaluationConfigFactory.create(team=team, dataset=dataset, base_experiment=experiment, evaluators=[evaluator])
 
@@ -258,6 +259,7 @@ def test_clone_team_clones_evaluations(source_team):
     assert target_evaluator.llm_provider.name == source_evaluator.llm_provider.name
     assert target_evaluator.llm_provider_model.team == target
     assert target_evaluator.llm_provider_model.name == source_evaluator.llm_provider_model.name
+    assert target_evaluator.evaluation_mode == source_evaluator.evaluation_mode
 
     # Verify datasets cloned
     source_ds_count = EvaluationDataset.objects.filter(team=source_team).count()

--- a/apps/utils/factories/evaluations.py
+++ b/apps/utils/factories/evaluations.py
@@ -30,6 +30,10 @@ class EvaluatorFactory(DjangoModelFactory):
     type = "LlmEvaluator"
     name = factory.Sequence(lambda n: f"Test Evaluator {n}")
     evaluation_mode = "message"
+    # An LlmEvaluator needs both to be runnable, so the default is a valid one. Pass
+    # ``llm_provider=None, llm_provider_model=None`` for an evaluator with nothing selected.
+    llm_provider = factory.SubFactory(LlmProviderFactory, team=factory.SelfAttribute("..team"))
+    llm_provider_model = factory.SubFactory(LlmProviderModelFactory, team=factory.SelfAttribute("..team"))
     params = factory.LazyFunction(
         lambda: {
             "llm_prompt": "give me the sentiment of the user messages",
@@ -50,22 +54,6 @@ class EvaluatorFactory(DjangoModelFactory):
             },
         }
     )
-
-
-def configure_evaluator_llm_provider(evaluator: Evaluator) -> Evaluator:
-    """Point an LLM evaluator at real providers in its own team, making it runnable.
-
-    ``EvaluatorFactory`` leaves the provider ids out of ``params``, so by default an
-    ``LlmEvaluator`` it builds names no provider — which the form rejects on save and an
-    evaluation run rejects pre-flight. Tests that post the evaluator form, or drive a run
-    through the coordinator, need this; most tests do not.
-    """
-    evaluator.params |= {
-        "llm_provider_id": LlmProviderFactory.create(team=evaluator.team).id,
-        "llm_provider_model_id": LlmProviderModelFactory.create(team=evaluator.team).id,
-    }
-    evaluator.save(update_fields=["params"])
-    return evaluator
 
 
 class EvaluationTagFactory(DjangoModelFactory):

--- a/apps/utils/factories/evaluations.py
+++ b/apps/utils/factories/evaluations.py
@@ -33,7 +33,15 @@ class EvaluatorFactory(DjangoModelFactory):
     # An LlmEvaluator needs both to be runnable, so the default is a valid one. Pass
     # ``llm_provider=None, llm_provider_model=None`` for an evaluator with nothing selected.
     llm_provider = factory.SubFactory(LlmProviderFactory, team=factory.SelfAttribute("..team"))
-    llm_provider_model = factory.SubFactory(LlmProviderModelFactory, team=factory.SelfAttribute("..team"))
+    # The model's type has to match the provider's or the pair is one the evaluator form rejects,
+    # so follow the provider rather than defaulting both to OpenAI independently.
+    llm_provider_model = factory.LazyAttribute(
+        lambda evaluator: (
+            LlmProviderModelFactory(team=evaluator.team, type=evaluator.llm_provider.type)
+            if evaluator.llm_provider
+            else None
+        )
+    )
     params = factory.LazyFunction(
         lambda: {
             "llm_prompt": "give me the sentiment of the user messages",

--- a/apps/utils/factories/evaluations.py
+++ b/apps/utils/factories/evaluations.py
@@ -17,6 +17,7 @@ from apps.evaluations.models import (
     Evaluator,
     EvaluatorTagRule,
 )
+from apps.service_providers.models import LlmProviderTypes
 from apps.utils.factories.experiment import ChatFactory, ChatMessageFactory, ExperimentFactory
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 from apps.utils.factories.team import TeamFactory
@@ -34,13 +35,12 @@ class EvaluatorFactory(DjangoModelFactory):
     # ``llm_provider=None, llm_provider_model=None`` for an evaluator with nothing selected.
     llm_provider = factory.SubFactory(LlmProviderFactory, team=factory.SelfAttribute("..team"))
     # The model's type has to match the provider's or the pair is one the evaluator form rejects,
-    # so follow the provider rather than defaulting both to OpenAI independently.
-    llm_provider_model = factory.LazyAttribute(
-        lambda evaluator: (
-            LlmProviderModelFactory(team=evaluator.team, type=evaluator.llm_provider.type)
-            if evaluator.llm_provider
-            else None
-        )
+    # so follow the provider rather than defaulting both to OpenAI independently. This stays a
+    # SubFactory so ``build()`` builds the model instead of saving it against an unsaved team.
+    llm_provider_model = factory.SubFactory(
+        LlmProviderModelFactory,
+        team=factory.SelfAttribute("..team"),
+        type=factory.SelfAttribute("..llm_provider.type", default=str(LlmProviderTypes.openai)),
     )
     params = factory.LazyFunction(
         lambda: {

--- a/apps/web/management/commands/bootstrap_data.py
+++ b/apps/web/management/commands/bootstrap_data.py
@@ -605,7 +605,6 @@ class Command(BaseCommand):
 
     def _seed_evaluator(self, team, llm_provider, llm_model) -> Evaluator:
         params = {
-            "llm_provider_id": llm_provider.id,
             "llm_temperature": 0.3,
             "prompt": (
                 "Analyse the sentiment of the user message.\n\nUser: {input.content}\nAssistant: {output.content}"
@@ -626,9 +625,6 @@ class Command(BaseCommand):
                 },
             },
         }
-        if llm_model:
-            params["llm_provider_model_id"] = llm_model.id
-
         evaluator, created = Evaluator.objects.get_or_create(
             team=team,
             name="Sentiment Analyzer",
@@ -636,6 +632,8 @@ class Command(BaseCommand):
                 "type": "LlmEvaluator",
                 "evaluation_mode": EvaluationMode.MESSAGE,
                 "params": params,
+                "llm_provider": llm_provider,
+                "llm_provider_model": llm_model,
             },
         )
         self._log_created("evaluator", evaluator.name, created)

--- a/templates/evaluations/evaluator_form.html
+++ b/templates/evaluations/evaluator_form.html
@@ -29,50 +29,58 @@
     <!-- Dynamic Parameter Fields -->
     <div x-show="selectedSchema" class="mt-4">
       <h3 class="text-lg font-medium mb-3">{% translate "Evaluator Parameters" %}</h3>
+
+      {# The provider selection is stored on the Evaluator FK columns, not in params, so these #}
+      {# two are real form fields rather than schema-driven parameters. x-if rather than x-show: #}
+      {# an evaluator type with no LLM must not post a provider at all. #}
+      <template x-if="selectedSchema?.requires_llm_provider">
+        <div>
+          <div class="fieldset w-full">
+            <label class="label font-bold" for="id_llm_provider">
+              <div>{% translate "LLM Provider" %}</div>
+            </label>
+            <select id="id_llm_provider"
+                    name="{{ form.llm_provider.html_name }}"
+                    x-model="llmProviderId"
+                    @change="onLlmProviderChange()"
+                    class="select w-full">
+              <option value="">{% translate "Select LLM Provider..." %}</option>
+              {# :selected as well as x-model — the options are rendered after the select's own #}
+              {# bindings run, so x-model alone cannot select one that does not exist yet. #}
+              <template x-for="option in parameterValues.LlmProviderId || []" :key="option.value">
+                <option :value="option.value" :selected="option.value == llmProviderId" x-text="option.label"></option>
+              </template>
+            </select>
+            {{ form.llm_provider.errors }}
+          </div>
+
+          {# Outside the x-show below: with no provider chosen the model select is hidden, and an #}
+          {# error rendered inside it would be invisible to the user it is meant for. #}
+          {% if form.llm_provider_model.errors %}
+            <div class="fieldset w-full">{{ form.llm_provider_model.errors }}</div>
+          {% endif %}
+
+          <div class="fieldset w-full" x-show="llmProviderId">
+            <label class="label font-bold" for="id_llm_provider_model">
+              <div>{% translate "LLM Model" %}</div>
+            </label>
+            <select id="id_llm_provider_model"
+                    name="{{ form.llm_provider_model.html_name }}"
+                    x-model="llmProviderModelId"
+                    class="select w-full">
+              <option value="">{% translate "Select Model..." %}</option>
+              <template x-for="model in getAvailableModels()" :key="model.value">
+                <option :value="model.value" :selected="model.value == llmProviderModelId" x-text="model.label"></option>
+              </template>
+            </select>
+            <small class="form-text text-muted">{% translate "Select the specific model to use for evaluation" %}</small>
+          </div>
+        </div>
+      </template>
+
       <div id="dynamic-params">
         <template x-for="(field, fieldName) in selectedSchema?.properties || {}" :key="fieldName">
           <div x-show="fieldName !== 'type'" class="fieldset w-full">
-
-            <!-- LLM Provider Widget -->
-            <template x-if="getWidget(field) === 'llm_provider_model'">
-              <div>
-                <label :for="'param_' + fieldName" class="label font-bold">
-                  <div x-text="field.title || fieldName"></div>
-                </label>
-                <select :id="'param_' + fieldName"
-                        :name="'param_' + fieldName"
-                        x-model="params[fieldName]"
-                        @change="updateLlmProviderModel(fieldName)"
-                        class="select w-full"
-                        :required="isRequired(fieldName)">
-                  <option value="">{% translate "Select LLM Provider..." %}</option>
-                  <template x-for="option in parameterValues.LlmProviderId || []" :key="option.value">
-                    <option :value="option.value" x-text="option.label"></option>
-                  </template>
-                </select>
-                <small class="form-text text-muted" x-show="field.description" x-text="field.description"></small>
-              </div>
-            </template>
-
-            <!-- LLM Provider Model Selection (show after provider selected) -->
-            <template x-if="fieldName === 'llm_provider_model_id' && params.llm_provider_id && getWidget(field) === 'none'">
-              <div>
-                <label :for="'param_' + fieldName" class="label font-bold">
-                  <div>{% translate "LLM Model" %}</div>
-                </label>
-                <select :id="'param_' + fieldName"
-                        :name="'param_' + fieldName"
-                        x-model="params[fieldName]"
-                        class="select w-full"
-                        :required="isRequired(fieldName)">
-                  <option value="">{% translate "Select Model..." %}</option>
-                  <template x-for="model in getAvailableModels()" :key="model.value">
-                    <option :value="model.value" x-text="model.label"></option>
-                  </template>
-                </select>
-                <small class="form-text text-muted">{% translate "Select the specific model to use for evaluation" %}</small>
-              </div>
-            </template>
 
             <!-- Range Widget (for temperature) -->
             <template x-if="getWidget(field) === 'range'">
@@ -508,16 +516,16 @@
           onload="SiteJS.tagRuleSelect.bootstrapTagRuleSelects();"></script>
   {{ evaluator_schemas|json_script:"evaluator-schemas" }}
   {{ parameter_values|json_script:"parameter-values" }}
-  {{ default_values|json_script:"default-values" }}
   {% if object.params %}{{ object.params|json_script:"existing-params" }}{% elif form.params.value %}{{ form.params.value|json_script:"existing-params" }}{% endif %}
   <script>
     document.addEventListener('alpine:init', () => {
       Alpine.data('evaluatorForm', () => ({
         evaluatorSchemas: JSON.parse(document.getElementById("evaluator-schemas").textContent),
         parameterValues: JSON.parse(document.getElementById("parameter-values").textContent),
-        defaultValues: JSON.parse(document.getElementById("default-values").textContent),
         selectedType: '{% if object.type %}{{ object.type|escapejs }}{% else %}{{ form.type.value|default:"" }}{% endif %}',
         evaluationMode: '{{ form.evaluation_mode.value|default:"message" }}',
+        llmProviderId: '{{ llm_provider_selection.llm_provider_id|default_if_none:""|escapejs }}',
+        llmProviderModelId: '{{ llm_provider_selection.llm_provider_model_id|default_if_none:""|escapejs }}',
         selectedSchema: null,
         params: {},
         keyValuePairs: {},
@@ -542,15 +550,13 @@
 
             if (existingParams) {
               try {
-                this.params = { ...this.defaultValues, ...existingParams };
+                this.params = { ...this.params, ...existingParams };
                 // Initialize key-value pairs for all key_value_pairs widgets
                 this.initializeKeyValuePairs();
               } catch(e) {
                 console.error('Error parsing existing params:', e);
-                this.params = { ...this.defaultValues };
+                this.params = {};
               }
-            } else {
-              this.params = { ...this.defaultValues };
             }
           }
         },
@@ -564,15 +570,8 @@
 
             // Only add default values for fields that exist in this evaluator's schema
             Object.keys(this.selectedSchema.properties).forEach(key => {
-              if (key !== 'type') {
-                // Check if this field exists in defaultValues and add it
-                if (this.defaultValues[key] !== undefined) {
-                  newParams[key] = this.defaultValues[key];
-                }
-                // Override with schema-specific defaults if they exist
-                if (this.selectedSchema.properties[key].default !== undefined) {
-                  newParams[key] = this.selectedSchema.properties[key].default;
-                }
+              if (key !== 'type' && this.selectedSchema.properties[key].default !== undefined) {
+                newParams[key] = this.selectedSchema.properties[key].default;
               }
             });
 
@@ -623,24 +622,19 @@
           this.selectedSchema.required.includes(fieldName);
         },
 
-        updateLlmProviderModel(fieldName) {
-          // When LLM provider changes, update the model options
-          const providerId = this.params[fieldName];
+        onLlmProviderChange() {
+          // The model list is filtered by the provider's type, so the previous choice may no
+          // longer be on offer: fall back to the first model this provider can serve.
           const availableModels = this.getAvailableModels();
-
-          // Set the first available model as default
-          if (availableModels.length > 0) {
-            this.params.llm_provider_model_id = availableModels[0].value;
-          } else {
-            this.params.llm_provider_model_id = null;
+          if (!availableModels.some(model => model.value == this.llmProviderModelId)) {
+            this.llmProviderModelId = availableModels.length > 0 ? availableModels[0].value : '';
           }
         },
 
         getAvailableModels() {
-          const providerId = this.params.llm_provider_id;
-          if (!providerId) return [];
+          if (!this.llmProviderId) return [];
 
-          const provider = this.parameterValues.LlmProviderId.find(p => p.value == providerId);
+          const provider = this.parameterValues.LlmProviderId.find(p => p.value == this.llmProviderId);
           if (!provider) return [];
 
           return this.parameterValues.LlmProviderModelId.filter(model => model.type === provider.type);


### PR DESCRIPTION
Part 2 of #3977 — closes #3995. #3992 made `Evaluator.llm_provider` / `llm_provider_model` authoritative but left `params` carrying a copy of both ids, because the edit form is generated from the pydantic schema and the fields had to be in it for the picker to exist. The invariant "params is written, the FK is derived" was enforced only by convention: any writer that set the FK directly, or used `QuerySet.update()`, drifted.

The form now edits `llm_provider` / `llm_provider_model` as real `ModelChoiceField`s. The two ids stay on `LLMResponseMixin` (it's a pydantic model that needs them to construct) but are stripped from the rendered schema in favour of a `requires_llm_provider` flag, so `params` can't carry them again by construction — and team scoping is now a queryset rather than a hand-rolled id lookup.

Evaluations-only by choice: `Widgets.llm_provider_model` is nominally shared with pipeline nodes, but the evaluator form renders its own Alpine select and never touches `assets/javascript/apps/pipeline/nodes/widgets.tsx`. `Node` keeps the params-plus-derived-FK arrangement of ADR-0046, untouched.

Worth a look:

- `_initial_llm_provider_selection` — only a *new* evaluator gets a default provider. An existing one shows exactly what it has, even when that's nothing because its provider was deleted; defaulting there is one Update away from silently repointing an evaluator at a provider nobody chose.
- The picker needs `:selected` on its options as well as `x-model` — Alpine runs the select's own bindings before the `x-for` renders any options, so `x-model` alone left the saved selection blank.
- `_repoint_evaluators` survives only for its guard (old migration states with no `Evaluator` in the app state); the generic FK pass in both callers now covers the actual repointing, which is why the evaluator loop in `remove_deprecated_models` is gone.
- Incidental fix: the team export/import sync remapped node params but never evaluator params, so a synced evaluator pointed at the *source* server's provider ids. The FK columns go through `resolve_fk`, so dropping the copy fixes that.

### Migrations

None here, deliberately. Stripping the ids from existing `params` needs its own deploy step: the code being removed derives the FKs from `params` on save, so an old instance handling a Save after the migration would repoint or null the FKs. It follows in #4029, to be merged once this is deployed. Until then legacy rows keep the copy and it is ignored — `get_evaluator_params()` overlays the FK values, covered by `test_a_legacy_params_copy_is_overridden_by_the_fks`.

### Demo

Driven in the browser on top of real seeded data: edit preselects the saved provider/model, create preselects the team's first provider, changing the provider refilters the model list, saving repoints the FK with `params` staying clean, switching to Python Evaluator removes the picker from the DOM (so no provider is posted and the FKs clear), and clearing the provider re-renders with both field errors visible.

### Docs and Changelog
- [ ] This PR requires docs/changelog update