### PR TITLE
Fix broken pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,9 +843,6 @@ packages:
   '@codemirror/view@6.43.7':
     resolution: {integrity: sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==}
 
-  '@codemirror/view@6.43.7':
-    resolution: {integrity: sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==}
-
   '@cypress/request@4.0.1':
     resolution: {integrity: sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==}
     engines: {node: '>= 14.17.0'}
@@ -4778,13 +4775,6 @@ snapshots:
       '@codemirror/state': 6.7.1
       '@codemirror/view': 6.43.7
       '@lezer/highlight': 1.2.3
-
-  '@codemirror/view@6.43.7':
-    dependencies:
-      '@codemirror/state': 6.7.1
-      crelt: 1.0.7
-      style-mod: 4.1.3
-      w3c-keyname: 2.2.8
 
   '@codemirror/view@6.43.7':
     dependencies:


### PR DESCRIPTION
### Product Description
None — CI unbreak.

### Technical Description
`pnpm-lock.yaml` on main had `'@codemirror/view@6.43.7'` duplicated in both the `packages` and `snapshots` sections, a merge artifact between the codemirror and daisyui dependabot bumps. pnpm rejects the file (`ERR_PNPM_BROKEN_LOCKFILE`), failing `build-frontend` and `build-image`.

The duplicated blocks were byte-identical, so removing them changes no resolutions.

### Migrations
- [x] The migrations are backwards compatible

### Demo
`pnpm install --frozen-lockfile`, `pnpm run build`, and `pnpm run type-check` all pass locally.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)