### PR TITLE
Fix collection polling targets and extract PDF text with PDFium

### DIFF
--- a/apps/documents/readers.py
+++ b/apps/documents/readers.py
@@ -103,9 +103,9 @@ def pdf_read(file_obj) -> Document:
     so a thread cannot be cancelled, and a SIGALRM budget fires only on the main thread,
     which is not where our gevent or threaded workers run requests.
 
-    PDFium itself is not thread-safe, and both the Celery workers (--pool threads) and
-    gunicorn (--threads) parse PDFs concurrently in one process, so a module lock serialises
-    every parse: unsynchronised concurrent use corrupts library state and fails valid PDFs.
+    PDFium itself is not thread-safe and we parse PDFs from threaded workers, so a module lock
+    serialises every parse: unsynchronised concurrent use corrupts library state and fails
+    valid PDFs.
     """
     import pypdfium2  # noqa: PLC0415 - TID253: loads a shared library, keep off the import path
 

--- a/apps/documents/readers.py
+++ b/apps/documents/readers.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from io import BytesIO
 
 from bs4 import UnicodeDammit
@@ -7,6 +8,17 @@ from pydantic import BaseModel, Field
 from apps.files.models import File
 
 logger = logging.getLogger("ocs.documents")
+
+PDF_MAGIC = b"%PDF-"
+PDF_HEADER_SCAN_BYTES = 1024
+
+_pdfium_lock = threading.Lock()
+
+
+def _looks_like_pdf(head: bytes) -> bool:
+    """The PDF header may sit anywhere in the first 1024 bytes, not just at offset zero;
+    mail gateways and misbehaving HTTP servers produce such files, and PDFium reads them."""
+    return PDF_MAGIC in head[:PDF_HEADER_SCAN_BYTES]
 
 
 class FileReadException(Exception):
@@ -26,9 +38,8 @@ class Document(BaseModel):
 
     @classmethod
     def from_file(cls, file: File):
-        reader = get_file_content_reader(file.content_type)
         with file.file.open("rb") as fh:
-            return reader(fh).with_metadata(
+            return read_file_content(fh, file.content_type).with_metadata(
                 {
                     "source_file_id": file.id,
                     "source_file_name": file.name,
@@ -43,6 +54,16 @@ class Document(BaseModel):
         return "".join(part.content for part in self.parts)
 
 
+def read_file_content(file_obj, content_type: str | None = None) -> "Document":
+    """Read a file to text, picking a reader by content type.
+
+    The single funnel both the document sync and index ingestion use, so a file that cannot
+    be read raises ``FileReadException`` for either and is recorded as failed.
+    """
+    reader = get_file_content_reader(content_type)
+    return reader(file_obj)
+
+
 def get_file_content_reader(content_type) -> callable:
     if content_type in READERS:
         return READERS[content_type]
@@ -50,8 +71,70 @@ def get_file_content_reader(content_type) -> callable:
     if mime_class in READERS:
         return READERS[mime_class]
 
-    logger.warning(f"No reader found for content type {content_type}. Using default text reader.")
-    return markitdown_read
+    logger.warning(f"No reader found for content type {content_type}. Sniffing the content instead.")
+    return default_read
+
+
+def _pdf_page_text(page) -> str:
+    """Text of one PDFium page, normalised and newline-terminated.
+
+    ``Document.get_contents_as_string`` concatenates parts with no separator, so each page
+    carries its own break or the last word of one page runs into the first word of the next.
+    PDFium also emits \\r\\n, which would otherwise reach the index verbatim.
+    """
+    text = page.get_textpage().get_text_range().replace("\r\n", "\n").replace("\r", "\n")
+    if text and not text.endswith("\n"):
+        text += "\n"
+    return text
+
+
+def pdf_read(file_obj) -> Document:
+    """Read a PDF with PDFium, one part per page.
+
+    PDFium is ~115x faster than pdfminer on a large document, and its text is better:
+    pdfminer's layout analysis fragments complex pages into single characters (65%
+    one-character tokens on a table-heavy 144-page report, against 8% for PDFium) and
+    scatters table columns away from the rows they belong to.
+
+    There is deliberately no pdfminer fallback for a file PDFium cannot open. PDFium already
+    recovers the damage worth recovering -- it rebuilds a clobbered xref table in under a
+    millisecond, the same damage that took pdfminer ~13 minutes to return a fragment of --
+    and pdfminer's slow path cannot be bounded once it starts: it is CPU-bound pure Python,
+    so a thread cannot be cancelled, and a SIGALRM budget fires only on the main thread,
+    which is not where our gevent or threaded workers run requests.
+
+    PDFium itself is not thread-safe, and both the Celery workers (--pool threads) and
+    gunicorn (--threads) parse PDFs concurrently in one process, so a module lock serialises
+    every parse: unsynchronised concurrent use corrupts library state and fails valid PDFs.
+    """
+    import pypdfium2  # noqa: PLC0415 - TID253: loads a shared library, keep off the import path
+
+    file_obj.seek(0)
+    data = file_obj.read()
+    try:
+        with _pdfium_lock:
+            pdf = pypdfium2.PdfDocument(data)
+            try:
+                parts = [DocumentPart(content=_pdf_page_text(page)) for page in pdf]
+            finally:
+                pdf.close()
+    except Exception as exc:
+        raise FileReadException(f"Could not extract text from this PDF: {exc}") from exc
+    return Document(parts=parts)
+
+
+def default_read(file_obj) -> Document:
+    """Read a file whose content type we have no trustworthy claim about.
+
+    The sync loader takes file types from a third-party feed, so the bytes decide: a
+    mislabelled PDF would otherwise reach pdfminer and cost minutes instead of milliseconds.
+    """
+    file_obj.seek(0)
+    head = file_obj.read(PDF_HEADER_SCAN_BYTES)
+    file_obj.seek(0)
+    if _looks_like_pdf(head):
+        return pdf_read(file_obj)
+    return markitdown_read(file_obj)
 
 
 def markitdown_read(file_obj) -> Document:
@@ -63,15 +146,18 @@ def markitdown_read(file_obj) -> Document:
     )
 
     md = MarkItDown(enable_plugins=False)
+    content = file_obj.read()
     try:
-        result = md.convert(BytesIO(file_obj.read()))
+        result = md.convert(BytesIO(content))
         return Document(parts=[DocumentPart(content=result.markdown)])
-    except FileConversionException:
-        file_obj.seek(0)  # Reset file pointer to beginning before fallback
-        return plaintext_reader(file_obj)
-    except UnsupportedFormatException:
-        file_obj.seek(0)  # Reset file pointer to beginning before fallback
-        return plaintext_reader(file_obj)
+    except (FileConversionException, UnsupportedFormatException) as exc:
+        # Falling back to a plaintext decode is useful for a genuinely textual file with an
+        # unrecognised extension. For a PDF it is worse than failing: decoding the raw bytes
+        # yields megabytes of noise (mean word length ~158 characters) that would be indexed
+        # and retrieved as if it were the document.
+        if _looks_like_pdf(content):
+            raise FileReadException("Could not extract text from this PDF") from exc
+        return plaintext_reader(BytesIO(content))
     except UnicodeDecodeError as e:
         raise FileReadException("Unable to decode file contents to text") from e
 
@@ -93,4 +179,10 @@ def plaintext_reader(file_obj) -> Document:
     return Document(parts=[DocumentPart(content=content)])
 
 
-READERS = {None: markitdown_read, "text/markdown": plaintext_reader, "text/plain": plaintext_reader}
+READERS = {
+    None: default_read,
+    "application/pdf": pdf_read,
+    "application/x-pdf": pdf_read,
+    "text/markdown": plaintext_reader,
+    "text/plain": plaintext_reader,
+}

--- a/apps/documents/source_loaders/json_collection.py
+++ b/apps/documents/source_loaders/json_collection.py
@@ -10,7 +10,7 @@ from langchain_core.documents import Document
 
 from apps.documents.datamodels import JSONCollectionSourceConfig
 from apps.documents.models import Collection, DocumentSource
-from apps.documents.readers import markitdown_read
+from apps.documents.readers import read_file_content
 from apps.documents.source_loaders.base import BaseDocumentLoader
 from apps.utils.urlvalidate import InvalidURL, validate_user_input_url
 
@@ -155,8 +155,10 @@ class JSONCollectionLoader(BaseDocumentLoader[JSONCollectionSourceConfig]):
         except InvalidURL as exc:
             raise ValueError(f"Refusing to fetch attachment URL: {exc}") from exc
         content = self._read_with_size_limit(url)
-        doc = markitdown_read(BytesIO(content))
-        return doc.get_contents_as_string()
+        # No trustworthy content type here -- the feed's `file_type` is a third party's claim --
+        # so let the bytes pick the reader. A damaged PDF is refused in milliseconds instead of
+        # occupying the worker for minutes; the caller records it as failed and moves on.
+        return read_file_content(BytesIO(content)).get_contents_as_string()
 
     def _read_with_size_limit(self, url: str) -> bytes:
         """GET `url` and return the body, raising ValueError if it exceeds the size cap.

--- a/apps/documents/test_readers.py
+++ b/apps/documents/test_readers.py
@@ -160,7 +160,14 @@ class TestDefaultRead:
 
 
 class TestBinaryIsNeverDecodedAsText:
-    def test_unreadable_pdf_fails_instead_of_being_decoded(self):
+    @pytest.mark.parametrize(
+        "content",
+        [
+            pytest.param(b"%PDF-1.4 binary junk", id="header-at-start"),
+            pytest.param(b"junk prefix %PDF-1.4 then binary junk", id="header-with-prefix"),
+        ],
+    )
+    def test_unreadable_pdf_fails_instead_of_being_decoded(self, content):
         """markitdown falls back to a plaintext decode when no converter can read a file. For a
         PDF that puts ~4MB of the raw file into the index as 'text', which is worse than
         failing: mean word length of that output is 158 characters."""
@@ -168,14 +175,7 @@ class TestBinaryIsNeverDecodedAsText:
             markitdown.return_value.convert.side_effect = FileConversionException(attempts=[])
 
             with pytest.raises(FileReadException, match="Could not extract text"):
-                markitdown_read(BytesIO(b"%PDF-1.4 binary junk"))
-
-    def test_unreadable_pdf_with_offset_header_fails_instead_of_being_decoded(self):
-        with mock.patch("markitdown.MarkItDown") as markitdown:
-            markitdown.return_value.convert.side_effect = FileConversionException(attempts=[])
-
-            with pytest.raises(FileReadException, match="Could not extract text"):
-                markitdown_read(BytesIO(b"junk prefix %PDF-1.4 then binary junk"))
+                markitdown_read(BytesIO(content))
 
     def test_undecodable_non_pdf_still_falls_back_to_plaintext(self):
         """The fallback is useful for genuinely textual files with an unknown extension."""

--- a/apps/documents/test_readers.py
+++ b/apps/documents/test_readers.py
@@ -1,9 +1,21 @@
+import threading
 from io import BytesIO
+from pathlib import Path
 from unittest import mock
 
 import pytest
+from markitdown._exceptions import FileConversionException  # noqa: TID253
 
-from apps.documents.readers import FileReadException, plaintext_reader
+from apps.documents.readers import (
+    FileReadException,
+    default_read,
+    get_file_content_reader,
+    markitdown_read,
+    pdf_read,
+    plaintext_reader,
+)
+
+TEST_PDF = Path(__file__).parent / "tests" / "data" / "test.pdf"
 
 
 class TestPlaintextReader:
@@ -52,3 +64,124 @@ class TestPlaintextReader:
 
             with pytest.raises(FileReadException, match="Unable to decode file contents to text"):
                 plaintext_reader(file_obj)
+
+
+class TestPdfRead:
+    def test_reads_pdf_via_pdfium(self):
+        doc = pdf_read(BytesIO(TEST_PDF.read_bytes()))
+
+        assert doc.get_contents_as_string() == "PDF documents can be\nhard to read 🫠\n"
+
+    def test_normalises_line_endings(self):
+        """PDFium emits \\r\\n; carriage returns would otherwise reach the index verbatim."""
+        with mock.patch("pypdfium2.PdfDocument") as pdfium_doc:
+            page = mock.Mock()
+            page.get_textpage.return_value.get_text_range.return_value = "line one\r\nline two\r"
+            pdf = mock.MagicMock()
+            pdf.__iter__.return_value = iter([page])
+            pdfium_doc.return_value = pdf
+
+            doc = pdf_read(BytesIO(b"%PDF-1.4 stub"))
+
+        pdf.close.assert_called_once()
+
+        assert "\r" not in doc.get_contents_as_string()
+        assert doc.get_contents_as_string() == "line one\nline two\n"
+
+    def test_concurrent_reads_do_not_corrupt_pdfium(self):
+        """PDFium is not thread-safe and both the Celery workers (--pool threads) and gunicorn
+        (--threads 8) parse PDFs concurrently in one process. Without serialisation, concurrent
+        parses corrupt library state and valid PDFs fail with 'Data format error'."""
+        pdf_bytes = TEST_PDF.read_bytes()
+        errors = []
+
+        def parse_repeatedly():
+            for _ in range(20):
+                try:
+                    pdf_read(BytesIO(pdf_bytes))
+                except Exception as exc:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=parse_repeatedly) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert not errors
+
+    def test_a_damaged_file_is_refused_rather_than_handed_to_pdfminer(self):
+        """pdfminer takes minutes on a damaged file with no way to interrupt it, so a file
+        PDFium cannot open fails here instead of falling back to it."""
+        with (
+            mock.patch("apps.documents.readers.markitdown_read") as markitdown,
+            pytest.raises(FileReadException, match="Could not extract text from this PDF"),
+        ):
+            pdf_read(BytesIO(b"%PDF-1.4 truncated before the xref"))
+
+        markitdown.assert_not_called()
+
+
+class TestDefaultRead:
+    def test_sniffs_pdf_magic_and_uses_the_pdf_reader(self):
+        """The sync loader has no trustworthy content type, so the bytes have to say."""
+        with mock.patch("apps.documents.readers.pdf_read") as pdf:
+            pdf.return_value = mock.sentinel.pdf_document
+            result = default_read(BytesIO(TEST_PDF.read_bytes()))
+
+        assert result is mock.sentinel.pdf_document
+
+    def test_a_pdf_with_junk_before_the_header_is_still_read_as_pdf(self):
+        """The PDF header may sit anywhere in the first 1024 bytes; mail gateways and bad HTTP
+        responses produce such files. They must reach PDFium, not fall through to pdfminer."""
+        junked = b"X" * 100 + TEST_PDF.read_bytes()
+
+        doc = default_read(BytesIO(junked))
+
+        # this exact output proves the PDFium path ran; pdfminer renders it differently
+        assert doc.get_contents_as_string() == "PDF documents can be\nhard to read 🫠\n"
+
+    def test_pdf_magic_beyond_the_first_kilobyte_is_not_treated_as_pdf(self):
+        with mock.patch("apps.documents.readers.markitdown_read") as markitdown:
+            markitdown.return_value = mock.sentinel.other_document
+            result = default_read(BytesIO(b"X" * 2000 + b"%PDF-1.4"))
+
+        assert result is mock.sentinel.other_document
+
+    def test_non_pdf_goes_to_markitdown(self):
+        with mock.patch("apps.documents.readers.markitdown_read") as markitdown:
+            markitdown.return_value = mock.sentinel.other_document
+            result = default_read(BytesIO(b"PK\x03\x04 a docx, not a pdf"))
+
+        assert result is mock.sentinel.other_document
+
+    def test_unknown_content_type_falls_back_to_sniffing(self):
+        assert get_file_content_reader("application/octet-stream") is default_read
+
+
+class TestBinaryIsNeverDecodedAsText:
+    def test_unreadable_pdf_fails_instead_of_being_decoded(self):
+        """markitdown falls back to a plaintext decode when no converter can read a file. For a
+        PDF that puts ~4MB of the raw file into the index as 'text', which is worse than
+        failing: mean word length of that output is 158 characters."""
+        with mock.patch("markitdown.MarkItDown") as markitdown:
+            markitdown.return_value.convert.side_effect = FileConversionException(attempts=[])
+
+            with pytest.raises(FileReadException, match="Could not extract text"):
+                markitdown_read(BytesIO(b"%PDF-1.4 binary junk"))
+
+    def test_unreadable_pdf_with_offset_header_fails_instead_of_being_decoded(self):
+        with mock.patch("markitdown.MarkItDown") as markitdown:
+            markitdown.return_value.convert.side_effect = FileConversionException(attempts=[])
+
+            with pytest.raises(FileReadException, match="Could not extract text"):
+                markitdown_read(BytesIO(b"junk prefix %PDF-1.4 then binary junk"))
+
+    def test_undecodable_non_pdf_still_falls_back_to_plaintext(self):
+        """The fallback is useful for genuinely textual files with an unknown extension."""
+        with mock.patch("markitdown.MarkItDown") as markitdown:
+            markitdown.return_value.convert.side_effect = FileConversionException(attempts=[])
+
+            doc = markitdown_read(BytesIO(b"just some text"))
+
+        assert doc.get_contents_as_string() == "just some text"

--- a/apps/documents/test_readers.py
+++ b/apps/documents/test_readers.py
@@ -89,9 +89,9 @@ class TestPdfRead:
         assert doc.get_contents_as_string() == "line one\nline two\n"
 
     def test_concurrent_reads_do_not_corrupt_pdfium(self):
-        """PDFium is not thread-safe and both the Celery workers (--pool threads) and gunicorn
-        (--threads 8) parse PDFs concurrently in one process. Without serialisation, concurrent
-        parses corrupt library state and valid PDFs fail with 'Data format error'."""
+        """PDFium is not thread-safe and we parse PDFs from threaded workers. Without
+        serialisation, concurrent parses corrupt library state and valid PDFs fail with
+        'Data format error'."""
         pdf_bytes = TEST_PDF.read_bytes()
         errors = []
 

--- a/apps/documents/tests/test_document.py
+++ b/apps/documents/tests/test_document.py
@@ -12,7 +12,9 @@ BASE_PATH = pathlib.Path(__file__).parent / "data"
 @pytest.mark.parametrize(
     ("filename", "expected_content", "part_count"),
     [
-        pytest.param("test.pdf", "PDF documents can be\n\n\x0chard to read 🫠\n\n", 1, id="pdf"),
+        # PDFs are read by PDFium, one part per page. pdfminer used to return a single part
+        # separated by a form feed (\x0c) with doubled newlines around it.
+        pytest.param("test.pdf", "PDF documents can be\nhard to read 🫠\n", 2, id="pdf"),
         pytest.param("test.txt", "Hi\n\nHere is a text file with 🥰 emoji.\n", 1, id="txt"),
         pytest.param("test.docx", "doc, but with an x 😊", 1, id="docx"),
     ],

--- a/apps/documents/tests/test_json_collection_loader.py
+++ b/apps/documents/tests/test_json_collection_loader.py
@@ -120,7 +120,7 @@ class TestLoadDocumentsAttachments:
         )
 
         loader = _make_loader(json_config, collection_id=42)
-        with mock.patch("apps.documents.source_loaders.json_collection.markitdown_read") as md:
+        with mock.patch("apps.documents.source_loaders.json_collection.read_file_content") as md:
             md.side_effect = [
                 _stub_doc("text from pdf 1"),
                 _stub_doc("text from pdf 2"),
@@ -207,7 +207,7 @@ class TestItemMetadataPropagation:
         httpx_mock.add_response(url="https://example.com/file.pdf", content=b"PDF")
         loader = _make_loader(json_config)
         with mock.patch(
-            "apps.documents.source_loaders.json_collection.markitdown_read",
+            "apps.documents.source_loaders.json_collection.read_file_content",
             return_value=_stub_doc("body"),
         ):
             docs = list(loader.load_documents())
@@ -228,7 +228,7 @@ class TestItemMetadataPropagation:
         httpx_mock.add_response(url="https://example.com/file.pdf", content=b"PDF")
         loader = _make_loader(json_config)
         with mock.patch(
-            "apps.documents.source_loaders.json_collection.markitdown_read",
+            "apps.documents.source_loaders.json_collection.read_file_content",
             return_value=_stub_doc("body"),
         ):
             meta = list(loader.load_documents())[0].metadata
@@ -243,7 +243,7 @@ class TestItemMetadataPropagation:
 
         with caplog.at_level(logging.WARNING, logger="apps.documents.source_loaders.json_collection"):
             with mock.patch(
-                "apps.documents.source_loaders.json_collection.markitdown_read",
+                "apps.documents.source_loaders.json_collection.read_file_content",
                 return_value=_stub_doc("body"),
             ):
                 docs = list(loader.load_documents())
@@ -332,7 +332,7 @@ class TestMetadataFilters:
             httpx_mock.add_response(url="https://example.com/file.pdf", content=b"PDF")
         loader = _make_loader(config)
         with mock.patch(
-            "apps.documents.source_loaders.json_collection.markitdown_read",
+            "apps.documents.source_loaders.json_collection.read_file_content",
             return_value=_stub_doc("body"),
         ):
             docs = list(loader.load_documents())
@@ -371,7 +371,7 @@ class TestUnsupportedFileTypes:
         loader = _make_loader(json_config)
         with caplog.at_level(logging.WARNING, logger="apps.documents.source_loaders.json_collection"):
             with mock.patch(
-                "apps.documents.source_loaders.json_collection.markitdown_read",
+                "apps.documents.source_loaders.json_collection.read_file_content",
                 return_value=_stub_doc("body"),
             ):
                 docs = list(loader.load_documents())
@@ -417,7 +417,7 @@ class TestLoadDocumentsAttachmentFailures:
 
         loader = _make_loader(json_config)
         with mock.patch(
-            "apps.documents.source_loaders.json_collection.markitdown_read",
+            "apps.documents.source_loaders.json_collection.read_file_content",
             return_value=_stub_doc("good text"),
         ):
             docs = list(loader.load_documents())
@@ -443,7 +443,7 @@ class TestLoadDocumentsAttachmentFailures:
 
         loader = _make_loader(json_config)
         with mock.patch(
-            "apps.documents.source_loaders.json_collection.markitdown_read",
+            "apps.documents.source_loaders.json_collection.read_file_content",
             side_effect=[RuntimeError("boom"), _stub_doc("ok text")],
         ):
             docs = list(loader.load_documents())
@@ -614,7 +614,7 @@ class TestAuthHeadersPropagation:
         )
         loader = _loader_with_fake_auth(json_config)
         with mock.patch(
-            "apps.documents.source_loaders.json_collection.markitdown_read",
+            "apps.documents.source_loaders.json_collection.read_file_content",
             return_value=_stub_doc("body"),
         ):
             docs = list(loader.load_documents())

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -344,11 +344,14 @@ def sync_document_source(request, team_slug: str, collection_id: int, pk: int):
     """Trigger manual sync of a document source"""
     document_source = get_object_or_404(DocumentSource, id=pk, collection_id=collection_id, team=request.team)
 
-    if not _queue_document_source_sync(document_source):
+    if _queue_document_source_sync(document_source):
+        messages.success(request, "Document source sync has been queued. This may take a few minutes.")
+    else:
+        # Still re-render: the caller swaps #document_source_<id> outerHTML, so an empty body
+        # would delete the source (and its file list) from the page. Repainting instead brings
+        # the stale page that offered the button back in line with the running sync.
         messages.warning(request, "This document source is already syncing.")
-        return HttpResponse()
 
-    messages.success(request, "Document source sync has been queued. This may take a few minutes.")
     return render(
         request,
         "documents/partials/document_source.html",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ dependencies = [
     "djlint>=1.42.3",
     "transformers",
     "packaging>=23.2",
+    "pypdfium2>=5.12.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     "pgvector",
     "backoff",
     "django-cors-headers>=4.7.0",
-    "markitdown[pdf, docx, xlsx, xls, outlook, pptx]",
+    "markitdown[docx, xlsx, xls, outlook, pptx]",
     "langchain-mcp-adapters",
     "atlassian-python-api>=4.0.7",
     "audioop-lts>=0.2.2",

--- a/templates/documents/_collection_snapshots.html
+++ b/templates/documents/_collection_snapshots.html
@@ -2,6 +2,7 @@
      {% if collection.create_version_task_id %}
        hx-get="{% url 'documents:collection_snapshots' request.team.slug collection.id %}"
        hx-trigger="every 2s"
+       hx-target="this"
        hx-swap="outerHTML"
      {% endif %}
 >

--- a/templates/documents/collection_file_status.html
+++ b/templates/documents/collection_file_status.html
@@ -10,6 +10,7 @@
      {% if collection_file.status == 'pending' or collection_file.status == 'in_progress' %}
        hx-get="{% url 'documents:get_collection_file_status' team.slug collection.id collection_file.id %}"
        hx-trigger="every 5s"
+       hx-target="this"
        hx-swap="outerHTML"
      {% endif %}>
   {% if collection_file.status == 'pending' %}

--- a/templates/documents/partials/collection_files.html
+++ b/templates/documents/partials/collection_files.html
@@ -7,6 +7,7 @@
     {% if document_source and document_source.sync_task_id %}
       hx-get="{% url "documents:document_source_files_list" request.team.slug collection.id document_source.id %}"
       hx-trigger="every 5s"
+      hx-target="this"
       hx-swap="outerHTML"
       hx-include="#search-input"
     {% endif %}

--- a/uv.lock
+++ b/uv.lock
@@ -3051,6 +3051,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydub" },
     { name = "pygments" },
+    { name = "pypdfium2" },
     { name = "pytelegrambotapi" },
     { name = "python-json-logger" },
     { name = "python-magic" },
@@ -3170,6 +3171,7 @@ requires-dist = [
     { name = "pydantic" },
     { name = "pydub" },
     { name = "pygments" },
+    { name = "pypdfium2", specifier = ">=5.12.1" },
     { name = "pytelegrambotapi", specifier = "==4.12.0" },
     { name = "python-json-logger", specifier = ">=3.2.1" },
     { name = "python-magic" },
@@ -3925,6 +3927,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/b6/1ae53367e28b9cffa3be7574e13fbe4589694272fd47710fbdbafd3d63c6/pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6", size = 269415, upload-time = "2026-06-23T02:27:43.826Z" },
+]
+
+[[package]]
+name = "pypdfium2"
+version = "5.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/42/0b51bdf50ccf13f3deb3209ca996179a49761dc191748469cf0de55b0055/pypdfium2-5.12.1.tar.gz", hash = "sha256:d0e0648fb2e28f50efcd1ec0a5a18ced9f4d66b2c227fae9b603f0a883b2d13f", size = 274428, upload-time = "2026-07-17T10:01:22.713Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/7e/bd8df53b1131c582f6646372047b49162032bd01628d49b9a60cd94d2181/pypdfium2-5.12.1-py3-none-android_23_arm64_v8a.whl", hash = "sha256:05bab9b1ba2de7fc299ae2af25cb9c8a0543bc8bb893e879fe8c9ba8310e9ce4", size = 3392276, upload-time = "2026-07-17T10:00:47.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/13/a2b71e17b0439d2af78c817a381e3557371c6c56098581da8485aef65ea6/pypdfium2-5.12.1-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:d4ee061e566a6422b660cdddaaa799a2d1cbf2f016921bcaf24d61426d01d942", size = 2848776, upload-time = "2026-07-17T10:00:49.09Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a8/d7a61700db3022792b28bce5264be90a7d2e7104998362af6b93766f50b2/pypdfium2-5.12.1-py3-none-macosx_13_0_arm64.whl", hash = "sha256:66a9ed40d70a5d728cd42148fecb9d7a0917c6161d6bb67c844093a4ed1df089", size = 3480243, upload-time = "2026-07-17T10:00:50.674Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2c/d7a38fad74b6da0947cf8763aee0f8e6c9d3c12fc8e137aa615f7f8ae76c/pypdfium2-5.12.1-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:847378a5ab41332998b2621b21bab2e96dc8c3eff36a08bce26695b964163983", size = 3643490, upload-time = "2026-07-17T10:00:52.236Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/29/aca739676323558595fcf8cdc8d7939d2b25aaaa6f538e829f1fee938cdd/pypdfium2-5.12.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6eabf028ad8e7bc7811c9acf3a72718c180569b624b844d2c6cc974609784275", size = 3649734, upload-time = "2026-07-17T10:00:53.776Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e0/e4ecc05f4f1a11d11c8d684a24b2fc8be8207f341be985dac301caa4f6aa/pypdfium2-5.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7857cfa6642ec5a09db12ff8f5cf6b6494585b5e3a605399fddc4fb862837b63", size = 3380828, upload-time = "2026-07-17T10:00:55.377Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1b/c94c9d486791276e736350917a11fe2cf3acba2c6c7f03f9ac0d51f8952a/pypdfium2-5.12.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05bfa20a08a96584253bbe38b60e13f81a037eac31c5579e607ec1480ad25dbf", size = 3777202, upload-time = "2026-07-17T10:00:57.212Z" },
+    { url = "https://files.pythonhosted.org/packages/14/aa/7f81f0c035fc32850dfab9daf78530814f215be226dad7491e3caa0a3e8c/pypdfium2-5.12.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9f059f7bdbdf4352eb83691071096940d769d6ae5930b8734237fdb1bd78fbc2", size = 4186083, upload-time = "2026-07-17T10:00:59.022Z" },
+    { url = "https://files.pythonhosted.org/packages/23/16/21420a6f2bc5f981299c336817dd5d72709dad5fda30ac38cbd5f0f7b372/pypdfium2-5.12.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e10cbf41b21233ec5e20adfc170cf60edd77abead86a97dc708fff55a8a886c7", size = 3701734, upload-time = "2026-07-17T10:01:00.952Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a1/bb89f49e2b3ea3e945b67859d2ec6e73e722a83c006099c675692641e51d/pypdfium2-5.12.1-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07eeebb2784f4cd38d386b924235df43217a397442796673296bb6efbdaad1d0", size = 4030403, upload-time = "2026-07-17T10:01:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a7/cea5eb0c39e9c6fdf9853a3008bf021d08f962228073af90354b60c5ccdc/pypdfium2-5.12.1-py3-none-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5c3e6cbe43581af79526184643920ab03a9401a0c79f2226bea9d4d1e3d34008", size = 3994411, upload-time = "2026-07-17T10:01:04.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/43/5e470213b27c13b0d94d03d97fc3740507edadea1d1e2ce2049bfbec4aa0/pypdfium2-5.12.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4648f0905441bcb141687ca2263bbf38a1aa056b943eef06019f91cff3e1da4a", size = 4993687, upload-time = "2026-07-17T10:01:05.811Z" },
+    { url = "https://files.pythonhosted.org/packages/db/da/af7972ca72f24ed720db6501333fd67bc66aa6aa5a5ec698551bd30ae62e/pypdfium2-5.12.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:bdff622181fab64f32328591c9c8287cdc745c9a1f2afc26ca3feba39e3e6645", size = 4534560, upload-time = "2026-07-17T10:01:07.291Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/63/06a7f2cd691f7e336cbc53fd65453fee516042c8ddb016bc50d1cd2bed45/pypdfium2-5.12.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:236dbdc88aa54f14b27937ccb2ebe3dcf08c10dbb8652f432ea982dc9af39732", size = 5237681, upload-time = "2026-07-17T10:01:08.997Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f5/937b080671758ab0b3d3d69b2657006682e4c6a0134b36774be4ed1afcfb/pypdfium2-5.12.1-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:9c8856ce7dd77a7827476c7d75afe1197d6cd505f5cb4167b6aacf661f3f8ea5", size = 5143027, upload-time = "2026-07-17T10:01:10.69Z" },
+    { url = "https://files.pythonhosted.org/packages/32/02/094632700c24728fa443dc89d9d1c6e4fc05bb00778b22e8482fdb133da0/pypdfium2-5.12.1-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:5f257bb40fa44ce9ba18d2c919777dbd3f16bf22548b1d68fd56c7c92f1de530", size = 4647048, upload-time = "2026-07-17T10:01:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d0/12d84bf55a4fcf2c0ed242afc94168933194f672067e1d162aa60a8e4426/pypdfium2-5.12.1-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:974082344172da76a5c3c0782eaedfe6069dbe88db77d8c671ef36b61e9b14e2", size = 5088747, upload-time = "2026-07-17T10:01:14.42Z" },
+    { url = "https://files.pythonhosted.org/packages/92/9c/92a460bac1f6cfd6f96251802b3098a804fb251dfe0b5eb004ede958ae0e/pypdfium2-5.12.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:715ae16b34ea1d64884d58800155179ba700e9ea65a2f583b020666acd2bfb12", size = 5049695, upload-time = "2026-07-17T10:01:15.961Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/67/53c61d366222550220b42a9212131407f49d3dbcf050178c620bf80fa899/pypdfium2-5.12.1-py3-none-win32.whl", hash = "sha256:e5358d2ce4ebc5c899aab1df9ca5d215357244e9168aa443225d3c1e649c7eac", size = 3725466, upload-time = "2026-07-17T10:01:17.773Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c3/08b62718faf2f6b6aa49207626e3113ff3ec1b3cd076c0ef8fd852f0e57c/pypdfium2-5.12.1-py3-none-win_amd64.whl", hash = "sha256:9609be73a6701a68f29dffe0335f7a2e4b3ba581542ed65d35d49f761a4600ca", size = 3859845, upload-time = "2026-07-17T10:01:19.417Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d5/ad551e55790134c8bc87ea16e0866a3721def0620fbfa19112c8ad4a25a6/pypdfium2-5.12.1-py3-none-win_arm64.whl", hash = "sha256:afc0b7e0c975a429abc75875209ce17b66d749f6ac5cbe8ba72470e83901e304", size = 3674605, upload-time = "2026-07-17T10:01:21.008Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2659,9 +2659,6 @@ docx = [
 outlook = [
     { name = "olefile" },
 ]
-pdf = [
-    { name = "pdfminer-six" },
-]
 pptx = [
     { name = "python-pptx" },
 ]
@@ -3036,7 +3033,7 @@ dependencies = [
     { name = "loguru" },
     { name = "mail-parser-reply" },
     { name = "markdown" },
-    { name = "markitdown", extra = ["docx", "outlook", "pdf", "pptx", "xls", "xlsx"] },
+    { name = "markitdown", extra = ["docx", "outlook", "pptx", "xls", "xlsx"] },
     { name = "nh3" },
     { name = "oauthlib" },
     { name = "openai" },
@@ -3156,7 +3153,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "mail-parser-reply", specifier = ">=0.20" },
     { name = "markdown" },
-    { name = "markitdown", extras = ["pdf", "docx", "xlsx", "xls", "outlook", "pptx"] },
+    { name = "markitdown", extras = ["docx", "xlsx", "xls", "outlook", "pptx"] },
     { name = "nh3" },
     { name = "oauthlib", specifier = ">=3.3.1" },
     { name = "openai" },
@@ -3465,19 +3462,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
-]
-
-[[package]]
-name = "pdfminer-six"
-version = "20250506"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "charset-normalizer" },
-    { name = "cryptography" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/78/46/5223d613ac4963e1f7c07b2660fe0e9e770102ec6bda8c038400113fb215/pdfminer_six-20250506.tar.gz", hash = "sha256:b03cc8df09cf3c7aba8246deae52e0bca7ebb112a38895b5e1d4f5dd2b8ca2e7", size = 7387678, upload-time = "2025-05-06T16:17:00.787Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/16/7a432c0101fa87457e75cb12c879e1749c5870a786525e2e0f42871d6462/pdfminer_six-20250506-py3-none-any.whl", hash = "sha256:d81ad173f62e5f841b53a8ba63af1a4a355933cfc0ffabd608e568b9193909e3", size = 5620187, upload-time = "2025-05-06T16:16:58.669Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Product Description

Collection file lists no longer disappear while a sync is running, and PDF text extraction is faster and more accurate, especially on table-heavy documents.

### Technical Description

Two independent changes in the same feature area; review separately.

**htmx polling targets** (`970f449c`) — htmx resolves `hx-target="this"` to the closest ancestor that *declares* the attribute, not the element making the request. Three polling fragments declared none, so their 5s polls replaced the file-list container with a single status badge, taking its `search-files` subscription with it. Each is now pinned to itself. The manual-sync view hit the same symptom by returning an empty body mid-sync against an `outerHTML` swap.

**PDF extraction via PDFium** (`513257f1`, `bf6d8ea9`) — PDFs route to a pypdfium2 reader, one `DocumentPart` per page; sync and index ingestion both funnel through `read_file_content`.

Decisions worth attention:

- **No pdfminer fallback.** An unopenable PDF raises `FileReadException` rather than plaintext-decoding the raw bytes, which used to index megabytes of noise as document text. pdfminer isn't kept as a backstop because its slow path is unbounded CPU-bound pure Python — on a damaged 133-page WHO document it ran 10 minutes without finishing, where PDFium fails in milliseconds.
- **A module lock serialises parsing.** PDFium isn't thread-safe and Celery runs `--pool threads --concurrency 20`; unsynchronised, 386 of 400 concurrent parses of a *valid* PDF failed, which would mark good files permanently FAILED under load. Pinned by `test_concurrent_reads_do_not_corrupt_pdfium`.
- **Header sniffing scans 1024 bytes**, not just offset 0 — the spec allows `%PDF-` at a non-zero offset, and such files previously fell through to pdfminer. Trade-off: a text file mentioning `%PDF-` early now fails instead of being read as text.

### Docs and Changelog
- [x] This PR requires docs/changelog update

Extracted text differs from pdfminer's (per-page parts, collapsed justification whitespace), so re-syncing an existing collection regenerates different chunks and embeddings. Adds `pypdfium2` (BSD-3-Clause / Apache-2.0).
