### PR TITLE
Deprecate Gemini 2.5 models on Vertex AI

### DIFF
--- a/apps/cost_tracking/seed_data/llm_pricing.json
+++ b/apps/cost_tracking/seed_data/llm_pricing.json
@@ -700,6 +700,24 @@
     ]
   },
   {
+    "provider_type": "google_vertex_ai",
+    "model_name": "gemini-3.1-flash-lite",
+    "rules": [
+      {
+        "service_kind": "llm_input",
+        "unit_price": "0.00025"
+      },
+      {
+        "service_kind": "llm_output",
+        "unit_price": "0.0015"
+      },
+      {
+        "service_kind": "llm_cached_input",
+        "unit_price": "0.000025"
+      }
+    ]
+  },
+  {
     "provider_type": "groq",
     "model_name": "llama-3.1-8b-instant",
     "rules": [

--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -146,13 +146,16 @@ DEFAULT_LLM_PROVIDER_MODELS = {
         Model("gemini-2.0-flash", 1048576, deprecated=True),
     ],
     "google_vertex_ai": [
-        Model("gemini-3.6-flash", 1048576),
-        Model("gemini-3.5-flash", 1048576),
+        Model("gemini-3.6-flash", 1048576, is_translation_default=True),
+        Model("gemini-3.5-flash", 1048576, is_default=True),
         Model("gemini-3.5-flash-lite", 1048576),
         Model("gemini-3.1-pro-preview", 1048576),
-        Model("gemini-2.5-pro", 1048576, is_translation_default=True),
-        Model("gemini-2.5-flash", 1048576, is_default=True),
-        Model("gemini-2.5-flash-lite", 1048576),
+        Model("gemini-3.1-flash-lite", 1048576),
+        # Google is retiring the 2.5 models on the Gemini Enterprise Agent Platform: they enter
+        # Extended Lifecycle Access on 2026-10-20 and lose ELA pricing on 2027-01-28.
+        Model("gemini-2.5-pro", 1048576, deprecated=True, replacement="gemini-3.6-flash"),
+        Model("gemini-2.5-flash", 1048576, deprecated=True, replacement="gemini-3.5-flash"),
+        Model("gemini-2.5-flash-lite", 1048576, deprecated=True, replacement="gemini-3.1-flash-lite"),
     ],
 }
 

--- a/apps/service_providers/migrations/0070_deepseek_model_updates.py
+++ b/apps/service_providers/migrations/0070_deepseek_model_updates.py
@@ -1,24 +1,15 @@
 from django.db import migrations
 
-from apps.cost_tracking.migration_utils import load_pricing_data
-
 
 class Migration(migrations.Migration):
     dependencies = [
         ("service_providers", "0069_add_deepseek_v4_flash"),
+        # Retained so the graph stays stable for environments that already applied this.
         ("cost_tracking", "0001_initial"),
-        # Retained from when this migration ran llm_model_migration() /
-        # notify_deprecated_models, so the graph stays stable for environments that
-        # already applied it.
         ("evaluations", "0018_evaluator_llm_provider_fks"),
         ("teams", "0013_team_files_export_team_files_export_task_id"),
     ]
 
     operations = [
-        # Add deepseek-v4-pro and mark deepseek-chat / deepseek-reasoner deprecated
-        # (replacement: deepseek-v4-flash).
-        # llm_model_migration() and notify_deprecated_models moved to 0071_deprecate_vertex_gemini_2_5
-        #
-        # Seed pricing for deepseek-v4-flash and deepseek-v4-pro (off-peak rates).
-        load_pricing_data(),
+        # Moved to 0071_deprecate_vertex_gemini_2_5, which reruns them.
     ]

--- a/apps/service_providers/migrations/0070_deepseek_model_updates.py
+++ b/apps/service_providers/migrations/0070_deepseek_model_updates.py
@@ -1,27 +1,24 @@
 from django.db import migrations
 
 from apps.cost_tracking.migration_utils import load_pricing_data
-from apps.data_migrations.utils.migrations import RunDataMigration
-from apps.service_providers.migration_utils import llm_model_migration
 
 
 class Migration(migrations.Migration):
     dependencies = [
         ("service_providers", "0069_add_deepseek_v4_flash"),
         ("cost_tracking", "0001_initial"),
-        # llm_model_migration() repoints evaluators off any custom model it replaces, so the
-        # Evaluator FK must be in this migration's app state (see _repoint_evaluators).
+        # Retained from when this migration ran llm_model_migration() /
+        # notify_deprecated_models, so the graph stays stable for environments that
+        # already applied it.
         ("evaluations", "0018_evaluator_llm_provider_fks"),
-        # notify_deprecated_models queries Team with live models, so all Team
-        # schema changes must be applied first.
         ("teams", "0013_team_files_export_team_files_export_task_id"),
     ]
 
     operations = [
         # Add deepseek-v4-pro and mark deepseek-chat / deepseek-reasoner deprecated
         # (replacement: deepseek-v4-flash).
-        llm_model_migration(),
+        # llm_model_migration() and notify_deprecated_models moved to 0071_deprecate_vertex_gemini_2_5
+        #
         # Seed pricing for deepseek-v4-flash and deepseek-v4-pro (off-peak rates).
         load_pricing_data(),
-        RunDataMigration("notify_deprecated_models", command_options={"force": True}),
     ]

--- a/apps/service_providers/migrations/0071_deprecate_vertex_gemini_2_5.py
+++ b/apps/service_providers/migrations/0071_deprecate_vertex_gemini_2_5.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+from apps.cost_tracking.migration_utils import load_pricing_data
+from apps.data_migrations.utils.migrations import RunDataMigration
+from apps.service_providers.migration_utils import llm_model_migration
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("service_providers", "0070_deepseek_model_updates"),
+        ("cost_tracking", "0001_initial"),
+        # llm_model_migration() repoints evaluators off any custom model it replaces, so the
+        # Evaluator FK must be in this migration's app state (see _repoint_evaluators).
+        ("evaluations", "0018_evaluator_llm_provider_fks"),
+        # notify_deprecated_models queries Team with live models, so all Team
+        # schema changes must be applied first.
+        ("teams", "0013_team_files_export_team_files_export_task_id"),
+    ]
+
+    operations = [
+        # Add gemini-3.1-flash-lite and mark the google_vertex_ai gemini-2.5 models deprecated
+        # ahead of Google's 2026-10-20 Extended Lifecycle Access date.
+        llm_model_migration(),
+        # Seed pricing for gemini-3.1-flash-lite.
+        load_pricing_data(),
+        RunDataMigration("notify_deprecated_models", command_options={"force": True}),
+    ]


### PR DESCRIPTION
### Product Description
Teams on the Google Vertex AI provider are moved off the Gemini 2.5 models ahead of Google's retirement dates (Extended Lifecycle Access 2026-10-20, ELA pricing ends 2027-01-28). New chatbots default to `gemini-3.5-flash` instead of the deprecated `gemini-2.5-flash`, and teams still referencing a 2.5 model are notified with the recommended replacement.

### Technical Description
Closes part of #4008 (items 2 and 3).

- Adds `gemini-3.1-flash-lite` to `google_vertex_ai` (1M context, GA) with pricing.
- Moves `is_default` to `gemini-3.5-flash` and `is_translation_default` to `gemini-3.6-flash`. These flags are runtime-only (form preselection and `get_default_model`) and are not persisted, so no DB repointing is needed — existing explicit references stay put and are covered by the deprecation notification instead.
- Marks all three 2.5 models `deprecated=True` with replacements.
- `llm_model_migration()` and `notify_deprecated_models` move from `0070` to the new `0071` per the once-per-deployment rule in `docs/developer_guides/managing_models.md`. `0070`'s `load_pricing_data()` stays (safe to re-run).

The `google` (AI Studio) provider is deliberately untouched — Google's notice excludes it and a separate notice is expected (#4008 item 5).

Issue #4008 item 4 (thought signature circulation) was investigated and needs no code change; findings are in a comment on the issue. Short version: the tool-calling loop runs in a single in-process `agent.invoke()` with no checkpointer, so `langchain-google-*` keeps signatures in `additional_kwargs` for the whole loop, and OCS never persists tool messages. One risk worth knowing: `langchain-google-vertexai` has no dummy-signature fallback, so anything that splits a turn across process boundaries would 400 on Gemini 3 here where the AI Studio provider degrades silently.

### Migrations
- [x] The migrations are backwards compatible

### Demo
```
vertex default: gemini-3.5-flash
translation defaults: {... 'Google Vertex AI': 'gemini-3.6-flash'}
```

### Docs and Changelog
- [ ] This PR requires docs/changelog update
