### PR TITLE
Dispatch per-source document sync tasks instead of Task.map()

### DIFF
--- a/apps/documents/tasks.py
+++ b/apps/documents/tasks.py
@@ -258,10 +258,17 @@ def sync_all_document_sources_task():
         .values_list("id", flat=True)
     )
 
-    # `.map()` builds a `celery.map` builtin task whose own routing options are used, not
-    # `sync_document_source_task`'s decorator — pass `queue=` explicitly or this silently
-    # falls through to the default (chat) queue instead of Queues.BACKGROUND.
-    sync_document_source_task.map(auto_sources).apply_async(queue=Queues.BACKGROUND)
+    # Dispatch one message per source rather than `sync_document_source_task.map(...)`: the
+    # `celery.map` builtin calls the task inline in a list comprehension, so every source would
+    # be synced serially inside a single task execution — no parallelism across the worker pool,
+    # no isolation (one source raising aborts every source after it), and no real per-item task
+    # backing the retry/timeout and `self.request.id` sync lock.
+    dispatched = 0
+    for source_id in auto_sources.iterator(100):
+        sync_document_source_task.delay(source_id)
+        dispatched += 1
+
+    logger.info("Dispatched auto-sync for %s document sources", dispatched)
 
 
 @shared_task(queue=Queues.BACKGROUND)

--- a/apps/documents/tests/test_tasks.py
+++ b/apps/documents/tests/test_tasks.py
@@ -444,6 +444,32 @@ def test_create_collection_zip_task_celery_retries_on_zip_creation_error(progres
     retry_mock.assert_called_once()
 
 
+def _dispatched_source_ids(mock_sync_task) -> set[int]:
+    """The source ids the scheduler dispatched, one task message per source."""
+    return {call.args[0] for call in mock_sync_task.delay.call_args_list}
+
+
+@pytest.mark.django_db()
+@patch("apps.documents.tasks.sync_document_source_task")
+def test_auto_sync_dispatches_one_task_per_source(mock_sync_task):
+    """Each source gets its own task message.
+
+    Regression: ``sync_document_source_task.map(...)`` sent a single ``celery.map`` message that
+    synced every source serially in one execution — no parallelism, no per-source isolation, and
+    no real task backing each item's retry/lock semantics.
+    """
+    index = CollectionFactory.create(is_index=True)
+    sources = [
+        DocumentSourceFactory.create(collection=index, source_type="github", auto_sync_enabled=True) for _ in range(3)
+    ]
+
+    sync_all_document_sources_task()
+
+    mock_sync_task.map.assert_not_called()
+    assert mock_sync_task.delay.call_count == 3
+    assert _dispatched_source_ids(mock_sync_task) == {source.id for source in sources}
+
+
 @pytest.mark.django_db()
 @patch("apps.documents.tasks.sync_document_source_task")
 def test_auto_sync_excludes_versioned_collections(mock_sync_task):
@@ -466,8 +492,7 @@ def test_auto_sync_excludes_versioned_collections(mock_sync_task):
 
     sync_all_document_sources_task()
 
-    dispatched_ids = set(mock_sync_task.map.call_args.args[0])
-    assert dispatched_ids == {working_source.id}
+    assert _dispatched_source_ids(mock_sync_task) == {working_source.id}
 
 
 # ---------------------------------------------------------------------------
@@ -607,8 +632,7 @@ def test_auto_sync_skips_fresh_lock_but_includes_stale(mock_sync_task):
 
     sync_all_document_sources_task()
 
-    dispatched_ids = set(mock_sync_task.map.call_args.args[0])
-    assert dispatched_ids == {unlocked.id, stale.id, no_start_time.id}
+    assert _dispatched_source_ids(mock_sync_task) == {unlocked.id, stale.id, no_start_time.id}
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
### Product Description
The weekly document-source auto-sync now runs sources in parallel across the worker pool and isolates failures, so one broken source no longer silently skips every source after it in that week's run.

### Technical Description
`sync_all_document_sources_task` dispatched via `sync_document_source_task.map(auto_sources).apply_async(...)`. Celery's `celery.map` builtin is not a parallel fan-out — it calls the task inline (`[task(item) for item in it]`), so a single message was sent and one worker thread looped through every stale source serially in-process. Consequences: no parallelism regardless of concurrency, no isolation between sources, and no real per-item task backing `sync_document_source_task`'s retry/timeout and `self.request.id`-based sync lock.

This replaces the `.map()` call with a loop of `.delay(source_id)`, matching the existing periodic fan-out idiom in `apps/custom_actions/tasks.py` and the manual "sync now" dispatch in `apps/documents/views.py`. The explicit `queue=Queues.BACKGROUND` override is dropped because it was only needed to route the `celery.map` wrapper (which used its own routing options) — a direct `.delay()` picks up `sync_document_source_task`'s own decorator, which already declares `queue=Queues.BACKGROUND`. Ids are streamed with `.iterator(100)`.

Tests: added `test_auto_sync_dispatches_one_task_per_source` (asserts `.map` unused and one `.delay` per source); updated the two existing scheduler tests to read dispatched ids from the per-source calls.

Fixes #4107

### Migrations
- [x] The migrations are backwards compatible

No migrations in this PR.

### Demo
N/A — internal task dispatch change, no UI surface.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Generated with [Claude Code](https://claude.ai/code)