### PR TITLE
fix: make the evaluator provider default deterministic

### DIFF
--- a/apps/evaluations/tests/test_evaluator_views.py
+++ b/apps/evaluations/tests/test_evaluator_views.py
@@ -187,6 +187,17 @@ class TestEvaluatorPickerInitialState:
         model = LlmProviderModel.objects.get(id=selection["llm_provider_model_id"])
         assert (model.type, model.name) == (provider.type, get_default_model(provider.type).name)
 
+    def test_creating_with_an_embedding_only_provider_starts_on_no_model(self, client_with_user, team):
+        """Voyage has no chat models to default to, and that must leave the page renderable."""
+        provider = LlmProviderFactory.create(team=team, type=str(LlmProviderTypes.voyage))
+
+        response = client_with_user.get(reverse("evaluations:evaluator_new", args=[team.slug]))
+
+        assert response.context_data["llm_provider_selection"] == {
+            "llm_provider_id": provider.id,
+            "llm_provider_model_id": None,
+        }
+
     def test_editing_an_evaluator_whose_provider_was_deleted_starts_on_nothing(self, client_with_user, team, evaluator):
         """Defaulting here would repoint the evaluator at an unchosen provider on the next Update."""
         evaluator.llm_provider.delete()

--- a/apps/evaluations/tests/test_evaluator_views.py
+++ b/apps/evaluations/tests/test_evaluator_views.py
@@ -177,6 +177,8 @@ class TestEvaluatorPickerInitialState:
     def test_creating_starts_on_the_teams_first_provider(self, client_with_user, team):
         """The pair has to be one the form accepts, so the model must be one this provider can serve."""
         provider = LlmProviderFactory.create(team=team)
+        # Don't lean on the seeded global models: they are absent under --no-migrations.
+        LlmProviderModelFactory.create(team=team, type=provider.type, name=get_default_model(provider.type).name)
 
         response = client_with_user.get(reverse("evaluations:evaluator_new", args=[team.slug]))
 

--- a/apps/evaluations/tests/test_evaluator_views.py
+++ b/apps/evaluations/tests/test_evaluator_views.py
@@ -10,7 +10,8 @@ from django.urls import reverse
 from apps.evaluations import evaluators
 from apps.evaluations.models import ConditionType
 from apps.evaluations.views.evaluator_views import _get_evaluator_schema
-from apps.service_providers.models import LlmProviderTypes
+from apps.service_providers.llm_service.default_models import get_default_model
+from apps.service_providers.models import LlmProviderModel, LlmProviderTypes
 from apps.utils.factories.evaluations import EvaluatorFactory, EvaluatorTagRuleFactory
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 from apps.utils.factories.team import TeamWithUsersFactory
@@ -174,15 +175,15 @@ class TestEvaluatorPickerInitialState:
         }
 
     def test_creating_starts_on_the_teams_first_provider(self, client_with_user, team):
+        """The pair has to be one the form accepts, so the model must be one this provider can serve."""
         provider = LlmProviderFactory.create(team=team)
-        model = LlmProviderModelFactory.create(team=team, type=provider.type)
 
         response = client_with_user.get(reverse("evaluations:evaluator_new", args=[team.slug]))
 
-        assert response.context_data["llm_provider_selection"] == {
-            "llm_provider_id": provider.id,
-            "llm_provider_model_id": model.id,
-        }
+        selection = response.context_data["llm_provider_selection"]
+        assert selection["llm_provider_id"] == provider.id
+        model = LlmProviderModel.objects.get(id=selection["llm_provider_model_id"])
+        assert (model.type, model.name) == (provider.type, get_default_model(provider.type).name)
 
     def test_editing_an_evaluator_whose_provider_was_deleted_starts_on_nothing(self, client_with_user, team, evaluator):
         """Defaulting here would repoint the evaluator at an unchosen provider on the next Update."""

--- a/apps/evaluations/views/evaluator_views.py
+++ b/apps/evaluations/views/evaluator_views.py
@@ -18,6 +18,7 @@ from apps.evaluations.forms import EvaluatorForm, EvaluatorTagRuleFormSet
 from apps.evaluations.models import Evaluator
 from apps.evaluations.tables import EvaluatorTable
 from apps.service_providers.models import LlmProvider, LlmProviderModel
+from apps.service_providers.utils import get_first_llm_provider_by_team, get_first_llm_provider_model
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 from apps.web.waf import WafRule, waf_allow
 
@@ -116,7 +117,7 @@ class EvaluatorFormsetMixin:
         return {
             "evaluator_schemas": _evaluator_schemas(),
             "parameter_values": _evaluator_parameter_values(self.request.team, llm_providers, llm_provider_models),
-            "llm_provider_selection": _initial_llm_provider_selection(form, llm_providers, llm_provider_models),
+            "llm_provider_selection": _initial_llm_provider_selection(form, self.request.team),
         }
 
 
@@ -273,7 +274,7 @@ def _evaluator_parameter_values(team, llm_providers, llm_provider_models):
     }
 
 
-def _initial_llm_provider_selection(form, llm_providers: list[dict], llm_provider_models) -> dict:
+def _initial_llm_provider_selection(form, team) -> dict:
     """Which provider and model the picker starts on.
 
     Only a brand new evaluator is given a default. An existing one shows exactly what it has,
@@ -287,21 +288,14 @@ def _initial_llm_provider_selection(form, llm_providers: list[dict], llm_provide
     }
     if form.is_bound or form.instance.pk:
         return selection
-    return _default_llm_provider_selection(llm_providers, llm_provider_models)
+    return _default_llm_provider_selection(team)
 
 
-def _default_llm_provider_selection(llm_providers: list[dict], llm_provider_models) -> dict:
-    """The team's first provider and a model it can serve, so the model list has something to filter by."""
-    llm_provider_model_id = None
-    provider_id = None
-    if llm_providers:
-        provider = llm_providers[0]
-        provider_id = provider["id"]
-        first_model = next((m for m in llm_provider_models if m.type == provider["type"]), None)
-        if first_model:
-            llm_provider_model_id = first_model.id
-
+def _default_llm_provider_selection(team) -> dict:
+    """The team's first provider and that provider's default model, seeded the same way a new chatbot is."""
+    provider = get_first_llm_provider_by_team(team.id)
+    model = get_first_llm_provider_model(provider, team.id) if provider else None
     return {
-        "llm_provider_id": provider_id,
-        "llm_provider_model_id": llm_provider_model_id,
+        "llm_provider_id": provider.id if provider else None,
+        "llm_provider_model_id": model.id if model else None,
     }

--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -240,7 +240,12 @@ def get_model_parameters(model_name: str, **param_overrides) -> dict:
 
 
 def get_default_model(provider_type: str) -> Model | None:
-    return next((m for m in DEFAULT_LLM_PROVIDER_MODELS[provider_type] if m.is_default), None)
+    """The provider's default model, or None if it has no default.
+
+    Not every ``LlmProviderTypes`` member has chat models here (``voyage`` is embeddings
+    only), so a missing provider is a legitimate miss rather than a programming error.
+    """
+    return next((m for m in DEFAULT_LLM_PROVIDER_MODELS.get(provider_type, ()) if m.is_default), None)
 
 
 def get_default_translation_models_by_provider() -> dict:

--- a/apps/service_providers/tests/test_default_models.py
+++ b/apps/service_providers/tests/test_default_models.py
@@ -27,6 +27,12 @@ def test_all_providers_have_default_models():
         assert get_default_model(provider_type) is not None
 
 
+def test_a_provider_with_no_chat_models_has_no_default():
+    """``voyage`` is an embedding-only provider, so callers get a miss rather than a KeyError."""
+    assert "voyage" not in DEFAULT_LLM_PROVIDER_MODELS
+    assert get_default_model("voyage") is None
+
+
 @pytest.mark.django_db()
 def test_updates_existing_models():
     candidate = DEFAULT_LLM_PROVIDER_MODELS["openai"][0]

--- a/apps/teams/management/commands/clone_team.py
+++ b/apps/teams/management/commands/clone_team.py
@@ -262,9 +262,14 @@ class Command(BaseCommand):
             flag.save()
 
     def _clone_providers(self, ctx: CloneContext):
-        """Clone LLM, Voice, and Trace providers."""
+        """Clone LLM, Voice, and Trace providers.
+
+        Each source queryset is ordered so the clones are created in a fixed order: without it
+        the target rows' ids follow whatever order the database happens to return, which makes
+        the clone unreproducible.
+        """
         # LLM Providers
-        for provider in LlmProvider.objects.filter(team=ctx.source_team):
+        for provider in LlmProvider.objects.filter(team=ctx.source_team).order_by("id"):
             new_provider = LlmProvider.objects.create(
                 team=ctx.target_team,
                 type=provider.type,
@@ -274,7 +279,7 @@ class Command(BaseCommand):
             ctx.llm_providers[provider.id] = new_provider
 
         # LLM Provider Models (team-scoped only)
-        for model in LlmProviderModel.objects.filter(team=ctx.source_team):
+        for model in LlmProviderModel.objects.filter(team=ctx.source_team).order_by("id"):
             new_model = LlmProviderModel.objects.create(
                 team=ctx.target_team,
                 type=model.type,
@@ -284,7 +289,7 @@ class Command(BaseCommand):
             ctx.llm_provider_models[model.id] = new_model
 
         # Voice Providers
-        for provider in VoiceProvider.objects.filter(team=ctx.source_team):
+        for provider in VoiceProvider.objects.filter(team=ctx.source_team).order_by("id"):
             new_provider = VoiceProvider.objects.create(
                 team=ctx.target_team,
                 type=provider.type,
@@ -294,7 +299,7 @@ class Command(BaseCommand):
             ctx.voice_providers[provider.id] = new_provider
 
         # Trace Providers
-        for provider in TraceProvider.objects.filter(team=ctx.source_team):
+        for provider in TraceProvider.objects.filter(team=ctx.source_team).order_by("id"):
             new_provider = TraceProvider.objects.create(
                 team=ctx.target_team,
                 type=provider.type,


### PR DESCRIPTION
`TestEvaluatorPickerInitialState::test_creating_starts_on_the_teams_first_provider` has been failing on main since #4028. Not flakiness — it reproduces standalone and on a fresh test DB. `_default_llm_provider_selection` scanned an unordered `LlmProviderModel.objects.for_team(...)`, which includes the migration-seeded global models, so the create form's default model was whatever row Postgres handed back first (in practice a global one, possibly a deprecated one). The provider side had the same problem for teams with more than one provider, since `llm_providers` is an unordered `.values()`.

Rather than sorting the lists, this reuses `get_first_llm_provider_by_team` / `get_first_llm_provider_model` — the pair already used to seed a new chatbot's pipeline and `bootstrap_data` — so the picker now starts on the provider type's default model (e.g. `gpt-4.1-mini`) and the three paths agree.

One behaviour note for review: `get_first_llm_provider_model` filters by the default model's *name*, so if a team's provider type has no row for its default model the picker starts with no model selected, where before it would have found some other model of that type. Same as chatbot creation today; flagging it since it's the one case that got narrower.

Two follow-ons that routing through that helper surfaced:

- `get_default_model` indexed `DEFAULT_LLM_PROVIDER_MODELS` directly, so an embedding-only provider type (`voyage`) raised `KeyError`. It now returns `None` for a provider with no chat models, as its annotation always claimed.
- `clone_team` copied providers from unordered querysets, leaving the target rows' ids in database order. That is what made `test_clone_team_remaps_pipeline_node_params` fail in PR CI.

### Product Description
The evaluator create form now defaults to the provider's default model instead of an arbitrary one.

### Migrations
N/A

### Docs and Changelog
- [ ] This PR requires docs/changelog update
