### PR TITLE
fix: don't build an index manager for non-indexed collections during file deletion

### DIFF
--- a/apps/documents/tests/test_delete_collection_files.py
+++ b/apps/documents/tests/test_delete_collection_files.py
@@ -96,3 +96,18 @@ class TestBulkDeleteCollectionFiles:
 
         assert CollectionFile.objects.filter(collection=collection).count() == 0
         assert not File.objects.filter(id=file1.id).exists()
+
+    def test_delete_files_non_index_collection_with_no_llm_provider(self, team_with_users):
+        """Non-indexed collections have llm_provider=None (forms.py clears it on save), so
+        get_index_manager() must never be called for them. Regression: it was called
+        unconditionally, raising AttributeError on the None llm_provider."""
+        collection = CollectionFactory.create(team=team_with_users, is_index=False, llm_provider=None)
+        file1 = FileFactory.create(team=team_with_users)
+
+        collection.files.add(file1)
+        collection_files = list(CollectionFile.objects.filter(collection=collection))
+
+        bulk_delete_collection_files(collection, collection_files)
+
+        assert CollectionFile.objects.filter(collection=collection).count() == 0
+        assert not File.objects.filter(id=file1.id).exists()

--- a/apps/documents/utils.py
+++ b/apps/documents/utils.py
@@ -42,7 +42,7 @@ def bulk_delete_collection_files(
 
     files_in_use = get_related_m2m_objects(files)
 
-    index_manager = collection.get_index_manager()
+    index_manager = collection.get_index_manager() if collection.is_index else None
     index_only_delete = [file for file in files if file in files_in_use]
     full_delete = [file for file in files if file not in files_in_use]
     if index_only_delete and collection.is_index:


### PR DESCRIPTION
### Product Description
no change

### Technical Description
`bulk_delete_collection_files` called `collection.get_index_manager()` unconditionally, before checking `collection.is_index`. Non-indexed collections have `llm_provider=None` (cleared by `CollectionForm.clean()` when `is_index` is false), so deleting an archived, non-indexed collection's files crashed:

```
AttributeError: 'NoneType' object has no attribute 'get_local_index_manager'
```

Fix makes the index manager lookup conditional on `is_index`, matching the pattern already used by the single-file `delete_collection_file` in the same module. Added a regression test with `llm_provider=None`, which the existing tests didn't catch since `CollectionFactory` always sets an `llm_provider` by default.

### Migrations
N/A — no migrations

### Demo
N/A — bug fix, no user-facing behavior change

### Docs and Changelog
- [ ] This PR requires docs/changelog update