### PR TITLE
Add periodic task to delete expired sessions

### DIFF
--- a/apps/web/tasks.py
+++ b/apps/web/tasks.py
@@ -1,9 +1,49 @@
+import logging
+
 from celery import shared_task
+from django.contrib.sessions.models import Session
 from django.core.management import call_command
+from django.utils import timezone
 
 from apps.utils.celery import Queues
+
+logger = logging.getLogger("ocs.web.tasks")
+
+#: Expired sessions are deleted in chunks this size. Django's own ``clearsessions``
+#: issues a single unbounded ``DELETE``, which on a large backlog means one long
+#: transaction and a matching spike in WAL.
+SESSION_CLEANUP_BATCH_SIZE = 10_000
 
 
 @shared_task(queue=Queues.BACKGROUND)
 def cleanup_silk_data():
     call_command("silk_request_garbage_collect")
+
+
+@shared_task(ignore_result=True, queue=Queues.BACKGROUND)
+def clear_expired_sessions():
+    """Delete session rows whose ``expire_date`` has passed.
+
+    Django never prunes these on its own — the db session backend only writes
+    rows and relies on ``clearsessions`` being run periodically, so without this
+    the table grows for the lifetime of the deployment.
+
+    Deletes in batches rather than calling ``clearsessions``: the command's
+    single ``DELETE`` is fine once the table is kept trimmed, but not for
+    working through an accumulated backlog on a live database.
+    """
+    now = timezone.now()
+    deleted_total = 0
+    while True:
+        expired_ids = list(
+            Session.objects.filter(expire_date__lt=now).values_list("session_key", flat=True)[
+                :SESSION_CLEANUP_BATCH_SIZE
+            ]
+        )
+        if not expired_ids:
+            break
+        deleted_count, _ = Session.objects.filter(session_key__in=expired_ids).delete()
+        deleted_total += deleted_count
+
+    if deleted_total:
+        logger.info("Deleted %s expired sessions", deleted_total)

--- a/apps/web/tasks.py
+++ b/apps/web/tasks.py
@@ -42,7 +42,10 @@ def clear_expired_sessions():
         )
         if not expired_ids:
             break
-        deleted_count, _ = Session.objects.filter(session_key__in=expired_ids).delete()
+        deleted_count, _ = Session.objects.filter(
+            session_key__in=expired_ids,
+            expire_date__lt=now,
+        ).delete()
         deleted_total += deleted_count
 
     if deleted_total:

--- a/apps/web/tests/test_tasks.py
+++ b/apps/web/tests/test_tasks.py
@@ -24,6 +24,28 @@ def test_clear_expired_sessions_deletes_only_expired():
 
 
 @pytest.mark.django_db()
+def test_clear_expired_sessions_skips_session_renewed_after_selection(monkeypatch):
+    """A session renewed between the select and the delete must survive."""
+    now = timezone.now()
+    renewed = _create_session("renewed", now - timedelta(days=1))
+
+    real_filter = Session.objects.filter
+
+    def filter_then_renew(*args, **kwargs):
+        qs = real_filter(*args, **kwargs)
+        if "session_key__in" in kwargs:
+            # Simulate a request renewing the session between the select and this delete.
+            real_filter(session_key=renewed.session_key).update(expire_date=now + timedelta(days=1))
+        return qs
+
+    monkeypatch.setattr(Session.objects, "filter", filter_then_renew)
+
+    clear_expired_sessions()
+
+    assert Session.objects.filter(session_key=renewed.session_key).exists()
+
+
+@pytest.mark.django_db()
 def test_clear_expired_sessions_works_across_batches(monkeypatch):
     """The batching loop must drain the backlog, not just the first chunk."""
     monkeypatch.setattr("apps.web.tasks.SESSION_CLEANUP_BATCH_SIZE", 2)

--- a/apps/web/tests/test_tasks.py
+++ b/apps/web/tests/test_tasks.py
@@ -1,0 +1,36 @@
+from datetime import timedelta
+
+import pytest
+from django.contrib.sessions.models import Session
+from django.utils import timezone
+
+from apps.web.tasks import clear_expired_sessions
+
+
+def _create_session(session_key: str, expire_date):
+    return Session.objects.create(session_key=session_key, session_data="", expire_date=expire_date)
+
+
+@pytest.mark.django_db()
+def test_clear_expired_sessions_deletes_only_expired():
+    now = timezone.now()
+    expired = _create_session("expired", now - timedelta(days=1))
+    live = _create_session("live", now + timedelta(days=1))
+
+    clear_expired_sessions()
+
+    assert not Session.objects.filter(session_key=expired.session_key).exists()
+    assert Session.objects.filter(session_key=live.session_key).exists()
+
+
+@pytest.mark.django_db()
+def test_clear_expired_sessions_works_across_batches(monkeypatch):
+    """The batching loop must drain the backlog, not just the first chunk."""
+    monkeypatch.setattr("apps.web.tasks.SESSION_CLEANUP_BATCH_SIZE", 2)
+    expired_at = timezone.now() - timedelta(days=1)
+    for i in range(5):
+        _create_session(f"expired-{i}", expired_at)
+
+    clear_expired_sessions()
+
+    assert not Session.objects.exists()


### PR DESCRIPTION
### Product Description
No change.

### Technical Description
`clearsessions` appears nowhere in the codebase and `SESSION_ENGINE` is unset, so the default db backend has been writing `django_session` rows and never removing them. In prod that table is 653 MB across 1.8M rows (290 MB heap, 363 MB index) — the fifth-largest table, and essentially all of it expired.

Adds `clear_expired_sessions` next to the existing `cleanup_silk_data` in `apps/web/tasks.py`.

It deletes in batches rather than calling `clearsessions`, because the command issues one unbounded `DELETE`. That is fine on a table that is kept trimmed, but the initial 1.8M-row backlog would be a single long transaction with a matching WAL spike, on the same volume we are trying to reclaim space on.

### Migrations
No migrations.

### Deploy notes
Beat uses `DatabaseScheduler`, so this does nothing until the task is registered as a periodic task in the admin. Daily is plenty.

Two things worth knowing when it first runs:

- Postgres marks the freed pages reusable but does not return them to the OS, so `FreeStorageSpace` will not move until `VACUUM FULL django_session` or pg_repack. `VACUUM FULL` takes an ACCESS EXCLUSIVE lock — brief on a 653 MB table, but it blocks logins while it runs.
- Deleting an unexpired session logs that user out. This only touches rows where `expire_date` has already passed, so no live sessions are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)