### PR TITLE
Split Celery into chat, background, and evaluations queues

### DIFF
--- a/apps/analysis/tasks.py
+++ b/apps/analysis/tasks.py
@@ -10,6 +10,7 @@ from django.core.files.base import ContentFile
 from apps.service_providers.llm_service.default_models import get_model_parameters
 from apps.service_providers.llm_service.retry import with_llm_retry
 from apps.teams.utils import current_team
+from apps.utils.celery import Queues
 
 from .models import AnalysisStatus, TranscriptAnalysis
 from .translation import get_message_content, translate_messages_with_llm
@@ -17,7 +18,7 @@ from .translation import get_message_content, translate_messages_with_llm
 logger = get_task_logger("ocs.analysis")
 
 
-@shared_task(bind=True)
+@shared_task(bind=True, queue=Queues.BACKGROUND)
 def process_transcript_analysis(self, analysis_id):
     progress_recorder = ProgressRecorder(self)
 

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -1,10 +1,7 @@
 import httpx
 from celery.app import shared_task
 from celery.utils.log import get_task_logger
-from django.db.models import Subquery
 
-from apps.channels.clients.connect_client import CommCareConnectClient
-from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chatbots.version_resolver import resolve_published_or_working
 from apps.experiments.models import ExperimentSession, ParticipantData
 from apps.service_providers.tracing import TraceInfo
@@ -41,69 +38,6 @@ def connect_channel_error_details(error: Exception, identifier: str) -> tuple[in
         return 400, f"Failed to create channel: {error.response.text}"
     logger.error("Failed to create CommCare Connect channel for participant %s: %s", identifier, str(error))
     return 503, "Failed to create channel: Unable to connect to CommCare Connect service"
-
-
-@shared_task(
-    bind=True,
-    acks_late=True,
-    ignore_result=True,
-    max_retries=3,
-)
-def setup_connect_channels_for_bots(self, connect_id: str, experiment_data_map: dict):
-    """
-    DEPRECATED: no longer queued; channels are created synchronously in the update-participant API
-    view. Kept so in-flight tasks survive deploy. Remove in a follow-up.
-
-    Set up Connect channels for experiments that are using the ConnectMessaging channel
-
-    experiment_data_map: {experiment_id: participant_data_id}
-    """
-
-    experiment_ids = list(experiment_data_map.keys())
-    participant_data_ids = list(experiment_data_map.values())
-
-    # Only create channels for experiments that are using the ConnectMessaging channel
-    experiments_using_connect = ExperimentChannel.objects.filter(
-        platform=ChannelPlatform.COMMCARE_CONNECT,
-        experiment__id__in=experiment_ids,
-    ).values_list("experiment_id", flat=True)
-
-    participant_data = (
-        ParticipantData.objects.filter(
-            id__in=participant_data_ids,
-            experiment_id__in=Subquery(experiments_using_connect),
-        )
-        .exclude(system_metadata__has_key="commcare_connect_channel_id")
-        .prefetch_related("experiment")
-        .all()
-    )
-
-    connect_client = CommCareConnectClient()
-
-    channels = ExperimentChannel.objects.filter(
-        platform=ChannelPlatform.COMMCARE_CONNECT,
-        experiment_id__in=[participant_data.experiment_id for participant_data in participant_data],
-    )
-
-    channels = {ch.experiment_id: ch for ch in channels}
-
-    successful_ids = set()
-    for participant_datum in participant_data:
-        try:
-            experiment = participant_datum.experiment
-            channel = channels[experiment.id]
-            create_connect_channel_for_participant(channel, connect_client, connect_id, participant_datum)
-            successful_ids.add(experiment.id)
-        except DuplicateConnectChannelError:
-            # Deterministic conflict, already logged — retrying will not resolve it.
-            continue
-        except Exception as e:
-            if self.request.retries == self.max_retries:
-                failed_ids = set(experiment_ids) - successful_ids
-                logger.exception(
-                    "Failed to create channel for participant '%s' and experiments '{}'", connect_id, failed_ids
-                )
-            raise self.retry(exc=e, countdown=60) from None
 
 
 def create_connect_channel_for_participant(channel, connect_client, connect_id, participant_data):

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -6,6 +6,7 @@ from apps.chatbots.version_resolver import resolve_published_or_working
 from apps.experiments.models import ExperimentSession, ParticipantData
 from apps.service_providers.tracing import TraceInfo
 from apps.teams.utils import current_team
+from apps.utils.celery import Queues
 
 logger = get_task_logger("ocs.api")
 
@@ -88,7 +89,7 @@ def create_connect_channel_for_participant(channel, connect_client, connect_id, 
         participant_data.generate_encryption_key()
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.CHAT)
 def trigger_bot_message_task(session_external_id: str, prompt_text: str | None, message_text: str | None):
     """
     Trigger a bot message for a participant on a specific platform.

--- a/apps/assistants/tasks.py
+++ b/apps/assistants/tasks.py
@@ -11,6 +11,7 @@ from openai import (
 
 from apps.assistants.models import OpenAiAssistant
 from apps.assistants.sync import OpenAiSyncError, delete_openai_assistant
+from apps.utils.celery import Queues
 
 logger = get_task_logger("ocs.openai_sync")
 
@@ -20,6 +21,7 @@ logger = get_task_logger("ocs.openai_sync")
     retry_backoff=True,
     acks_late=True,
     bind=True,
+    queue=Queues.BACKGROUND,
 )
 def delete_openai_assistant_task(self, assistant_id: int):
     try:

--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -34,12 +34,13 @@ from apps.ocs_notifications.notifications import widget_auth_level_upgrade_notif
 from apps.service_providers.models import MessagingProviderType
 from apps.service_providers.tracing.base import Tracer
 from apps.teams.utils import set_current_team
+from apps.utils.celery import Queues
 from apps.utils.taskbadger import update_taskbadger_data
 
 log = get_task_logger("ocs.channels")
 
 
-@shared_task(bind=True, base=TaskbadgerTask, ignore_result=True)
+@shared_task(bind=True, base=TaskbadgerTask, ignore_result=True, queue=Queues.CHAT)
 def handle_telegram_message(self, message_data: str, channel_external_id: uuid):
     experiment_channel = get_experiment_channel(ChannelPlatform.TELEGRAM, external_id=channel_external_id)
     if not experiment_channel:
@@ -63,7 +64,7 @@ def handle_telegram_message(self, message_data: str, channel_external_id: uuid):
     message_handler.new_user_message(message)
 
 
-@shared_task(bind=True, base=TaskbadgerTask, ignore_result=True)
+@shared_task(bind=True, base=TaskbadgerTask, ignore_result=True, queue=Queues.CHAT)
 def handle_twilio_message(self, message_data: dict):
     message = TwilioMessage.parse(message_data)
 
@@ -109,7 +110,7 @@ def validate_twillio_request(experiment_channel, raw_data, request_uri, signatur
         return False
 
 
-@shared_task(bind=True, base=TaskbadgerTask)
+@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.CHAT)
 def handle_sureadhere_message(self, sureadhere_tenant_id: str, message_data: dict):
     message = SureAdhereMessage.parse(message_data)
     experiment_channel = get_experiment_channel(
@@ -125,7 +126,7 @@ def handle_sureadhere_message(self, sureadhere_tenant_id: str, message_data: dic
     channel.new_user_message(message)
 
 
-@shared_task(bind=True, base=TaskbadgerTask, ignore_result=True)
+@shared_task(bind=True, base=TaskbadgerTask, ignore_result=True, queue=Queues.CHAT)
 def handle_turn_message(self, experiment_id: uuid, message_data: dict):
     message = WhatsAppMessage.parse(message_data)
     experiment_channel = get_experiment_channel(
@@ -181,7 +182,7 @@ def handle_evaluation_message(
     return channel.new_user_message(message)
 
 
-@shared_task(bind=True, base=TaskbadgerTask, ignore_result=True)
+@shared_task(bind=True, base=TaskbadgerTask, ignore_result=True, queue=Queues.CHAT)
 def handle_commcare_connect_message(self, experiment_id: int, participant_data_id: int, messages: list[Message]):
     participant_data = ParticipantData.objects.prefetch_related("participant").get(id=participant_data_id)
     experiment_channel = get_experiment_channel(ChannelPlatform.COMMCARE_CONNECT, experiment_id=experiment_id)
@@ -218,7 +219,7 @@ def get_experiment_channel_base_query(platform, **query_kwargs):
     ).filter(experiment__is_archived=False)
 
 
-@shared_task(bind=True, base=TaskbadgerTask, ignore_result=True)
+@shared_task(bind=True, base=TaskbadgerTask, ignore_result=True, queue=Queues.CHAT)
 def handle_meta_cloud_api_message(self, channel_id: int, team_slug: str, message_data: dict):
     message = WhatsAppMessage.parse(message_data)
     experiment_channel = (
@@ -248,6 +249,7 @@ def handle_meta_cloud_api_message(self, channel_id: int, team_slug: str, message
     retry_backoff=60,
     retry_backoff_max=300,
     retry_jitter=True,
+    queue=Queues.CHAT,
 )
 def handle_email_message(self, email_data: dict, channel_id: int | None = None, session_id: int | None = None):
     from apps.channels.email_channel import (  # noqa: PLC0415 - tests patch EmailChannel at source module
@@ -302,7 +304,7 @@ def handle_email_message(self, email_data: dict, channel_id: int | None = None, 
     channel.new_user_message(message)
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def ratchet_widget_auth_levels():
     """Raise required_auth_level for embedded-widget channels whose widget has upgraded.
 

--- a/apps/chatbots/tasks.py
+++ b/apps/chatbots/tasks.py
@@ -2,9 +2,10 @@ from celery import shared_task
 
 from apps.experiments.models import ExperimentSession
 from apps.service_providers.tracing import TraceInfo
+from apps.utils.celery import Queues
 
 
-@shared_task
+@shared_task(queue=Queues.CHAT)
 def send_bot_message(session_id: int, instruction_prompt: str):
     session = ExperimentSession.objects.get(id=session_id)
     session.ad_hoc_bot_message(

--- a/apps/custom_actions/tasks.py
+++ b/apps/custom_actions/tasks.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from apps.custom_actions.models import CustomAction, HealthCheckStatus
 from apps.ocs_notifications.notifications import custom_action_health_check_failure_notification
+from apps.utils.celery import Queues
 
 logger = logging.getLogger("ocs.custom_actions")
 
@@ -13,7 +14,7 @@ logger = logging.getLogger("ocs.custom_actions")
 HEALTH_CHECK_TIMEOUT = 5
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def check_all_custom_actions_health():
     """Periodic task to check health of all custom actions with health endpoints configured."""
     custom_actions = CustomAction.objects.exclude(healthcheck_path__isnull=True).exclude(healthcheck_path="")
@@ -24,7 +25,7 @@ def check_all_custom_actions_health():
     logger.info(f"Scheduled health checks for {custom_actions.count()} custom actions")
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def check_single_custom_action_health(action_id: int):
     """Check health of a single custom action.
 

--- a/apps/dashboard/tasks.py
+++ b/apps/dashboard/tasks.py
@@ -2,12 +2,14 @@ from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.utils import timezone
 
+from apps.utils.celery import Queues
+
 from .models import DashboardCache
 
 logger = get_task_logger("ocs.dashboard")
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def cleanup_expired_cache_entries():
     """
     Clean up expired cache entries to prevent database bloat.

--- a/apps/documents/tasks.py
+++ b/apps/documents/tasks.py
@@ -34,18 +34,18 @@ from apps.documents.utils import bulk_delete_collection_files
 from apps.files.models import File, FilePurpose
 from apps.service_providers.models import LlmProvider
 from apps.teams.utils import current_team
-from apps.utils.celery import TaskbadgerTaskWrapper
+from apps.utils.celery import Queues, TaskbadgerTaskWrapper
 
 logger = get_task_logger("ocs.documents")
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def index_collection_files_task(collection_file_ids: list[int]):
     collection_files = CollectionFile.objects.filter(id__in=collection_file_ids)
     index_collection_files(collection_files_queryset=collection_files)
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def migrate_vector_stores(collection_id: int, from_vector_store_id: str, from_llm_provider_id: int):
     """Migrate vector stores from one provider to another"""
     collection_files = CollectionFile.objects.filter(collection_id=collection_id)
@@ -111,7 +111,7 @@ def _cleanup_old_vector_store(llm_provider_id: int, vector_store_id: str, file_i
             old_manager.client.files.delete(file_id)
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def create_collection_from_assistant_task(collection_id: int, assistant_id: int):
     """Create a collection from an assistant's file search resources"""
     # Get file search resources from the assistant
@@ -175,7 +175,7 @@ def create_collection_from_assistant_task(collection_id: int, assistant_id: int)
         index_collection_files_task(collection_file_ids=file_ids_to_index)
 
 
-@shared_task(bind=True, ignore_result=True)
+@shared_task(bind=True, ignore_result=True, queue=Queues.BACKGROUND)
 def sync_document_source_task(self, document_source_id: int):
     """Sync a specific document source"""
     task_id = self.request.id or str(uuid.uuid4())
@@ -240,7 +240,7 @@ def sync_document_source_task(self, document_source_id: int):
         )
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def sync_all_document_sources_task():
     """Sync all document sources that have auto_sync_enabled=True"""
     stale_cutoff = timezone.now() - SYNC_LOCK_TIMEOUT
@@ -261,7 +261,7 @@ def sync_all_document_sources_task():
     sync_document_source_task.map(auto_sources).delay()
 
 
-@shared_task(bind=True, base=TaskbadgerTask)
+@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
 def async_create_collection_version(self, collection_id: int):
     try:
         collection = Collection.objects.get(id=collection_id)
@@ -278,6 +278,7 @@ def async_create_collection_version(self, collection_id: int):
     ignore_result=True,
     autoretry_for=(Exception,),
     retry_kwargs={"max_retries": 3, "countdown": 60},
+    queue=Queues.BACKGROUND,
 )
 def delete_collection_task(self, collection_id: int):
     try:
@@ -312,6 +313,7 @@ def delete_collection_task(self, collection_id: int):
     ignore_result=True,
     autoretry_for=(Exception,),
     retry_kwargs={"max_retries": 3, "countdown": 60},
+    queue=Queues.BACKGROUND,
 )
 def delete_document_source_task(self, document_source_id: int):
     """Delete or archive a DocumentSource and it's files"""
@@ -406,6 +408,7 @@ _ZIP_MAX_RETRIES = 3
     autoretry_for=(Exception,),
     dont_autoretry_for=(ZipIntegrityError,),
     retry_kwargs={"max_retries": _ZIP_MAX_RETRIES, "countdown": 60},
+    queue=Queues.BACKGROUND,
 )
 def create_collection_zip_task(self, collection_id: int, team_id: int):
     """

--- a/apps/documents/tasks.py
+++ b/apps/documents/tasks.py
@@ -258,7 +258,10 @@ def sync_all_document_sources_task():
         .values_list("id", flat=True)
     )
 
-    sync_document_source_task.map(auto_sources).delay()
+    # `.map()` builds a `celery.map` builtin task whose own routing options are used, not
+    # `sync_document_source_task`'s decorator — pass `queue=` explicitly or this silently
+    # falls through to the default (chat) queue instead of Queues.BACKGROUND.
+    sync_document_source_task.map(auto_sources).apply_async(queue=Queues.BACKGROUND)
 
 
 @shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)

--- a/apps/documents/tasks.py
+++ b/apps/documents/tasks.py
@@ -264,8 +264,8 @@ def sync_all_document_sources_task():
     sync_document_source_task.map(auto_sources).apply_async(queue=Queues.BACKGROUND)
 
 
-@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
-def async_create_collection_version(self, collection_id: int):
+@shared_task(queue=Queues.BACKGROUND)
+def async_create_collection_version(collection_id: int):
     try:
         collection = Collection.objects.get(id=collection_id)
         with current_team(collection.team):
@@ -404,7 +404,6 @@ _ZIP_MAX_RETRIES = 3
 
 @shared_task(
     bind=True,
-    base=TaskbadgerTask,
     acks_late=True,
     ignore_result=False,
     max_retries=_ZIP_MAX_RETRIES,

--- a/apps/evaluations/auto_population.py
+++ b/apps/evaluations/auto_population.py
@@ -20,6 +20,7 @@ from apps.evaluations.notifications import auto_population_rule_disabled_notific
 from apps.evaluations.utils import iter_session_evaluation_messages_for_sessions
 from apps.experiments.filters import ExperimentSessionFilter
 from apps.experiments.models import ExperimentSession
+from apps.utils.celery import Queues
 from apps.web.dynamic_filters.datastructures import FilterParams
 
 logger = get_task_logger("ocs.evaluations")
@@ -111,7 +112,7 @@ def _ingest_rule(rule: DatasetAutoPopulationRule) -> list[int]:
     return appended
 
 
-@shared_task(base=TaskbadgerTask)
+@shared_task(base=TaskbadgerTask, queue=Queues.BACKGROUND)
 def auto_populate_eval_datasets():
     """Periodic task: walk enabled DatasetAutoPopulationRules and ingest matches.
 

--- a/apps/evaluations/auto_population.py
+++ b/apps/evaluations/auto_population.py
@@ -7,7 +7,6 @@ from django.db import transaction
 from django.db.models import F
 from django.http import QueryDict
 from django.utils import timezone
-from taskbadger.celery import Task as TaskbadgerTask
 
 from apps.evaluations.models import (
     AutoPopulationRunStatus,
@@ -112,7 +111,7 @@ def _ingest_rule(rule: DatasetAutoPopulationRule) -> list[int]:
     return appended
 
 
-@shared_task(base=TaskbadgerTask, queue=Queues.BACKGROUND)
+@shared_task(queue=Queues.BACKGROUND)
 def auto_populate_eval_datasets():
     """Periodic task: walk enabled DatasetAutoPopulationRules and ingest matches.
 

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -15,7 +15,6 @@ from django.db.models import Count, Exists, Max, OuterRef, Prefetch, QuerySet
 from django.http import QueryDict
 from django.utils import timezone
 from taskbadger import StatusEnum
-from taskbadger.celery import Task as TaskbadgerTask
 
 from apps.assessments.score_writers import write_scores_from_evaluation_result
 from apps.channels.models import ChannelPlatform, ExperimentChannel
@@ -697,7 +696,7 @@ def _create_message_history(chat: Chat, history: list[dict]) -> None:
     ChatMessage.objects.bulk_create(history_messages)
 
 
-@shared_task(base=TaskbadgerTask, queue=Queues.BACKGROUND)
+@shared_task(queue=Queues.BACKGROUND)
 def cleanup_old_evaluation_data() -> None:
     """Delete ExperimentSessions that were created during evaluation runs and
     are older than one week.
@@ -720,7 +719,7 @@ def cleanup_old_evaluation_data() -> None:
     logger.info(f"Cleanup completed: deleted {deleted_chats[0]} chat records and associated evaluation sessions")
 
 
-@shared_task(base=TaskbadgerTask, queue=Queues.BACKGROUND)
+@shared_task(queue=Queues.BACKGROUND)
 def cleanup_old_preview_evaluation_runs() -> None:
     """Delete preview evaluation runs older than 1 day"""
     one_day_ago = timezone.now() - timedelta(days=1)
@@ -735,7 +734,7 @@ def cleanup_old_preview_evaluation_runs() -> None:
     logger.info(f"Cleanup completed: deleted {deleted_preview_runs[0]} preview evaluation runs")
 
 
-@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
+@shared_task(bind=True, queue=Queues.BACKGROUND)
 def update_dataset_from_csv_task(self, dataset_id: int, file_id: int, team_id: int) -> dict:
     """
     Process CSV upload for dataset asynchronously with progress tracking.
@@ -777,7 +776,7 @@ def update_dataset_from_csv_task(self, dataset_id: int, file_id: int, team_id: i
         return {"success": False, "error": str(e)}
 
 
-@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
+@shared_task(bind=True, queue=Queues.BACKGROUND)
 def create_dataset_from_csv_task(
     self,
     dataset_id: int,
@@ -1112,7 +1111,7 @@ def process_csv_rows(
     return stats
 
 
-@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
+@shared_task(bind=True, queue=Queues.BACKGROUND)
 def upload_evaluation_run_results_task(
     self, evaluation_run_id: int, csv_data: list[dict], team_id: int, column_mappings: dict | None = None
 ) -> dict:
@@ -1265,7 +1264,7 @@ def process_evaluation_results_csv_rows(
     return stats
 
 
-@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
+@shared_task(bind=True, queue=Queues.BACKGROUND)
 def create_dataset_from_session_messages_task(
     self,
     dataset_id: int,
@@ -1369,7 +1368,7 @@ def _sessions_for_session_mode_clone(
     return ExperimentSession.objects.filter(team=dataset.team, external_id__in=session_ids)
 
 
-@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
+@shared_task(bind=True, queue=Queues.BACKGROUND)
 def create_dataset_from_sessions_task(
     self,
     dataset_id: int,
@@ -1477,7 +1476,7 @@ def _get_bulk_results_queryset(config: EvaluationConfig, team: Team) -> QuerySet
     )
 
 
-@shared_task(base=TaskbadgerTask, queue=Queues.BACKGROUND)
+@shared_task(queue=Queues.BACKGROUND)
 def export_evaluation_bulk_results_task(evaluation_config_id: int, team_id: int) -> dict:
     """
     Async export of the most recent evaluation result for each dataset item,

--- a/apps/evaluations/tasks.py
+++ b/apps/evaluations/tasks.py
@@ -53,6 +53,7 @@ from apps.experiments.models import Experiment, ExperimentSession, Participant
 from apps.files.models import File, FilePurpose
 from apps.teams.models import Team
 from apps.teams.utils import current_team
+from apps.utils.celery import Queues
 from apps.web.dynamic_filters.datastructures import FilterParams
 
 EVAL_SESSIONS_TTL_DAYS = 30
@@ -235,7 +236,7 @@ def evaluate_message(evaluation_run_id: int, evaluator_ids: list[int], message_i
             _run_evaluator_on_message(evaluation_run, evaluator, message, bot_response, session_id)
 
 
-@shared_task(acks_late=True, soft_time_limit=BATCH_SOFT_TIME_LIMIT)
+@shared_task(acks_late=True, soft_time_limit=BATCH_SOFT_TIME_LIMIT, queue=Queues.EVALUATIONS)
 def evaluate_message_batch(evaluation_run_id: int, message_ids: list[int]) -> None:
     """Evaluate a small batch of messages in-process, then exit.
 
@@ -463,7 +464,7 @@ def _drive_run(run_id: int) -> None:
             finalize_evaluation_run.delay(run.id)
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def finalize_evaluation_run(run_id: int) -> None:
     """Completion side effects for a run already committed as COMPLETED.
 
@@ -491,7 +492,7 @@ def finalize_evaluation_run(run_id: int) -> None:
     run.save(update_fields=["finalized_at"])
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def drive_evaluation_run(run_id: int) -> None:
     """One coordination tick for a single run.
 
@@ -507,7 +508,7 @@ def drive_evaluation_run(run_id: int) -> None:
         logger.exception("Coordination tick failed for evaluation run %s", run_id)
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def coordinate_evaluation_runs() -> None:
     """Beat task (every 30s): dispatch one coordination tick per active evaluation run.
 
@@ -696,7 +697,7 @@ def _create_message_history(chat: Chat, history: list[dict]) -> None:
     ChatMessage.objects.bulk_create(history_messages)
 
 
-@shared_task(base=TaskbadgerTask)
+@shared_task(base=TaskbadgerTask, queue=Queues.BACKGROUND)
 def cleanup_old_evaluation_data() -> None:
     """Delete ExperimentSessions that were created during evaluation runs and
     are older than one week.
@@ -719,7 +720,7 @@ def cleanup_old_evaluation_data() -> None:
     logger.info(f"Cleanup completed: deleted {deleted_chats[0]} chat records and associated evaluation sessions")
 
 
-@shared_task(base=TaskbadgerTask)
+@shared_task(base=TaskbadgerTask, queue=Queues.BACKGROUND)
 def cleanup_old_preview_evaluation_runs() -> None:
     """Delete preview evaluation runs older than 1 day"""
     one_day_ago = timezone.now() - timedelta(days=1)
@@ -734,7 +735,7 @@ def cleanup_old_preview_evaluation_runs() -> None:
     logger.info(f"Cleanup completed: deleted {deleted_preview_runs[0]} preview evaluation runs")
 
 
-@shared_task(bind=True, base=TaskbadgerTask)
+@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
 def update_dataset_from_csv_task(self, dataset_id: int, file_id: int, team_id: int) -> dict:
     """
     Process CSV upload for dataset asynchronously with progress tracking.
@@ -776,7 +777,7 @@ def update_dataset_from_csv_task(self, dataset_id: int, file_id: int, team_id: i
         return {"success": False, "error": str(e)}
 
 
-@shared_task(bind=True, base=TaskbadgerTask)
+@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
 def create_dataset_from_csv_task(
     self,
     dataset_id: int,
@@ -1111,7 +1112,7 @@ def process_csv_rows(
     return stats
 
 
-@shared_task(bind=True, base=TaskbadgerTask)
+@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
 def upload_evaluation_run_results_task(
     self, evaluation_run_id: int, csv_data: list[dict], team_id: int, column_mappings: dict | None = None
 ) -> dict:
@@ -1264,7 +1265,7 @@ def process_evaluation_results_csv_rows(
     return stats
 
 
-@shared_task(bind=True, base=TaskbadgerTask)
+@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
 def create_dataset_from_session_messages_task(
     self,
     dataset_id: int,
@@ -1368,7 +1369,7 @@ def _sessions_for_session_mode_clone(
     return ExperimentSession.objects.filter(team=dataset.team, external_id__in=session_ids)
 
 
-@shared_task(bind=True, base=TaskbadgerTask)
+@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
 def create_dataset_from_sessions_task(
     self,
     dataset_id: int,
@@ -1476,7 +1477,7 @@ def _get_bulk_results_queryset(config: EvaluationConfig, team: Team) -> QuerySet
     )
 
 
-@shared_task(base=TaskbadgerTask)
+@shared_task(base=TaskbadgerTask, queue=Queues.BACKGROUND)
 def export_evaluation_bulk_results_task(evaluation_config_id: int, team_id: int) -> dict:
     """
     Async export of the most recent evaluation result for each dataset item,

--- a/apps/events/tasks.py
+++ b/apps/events/tasks.py
@@ -4,11 +4,12 @@ from celery.utils.log import get_task_logger
 from apps.events.models import ScheduledMessage, StaticTrigger, StaticTriggerType, TimeoutTrigger
 from apps.experiments.models import ExperimentSession
 from apps.teams.export_service import migrating_team_ids
+from apps.utils.celery import Queues
 
 logger = get_task_logger("ocs.events")
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.CHAT)
 def enqueue_static_triggers(session_id, trigger_type):
     trigger_ids = _get_static_triggers_to_fire(session_id, trigger_type)
     for trigger_id in trigger_ids:
@@ -31,7 +32,7 @@ def _get_static_triggers_to_fire(session_id: int, trigger_type: StaticTrigger):
     return queryset.values_list("id", flat=True)
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.CHAT)
 def fire_static_trigger(trigger_id, session_id):
     trigger = StaticTrigger.objects.get(id=trigger_id)
     session = ExperimentSession.objects.get(id=session_id)
@@ -39,7 +40,7 @@ def fire_static_trigger(trigger_id, session_id):
     return triggered
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.CHAT)
 def enqueue_timed_out_events():
     active_triggers = (
         TimeoutTrigger.objects.published_versions()
@@ -59,7 +60,7 @@ def enqueue_timed_out_events():
                 fire_trigger.delay(trigger.id, session.id)
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.CHAT)
 def fire_trigger(trigger_id, session_id):
     trigger = TimeoutTrigger.objects.get(id=trigger_id)
     session = ExperimentSession.objects.get(id=session_id)
@@ -67,7 +68,7 @@ def fire_trigger(trigger_id, session_id):
     return triggered
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.CHAT)
 def poll_scheduled_messages():
     """Polls scheduled messages and triggers those that are due. After triggering, it updates the database with the
     new trigger details for each message."""
@@ -76,7 +77,7 @@ def poll_scheduled_messages():
         message.safe_trigger()
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.CHAT)
 def retry_scheduled_message(scheduled_message_id: int, attempt_number: int):
     try:
         message = ScheduledMessage.objects.get(id=scheduled_message_id)

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -28,7 +28,7 @@ from apps.utils.taskbadger import update_taskbadger_data
 logger = get_task_logger("ocs.experiments")
 
 
-@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
+@shared_task(bind=True, queue=Queues.BACKGROUND)
 def async_export_chat(self, experiment_id: int, query_params: str, time_zone) -> dict:
     # The filters need a QueryDict (multi-value params, `.getlist()`), but Celery's JSON
     # serializer would flatten one into a plain dict, so the caller passes the raw query
@@ -61,9 +61,9 @@ def async_export_chat(self, experiment_id: int, query_params: str, time_zone) ->
     return {"file_id": file_obj.id}
 
 
-@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
+@shared_task(queue=Queues.BACKGROUND)
 def async_create_experiment_version(
-    self, experiment_id: int, version_description: str | None = None, make_default: bool = False
+    experiment_id: int, version_description: str | None = None, make_default: bool = False
 ):
     try:
         experiment = Experiment.objects.prefetch_related("pipeline").get(id=experiment_id)

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -22,12 +22,13 @@ from apps.service_providers.llm_service.retry import with_llm_retry
 from apps.service_providers.models import LlmProvider, LlmProviderModel
 from apps.teams.utils import current_team
 from apps.users.models import CustomUser
+from apps.utils.celery import Queues
 from apps.utils.taskbadger import update_taskbadger_data
 
 logger = get_task_logger("ocs.experiments")
 
 
-@shared_task(bind=True, base=TaskbadgerTask)
+@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
 def async_export_chat(self, experiment_id: int, query_params: str, time_zone) -> dict:
     # The filters need a QueryDict (multi-value params, `.getlist()`), but Celery's JSON
     # serializer would flatten one into a plain dict, so the caller passes the raw query
@@ -60,7 +61,7 @@ def async_export_chat(self, experiment_id: int, query_params: str, time_zone) ->
     return {"file_id": file_obj.id}
 
 
-@shared_task(bind=True, base=TaskbadgerTask)
+@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.BACKGROUND)
 def async_create_experiment_version(
     self, experiment_id: int, version_description: str | None = None, make_default: bool = False
 ):
@@ -96,7 +97,7 @@ def start_version_creation(experiment, version_description: str = "", make_defau
     return True
 
 
-@shared_task(bind=True, base=TaskbadgerTask)
+@shared_task(bind=True, base=TaskbadgerTask, queue=Queues.CHAT)
 def get_response_for_webchat_task(
     self,
     experiment_session_id: int,
@@ -153,7 +154,7 @@ def get_response_for_webchat_task(
     return response
 
 
-@shared_task
+@shared_task(queue=Queues.CHAT)
 def get_prompt_builder_response_task(team_id: int, user_id, data_dict: dict) -> dict[str, str | int]:
     llm_service = LlmProvider.objects.get(id=data_dict["provider"]).get_llm_service()
     llm_provider_model = LlmProviderModel.objects.get(id=data_dict["providerModelId"])

--- a/apps/files/tasks.py
+++ b/apps/files/tasks.py
@@ -2,9 +2,10 @@ from celery.app import shared_task
 from django.utils import timezone
 
 from apps.files.models import File
+from apps.utils.celery import Queues
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def clean_up_expired_files():
     """
     Cleans up expired files

--- a/apps/mcp_integrations/tasks.py
+++ b/apps/mcp_integrations/tasks.py
@@ -1,9 +1,10 @@
 from celery import shared_task
 
 from apps.mcp_integrations.models import McpServer
+from apps.utils.celery import Queues
 
 
-@shared_task
+@shared_task(queue=Queues.BACKGROUND)
 def sync_tools_task(mcp_server_id: int):
     """
     Celery task to synchronize tools for an McpServer instance.

--- a/apps/ocs_notifications/tasks.py
+++ b/apps/ocs_notifications/tasks.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from apps.ocs_notifications.models import (
     NotificationEvent,
 )
+from apps.utils.celery import Queues
 from apps.web.meta import absolute_url
 
 if TYPE_CHECKING:
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("ocs.notifications")
 
 
-@shared_task
+@shared_task(queue=Queues.BACKGROUND)
 def send_notification_email_async(user_ids, notification_event_id):
     from apps.users.models import (  # noqa: PLC0415 - circular: users.models → ocs_notifications.utils → ocs_notifications.tasks
         CustomUser,
@@ -89,7 +90,7 @@ def send_notification_email(users: list[CustomUser], notification_event: Notific
             )
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def cleanup_old_notification_events():
     """Delete NotificationEvent records older than 3 months."""
     three_months_ago = timezone.now() - timedelta(days=90)

--- a/apps/pipelines/tasks.py
+++ b/apps/pipelines/tasks.py
@@ -11,9 +11,10 @@ from apps.pipelines.exceptions import (
 )
 from apps.pipelines.models import Pipeline
 from apps.service_providers.llm_service.runnables import GenerationError
+from apps.utils.celery import Queues
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.CHAT)
 def send_email_from_pipeline(recipient_list, subject, message):
     send_mail(
         subject=subject,
@@ -24,7 +25,7 @@ def send_email_from_pipeline(recipient_list, subject, message):
     )
 
 
-@shared_task
+@shared_task(queue=Queues.CHAT)
 def get_response_for_pipeline_test_message(pipeline_id: int, message_text: str, user_id: int):
     """
     Retrieve a response from a pipeline for a test message.

--- a/apps/teams/tasks.py
+++ b/apps/teams/tasks.py
@@ -14,6 +14,7 @@ from apps.files.models import File, FilePurpose
 from apps.teams.invitations import send_invitation_accepted
 from apps.teams.models import Invitation, Membership, Team
 from apps.teams.utils import current_team
+from apps.utils.celery import Queues
 from apps.utils.deletion import (
     chunk_list,
     delete_object_with_auditing_of_related_objects,
@@ -26,13 +27,13 @@ logger = logging.getLogger("ocs.teams")
 CHUNK_SIZE = 64 * 1024
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
 def send_invitation_accepted_notification(invitation_id):
     invitation = Invitation.objects.get(id=invitation_id)
     send_invitation_accepted(invitation)
 
 
-@shared_task
+@shared_task(queue=Queues.BACKGROUND)
 def delete_team_async(team_id, user_email, notify_recipients="self"):
     team = Team.objects.get(id=team_id)
     emails = [user_email]  # default case: user sends email just to themselves
@@ -74,7 +75,7 @@ def _export_arcname(file: File) -> str:
     return name
 
 
-@shared_task(bind=True, base=TaskbadgerTask, ignore_result=False)
+@shared_task(bind=True, base=TaskbadgerTask, ignore_result=False, queue=Queues.BACKGROUND)
 def create_team_files_zip_task(self, team_id: int) -> int:
     """Build a zip of the team's current files and store it as a DATA_EXPORT file.
 

--- a/apps/teams/tasks.py
+++ b/apps/teams/tasks.py
@@ -8,7 +8,6 @@ from celery import shared_task
 from celery_progress.backend import ProgressRecorder
 from django.core.files import File as DjangoFile
 from django.utils import timezone
-from taskbadger.celery import Task as TaskbadgerTask
 
 from apps.files.models import File, FilePurpose
 from apps.teams.invitations import send_invitation_accepted
@@ -75,7 +74,7 @@ def _export_arcname(file: File) -> str:
     return name
 
 
-@shared_task(bind=True, base=TaskbadgerTask, ignore_result=False, queue=Queues.BACKGROUND)
+@shared_task(bind=True, ignore_result=False, queue=Queues.BACKGROUND)
 def create_team_files_zip_task(self, team_id: int) -> int:
     """Build a zip of the team's current files and store it as a DATA_EXPORT file.
 

--- a/apps/utils/celery.py
+++ b/apps/utils/celery.py
@@ -1,3 +1,34 @@
+from enum import StrEnum
+
+
+class Queues(StrEnum):
+    """The Celery queues tasks are routed to.
+
+    Every task defined under ``apps/`` must declare one explicitly via ``@shared_task(queue=...)``;
+    ``apps/utils/tests/test_celery_queues.py`` fails the build if one doesn't. The point of the
+    split is that a backed-up evaluation run can never starve inbound chat messages of workers.
+
+    A worker started without ``-Q`` consumes every queue in ``settings.CELERY_TASK_QUEUES``, so the
+    single-worker setups (local dev, docker compose, Heroku, Kamal, self-hosters) keep working
+    unchanged. Only production runs a dedicated worker per queue.
+    """
+
+    #: Latency-sensitive chat path: inbound message handlers, event triggers, outbound bot
+    #: messages. Named "celery" because it is also ``task_default_queue`` — third-party and
+    #: built-in tasks (e.g. ``celery.backend_cleanup``) fall through to it, and keeping the
+    #: default name means nothing enqueued before this split was introduced was stranded.
+    CHAT = "celery"
+
+    #: Long-running or resource-intensive work: indexing, exports, imports, cleanup crons, and
+    #: the evaluation control plane.
+    BACKGROUND = "background"
+
+    #: Evaluation fan-out only. Deliberately excludes the tasks that dispatch and drain it
+    #: (``coordinate_evaluation_runs``, ``drive_evaluation_run``, ``finalize_evaluation_run``) so
+    #: a saturated queue can never block its own drain.
+    EVALUATIONS = "evaluations"
+
+
 class TaskbadgerTaskWrapper:
     """Wrapper for Celery tasks to provide progress reporting via taskbadger.
 

--- a/apps/utils/tests/test_celery_queues.py
+++ b/apps/utils/tests/test_celery_queues.py
@@ -49,6 +49,20 @@ def _declared_queue(decorator: ast.expr) -> str | None:
     return None
 
 
+def _tasks_in_module(path: Path) -> list[tuple[str, str, str | None]]:
+    """Every task-decorated function defined in a single module."""
+    found = []
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for decorator in node.decorator_list:
+            if _is_task_decorator(decorator):
+                location = f"{path.relative_to(APPS_DIR.parent)}:{node.lineno}"
+                found.append((location, node.name, _declared_queue(decorator)))
+    return found
+
+
 @cache
 def _source_tasks() -> list[tuple[str, str, str | None]]:
     """Every task defined under ``apps/`` as ``(location, function name, declared queue)``.
@@ -60,14 +74,7 @@ def _source_tasks() -> list[tuple[str, str, str | None]]:
     for path in sorted(APPS_DIR.rglob("*.py")):
         if "migrations" in path.parts:
             continue
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
-                continue
-            for decorator in node.decorator_list:
-                if _is_task_decorator(decorator):
-                    location = f"{path.relative_to(APPS_DIR.parent)}:{node.lineno}"
-                    found.append((location, node.name, _declared_queue(decorator)))
+        found.extend(_tasks_in_module(path))
     return found
 
 

--- a/apps/utils/tests/test_celery_queues.py
+++ b/apps/utils/tests/test_celery_queues.py
@@ -49,6 +49,11 @@ def _declared_queue(decorator: ast.expr) -> str | None:
     return None
 
 
+def _task_decorator(node: ast.FunctionDef | ast.AsyncFunctionDef) -> ast.expr | None:
+    """The task decorator on this function definition, if it has one."""
+    return next((decorator for decorator in node.decorator_list if _is_task_decorator(decorator)), None)
+
+
 def _tasks_in_module(path: Path) -> list[tuple[str, str, str | None]]:
     """Every task-decorated function defined in a single module."""
     found = []
@@ -56,10 +61,11 @@ def _tasks_in_module(path: Path) -> list[tuple[str, str, str | None]]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
             continue
-        for decorator in node.decorator_list:
-            if _is_task_decorator(decorator):
-                location = f"{path.relative_to(APPS_DIR.parent)}:{node.lineno}"
-                found.append((location, node.name, _declared_queue(decorator)))
+        decorator = _task_decorator(node)
+        if decorator is None:
+            continue
+        location = f"{path.relative_to(APPS_DIR.parent)}:{node.lineno}"
+        found.append((location, node.name, _declared_queue(decorator)))
     return found
 
 

--- a/apps/utils/tests/test_celery_queues.py
+++ b/apps/utils/tests/test_celery_queues.py
@@ -17,6 +17,7 @@ Two complementary checks:
 """
 
 import ast
+from functools import cache
 from pathlib import Path
 
 import pytest
@@ -48,8 +49,13 @@ def _declared_queue(decorator: ast.expr) -> str | None:
     return None
 
 
+@cache
 def _source_tasks() -> list[tuple[str, str, str | None]]:
-    """Every task defined under ``apps/`` as ``(location, function name, declared queue)``."""
+    """Every task defined under ``apps/`` as ``(location, function name, declared queue)``.
+
+    Cached: several tests below each need this, and re-parsing the whole ``apps/`` tree per
+    test is pure waste since the source doesn't change within a test run.
+    """
     found = []
     for path in sorted(APPS_DIR.rglob("*.py")):
         if "migrations" in path.parts:
@@ -65,7 +71,11 @@ def _source_tasks() -> list[tuple[str, str, str | None]]:
     return found
 
 
+@cache
 def _registered_tasks() -> dict[str, object]:
+    """Cached for the same reason as ``_source_tasks``: rebuilt on every call otherwise,
+    including once per parametrized case in ``test_router_sends_task_to_expected_queue``.
+    """
     current_app.loader.import_default_modules()
     return {name: task for name, task in current_app.tasks.items() if name.startswith("apps.")}
 
@@ -123,6 +133,7 @@ def test_all_queues_are_declared_in_settings():
         # can never block the tasks responsible for draining it.
         pytest.param("apps.evaluations.tasks.coordinate_evaluation_runs", Queues.BACKGROUND, id="eval-coordinator"),
         pytest.param("apps.evaluations.tasks.drive_evaluation_run", Queues.BACKGROUND, id="eval-driver"),
+        pytest.param("apps.evaluations.tasks.finalize_evaluation_run", Queues.BACKGROUND, id="eval-finalizer"),
     ],
 )
 def test_router_sends_task_to_expected_queue(task_name, expected_queue):

--- a/apps/utils/tests/test_celery_queues.py
+++ b/apps/utils/tests/test_celery_queues.py
@@ -1,0 +1,142 @@
+"""Guard tests for Celery queue routing.
+
+Tasks are split across queues (see ``apps.utils.celery.Queues``) so that long-running work —
+evaluation fan-out, indexing, exports — can never starve inbound chat messages of workers. That
+only holds if *every* task says which queue it belongs on: an un-annotated task silently falls
+back to the default queue, which is the latency-sensitive chat queue, i.e. exactly the
+regression the split exists to prevent.
+
+Two complementary checks:
+
+* **Source scan** — parses every module under ``apps/`` and requires an explicit ``queue=`` on
+  each ``@shared_task``. This is the exhaustive one: it sees tasks in modules that nothing
+  happens to import, which the runtime registry would miss.
+* **Registry scan** — for tasks that are registered, checks the declared queue actually exists
+  in ``settings.CELERY_TASK_QUEUES`` and that Celery's router agrees. Catches a typo'd queue
+  name or a broken queue declaration, which the source scan alone would wave through.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+from celery import current_app
+from django.conf import settings
+
+from apps.utils.celery import Queues
+
+APPS_DIR = Path(__file__).resolve().parents[2]
+
+TASK_DECORATORS = ("shared_task", "task")
+
+
+def _is_task_decorator(node: ast.expr) -> bool:
+    """True for ``@shared_task``, ``@shared_task(...)``, ``@app.task(...)`` and friends."""
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Attribute):
+        return node.attr in TASK_DECORATORS
+    return isinstance(node, ast.Name) and node.id in TASK_DECORATORS
+
+
+def _declared_queue(decorator: ast.expr) -> str | None:
+    if not isinstance(decorator, ast.Call):
+        return None  # bare @shared_task takes no arguments, so it cannot declare a queue
+    for keyword in decorator.keywords:
+        if keyword.arg == "queue":
+            return ast.unparse(keyword.value)
+    return None
+
+
+def _source_tasks() -> list[tuple[str, str, str | None]]:
+    """Every task defined under ``apps/`` as ``(location, function name, declared queue)``."""
+    found = []
+    for path in sorted(APPS_DIR.rglob("*.py")):
+        if "migrations" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            for decorator in node.decorator_list:
+                if _is_task_decorator(decorator):
+                    location = f"{path.relative_to(APPS_DIR.parent)}:{node.lineno}"
+                    found.append((location, node.name, _declared_queue(decorator)))
+    return found
+
+
+def _registered_tasks() -> dict[str, object]:
+    current_app.loader.import_default_modules()
+    return {name: task for name, task in current_app.tasks.items() if name.startswith("apps.")}
+
+
+def test_source_scan_finds_tasks():
+    """Guard the guard: a broken scan would make every check below vacuously pass."""
+    assert len(_source_tasks()) > 40
+
+
+def test_every_task_declares_an_explicit_queue():
+    undeclared = [f"{location} {name}" for location, name, queue in _source_tasks() if queue is None]
+    assert not undeclared, (
+        "These Celery tasks don't declare a queue, so they fall back to the chat queue and will "
+        "compete with inbound messages. Add queue=Queues.<CHAT|BACKGROUND|EVALUATIONS>:\n" + "\n".join(undeclared)
+    )
+
+
+def test_declared_queues_use_the_queues_enum():
+    valid = {f"Queues.{member.name}" for member in Queues}
+    wrong = [f"{location} {name} -> {queue}" for location, name, queue in _source_tasks() if queue not in valid]
+    assert not wrong, (
+        f"Celery tasks must route via the {sorted(valid)} constants rather than a bare string, so "
+        "that renaming a queue is a single edit:\n" + "\n".join(wrong)
+    )
+
+
+def test_registered_task_queues_are_declared_in_settings():
+    declared = {queue.name for queue in settings.CELERY_TASK_QUEUES}
+    # getattr default: an un-annotated task has no `queue` attribute at all, and should be
+    # reported here rather than blowing up with an AttributeError.
+    unroutable = {
+        name: getattr(task, "queue", None)
+        for name, task in _registered_tasks().items()
+        if str(getattr(task, "queue", None)) not in declared
+    }
+    assert not unroutable, (
+        f"These tasks route to queues absent from CELERY_TASK_QUEUES ({sorted(declared)}), so no "
+        f"worker would consume them: {unroutable}"
+    )
+
+
+def test_all_queues_are_declared_in_settings():
+    """A worker started without ``-Q`` consumes exactly the queues declared here."""
+    assert {queue.name for queue in settings.CELERY_TASK_QUEUES} == {member.value for member in Queues}
+
+
+@pytest.mark.parametrize(
+    ("task_name", "expected_queue"),
+    [
+        pytest.param("apps.channels.tasks.handle_telegram_message", Queues.CHAT, id="inbound-message"),
+        pytest.param("apps.events.tasks.poll_scheduled_messages", Queues.CHAT, id="event-polling"),
+        pytest.param("apps.documents.tasks.index_collection_files_task", Queues.BACKGROUND, id="indexing"),
+        pytest.param("apps.evaluations.tasks.evaluate_message_batch", Queues.EVALUATIONS, id="eval-fan-out"),
+        # The eval control plane stays off the queue it drains, so a saturated evaluations queue
+        # can never block the tasks responsible for draining it.
+        pytest.param("apps.evaluations.tasks.coordinate_evaluation_runs", Queues.BACKGROUND, id="eval-coordinator"),
+        pytest.param("apps.evaluations.tasks.drive_evaluation_run", Queues.BACKGROUND, id="eval-driver"),
+    ],
+)
+def test_router_sends_task_to_expected_queue(task_name, expected_queue):
+    """End-to-end through Celery's router, which is what actually decides the destination.
+
+    ``Task.apply_async`` merges ``_get_exec_options()`` (where the decorator's ``queue=`` ends up)
+    into the options it hands the router, so routing with anything less than that answers a
+    different question — an empty dict resolves every task to the default queue.
+    """
+    task = _registered_tasks()[task_name]
+    route = current_app.amqp.router.route(task._get_exec_options(), task_name)
+    assert route["queue"].name == expected_queue
+
+
+def test_unrouted_tasks_land_on_a_consumed_queue():
+    """Third-party tasks can't carry our decorator, so the default must be a queue we consume."""
+    assert current_app.conf.task_default_queue == Queues.CHAT

--- a/apps/web/tasks.py
+++ b/apps/web/tasks.py
@@ -1,7 +1,9 @@
 from celery import shared_task
 from django.core.management import call_command
 
+from apps.utils.celery import Queues
 
-@shared_task
+
+@shared_task(queue=Queues.BACKGROUND)
 def cleanup_silk_data():
     call_command("silk_request_garbage_collect")

--- a/config/settings.py
+++ b/config/settings.py
@@ -19,7 +19,10 @@ from pathlib import Path
 import environ
 from celery.schedules import crontab
 from django.utils.translation import gettext_lazy
+from kombu import Queue
 from pythonjsonlogger.json import JsonFormatter
+
+from apps.utils.celery import Queues
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -567,6 +570,13 @@ CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 # see https://docs.celeryq.dev/en/stable/userguide/workers.html#soft-shutdown
 CELERY_WORKER_SOFT_SHUTDOWN_TIMEOUT = 10
 CELERY_WORKER_ENABLE_SOFT_SHUTDOWN_ON_IDLE = True
+
+# Declaring the queues is what keeps single-worker deployments working: a worker started without
+# `-Q` consumes every queue listed here. Only production splits them out with a worker per queue.
+# It also extends the `/status/` celery healthcheck, which reports any declared queue that has no
+# active consumer. `task_default_queue` is left at its default ("celery" == Queues.CHAT) so
+# third-party tasks land on a queue that is always consumed.
+CELERY_TASK_QUEUES = tuple(Queue(queue.value) for queue in Queues)
 
 SCHEDULED_TASKS = {
     "files.tasks.clean_up_expired_files": {

--- a/config/settings.py
+++ b/config/settings.py
@@ -571,12 +571,17 @@ CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 CELERY_WORKER_SOFT_SHUTDOWN_TIMEOUT = 10
 CELERY_WORKER_ENABLE_SOFT_SHUTDOWN_ON_IDLE = True
 
-# Declaring the queues is what keeps single-worker deployments working: a worker started without
-# `-Q` consumes every queue listed here. Only production splits them out with a worker per queue.
-# It also extends the `/status/` celery healthcheck, which reports any declared queue that has no
-# active consumer. `task_default_queue` is left at its default ("celery" == Queues.CHAT) so
-# third-party tasks land on a queue that is always consumed.
-CELERY_TASK_QUEUES = tuple(Queue(queue.value) for queue in Queues)
+
+def _celery_task_queues() -> tuple[Queue, ...]:
+    """Declaring the queues is what keeps single-worker deployments working: a worker started
+    without `-Q` consumes every queue listed here. Only production splits them out with a worker
+    per queue. It also extends the `/status/` celery healthcheck, which reports any declared queue
+    that has no active consumer. `task_default_queue` is left at its default ("celery" ==
+    Queues.CHAT) so third-party tasks land on a queue that is always consumed."""
+    return tuple(Queue(queue.value) for queue in Queues)
+
+
+CELERY_TASK_QUEUES = _celery_task_queues()
 
 SCHEDULED_TASKS = {
     "files.tasks.clean_up_expired_files": {

--- a/docs/getting-started/docker-setup.md
+++ b/docs/getting-started/docker-setup.md
@@ -58,7 +58,7 @@ As an alternative to running Django and Celery on the host, you can run the full
 | `redis` | Redis (used as Celery broker and result backend) |
 | `migrate` | Runs `manage.py migrate` on startup, then exits |
 | `web` | Django dev server with auto-reload (`runserver`) |
-| `celery_worker` | Celery worker for background tasks |
+| `celery_worker` | Celery worker for background tasks (consumes all [task queues](../hosting/index.md#task-queues)) |
 | `celery_beat` | Celery Beat scheduler (uses `django_celery_beat` database scheduler) |
 
 ## Useful commands

--- a/docs/getting-started/local-setup.md
+++ b/docs/getting-started/local-setup.md
@@ -104,6 +104,16 @@ Open Chat Studio uses [UV](https://docs.astral.sh/uv/getting-started/installatio
     inv celery --threads
     ```
 
+    Either form consumes all [task queues](../hosting/index.md#task-queues). To reproduce the
+    production split — where chat, background and evaluation work get separate workers — run one
+    process per queue:
+
+    ```bash
+    inv celery --queues=celery
+    inv celery --queues=background
+    inv celery --queues=evaluations
+    ```
+
 ---
 
 Next: [Common Development Tasks](common-tasks.md)

--- a/docs/hosting/heroku.md
+++ b/docs/hosting/heroku.md
@@ -95,6 +95,10 @@ The `heroku.yml` defines three process types:
 | `worker` | `celery -A config worker -l INFO --pool threads --concurrency 20` | Scale as needed |
 | `beat` | `celery -A config beat -l INFO` | **Always exactly 1** |
 
+The `worker` process consumes all three [task queues](index.md#task-queues). To stop evaluation
+load from delaying chat responses, add dedicated process types with `-Q` and scale them
+independently.
+
 Scale dynos:
 
 ```bash

--- a/docs/hosting/index.md
+++ b/docs/hosting/index.md
@@ -42,6 +42,36 @@ flowchart TD
 | `celery_worker` | `celery -A config worker -l INFO --pool threads --concurrency 20` | Handles all async tasks (LLM calls, messaging, evaluations). |
 | `celery_beat` | `celery -A config beat -l INFO` | Scheduled/periodic tasks. **Run exactly one instance.** |
 
+## Task Queues
+
+Tasks are routed to one of three queues:
+
+| Queue | Contents |
+|-------|----------|
+| `celery` | Latency-sensitive chat path — inbound message handlers, event triggers, outbound bot messages. Also the default queue. |
+| `background` | Long-running work — document indexing, exports, CSV imports, cleanup jobs, and evaluation coordination. |
+| `evaluations` | Evaluation fan-out, which can run hundreds of LLM calls per run. |
+
+**The single `celery_worker` command above consumes all three**, so a deployment needs no changes
+to keep working. A worker started without `-Q` consumes every declared queue.
+
+Splitting them is an optional scaling step. It's worth doing once evaluation or indexing load
+starts delaying chat responses, because it stops a backed-up evaluation run from occupying every
+worker thread. Replace the single worker with one process per queue:
+
+```bash
+celery -A config worker -l INFO --pool threads --concurrency 20 -Q celery
+celery -A config worker -l INFO --pool threads --concurrency 10 -Q background
+celery -A config worker -l INFO --pool threads --concurrency 20 -Q evaluations
+```
+
+!!! warning "Every queue needs a consumer"
+
+    Once you pass `-Q`, each queue needs at least one running worker or its tasks will sit
+    unprocessed. The `/status/` healthcheck reports `No worker for Celery task queue <name>` when
+    one is unconsumed. To roll back, drop the `-Q` flags — workers go straight back to consuming
+    everything.
+
 ## Docker Image
 
 The production Dockerfile is a multi-stage build:

--- a/docs/hosting/kamal.md
+++ b/docs/hosting/kamal.md
@@ -40,6 +40,9 @@ servers:
       - your-server-ip
     options:
       expose: "8000"
+  # Consumes all three task queues. To isolate chat latency from evaluation and background
+  # load, split this into one role per queue with `-Q celery` / `-Q background` /
+  # `-Q evaluations`. See docs/hosting/index.md#task-queues.
   workers:
     hosts:
       - your-server-ip

--- a/tasks.py
+++ b/tasks.py
@@ -220,12 +220,21 @@ def runserver(c: Context, public=False):
     help={
         "threads": "Use thread pool for async tasks (disables beat scheduler)",
         "beat": "Include beat scheduler for periodic tasks (default: False)",
+        "queues": "Comma-separated queues to consume (default: all of them). "
+        "Use this to reproduce the production split locally, e.g. --queues=celery",
     }
 )
-def celery(c: Context, threads=False, beat=False):
-    """Start Celery worker with auto-reload on code changes."""
+def celery(c: Context, threads=False, beat=False, queues=""):
+    """Start Celery worker with auto-reload on code changes.
+
+    Without --queues the worker consumes every queue in settings.CELERY_TASK_QUEUES, which is the
+    normal way to run this locally. Production instead runs one worker per queue so that
+    evaluation and background load can't starve the chat queue.
+    """
     _disable_stdin_forwarding(c)
     cmd = "celery -A config worker -l INFO"
+    if queues:
+        cmd += f" -Q {queues}"
     if threads:
         cmd += " --pool threads --concurrency 10"
     else:


### PR DESCRIPTION
### Product Description
No user-facing change. Background/evaluation load (indexing, exports, eval fan-out) can no longer delay inbound chat message handling.

### Technical Description
Closes #4022. Every task now declares an explicit `queue=Queues.{CHAT,BACKGROUND,EVALUATIONS}`, enforced by a new guard test (`apps/utils/tests/test_celery_queues.py`) that fails if any task under `apps/` omits it — an unannotated task defaults to the chat queue, which is exactly the regression this split exists to prevent.

Rollout is backwards compatible by construction: `CELERY_TASK_QUEUES` declares all three queues, and a worker started without `-Q` consumes all of them (verified live — see commit `61d11f91f`). So this PR alone changes nothing operationally; local dev, Docker, Heroku, and Kamal keep running a single worker. Splitting into dedicated workers is a separate ocs-deploy change with no ordering dependency on this one.

Worth a closer look:
- `evaluate_message_batch` (the fan-out unit) is the only task on `Queues.EVALUATIONS`. `coordinate_evaluation_runs`/`drive_evaluation_run`/`finalize_evaluation_run` stay on `Queues.BACKGROUND` deliberately — they're the control plane that dispatches and drains the eval queue, so putting them on the queue they control would let a saturated queue block its own drain.
- `sync_document_source_task.map(...)` was silently falling through to the chat queue — `Task.map()` wraps calls in Celery's builtin `celery.map` task, which doesn't inherit the mapped task's `queue=` decorator. Fixed by passing `queue=` explicitly on the `.map(...).apply_async()` call. `.map()`'s sequential-in-process execution model is a separate, pre-existing issue tracked at #4107.
- Also dropped `bind=True`/`base=TaskbadgerTask` from several tasks that never referenced `self` — Taskbadger auto-tracks every task by name regardless of base class, so the annotation was dead weight, not a correctness fix.

### Migrations
N/A — no migrations.

### Demo
N/A — no user-facing behavior change; verified via live worker/beat/healthcheck testing described in commit `61d11f91f`.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Hosting docs (`docs/hosting/index.md`, `heroku.md`, `kamal.md`, `docs/getting-started/docker-setup.md`, `local-setup.md`) updated in this PR to describe the queues and the optional worker-split scaling step.