### PR TITLE
Mark all prelogin views with waf_allow(NoUserAgent_HEADER)

### DIFF
--- a/apps/prelogin/urls.py
+++ b/apps/prelogin/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from django.views.generic import RedirectView, TemplateView
 
 from . import views
 
@@ -8,15 +7,15 @@ urlpatterns = [
     path("", views.home, name="home"),
     path(
         "about/",
-        TemplateView.as_view(template_name="prelogin/about.html", extra_context={"active_nav": "about"}),
+        views.PreloginTemplateView.as_view(template_name="prelogin/about.html", extra_context={"active_nav": "about"}),
         name="about",
     ),
     path("contact/", views.contact, name="contact"),
     path("applications/", views.applications, name="applications"),
     path(
         "open-opportunities/",
-        TemplateView.as_view(template_name="prelogin/open_opportunities.html"),
+        views.PreloginTemplateView.as_view(template_name="prelogin/open_opportunities.html"),
         name="open_opportunities",
     ),
-    path("platform/", RedirectView.as_view(url="/#how-it-works", permanent=True), name="platform"),
+    path("platform/", views.PreloginRedirectView.as_view(url="/#how-it-works", permanent=True), name="platform"),
 ]

--- a/apps/prelogin/views.py
+++ b/apps/prelogin/views.py
@@ -6,10 +6,30 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+from django.views.generic import RedirectView, TemplateView
 
 from apps.web.waf import WafRule, waf_allow
 
 logger = logging.getLogger(__name__)
+
+
+@waf_allow(WafRule.NoUserAgent_HEADER)
+class PreloginTemplateView(TemplateView):
+    """A static prelogin page, excluded from the NoUserAgent_HEADER WAF rule.
+
+    Prelogin pages are public and get hit by clients that don't send a User-Agent. `waf_allow`
+    keys class-based views on the class, so this subclass exists to scope the exception to the
+    prelogin URLs — decorating `TemplateView` itself would pull every other use of it in the
+    project into the exception list too.
+    """
+
+
+@waf_allow(WafRule.NoUserAgent_HEADER)
+class PreloginRedirectView(RedirectView):
+    """A prelogin redirect, excluded from the NoUserAgent_HEADER WAF rule.
+
+    Subclassed for the same reason as `PreloginTemplateView`.
+    """
 
 
 @waf_allow(WafRule.NoUserAgent_HEADER)
@@ -52,6 +72,7 @@ def _configured_demo_bots() -> dict:
     return configured
 
 
+@waf_allow(WafRule.NoUserAgent_HEADER)
 def applications(request):
     return render(
         request,
@@ -63,6 +84,7 @@ def applications(request):
     )
 
 
+@waf_allow(WafRule.NoUserAgent_HEADER)
 def contact(request):
     hubspot_form = None
     if settings.HUBSPOT_FORM_PORTAL_ID and settings.HUBSPOT_FORM_ID:


### PR DESCRIPTION
### Product Description
No change.

### Technical Description
The prelogin pages are public and get hit by clients that don't send a `User-Agent`, so they all want the `NoUserAgent_HEADER` exception. `contact/`, `applications/` and `platform/` were missing it.

The wrinkle: `waf_allow` registers class-based views by *class*, not by URL pattern. So `about/` and `open-opportunities/` were already landing in the allow list, but only as a side effect of `robots.txt` in `apps/web/urls.py` having registered bare `TemplateView` — they'd have silently dropped off if that line ever changed. And marking a bare `RedirectView` for `platform/` would have dragged `/favicon.ico`, `/django-admin/login/` and two `/a/<team>/experiments/` redirects into the exception list as collateral.

Hence the two no-op subclasses in `views.py`: they scope the class-keyed registration to prelogin. `export_waf_allow_list` gains exactly three patterns and nothing else — `^/applications/$`, `^/contact/$`, `^/platform/$`.

Needs the corresponding `NoUserAgent_HEADER` block copied into the ocs-deploy `waf` module.

Two pre-existing issues found while doing this, both left alone:

- `^/api/docs/$` is in the allow list by the same accidental bare-`TemplateView` mechanism, rather than because anyone decided it.
- `MetaCloudAPIWebhookView` (`apps/channels/views.py:500`) is marked via `@method_decorator(waf_allow(...), name="dispatch")`, which hands `waf_allow` the `dispatch` function instead of an `as_view()` result — so it registers something that matches no URL pattern. That webhook is absent from the exported list, before and after this PR.

### Demo
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update
