### PR TITLE
feat: pipeline build-state reporting + additive inspect fields (write API phase 1, PRs 1–2)

### DIFF
--- a/api-schemas/v2.yml
+++ b/api-schemas/v2.yml
@@ -722,7 +722,24 @@ components:
           allOf:
           - $ref: '#/components/schemas/InspectPipeline'
           readOnly: true
-          nullable: true
+        pipeline_valid:
+          type: boolean
+          readOnly: true
+          description: Whether this chatbot's pipeline validates cleanly
+        pipeline_errors:
+          allOf:
+          - $ref: '#/components/schemas/PipelineBuildErrors'
+          readOnly: true
+        unwired_handles:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: '#/components/schemas/InspectOutputHandle'
+          description: 'Advisory ''what still needs wiring'' map, keyed by ``node_id``:
+            every output handle with no outgoing edge and every implicit ``input``
+            handle with no incoming edge. Never an error and never blocks a publish.'
+          readOnly: true
         events:
           $ref: '#/components/schemas/InspectEvents'
       required:
@@ -734,9 +751,12 @@ components:
       - is_unreleased
       - name
       - pipeline
+      - pipeline_errors
+      - pipeline_valid
       - settings
       - team_slug
       - trace_provider
+      - unwired_handles
       - version_description
       - voice
     ChatbotVersion:
@@ -888,6 +908,11 @@ components:
         provider_name:
           type: string
           nullable: true
+        model_id:
+          type: integer
+          nullable: true
+          description: The model's id — the value to write back as the node's model
+            reference.
         type:
           type: string
           nullable: true
@@ -917,6 +942,11 @@ components:
         provider_name:
           type: string
           nullable: true
+        model_id:
+          type: integer
+          nullable: true
+          description: The model's id — the value to write back as the node's model
+            reference.
         type:
           type: string
           nullable: true
@@ -938,6 +968,11 @@ components:
         provider_name:
           type: string
           nullable: true
+        synthetic_voice_id:
+          type: integer
+          nullable: true
+          description: The synthetic voice's id — the value to write back to set the
+            voice.
         type:
           type: string
           nullable: true
@@ -1127,6 +1162,11 @@ components:
     InspectGraphEdge:
       type: object
       properties:
+        id:
+          type: string
+          nullable: true
+          description: The edge's identity — the address a write-API caller uses to
+            delete this edge.
         source:
           type: string
           description: '``node_id`` the edge leaves from.'
@@ -1145,6 +1185,7 @@ components:
           description: Input handle on the target node; currently always null (nodes
             have one implicit input).
       required:
+      - id
       - source
       - source_handle
       - target
@@ -1183,6 +1224,11 @@ components:
           readOnly: true
           description: The node's non-resource configuration, verbatim; keys vary
             by node type.
+        output_handles:
+          type: array
+          items:
+            $ref: '#/components/schemas/InspectOutputHandle'
+          readOnly: true
         llm:
           allOf:
           - $ref: '#/components/schemas/FlattenedLlm'
@@ -1221,6 +1267,7 @@ components:
       required:
       - label
       - node_id
+      - output_handles
       - params
       - type
     InspectNodeParams:
@@ -1236,6 +1283,21 @@ components:
       - $ref: '#/components/schemas/AssistantNodeParams'
       - $ref: '#/components/schemas/ExtractStructuredDataParams'
       - $ref: '#/components/schemas/ExtractParticipantDataParams'
+    InspectOutputHandle:
+      type: object
+      description: One output handle a node offers, for wiring edges from it.
+      properties:
+        handle:
+          type: string
+          description: Handle name to copy verbatim into an edge's ``source_handle``.
+        label:
+          type: string
+          nullable: true
+          description: The router branch keyword this handle routes; null for a plain
+            node's single output.
+      required:
+      - handle
+      - label
     InspectPipeline:
       type: object
       properties:
@@ -1623,6 +1685,36 @@ components:
       - identifier
       - platform
       - public_id
+    PipelineBuildErrors:
+      type: object
+      description: The normalized three-bucket errors report the publish gate rejects
+        on.
+      properties:
+        node:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
+          description: Per-field error messages keyed by ``node_id``. Node-level errors
+            that aren't about a single field (e.g. 'End node is not reachable') appear
+            under the ``root`` key.
+        edge:
+          type: array
+          items:
+            type: string
+          description: Ids of edges stranded on a handle their source node no longer
+            offers.
+        pipeline:
+          type: array
+          items:
+            type: string
+          description: Graph-level error messages that name no single node or edge
+            (e.g. 'A cycle was detected').
+      required:
+      - edge
+      - node
+      - pipeline
     PlatformEnum:
       enum:
       - telegram

--- a/apps/api/v2/inspect/nodes.py
+++ b/apps/api/v2/inspect/nodes.py
@@ -51,12 +51,13 @@ def nodes_in_render_order(pipeline) -> list:
 def graph_digest(node_list, pipeline_data: dict | None) -> dict:
     """Build a lightweight view of the pipeline's shape.
 
-    Returns just the nodes (each as ``{flow_id, type, label}``) and the edges between them, with
-    canvas positions removed and the edge handle keys renamed to snake_case.
+    Returns just the nodes (each as ``{flow_id, type, label}``) and the edges between them — each
+    with its ``id`` — with canvas positions removed and the edge handle keys renamed to snake_case.
     """
     nodes = [{"flow_id": node.flow_id, "type": node.type, "label": node.label} for node in node_list]
     edges = [
         {
+            "id": edge.get("id"),
             "source": edge.get("source"),
             "target": edge.get("target"),
             "source_handle": edge.get("sourceHandle"),

--- a/apps/api/v2/inspect/serializers.py
+++ b/apps/api/v2/inspect/serializers.py
@@ -35,6 +35,7 @@ from apps.documents.models import Collection
 from apps.events.models import EventAction, EventActionType, StaticTrigger, TimeoutTrigger
 from apps.experiments.models import ConsentForm, Experiment, SourceMaterial
 from apps.files.models import File
+from apps.pipelines.build_state import node_output_handles
 from apps.pipelines.models import Node, Pipeline
 from apps.utils.fields import as_int
 
@@ -473,6 +474,17 @@ class GraphSerializer(serializers.Serializer):
 
 
 # ── Node (ADR-0025) ──────────────────────────────────────────────────────────────────────────────
+@extend_schema_serializer(component_name="InspectOutputHandle")
+class OutputHandleSerializer(serializers.Serializer):
+    """One output handle a node offers, for wiring edges from it."""
+
+    handle = serializers.CharField(help_text="Handle name to copy verbatim into an edge's ``source_handle``.")
+    label = serializers.CharField(
+        allow_null=True,
+        help_text="The router branch keyword this handle routes; null for a plain node's single output.",
+    )
+
+
 class InspectNodeSerializer(serializers.ModelSerializer):
     """One pipeline node, with the resources it references inlined.
 
@@ -510,6 +522,7 @@ class InspectNodeSerializer(serializers.ModelSerializer):
     params = serializers.SerializerMethodField(
         help_text="The node's non-resource configuration, verbatim; keys vary by node type."
     )
+    output_handles = serializers.SerializerMethodField()
     llm = serializers.SerializerMethodField()
     voice = serializers.SerializerMethodField()
     custom_actions = serializers.SerializerMethodField()
@@ -527,6 +540,7 @@ class InspectNodeSerializer(serializers.ModelSerializer):
             "type",
             "label",
             "params",
+            "output_handles",
             "llm",
             "voice",
             "source_material",
@@ -554,6 +568,12 @@ class InspectNodeSerializer(serializers.ModelSerializer):
         if "max_results" in params:
             params["max_indexed_collection_search_results"] = params.pop("max_results")
         return params
+
+    @extend_schema_field(OutputHandleSerializer(many=True))
+    def get_output_handles(self, node) -> list:
+        # Server-derived (W5): routers get one handle per branch keyword, plain nodes the single
+        # standard output, End none — so a caller can wire edges from any node it reads back.
+        return node_output_handles(node)
 
     @extend_schema_field(FlattenedLlmSerializer(allow_null=True))
     def get_llm(self, node):

--- a/apps/api/v2/inspect/serializers.py
+++ b/apps/api/v2/inspect/serializers.py
@@ -262,6 +262,12 @@ class FlattenedModelProviderSerializer(FlattenedProviderSerializer):
     Expects a :class:`ProviderModelPair`; a missing provider or model renders its fields as null.
     """
 
+    model_id = serializers.IntegerField(
+        source="model.id",
+        default=None,
+        allow_null=True,
+        help_text="The model's id — the value to write back as the node's model reference.",
+    )
     # ``ProviderModelPair.type`` — provider type with model-type fallback.
     type = serializers.CharField(allow_null=True)
     model = serializers.CharField(source="model.name", default=None, allow_null=True)
@@ -290,6 +296,12 @@ class FlattenedVoiceSerializer(FlattenedProviderSerializer):
     Expects a :class:`VoicePair`.
     """
 
+    synthetic_voice_id = serializers.IntegerField(
+        source="voice.id",
+        default=None,
+        allow_null=True,
+        help_text="The synthetic voice's id — the value to write back to set the voice.",
+    )
     # Unlike the llm/embedding pairs, ``type`` has no fallback to the voice half — a provider-less
     # voice renders ``type: null`` (matches the pre-refactor shape).
     type = serializers.CharField(
@@ -427,6 +439,10 @@ class GraphNodeSerializer(serializers.Serializer):
 
 @extend_schema_serializer(component_name="InspectGraphEdge")
 class GraphEdgeSerializer(serializers.Serializer):
+    id = serializers.CharField(
+        allow_null=True,
+        help_text="The edge's identity — the address a write-API caller uses to delete this edge.",
+    )
     source = serializers.CharField(help_text="``node_id`` the edge leaves from.")
     target = serializers.CharField(help_text="``node_id`` the edge points to.")
     source_handle = serializers.CharField(

--- a/apps/api/v2/inspect/serializers.py
+++ b/apps/api/v2/inspect/serializers.py
@@ -35,7 +35,7 @@ from apps.documents.models import Collection
 from apps.events.models import EventAction, EventActionType, StaticTrigger, TimeoutTrigger
 from apps.experiments.models import ConsentForm, Experiment, SourceMaterial
 from apps.files.models import File
-from apps.pipelines.build_state import node_output_handles
+from apps.pipelines.build_state import node_output_handles, pipeline_build_state
 from apps.pipelines.models import Node, Pipeline
 from apps.utils.fields import as_int
 
@@ -728,6 +728,26 @@ class InspectEventsSerializer(serializers.Serializer):
 
 
 # ── Root (ADR-0024) ──────────────────────────────────────────────────────────────────────────────
+class PipelineBuildErrorsSerializer(serializers.Serializer):
+    """The normalized three-bucket errors report the publish gate rejects on."""
+
+    node = serializers.DictField(
+        child=serializers.DictField(child=serializers.CharField()),
+        help_text=(
+            "Per-field error messages keyed by ``node_id``. Node-level errors that aren't about a "
+            "single field (e.g. 'End node is not reachable') appear under the ``root`` key."
+        ),
+    )
+    edge = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="Ids of edges stranded on a handle their source node no longer offers.",
+    )
+    pipeline = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="Graph-level error messages that name no single node or edge (e.g. 'A cycle was detected').",
+    )
+
+
 class ChatbotInspectSerializer(serializers.ModelSerializer):
     """The whole chatbot configuration in one read-only response (ADR-0024).
 
@@ -753,7 +773,10 @@ class ChatbotInspectSerializer(serializers.ModelSerializer):
     trace_provider = ProviderSerializer(allow_null=True)
     voice = serializers.SerializerMethodField()
     channels = serializers.SerializerMethodField()
-    pipeline = InspectPipelineSerializer(allow_null=True, read_only=True)
+    pipeline = InspectPipelineSerializer(read_only=True)
+    pipeline_valid = serializers.SerializerMethodField(help_text=("Whether this chatbot's pipeline validates cleanly"))
+    pipeline_errors = serializers.SerializerMethodField()
+    unwired_handles = serializers.SerializerMethodField()
     events = InspectEventsSerializer(source="*")
 
     class Meta:
@@ -773,6 +796,9 @@ class ChatbotInspectSerializer(serializers.ModelSerializer):
             "trace_provider",
             "channels",
             "pipeline",
+            "pipeline_valid",
+            "pipeline_errors",
+            "unwired_handles",
             "events",
         ]
 
@@ -784,6 +810,36 @@ class ChatbotInspectSerializer(serializers.ModelSerializer):
     @extend_schema_field(ChannelSerializer(many=True))
     def get_channels(self, experiment) -> list:
         return ChannelSerializer(get_channels(experiment), many=True).data
+
+    def _build_state(self, experiment) -> dict:
+        # Computed once per instance (validate() builds the whole graph) and shared by the three
+        # build-state fields below. Keyed by pk because DRF reuses one serializer instance across
+        # items under many=True.
+        cached = getattr(self, "_build_state_cache", None)
+        if cached is None or cached[0] != experiment.pk:
+            self._build_state_cache = (experiment.pk, pipeline_build_state(experiment.pipeline))
+        return self._build_state_cache[1]
+
+    @extend_schema_field(serializers.BooleanField())
+    def get_pipeline_valid(self, experiment) -> bool:
+        return self._build_state(experiment)["pipeline_valid"]
+
+    @extend_schema_field(PipelineBuildErrorsSerializer())
+    def get_pipeline_errors(self, experiment) -> dict:
+        return self._build_state(experiment)["errors"]
+
+    @extend_schema_field(
+        serializers.DictField(
+            child=serializers.ListField(child=OutputHandleSerializer()),
+            help_text=(
+                "Advisory 'what still needs wiring' map, keyed by ``node_id``: every output handle "
+                "with no outgoing edge and every implicit ``input`` handle with no incoming edge. "
+                "Never an error and never blocks a publish."
+            ),
+        )
+    )
+    def get_unwired_handles(self, experiment) -> dict:
+        return self._build_state(experiment)["unwired_handles"]
 
 
 # ── Schema extensions ──────────────────────────────────────────────────────────────────────────

--- a/apps/api/v2/inspect/tests/test_flattened_serializers.py
+++ b/apps/api/v2/inspect/tests/test_flattened_serializers.py
@@ -34,6 +34,7 @@ def test_flattened_llm_full_pair():
     provider = LlmProviderFactory.create(team=team, name="Prod OpenAI", type="openai")
     model = LlmProviderModelFactory.create(team=team, name="gpt-4o", max_token_limit=128000, deprecated=False)
     assert FlattenedLlmSerializer(ProviderModelPair(provider, model)).data == {
+        "model_id": model.id,
         "provider_id": provider.id,
         "provider_name": "Prod OpenAI",
         "type": "openai",
@@ -47,6 +48,7 @@ def test_flattened_llm_full_pair():
 def test_flattened_llm_model_only_falls_back_to_model_type():
     model = LlmProviderModelFactory.create(name="gpt-4o")
     data = FlattenedLlmSerializer(ProviderModelPair(None, model)).data
+    assert data["model_id"] == model.id
     assert data["provider_id"] is None
     assert data["provider_name"] is None
     assert data["type"] == model.type
@@ -57,6 +59,7 @@ def test_flattened_llm_model_only_falls_back_to_model_type():
 def test_flattened_llm_provider_only_emits_null_model_fields():
     provider = LlmProviderFactory.create(type="openai")
     data = FlattenedLlmSerializer(ProviderModelPair(provider, None)).data
+    assert data["model_id"] is None
     assert data["type"] == "openai"
     assert data["model"] is None
     assert data["max_token_limit"] is None
@@ -68,6 +71,7 @@ def test_flattened_voice():
     provider = VoiceProviderFactory.create(name="ElevenLabs", type="elevenlabs")
     voice = SyntheticVoiceFactory.create(name="Rachel", language="English", neural=True, voice_provider=provider)
     assert FlattenedVoiceSerializer(VoicePair(provider, voice)).data == {
+        "synthetic_voice_id": voice.id,
         "provider_id": provider.id,
         "provider_name": "ElevenLabs",
         "type": "elevenlabs",
@@ -83,6 +87,7 @@ def test_flattened_embedding():
     provider = LlmProviderFactory.create(team=team, name="Prod OpenAI", type="openai")
     model = EmbeddingProviderModelFactory.create(team=team, name="text-embedding-3-small")
     assert FlattenedModelProviderSerializer(ProviderModelPair(provider, model)).data == {
+        "model_id": model.id,
         "provider_id": provider.id,
         "provider_name": "Prod OpenAI",
         "type": "openai",
@@ -94,6 +99,7 @@ def test_flattened_embedding():
 def test_flattened_embedding_model_only_falls_back_to_model_type():
     model = EmbeddingProviderModelFactory.create(name="text-embedding-3-small")
     data = FlattenedModelProviderSerializer(ProviderModelPair(None, model)).data
+    assert data["model_id"] == model.id
     assert data["provider_id"] is None
     assert data["type"] == model.type
     assert data["model"] == "text-embedding-3-small"
@@ -103,6 +109,7 @@ def test_flattened_embedding_model_only_falls_back_to_model_type():
 def test_flattened_voice_provider_only_emits_null_voice_fields():
     provider = VoiceProviderFactory.create(type="elevenlabs")
     data = FlattenedVoiceSerializer(VoicePair(provider, None)).data
+    assert data["synthetic_voice_id"] is None
     assert data["type"] == provider.type
     assert data["voice_name"] is None
     assert data["neural"] is None

--- a/apps/api/v2/inspect/tests/test_node_rendering.py
+++ b/apps/api/v2/inspect/tests/test_node_rendering.py
@@ -23,7 +23,7 @@ def _render(node_type, params):
 @pytest.mark.django_db()
 def test_start_node_carries_no_resource_keys():
     data = _render("StartNode", {})
-    assert set(data) == {"node_id", "type", "label", "params"}
+    assert set(data) == {"node_id", "type", "label", "params", "output_handles"}
 
 
 @pytest.mark.django_db()
@@ -65,3 +65,25 @@ def test_voice_not_dropped_when_only_synthetic_voice_field_set():
         "language": "English",
         "neural": True,
     }
+
+
+@pytest.mark.django_db()
+def test_plain_node_has_single_output_handle():
+    data = _render("LLMResponseWithPrompt", {"prompt": "hi"})
+    assert data["output_handles"] == [{"handle": "output", "label": None}]
+
+
+@pytest.mark.django_db()
+def test_end_node_has_no_output_handles():
+    data = _render("EndNode", {})
+    assert data["output_handles"] == []
+
+
+@pytest.mark.django_db()
+def test_router_output_handles_regenerate_from_keywords_with_upper_cased_labels():
+    data = _render("StaticRouterNode", {"route_key": "k", "keywords": ["schedule", "reschedule", "cancel"]})
+    assert data["output_handles"] == [
+        {"handle": "output_0", "label": "SCHEDULE"},
+        {"handle": "output_1", "label": "RESCHEDULE"},
+        {"handle": "output_2", "label": "CANCEL"},
+    ]

--- a/apps/api/v2/inspect/tests/test_node_rendering.py
+++ b/apps/api/v2/inspect/tests/test_node_rendering.py
@@ -57,6 +57,7 @@ def test_voice_not_dropped_when_only_synthetic_voice_field_set():
     data = _render("LLMResponseWithPrompt", {"synthetic_voice_id": voice.id})
 
     assert data["voice"] == {
+        "synthetic_voice_id": voice.id,
         "provider_id": provider.id,
         "provider_name": provider.name,
         "type": provider.type,

--- a/apps/api/v2/inspect/tests/test_nodes.py
+++ b/apps/api/v2/inspect/tests/test_nodes.py
@@ -42,10 +42,10 @@ def test_nodes_in_render_order_is_stable_whatever_order_the_db_returns():
 
 def test_graph_digest_strips_positions_and_normalises_handles():
     nodes = [SimpleNamespace(flow_id="a", type="StartNode", label="Start")]
-    data = {"edges": [{"source": "a", "target": "b", "sourceHandle": "out", "targetHandle": "in", "x": 1}]}
+    data = {"edges": [{"id": "e1", "source": "a", "target": "b", "sourceHandle": "out", "targetHandle": "in", "x": 1}]}
     assert graph_digest(nodes, data) == {
         "nodes": [{"flow_id": "a", "type": "StartNode", "label": "Start"}],
-        "edges": [{"source": "a", "target": "b", "source_handle": "out", "target_handle": "in"}],
+        "edges": [{"id": "e1", "source": "a", "target": "b", "source_handle": "out", "target_handle": "in"}],
     }
 
 

--- a/apps/api/v2/tests/test_chatbots_inspect.py
+++ b/apps/api/v2/tests/test_chatbots_inspect.py
@@ -443,6 +443,23 @@ def test_build_state_reports_node_errors_and_unwired_handles_together():
 
 
 @pytest.mark.django_db()
+def test_build_state_reports_a_node_type_that_is_not_a_node_class():
+    """``Node.type`` is unvalidated graph data, so it can name any attribute of the nodes module —
+    here a logger. The read must report it as an unknown type, not 500 on what it resolved to."""
+    experiment = _build_state_bot()
+    _make_node(pipeline=experiment.pipeline, flow_id="odd-1", type="logger", label="Odd", params={"name": "Odd"})
+
+    response = _client(experiment).get(_inspect_url(experiment))
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["pipeline_valid"] is False
+    assert payload["pipeline_errors"]["node"]["odd-1"] == {"root": "Unknown node type: logger"}
+    # Its outputs are unknowable, so only the implicit input is reported.
+    assert payload["unwired_handles"] == {"odd-1": [{"handle": "input", "label": None}]}
+
+
+@pytest.mark.django_db()
 def test_build_state_present_on_version_reads():
     experiment = _build_state_bot()
     version = experiment.create_new_version()

--- a/apps/api/v2/tests/test_chatbots_inspect.py
+++ b/apps/api/v2/tests/test_chatbots_inspect.py
@@ -567,6 +567,7 @@ def _expected_pipeline_nodes(bot):
             "type": "LLMResponseWithPrompt",
             "label": "Answer",
             "params": {"prompt": "Answer the user"},
+            "output_handles": [{"handle": "output", "label": None}],
             "llm": {
                 "model_id": bot.llm_model.id,
                 "provider_id": bot.llm_provider.id,
@@ -649,6 +650,7 @@ def _expected_pipeline_nodes(bot):
             "type": "AssistantNode",
             "label": "Assistant",
             "params": {"citations_enabled": True},
+            "output_handles": [{"handle": "output", "label": None}],
             "assistant": {
                 "id": bot.assistant.id,
                 "name": "Helper",
@@ -869,8 +871,10 @@ def _adversarial_bot():
 # Empirically derived. The SAME number must hold for every version mode, because resolve_inspect_version
 # resolves AND prefetches the target with a fixed prefetch set — including each node's resource FK/M2M
 # relations (inspect_node_queryset) — so node fan-out adds no queries. Resolution costs one query in
-# every mode, so folding it into the measured block keeps the count constant.
-EXPECTED_RENDER_QUERIES = 13
+# every mode, so folding it into the measured block keeps the count constant. Deriving output_handles
+# validates each router node, whose LLM-backed variant looks its provider model up through ORMRepository
+# (not the prefetched relation) — one query for this bot's single router.
+EXPECTED_RENDER_QUERIES = 14
 
 
 @pytest.mark.django_db()

--- a/apps/api/v2/tests/test_chatbots_inspect.py
+++ b/apps/api/v2/tests/test_chatbots_inspect.py
@@ -557,14 +557,149 @@ def _full_bot():
     )
 
 
-@pytest.mark.django_db()
-def test_full_response_body():
-    """A fully populated bot whose response has no null fields, so every serializer runs."""
-    bot = _full_bot()
+def _expected_pipeline_nodes(bot):
+    """The two fully-populated node objects in ``_full_bot()``'s pipeline."""
+    return [
+        {
+            "node_id": "llm",
+            "type": "LLMResponseWithPrompt",
+            "label": "Answer",
+            "params": {"prompt": "Answer the user"},
+            "llm": {
+                "provider_id": bot.llm_provider.id,
+                "provider_name": "Prod OpenAI",
+                "type": "openai",
+                "model": "gpt-4o",
+                "max_token_limit": 128000,
+                "deprecated": False,
+            },
+            "source_material": {
+                "id": bot.source.id,
+                "topic": "Returns",
+                "description": "Returns policy",
+                "material": "# Returns",
+            },
+            "media_collection": {
+                "id": bot.media_collection.id,
+                "name": "Media docs",
+                "files": [
+                    {
+                        "id": bot.media_file.id,
+                        "name": "guide.pdf",
+                        "content_type": "application/pdf",
+                        "content_size": 50321,
+                        "external_source": "",
+                        "external_id": "",
+                    }
+                ],
+            },
+            "indexed_collections": [
+                {
+                    "id": bot.index_collection.id,
+                    "name": "Policy index",
+                    "embedding": {
+                        "provider_id": bot.llm_provider.id,
+                        "provider_name": "Prod OpenAI",
+                        "type": "openai",
+                        "model": "text-embedding-3-small",
+                    },
+                    "files": [
+                        {
+                            "id": bot.index_file.id,
+                            "name": "policy.pdf",
+                            "content_type": "application/pdf",
+                            "content_size": 40112,
+                            "external_source": "",
+                            "external_id": "",
+                        }
+                    ],
+                }
+            ],
+            "custom_actions": [
+                {
+                    "id": bot.action.id,
+                    "name": "Session Completion",
+                    "description": "Custom action description",
+                    "server_url": "https://api.weather.com",
+                    "allowed_operations": ["weather_get", "pollen_get"],
+                    "api_schema": {"paths": ["/pollen", "/weather"]},
+                    "auth_provider": {
+                        "id": bot.auth_provider.id,
+                        "type": bot.auth_provider.type,
+                        "name": "Partner Auth",
+                    },
+                }
+            ],
+            "voice": {
+                "provider_id": bot.voice_provider.id,
+                "provider_name": "ElevenLabs Prod",
+                "type": bot.voice_provider.type,
+                "voice_name": "Rachel",
+                "language": "English",
+                "neural": True,
+            },
+        },
+        {
+            "node_id": "assist",
+            "type": "AssistantNode",
+            "label": "Assistant",
+            "params": {"citations_enabled": True},
+            "assistant": {
+                "id": bot.assistant.id,
+                "name": "Helper",
+                "assistant_id": "asst_123",
+                "instructions": "Be helpful",
+                "builtin_tools": [],
+                "tools": [],
+                "temperature": 1.0,
+                "top_p": 1.0,
+            },
+        },
+    ]
 
-    payload = _get(bot)
 
-    assert payload == {
+def _expected_events(bot):
+    """``_full_bot()``'s schedule and timeout triggers as rendered."""
+    return {
+        "static_triggers": [
+            {
+                "id": bot.schedule_trigger.id,
+                "type": "conversation_start",
+                "is_active": True,
+                "action": {
+                    "type": "schedule_trigger",
+                    "params": {
+                        "scheduled_message": {
+                            "name": "Daily nudge",
+                            "frequency": 1,
+                            "time_period": "days",
+                            "repetitions": 3,
+                            "prompt_text": "Hi",
+                        },
+                    },
+                },
+            }
+        ],
+        "timeout_triggers": [
+            {
+                "id": bot.timeout_trigger.id,
+                "delay_seconds": 86400,
+                "total_num_triggers": 1,
+                "trigger_from_first_message": False,
+                "is_active": True,
+                "action": {"type": "send_message_to_bot", "params": {"message_to_bot": "Still there?"}},
+            }
+        ],
+    }
+
+
+def _expected_full_response(bot):
+    """The complete inspect response for ``_full_bot()``.
+
+    Split across three builders only to keep each one readable; the test still asserts the whole
+    payload in one equality, so any contract change shows up as a diff.
+    """
+    return {
         "id": str(bot.experiment.public_id),
         "name": "Support Bot",
         "description": "Customer support bot",
@@ -623,136 +758,18 @@ def test_full_response_body():
                 ],
                 "edges": [{"source": "llm", "target": "assist", "source_handle": "output", "target_handle": "input"}],
             },
-            "nodes": [
-                {
-                    "node_id": "llm",
-                    "type": "LLMResponseWithPrompt",
-                    "label": "Answer",
-                    "params": {"prompt": "Answer the user"},
-                    "llm": {
-                        "provider_id": bot.llm_provider.id,
-                        "provider_name": "Prod OpenAI",
-                        "type": "openai",
-                        "model": "gpt-4o",
-                        "max_token_limit": 128000,
-                        "deprecated": False,
-                    },
-                    "source_material": {
-                        "id": bot.source.id,
-                        "topic": "Returns",
-                        "description": "Returns policy",
-                        "material": "# Returns",
-                    },
-                    "media_collection": {
-                        "id": bot.media_collection.id,
-                        "name": "Media docs",
-                        "files": [
-                            {
-                                "id": bot.media_file.id,
-                                "name": "guide.pdf",
-                                "content_type": "application/pdf",
-                                "content_size": 50321,
-                                "external_source": "",
-                                "external_id": "",
-                            }
-                        ],
-                    },
-                    "indexed_collections": [
-                        {
-                            "id": bot.index_collection.id,
-                            "name": "Policy index",
-                            "embedding": {
-                                "provider_id": bot.llm_provider.id,
-                                "provider_name": "Prod OpenAI",
-                                "type": "openai",
-                                "model": "text-embedding-3-small",
-                            },
-                            "files": [
-                                {
-                                    "id": bot.index_file.id,
-                                    "name": "policy.pdf",
-                                    "content_type": "application/pdf",
-                                    "content_size": 40112,
-                                    "external_source": "",
-                                    "external_id": "",
-                                }
-                            ],
-                        }
-                    ],
-                    "custom_actions": [
-                        {
-                            "id": bot.action.id,
-                            "name": "Session Completion",
-                            "description": "Custom action description",
-                            "server_url": "https://api.weather.com",
-                            "allowed_operations": ["weather_get", "pollen_get"],
-                            "api_schema": {"paths": ["/pollen", "/weather"]},
-                            "auth_provider": {
-                                "id": bot.auth_provider.id,
-                                "type": bot.auth_provider.type,
-                                "name": "Partner Auth",
-                            },
-                        }
-                    ],
-                    "voice": {
-                        "provider_id": bot.voice_provider.id,
-                        "provider_name": "ElevenLabs Prod",
-                        "type": bot.voice_provider.type,
-                        "voice_name": "Rachel",
-                        "language": "English",
-                        "neural": True,
-                    },
-                },
-                {
-                    "node_id": "assist",
-                    "type": "AssistantNode",
-                    "label": "Assistant",
-                    "params": {"citations_enabled": True},
-                    "assistant": {
-                        "id": bot.assistant.id,
-                        "name": "Helper",
-                        "assistant_id": "asst_123",
-                        "instructions": "Be helpful",
-                        "builtin_tools": [],
-                        "tools": [],
-                        "temperature": 1.0,
-                        "top_p": 1.0,
-                    },
-                },
-            ],
+            "nodes": _expected_pipeline_nodes(bot),
         },
-        "events": {
-            "static_triggers": [
-                {
-                    "id": bot.schedule_trigger.id,
-                    "type": "conversation_start",
-                    "is_active": True,
-                    "action": {
-                        "type": "schedule_trigger",
-                        "params": {
-                            "scheduled_message": {
-                                "name": "Daily nudge",
-                                "frequency": 1,
-                                "time_period": "days",
-                                "repetitions": 3,
-                                "prompt_text": "Hi",
-                            },
-                        },
-                    },
-                }
-            ],
-            "timeout_triggers": [
-                {
-                    "id": bot.timeout_trigger.id,
-                    "delay_seconds": 86400,
-                    "total_num_triggers": 1,
-                    "trigger_from_first_message": False,
-                    "is_active": True,
-                    "action": {"type": "send_message_to_bot", "params": {"message_to_bot": "Still there?"}},
-                }
-            ],
-        },
+        "events": _expected_events(bot),
     }
+
+
+@pytest.mark.django_db()
+def test_full_response_body():
+    """A fully populated bot whose response has no null fields, so every serializer runs."""
+    bot = _full_bot()
+
+    assert _get(bot) == _expected_full_response(bot)
 
 
 # ── Embedded pipeline (pipeline_start) + context propagation (review issue #6) ──────────────────

--- a/apps/api/v2/tests/test_chatbots_inspect.py
+++ b/apps/api/v2/tests/test_chatbots_inspect.py
@@ -13,6 +13,7 @@ from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.events.models import EventActionType
 from apps.experiments.models import Experiment
 from apps.files.models import File
+from apps.pipelines.tests.utils import create_pipeline_model, end_node, start_node
 from apps.teams.utils import current_team
 from apps.utils.deletion import delete_object_with_auditing_of_related_objects
 from apps.utils.factories.assistants import OpenAiAssistantFactory
@@ -395,6 +396,65 @@ def test_unknown_version_404(inspect_bot):
     assert _client(inspect_bot.experiment).get(f"{url}?version=999").status_code == 404
 
 
+# ── Top-level build state (pipeline_valid / errors / unwired_handles) ────────────────────────────
+def _build_state_bot():
+    """A bot with a valid, fully wired start -> end pipeline.
+
+    ``PipelineFactory``'s default data seeds start/end nodes without a ``name`` param, which
+    ``Pipeline.validate()`` flags, so build the pipeline through the same helper the pipeline
+    validation tests use (it names every node).
+    """
+    team = TeamWithUsersFactory.create()
+    pipeline = PipelineFactory.create(team=team)
+    create_pipeline_model([start_node(), end_node()], pipeline=pipeline)
+    pipeline.save()  # create_pipeline_model mutates pipeline.data without persisting it
+    return ExperimentFactory.create(team=team, pipeline=pipeline)
+
+
+@pytest.mark.django_db()
+def test_build_state_valid_and_fully_wired():
+    experiment = _build_state_bot()  # default pipeline: start -> end, fully wired
+    payload = _client(experiment).get(_inspect_url(experiment)).json()
+    assert payload["pipeline_valid"] is True
+    assert payload["pipeline_errors"] == {"node": {}, "edge": [], "pipeline": []}
+    assert payload["unwired_handles"] == {}
+
+
+@pytest.mark.django_db()
+def test_build_state_reports_node_errors_and_unwired_handles_together():
+    """An off-graph node missing a required param: the param error lands in errors.node, while its
+    dangling input/output land in the advisory unwired_handles map."""
+    experiment = _build_state_bot()
+    _make_node(
+        pipeline=experiment.pipeline,
+        flow_id="island-1",
+        type="LLMResponseWithPrompt",
+        label="Island",
+        params={"name": "Island", "prompt": "hi"},
+    )
+
+    payload = _client(experiment).get(_inspect_url(experiment)).json()
+
+    assert payload["pipeline_valid"] is False
+    assert "llm_provider_id" in payload["pipeline_errors"]["node"]["island-1"]
+    assert payload["unwired_handles"] == {
+        "island-1": [{"handle": "input", "label": None}, {"handle": "output", "label": None}]
+    }
+
+
+@pytest.mark.django_db()
+def test_build_state_present_on_version_reads():
+    experiment = _build_state_bot()
+    version = experiment.create_new_version()
+    url = _inspect_url(experiment)
+
+    payload = _client(experiment).get(f"{url}?version={version.version_number}").json()
+
+    assert payload["pipeline_valid"] is True
+    assert payload["pipeline_errors"] == {"node": {}, "edge": [], "pipeline": []}
+    assert payload["unwired_handles"] == {}
+
+
 # ── Full response body ───────────────────────────────────────────────────────────────────────────
 def _full_bot():
     """A fully populated bot whose response has no null fields, so every serializer runs.
@@ -468,6 +528,7 @@ def _full_bot():
                         "label": "Answer",
                         # the react FE persists ids as strings
                         "params": {
+                            "name": "Answer",
                             "llm_provider_id": str(llm_provider.id),
                             "llm_provider_model_id": str(llm_model.id),
                             "source_material_id": str(source.id),
@@ -475,7 +536,9 @@ def _full_bot():
                             "collection_index_ids": [str(index_collection.id)],
                             "custom_actions": [f"{action.id}:weather_get", f"{action.id}:pollen_get"],
                             "synthetic_voice_id": str(synthetic_voice.id),
-                            "prompt": "Answer the user",
+                            # source_material_id is set, so the prompt must reference the variable
+                            # or node validation flags it.
+                            "prompt": "Answer the user using {source_material} and {media}",
                         },
                     },
                 },
@@ -485,7 +548,7 @@ def _full_bot():
                         "id": "assist",
                         "type": "AssistantNode",
                         "label": "Assistant",
-                        "params": {"assistant_id": str(assistant.id), "citations_enabled": True},
+                        "params": {"name": "Assistant", "assistant_id": str(assistant.id), "citations_enabled": True},
                     },
                 },
             ],
@@ -566,7 +629,7 @@ def _expected_pipeline_nodes(bot):
             "node_id": "llm",
             "type": "LLMResponseWithPrompt",
             "label": "Answer",
-            "params": {"prompt": "Answer the user"},
+            "params": {"prompt": "Answer the user using {source_material} and {media}"},
             "output_handles": [{"handle": "output", "label": None}],
             "llm": {
                 "model_id": bot.llm_model.id,
@@ -776,6 +839,19 @@ def _expected_full_response(bot):
             },
             "nodes": _expected_pipeline_nodes(bot),
         },
+        # The pipeline has no Start/End nodes, so it is reported invalid (a graph-level error), and
+        # the unwired sides of its two nodes land in the advisory map. Neither blocked the read.
+        "pipeline_valid": False,
+        "pipeline_errors": {
+            "node": {},
+            "edge": [],
+            # Both terminals are missing and both are reported; neither hides the other.
+            "pipeline": ["There should be exactly 1 Start node", "There should be exactly 1 End node"],
+        },
+        "unwired_handles": {
+            "llm": [{"handle": "input", "label": None}],
+            "assist": [{"handle": "output", "label": None}],
+        },
         "events": _expected_events(bot),
     }
 
@@ -871,10 +947,11 @@ def _adversarial_bot():
 # Empirically derived. The SAME number must hold for every version mode, because resolve_inspect_version
 # resolves AND prefetches the target with a fixed prefetch set — including each node's resource FK/M2M
 # relations (inspect_node_queryset) — so node fan-out adds no queries. Resolution costs one query in
-# every mode, so folding it into the measured block keeps the count constant. Deriving output_handles
-# validates each router node, whose LLM-backed variant looks its provider model up through ORMRepository
-# (not the prefetched relation) — one query for this bot's single router.
-EXPECTED_RENDER_QUERIES = 14
+# every mode, so folding it into the measured block keeps the count constant. The top-level build-state
+# fields run Pipeline.validate(), whose LLM-node validators each look the provider model up through
+# ORMRepository (not the prefetched relation) — the same cost the builder pays on save; that adds a
+# fixed number of queries for this bot's two LLM-bearing nodes.
+EXPECTED_RENDER_QUERIES = 17
 
 
 @pytest.mark.django_db()

--- a/apps/api/v2/tests/test_chatbots_inspect.py
+++ b/apps/api/v2/tests/test_chatbots_inspect.py
@@ -169,6 +169,7 @@ def _node(payload, label):
 
 def _expected_llm(bot):
     return {
+        "model_id": bot.model.id,
         "provider_id": bot.provider.id,
         "provider_name": "Prod OpenAI",
         "type": "openai",
@@ -222,6 +223,7 @@ def test_acceptance_3_rag_collection_files(inspect_bot):
             "id": inspect_bot.collection.id,
             "name": "Policy index",
             "embedding": {
+                "model_id": inspect_bot.collection.embedding_provider_model_id,
                 "provider_id": inspect_bot.collection.llm_provider_id,
                 "provider_name": inspect_bot.collection.llm_provider.name,
                 "type": inspect_bot.collection.llm_provider.type,
@@ -566,6 +568,7 @@ def _expected_pipeline_nodes(bot):
             "label": "Answer",
             "params": {"prompt": "Answer the user"},
             "llm": {
+                "model_id": bot.llm_model.id,
                 "provider_id": bot.llm_provider.id,
                 "provider_name": "Prod OpenAI",
                 "type": "openai",
@@ -598,6 +601,7 @@ def _expected_pipeline_nodes(bot):
                     "id": bot.index_collection.id,
                     "name": "Policy index",
                     "embedding": {
+                        "model_id": bot.index_collection.embedding_provider_model_id,
                         "provider_id": bot.llm_provider.id,
                         "provider_name": "Prod OpenAI",
                         "type": "openai",
@@ -631,6 +635,7 @@ def _expected_pipeline_nodes(bot):
                 }
             ],
             "voice": {
+                "synthetic_voice_id": bot.synthetic_voice.id,
                 "provider_id": bot.voice_provider.id,
                 "provider_name": "ElevenLabs Prod",
                 "type": bot.voice_provider.type,
@@ -726,6 +731,7 @@ def _expected_full_response(bot):
             "identifier_type": "email",
         },
         "voice": {
+            "synthetic_voice_id": bot.synthetic_voice.id,
             "provider_id": bot.voice_provider.id,
             "provider_name": "ElevenLabs Prod",
             "type": bot.voice_provider.type,
@@ -756,7 +762,15 @@ def _expected_full_response(bot):
                     {"node_id": "llm", "type": "LLMResponseWithPrompt", "label": "Answer"},
                     {"node_id": "assist", "type": "AssistantNode", "label": "Assistant"},
                 ],
-                "edges": [{"source": "llm", "target": "assist", "source_handle": "output", "target_handle": "input"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "llm",
+                        "target": "assist",
+                        "source_handle": "output",
+                        "target_handle": "input",
+                    }
+                ],
             },
             "nodes": _expected_pipeline_nodes(bot),
         },

--- a/apps/api/v2/tests/test_inspect_schema.py
+++ b/apps/api/v2/tests/test_inspect_schema.py
@@ -34,6 +34,9 @@ def test_inspect_component_documents_the_payload_envelope(api_schema):
         "trace_provider",
         "channels",
         "pipeline",
+        "pipeline_valid",
+        "pipeline_errors",
+        "unwired_handles",
         "events",
     }
 

--- a/apps/api/v2/tests/test_inspect_schema.py
+++ b/apps/api/v2/tests/test_inspect_schema.py
@@ -40,7 +40,7 @@ def test_inspect_component_documents_the_payload_envelope(api_schema):
 
 def test_node_component_declares_reference_keys(api_schema):
     node = api_schema["components"]["schemas"]["InspectNode"]
-    assert {"node_id", "type", "label", "params"} <= set(node["required"])
+    assert {"node_id", "type", "label", "params", "output_handles"} <= set(node["required"])
     assert {
         "llm",
         "voice",

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -52,6 +52,7 @@ from apps.filters.models import FilterSet
 from apps.generics import actions
 from apps.generics.help import render_help_with_link
 from apps.generics.views import paginate_session, render_session_details
+from apps.pipelines.exceptions import has_errors
 from apps.pipelines.views import (
     _pipeline_node_default_values,
     _pipeline_node_parameter_values,
@@ -458,8 +459,7 @@ class CreateChatbotVersion(LoginAndTeamRequiredMixin, PermissionRequiredMixin, F
         """Checks if the pipeline has errors before creating a new version."""
         experiment = self.object
         if pipeline := experiment.pipeline:
-            errors = pipeline.validate()
-            if errors:
+            if has_errors(pipeline.validate()):
                 return "Unable to create a new version when the pipeline has errors"
         return None
 

--- a/apps/pipelines/build_state.py
+++ b/apps/pipelines/build_state.py
@@ -1,0 +1,21 @@
+"""Build-state reporting for a pipeline: the errors report.
+
+``Pipeline.validate()`` returns a complete :class:`~apps.pipelines.exceptions.ErrorReport`, which
+this passes through unchanged::
+
+    {"node": {<node_id>: {<field>: <message>}}, "edge": [<edge_id>], "pipeline": [<message>]}
+
+``pipeline_valid`` is exactly "all three buckets empty" — nothing more.
+"""
+
+from apps.pipelines.exceptions import has_errors
+from apps.pipelines.models import Pipeline
+
+
+def pipeline_build_state(pipeline: Pipeline) -> dict:
+    """``pipeline_valid`` + ``errors`` for a pipeline."""
+    errors = pipeline.validate()
+    return {
+        "pipeline_valid": not has_errors(errors),
+        "errors": errors,
+    }

--- a/apps/pipelines/build_state.py
+++ b/apps/pipelines/build_state.py
@@ -1,4 +1,4 @@
-"""Build-state reporting for a pipeline: the errors report.
+"""Build-state reporting for a pipeline: the errors report and the advisory unwired-handles map.
 
 ``Pipeline.validate()`` returns a complete :class:`~apps.pipelines.exceptions.ErrorReport`, which
 this passes through unchanged::
@@ -6,16 +6,101 @@ this passes through unchanged::
     {"node": {<node_id>: {<field>: <message>}}, "edge": [<edge_id>], "pipeline": [<message>]}
 
 ``pipeline_valid`` is exactly "all three buckets empty" — nothing more.
+
+Validation never flags an unwired node or branch (the build only checks reachable nodes), so
+:func:`unwired_handles` reports those separately as an advisory "what still needs wiring" map. It
+never blocks anything.
 """
 
-from apps.pipelines.exceptions import has_errors
-from apps.pipelines.models import Pipeline
+import pydantic
+
+from apps.pipelines.const import STANDARD_INPUT_NAME, STANDARD_OUTPUT_NAME
+from apps.pipelines.exceptions import PipelineNodeBuildError, has_errors
+from apps.pipelines.flow import Flow
+from apps.pipelines.models import Node, Pipeline
+from apps.pipelines.nodes import nodes as pipeline_nodes
+from apps.pipelines.nodes.base import PipelineRouterNode
+from apps.pipelines.nodes.nodes import EndNode, StartNode
 
 
 def pipeline_build_state(pipeline: Pipeline) -> dict:
-    """``pipeline_valid`` + ``errors`` for a pipeline."""
+    """``pipeline_valid`` + ``errors`` + advisory ``unwired_handles`` for a pipeline."""
     errors = pipeline.validate()
     return {
         "pipeline_valid": not has_errors(errors),
         "errors": errors,
+        "unwired_handles": unwired_handles(pipeline),
     }
+
+
+def unwired_handles(pipeline: Pipeline) -> dict:
+    """The advisory ``{node_id: [{handle, label}]}`` map of handles with no edge.
+
+    Covers both sides: output handles with no outgoing edge and the implicit ``input`` handle when
+    a node has no incoming edge — so an off-graph island shows up in full. Start's input and End's
+    output are excluded (they have none).
+    """
+    # The empty defaults keep a pipeline with no stored graph yet from failing Flow validation.
+    edges = Flow.model_validate({"nodes": [], "edges": [], **(pipeline.data or {})}).edges
+    # Wiredness is judged purely from the stored edges: an edge pointing at a handle its source no
+    # longer offers still marks that (source, handle) pair "wired" here — the stranded edge itself
+    # is the errors.edge bucket's concern (and, like validation, only surfaces for reachable nodes).
+    wired_outputs = {(edge.source, edge.sourceHandle or STANDARD_OUTPUT_NAME) for edge in edges}
+    wired_inputs = {edge.target for edge in edges}
+
+    unwired = {}
+    for node in pipeline.node_set.all():
+        if dangling := _dangling_handles(node, wired_inputs, wired_outputs):
+            unwired[node.flow_id] = dangling
+    return unwired
+
+
+def _dangling_handles(node: Node, wired_inputs: set[str], wired_outputs: set[tuple[str, str]]) -> list[dict]:
+    """One node's unwired handles: the implicit input plus any output with no edge."""
+    dangling = []
+    if node.type != StartNode.__name__ and node.flow_id not in wired_inputs:
+        dangling.append({"handle": STANDARD_INPUT_NAME, "label": None})
+    for handle in node_output_handles(node):
+        if (node.flow_id, handle["handle"]) not in wired_outputs:
+            dangling.append(handle)
+    return dangling
+
+
+def node_output_handles(node: Node) -> list[dict]:
+    """The output handles a :class:`~apps.pipelines.models.Node` offers, as ``{handle, label}``.
+
+    Routers get one handle per branch from ``get_output_map()`` (``output_0``, ``output_1``, …,
+    labelled with the branch keyword); plain nodes get the single standard output with no label;
+    End has no outputs.
+    """
+    if node.type == EndNode.__name__:
+        return []
+    node_class = getattr(pipeline_nodes, node.type, None)
+    if node_class is None:
+        # A node whose class was removed: validation reports it; we can't know its handles.
+        return []
+    if issubclass(node_class, PipelineRouterNode):
+        output_map = _router_output_map(node_class, node)
+        return [{"handle": handle, "label": label} for handle, label in output_map.items()]
+    return [{"handle": STANDARD_OUTPUT_NAME, "label": None}]
+
+
+def _router_output_map(node_class: type[PipelineRouterNode], node: Node) -> dict:
+    """A router's handle -> branch-label map, tolerant of invalid params.
+
+    Prefer full validation so every field normalization applies — a router type whose
+    ``get_output_map()`` depends on validated/derived fields stays correct at the cost of one
+    redundant validation per read. An incrementally-built router can be invalid in ways unrelated
+    to its branches (a missing required field, a broken resource reference raising
+    ``PipelineNodeBuildError``), and must still report its handles, so fall back to an unvalidated
+    instance with the keywords upper-cased to match ``RouterMixin.ensure_keywords_are_uppercase``.
+    """
+    params = node.params or {}
+    try:
+        instance = node_class.model_validate({**params, "node_id": node.flow_id, "django_node": node})
+    except (pydantic.ValidationError, PipelineNodeBuildError):
+        fallback = dict(params)
+        if isinstance(fallback.get("keywords"), list):
+            fallback["keywords"] = [str(keyword).upper() for keyword in fallback["keywords"]]
+        instance = node_class.model_construct(**fallback)
+    return instance.get_output_map()

--- a/apps/pipelines/build_state.py
+++ b/apps/pipelines/build_state.py
@@ -18,8 +18,7 @@ from apps.pipelines.const import STANDARD_INPUT_NAME, STANDARD_OUTPUT_NAME
 from apps.pipelines.exceptions import PipelineNodeBuildError, has_errors
 from apps.pipelines.flow import Flow
 from apps.pipelines.models import Node, Pipeline
-from apps.pipelines.nodes import nodes as pipeline_nodes
-from apps.pipelines.nodes.base import PipelineRouterNode
+from apps.pipelines.nodes.base import PipelineRouterNode, resolve_node_class
 from apps.pipelines.nodes.nodes import EndNode, StartNode
 
 
@@ -75,9 +74,10 @@ def node_output_handles(node: Node) -> list[dict]:
     """
     if node.type == EndNode.__name__:
         return []
-    node_class = getattr(pipeline_nodes, node.type, None)
+    node_class = resolve_node_class(node.type)
     if node_class is None:
-        # A node whose class was removed: validation reports it; we can't know its handles.
+        # A type naming no node class (removed since, or never one): validation reports it; we can't
+        # know its handles.
         return []
     if issubclass(node_class, PipelineRouterNode):
         output_map = _router_output_map(node_class, node)

--- a/apps/pipelines/exceptions.py
+++ b/apps/pipelines/exceptions.py
@@ -1,3 +1,20 @@
+from typing import TypedDict
+
+
+class ErrorReport(TypedDict):
+    """Everything wrong with a pipeline, bucketed by what the problem is attached to.
+
+    ``node`` maps a node's flow id to its ``{field: message}`` errors, with non-field problems under
+    the ``"root"`` sentinel. ``edge`` holds the ids of offending edges. ``pipeline`` holds messages
+    that name no single node or edge. All three keys are always present; a report with all three
+    empty means the pipeline is valid.
+    """
+
+    node: dict[str, dict[str, str]]
+    edge: list[str]
+    pipeline: list[str]
+
+
 class MissingNodeDataError(ValueError):
     """A saved graph contains node ids with no provided content and no existing Node row."""
 
@@ -25,6 +42,33 @@ class PipelineBuildError(Exception):
         if self.node_id:
             return {"node": {self.node_id: {"root": self.message}}, "edge": self.edge_ids}
         return {"pipeline": self.message, "edge": self.edge_ids}
+
+
+def has_errors(report: ErrorReport) -> bool:
+    """Whether a report holds anything. All three buckets empty means the pipeline is valid."""
+    return any(report.values())
+
+
+def error_report(node_errors: dict, build_errors: list["PipelineBuildError"]) -> ErrorReport:
+    """The three-bucket report: per-node field errors merged with graph-level build errors.
+
+    A build error carrying a ``node_id`` is attributed to that node under the ``root`` sentinel,
+    alongside any field errors it already has; the rest are graph-level and collect in ``pipeline``.
+    ``edge_ids`` accumulate from every error, since an edge id identifies the offending edge whichever
+    check produced it.
+    """
+    node = {flow_id: dict(fields) for flow_id, fields in node_errors.items()}
+    edge: list[str] = []
+    pipeline: list[str] = []
+    for error in build_errors:
+        if error.node_id:
+            # One "root" per node: two graph-level errors naming the same node isn't a shape the
+            # checks produce today.
+            node.setdefault(error.node_id, {})["root"] = error.message
+        else:
+            pipeline.append(error.message)
+        edge.extend(error.edge_ids or [])
+    return {"node": node, "edge": edge, "pipeline": pipeline}
 
 
 class PipelineNodeBuildError(Exception):

--- a/apps/pipelines/graph.py
+++ b/apps/pipelines/graph.py
@@ -47,7 +47,10 @@ class Edge(pydantic.BaseModel):
     sourceHandle: str | None = STANDARD_OUTPUT_NAME
 
     def is_conditional(self):
-        return self.sourceHandle != STANDARD_OUTPUT_NAME
+        # An explicit null handle means the default output — it is this field's own default, and
+        # unwired_handles reads it that way too. Treating it as conditional would report the edge
+        # stranded (no node offers a "None" handle) and drop it from the wired graph.
+        return (self.sourceHandle or STANDARD_OUTPUT_NAME) != STANDARD_OUTPUT_NAME
 
 
 class PipelineGraph(pydantic.BaseModel):
@@ -101,15 +104,77 @@ class PipelineGraph(pydantic.BaseModel):
         return {node.id for node in self.reachable_nodes}
 
     @cached_property
+    def _output_maps(self) -> dict[str, dict | None]:
+        """Memo for :meth:`_output_map_for`, keyed by node id."""
+        return {}
+
+    def _output_map_for(self, node_id: str) -> dict | None:
+        """A node's named output handles, or ``None`` when they can't be determined.
+
+        Empty and unknown are different answers: a plain node genuinely offers no named handles (only
+        the router types do), whereas a node whose params don't validate can't report its branches at
+        all — and must not have its edges called stranded on the strength of that.
+
+        Memoized because building the node instance runs its validators, which query the provider
+        model for an LLM-backed router — and every conditional edge out of one asks the same question.
+
+        Only the failures the node stage itself reports are treated as "unknown": a removed node
+        type, and the two ways a validator declines its params. Anything else a validator raises —
+        a ``DatabaseError`` above all, which would poison an enclosing ``transaction.atomic()`` if
+        swallowed here — propagates.
+        """
+        if node_id not in self._output_maps:
+            node = self.nodes_by_id[node_id]
+            if getattr(pipeline_nodes_module, node.type, None) is None:
+                self._output_maps[node_id] = None  # removed node type; the node stage names it
+                return self._output_maps[node_id]
+            try:
+                node_instance = node.pipeline_node_instance
+            except (ValidationError, PipelineNodeBuildError):
+                self._output_maps[node_id] = None  # the node stage reports why this node is broken
+            else:
+                # ``get_output_map`` only exists on PipelineRouterNode.
+                self._output_maps[node_id] = getattr(node_instance, "get_output_map", dict)()
+        return self._output_maps[node_id]
+
+    @cached_property
     def conditional_edge_map(self) -> dict[str, dict[str, str]]:
+        """``{source_id: {branch_label: target_id}}`` for every resolvable reachable router edge.
+
+        Edges stranded on a handle their source no longer offers are left out; reporting them is
+        :meth:`_stranded_edge_errors`' job, which ``build_runnable`` runs before it builds anything.
+        """
         conditional_edge_map = defaultdict(dict)
+        # The build only wires reachable nodes, so this matches that scope: an unreachable router's
+        # edges are the advisory unwired map's concern, not the build's.
         for edge in self.conditional_edges:
-            source_node = self.nodes_by_id[edge.source].pipeline_node_instance
-            output_map = source_node.get_output_map()
-            # this creates a map of the form:
-            # {source_node: {'source_handle_1': value_to_follow_edge_1, 'source_handle_2': value_to_follow_edge_2}}
-            conditional_edge_map[edge.source][output_map[edge.sourceHandle]] = edge.target
+            if edge.source not in self.reachable_ids:
+                continue
+            output_map = self._output_map_for(edge.source) or {}
+            if edge.sourceHandle in output_map:
+                # {source_node: {'source_handle_1': value_to_follow_edge_1, ...}}
+                conditional_edge_map[edge.source][output_map[edge.sourceHandle]] = edge.target
         return conditional_edge_map
+
+    def _stranded_edge_errors(self) -> list[PipelineBuildError]:
+        """Reachable conditional edges pointing at a handle their source doesn't offer.
+
+        Nothing validates a ``sourceHandle`` against its source node on write, so an edge can be left
+        pointing at a handle that no longer exists — a write that drops a router keyword but keeps the
+        edge, or a named handle on a node that was never a router at all.
+        """
+        stranded = [
+            edge.id
+            for edge in self.conditional_edges
+            if edge.source in self.reachable_ids
+            and (output_map := self._output_map_for(edge.source)) is not None
+            and edge.sourceHandle not in output_map
+        ]
+        if not stranded:
+            return []
+        return [
+            PipelineBuildError("One or more edges reference a router output that no longer exists", edge_ids=stranded)
+        ]
 
     @cached_property
     def unconditional_edges(self) -> list[Edge]:
@@ -133,22 +198,27 @@ class PipelineGraph(pydantic.BaseModel):
         """Every structural problem with this graph that is checkable, not just the first.
 
         The checks tier, because later ones presuppose earlier ones: reachability needs exactly one
-        Start node. So a failing tier suppresses the tiers below it — those answers don't exist yet,
-        rather than being withheld for brevity.
+        Start node, and a dangling edge endpoint breaks both cycle detection and reachability. So a
+        failing tier suppresses the tiers below it — those answers don't exist yet, rather than being
+        withheld for brevity.
 
         Node params are *not* checked here; ``Pipeline._node_validation_errors`` owns that and merges
         its results with these. This avoids building node instances wherever it can, so an invalid
-        node doesn't stop it reporting what it can.
+        node doesn't stop it reporting what it can — and it is cached, because the stranded-edge check
+        does build the source node of a conditional edge, which costs queries.
         """
         if not self.nodes:
             return [PipelineBuildError("There are no nodes in the graph")]
 
         # Tier 1 — needs nothing.
         errors = self._start_end_node_errors()
-        if self._check_for_cycles():
+        endpoint_errors = self._dangling_edge_endpoint_errors()
+        errors.extend(endpoint_errors)
+        if not endpoint_errors and self._check_for_cycles():
+            # Cycle detection walks edges by id, so it can't run over a dangling endpoint.
             errors.append(PipelineBuildError("A cycle was detected"))
 
-        # Tier 2 — needs exactly one Start/End node.
+        # Tier 2 — needs exactly one Start/End node and edges that resolve.
         if errors:
             return errors
         if self.end_node not in self.reachable_nodes:
@@ -159,6 +229,7 @@ class PipelineGraph(pydantic.BaseModel):
                     node_id=self.end_node.id,
                 )
             )
+        errors.extend(self._stranded_edge_errors())
         return errors
 
     def build_runnable(self) -> CompiledStateGraph:
@@ -261,3 +332,16 @@ class PipelineGraph(pydantic.BaseModel):
                 label = node_class.model_config["json_schema_extra"].label
                 errors.append(PipelineBuildError(f"There should be exactly 1 {label} node"))
         return errors
+
+    def _dangling_edge_endpoint_errors(self) -> list[PipelineBuildError]:
+        """Edges whose source or target names no node in the graph.
+
+        Nothing cross-checks an edge's endpoints on write, and a dangling one otherwise surfaces as a
+        bare ``KeyError`` from cycle detection or reachability. The edge is what's broken.
+        """
+        dangling = [
+            edge.id for edge in self.edges if edge.source not in self.nodes_by_id or edge.target not in self.nodes_by_id
+        ]
+        if not dangling:
+            return []
+        return [PipelineBuildError("One or more edges reference a node that no longer exists", edge_ids=dangling)]

--- a/apps/pipelines/graph.py
+++ b/apps/pipelines/graph.py
@@ -92,6 +92,15 @@ class PipelineGraph(pydantic.BaseModel):
         return end_nodes[0]
 
     @cached_property
+    def reachable_nodes(self) -> list[Node]:
+        """The nodes the build actually wires. Requires exactly one Start node and no cycle."""
+        return self._get_reachable_nodes(self.start_node)
+
+    @cached_property
+    def reachable_ids(self) -> set[str]:
+        return {node.id for node in self.reachable_nodes}
+
+    @cached_property
     def conditional_edge_map(self) -> dict[str, dict[str, str]]:
         conditional_edge_map = defaultdict(dict)
         for edge in self.conditional_edges:
@@ -119,23 +128,53 @@ class PipelineGraph(pydantic.BaseModel):
         edge_data = [Edge(**edge) for edge in pipeline.data["edges"]]
         return cls(nodes=node_data, edges=edge_data)
 
-    def build_runnable(self) -> CompiledStateGraph:
+    @cached_property
+    def build_errors(self) -> list[PipelineBuildError]:
+        """Every structural problem with this graph that is checkable, not just the first.
 
+        The checks tier, because later ones presuppose earlier ones: reachability needs exactly one
+        Start node. So a failing tier suppresses the tiers below it — those answers don't exist yet,
+        rather than being withheld for brevity.
+
+        Node params are *not* checked here; ``Pipeline._node_validation_errors`` owns that and merges
+        its results with these. This avoids building node instances wherever it can, so an invalid
+        node doesn't stop it reporting what it can.
+        """
         if not self.nodes:
-            raise PipelineBuildError("There are no nodes in the graph")
+            return [PipelineBuildError("There are no nodes in the graph")]
 
-        self._validate_start_end_nodes()
+        # Tier 1 — needs nothing.
+        errors = self._start_end_node_errors()
         if self._check_for_cycles():
-            raise PipelineBuildError("A cycle was detected")
+            errors.append(PipelineBuildError("A cycle was detected"))
+
+        # Tier 2 — needs exactly one Start/End node.
+        if errors:
+            return errors
+        if self.end_node not in self.reachable_nodes:
+            errors.append(
+                PipelineBuildError(
+                    f"{EndNode.model_config['json_schema_extra'].label} node is not reachable "
+                    f"from {StartNode.model_config['json_schema_extra'].label} node",
+                    node_id=self.end_node.id,
+                )
+            )
+        return errors
+
+    def build_runnable(self) -> CompiledStateGraph:
+        # build_errors is the single source of truth for what's wrong with the graph; the runtime
+        # still fails fast, on the first problem in dependency order. Cached, so a caller that has
+        # already read it (Pipeline.validate) doesn't pay for it twice.
+        if errors := self.build_errors:
+            raise errors[0]
 
         state_graph = StateGraph(PipelineState)
 
         state_graph.set_entry_point(self.start_node.id)
         state_graph.set_finish_point(self.end_node.id)
 
-        reachable_nodes = self._get_reachable_nodes(self.start_node)
-        self._add_nodes_to_graph(state_graph, reachable_nodes)
-        self._add_edges_to_graph(state_graph, reachable_nodes)
+        self._add_nodes_to_graph(state_graph, self.reachable_nodes)
+        self._add_edges_to_graph(state_graph, self.reachable_nodes)
 
         try:
             compiled_graph = state_graph.compile()
@@ -182,13 +221,7 @@ class PipelineGraph(pydantic.BaseModel):
         return list(self.nodes_by_id[node_id] for node_id in visited)
 
     def _add_nodes_to_graph(self, state_graph: StateGraph, nodes: list[Node]):
-        if self.end_node not in nodes:
-            raise PipelineBuildError(
-                f"{EndNode.model_config['json_schema_extra'].label} node is not reachable "
-                f"from {StartNode.model_config['json_schema_extra'].label} node",
-                node_id=self.end_node.id,
-            )
-
+        # End-reachability is checked by build_errors, which build_runnable reads first.
         retry_policy = get_retry_policy()
 
         for node in nodes:
@@ -219,14 +252,12 @@ class PipelineGraph(pydantic.BaseModel):
                     # conditional edges are handled by router node outputs
                     state_graph.add_edge(edge.source, edge.target)
 
-    def _validate_start_end_nodes(self):
-        start_nodes = [node for node in self.nodes if node.type == StartNode.__name__]
-        if len(start_nodes) != 1:
-            raise PipelineBuildError(
-                f"There should be exactly 1 {StartNode.model_config['json_schema_extra'].label} node"
-            )
-        end_nodes = [node for node in self.nodes if node.type == EndNode.__name__]
-        if len(end_nodes) != 1:
-            raise PipelineBuildError(
-                f"There should be exactly 1 {EndNode.model_config['json_schema_extra'].label} node"
-            )
+    def _start_end_node_errors(self) -> list[PipelineBuildError]:
+        """Both counts, reported together — one missing terminal shouldn't hide the other."""
+        errors = []
+        for node_class in (StartNode, EndNode):
+            matching = [node for node in self.nodes if node.type == node_class.__name__]
+            if len(matching) != 1:
+                label = node_class.model_config["json_schema_extra"].label
+                errors.append(PipelineBuildError(f"There should be exactly 1 {label} node"))
+        return errors

--- a/apps/pipelines/graph.py
+++ b/apps/pipelines/graph.py
@@ -10,8 +10,7 @@ from pydantic_core import ValidationError
 from apps.pipelines.const import STANDARD_OUTPUT_NAME
 from apps.pipelines.exceptions import PipelineBuildError, PipelineNodeBuildError
 from apps.pipelines.models import Pipeline
-from apps.pipelines.nodes import nodes as pipeline_nodes_module
-from apps.pipelines.nodes.base import PipelineRouterNode, PipelineState
+from apps.pipelines.nodes.base import PipelineRouterNode, PipelineState, resolve_node_class
 from apps.pipelines.nodes.nodes import CodeNode, EndNode, StartNode
 from apps.service_providers.llm_service.retry import get_retry_policy
 
@@ -25,7 +24,12 @@ class Node(pydantic.BaseModel):
 
     @property
     def pipeline_node_class(self):
-        return getattr(pipeline_nodes_module, self.type)
+        """This node's class. Raises for a type that names no node class, which is what a removed
+        type has always done — so a caller guarding against one guards against both."""
+        node_class = resolve_node_class(self.type)
+        if node_class is None:
+            raise AttributeError(f"Unknown pipeline node type: {self.type}")
+        return node_class
 
     @cached_property
     def pipeline_node_instance(self):
@@ -118,15 +122,15 @@ class PipelineGraph(pydantic.BaseModel):
         Memoized because building the node instance runs its validators, which query the provider
         model for an LLM-backed router — and every conditional edge out of one asks the same question.
 
-        Only the failures the node stage itself reports are treated as "unknown": a removed node
-        type, and the two ways a validator declines its params. Anything else a validator raises —
-        a ``DatabaseError`` above all, which would poison an enclosing ``transaction.atomic()`` if
-        swallowed here — propagates.
+        Only the failures the node stage itself reports are treated as "unknown": a type naming no
+        node class, and the two ways a validator declines its params. Anything else a validator
+        raises — a ``DatabaseError`` above all, which would poison an enclosing
+        ``transaction.atomic()`` if swallowed here — propagates.
         """
         if node_id not in self._output_maps:
             node = self.nodes_by_id[node_id]
-            if getattr(pipeline_nodes_module, node.type, None) is None:
-                self._output_maps[node_id] = None  # removed node type; the node stage names it
+            if resolve_node_class(node.type) is None:
+                self._output_maps[node_id] = None  # unknown node type; the node stage names it
                 return self._output_maps[node_id]
             try:
                 node_instance = node.pipeline_node_instance

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -252,11 +252,12 @@ class Pipeline(BaseTeamModel, VersionsMixin):
     @staticmethod
     def _node_validation_errors(node) -> dict:
         """Field -> message errors for one node's params; non-field failures land under "root"."""
-        from apps.pipelines.nodes import nodes as pipeline_nodes  # noqa: PLC0415 - circular: nodes.nodes→models
+        from apps.pipelines.nodes.base import resolve_node_class  # noqa: PLC0415 - heavy: nodes→langgraph
 
-        node_class = getattr(pipeline_nodes, node.type, None)
+        node_class = resolve_node_class(node.type)
         if node_class is None:
-            # A node whose class has since been removed must be reported, not crash validation.
+            # A type naming no node class — removed since, or never one — must be reported, not crash
+            # validation.
             return {"root": f"Unknown node type: {node.type}"}
         try:
             node_class.model_validate({**node.params, "node_id": node.flow_id, "django_node": node})
@@ -518,9 +519,9 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
 
     def has_parameter(self, param_name: str) -> bool:
         """True if this node's type declares ``param_name`` as a param. Unknown types have none."""
-        from apps.pipelines.nodes import nodes as pipeline_nodes  # noqa: PLC0415 - circular: nodes.nodes→models
+        from apps.pipelines.nodes.base import resolve_node_class  # noqa: PLC0415 - heavy: nodes→langgraph
 
-        node_class = getattr(pipeline_nodes, self.type, None)
+        node_class = resolve_node_class(self.type)
         return node_class is not None and param_name in node_class.model_fields
 
     def create_new_version(self, is_copy=False, new_flow_id=None, pipeline=None):  # ty: ignore[invalid-method-override]

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -15,7 +15,13 @@ from apps.custom_actions.form_utils import set_custom_actions
 from apps.custom_actions.mixins import CustomActionOperationMixin
 from apps.experiments.models import ExperimentSession, VersionFieldDisplayFormatters
 from apps.experiments.versioning import VersionDetails, VersionField, VersionsMixin, VersionsObjectManagerMixin
-from apps.pipelines.exceptions import MissingNodeDataError, PipelineBuildError
+from apps.pipelines.exceptions import (
+    ErrorReport,
+    MissingNodeDataError,
+    PipelineBuildError,
+    error_report,
+    has_errors,
+)
 from apps.pipelines.flow import (
     Flow,
     FlowNode,
@@ -198,21 +204,20 @@ class Pipeline(BaseTeamModel, VersionsMixin):
         with contextlib.suppress(AttributeError):  # nothing cached if flow_data was never read
             del self.flow_data
 
-    def validate(self, full=True) -> dict:
-        """Validate the pipeline nodes and return a dictionary of errors"""
+    def validate(self, full=True) -> ErrorReport:
+        """Every problem with this pipeline. All three buckets empty means it is valid.
+
+        Callers should test the result with :func:`~apps.pipelines.exceptions.has_errors` rather than
+        for truthiness — the report is always fully populated, so an error-free one is still a dict
+        with three empty values.
+        """
         from apps.pipelines.graph import PipelineGraph  # noqa: PLC0415 - circular: graph.py imports models
-        from apps.pipelines.nodes import nodes as pipeline_nodes  # noqa: PLC0415 - circular: nodes.nodes→models
 
         errors = defaultdict(dict)
         nodes = self.node_set.all()
         for node in nodes:
-            node_class = getattr(pipeline_nodes, node.type)
-            try:
-                node_class.model_validate({**node.params, "node_id": node.flow_id, "django_node": node})
-            except pydantic.ValidationError as e:
-                for error in e.errors():
-                    field = error["loc"][0] if error["loc"] else error["ctx"]["field"]
-                    errors[node.flow_id][field] = error["msg"]
+            if node_errors := self._node_validation_errors(node):
+                errors[node.flow_id].update(node_errors)
 
         name_to_flow_id = defaultdict(list)
         for node in nodes:
@@ -223,15 +228,35 @@ class Pipeline(BaseTeamModel, VersionsMixin):
                 for flow_id in flow_ids:
                     errors[flow_id].update({"name": "All node names must be unique"})
 
-        if errors:
-            return {"node": errors}
+        if not full:
+            return error_report(errors, [])
 
-        if full:
+        graph = PipelineGraph.build_from_pipeline(self)
+        report = error_report(errors, graph.build_errors)
+
+        # The remaining checks — building each node instance, then compiling — genuinely require
+        # everything above to pass, so they stay staged behind it. Skipping them when the report is
+        # already non-empty also means an invalid pipeline no longer pays for a doomed build.
+        if not has_errors(report):
             try:
-                PipelineGraph.build_runnable_from_pipeline(self)
+                graph.build_runnable()
             except PipelineBuildError as e:
-                return e.to_json()
+                report = error_report(errors, [e])
 
+        return report
+
+    @staticmethod
+    def _node_validation_errors(node) -> dict:
+        """Field -> message errors for one node's params."""
+        from apps.pipelines.nodes import nodes as pipeline_nodes  # noqa: PLC0415 - circular: nodes.nodes→models
+
+        node_class = getattr(pipeline_nodes, node.type)
+        try:
+            node_class.model_validate({**node.params, "node_id": node.flow_id, "django_node": node})
+        except pydantic.ValidationError as e:
+            # A model-level error carries no ``loc`` and names its field in ``ctx`` instead (see the
+            # PydanticCustomError raises under apps/pipelines/nodes).
+            return {(error["loc"][0] if error["loc"] else error["ctx"]["field"]): error["msg"] for error in e.errors()}
         return {}
 
     @property

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -19,6 +19,7 @@ from apps.pipelines.exceptions import (
     ErrorReport,
     MissingNodeDataError,
     PipelineBuildError,
+    PipelineNodeBuildError,
     error_report,
     has_errors,
 )
@@ -242,21 +243,35 @@ class Pipeline(BaseTeamModel, VersionsMixin):
                 graph.build_runnable()
             except PipelineBuildError as e:
                 report = error_report(errors, [e])
+            except PipelineNodeBuildError as e:
+                # Not a PipelineBuildError subclass, and carries no node id of its own.
+                report["pipeline"].append(str(e))
 
         return report
 
     @staticmethod
     def _node_validation_errors(node) -> dict:
-        """Field -> message errors for one node's params."""
+        """Field -> message errors for one node's params; non-field failures land under "root"."""
         from apps.pipelines.nodes import nodes as pipeline_nodes  # noqa: PLC0415 - circular: nodes.nodes→models
 
-        node_class = getattr(pipeline_nodes, node.type)
+        node_class = getattr(pipeline_nodes, node.type, None)
+        if node_class is None:
+            # A node whose class has since been removed must be reported, not crash validation.
+            return {"root": f"Unknown node type: {node.type}"}
         try:
             node_class.model_validate({**node.params, "node_id": node.flow_id, "django_node": node})
         except pydantic.ValidationError as e:
             # A model-level error carries no ``loc`` and names its field in ``ctx`` instead (see the
-            # PydanticCustomError raises under apps/pipelines/nodes).
-            return {(error["loc"][0] if error["loc"] else error["ctx"]["field"]): error["msg"] for error in e.errors()}
+            # PydanticCustomError raises under apps/pipelines/nodes). A validator raising a plain
+            # ValueError has neither, so that error lands on the node as a whole.
+            return {
+                (error["loc"][0] if error["loc"] else error.get("ctx", {}).get("field", "root")): error["msg"]
+                for error in e.errors()
+            }
+        except PipelineNodeBuildError as e:
+            # Raised from inside a validator for a broken resource reference (e.g. a deleted
+            # provider model); pydantic doesn't wrap it, so fold it into the report here.
+            return {"root": str(e)}
         return {}
 
     @property

--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -415,6 +415,27 @@ class PipelineRouterNode(BasePipelineNode):
         raise NotImplementedError()
 
 
+def resolve_node_class(node_type: str) -> type[BasePipelineNode] | None:
+    """The node class a stored ``Node.type`` names, or ``None`` if it names no usable node type.
+
+    ``Node.type`` is graph data with nothing validating it against the node classes, so it can name
+    any module-level attribute of ``apps.pipelines.nodes.nodes`` — a logger, an imported module, a
+    helper function, a class that isn't a node. A bare ``getattr`` would hand one of those to
+    ``issubclass``/``model_validate``/instantiation and raise; here they all collapse to ``None``,
+    which callers already report as an unknown type. The accepted set is exactly the one the editor
+    offers (see ``apps.pipelines.views._pipeline_node_schemas``): concrete node classes only, so the
+    two abstract bases are rejected as well.
+    """
+    from apps.pipelines.nodes import nodes as pipeline_nodes  # noqa: PLC0415 - circular: nodes.nodes→base
+
+    node_class = getattr(pipeline_nodes, node_type, None)
+    if not isinstance(node_class, type) or not issubclass(node_class, PipelineNode | PipelineRouterNode):
+        return None
+    if node_class in (PipelineNode, PipelineRouterNode):
+        return None
+    return node_class
+
+
 class Widgets(StrEnum):
     expandable_text = "expandable_text"
     code = "code"

--- a/apps/pipelines/tasks.py
+++ b/apps/pipelines/tasks.py
@@ -3,7 +3,12 @@ from django.conf import settings
 from django.core.mail import send_mail
 
 from apps.chat.bots import PipelineTestBot
-from apps.pipelines.exceptions import PipelineBuildError, PipelineNodeBuildError, PipelineNodeRunError
+from apps.pipelines.exceptions import (
+    PipelineBuildError,
+    PipelineNodeBuildError,
+    PipelineNodeRunError,
+    has_errors,
+)
 from apps.pipelines.models import Pipeline
 from apps.service_providers.llm_service.runnables import GenerationError
 
@@ -26,8 +31,7 @@ def get_response_for_pipeline_test_message(pipeline_id: int, message_text: str, 
     Attempts to invoke a pipeline with a given message and user, handling potential pipeline build errors.
     """
     pipeline = Pipeline.objects.get(id=pipeline_id)
-    errors = pipeline.validate(full=False)
-    if errors:
+    if has_errors(pipeline.validate(full=False)):
         return {"error": "There are errors in the pipeline configuration. Please correct those before running a test."}
     bot = PipelineTestBot(pipeline=pipeline, user_id=user_id)
     try:

--- a/apps/pipelines/tests/test_build_state.py
+++ b/apps/pipelines/tests/test_build_state.py
@@ -1,0 +1,103 @@
+"""Tests for the pipeline build-state helpers: the three-bucket errors report and ``pipeline_valid``."""
+
+import pytest
+
+from apps.pipelines.build_state import pipeline_build_state
+from apps.pipelines.models import Node, Pipeline
+from apps.pipelines.tests.utils import (
+    create_pipeline_model,
+    end_node,
+    passthrough_node,
+    start_node,
+)
+
+
+class TestNodeValidationErrors:
+    """How one node's pydantic errors are keyed by field."""
+
+    def test_field_error_is_keyed_by_its_field(self):
+        node = Node(flow_id="router-1", type="StaticRouterNode", params={"name": "router", "keywords": ["a"]})
+        assert "route_key" in Pipeline._node_validation_errors(node)
+
+
+@pytest.mark.django_db()
+class TestPipelineBuildState:
+    def test_fully_wired_pipeline_is_valid(self):
+        start, end = start_node(), end_node()
+        pipeline = create_pipeline_model([start, end])
+
+        state = pipeline_build_state(pipeline)
+
+        assert state == {
+            "pipeline_valid": True,
+            "errors": {"node": {}, "edge": [], "pipeline": []},
+        }
+
+    def test_missing_required_param_reports_node_error(self):
+        start, end = start_node(), end_node()
+        llm = {"id": "llm-1", "type": "LLMResponseWithPrompt", "params": {"name": "llm-1"}}
+        edges = [
+            {"id": "e1", "source": start["id"], "target": "llm-1"},
+            {"id": "e2", "source": "llm-1", "target": end["id"]},
+        ]
+        pipeline = create_pipeline_model([start, llm, end], edges)
+
+        state = pipeline_build_state(pipeline)
+
+        assert state == {
+            "pipeline_valid": False,
+            "errors": {
+                "node": {
+                    "llm-1": {
+                        "llm_provider_id": "Field required",
+                        "llm_provider_model_id": "Field required",
+                    }
+                },
+                "edge": [],
+                "pipeline": [],
+            },
+        }
+
+    def test_node_and_graph_errors_are_reported_together(self):
+        """A bad node param no longer hides the graph's own problems: the missing provider id and
+        the missing Start node arrive in the same report, so the client sees both in one read."""
+        end = end_node()
+        llm = {"id": "llm-1", "type": "LLMResponseWithPrompt", "params": {"name": "llm-1"}}
+        edges = [{"id": "e-llm-end", "source": llm["id"], "target": end["id"]}]
+        pipeline = create_pipeline_model([llm, end], edges)
+
+        state = pipeline_build_state(pipeline)
+
+        assert state["pipeline_valid"] is False
+        assert "llm_provider_id" in state["errors"]["node"]["llm-1"]
+        assert state["errors"]["pipeline"] == ["There should be exactly 1 Start node"]
+
+    def test_every_graph_level_error_is_reported_not_just_the_first(self):
+        """Independent structural checks accumulate rather than short-circuiting."""
+        plain = passthrough_node(name="plain")
+        pipeline = create_pipeline_model([plain], edges=[])
+
+        state = pipeline_build_state(pipeline)
+
+        assert state["errors"]["pipeline"] == [
+            "There should be exactly 1 Start node",
+            "There should be exactly 1 End node",
+        ]
+
+    def test_unreachable_end_is_an_error(self):
+        # The build raises this one with the End node's id, so it normalizes into the node bucket
+        # under the "root" sentinel rather than the pipeline bucket.
+        start, island, end = start_node(), passthrough_node(), end_node()
+        edges = [{"id": "e-start-island", "source": start["id"], "target": island["id"]}]
+        pipeline = create_pipeline_model([start, island, end], edges)
+
+        state = pipeline_build_state(pipeline)
+
+        assert state == {
+            "pipeline_valid": False,
+            "errors": {
+                "node": {end["id"]: {"root": "End node is not reachable from Start node"}},
+                "edge": [],
+                "pipeline": [],
+            },
+        }

--- a/apps/pipelines/tests/test_build_state.py
+++ b/apps/pipelines/tests/test_build_state.py
@@ -15,6 +15,18 @@ from apps.pipelines.tests.utils import (
     state_key_router_node,
 )
 
+# ``Node.type`` is graph data, so it can name any module-level attribute of
+# ``apps.pipelines.nodes.nodes`` — not just a node class. None of these are usable node types, so
+# each must be reported like a removed type rather than crashing whatever the resolved object is
+# then handed to.
+NON_NODE_ATTRIBUTES = [
+    pytest.param("logger", id="module-level-instance"),
+    pytest.param("json", id="imported-module"),
+    pytest.param("send_email_from_pipeline", id="module-level-function"),
+    pytest.param("BaseModel", id="class-that-is-not-a-node"),
+    pytest.param("END", id="string-constant"),
+]
+
 
 class TestNodeValidationErrors:
     """How one node's pydantic errors are keyed by field."""
@@ -36,6 +48,11 @@ class TestNodeValidationErrors:
         node = Node(flow_id="bare-1", type="BareValueErrorNode", params={"name": "bare"})
 
         assert Pipeline._node_validation_errors(node) == {"root": "Value error, boom"}
+
+    @pytest.mark.parametrize("node_type", NON_NODE_ATTRIBUTES)
+    def test_node_type_naming_a_non_node_attribute_is_reported_as_unknown(self, node_type):
+        node = Node(flow_id="odd-1", type=node_type, params={"name": "odd"})
+        assert Pipeline._node_validation_errors(node) == {"root": f"Unknown node type: {node_type}"}
 
 
 class TestNodeOutputHandles:
@@ -93,6 +110,11 @@ class TestNodeOutputHandles:
 
     def test_unknown_node_type_has_no_output_handles(self):
         node = Node(flow_id="ghost-1", type="GhostNode", params={"name": "ghost"})
+        assert node_output_handles(node) == []
+
+    @pytest.mark.parametrize("node_type", NON_NODE_ATTRIBUTES)
+    def test_node_type_naming_a_non_node_attribute_has_no_output_handles(self, node_type):
+        node = Node(flow_id="odd-1", type=node_type, params={"name": "odd"})
         assert node_output_handles(node) == []
 
     def test_boolean_node_handles_are_static(self):
@@ -261,6 +283,31 @@ class TestPipelineBuildState:
             "pipeline_valid": False,
             "errors": {
                 "node": {"ghost-1": {"root": "Unknown node type: GhostNode"}},
+                "edge": [],
+                "pipeline": [],
+            },
+            "unwired_handles": {},
+        }
+
+    @pytest.mark.parametrize("node_type", NON_NODE_ATTRIBUTES)
+    def test_node_type_naming_a_non_node_attribute_does_not_raise(self, node_type):
+        """A node type that resolves to something other than a node class must travel the same
+        reported-error path as a removed type — through node validation, the graph's output-map
+        lookup and the build — instead of raising on the object it resolved to."""
+        start, end = start_node(), end_node()
+        odd = {"id": "odd-1", "type": node_type, "params": {"name": "odd"}}
+        edges = [
+            {"id": "e-start-odd", "source": start["id"], "target": odd["id"]},
+            {"id": "e-odd-end", "source": odd["id"], "target": end["id"], "sourceHandle": "output_0"},
+        ]
+        pipeline = create_pipeline_model([start, odd, end], edges)
+
+        state = pipeline_build_state(pipeline)
+
+        assert state == {
+            "pipeline_valid": False,
+            "errors": {
+                "node": {"odd-1": {"root": f"Unknown node type: {node_type}"}},
                 "edge": [],
                 "pipeline": [],
             },

--- a/apps/pipelines/tests/test_build_state.py
+++ b/apps/pipelines/tests/test_build_state.py
@@ -1,14 +1,16 @@
-"""Tests for the pipeline build-state helpers: the three-bucket errors report and ``pipeline_valid``."""
+"""Tests for the pipeline build-state helpers: the three-bucket errors report, ``pipeline_valid``
+and the advisory ``unwired_handles`` map."""
 
 import pytest
 
-from apps.pipelines.build_state import pipeline_build_state
+from apps.pipelines.build_state import node_output_handles, pipeline_build_state, unwired_handles
 from apps.pipelines.models import Node, Pipeline
 from apps.pipelines.tests.utils import (
     create_pipeline_model,
     end_node,
     passthrough_node,
     start_node,
+    state_key_router_node,
 )
 
 
@@ -20,9 +22,74 @@ class TestNodeValidationErrors:
         assert "route_key" in Pipeline._node_validation_errors(node)
 
 
+class TestNodeOutputHandles:
+    def test_start_node_has_an_output_handle(self):
+        node = Node(flow_id="start-1", type="StartNode", params={"name": "start"})
+        assert node_output_handles(node) == [{"handle": "output", "label": None}]
+
+    def test_end_node_has_no_output_handles(self):
+        node = Node(flow_id="end-1", type="EndNode", params={"name": "end"})
+        assert node_output_handles(node) == []
+
+    def test_router_handles_come_from_keywords_in_order_upper_cased(self):
+        node = Node(
+            flow_id="router-1",
+            type="StaticRouterNode",
+            params={"name": "router", "route_key": "k", "keywords": ["schedule", "reschedule"]},
+        )
+        assert node_output_handles(node) == [
+            {"handle": "output_0", "label": "SCHEDULE"},
+            {"handle": "output_1", "label": "RESCHEDULE"},
+        ]
+
+    def test_invalid_router_still_reports_handles(self):
+        # route_key is required, so full pydantic validation fails; the handles must still derive
+        # from the keywords (upper-cased) so an incrementally-built router shows its branches.
+        node = Node(
+            flow_id="router-1",
+            type="StaticRouterNode",
+            params={"name": "router", "keywords": ["a", "b"]},
+        )
+        assert node_output_handles(node) == [
+            {"handle": "output_0", "label": "A"},
+            {"handle": "output_1", "label": "B"},
+        ]
+
+    @pytest.mark.django_db()
+    def test_router_with_dangling_provider_model_still_reports_handles(self):
+        # A stale llm_provider_model_id makes the LLM mixin's before-validator raise
+        # PipelineNodeBuildError (not a pydantic error); handle derivation must fall back, not crash.
+        node = Node(
+            flow_id="router-1",
+            type="RouterNode",
+            params={
+                "name": "router",
+                "prompt": "route",
+                "keywords": ["a", "b"],
+                "llm_provider_id": 999999,
+                "llm_provider_model_id": 999999,
+            },
+        )
+        assert node_output_handles(node) == [
+            {"handle": "output_0", "label": "A"},
+            {"handle": "output_1", "label": "B"},
+        ]
+
+    def test_unknown_node_type_has_no_output_handles(self):
+        node = Node(flow_id="ghost-1", type="GhostNode", params={"name": "ghost"})
+        assert node_output_handles(node) == []
+
+    def test_boolean_node_handles_are_static(self):
+        node = Node(flow_id="bool-1", type="BooleanNode", params={"name": "bool", "input_equals": "hi"})
+        assert node_output_handles(node) == [
+            {"handle": "output_0", "label": "true"},
+            {"handle": "output_1", "label": "false"},
+        ]
+
+
 @pytest.mark.django_db()
 class TestPipelineBuildState:
-    def test_fully_wired_pipeline_is_valid(self):
+    def test_fully_wired_pipeline_has_no_unwired_handles_and_is_valid(self):
         start, end = start_node(), end_node()
         pipeline = create_pipeline_model([start, end])
 
@@ -31,6 +98,49 @@ class TestPipelineBuildState:
         assert state == {
             "pipeline_valid": True,
             "errors": {"node": {}, "edge": [], "pipeline": []},
+            "unwired_handles": {},
+        }
+
+    def test_dangling_router_branch_is_advisory_not_an_error(self):
+        """A valid graph with an unwired router branch stays pipeline_valid; the branch shows up
+        only in unwired_handles, with its keyword as the label."""
+        start, router, end = start_node(), state_key_router_node("k", ["A", "B"]), end_node()
+        edges = [
+            {"id": "e-start-router", "source": start["id"], "target": router["id"]},
+            {"id": "e-router-end", "source": router["id"], "target": end["id"], "sourceHandle": "output_0"},
+        ]
+        pipeline = create_pipeline_model([start, router, end], edges)
+
+        state = pipeline_build_state(pipeline)
+
+        assert state == {
+            "pipeline_valid": True,
+            "errors": {"node": {}, "edge": [], "pipeline": []},
+            "unwired_handles": {router["id"]: [{"handle": "output_1", "label": "B"}]},
+        }
+
+    def test_off_graph_island_reports_input_and_output_unwired(self):
+        start, island, end = start_node(), passthrough_node(), end_node()
+        edges = [{"id": "e-start-end", "source": start["id"], "target": end["id"]}]
+        pipeline = create_pipeline_model([start, island, end], edges)
+
+        state = pipeline_build_state(pipeline)
+
+        assert state == {
+            "pipeline_valid": True,
+            "errors": {"node": {}, "edge": [], "pipeline": []},
+            "unwired_handles": {
+                island["id"]: [{"handle": "input", "label": None}, {"handle": "output", "label": None}]
+            },
+        }
+
+    def test_start_input_and_end_output_are_never_reported(self):
+        start, end = start_node(), end_node()
+        pipeline = create_pipeline_model([start, end], edges=[])
+
+        assert unwired_handles(pipeline) == {
+            start["id"]: [{"handle": "output", "label": None}],
+            end["id"]: [{"handle": "input", "label": None}],
         }
 
     def test_missing_required_param_reports_node_error(self):
@@ -56,6 +166,7 @@ class TestPipelineBuildState:
                 "edge": [],
                 "pipeline": [],
             },
+            "unwired_handles": {},
         }
 
     def test_node_and_graph_errors_are_reported_together(self):
@@ -84,7 +195,7 @@ class TestPipelineBuildState:
             "There should be exactly 1 End node",
         ]
 
-    def test_unreachable_end_is_an_error(self):
+    def test_unreachable_end_is_an_error_but_still_reports_unwired_map(self):
         # The build raises this one with the End node's id, so it normalizes into the node bucket
         # under the "root" sentinel rather than the pipeline bucket.
         start, island, end = start_node(), passthrough_node(), end_node()
@@ -99,5 +210,9 @@ class TestPipelineBuildState:
                 "node": {end["id"]: {"root": "End node is not reachable from Start node"}},
                 "edge": [],
                 "pipeline": [],
+            },
+            "unwired_handles": {
+                island["id"]: [{"handle": "output", "label": None}],
+                end["id"]: [{"handle": "input", "label": None}],
             },
         }

--- a/apps/pipelines/tests/test_build_state.py
+++ b/apps/pipelines/tests/test_build_state.py
@@ -1,10 +1,12 @@
-"""Tests for the pipeline build-state helpers: the three-bucket errors report, ``pipeline_valid``
-and the advisory ``unwired_handles`` map."""
+"""Tests for the pipeline build-state helpers: the three-bucket errors report, ``pipeline_valid``,
+the advisory ``unwired_handles`` map, and the stranded-router-edge guard."""
 
 import pytest
+from pydantic import model_validator
 
 from apps.pipelines.build_state import node_output_handles, pipeline_build_state, unwired_handles
 from apps.pipelines.models import Node, Pipeline
+from apps.pipelines.nodes import nodes as pipeline_nodes
 from apps.pipelines.tests.utils import (
     create_pipeline_model,
     end_node,
@@ -20,6 +22,20 @@ class TestNodeValidationErrors:
     def test_field_error_is_keyed_by_its_field(self):
         node = Node(flow_id="router-1", type="StaticRouterNode", params={"name": "router", "keywords": ["a"]})
         assert "route_key" in Pipeline._node_validation_errors(node)
+
+    def test_model_level_error_naming_no_field_lands_on_the_node(self, monkeypatch):
+        """A model validator raising a plain ValueError has neither a ``loc`` nor a ``ctx["field"]``.
+        Reading the field must fall back to "root", not raise a KeyError out of validation."""
+
+        class BareValueErrorNode(pipeline_nodes.Passthrough):
+            @model_validator(mode="after")
+            def always_fails(self):
+                raise ValueError("boom")
+
+        monkeypatch.setattr(pipeline_nodes, "BareValueErrorNode", BareValueErrorNode, raising=False)
+        node = Node(flow_id="bare-1", type="BareValueErrorNode", params={"name": "bare"})
+
+        assert Pipeline._node_validation_errors(node) == {"root": "Value error, boom"}
 
 
 class TestNodeOutputHandles:
@@ -169,6 +185,148 @@ class TestPipelineBuildState:
             "unwired_handles": {},
         }
 
+    def test_dangling_provider_model_reference_reports_node_error_instead_of_raising(self):
+        """A node whose params reference a deleted LlmProviderModel raises PipelineNodeBuildError
+        from inside pydantic validation; the build state must fold it into errors.node, not 500."""
+        start, end = start_node(), end_node()
+        llm = {
+            "id": "llm-1",
+            "type": "LLMResponseWithPrompt",
+            "params": {
+                "name": "llm-1",
+                "prompt": "hi",
+                "llm_provider_id": 999999,
+                "llm_provider_model_id": 999999,
+            },
+        }
+        edges = [
+            {"id": "e1", "source": start["id"], "target": "llm-1"},
+            {"id": "e2", "source": "llm-1", "target": end["id"]},
+        ]
+        pipeline = create_pipeline_model([start, llm, end], edges)
+
+        state = pipeline_build_state(pipeline)
+
+        assert state == {
+            "pipeline_valid": False,
+            "errors": {
+                "node": {"llm-1": {"root": "LLM provider model with id 999999 does not exist"}},
+                "edge": [],
+                "pipeline": [],
+            },
+            "unwired_handles": {},
+        }
+
+    def test_unknown_node_type_reports_node_error_instead_of_raising(self):
+        """The unknown type is a node error; with no edges at all the End node is also unreachable.
+        Both are reported together — a broken node no longer hides the graph's own problems."""
+        start, end = start_node(), end_node()
+        ghost = {"id": "ghost-1", "type": "GhostNode", "params": {"name": "ghost"}}
+        pipeline = create_pipeline_model([start, ghost, end], edges=[])
+
+        state = pipeline_build_state(pipeline)
+
+        assert state == {
+            "pipeline_valid": False,
+            "errors": {
+                "node": {
+                    "ghost-1": {"root": "Unknown node type: GhostNode"},
+                    end["id"]: {"root": "End node is not reachable from Start node"},
+                },
+                "edge": [],
+                "pipeline": [],
+            },
+            "unwired_handles": {
+                start["id"]: [{"handle": "output", "label": None}],
+                # An unknown type's outputs are unknowable, so only its implicit input is reported.
+                ghost["id"]: [{"handle": "input", "label": None}],
+                end["id"]: [{"handle": "input", "label": None}],
+            },
+        }
+
+    def test_removed_node_type_with_a_named_handle_edge_does_not_raise(self):
+        """A removed node type can't report its branches, so a named handle on it is unknowable
+        rather than stranded. Reaching its output map must not raise on the missing node class."""
+        start, end = start_node(), end_node()
+        ghost = {"id": "ghost-1", "type": "GhostNode", "params": {"name": "ghost"}}
+        edges = [
+            {"id": "e-start-ghost", "source": start["id"], "target": ghost["id"]},
+            {"id": "e-ghost-end", "source": ghost["id"], "target": end["id"], "sourceHandle": "output_0"},
+        ]
+        pipeline = create_pipeline_model([start, ghost, end], edges)
+
+        state = pipeline_build_state(pipeline)
+
+        assert state == {
+            "pipeline_valid": False,
+            "errors": {
+                "node": {"ghost-1": {"root": "Unknown node type: GhostNode"}},
+                "edge": [],
+                "pipeline": [],
+            },
+            "unwired_handles": {},
+        }
+
+    def test_stranded_router_edge_lands_in_edge_bucket_without_raising(self):
+        """Removing a router keyword strands the edge wired to its handle: the build must report
+        the edge id in errors.edge (not raise a KeyError) and flip pipeline_valid."""
+        start, router, end = start_node(), state_key_router_node("k", ["A", "B"]), end_node()
+        edges = [
+            {"id": "e-start-router", "source": start["id"], "target": router["id"]},
+            {"id": "e-router-end", "source": router["id"], "target": end["id"], "sourceHandle": "output_1"},
+        ]
+        pipeline = create_pipeline_model([start, router, end], edges)
+
+        router["params"]["keywords"] = ["A"]
+        create_pipeline_model([start, router, end], edges, pipeline=pipeline)
+
+        state = pipeline_build_state(pipeline)
+
+        assert state == {
+            "pipeline_valid": False,
+            "errors": {
+                "node": {},
+                "edge": ["e-router-end"],
+                "pipeline": ["One or more edges reference a router output that no longer exists"],
+            },
+            "unwired_handles": {router["id"]: [{"handle": "output_0", "label": "A"}]},
+        }
+
+    def test_stranded_edge_on_unreachable_router_does_not_block_the_build(self):
+        """A stranded conditional edge only blocks the build when its router is reachable — an
+        off-graph island's stranded edge stays the advisory unwired map's concern."""
+        start, end = start_node(), end_node()
+        router = state_key_router_node("k", ["A", "B"], name="main-router")
+        island_router = state_key_router_node("k2", ["A"], name="island-router")
+        island_target = passthrough_node(name="island-target")
+        edges = [
+            {"id": "e-start-router", "source": start["id"], "target": router["id"]},
+            {"id": "e-router-end-0", "source": router["id"], "target": end["id"], "sourceHandle": "output_0"},
+            {"id": "e-router-end-1", "source": router["id"], "target": end["id"], "sourceHandle": "output_1"},
+            # output_1 does not exist on the island router (it only has one keyword) — stranded.
+            {
+                "id": "e-island-stranded",
+                "source": island_router["id"],
+                "target": island_target["id"],
+                "sourceHandle": "output_1",
+            },
+        ]
+        pipeline = create_pipeline_model([start, router, end, island_router, island_target], edges)
+
+        state = pipeline_build_state(pipeline)
+
+        assert state == {
+            "pipeline_valid": True,
+            "errors": {"node": {}, "edge": [], "pipeline": []},
+            "unwired_handles": {
+                island_router["id"]: [
+                    {"handle": "input", "label": None},
+                    {"handle": "output_0", "label": "A"},
+                ],
+                island_target["id"]: [{"handle": "output", "label": None}],
+            },
+        }
+
     def test_node_and_graph_errors_are_reported_together(self):
         """A bad node param no longer hides the graph's own problems: the missing provider id and
         the missing Start node arrive in the same report, so the client sees both in one read."""
@@ -194,6 +352,43 @@ class TestPipelineBuildState:
             "There should be exactly 1 Start node",
             "There should be exactly 1 End node",
         ]
+
+    def test_null_source_handle_is_the_standard_output_not_a_stranded_handle(self):
+        """``sourceHandle: null`` is what a non-editor write produces for the default output — it is
+        the field's own default and how ``unwired_handles`` reads it. Mistaking it for a named handle
+        would report the edge stranded (no node offers a ``None`` handle) and block the publish."""
+        start, plain, end = start_node(), passthrough_node(name="plain"), end_node()
+        edges = [
+            {"id": "e-start-plain", "source": start["id"], "target": plain["id"]},
+            {"id": "e-plain-end", "source": plain["id"], "target": end["id"], "sourceHandle": None},
+        ]
+        pipeline = create_pipeline_model([start, plain, end], edges)
+
+        state = pipeline_build_state(pipeline)
+
+        assert state == {
+            "pipeline_valid": True,
+            "errors": {"node": {}, "edge": [], "pipeline": []},
+            "unwired_handles": {},
+        }
+
+    def test_invalid_router_does_not_have_its_edges_called_stranded(self):
+        """A router whose params don't validate can't report its branches, so its handles are
+        unknown — not empty. Its edges must not be reported stranded on the strength of that."""
+        start, end = start_node(), end_node()
+        router = state_key_router_node("k", ["A", "B"], name="router")
+        del router["params"]["route_key"]  # required, so the node no longer validates
+        edges = [
+            {"id": "e-start-router", "source": start["id"], "target": router["id"]},
+            {"id": "e-router-end", "source": router["id"], "target": end["id"], "sourceHandle": "output_0"},
+        ]
+        pipeline = create_pipeline_model([start, router, end], edges)
+
+        state = pipeline_build_state(pipeline)
+
+        assert state["pipeline_valid"] is False
+        assert "route_key" in state["errors"]["node"][router["id"]]
+        assert state["errors"]["edge"] == []
 
     def test_unreachable_end_is_an_error_but_still_reports_unwired_map(self):
         # The build raises this one with the End node's id, so it normalizes into the node bucket

--- a/apps/pipelines/tests/test_models.py
+++ b/apps/pipelines/tests/test_models.py
@@ -8,6 +8,7 @@ from apps.chat.bots import PipelineTestBot
 from apps.documents.models import CollectionFile
 from apps.events.models import EventActionType
 from apps.experiments.models import Experiment, ExperimentSession, Participant
+from apps.pipelines.exceptions import has_errors
 from apps.pipelines.flow import Flow, FlowNode, split_flow_data
 from apps.pipelines.models import Node, Pipeline
 from apps.pipelines.nodes.nodes import AssistantNode, LLMResponseWithPrompt
@@ -879,8 +880,7 @@ class TestPipelineValidation:
         layout, node_data = split_flow_data(Flow(edges=edges, nodes=flow_nodes))
         pipeline.data = layout.model_dump()
         pipeline.update_nodes_from_data(node_data)
-        errors = pipeline.validate()
-        assert not errors
+        assert not has_errors(pipeline.validate())
 
 
 @pytest.mark.parametrize(

--- a/apps/pipelines/tests/test_tasks.py
+++ b/apps/pipelines/tests/test_tasks.py
@@ -1,0 +1,52 @@
+import pytest
+
+from apps.pipelines.tasks import get_response_for_pipeline_test_message
+from apps.pipelines.tests.utils import create_pipeline_model, end_node, render_template_node, start_node
+from apps.utils.factories.pipelines import PipelineFactory
+
+CONFIG_ERROR = {"error": "There are errors in the pipeline configuration. Please correct those before running a test."}
+
+
+@pytest.mark.django_db()
+class TestGetResponseForPipelineTestMessage:
+    """The task refuses to run a misconfigured pipeline, and must not refuse a valid one.
+
+    ``Pipeline.validate()`` returns an always-populated report, so the guard has to ask
+    ``has_errors()`` — testing the report for truthiness rejects every pipeline.
+    """
+
+    def test_valid_pipeline_runs(self, team_with_users):
+        user = team_with_users.members.first()
+        # Named explicitly: nodes without a ``name`` param all collide on ``None`` and trip the
+        # node-name uniqueness check.
+        pipeline = create_pipeline_model(
+            [start_node(), end_node()], pipeline=PipelineFactory.create(team=team_with_users)
+        )
+        pipeline.save()
+
+        result = get_response_for_pipeline_test_message(pipeline_id=pipeline.id, message_text="test", user_id=user.id)
+
+        assert "error" not in result
+        assert result["messages"][-1] == "test"
+
+    @pytest.mark.parametrize(
+        "nodes",
+        [
+            pytest.param(
+                [start_node(), render_template_node(template_string="{{ foo }"), end_node()],
+                id="node_with_invalid_params",
+            ),
+            pytest.param(
+                [start_node(), render_template_node(name="dupe"), render_template_node(name="dupe"), end_node()],
+                id="duplicate_node_names",
+            ),
+        ],
+    )
+    def test_misconfigured_pipeline_is_refused(self, nodes, team_with_users):
+        user = team_with_users.members.first()
+        pipeline = create_pipeline_model(nodes, pipeline=PipelineFactory.create(team=team_with_users))
+        pipeline.save()
+
+        result = get_response_for_pipeline_test_message(pipeline_id=pipeline.id, message_text="test", user_id=user.id)
+
+        assert result == CONFIG_ERROR

--- a/assets/javascript/apps/pipeline/Page.tsx
+++ b/assets/javascript/apps/pipeline/Page.tsx
@@ -11,7 +11,7 @@ export default function Page() {
   const savePipeline = usePipelineStore((state) => state.savePipeline);
   const dirty = usePipelineStore((state) => state.dirty);
   const isSaving = usePipelineStore((state) => state.isSaving);
-  const error = usePipelineStore((state) => state.getPipelineError());
+  const errors = usePipelineStore((state) => state.getPipelineError());
   const conflictDetected = usePipelineStore((state) => state.conflictDetected);
   const dismissConflict = usePipelineStore((state) => state.dismissConflict);
   const loadPipeline = usePipelineStore((state) => state.loadPipeline);
@@ -74,10 +74,12 @@ export default function Page() {
                 }
               </button>
             </div>
-            {!isSaving && error && (
+            {!isSaving && errors.length > 0 && (
               <div className="content-center">
                 <i className="fa fa-exclamation-triangle text-red-500 mr-2"></i>
-                <small className="text-red-500">{error}</small>
+                {errors.map((error, index) => (
+                  <small key={index} className="text-red-500 mr-2">{error}</small>
+                ))}
               </div>
             )}
             {readOnly &&  (

--- a/assets/javascript/apps/pipeline/stores/pipelineStore.ts
+++ b/assets/javascript/apps/pipeline/stores/pipelineStore.ts
@@ -17,6 +17,11 @@ import {ErrorsType, PipelineManagerStoreType} from "../types/pipelineManagerStor
 import {apiClient} from "../api/api";
 import {PipelineDiffPayload, PipelineType, PipelineSaveResponse} from "../types/pipeline";
 import {computePipelineDiff} from "../diffPipeline";
+// Returned whenever there are no graph-level errors. Must be a single shared instance: the store is
+// read via useSyncExternalStore, which compares snapshots by identity, so handing back a fresh []
+// each call makes every render look like a change and loops until React bails out.
+const NO_PIPELINE_ERRORS: string[] = [];
+
 let saveTimeoutId: NodeJS.Timeout | null = null;
 // Serialization guard for autosave (see issue #3895). While a PATCH is in-flight
 // its response has not yet bumped `currentRevision`, so firing a second PATCH would
@@ -455,7 +460,7 @@ const createPipelineManagerStore: StateCreator<
     return !!get().errors["edge"] && get().errors["edge"]!.includes(edgeId);
   },
   getPipelineError: () => {
-    return get().errors["pipeline"];
+    return get().errors["pipeline"] ?? NO_PIPELINE_ERRORS;
   },
 })
 

--- a/assets/javascript/apps/pipeline/types/pipelineManagerStore.ts
+++ b/assets/javascript/apps/pipeline/types/pipelineManagerStore.ts
@@ -25,11 +25,13 @@ export type PipelineManagerStoreType = {
   nodeHasErrors: (nodeId: string) => boolean;
   getNodeFieldError: (nodeId: string, fieldName: string) => string | undefined;
   edgeHasErrors: (edgeId: string) => boolean;
-  getPipelineError: () => string | undefined;
+  getPipelineError: () => string[];
 };
 
 export type ErrorsType = {
   node?: {[nodeId: string]: {[field: string]: string}};
   edge?: string[];
-  pipeline?: string;
+  // Graph-level messages that name no single node or edge. A list: independent structural checks
+  // are reported together rather than one per save.
+  pipeline?: string[];
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,9 +843,6 @@ packages:
   '@codemirror/view@6.43.7':
     resolution: {integrity: sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==}
 
-  '@codemirror/view@6.43.7':
-    resolution: {integrity: sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==}
-
   '@cypress/request@4.0.1':
     resolution: {integrity: sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==}
     engines: {node: '>= 14.17.0'}
@@ -4778,13 +4775,6 @@ snapshots:
       '@codemirror/state': 6.7.1
       '@codemirror/view': 6.43.7
       '@lezer/highlight': 1.2.3
-
-  '@codemirror/view@6.43.7':
-    dependencies:
-      '@codemirror/state': 6.7.1
-      crelt: 1.0.7
-      style-mod: 4.1.3
-      w3c-keyname: 2.2.8
 
   '@codemirror/view@6.43.7':
     dependencies:


### PR DESCRIPTION
Supersedes #3908 — same tree, split into nine reviewable commits. PRs 1 and 2 of the [write API plan](https://docs.google.com/document/d/1oD25fmxCjdam728UOinAj7bry15ih1pxdhf5paokalw/edit?tab=t.xzd2t2em41gc#heading=h.rvrvnj6iypo8).

### Product Description

`GET /api/v2/chatbots/{id}/inspect/` now reports whether a chatbot's pipeline is usable (`pipeline_valid`, `pipeline_errors`, `unwired_handles`) plus the ids needed to write things back (`output_handles` per node, `id` per edge, `model_id`, `synthetic_voice_id`).

The pipeline editor now shows all graph-level errors at once instead of only the first.

### Technical Description

No write endpoints yet — the read side plus the reporting core both sides will share. Read it commit by commit; each is self-contained and green on its own.

Three things worth your attention:

- **`Pipeline.validate()`'s contract changed for every caller.** It always returns a fully-populated `ErrorReport`, so an error-free report is a *truthy* dict of three empty values — callers must use `has_errors()`. `errors["pipeline"]` went from a string to a list. Anything outside this diff reading it needs checking.
- **A pipeline-less chatbot now 500s** where `main` returned `pipeline: null` (the schema drops `nullable: true`). Deliberate — that's a corrupt row, not a supported state — but nothing enforces the invariant at the model level.
- **`validate()` runs on every GET**, so queries grow per LLM-bearing node (3 + 4n, 6n for LLM-backed routers). `EXPECTED_RENDER_QUERIES` rose 13 → 17 and guards one fixed bot; no slope guard yet.

Smaller: `errors` → `pipeline_errors` at the response root, renamed before phase 2 builds against it. Six cases that previously crashed validation (stranded edges, missing node rows, removed node types) now land in the report instead.

### Migrations

None.

- [x] The migrations are backwards compatible

### Demo

The surface is a JSON response, pinned by the golden-master `test_full_response_body` and the regenerated `api-schemas/v2.yml`.

### Docs and Changelog

Schema regenerated in-repo, so the reference docs follow.

- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
