### PR TITLE
fix: stop empty messages poisoning a session's history

### DIFF
--- a/apps/channels/stages/core.py
+++ b/apps/channels/stages/core.py
@@ -36,6 +36,7 @@ from apps.ocs_notifications.notifications import (
 from apps.service_providers.llm_service.history_managers import ExperimentHistoryManager
 from apps.service_providers.tracing import TraceInfo
 from apps.service_providers.tracing.base import SpanNotificationConfig
+from apps.utils.llm_messages import EMPTY_MESSAGE_PLACEHOLDER
 
 if TYPE_CHECKING:
     from apps.users.models import CustomUser
@@ -578,6 +579,14 @@ class ChatMessageCreationStage(ProcessingStage):
         # Add trace metadata
         if ctx.trace_service:
             metadata.update(ctx.trace_service.get_trace_metadata())
+
+        # A message with nothing in it at all is sent to the LLM as a placeholder
+        # (see `format_multimodal_input`), so store that same placeholder -- persisting the
+        # raw empty string makes every later turn replay an empty text content block, which
+        # Anthropic rejects. Attachment-only messages keep their empty text: the content is
+        # in the attachments, which the UI renders.
+        if not ctx.user_query.strip() and not metadata[attachments_key]:
+            ctx.user_query = EMPTY_MESSAGE_PLACEHOLDER
 
         # Create the DB record
         ctx.human_message = ChatMessage.objects.create(

--- a/apps/channels/stages/core.py
+++ b/apps/channels/stages/core.py
@@ -547,30 +547,8 @@ class ChatMessageCreationStage(ProcessingStage):
         is_voice = ctx.message.content_type == MESSAGE_TYPES.VOICE
 
         # Save voice note as attachment
-        if is_voice and ctx.message.cached_media_data:
-            # Guard against zero-byte / exhausted audio streams. Persisting a
-            # File row without storage leads to ValueError later when the
-            # attachment is downloaded (see OPEN-CHAT-STUDIO-248).
-            ctx.message.cached_media_data.data.seek(0)
-            audio_bytes = ctx.message.cached_media_data.data.read()
-            if not audio_bytes:
-                logger.warning(
-                    "Skipping voice_note attachment for experiment=%s session=%s: empty audio stream",
-                    ctx.experiment.id,
-                    getattr(ctx.experiment_session, "id", None),
-                )
-            else:
-                ctx.message.cached_media_data.data.seek(0)
-                ext = ctx.message.cached_media_data.content_type.split("/")[1]
-                file = File.create(
-                    f"voice_note.{ext}",
-                    ctx.message.cached_media_data.data,
-                    ctx.experiment.team_id,
-                    purpose=FilePurpose.MESSAGE_MEDIA,
-                    content_type=ctx.message.cached_media_data.content_type,
-                )
-                ctx.experiment_session.chat.attach_files("voice_message", [file])
-                metadata[attachments_key].append(file.id)
+        if is_voice:
+            metadata[attachments_key].extend(self._save_voice_note(ctx))
 
         # Record attachment IDs
         if ctx.message.attachments:
@@ -607,6 +585,36 @@ class ChatMessageCreationStage(ProcessingStage):
         # Fire NEW_HUMAN_MESSAGE trigger (gated by capability)
         if ctx.capabilities.supports_static_triggers:
             enqueue_static_triggers.delay(ctx.experiment_session.id, StaticTriggerType.NEW_HUMAN_MESSAGE)
+
+    def _save_voice_note(self, ctx: MessageProcessingContext) -> list[int]:
+        """Persist the voice note as a chat attachment, returning the file IDs to record."""
+        if not ctx.message.cached_media_data:
+            return []
+
+        # Guard against zero-byte / exhausted audio streams. Persisting a
+        # File row without storage leads to ValueError later when the
+        # attachment is downloaded (see OPEN-CHAT-STUDIO-248).
+        ctx.message.cached_media_data.data.seek(0)
+        audio_bytes = ctx.message.cached_media_data.data.read()
+        if not audio_bytes:
+            logger.warning(
+                "Skipping voice_note attachment for experiment=%s session=%s: empty audio stream",
+                ctx.experiment.id,
+                getattr(ctx.experiment_session, "id", None),
+            )
+            return []
+
+        ctx.message.cached_media_data.data.seek(0)
+        ext = ctx.message.cached_media_data.content_type.split("/")[1]
+        file = File.create(
+            f"voice_note.{ext}",
+            ctx.message.cached_media_data.data,
+            ctx.experiment.team_id,
+            purpose=FilePurpose.MESSAGE_MEDIA,
+            content_type=ctx.message.cached_media_data.content_type,
+        )
+        ctx.experiment_session.chat.attach_files("voice_message", [file])
+        return [file.id]
 
 
 # ---------------------------------------------------------------------------

--- a/apps/channels/tests/channels/stages/test_chat_message_creation.py
+++ b/apps/channels/tests/channels/stages/test_chat_message_creation.py
@@ -2,11 +2,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from apps.channels.datamodels import Attachment
 from apps.channels.stages.core import ChatMessageCreationStage
 from apps.channels.tests.channels.conftest import make_capabilities, make_context
 from apps.channels.tests.message_examples.base_messages import audio_message, text_message
 from apps.chat.models import ChatMessageType
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
+from apps.utils.llm_messages import EMPTY_MESSAGE_PLACEHOLDER
 
 
 @pytest.mark.django_db()
@@ -34,6 +36,61 @@ class TestChatMessageCreationStage:
         assert ctx.human_message is not None
         assert ctx.human_message.message_type == ChatMessageType.HUMAN
         assert ctx.human_message.content == "Hello"
+
+    @pytest.mark.parametrize(
+        "user_query",
+        [
+            pytest.param("", id="empty"),
+            pytest.param("   ", id="spaces"),
+            pytest.param("\n\n", id="newlines"),
+        ],
+    )
+    def test_empty_query_persists_placeholder(self, user_query):
+        """An empty message must be stored as the placeholder the LLM is given.
+
+        Persisting the raw empty string makes every later turn in the session replay an
+        empty text content block, which Anthropic rejects with a 400.
+        """
+        experiment = ExperimentFactory()
+        session = ExperimentSessionFactory(experiment=experiment, team=experiment.team)
+        ctx = make_context(
+            experiment=experiment,
+            experiment_session=session,
+            message=text_message(message_text=user_query),
+            user_query=user_query,
+        )
+
+        self.stage(ctx)
+
+        assert ctx.human_message.content == EMPTY_MESSAGE_PLACEHOLDER
+        assert ctx.user_query == EMPTY_MESSAGE_PLACEHOLDER
+
+    def test_empty_query_with_attachment_is_left_empty(self):
+        """Attachment-only messages carry their content in the attachments, not the text."""
+        experiment = ExperimentFactory()
+        session = ExperimentSessionFactory(experiment=experiment, team=experiment.team)
+        msg = text_message(message_text="")
+        msg.attachments = [
+            Attachment(
+                file_id=1,
+                type="code_interpreter",
+                name="thing.png",
+                size=10,
+                content_type="image/png",
+                download_link="http://example.com/thing.png",
+            )
+        ]
+        ctx = make_context(
+            experiment=experiment,
+            experiment_session=session,
+            message=msg,
+            user_query="",
+        )
+
+        self.stage(ctx)
+
+        assert ctx.human_message.content == ""
+        assert ctx.user_query == ""
 
     def test_voice_message_tagged(self):
         experiment = ExperimentFactory()

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -14,6 +14,7 @@ from apps.files.models import File
 from apps.teams.models import BaseTeamModel
 from apps.teams.utils import get_slug_for_team
 from apps.utils.fields import SanitizedJSONField
+from apps.utils.llm_messages import ensure_non_empty_text
 from apps.utils.models import BaseModel
 
 
@@ -254,7 +255,13 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
         return ChatMessage.make_summary_message(self)
 
     def to_langchain_dict(self) -> dict:
-        return self._get_langchain_dict(self.content, self.message_type)
+        content = self.content
+        if self.is_human_message:
+            # Messages stored before the placeholder was persisted (and attachment-only
+            # messages, whose text is legitimately empty) would otherwise replay as an empty
+            # text content block, which Anthropic rejects with a 400.
+            content = ensure_non_empty_text(content)
+        return self._get_langchain_dict(content, self.message_type)
 
     def to_langchain_message(self) -> BaseMessage:
         return messages_from_dict([self.to_langchain_dict()])[0]

--- a/apps/chat/tests/test_models.py
+++ b/apps/chat/tests/test_models.py
@@ -2,9 +2,11 @@ import pytest
 
 from apps.annotations.models import TagCategories
 from apps.chat.models import ChatMessage, ChatMessageType
+from apps.pipelines.models import PipelineChatHistoryModes
 from apps.utils.factories.assistants import OpenAiAssistantFactory
 from apps.utils.factories.experiment import ExperimentSessionFactory
 from apps.utils.factories.files import FileFactory
+from apps.utils.llm_messages import EMPTY_MESSAGE_PLACEHOLDER
 
 
 @pytest.mark.django_db()
@@ -63,3 +65,42 @@ class TestChatMessage:
         """ChatMessage.rating() must return None (not raise) when the instance has no pk."""
         message = ChatMessage(message_type=ChatMessageType.AI, content="Hi")
         assert message.rating() is None
+
+
+@pytest.mark.django_db()
+class TestEmptyHumanMessageReplay:
+    """Human messages already stored with empty content must not replay as empty text blocks.
+
+    Anthropic rejects those with `400 text content blocks must contain non-whitespace text`,
+    which broke every subsequent turn in a session that contained one.
+    """
+
+    @pytest.mark.parametrize(
+        ("content", "expected"),
+        [
+            pytest.param("", EMPTY_MESSAGE_PLACEHOLDER, id="empty"),
+            pytest.param("   ", EMPTY_MESSAGE_PLACEHOLDER, id="spaces"),
+            pytest.param("\n\t", EMPTY_MESSAGE_PLACEHOLDER, id="whitespace"),
+            pytest.param("Hi", "Hi", id="normal-content-untouched"),
+            pytest.param("  padded  ", "  padded  ", id="padding-preserved"),
+        ],
+    )
+    def test_human_message_content(self, content, expected):
+        session = ExperimentSessionFactory.create()
+        message = ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN, content=content)
+        assert message.to_langchain_message().content == expected
+
+    def test_ai_message_is_not_substituted(self):
+        """Empty AI messages are out of scope for this fix -- they are tracked separately."""
+        session = ExperimentSessionFactory.create()
+        message = ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.AI, content="")
+        assert message.to_langchain_message().content == ""
+
+    def test_history_replay_substitutes_placeholder(self):
+        session = ExperimentSessionFactory.create()
+        ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN, content="")
+        ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.AI, content="How can I help?")
+
+        messages = session.chat.get_langchain_messages_until_marker(PipelineChatHistoryModes.SUMMARIZE)
+
+        assert [m.content for m in messages] == [EMPTY_MESSAGE_PLACEHOLDER, "How can I help?"]

--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -34,6 +34,7 @@ from apps.experiments.models import ExperimentSession
 from apps.teams.models import BaseTeamModel, Team
 from apps.teams.utils import get_slug_for_team
 from apps.utils.fields import SanitizedJSONField
+from apps.utils.llm_messages import ensure_non_empty_text
 from apps.utils.models import BaseModel
 
 if TYPE_CHECKING:
@@ -280,7 +281,9 @@ class EvaluationMessage(BaseModel):
 
     def as_human_langchain_message(self) -> BaseMessage:
         return HumanMessage(
-            content=self.input["content"],
+            # Dataset rows cloned from a session can carry an empty human message, which
+            # Anthropic rejects as an empty text content block. See `ensure_non_empty_text`.
+            content=ensure_non_empty_text(self.input.get("content")),
             additional_kwargs={"id": self.id, "chat_message_id": self.input_chat_message_id},
         )
 

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -36,6 +36,7 @@ from apps.pipelines.versioning import get_versioned_param_specs
 from apps.teams.models import BaseTeamModel
 from apps.teams.utils import get_slug_for_team
 from apps.utils.fields import SanitizedJSONField, as_int
+from apps.utils.llm_messages import ensure_non_empty_text
 from apps.utils.models import BaseModel
 
 
@@ -785,7 +786,12 @@ class PipelineChatMessages(BaseModel):
         """
         langchain_messages: list[BaseMessage] = [
             AIMessage(content=self.ai_message, additional_kwargs={"id": self.id, "node_id": self.node_id}),
-            HumanMessage(content=self.human_message, additional_kwargs={"id": self.id, "node_id": self.node_id}),
+            # An empty human message replays as an empty text content block, which Anthropic
+            # rejects with a 400. See `ensure_non_empty_text`.
+            HumanMessage(
+                content=ensure_non_empty_text(self.human_message),
+                additional_kwargs={"id": self.id, "node_id": self.node_id},
+            ),
         ]
         if include_summary and self.summary:
             langchain_messages.append(

--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -71,6 +71,7 @@ from apps.service_providers.llm_service.runnables import (
     AssistantChat,
     ChainOutput,
 )
+from apps.utils.llm_messages import ensure_non_empty_text
 from apps.utils.prompt import PromptVars, validate_prompt_variables
 from apps.utils.python_execution import RestrictedPythonExecutionMixin, get_code_error_message
 from apps.utils.restricted_http import RestrictedHttpClient
@@ -694,7 +695,9 @@ class RouterNode(RouterMixin, PipelineRouterNode, HistoryMixin):
 
         is_default_keyword = False
         try:
-            agent_input = {"messages": [HumanMessage(content=node_input)]}
+            # An upstream node can hand this node an empty output; an empty text content
+            # block is rejected by Anthropic. See `ensure_non_empty_text`.
+            agent_input = {"messages": [HumanMessage(content=ensure_non_empty_text(node_input))]}
             result = agent.invoke(agent_input, config=self._config)
             structured_response = result["structured_response"]
             keyword = structured_response.route.upper()  # ensure case-insensitive matching

--- a/apps/pipelines/tests/test_pipeline_history.py
+++ b/apps/pipelines/tests/test_pipeline_history.py
@@ -4,7 +4,7 @@ import pytest
 
 from apps.chat.bots import PipelineBot
 from apps.chat.models import ChatMessage, ChatMessageType
-from apps.pipelines.models import PipelineChatHistory
+from apps.pipelines.models import PipelineChatHistory, PipelineChatHistoryTypes
 from apps.pipelines.nodes.base import PipelineState
 from apps.pipelines.repository import ORMRepository
 from apps.pipelines.tests.utils import create_runnable, end_node, llm_response_with_prompt_node, start_node
@@ -14,6 +14,7 @@ from apps.utils.factories.experiment import (
 )
 from apps.utils.factories.pipelines import PipelineFactory
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
+from apps.utils.llm_messages import EMPTY_MESSAGE_PLACEHOLDER
 from apps.utils.tests.langchain import (
     FakeLlmEcho,
     build_fake_llm_service,
@@ -395,3 +396,26 @@ def test_llm_with_no_history(get_llm_service, provider, pipeline, experiment_ses
     assert [
         [(message.type, message.text()) for message in call] for call in llm.get_call_messages()
     ] == expected_call_messages
+
+
+@pytest.mark.django_db()
+class TestEmptyNodeHistoryReplay:
+    """A node history row stored with an empty human message must not replay as an empty text block."""
+
+    @pytest.mark.parametrize(
+        ("human_message", "expected"),
+        [
+            pytest.param("", EMPTY_MESSAGE_PLACEHOLDER, id="empty"),
+            pytest.param("  ", EMPTY_MESSAGE_PLACEHOLDER, id="spaces"),
+            pytest.param("Hi", "Hi", id="normal-content-untouched"),
+        ],
+    )
+    def test_human_message_content(self, experiment_session, human_message, expected):
+        history = PipelineChatHistory.objects.create(
+            session=experiment_session, type=PipelineChatHistoryTypes.NODE, name="node-1"
+        )
+        message = history.messages.create(node_id="node-1", human_message=human_message, ai_message="Response")
+
+        ai_message, human = message.as_langchain_messages()
+        assert human.content == expected
+        assert ai_message.content == "Response"

--- a/apps/pipelines/tests/test_runnable_builder.py
+++ b/apps/pipelines/tests/test_runnable_builder.py
@@ -53,6 +53,7 @@ from apps.utils.factories.experiment import (
 )
 from apps.utils.factories.pipelines import PipelineFactory
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
+from apps.utils.llm_messages import EMPTY_MESSAGE_PLACEHOLDER
 from apps.utils.tests.langchain import (
     FakeLlmEcho,
     FakeLlmService,
@@ -490,6 +491,51 @@ class TestRouterNode:
         assert output["messages"][-1] == "Template D: d"
         output = runnable.invoke(PipelineState(messages=["z"], experiment_session=experiment_session), config=config)
         assert output["messages"][-1] == "Template A: z"
+
+    @pytest.mark.django_db()
+    @pytest.mark.parametrize(
+        ("node_input", "expected"),
+        [
+            pytest.param("", EMPTY_MESSAGE_PLACEHOLDER, id="empty"),
+            pytest.param("  \n", EMPTY_MESSAGE_PLACEHOLDER, id="whitespace"),
+            pytest.param("a", "a", id="normal-input-untouched"),
+        ],
+    )
+    @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
+    @mock.patch("apps.pipelines.nodes.nodes.create_agent")
+    def test_router_node_never_sends_empty_text(
+        self, create_agent_mock, get_llm_service, provider, provider_model, experiment_session, node_input, expected
+    ):
+        """An upstream node can hand the router nothing, and an empty text block is a provider 400."""
+        get_llm_service.return_value = build_fake_llm_echo_service()
+
+        mock_agent = mock.Mock()
+        RouterOutput = create_model("RouterOutput", route=(Literal["A"], Field(description="Route")))
+        mock_agent.invoke.return_value = {"structured_response": RouterOutput(route="A")}
+        create_agent_mock.return_value = mock_agent
+
+        node = RouterNode(
+            node_id="test",
+            django_node=None,
+            name="test router",
+            prompt="You are a router",
+            keywords=["A"],
+            llm_provider_id=provider.id,
+            llm_provider_model_id=provider_model.id,
+        )
+        node._repo = ORMRepository(session=experiment_session)
+        state = PipelineState(
+            outputs={"123": {"message": node_input}},
+            messages=[node_input],
+            experiment_session=experiment_session,
+            node_inputs=[node_input],
+            last_node_input=node_input,
+        )
+
+        node._process_conditional(NodeContext(state))
+
+        sent_messages = mock_agent.invoke.call_args[0][0]["messages"]
+        assert [m.content for m in sent_messages] == [expected]
 
     @pytest.mark.django_db()
     def test_router_node_output_structure(self, provider, provider_model, pipeline, experiment_session):

--- a/apps/service_providers/llm_service/utils.py
+++ b/apps/service_providers/llm_service/utils.py
@@ -12,6 +12,7 @@ from apps.chat.exceptions import UserReportableError
 from apps.experiments.models import ExperimentSession
 from apps.files.models import File
 from apps.service_providers.llm_service.image_types import DEFAULT_SUPPORTED_IMAGE_CONTENT_TYPES, image_type_names
+from apps.utils.llm_messages import EMPTY_MESSAGE_PLACEHOLDER
 
 logger = logging.getLogger("ocs.llm_service")
 
@@ -143,7 +144,7 @@ def format_multimodal_input(
         if block:
             parts.append(block)
     if not parts:
-        parts.append({"type": "text", "text": "[empty message]"})
+        parts.append({"type": "text", "text": EMPTY_MESSAGE_PLACEHOLDER})
     return HumanMessage(content=parts)
 
 

--- a/apps/utils/llm_messages.py
+++ b/apps/utils/llm_messages.py
@@ -1,0 +1,24 @@
+"""Helpers for keeping message content acceptable to LLM providers.
+
+Anthropic rejects a text content block that holds only whitespace with
+``400 messages: text content blocks must contain non-whitespace text``. Participants can
+legitimately send nothing (an empty Connect message, a transcript that came back blank),
+so we substitute a visible placeholder instead of failing the turn.
+
+The placeholder is applied both when building the outgoing turn and when the stored
+message is replayed as history -- a message persisted with empty content would otherwise
+poison every subsequent turn in that session.
+"""
+
+EMPTY_MESSAGE_PLACEHOLDER = "[empty message]"
+
+
+def ensure_non_empty_text(content: str | None) -> str:
+    """Return ``content`` unchanged, or the placeholder if it has no non-whitespace text.
+
+    ``None`` is accepted because JSON-sourced content (e.g. ``EvaluationMessage.input``)
+    can legitimately be null.
+    """
+    if content and content.strip():
+        return content
+    return EMPTY_MESSAGE_PLACEHOLDER

--- a/apps/utils/tests/test_llm_messages.py
+++ b/apps/utils/tests/test_llm_messages.py
@@ -1,0 +1,18 @@
+import pytest
+
+from apps.utils.llm_messages import EMPTY_MESSAGE_PLACEHOLDER, ensure_non_empty_text
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        pytest.param("", EMPTY_MESSAGE_PLACEHOLDER, id="empty"),
+        pytest.param(" ", EMPTY_MESSAGE_PLACEHOLDER, id="space"),
+        pytest.param("\n\t\r ", EMPTY_MESSAGE_PLACEHOLDER, id="whitespace-only"),
+        pytest.param("Hi", "Hi", id="text"),
+        pytest.param("  Hi  ", "  Hi  ", id="surrounding-whitespace-preserved"),
+        pytest.param("0", "0", id="falsy-looking-text"),
+    ],
+)
+def test_ensure_non_empty_text(content, expected):
+    assert ensure_non_empty_text(content) == expected


### PR DESCRIPTION
### Product Description
A participant who sends an empty message (a blank Connect message, a transcript that came back silent) permanently breaks that conversation — the bot answers the empty message fine, then every subsequent message in the session fails.

### Technical Description
Sentry shows `anthropic.AnthropicError: 400 messages: text content blocks must contain non-whitespace text` from `handle_commcare_connect_message`.

The placeholder for an empty turn was applied only at call time, in `format_multimodal_input`, and never persisted. So the `ChatMessage` row kept the raw empty string: the first turn worked, and from then on history replayed that row as `{"type": "text", "text": ""}`.

Fixed on both sides — write, so no new bad rows appear; read, so the sessions already broken in production recover without a backfill. Attachment-only messages deliberately keep their empty text on the write side, since their content is in the attachments and the UI renders those; the read side still substitutes for them.

Worth a look:

- **The read path is human-messages-only.** An empty *AI* row can still poison a session: `_get_final_ai_message` falls back to `messages[-1]` on a pure tool-call chain, whose `.text` is empty, and that gets persisted. Left out on purpose — putting placeholder text into an assistant turn is a product call, not a bug fix. Happy to widen it if you'd rather.
- **The `EvaluationMessage` hunk guards dead code.** `as_langchain_messages` has no production callers (eval generation goes through `ChatMessageCreationStage` instead). Included because it's the same defect one line away from being live; say the word and I'll drop it to keep the diff focused.
- `apps/experiments/tasks.py:219` has the same unguarded pattern in prompt-builder history. Different feature, different data source, left alone.

### Migrations
N/A — no schema or data changes. Existing empty rows are handled on read.

### Demo
Reproduces without a live provider: send an empty message to a Connect-channel bot, then send a second message. Every new assertion was confirmed to fail against unmodified source and pass after, and the "normal content untouched" cases pass either way so the substitution isn't over-reaching.

### Docs and Changelog
- [x] This PR requires docs/changelog update

Changelog note: fixes empty participant messages breaking the rest of a conversation.