### PR TITLE
Announce each deprecated model to a team once

### DIFF
--- a/apps/data_migrations/tests/test_notify_deprecated_models.py
+++ b/apps/data_migrations/tests/test_notify_deprecated_models.py
@@ -3,13 +3,17 @@ from unittest.mock import patch
 import pytest
 from django.core.management import call_command
 
+from apps.ocs_notifications.models import EventType, EventUser, NotificationEvent
+from apps.ocs_notifications.utils import toggle_notification_read
 from apps.pipelines.models import Pipeline
 from apps.pipelines.tests.utils import content_flow_node
 from apps.service_providers.llm_service.default_models import Model
+from apps.teams.backends import get_team_owner_groups
 from apps.utils.factories.evaluations import EvaluatorFactory
 from apps.utils.factories.experiment import ExperimentFactory
 from apps.utils.factories.pipelines import PipelineFactory
 from apps.utils.factories.service_provider_factories import LlmProviderModelFactory
+from apps.utils.factories.team import MembershipFactory
 
 FAKE_DEPRECATED_MODELS = {
     "openai": [
@@ -118,6 +122,34 @@ class TestNotifyDeprecatedModelsCommand:
             call_command("notify_deprecated_models", dry_run=True)
 
         mock_notify.assert_not_called()
+
+    def test_a_second_run_does_not_re_announce_the_same_model(self):
+        """A later migration deprecating a different model must not re-notify about this one.
+
+        The command re-scans every deprecated model on each run, so the guard against
+        duplicates has to live in the notification itself.
+        """
+        deprecated_model = LlmProviderModelFactory(
+            team=None, type="openai", name="test-deprecated-model", deprecated=True
+        )
+        experiment = ExperimentFactory(pipeline=_make_pipeline_referencing(deprecated_model))
+        user = MembershipFactory(team=experiment.team, groups=get_team_owner_groups).user
+
+        with patch(
+            "apps.data_migrations.management.commands.notify_deprecated_models.DEFAULT_LLM_PROVIDER_MODELS",
+            FAKE_DEPRECATED_MODELS,
+        ):
+            call_command("notify_deprecated_models", force=True)
+
+            event_type = EventType.objects.get(team=experiment.team)
+            event_user = EventUser.objects.get(event_type=event_type, user=user)
+            toggle_notification_read(user, event_user=event_user, read=True)
+
+            call_command("notify_deprecated_models", force=True)
+
+        assert NotificationEvent.objects.filter(event_type=event_type).count() == 1
+        event_user.refresh_from_db()
+        assert event_user.read is True, "The team should not be re-notified about a model already announced"
 
     @patch("apps.data_migrations.management.commands.notify_deprecated_models.deprecated_model_notification")
     def test_skips_teams_with_no_active_references(self, mock_notify):

--- a/apps/ocs_notifications/notifications.py
+++ b/apps/ocs_notifications/notifications.py
@@ -260,7 +260,12 @@ def deprecated_model_notification(
     replacement_model_name: str | None,
     affected: AffectedResources,
 ) -> None:
-    """Notify a team that a model they use has been deprecated."""
+    """Notify a team that a model they use has been deprecated.
+
+    Announced once per team per model: the notification command re-scans every deprecated
+    model on each run, so without this a model deprecated in an earlier release would be
+    re-announced every time a later release deprecates something else.
+    """
     message = (
         f"The model '{model_name}' has been deprecated and will be removed soon. "
         f"{affected.summary_text()} are still using it."
@@ -277,6 +282,7 @@ def deprecated_model_notification(
         event_data={"model_name": model_name},
         permissions=["service_providers.change_llmprovidermodel"],
         links=affected.links(),
+        once_per_event_type=True,
     )
 
 
@@ -377,7 +383,13 @@ def deleted_model_notification(
     replacement_model_name: str | None,
     affected: AffectedResources,
 ) -> None:
-    """Notify a team that a model has been removed from the platform."""
+    """Notify a team that a model has been removed from the platform.
+
+    Announced once per team per model. Belt and braces rather than load-bearing: the removal
+    command deletes the model row before notifying, so a re-run finds nothing to report and
+    never reaches here. The guard keeps that from being the only thing standing between a
+    caller and a duplicate.
+    """
     if replacement_model_name:
         action_text = f"References have been automatically updated to use '{replacement_model_name}'."
     else:
@@ -396,4 +408,5 @@ def deleted_model_notification(
         event_data={"model_name": model_name},
         permissions=["service_providers.change_llmprovidermodel"],
         links=affected.links(),
+        once_per_event_type=True,
     )

--- a/apps/ocs_notifications/tests/test_notifications.py
+++ b/apps/ocs_notifications/tests/test_notifications.py
@@ -436,6 +436,7 @@ class TestDeprecatedModelNotification:
             event_data={"model_name": "gpt-4"},
             permissions=["service_providers.change_llmprovidermodel"],
             links={"My Bot": "/chatbots/my-bot/"},
+            once_per_event_type=True,
         )
 
     @pytest.mark.django_db()
@@ -463,6 +464,7 @@ class TestDeprecatedModelNotification:
             event_data={"model_name": "gpt-4"},
             permissions=["service_providers.change_llmprovidermodel"],
             links={"My Pipeline": "/pipelines/1/", "My Assistant": "/assistants/1/"},
+            once_per_event_type=True,
         )
 
 
@@ -490,6 +492,7 @@ class TestDeletedModelNotification:
             event_data={"model_name": "claude-2.0"},
             permissions=["service_providers.change_llmprovidermodel"],
             links={"Bot A": "/chatbots/a/", "Bot B": "/chatbots/b/"},
+            once_per_event_type=True,
         )
 
     @pytest.mark.django_db()
@@ -518,6 +521,7 @@ class TestDeletedModelNotification:
             event_data={"model_name": "claude-2.0"},
             permissions=["service_providers.change_llmprovidermodel"],
             links={"Pipeline X": "/pipelines/1/", "Assistant Y": "/assistants/1/"},
+            once_per_event_type=True,
         )
 
     @pytest.mark.django_db()

--- a/apps/ocs_notifications/tests/test_utils.py
+++ b/apps/ocs_notifications/tests/test_utils.py
@@ -7,7 +7,13 @@ from django.core.cache import cache
 from django.utils import timezone
 from time_machine import travel
 
-from apps.ocs_notifications.models import EventType, EventUser, LevelChoices, UserNotificationPreferences
+from apps.ocs_notifications.models import (
+    EventType,
+    EventUser,
+    LevelChoices,
+    NotificationEvent,
+    UserNotificationPreferences,
+)
 from apps.ocs_notifications.utils import (
     ALL_TEAMS_CACHE_KEY,
     CACHE_KEY_FORMAT,
@@ -182,6 +188,83 @@ class TestCreateNotification:
         assert user.unread_notifications_count(team_with_users) == 1
         event_user.refresh_from_db()
         assert event_user.read is False, "EventUser should be marked as unread again"
+
+    def test_once_per_event_type_skips_repeat_announcements(self, team_with_users):
+        """
+        Test that `once_per_event_type` suppresses a second notification for the same event type.
+
+        Verifies that:
+        1. The repeat call creates no new NotificationEvent
+        2. A user who read the first notification is not flipped back to unread
+        """
+        user = team_with_users.members.first()
+        kwargs = {
+            "title": "Model Deprecated",
+            "message": "Test message",
+            "level": LevelChoices.WARNING,
+            "team": team_with_users,
+            "slug": "llm-model-deprecated",
+            "event_data": {"model_name": "openai/gpt-4"},
+            "once_per_event_type": True,
+        }
+
+        assert create_notification(**kwargs) is not None
+        event_type = EventType.objects.get(
+            team=team_with_users, identifier=create_identifier("llm-model-deprecated", kwargs["event_data"])
+        )
+        for event_user in EventUser.objects.filter(event_type=event_type):
+            toggle_notification_read(event_user.user, event_user=event_user, read=True)
+
+        assert create_notification(**kwargs) is None
+
+        assert NotificationEvent.objects.filter(event_type=event_type).count() == 1
+        assert user.unread_notifications_count(team_with_users) == 0
+
+    def test_repeat_announcement_is_scoped_to_the_team(self, team_with_users):
+        """A different team still gets told, even though the event type exists elsewhere."""
+        other_team = TeamFactory()
+        add_user_to_team(other_team, UserFactory())
+        kwargs = {
+            "title": "Model Deprecated",
+            "message": "Test message",
+            "level": LevelChoices.WARNING,
+            "slug": "llm-model-deprecated",
+            "event_data": {"model_name": "openai/gpt-4"},
+            "once_per_event_type": True,
+        }
+
+        assert create_notification(team=team_with_users, **kwargs) is not None
+        assert create_notification(team=other_team, **kwargs) is not None
+
+    def test_announcement_that_reached_nobody_is_retried(self, team_with_users):
+        """A first attempt that notified no one must not permanently suppress the announcement.
+
+        The event type is created even when there are no recipients, so keying the skip on it
+        would silence a team whose only eligible member was on Do Not Disturb at the time.
+        """
+        kwargs = {
+            "title": "Model Deprecated",
+            "message": "Test message",
+            "level": LevelChoices.WARNING,
+            "team": team_with_users,
+            "slug": "llm-model-deprecated",
+            "event_data": {"model_name": "openai/gpt-4"},
+            "once_per_event_type": True,
+        }
+        identifier = create_identifier("llm-model-deprecated", kwargs["event_data"])
+
+        dnd_until = timezone.now() + datetime.timedelta(days=1)
+        for member in team_with_users.members.all():
+            UserNotificationPreferences.objects.create(
+                user=member, team=team_with_users, do_not_disturb_until=dnd_until
+            )
+
+        assert create_notification(**kwargs) is not None
+        assert not EventUser.objects.filter(team=team_with_users, event_type__identifier=identifier).exists()
+
+        with travel(dnd_until + datetime.timedelta(days=1)):
+            assert create_notification(**kwargs) is not None
+        assert EventUser.objects.filter(team=team_with_users, event_type__identifier=identifier).exists()
 
     def test_create_identifier(self):
         """

--- a/apps/ocs_notifications/utils.py
+++ b/apps/ocs_notifications/utils.py
@@ -53,6 +53,7 @@ def create_notification(
     event_data: dict | None = None,
     permissions: list[str] | None = None,
     links: dict | None = None,
+    once_per_event_type: bool = False,
 ):
     """
     Create a notification event and associate it with the given users.
@@ -64,17 +65,26 @@ def create_notification(
         team (Team, optional): A team whose members will be associated with the notification.
         slug (str): A slug to identify the event type. Used with event_data for uniqueness.
         event_data (dict, optional): Additional data to store with the event type. Combined with slug for uniqueness.
+        once_per_event_type (bool): For announcements rather than recurring conditions. Skip the notification
+            entirely if a member of this team has already been notified about this slug + event_data, so a
+            caller that re-runs over its whole subject list doesn't re-announce what the team was told.
+            Keyed on the recipients rather than the event type so that a first attempt which reached nobody
+            (no member held the required permission, or they were all on Do Not Disturb) is retried.
 
     Returns:
-        NotificationEvent: The created NotificationEvent instance, or None if creation failed.
+        NotificationEvent: The created NotificationEvent instance, or None if it was skipped or creation failed.
     """
     links = links or {}
+    event_data = event_data or {}
+    identifier = create_identifier(slug, event_data)
+
+    if once_per_event_type and EventUser.objects.filter(team=team, event_type__identifier=identifier).exists():
+        logger.debug("Skipping '%s' notification for team %s: already announced", slug, team.slug)
+        return None
 
     user_info = get_users_to_be_notified(team, permissions)
     users = list(user_info.keys())
 
-    event_data = event_data or {}
-    identifier = create_identifier(slug, event_data)
     event_type, _created = EventType.objects.get_or_create(
         team=team, identifier=identifier, defaults={"event_data": event_data, "level": level}
     )

--- a/docs/developer_guides/managing_models.md
+++ b/docs/developer_guides/managing_models.md
@@ -76,7 +76,7 @@ grep -rl "llm_model_migration\|notify_deprecated_models\|remove_deprecated_model
 
 For each migration in that list (except your new one), remove the call and its import, leaving `operations = []` if nothing else remains.
 
-> **Why?** Data migrations like `notify_deprecated_models` and `remove_deprecated_models` would fire multiple times, sending duplicate notifications to teams.
+> **Why?** Data migrations like `notify_deprecated_models` and `remove_deprecated_models` would otherwise do the same work repeatedly on every deploy. The notifications themselves are [announced once per team per model](#each-model-is-announced-once-per-team), so a slip here no longer spams teams — but the redundant scans still cost time on every migrate.
 
 ### Step 5: Seed pricing for the model
 
@@ -254,6 +254,16 @@ Notifications include:
 |---|---|
 | Deprecated model (user action needed) | `llm-model-deprecated` |
 | Deleted model references cleared/migrated | `llm-model-deleted` |
+
+### Each model is announced once per team
+
+`notify_deprecated_models` re-scans **every** model marked `deprecated=True` on each run, not just the ones your migration deprecated. So a release that deprecates one model would otherwise re-announce every model deprecated before it — a team that had already read the earlier notice would see it marked unread again and get a second email.
+
+Both model notifications therefore pass `once_per_event_type=True` to `create_notification`, which skips the notification if a member of the team has already been notified about that slug + model name. Nothing extra is needed in your migration; keep passing `force=True`.
+
+The check is keyed on the recipients (`EventUser`), not on the `EventType`, because the event type is created even when the run reaches nobody — if no team member held `service_providers.change_llmprovidermodel` at the time, or every eligible member was on Do Not Disturb, the next run still announces it.
+
+The consequence to be aware of: a team is told about a given model exactly once. If you need to re-announce the same model (say the recommended replacement changed), change the `event_data` so the identifier differs, or clear the team's existing `EventType` for it.
 
 ---
 


### PR DESCRIPTION
### Product Description
Teams no longer get a repeat deprecation notification for a model they've already been told about. Previously a release that deprecated one model re-announced every model deprecated before it — a team that had read the earlier notice saw it flip back to unread and got a second email.

### Technical Description
Root cause: each model migration runs `notify_deprecated_models` with `force: True` (required, since `migration_name` is fixed and `run_once` would otherwise block it), and the command re-scans **every** model marked `deprecated=True` rather than just the ones that migration deprecated. The docs' existing mitigation — strip the operation from earlier migrations — only stops the *same* migration re-firing, so it never covered this.

The `EventType` identifier is already an exact "this team was told about this model" key, so the fix is a lookup rather than new bookkeeping: an opt-in `once_per_event_type` on `create_notification`, default off so no other notification changes behaviour.

Worth a closer look: the guard is keyed on `EventUser`, not `EventType`. `create_notification` creates the `EventType` before it knows whether any recipient exists, so a run that reaches nobody (no member held `service_providers.change_llmprovidermodel`, or every eligible member was on Do Not Disturb) still leaves one behind — keying on it would silence that team's deprecation notice permanently. Trading a duplicate for a never-delivered notice is the worse failure, hence the recipient keying. `test_announcement_that_reached_nobody_is_retried` covers it.

The accepted consequence: a team hears about a given model exactly once, so `message` and `links` are frozen at the first announcement. A team that later has ten more affected chatbots keeps the original list. Re-announcing means varying the `event_data` or clearing the team's `EventType`; documented in `managing_models.md`.

`deleted_model_notification` gets the same flag, though it's defensive there — `remove_deprecated_models` deletes the model row before notifying, so a re-run finds nothing to report.

### Migrations
N/A — no schema or data migrations.

### Demo
Both new duplicate-suppression tests were confirmed to fail against the unguarded code (`assert 2 == 1` for the second `NotificationEvent`), and `test_announcement_that_reached_nobody_is_retried` fails against an `EventType`-keyed guard. `apps/ocs_notifications/` + `apps/data_migrations/`: 94 passed.

### Docs and Changelog
- [x] This PR requires docs/changelog update

`docs/developer_guides/managing_models.md` updated in this PR: new "Each model is announced once per team" section, and the "Why?" note under the strip-earlier-migrations step corrected — it credited that step with preventing duplicate notifications, which it never did.

Not covered: teams that already received the duplicate keep both notification rows. Say the word if a one-off cleanup is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)