### PR TITLE
don't ignore evals tasks in taskbadger integration

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -756,9 +756,6 @@ if TASKBADGER_API_KEY:
                     "apps.events.tasks.enqueue_timed_out_events",
                     # evaluation coordination manages one Taskbadger task per run itself
                     "apps.evaluations.tasks.coordinate_evaluation_runs",
-                    "apps.evaluations.tasks.drive_evaluation_run",
-                    "apps.evaluations.tasks.finalize_evaluation_run",
-                    "apps.evaluations.tasks.evaluate_message_batch",
                 ],
                 record_task_args=True,
                 # ping running tasks so long-running ones aren't marked stale


### PR DESCRIPTION
### Technical Description
Ignoring them means they are invisible in taskbadger and we don't get metrics like time-to-start etc.
