### PR TITLE
Stack the dashboard cost chart by usage source

### DIFF
--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -413,20 +413,31 @@ def coverage_gaps(team: Team, *, start: datetime, end: datetime, filters: CostFi
 def cost_timeseries(
     team: Team, *, start: datetime, end: datetime, granularity: str = "daily", filters: CostFilters | None = None
 ) -> list[dict]:
-    """Spend per time bucket in [start, end), ordered chronologically. Costs
-    are returned as floats for direct JSON/Chart.js consumption. Empty buckets
-    (no usage) are absent - the chart plots what's recorded.
+    """Spend per time bucket in [start, end), split by source, ordered chronologically.
+
+    One row per non-empty bucket: ``{'date': bucket, <source>: float, ...}``, carrying a
+    key for every source the read counts, zero-filled so the chart's stacked series stay
+    aligned. An unfiltered read is a team total and so carries every source; a filtered one
+    is per-entity attribution and so carries `chat` alone (ADR-0048) - the evaluation key is
+    absent there rather than a misleading zero. Costs are floats for direct JSON/Chart.js
+    consumption. Empty buckets (no usage) are absent - the chart plots what's recorded.
     """
+    filters = filters or CostFilters()
+    sources = [UsageSource.CHAT.value] if filters.narrows_to_entities else [source.value for source in UsageSource]
     trunc = _GRANULARITY_TRUNC.get(granularity, TruncDate)
     rows = (
         _scoped_records(team, filters)
         .filter(timestamp__gte=start, timestamp__lt=end)
         .annotate(bucket=trunc("timestamp"))
-        .values("bucket")
+        .values("bucket", "source")
         .annotate(cost=Coalesce(Sum("cost"), _ZERO, output_field=_COST_FIELD))
         .order_by("bucket")
     )
-    return [{"date": row["bucket"], "cost": float(row["cost"])} for row in rows]
+    buckets: dict = {}
+    for row in rows:
+        point = buckets.setdefault(row["bucket"], {"date": row["bucket"], **dict.fromkeys(sources, 0.0)})
+        point[row["source"]] = float(row["cost"])
+    return list(buckets.values())
 
 
 def usage_timeseries(
@@ -442,7 +453,7 @@ def usage_timeseries(
     bucket: ``{'bucket', 'cost' (Decimal), 'currency', 'prompt', 'completion', 'total'}``. Empty buckets
     are absent (the caller zero-fills). Shares the scoped-record path with ``cost_total``/``token_counts``
     so a bucketed usage response reconciles with the same window's totals. This is the API read; the
-    dashboard's Chart.js series is ``cost_timeseries`` (float, UTC-bucketed).
+    dashboard's Chart.js series is ``cost_timeseries`` (float, UTC-bucketed, split by source).
     """
     trunc = _GRANULARITY_TRUNC.get(granularity, TruncDate)
     scoped = _scoped_records(team, filters).filter(timestamp__gte=start, timestamp__lt=end)

--- a/apps/cost_tracking/tests/test_reporting.py
+++ b/apps/cost_tracking/tests/test_reporting.py
@@ -405,7 +405,7 @@ class TestCoverageGaps:
 
 @pytest.mark.django_db()
 class TestCostTimeseries:
-    """Per-bucket spend for the panel's daily-spend chart."""
+    """Per-bucket spend for the panel's daily-spend chart, split by source."""
 
     def test_buckets_by_day_ordered(self):
         team = TeamFactory.create()
@@ -415,7 +415,7 @@ class TestCostTimeseries:
 
         series = cost_timeseries(team, start=_NOW - timedelta(days=30), end=_NOW)
 
-        assert [point["cost"] for point in series] == [1.5, 2.0]
+        assert [point["chat"] for point in series] == [1.5, 2.0]
 
     def test_costs_are_floats(self):
         team = TeamFactory.create()
@@ -423,7 +423,31 @@ class TestCostTimeseries:
 
         series = cost_timeseries(team, start=_NOW - timedelta(days=30), end=_NOW)
 
-        assert isinstance(series[0]["cost"], float)
+        assert isinstance(series[0]["chat"], float)
+
+    def test_sources_are_separate_series_in_one_bucket(self):
+        team = TeamFactory.create()
+        when = _NOW - timedelta(days=1)
+        _usage(team, cost="1.00", when=when)
+        _usage(team, cost="0.25", when=when, source=UsageSource.EVALUATION)
+
+        series = cost_timeseries(team, start=_NOW - timedelta(days=30), end=_NOW)
+
+        assert len(series) == 1
+        assert series[0]["chat"] == 1.0
+        assert series[0]["evaluation"] == 0.25
+
+    def test_buckets_zero_fill_missing_sources(self):
+        """Stacked series have to line up bucket for bucket, so a bucket with only
+        eval spend still reports a chat figure."""
+        team = TeamFactory.create()
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=2))
+        _usage(team, cost="0.25", when=_NOW - timedelta(days=1), source=UsageSource.EVALUATION)
+
+        series = cost_timeseries(team, start=_NOW - timedelta(days=30), end=_NOW)
+
+        assert series[0] == {"date": series[0]["date"], "chat": 1.0, "evaluation": 0.0}
+        assert series[1] == {"date": series[1]["date"], "chat": 0.0, "evaluation": 0.25}
 
     def test_team_scoped(self):
         team = TeamFactory.create()
@@ -653,7 +677,7 @@ class TestCostFilters:
             team, start=_NOW - timedelta(days=30), end=_NOW, filters=CostFilters(participant_ids=[keep.participant_id])
         )
 
-        assert [point["cost"] for point in series] == [1.0]
+        assert [point["chat"] for point in series] == [1.0]
 
     def test_timeseries_filters_by_platform_via_session(self):
         team = TeamFactory.create()
@@ -667,7 +691,7 @@ class TestCostFilters:
             team, start=_NOW - timedelta(days=30), end=_NOW, filters=CostFilters(platform_names=["web"])
         )
 
-        assert [point["cost"] for point in series] == [1.0]
+        assert [point["chat"] for point in series] == [1.0]
 
     def test_costs_by_experiment_filters_by_experiment(self):
         team = TeamFactory.create()
@@ -771,6 +795,22 @@ class TestEvaluationSourceRule:
         team, experiment, _ = spend
 
         assert read(team, CostFilters(experiment_ids=[experiment.id])) == Decimal("1.00")
+
+    def test_timeseries_splits_both_sources_when_unfiltered(self, spend):
+        team, _, _ = spend
+
+        series = cost_timeseries(team, start=_START, end=_NOW)
+
+        assert [(point["chat"], point["evaluation"]) for point in series] == [(1.0, 0.25)]
+
+    def test_timeseries_filtered_to_one_chatbot_drops_the_evaluation_series(self, spend):
+        """Filtering makes it per-entity attribution, so eval spend isn't counted — and the
+        chart omits the series rather than showing a zero that reads as "no eval spend"."""
+        team, experiment, _ = spend
+
+        series = cost_timeseries(team, start=_START, end=_NOW, filters=CostFilters(experiment_ids=[experiment.id]))
+
+        assert series == [{"date": series[0]["date"], "chat": 1.0}]
 
     def test_unfiltered_read_stays_a_team_total(self, spend):
         """The flip side: with no filter the same read is a team total, so it counts

--- a/apps/dashboard/tests/test_cost_tracking_panel.py
+++ b/apps/dashboard/tests/test_cost_tracking_panel.py
@@ -7,7 +7,7 @@ import pytest
 from django.urls import reverse
 from time_machine import travel
 
-from apps.cost_tracking.models import Confidence
+from apps.cost_tracking.models import Confidence, UsageSource
 from apps.teams.models import Flag
 from apps.utils.factories.cost_tracking import UsageRecordFactory
 from apps.utils.factories.experiment import ExperimentFactory
@@ -194,7 +194,20 @@ class TestCostTimeseriesEndpoint:
 
         payload = response.json()
         assert len(payload) == 1
-        assert payload[0]["cost"] == 1.0
+        assert payload[0]["chat"] == 1.0
+
+    def test_series_are_split_by_source(self, authenticated_client, team):
+        _enable_flag_for(team)
+        _usage(team, cost="1.00", when=_NOW - timedelta(days=1))
+        _usage(team, cost="0.25", when=_NOW - timedelta(days=1), source=UsageSource.EVALUATION)
+
+        response = authenticated_client.get(
+            self._url(team) + "?date_range=custom&start_date=2026-06-01&end_date=2026-06-20"
+        )
+
+        payload = response.json()
+        assert payload[0]["chat"] == 1.0
+        assert payload[0]["evaluation"] == 0.25
 
     def test_respects_experiment_filter(self, authenticated_client, team, experiment):
         _enable_flag_for(team)
@@ -205,7 +218,7 @@ class TestCostTimeseriesEndpoint:
         matching = authenticated_client.get(base + f"&experiments={experiment.id}")
         other = authenticated_client.get(base + f"&experiments={other_experiment.id}")
 
-        assert matching.json()[0]["cost"] == 1.0
+        assert matching.json()[0]["chat"] == 1.0
         assert other.json() == []
 
 

--- a/assets/javascript/dashboard/charts.js
+++ b/assets/javascript/dashboard/charts.js
@@ -412,15 +412,24 @@ class ChartManager {
 
         this.destroyChart('costTimeseries');
 
+        const points = data || [];
+        // One stacked series per UsageRecord.source the backend reported. A read filtered to
+        // particular chatbots/participants/platforms counts chat only (ADR-0048), so the
+        // evaluation key is absent there and we drop the series rather than plot a zero.
+        const series = [
+            {key: 'chat', label: 'Chat', color: this.colorPalette.primary},
+            {key: 'evaluation', label: 'Evaluations', color: this.colorPalette.secondary}
+        ].filter(spend => points.some(item => item[spend.key] !== undefined));
+
         const chartData = {
-            labels: (data || []).map(item => this.formatDateLabel(item.date)),
-            datasets: [{
-                label: 'Spend',
-                data: (data || []).map(item => item.cost),
-                backgroundColor: this.colorPalette.primary + '80',
-                borderColor: this.colorPalette.primary,
+            labels: points.map(item => this.formatDateLabel(item.date)),
+            datasets: series.map(spend => ({
+                label: spend.label,
+                data: points.map(item => item[spend.key] || 0),
+                backgroundColor: spend.color + '80',
+                borderColor: spend.color,
                 borderWidth: 1
-            }]
+            }))
         };
 
         // Mirror main.js's formatCurrency: 4 decimals below $0.01 so sub-cent
@@ -431,23 +440,36 @@ class ChartManager {
             return `$${num.toFixed(decimals)}`;
         };
 
+        const tooltipCallbacks = {
+            label: (context) => `${context.dataset.label}: ${formatCost(context.parsed.y)}`
+        };
+        if (series.length > 1) {
+            tooltipCallbacks.footer = (items) =>
+                `Total: ${formatCost(items.reduce((total, item) => total + item.parsed.y, 0))}`;
+        }
+
         const options = {
             ...this.defaultOptions,
             plugins: {
                 ...this.defaultOptions.plugins,
                 legend: {
-                    display: false
+                    ...this.defaultOptions.plugins.legend,
+                    display: series.length > 1
                 },
                 tooltip: {
-                    callbacks: {
-                        label: (context) => `Spend: ${formatCost(context.parsed.y)}`
-                    }
+                    ...this.defaultOptions.plugins.tooltip,
+                    callbacks: tooltipCallbacks
                 }
             },
             scales: {
                 ...this.defaultOptions.scales,
+                x: {
+                    ...this.defaultOptions.scales.x,
+                    stacked: true
+                },
                 y: {
                     ...this.defaultOptions.scales.y,
+                    stacked: true,
                     ticks: {
                         callback: (value) => formatCost(value)
                     }


### PR DESCRIPTION
### Product Description
The Cost Tracking panel's daily-spend chart now shows chat spend and evaluation spend as separate stacked series, so a team can see how much of its LLM bill is evaluations. Previously the bar was one undifferentiated total.

### Technical Description
This is the "later" that ADR-0048 deferred — it recorded `UsageRecord.source` but deliberately left the split unsurfaced. Counting rules are unchanged; only the chart's presentation of them is new. ADR-0048 is still PROPOSED, so if you'd rather its "billing views count everything, without a per-source split" bullet be amended or superseded, say so and I'll do that separately.

The decision worth reviewing: under a chatbot/participant/platform filter, the read is per-entity attribution and so counts chat only (ADR-0048) — there is no evaluation spend to plot. Emitting `evaluation: 0` there would read as "this bot cost nothing to evaluate" rather than "not counted here", so `cost_timeseries` omits the key entirely and the frontend drops the series and legend. Filtered view is byte-for-byte the old single-series chart.

`cost_timeseries`'s return shape changed from `{date, cost}` to `{date, chat, evaluation}`. Its only consumer is the dashboard endpoint — the v2 usage API uses `usage_timeseries`, which is untouched.

### Demo
<img width="942" height="528" alt="cost-panel" src="https://github.com/user-attachments/assets/f67fd9fb-6a7e-49c8-bbe1-f8d5e4f7cefe" />


### Docs and Changelog
- [x] This PR requires docs/changelog update

Teams on the cost-monitoring flag will see their daily-spend chart split into chat vs evaluation spend. The panel headline total is unchanged (it always included evaluations).
