### PR TITLE
Guard Voyage local indexing against contextual models

### DIFF
--- a/apps/service_providers/llm_service/index_managers.py
+++ b/apps/service_providers/llm_service/index_managers.py
@@ -485,7 +485,17 @@ class VoyageAILocalIndexManager(LocalIndexManager):
         The langchain wrapper maps `embed_documents` and `embed_query` to
         Voyage's `input_type=document` and `input_type=query` API params
         respectively, which return different vectors for documents vs queries.
+
+        Contextual models are rejected: they route through Voyage's
+        `contextualized_embed` API with auto-chunking, which can return several
+        embeddings for a single input. This method returns one vector per chunk we
+        send, so the extra embeddings would be dropped and the tail of the chunk
+        silently lost from the index. Detection matches langchain-voyageai's own
+        `_is_context_model`, which is a substring check on the model name.
         """
+        if "context" in self.embedding_model_name:
+            raise ValueError(f"Contextual Voyage models are not supported: {self.embedding_model_name}")
+
         if not content:
             raise ValueError("Cannot embed empty string")
 

--- a/apps/service_providers/tests/test_index_managers.py
+++ b/apps/service_providers/tests/test_index_managers.py
@@ -648,6 +648,15 @@ class TestVoyageAILocalIndexManager:
             with pytest.raises(ValueError, match="Unknown input_type"):
                 index_manager.get_embedding_vector("some text", input_type="documents")  # type: ignore[arg-type]
 
+    @pytest.mark.parametrize("input_type", ["document", "query"])
+    def test_get_embedding_vector_rejects_contextual_models(self, input_type):
+        index_manager = VoyageAILocalIndexManager(api_key="test-api-key", embedding_model_name="voyage-context-4")
+        with mock.patch("langchain_voyageai.VoyageAIEmbeddings") as mock_embeddings_cls:
+            with pytest.raises(ValueError, match="Contextual Voyage models are not supported"):
+                index_manager.get_embedding_vector("some text", input_type=input_type)
+
+        mock_embeddings_cls.assert_not_called()
+
 
 class TestOpenAILlmServiceLocalIndexManager:
     def test_get_local_index_manager_threads_openai_api_base(self):

--- a/apps/service_providers/tests/test_index_managers.py
+++ b/apps/service_providers/tests/test_index_managers.py
@@ -657,6 +657,29 @@ class TestVoyageAILocalIndexManager:
 
         mock_embeddings_cls.assert_not_called()
 
+    def test_embeddings_constructor_kwargs_are_accepted_by_the_installed_client(self):
+        """Construct `VoyageAIEmbeddings` for real, unlike every other test in this class.
+
+        The mocked tests would keep passing if a langchain-voyageai bump renamed or removed
+        one of the kwargs we pass. `VoyageAIEmbeddings` sets `extra="forbid"` and constrains
+        `output_dimension` to a literal set, so this fails on that drift. Nothing is embedded,
+        so no network call is made.
+        """
+        from langchain_voyageai import VoyageAIEmbeddings  # noqa: PLC0415 - TID253: heavy lib, slow startup
+
+        embeddings = VoyageAIEmbeddings(
+            voyage_api_key="test-api-key",
+            model="voyage-4-large",
+            output_dimension=settings.EMBEDDING_VECTOR_SIZE,
+        )
+
+        assert embeddings.model == "voyage-4-large"
+        assert embeddings.output_dimension == settings.EMBEDDING_VECTOR_SIZE
+        # The contextual guard in `get_embedding_vector` reimplements this check; if the
+        # upstream detection changes, the guard needs to change with it.
+        assert VoyageAIEmbeddings(voyage_api_key="k", model="voyage-context-4")._is_context_model()
+        assert not embeddings._is_context_model()
+
 
 class TestOpenAILlmServiceLocalIndexManager:
     def test_get_local_index_manager_threads_openai_api_base(self):


### PR DESCRIPTION
Follow-up to #4068 (langchain-voyageai 0.3.3 → 0.4.0). 0.4.0 adds contextual embedding models; `voyage-context-*` routes through `contextualized_embed` with `enable_auto_chunking=True, chunk_size=32_000` and flattens the per-input results, so one input can come back as several embeddings. `get_embedding_vector` takes `[0]`, which would silently drop the tail of a chunk from the index. Rather than seed `voyage-context-4` into the defaults, blocking it is the safe half of that choice.

Two things worth a look:

- The guard sits in `get_embedding_vector`, not `__init__`. `index_collection_files` flips rows to `IN_PROGRESS` before calling `get_index_manager()`, so a constructor raise would leave them stuck there; raising per-chunk is caught by `LocalIndexManager.add_files` and lands each file `FAILED` with a visible reason. Query path is covered via `get_query_vector`.
- The `"context" in name` check duplicates langchain-voyageai's private `_is_context_model`. The second commit pins that coupling with an assertion so upstream drift fails loudly instead of diverging quietly.

That second commit also constructs `VoyageAIEmbeddings` for real — the rest of the class mocks it, so a renamed kwarg would have sailed through CI. Confirmed it catches drift: `extra="forbid"` and the `output_dimension` literal both reject bad input, and construction makes no network call.

### Product Description
No change — contextual Voyage models were never selectable.

### Technical Description
See above.

### Docs and Changelog
- [ ] This PR requires docs/changelog update
