### PR TITLE
Embed chat widgets for the prelogin demo bots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,10 @@ ACCOUNT_EMAIL_VERIFICATION=mandatory
 # HUBSPOT_FORM_REGION=na1
 # HUBSPOT_FORM_PORTAL_ID=
 # HUBSPOT_FORM_ID=
+## Chat widget config for the demo bots on the use cases page. Bots without an entry render as a
+## static card with no chat. Keys: nanibot, fp_coach, program_dashboard. Per bot, "id" and
+## "embed_key" are required; "header_text" is optional.
+# PRELOGIN_DEMO_BOTS={"nanibot": {"id": "<chatbot public id>", "embed_key": "<widget channel token>"}}
 
 ## Optional Slack integration
 SLACK_CLIENT_ID=

--- a/apps/prelogin/tests/test_views.py
+++ b/apps/prelogin/tests/test_views.py
@@ -1,6 +1,7 @@
 import pytest
 from django.urls import reverse
 
+from apps.channels.widget_versions import widget_script_url
 from apps.utils.factories.team import TeamWithUsersFactory
 
 
@@ -40,6 +41,36 @@ def test_applications_page_renders(client):
     response = client.get(reverse("prelogin:applications"))
     assert response.status_code == 200
     assert b"Use Cases" in response.content
+
+
+@pytest.mark.django_db()
+def test_applications_page_embeds_widget_for_configured_demo_bots(client, settings):
+    settings.PRELOGIN_DEMO_BOTS = {"nanibot": {"id": "6d5abc50-167d-4e78-a2a1-6ff6d3cb229c", "embed_key": "token-123"}}
+    response = client.get(reverse("prelogin:applications"))
+    content = response.content.decode()
+    assert 'chatbot-id="6d5abc50-167d-4e78-a2a1-6ff6d3cb229c"' in content
+    assert 'embed-key="token-123"' in content
+    assert widget_script_url() in content
+    # The configured bot's card opens the widget; the other two stay inert.
+    assert content.count('data-demo-bot-trigger="nanibot"') == 1
+    assert content.count('class="bot-card bot-card-h bot-card-interactive"') == 1
+    assert content.count("Try this bot") == 1
+    # Every demo widget carries the same demonstration-only banner.
+    assert 'banner-message="Example bot: for demonstration and research purposes only."' in content
+    assert 'banner-style="info"' in content
+
+
+@pytest.mark.django_db()
+def test_applications_page_cards_are_inert_without_demo_bot_config(client, settings):
+    settings.PRELOGIN_DEMO_BOTS = {}
+    response = client.get(reverse("prelogin:applications"))
+    content = response.content.decode()
+    assert "<open-chat-studio-widget" not in content
+    assert "data-demo-bot-trigger" not in content
+    assert 'bot-card-interactive"' not in content  # the class is only ever in the stylesheet
+    assert "Try this bot" not in content
+    # No links to the chat UI that replaced these cards.
+    assert "/experiments/e/" not in content
 
 
 @pytest.mark.django_db()

--- a/apps/prelogin/tests/test_views.py
+++ b/apps/prelogin/tests/test_views.py
@@ -61,9 +61,22 @@ def test_applications_page_embeds_widget_for_configured_demo_bots(client, settin
 
 
 @pytest.mark.django_db()
-def test_applications_page_ignores_demo_bot_missing_required_config(client, settings):
-    settings.PRELOGIN_DEMO_BOTS = {"nanibot": {"id": "6d5abc50-167d-4e78-a2a1-6ff6d3cb229c"}}  # no embed_key
+@pytest.mark.parametrize(
+    "demo_bots",
+    [
+        pytest.param({"nanibot": {"id": "6d5abc50-167d-4e78-a2a1-6ff6d3cb229c"}}, id="missing-embed-key"),
+        pytest.param({"nanibot": {"embed_key": "token-123"}}, id="missing-id"),
+        pytest.param({"nanibot": {"id": "", "embed_key": ""}}, id="blank-fields"),
+        pytest.param({"nanibot": "6d5abc50-167d-4e78-a2a1-6ff6d3cb229c"}, id="entry-not-an-object"),
+        pytest.param(["6d5abc50-167d-4e78-a2a1-6ff6d3cb229c"], id="setting-not-an-object"),
+        pytest.param("nanibot", id="setting-is-a-string"),
+    ],
+)
+def test_applications_page_ignores_malformed_demo_bot_config(client, settings, demo_bots):
+    """Operator-supplied JSON of the wrong shape degrades to static cards, it doesn't 500."""
+    settings.PRELOGIN_DEMO_BOTS = demo_bots
     response = client.get(reverse("prelogin:applications"))
+    assert response.status_code == 200
     content = response.content.decode()
     assert "<open-chat-studio-widget" not in content
     assert "data-demo-bot-trigger" not in content

--- a/apps/prelogin/tests/test_views.py
+++ b/apps/prelogin/tests/test_views.py
@@ -61,6 +61,16 @@ def test_applications_page_embeds_widget_for_configured_demo_bots(client, settin
 
 
 @pytest.mark.django_db()
+def test_applications_page_ignores_demo_bot_missing_required_config(client, settings):
+    settings.PRELOGIN_DEMO_BOTS = {"nanibot": {"id": "6d5abc50-167d-4e78-a2a1-6ff6d3cb229c"}}  # no embed_key
+    response = client.get(reverse("prelogin:applications"))
+    content = response.content.decode()
+    assert "<open-chat-studio-widget" not in content
+    assert "data-demo-bot-trigger" not in content
+    assert "Try this bot" not in content
+
+
+@pytest.mark.django_db()
 def test_applications_page_cards_are_inert_without_demo_bot_config(client, settings):
     settings.PRELOGIN_DEMO_BOTS = {}
     response = client.get(reverse("prelogin:applications"))

--- a/apps/prelogin/urls.py
+++ b/apps/prelogin/urls.py
@@ -12,11 +12,7 @@ urlpatterns = [
         name="about",
     ),
     path("contact/", views.contact, name="contact"),
-    path(
-        "applications/",
-        TemplateView.as_view(template_name="prelogin/applications.html", extra_context={"active_nav": "applications"}),
-        name="applications",
-    ),
+    path("applications/", views.applications, name="applications"),
     path(
         "open-opportunities/",
         TemplateView.as_view(template_name="prelogin/open_opportunities.html"),

--- a/apps/prelogin/views.py
+++ b/apps/prelogin/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.conf import settings
 from django.contrib import messages
 from django.http import HttpResponseRedirect
@@ -6,6 +8,8 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from apps.web.waf import WafRule, waf_allow
+
+logger = logging.getLogger(__name__)
 
 
 @waf_allow(WafRule.NoUserAgent_HEADER)
@@ -24,16 +28,37 @@ def home(request):
         return render(request, "prelogin/home.html", {"active_nav": "home"})
 
 
+def _configured_demo_bots() -> dict:
+    """The demo bots from PRELOGIN_DEMO_BOTS that can actually drive a chat widget.
+
+    The setting is operator-supplied JSON, so anything malformed — not an object, an entry
+    that isn't an object, an entry missing a required field — is dropped and logged. Those
+    cards then render static, which is how an absent entry behaves, rather than 500ing a
+    public page or emitting a widget with empty attributes.
+    """
+    demo_bots = settings.PRELOGIN_DEMO_BOTS
+    if not isinstance(demo_bots, dict):
+        logger.error("PRELOGIN_DEMO_BOTS must be a JSON object, got %s", type(demo_bots).__name__)
+        return {}
+
+    configured = {}
+    for key, bot in demo_bots.items():
+        if not isinstance(bot, dict):
+            logger.error("PRELOGIN_DEMO_BOTS[%r] must be a JSON object, got %s", key, type(bot).__name__)
+        elif not (bot.get("id") and bot.get("embed_key")):
+            logger.error("PRELOGIN_DEMO_BOTS[%r] is missing 'id' or 'embed_key'", key)
+        else:
+            configured[key] = bot
+    return configured
+
+
 def applications(request):
-    # A bot missing either required field can't drive a widget, so treat it as unconfigured
-    # and let its card render static rather than emitting empty widget attributes.
-    demo_bots = {key: bot for key, bot in settings.PRELOGIN_DEMO_BOTS.items() if bot.get("id") and bot.get("embed_key")}
     return render(
         request,
         "prelogin/applications.html",
         {
             "active_nav": "applications",
-            "demo_bots": demo_bots,
+            "demo_bots": _configured_demo_bots(),
         },
     )
 

--- a/apps/prelogin/views.py
+++ b/apps/prelogin/views.py
@@ -25,12 +25,15 @@ def home(request):
 
 
 def applications(request):
+    # A bot missing either required field can't drive a widget, so treat it as unconfigured
+    # and let its card render static rather than emitting empty widget attributes.
+    demo_bots = {key: bot for key, bot in settings.PRELOGIN_DEMO_BOTS.items() if bot.get("id") and bot.get("embed_key")}
     return render(
         request,
         "prelogin/applications.html",
         {
             "active_nav": "applications",
-            "demo_bots": settings.PRELOGIN_DEMO_BOTS,
+            "demo_bots": demo_bots,
         },
     )
 

--- a/apps/prelogin/views.py
+++ b/apps/prelogin/views.py
@@ -24,6 +24,17 @@ def home(request):
         return render(request, "prelogin/home.html", {"active_nav": "home"})
 
 
+def applications(request):
+    return render(
+        request,
+        "prelogin/applications.html",
+        {
+            "active_nav": "applications",
+            "demo_bots": settings.PRELOGIN_DEMO_BOTS,
+        },
+    )
+
+
 def contact(request):
     hubspot_form = None
     if settings.HUBSPOT_FORM_PORTAL_ID and settings.HUBSPOT_FORM_ID:

--- a/config/settings.py
+++ b/config/settings.py
@@ -670,6 +670,13 @@ PRELOGIN_CONTACT_EMAIL = env("PRELOGIN_CONTACT_EMAIL", default="")
 HUBSPOT_FORM_REGION = env("HUBSPOT_FORM_REGION", default="na1")
 HUBSPOT_FORM_PORTAL_ID = env("HUBSPOT_FORM_PORTAL_ID", default="")
 HUBSPOT_FORM_ID = env("HUBSPOT_FORM_ID", default="")
+# Chat widget config for the demo bots on the use cases page, keyed by the bot keys used in
+# templates/prelogin/applications.html. A bot without an entry keeps its link to the hosted chat page.
+# The bots live on production, so the widget talks to production regardless of which deploy serves
+# the page, unless a bot sets "api_base_url" to test against another deploy. Format:
+# {"<bot key>": {"id": "<chatbot public id>", "embed_key": "<widget channel token>",
+#                "header_text": "<chat window title>", "api_base_url": "<optional other deploy>"}}
+PRELOGIN_DEMO_BOTS = env.json("PRELOGIN_DEMO_BOTS", default={})
 
 # Sentry setup
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -671,7 +671,7 @@ HUBSPOT_FORM_REGION = env("HUBSPOT_FORM_REGION", default="na1")
 HUBSPOT_FORM_PORTAL_ID = env("HUBSPOT_FORM_PORTAL_ID", default="")
 HUBSPOT_FORM_ID = env("HUBSPOT_FORM_ID", default="")
 # Chat widget config for the demo bots on the use cases page, keyed by the bot keys used in
-# templates/prelogin/applications.html. A bot without an entry keeps its link to the hosted chat page.
+# templates/prelogin/applications.html. A bot without an entry renders as a static card with no chat.
 # The bots live on production, so the widget talks to production regardless of which deploy serves
 # the page, unless a bot sets "api_base_url" to test against another deploy. Format:
 # {"<bot key>": {"id": "<chatbot public id>", "embed_key": "<widget channel token>",

--- a/templates/prelogin/applications.html
+++ b/templates/prelogin/applications.html
@@ -1,5 +1,5 @@
 {% extends "prelogin/base.html" %}
-{% load static %}
+{% load chat_widget_tags static %}
 
 {% block title %}Use Cases | Open Chat Studio{% endblock %}
 
@@ -97,7 +97,19 @@
     overflow:hidden; box-shadow:0 12px 32px -14px rgba(22,0,109,0.28);
     transition:box-shadow 220ms ease,transform 220ms ease,border-color 220ms ease;
   }
-  .bot-card:hover { box-shadow:0 28px 60px -18px rgba(22,0,109,0.45); transform:translateY(-7px); border-color:rgba(22,0,109,0.3); color:inherit; }
+  /* The widget host ships without a z-index, so its chat window paints at the host's own
+     stacking level and page content wins. Lift it above the page chrome (sticky nav is 50,
+     jump nav 40, skip link 100) but below the mobile nav menu (200), which should stay on top. */
+  open-chat-studio-widget {
+    z-index: 150;
+    /* The widget places the window using --chat-window-width but renders it at least 300px wide,
+       so the default 25% hangs off the right edge below ~1200px. A fixed width keeps them agreed. */
+    --chat-window-width: 380px;
+  }
+  /* Only cards wired to a chat widget react to the pointer — the rest are static. */
+  .bot-card-interactive { cursor:pointer; }
+  .bot-card-interactive:hover { box-shadow:0 28px 60px -18px rgba(22,0,109,0.45); transform:translateY(-7px); border-color:rgba(22,0,109,0.3); color:inherit; }
+  .bot-card-interactive:focus-visible { outline:2px solid #16006D; outline-offset:3px; }
   .bot-card-head { padding:18px 22px; display:flex; align-items:center; gap:12px; }
   .bot-card-head svg { width:22px; height:22px; flex-shrink:0; }
   .bot-card-head-label { font-family:'JetBrains Mono',monospace; font-size:10px; font-weight:600; letter-spacing:0.1em; text-transform:uppercase; color:rgba(255,255,255,0.8); }
@@ -106,7 +118,7 @@
   .bot-card p { font-size:0.88rem; color:var(--muted); line-height:1.65; flex:1; margin:0; }
   .bot-card-footer { padding-top:14px; border-top:1px solid rgba(184,164,255,0.14); }
   .bot-card-link { font-size:0.74rem; font-weight:700; color:#fff; background:#16006D; display:inline-flex; align-items:center; gap:7px; font-family:'JetBrains Mono',monospace; letter-spacing:0.08em; text-transform:uppercase; transition:gap 150ms, background 150ms; padding:9px 18px; border-radius:100px; }
-  .bot-card:hover .bot-card-link { gap:11px; background:#2a1488; }
+  .bot-card-interactive:hover .bot-card-link { gap:11px; background:#2a1488; }
   .bot-disclaimer-sm { font-size:0.75rem; color:var(--muted); opacity:0.6; line-height:1.5; margin-top:10px; }
   .uc-bot-label {
     font-family:'JetBrains Mono',monospace; font-size:9.5px; font-weight:700;
@@ -265,7 +277,8 @@
             <p class="uc-panel-desc">Chatbots for behavior change communication, health coaching, and personal wellbeing, reaching people in their own language on the platforms they already use.</p>
             <div style="margin-top:32px;">
               <div class="uc-bot-label">Example Bot: For Demonstration &amp; Research Purposes Only</div>
-              <a class="bot-card bot-card-h" href="https://www.openchatstudio.com/a/dimagi/experiments/e/6d5abc50-167d-4e78-a2a1-6ff6d3cb229c/start/" target="_blank" rel="noopener">
+              <div class="bot-card bot-card-h{% if demo_bots.nanibot %} bot-card-interactive{% endif %}"
+                   {% if demo_bots.nanibot %}data-demo-bot-trigger="nanibot" role="button" tabindex="0"{% endif %}>
                 <div class="bot-card-head" style="background:linear-gradient(135deg,#16006D 0%,#16006D 100%);">
                   <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
@@ -275,10 +288,11 @@
                 <div class="bot-card-inner">
                   <h3>NaniBot</h3>
                   <p>Counselling expectant mothers to prepare for birth</p>
-                  <div class="bot-card-footer"><span class="bot-card-link">Try this bot →</span></div>
-
+                  {% if demo_bots.nanibot %}
+                    <div class="bot-card-footer"><span class="bot-card-link">Try this bot →</span></div>
+                  {% endif %}
                 </div>
-              </a>
+              </div>
             </div>
 
           </div>
@@ -339,7 +353,8 @@
             <p class="uc-panel-desc">Personal coaches that help community health workers build capability through role-play, case-based learning, and structured feedback, deployed on the messaging apps they already use.</p>
             <div style="margin-top:32px;">
               <div class="uc-bot-label">Example Bot: For Demonstration &amp; Research Purposes Only</div>
-              <a class="bot-card bot-card-h" href="https://www.openchatstudio.com/a/dimagi/experiments/e/d61f49c1-ebea-4d1e-98ec-d0b5cb111c10/start/" target="_blank" rel="noopener">
+              <div class="bot-card bot-card-h{% if demo_bots.fp_coach %} bot-card-interactive{% endif %}"
+                   {% if demo_bots.fp_coach %}data-demo-bot-trigger="fp_coach" role="button" tabindex="0"{% endif %}>
                 <div class="bot-card-head" style="background:linear-gradient(135deg,#16006D 0%,#16006D 100%);">
                   <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
@@ -351,10 +366,11 @@
                 <div class="bot-card-inner">
                   <h3>Family Planning Coach</h3>
                   <p>Coaching for community health workers on holistic growth (available in French)</p>
-                  <div class="bot-card-footer"><span class="bot-card-link">Try this bot →</span></div>
-
+                  {% if demo_bots.fp_coach %}
+                    <div class="bot-card-footer"><span class="bot-card-link">Try this bot →</span></div>
+                  {% endif %}
                 </div>
-              </a>
+              </div>
             </div>
           </div>
         </div>
@@ -414,7 +430,8 @@
             <p class="uc-panel-desc">Tools for multilateral agencies, funders, and implementing partners to improve knowledge navigation, data access, and program management at the systems level.</p>
             <div style="margin-top:32px;">
               <div class="uc-bot-label">Example Bot: For Demonstration &amp; Research Purposes Only</div>
-              <a class="bot-card bot-card-h" href="https://www.openchatstudio.com/a/dimagi/experiments/e/f4219b24-3f35-45c3-91e8-60949439ce3a/start/" target="_blank" rel="noopener">
+              <div class="bot-card bot-card-h{% if demo_bots.program_dashboard %} bot-card-interactive{% endif %}"
+                   {% if demo_bots.program_dashboard %}data-demo-bot-trigger="program_dashboard" role="button" tabindex="0"{% endif %}>
                 <div class="bot-card-head" style="background:linear-gradient(135deg,#16006D 0%,#16006D 100%);">
                   <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2"/>
@@ -426,10 +443,11 @@
                 <div class="bot-card-inner">
                   <h3>Program Dashboard Assistant</h3>
                   <p>AI for navigating multilateral program data and reports</p>
-                  <div class="bot-card-footer"><span class="bot-card-link">Try this bot →</span></div>
-
+                  {% if demo_bots.program_dashboard %}
+                    <div class="bot-card-footer"><span class="bot-card-link">Try this bot →</span></div>
+                  {% endif %}
                 </div>
-              </a>
+              </div>
             </div>
           </div>
         </div>
@@ -491,4 +509,52 @@
 </section>
 {% endblock content %}
 
-{# No page_scripts block — the hamburger toggle lives in base.html #}
+{# The hamburger toggle lives in base.html; this block only wires up the demo bot chat widgets. #}
+{% block page_scripts %}
+  {% if demo_bots %}
+    <script type="module" src="{% widget_script_url %}"></script>
+    {# Widgets are position:fixed, so they take no space where they are declared. #}
+    {% for key, bot in demo_bots.items %}
+      <open-chat-studio-widget data-demo-bot="{{ key }}"
+                               chatbot-id="{{ bot.id }}"
+                               embed-key="{{ bot.embed_key }}"
+                               header-text="{{ bot.header_text|default:'' }}"
+                               banner-message="Example bot: for demonstration and research purposes only."
+                               banner-style="info"
+                               {% if bot.api_base_url %}api-base-url="{{ bot.api_base_url }}"{% endif %}
+                               show-button="false"
+                               visible="false"
+                               position="right"></open-chat-studio-widget>
+    {% endfor %}
+    <script>
+      // Bot cards open their chatbot in the widget. The template only marks a card as a trigger
+      // when its bot has widget config, so unconfigured cards are inert and get no handlers.
+      (function () {
+        const widgets = new Map();
+        document.querySelectorAll("open-chat-studio-widget[data-demo-bot]").forEach(function (widget) {
+          widgets.set(widget.dataset.demoBot, widget);
+        });
+        document.querySelectorAll("[data-demo-bot-trigger]").forEach(function (trigger) {
+          const widget = widgets.get(trigger.dataset.demoBotTrigger);
+          if (!widget) {
+            return;
+          }
+          function open() {
+            // Only one chat window at a time, so the others don't overlap it.
+            widgets.forEach(function (other) {
+              other.setAttribute("visible", other === widget ? "true" : "false");
+            });
+          }
+          trigger.addEventListener("click", open);
+          // The cards are divs rather than links, so they need their own keyboard activation.
+          trigger.addEventListener("keydown", function (event) {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              open();
+            }
+          });
+        });
+      })();
+    </script>
+  {% endif %}
+{% endblock page_scripts %}


### PR DESCRIPTION
### Product Description
The three example bots on the Use Cases page now open in an embedded chat widget on the page itself, instead of linking out to the public chat UI (which is going away). A bot with no widget config renders as a plain, non-clickable card — there is no link fallback.

### Technical Description
Chatbot IDs and embed keys come from a new `PRELOGIN_DEMO_BOTS` env setting keyed by card slug (`nanibot`, `fp_coach`, `program_dashboard`), so the page needs no DB access and renders identically on any deploy. I considered storing this in `SiteConfig`/`OcsConfiguration` instead — worth revisiting if marketing ever wants to swap demo bots without a deploy, and if we go there the config should hold only the chatbot ID and resolve the embed key from the widget channel rather than duplicating the secret.

Cards are progressive-enhancement style: the template only marks a card as a trigger when its bot is configured, so unconfigured cards get no handlers, no CTA and no hover affordance. They're divs with `role="button"`, so keyboard activation is wired up explicitly.

Two CSS workarounds in the page worth a look:
- the widget host element has no `z-index` of its own, so the chat window painted at the host's stacking level and page content covered it;
- the widget positions the window from `--chat-window-width` (default `25%`) but renders it at `min-width: 300px`, so below a ~1200px viewport it hung off the right edge. Pinning the var to `380px` makes the two agree. That one is a bug in `components/chat_widget` (`initializePosition` ignores its own min-width) — fixing it properly needs a widget release, so I left it to the CSS var here.

**Before this does anything on production:** each demo bot's embedded-widget channel must have `www.openchatstudio.com` in its `allowed_domains`, or `WidgetDomainPermission` returns 403; and `PRELOGIN_DEMO_BOTS` has to be set. Until both are done the cards render as static cards, which is safe.

### Demo
To exercise it locally, point the config at a local bot with an embedded-widget channel:

```
PRELOGIN_DEMO_BOTS='{"nanibot": {"id": "<public id>", "embed_key": "<widget_token>", "header_text": "NaniBot", "api_base_url": "http://localhost:8000"}}' \
  uv run python manage.py runserver
```

Add `localhost` to that channel's `allowed_domains`, then open `/applications/` and click the NaniBot card.

Verified in the browser against local bots: `POST /api/chat/start/` → 201 and `POST /api/chat/<session>/message/` → 202 with the embed key, click and Enter/Space both open the window, opening a second bot closes the first, and the window sits fully inside the viewport at 700×700, 900×620, 1280×800 and 1600×900.

### Docs and Changelog
- [ ] This PR requires docs/changelog update
