### PR TITLE
Supply-chain hardening for dependency installs and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,33 @@
 version: 2
+
+# A note on `cooldown`: it delays *version* update PRs so a freshly published
+# release has time to be found malicious and unpublished before we adopt it.
+# It deliberately does not apply to Dependabot *security* updates, so advisory
+# fixes still land immediately. The npm ecosystems are additionally floored by
+# `minimumReleaseAge` in pnpm-workspace.yaml, which catches transitive bumps
+# that Dependabot never opens a PR for; uv, actions and pre-commit have no
+# client-side equivalent, so cooldown is the only lever there.
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     open-pull-requests-limit: 5
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "npm"
     directory: "/components/chat_widget"
     open-pull-requests-limit: 5
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "uv"
     directory: "/"
     open-pull-requests-limit: 5
@@ -20,11 +38,20 @@ updates:
     # so floors stay at the version we actually need rather than ratcheting to
     # the latest release and needlessly narrowing the resolver's options.
     versioning-strategy: "increase-if-necessary"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,10 @@ version: 2
 # It deliberately does not apply to Dependabot *security* updates, so advisory
 # fixes still land immediately. The npm ecosystems are additionally floored by
 # `minimumReleaseAge` in pnpm-workspace.yaml, which catches transitive bumps
-# that Dependabot never opens a PR for; uv, actions and pre-commit have no
-# client-side equivalent, so cooldown is the only lever there.
+# that Dependabot never opens a PR for. uv has a client-side equivalent
+# (`tool.uv.exclude-newer` in pyproject.toml) that we don't currently set;
+# actions and pre-commit have no such lever, so cooldown is the only guard
+# there.
 updates:
   - package-ecosystem: "npm"
     directory: "/"

--- a/.github/workflows/api-schema-dispatch.yml
+++ b/.github/workflows/api-schema-dispatch.yml
@@ -20,7 +20,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Repository Dispatch

--- a/.github/workflows/api-schema-dispatch.yml
+++ b/.github/workflows/api-schema-dispatch.yml
@@ -17,6 +17,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v4.0.1
         with:

--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -20,7 +20,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: take an issue

--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -17,6 +17,12 @@ jobs:
     timeout-minutes: 10
     if: ${{ github.repository_owner == 'dimagi' }}
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: take an issue
         uses: bdougie/take-action@1439165ac45a7461c2d89a59952cd7d941964b87 # v1.6.1
         with:

--- a/.github/workflows/auto-update-models.yml
+++ b/.github/workflows/auto-update-models.yml
@@ -49,7 +49,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout repository
@@ -177,7 +177,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout repository

--- a/.github/workflows/auto-update-models.yml
+++ b/.github/workflows/auto-update-models.yml
@@ -46,6 +46,12 @@ jobs:
       new_model_count: ${{ steps.reconcile.outputs.new_model_count }}
       new_model_ids: ${{ steps.reconcile.outputs.new_model_ids }}
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
@@ -168,6 +174,12 @@ jobs:
       DJANGO_DATABASE_PASSWORD: postgres_password
       SECRET_KEY: secret-test-key
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/build_components.yml
+++ b/.github/workflows/build_components.yml
@@ -19,6 +19,12 @@ jobs:
       matrix:
         node-version: [24.x]
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6.0.9
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/build_components.yml
+++ b/.github/workflows/build_components.yml
@@ -22,7 +22,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - uses: actions/checkout@v7

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,7 +46,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout repository

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,6 +43,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -35,6 +35,12 @@ jobs:
       id-token: write
 
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Resolve PR ref
         id: pr
         env:

--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -38,7 +38,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Resolve PR ref

--- a/.github/workflows/claude-followup.yml
+++ b/.github/workflows/claude-followup.yml
@@ -57,7 +57,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Find PR and check for followup label

--- a/.github/workflows/claude-followup.yml
+++ b/.github/workflows/claude-followup.yml
@@ -54,6 +54,12 @@ jobs:
       DJANGO_DATABASE_PASSWORD: postgres_password
       SECRET_KEY: secret-test-key
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Find PR and check for followup label
         id: check
         env:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,6 +45,12 @@ jobs:
       issue_body: ${{ steps.find.outputs.issue_body }}
       issue_title: ${{ steps.find.outputs.issue_title }}
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Find oldest labeled issue without an open PR
         id: find
         env:
@@ -136,6 +142,12 @@ jobs:
       DJANGO_DATABASE_PASSWORD: postgres_password
       SECRET_KEY: secret-test-key
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
@@ -250,6 +262,12 @@ jobs:
       DJANGO_DATABASE_PASSWORD: postgres_password
       SECRET_KEY: secret-test-key
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,7 +48,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Find oldest labeled issue without an open PR
@@ -145,7 +145,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout repository
@@ -265,7 +265,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
     # Audit only: records egress without blocking. Flip to `block` plus an
     # `allowed-endpoints` list once the recorded traffic looks stable.
     - name: Harden the runner
-      uses: step-security/harden-runner@v2
+      uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
       with:
         egress-policy: audit
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,13 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
+    # Audit only: records egress without blocking. Flip to `block` plus an
+    # `allowed-endpoints` list once the recorded traffic looks stable.
+    - name: Harden the runner
+      uses: step-security/harden-runner@v2
+      with:
+        egress-policy: audit
+
     - name: Checkout
       uses: actions/checkout@v7
 

--- a/.github/workflows/docs-changelog-dispatch.yml
+++ b/.github/workflows/docs-changelog-dispatch.yml
@@ -42,10 +42,10 @@ jobs:
 
           # Check if any files in components/ folder were changed
           if grep -q "^components/" /tmp/changed_files.txt; then
-            echo "is_widget_change=true" >> $GITHUB_OUTPUT
+            echo "is_widget_change=true" >> "$GITHUB_OUTPUT"
             echo "Widget files were changed"
           else
-            echo "is_widget_change=false" >> $GITHUB_OUTPUT
+            echo "is_widget_change=false" >> "$GITHUB_OUTPUT"
             echo "No widget files changed"
           fi
         env:
@@ -60,10 +60,10 @@ jobs:
           # Check for checked checkbox indicating docs/changelog update needed
           # Looks for: - [x] This PR requires docs/changelog update
           if printf '%s\n' "$PR_BODY" | grep -qiE -- '- \[[xX]\].*[Rr]equires (docs|changelog|documentation)'; then
-            echo "needs_docs_update=true" >> $GITHUB_OUTPUT
+            echo "needs_docs_update=true" >> "$GITHUB_OUTPUT"
             echo "PR indicates docs/changelog update is needed"
           else
-            echo "needs_docs_update=false" >> $GITHUB_OUTPUT
+            echo "needs_docs_update=false" >> "$GITHUB_OUTPUT"
             echo "No docs/changelog update needed (checkbox not checked)"
           fi
         env:

--- a/.github/workflows/docs-changelog-dispatch.yml
+++ b/.github/workflows/docs-changelog-dispatch.yml
@@ -26,7 +26,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout repository

--- a/.github/workflows/docs-changelog-dispatch.yml
+++ b/.github/workflows/docs-changelog-dispatch.yml
@@ -23,6 +23,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,6 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
@@ -43,5 +49,11 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,7 +22,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - uses: actions/checkout@v7
@@ -52,7 +52,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - id: deployment

--- a/.github/workflows/dora-report.yml
+++ b/.github/workflows/dora-report.yml
@@ -40,7 +40,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - uses: actions/checkout@v7

--- a/.github/workflows/dora-report.yml
+++ b/.github/workflows/dora-report.yml
@@ -37,6 +37,12 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v7
 
       - uses: astral-sh/setup-uv@v7

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -50,6 +50,12 @@ jobs:
           - 6379:6379
 
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v7
 
       - name: Set up Python

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -53,7 +53,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - uses: actions/checkout@v7

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -63,6 +63,12 @@ jobs:
       id-token: write
       contents: read
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
@@ -109,6 +115,12 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6.0.9
       - name: Use Node.js
@@ -129,6 +141,12 @@ jobs:
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -168,6 +186,12 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -188,6 +212,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v7
       - id: file_changes
         uses: trilom/file-changes-action@v1.2.4
@@ -224,6 +254,12 @@ jobs:
   check-uv-lock:
     runs-on: ubuntu-latest
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -261,6 +297,12 @@ jobs:
         ports:
           - 6379:6379
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -66,7 +66,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - uses: actions/checkout@v7
@@ -118,7 +118,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - uses: actions/checkout@v7
@@ -144,7 +144,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - uses: actions/checkout@v7
@@ -189,7 +189,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - uses: actions/checkout@v7
@@ -215,7 +215,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - uses: actions/checkout@v7
@@ -257,7 +257,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - uses: actions/checkout@v7
@@ -300,7 +300,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - uses: actions/checkout@v7

--- a/.github/workflows/publish_widget.yml
+++ b/.github/workflows/publish_widget.yml
@@ -13,6 +13,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v6.0.9

--- a/.github/workflows/publish_widget.yml
+++ b/.github/workflows/publish_widget.yml
@@ -16,7 +16,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - uses: actions/checkout@v7

--- a/.github/workflows/update-generated-files.yml
+++ b/.github/workflows/update-generated-files.yml
@@ -49,6 +49,12 @@ jobs:
         ports:
           - 6379:6379
     steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       # Push with a GitHub App token (not GITHUB_TOKEN) so the commit re-triggers CI.
       - name: Generate app token
         id: app-token

--- a/.github/workflows/update-generated-files.yml
+++ b/.github/workflows/update-generated-files.yml
@@ -52,7 +52,7 @@ jobs:
       # Audit only: records egress without blocking. Flip to `block` plus an
       # `allowed-endpoints` list once the recorded traffic looks stable.
       - name: Harden the runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       # Push with a GitHub App token (not GITHUB_TOKEN) so the commit re-triggers CI.

--- a/components/chat_widget/package.json
+++ b/components/chat_widget/package.json
@@ -39,8 +39,7 @@
     "@stencil/core": "^4.27.0",
     "dompurify": "^3.0.5",
     "js-cookie": "^3.0.5",
-    "marked": "^18.0.7",
-    "npmrc": "^1.1.1"
+    "marked": "^18.0.7"
   },
   "devDependencies": {
     "@stencil-community/postcss": "^2.2.0",

--- a/components/chat_widget/pnpm-lock.yaml
+++ b/components/chat_widget/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       marked:
         specifier: ^18.0.7
         version: 18.0.7
-      npmrc:
-        specifier: ^1.1.1
-        version: 1.1.1
     devDependencies:
       '@stencil-community/postcss':
         specifier: ^2.2.0
@@ -1430,10 +1427,6 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
-
-  npmrc@1.1.1:
-    resolution: {integrity: sha512-uBbR8YNnIvKhMCDyz27Ffvnm2bLntMesFcwiz6Yp0DYSQB+JqgM1MocewFwMlItKCex+1ytii/+vmLhigO1qhg==}
-    hasBin: true
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -3697,8 +3690,6 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
-
-  npmrc@1.1.1: {}
 
   nth-check@2.1.1:
     dependencies:

--- a/components/chat_widget/pnpm-workspace.yaml
+++ b/components/chat_widget/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+# See the root pnpm-workspace.yaml. The widget resolves against its own lockfile,
+# so it needs its own copy of the cooldown setting.
+minimumReleaseAge: 4320

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+# Supply-chain cooldown: refuse to resolve a version published less than 3 days
+# ago. Compromised releases are typically unpublished within hours, so a short
+# maturity window blocks automatic adoption of a malicious version without
+# meaningfully slowing normal dependency work.
+#
+# Only affects resolution (`pnpm add`, `pnpm update`, unfrozen `pnpm install`).
+# `pnpm install --frozen-lockfile` skips resolution and is unaffected.
+#
+# To take an urgent release inside the window, add it to minimumReleaseAgeExclude
+# (supports `pkg@version` and `@scope/*` patterns) rather than lowering the floor.
+minimumReleaseAge: 4320


### PR DESCRIPTION
### Product Description
No change.

### Technical Description
Applying the parts of a supply-chain review that are fixable in-repo. The threat model is the npm dropper pattern: a compromised maintainer account publishes a malicious version, CI installs it within minutes, and a lifecycle script runs the payload.

Install-script execution was already covered — pnpm 10 blocks dependency lifecycle scripts by default and both manifests carry explicit `onlyBuiltDependencies` allowlists — so this PR closes the remaining gaps:

**Release cooldown.** `minimumReleaseAge: 4320` (3 days) in `pnpm-workspace.yaml`, plus Dependabot `cooldown`. The two overlap deliberately: Dependabot only gates versions it opens PRs for, while `minimumReleaseAge` also catches transitive bumps that arrive silently through a resolution. Neither affects `--frozen-lockfile`, which skips resolution entirely — the gate applies at `pnpm add`/`update`, which is where a bad version would actually enter the lockfile. Dependabot cooldown does not apply to security updates, so advisory fixes still land immediately.

I confirmed pnpm honours the setting rather than ignoring an unknown key: under a deliberately absurd age floor it resolved `dompurify@0.8.2` instead of `3.4.13`. Both lockfiles are unchanged by adding the files.

**`npmrc` removal.** It sat in the widget's `dependencies` (not dev), so every consumer of the published package installed it, and nothing in `src` referenced it. `pnpm run build` still succeeds. The lockfile diff is a clean 9-line deletion with no collateral resolution churn.

**harden-runner, audit mode.** Added as the first step of all 26 jobs. Audit records outbound calls without blocking, which is what builds the traffic baseline needed before enforcing. Worth being explicit that this half enforces nothing on its own — #4117 tracks the switch to `block` with per-job `allowed-endpoints`, and expect those endpoint sets to differ sharply between the `claude*` workflows, `deploy.yml`, and `publish_widget.yml`.

`deploy.yml` uses 4-space step indentation unlike every other workflow, hence the one differently-indented insert.

Pinned `step-security/harden-runner` to a full commit SHA (`b09bb98e0...`, v2.20.1) rather than the mutable `@v2` tag, per review feedback — a security action is the best candidate to start SHA-pinning with.

### Out of scope
Three items from the same review need repo/org admin rather than a code change, tracked in #4118: tag and environment protection on the `w_v*` publish trigger, `enforce_admins: false` on `main`, and the empty `required_status_checks` that makes `strict: true` vacuous.

### Docs and Changelog
- [ ] This PR requires docs/changelog update
