### PR TITLE
Disable gunicorn control socket in deploy commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,4 +96,4 @@ USER django
 
 ENV PORT=8000
 
-CMD ["sh", "-c", "gunicorn --bind 0.0.0.0:${PORT} --workers 1 --threads 8 --timeout 0 config.wsgi:application"]
+CMD ["sh", "-c", "gunicorn --bind 0.0.0.0:${PORT} --workers 1 --threads 8 --timeout 0 --no-control-socket config.wsgi:application"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -63,6 +63,7 @@ services:
         --workers ${WEB_WORKERS:-2}
         --threads 8
         --timeout 0
+        --no-control-socket
         config.wsgi:application
     ports:
       - "${PORT:-8000}:${PORT:-8000}"

--- a/heroku.yml
+++ b/heroku.yml
@@ -16,7 +16,7 @@ release:
 run:
   web:
     command:
-      - gunicorn --bind 0.0.0.0:$PORT --workers 1 --threads 8 --timeout 0 config.wsgi:application
+      - gunicorn --bind 0.0.0.0:$PORT --workers 1 --threads 8 --timeout 0 --no-control-socket config.wsgi:application
     image: django
   worker:
     command:


### PR DESCRIPTION
Follow-up to #4066. Gunicorn 26 added a control socket that is on by default. Verified against 26.0.0 with no `XDG_RUNTIME_DIR` set (the container case): it creates and listens on `$HOME/.gunicorn/gunicorn.ctl` — `/home/django/.gunicorn/` in our image — mode 0600, exposing `shutdown`, `kill`, `reload` and `workers` to anything running as the app user. Nothing in OCS uses it, so `--no-control-socket` on the three web commands turns it off.

Celery workers are untouched — they don't run gunicorn.

### Product Description
no change

### Docs and Changelog
- [ ] This PR requires docs/changelog update