### PR TITLE
Converge the dashboard and usage-API activity metrics on one set of definitions (#3905)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,13 +110,15 @@ ADRs live at `docs/adr/` and are rendered into the docs site under Architecture 
 
 Split decisions along the *independent supersession* axis: a choice you would revise on its own earns its own ADR; a choice that exists only as a forced consequence of a bigger decision (e.g. a stub library dictated by the type-checker you chose) is folded into that decision's ADR. Use `extends:` to link related-but-separate ADRs — relatedness alone is not a reason to split.
 
-**Source-doc lifecycle.** Design and spec docs (anywhere under `docs/`) carry a `status` frontmatter field:
+**Source-doc lifecycle.** Design and spec docs (anywhere under `docs/`, excluding `docs/adr/`) carry a `status` frontmatter field:
 
 - `active` — still evolving; ADR extraction is gated off.
 - `stable` — decisions are settled; safe to extract.
 - `extracted` — already crystallised into ADRs; the source doc is now an index or has been deleted.
 
 When you finish a design doc and ship the work, flip `status` from `active` to `stable`, then run the extraction skill.
+
+ADRs do not carry this field. They are the extraction output rather than a source, and record status with the pill defined in `docs/adr/_template.md`.
 
 **Extracting ADRs.** Use the `/extract-adrs <source-doc>` skill at `.claude/skills/extract-adrs/SKILL.md`. It walks you through identifying candidate decisions, drafting each ADR, wiring up cross-references, and updating `mkdocs.yml` plus `docs/adr/index.md`. The skill never commits — review the diff yourself.
 

--- a/apps/api/v2/usage/services.py
+++ b/apps/api/v2/usage/services.py
@@ -588,8 +588,9 @@ def _session_count(query: UsageQuery) -> int:
 
 
 def _active_participant_count(query: UsageQuery) -> int:
-    """Distinct participants *active* in the window - those with at least one
-    human/AI message in it, keyed off message activity (not session creation)."""
+    """Distinct participants *active* in the window - those who authored at
+    least one HUMAN message in it, keyed off message activity (not session
+    creation). Receiving AI output is not activity (ADR-0051)."""
     return usage_metrics.active_participants(
         query.team, start=query.start, end=query.end, filters=_usage_filters(query)
     )
@@ -601,8 +602,9 @@ def _message_counts(query: UsageQuery) -> MessageCounts:
 
 
 def _message_queryset(query: UsageQuery) -> QuerySet[ChatMessage]:
-    """The `messages` metric universe - every message type, evaluation
-    sessions included (apps.usage_metrics)."""
+    """The `messages` metric universe - every message type, with
+    evaluation-harness and SETUP-session activity excluded (apps.usage_metrics,
+    ADR-0051)."""
     return usage_metrics.messages_queryset(query.team, start=query.start, end=query.end, filters=_usage_filters(query))
 
 

--- a/apps/api/v2/usage/services.py
+++ b/apps/api/v2/usage/services.py
@@ -21,7 +21,6 @@ from django.db.models import Count, F, QuerySet
 from django.db.models.functions import TruncDate, TruncMonth, TruncWeek
 from django.utils import timezone
 
-from apps.channels.models import ChannelPlatform
 from apps.chat.models import ChatMessage
 from apps.cost_tracking.services import reporting
 from apps.experiments.models import Experiment, ExperimentSession, Participant
@@ -190,12 +189,11 @@ def _chatbot_entities(query: "UsageQuery") -> QuerySet:
 def _platform_entities(query: "UsageQuery") -> QuerySet:
     # Platform has no backing model, so return the distinct slugs present, ordered on the ``platform``
     # alias (which also clears ``ChatMessage``'s default ``created_at`` ordering, keeping ``.distinct()``
-    # one row per slug). ``evaluations`` is excluded to match the session metric's exclusion.
+    # one row per slug). Evaluation sessions are already out of the message universe (ADR-0051).
     return (
         _message_queryset(query)
         .exclude(chat__experiment_session__platform__isnull=True)
         .exclude(chat__experiment_session__platform="")
-        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
         .values(platform=F("chat__experiment_session__platform"))
         .distinct()
         .order_by("chat__experiment_session__platform")

--- a/apps/api/v2/usage/services.py
+++ b/apps/api/v2/usage/services.py
@@ -18,7 +18,6 @@ from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
 from django.db.models import Count, F, QuerySet
-from django.db.models.functions import TruncDate, TruncMonth, TruncWeek
 from django.utils import timezone
 
 from apps.chat.models import ChatMessage
@@ -27,7 +26,13 @@ from apps.experiments.models import Experiment, ExperimentSession, Participant
 from apps.teams.models import Team
 from apps.usage_metrics import metrics as usage_metrics
 from apps.usage_metrics.filters import UsageFilters
-from apps.usage_metrics.metrics import MESSAGE_ANNOTATIONS, MessageCounts, message_counts_from_row
+from apps.usage_metrics.metrics import (
+    GRANULARITY_TRUNC,
+    MESSAGE_ANNOTATIONS,
+    MessageCounts,
+    bucket_date,
+    message_counts_from_row,
+)
 
 # Metric identifiers. Later slices extend SUPPORTED_METRICS; the param serializer validates against it.
 METRIC_MESSAGES = "messages"
@@ -62,13 +67,9 @@ GROUP_BY_CHOICES = (GROUP_PARTICIPANT, GROUP_CHATBOT, GROUP_PLATFORM)
 # :func:`grouped_page_size_cap`.
 MAX_GROUPED_ROWS = 10_000
 
-# DB truncation per bucketed granularity (Django's TruncWeek starts weeks on Monday, matching the
-# Python-side bucket boundaries below).
-_TRUNC = {
-    GRANULARITY_DAILY: TruncDate,
-    GRANULARITY_WEEKLY: TruncWeek,
-    GRANULARITY_MONTHLY: TruncMonth,
-}
+# DB truncation per bucketed granularity lives in apps.usage_metrics
+# (GRANULARITY_TRUNC); Django's TruncWeek starts weeks on Monday, matching the
+# Python-side bucket boundaries below.
 _STEP = {
     GRANULARITY_DAILY: relativedelta(days=1),
     GRANULARITY_WEEKLY: relativedelta(weeks=1),
@@ -336,9 +337,10 @@ def grouped_page_size_cap(query: UsageQuery) -> int:
 
 def _bucket_key(bucket: datetime | None, tz: ZoneInfo):
     """The local calendar date keying a bucket in the metric index; ``None`` at ``total`` granularity.
-    Delegates to :func:`_bucket_date` so the Python-generated bucket starts and the DB truncation results
+    Delegates to :func:`~apps.usage_metrics.metrics.bucket_date` so the Python-generated bucket starts
+    and the DB truncation results
     normalise to their local date the same way (they must agree for the index and rows to join)."""
-    return None if bucket is None else _bucket_date(bucket, tz)
+    return None if bucket is None else bucket_date(bucket, tz)
 
 
 def _grouped_rows(queryset: QuerySet, *, group_field: str | None, trunc, tz: ZoneInfo, **annotations):
@@ -352,7 +354,7 @@ def _grouped_rows(queryset: QuerySet, *, group_field: str | None, trunc, tz: Zon
         value_fields.append("bucket")
     for row in queryset.values(*value_fields).annotate(**annotations):
         group_key = row[group_field] if group_field else None
-        bucket_key = _bucket_date(row["bucket"], tz) if trunc is not None else None
+        bucket_key = bucket_date(row["bucket"], tz) if trunc is not None else None
         yield group_key, bucket_key, row
 
 
@@ -377,7 +379,7 @@ def _grouped_non_cost_metric_rows(query: UsageQuery, keys: list) -> list:
     """``(metric, (group_key, bucket_key, value) iterator)`` for each requested non-cost metric, built
     conditionally so a metric's query only runs when asked for. Cost/tokens share one UsageRecord read
     and are filled separately by the caller."""
-    trunc = None if query.granularity == GRANULARITY_TOTAL else _TRUNC[query.granularity]
+    trunc = None if query.granularity == GRANULARITY_TOTAL else GRANULARITY_TRUNC[query.granularity]
     spec = _GROUP_SPECS[query.group_by]
 
     def by_group(queryset, group_field, **annotations):
@@ -431,7 +433,7 @@ def _fill_grouped_cost_tokens(query: UsageQuery, keys: list, index: dict) -> Non
         )
     )
     for row in rows:
-        bucket_key = None if granularity is None else _bucket_date(row["bucket"], query.tz)
+        bucket_key = None if granularity is None else bucket_date(row["bucket"], query.tz)
         cell = index.get((row["key"], bucket_key))
         if cell is None:
             continue
@@ -522,7 +524,7 @@ def _cost_tokens_by_bucket(query: UsageQuery) -> dict:
         filters=cost_filter.filters,
     )
     return {
-        _bucket_date(row["bucket"], query.tz): {
+        bucket_date(row["bucket"], query.tz): {
             "cost": CostBlock(total=row["cost"], currency=row["currency"]),
             "tokens": TokenCounts(prompt=row["prompt"], completion=row["completion"], total=row["total"]),
         }
@@ -665,14 +667,6 @@ def _truncate_local(dt: datetime, granularity: str) -> datetime:
     if granularity == GRANULARITY_WEEKLY:
         return midnight - timedelta(days=midnight.weekday())  # Monday, matching Django's TruncWeek
     return midnight.replace(day=1)  # monthly
-
-
-def _bucket_date(value, tz: ZoneInfo):
-    """Normalise a DB truncation result to its local calendar date. ``TruncDate`` yields a ``date``
-    already; ``TruncWeek``/``TruncMonth`` yield a datetime whose local date is the bucket boundary."""
-    if isinstance(value, datetime):
-        return value.astimezone(tz).date()
-    return value
 
 
 def _month_bounds(period: str, tz: ZoneInfo) -> tuple[datetime, datetime]:

--- a/apps/api/v2/usage/tests/test_usage_sessions_participants.py
+++ b/apps/api/v2/usage/tests/test_usage_sessions_participants.py
@@ -88,7 +88,7 @@ def test_sessions_and_participants_use_different_windows():
 @pytest.mark.django_db()
 def test_participants_excludes_system_only_activity():
     """A participant whose only message is an internal ``system`` message is not "active": the
-    ``participants`` metric counts the same human/AI categories the ``messages`` metric surfaces."""
+    ``participants`` metric counts distinct authors of a ``HUMAN`` message only."""
     team = TeamWithUsersFactory.create()
     user = team.members.first()
     session = ExperimentSessionFactory.create(team=team)

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -9,16 +9,14 @@ from datetime import datetime
 from decimal import Decimal
 from zoneinfo import ZoneInfo
 
-from django.contrib.contenttypes.models import ContentType
-from django.db.models import Count, DecimalField, Exists, F, OuterRef, Q, Subquery, Sum
+from django.db.models import Count, DecimalField, F, Q, Sum
 from django.db.models.functions import Coalesce, TruncDate, TruncMonth, TruncWeek
 
-from apps.annotations.models import CustomTaggedItem
-from apps.chat.models import Chat, ChatMessage
 from apps.cost_tracking.models import Confidence, ServiceKind, UsageRecord, UsageSource
 from apps.experiments.models import ExperimentSession
 from apps.teams.models import Team
 from apps.trace.models import Trace
+from apps.usage_metrics.filters import chat_tag_exists_pair
 
 logger = logging.getLogger("ocs.cost_tracking")
 
@@ -206,29 +204,9 @@ def _scoped_records(team: Team, filters: CostFilters | None = None):
     if filters.platform_names:
         qs = qs.filter(session__platform__in=filters.platform_names)
     if filters.tag_ids:
-        # Exists() rather than join+distinct, matching the dashboard's tag filter.
-        chat_content_type = ContentType.objects.get_for_model(Chat)
-        message_content_type = ContentType.objects.get_for_model(ChatMessage)
-        tag_on_chat = Exists(
-            CustomTaggedItem.objects.filter(
-                team_id=team.id,
-                tag__team_id=team.id,
-                content_type=chat_content_type,
-                object_id=OuterRef("session__chat_id"),
-                tag_id__in=filters.tag_ids,
-            )
-        )
-        tag_on_msg = Exists(
-            CustomTaggedItem.objects.filter(
-                team_id=team.id,
-                tag__team_id=team.id,
-                content_type=message_content_type,
-                object_id__in=Subquery(
-                    ChatMessage.objects.filter(chat=OuterRef(OuterRef("session__chat_id"))).values("id")
-                ),
-                tag_id__in=filters.tag_ids,
-            )
-        )
+        # The same chat-or-message match as the dashboard's tag filter, from
+        # its single definition in apps.usage_metrics.
+        tag_on_chat, tag_on_msg = chat_tag_exists_pair(team, filters.tag_ids, "session__chat_id")
         qs = qs.annotate(_tag_on_chat=tag_on_chat, _tag_on_msg=tag_on_msg).filter(
             Q(_tag_on_chat=True) | Q(_tag_on_msg=True)
         )

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -259,25 +259,33 @@ def cost_summary(team: Team, *, start: datetime, end: datetime, filters: CostFil
     period_q = Q(timestamp__gte=start, timestamp__lt=end)
     previous_q = Q(timestamp__gte=previous_start, timestamp__lt=start)
 
-    agg = _scoped_records(team, filters).aggregate(
-        total=Coalesce(Sum("cost", filter=period_q), _ZERO, output_field=_COST_FIELD),
-        previous=Coalesce(Sum("cost", filter=previous_q), _ZERO, output_field=_COST_FIELD),
-        exact=Coalesce(
-            Sum("cost", filter=period_q & Q(confidence=Confidence.EXACT)),
-            _ZERO,
-            output_field=_COST_FIELD,
-        ),
-        estimated=Coalesce(
-            Sum("cost", filter=period_q & Q(confidence=Confidence.ESTIMATED)),
-            _ZERO,
-            output_field=_COST_FIELD,
-        ),
-        unknown_rows=Count("id", filter=period_q & Q(confidence=Confidence.UNKNOWN)),
-        # Rows that got recorded but the resolver couldn't price (no matching
-        # PricingRule). Excludes UNKNOWN-confidence rows because those have
-        # their own counter. Distinct row counter, not a sum - these rows
-        # contribute $0 to total_cost.
-        unpriced_rows=Count("id", filter=period_q & Q(pricing_rule__isnull=True) & ~Q(confidence=Confidence.UNKNOWN)),
+    # Bound the scan to the two periods the aggregates below actually read.
+    # Without it this scans the team's whole UsageRecord history on every load.
+    agg = (
+        _scoped_records(team, filters)
+        .filter(timestamp__gte=previous_start, timestamp__lt=end)
+        .aggregate(
+            total=Coalesce(Sum("cost", filter=period_q), _ZERO, output_field=_COST_FIELD),
+            previous=Coalesce(Sum("cost", filter=previous_q), _ZERO, output_field=_COST_FIELD),
+            exact=Coalesce(
+                Sum("cost", filter=period_q & Q(confidence=Confidence.EXACT)),
+                _ZERO,
+                output_field=_COST_FIELD,
+            ),
+            estimated=Coalesce(
+                Sum("cost", filter=period_q & Q(confidence=Confidence.ESTIMATED)),
+                _ZERO,
+                output_field=_COST_FIELD,
+            ),
+            unknown_rows=Count("id", filter=period_q & Q(confidence=Confidence.UNKNOWN)),
+            # Rows that got recorded but the resolver couldn't price (no matching
+            # PricingRule). Excludes UNKNOWN-confidence rows because those have
+            # their own counter. Distinct row counter, not a sum - these rows
+            # contribute $0 to total_cost.
+            unpriced_rows=Count(
+                "id", filter=period_q & Q(pricing_rule__isnull=True) & ~Q(confidence=Confidence.UNKNOWN)
+            ),
+        )
     )
 
     return CostSummary(

--- a/apps/cost_tracking/tests/test_reporting_filters.py
+++ b/apps/cost_tracking/tests/test_reporting_filters.py
@@ -295,6 +295,24 @@ class TestCostFilters:
 
 
 @pytest.mark.django_db()
+class TestCostSummaryWindowBound:
+    """`cost_summary` reads [previous_start, end) and nothing else. The bound is
+    on the queryset, not only inside the conditional aggregates, so the scan
+    does not grow with the team's whole history (#3905)."""
+
+    def test_records_far_outside_the_window_do_not_widen_the_scan(self, team):
+        start = _NOW - timedelta(days=7)
+        end = _NOW
+        _usage(team, cost="1.00", when=start + timedelta(days=1))
+        _usage(team, cost="99.00", when=start - timedelta(days=400))
+
+        summary = cost_summary(team, start=start, end=end)
+
+        assert summary.total_cost == Decimal("1.00")
+        assert summary.previous_period_cost == Decimal("0.00")
+
+
+@pytest.mark.django_db()
 class TestEvaluationSourceRule:
     """ADR-0048: evaluation spend is the team's spend, never a chatbot's, a
     participant's or a conversation's.

--- a/apps/cost_tracking/tests/test_reporting_filters.py
+++ b/apps/cost_tracking/tests/test_reporting_filters.py
@@ -169,7 +169,9 @@ class TestCostFilters:
     def test_tag_filter_ignores_other_teams_tag_links(self):
         """Filtering by a foreign team's tag id matches nothing: the outer
         queryset is team-scoped, and a generic tag link only references the
-        chat it was created for, so it can never point at this team's chats."""
+        chat it was created for, so it can never point at this team's chats.
+        Separate from the conjunct case list below: the target here is
+        foreign, so this pins outer-queryset scoping, not a link conjunct."""
         team = TeamFactory.create()
         other_team = TeamFactory.create()
         other_exp = ExperimentFactory.create(team=other_team)
@@ -185,71 +187,33 @@ class TestCostFilters:
 
         assert summary.total_cost == Decimal(0)
 
-    def test_tag_filter_ignores_cross_team_tag_links(self):
-        """The inconsistent-link shape: a CustomTaggedItem row carrying a
-        FOREIGN team_id whose tag is a local tag and whose object_id targets a
-        local chat. The link is not the reading team's, so it must not pull
-        the record into a tag-filtered read."""
+    @pytest.mark.parametrize(
+        ("failing_conjunct", "target"),
+        [
+            pytest.param("link-team", "chat", id="link-team-conjunct-on-chat"),
+            pytest.param("tag-team", "chat", id="tag-team-conjunct-on-chat"),
+            pytest.param("tag-team", "msg", id="tag-team-conjunct-on-msg"),
+            pytest.param("link-team", "msg", id="link-team-conjunct-on-msg"),
+        ],
+    )
+    def test_tag_filter_rejects_links_failing_one_scoping_conjunct(self, failing_conjunct, target):
+        """`chat_tag_exists_pair` scopes tag links with two conjuncts,
+        `team_id` and `tag__team_id`, applied on each of its two legs
+        (`tag_on_chat`, `tag_on_msg`). Each case builds a link where exactly
+        one conjunct fails on one leg while the other three predicates hold,
+        so deleting any one predicate turns exactly its named case red. Each
+        leg filters on its own content_type, which keeps the mapping 1:1 - a
+        chat-targeted link never reaches `tag_on_msg`, and vice versa.
+        Positive controls: `test_cost_summary_filters_by_tag_on_chat` /
+        `_on_message`."""
         team = TeamFactory.create()
         foreign_team = TeamFactory.create()
         exp = ExperimentFactory.create(team=team)
         session = ExperimentSessionFactory.create(team=team, experiment=exp)
-        tag = TagFactory.create(team=team)
-        CustomTaggedItemFactory.create(team=foreign_team, tag=tag, target=session.chat)
-        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=exp, session=session)
-
-        summary = cost_summary(team, start=_START, end=_NOW, filters=CostFilters(tag_ids=[tag.id]))
-
-        assert summary.total_cost == Decimal(0)
-
-    def test_tag_filter_ignores_locally_recorded_link_with_foreign_team_tag_on_chat(self):
-        """The mirror inconsistent-link shape: a CustomTaggedItem row with a
-        LOCAL team_id, whose tag belongs to a FOREIGN team, targeting the
-        session's chat. The tag isn't the reading team's, so it must not
-        pull the record into a tag-filtered read."""
-        team = TeamFactory.create()
-        foreign_team = TeamFactory.create()
-        exp = ExperimentFactory.create(team=team)
-        session = ExperimentSessionFactory.create(team=team, experiment=exp)
-        foreign_tag = TagFactory.create(team=foreign_team)
-        CustomTaggedItemFactory.create(team=team, tag=foreign_tag, target=session.chat)
-        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=exp, session=session)
-
-        summary = cost_summary(team, start=_START, end=_NOW, filters=CostFilters(tag_ids=[foreign_tag.id]))
-
-        assert summary.total_cost == Decimal(0)
-
-    def test_tag_filter_ignores_locally_recorded_link_with_foreign_team_tag_on_message(self):
-        """Same mirror shape as above, but the link targets a MESSAGE on the
-        session's chat rather than the chat itself - exercises `tag_on_msg`,
-        which a chat-targeted tag never reaches."""
-        team = TeamFactory.create()
-        foreign_team = TeamFactory.create()
-        exp = ExperimentFactory.create(team=team)
-        session = ExperimentSessionFactory.create(team=team, experiment=exp)
-        message = ChatMessageFactory.create(chat=session.chat)
-        foreign_tag = TagFactory.create(team=foreign_team)
-        CustomTaggedItemFactory.create(team=team, tag=foreign_tag, target=message)
-        _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=exp, session=session)
-
-        summary = cost_summary(team, start=_START, end=_NOW, filters=CostFilters(tag_ids=[foreign_tag.id]))
-
-        assert summary.total_cost == Decimal(0)
-
-    def test_tag_filter_ignores_foreign_team_link_with_local_tag_on_message(self):
-        """The remaining inconsistent-link shape: a CustomTaggedItem row with
-        a FOREIGN team_id, whose tag IS local, attached to a MESSAGE rather
-        than the chat - exercises `tag_on_msg` in `_scoped_records`
-        specifically. `test_tag_filter_ignores_cross_team_tag_links` targets
-        the chat and never reaches it. The positive control for a local link
-        on a message is `test_cost_summary_filters_by_tag_on_message` above."""
-        team = TeamFactory.create()
-        foreign_team = TeamFactory.create()
-        exp = ExperimentFactory.create(team=team)
-        session = ExperimentSessionFactory.create(team=team, experiment=exp)
-        tag = TagFactory.create(team=team)
-        message = ChatMessageFactory.create(chat=session.chat)
-        CustomTaggedItemFactory.create(team=foreign_team, tag=tag, target=message)
+        link_team = foreign_team if failing_conjunct == "link-team" else team
+        tag = TagFactory.create(team=foreign_team if failing_conjunct == "tag-team" else team)
+        link_target = ChatMessageFactory.create(chat=session.chat) if target == "msg" else session.chat
+        CustomTaggedItemFactory.create(team=link_team, tag=tag, target=link_target)
         _usage(team, cost="1.00", when=_NOW - timedelta(days=1), experiment=exp, session=session)
 
         summary = cost_summary(team, start=_START, end=_NOW, filters=CostFilters(tag_ids=[tag.id]))

--- a/apps/cost_tracking/tests/test_reporting_filters.py
+++ b/apps/cost_tracking/tests/test_reporting_filters.py
@@ -296,20 +296,22 @@ class TestCostFilters:
 
 @pytest.mark.django_db()
 class TestCostSummaryWindowBound:
-    """`cost_summary` reads [previous_start, end) and nothing else. The bound is
-    on the queryset, not only inside the conditional aggregates, so the scan
-    does not grow with the team's whole history (#3905)."""
+    """`cost_summary` reads exactly [previous_start, end): a record in the current
+    period lands in `total_cost`, a record in the prior period lands in
+    `previous_period_cost`, and a record far outside both lands in neither. This
+    pins the values a queryset-level bound must preserve (#3905)."""
 
-    def test_records_far_outside_the_window_do_not_widen_the_scan(self, team):
+    def test_reads_exactly_the_current_and_previous_periods(self, team):
         start = _NOW - timedelta(days=7)
         end = _NOW
         _usage(team, cost="1.00", when=start + timedelta(days=1))
+        _usage(team, cost="2.00", when=start - timedelta(days=3))
         _usage(team, cost="99.00", when=start - timedelta(days=400))
 
         summary = cost_summary(team, start=start, end=end)
 
         assert summary.total_cost == Decimal("1.00")
-        assert summary.previous_period_cost == Decimal("0.00")
+        assert summary.previous_period_cost == Decimal("2.00")
 
 
 @pytest.mark.django_db()

--- a/apps/dashboard/forms.py
+++ b/apps/dashboard/forms.py
@@ -147,9 +147,11 @@ class DashboardFilterForm(forms.Form):
             )
 
         if data.get("end_date"):
-            # Convert to datetime for filtering (end of day)
+            # Half-open [start, end) to match the querysets (ADR-0051): the selected
+            # end date stays fully included by windowing up to the start of the
+            # following day, exclusive.
             params["end_date"] = timezone.make_aware(
-                timezone.datetime.combine(data["end_date"], timezone.datetime.max.time())
+                timezone.datetime.combine(data["end_date"] + timedelta(days=1), timezone.datetime.min.time())
             )
 
         if data.get("experiments"):

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -13,8 +13,9 @@ from apps.annotations.models import CustomTaggedItem, TagCategories
 from apps.channels.models import ExperimentChannel
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.cost_tracking.services.reporting import CostFilters, costs_by_experiment
+from apps.experiments.models import SessionStatus
 from apps.usage_metrics.dashboard_querysets import filtered_querysets
-from apps.usage_metrics.metrics import CONVERSATION_MESSAGE_TYPES, conversation_message_total
+from apps.usage_metrics.metrics import CONVERSATION_MESSAGE_TYPES, conversation_message_total, conversation_messages
 
 from ..trace.models import Trace
 from .models import DashboardCache
@@ -105,7 +106,11 @@ class DashboardService:
             return cached_data
 
         querysets = self.get_filtered_queryset_base(**filters)
-        messages = querysets["messages"]
+        # Conversation turns only, SETUP sessions excluded, so each period's
+        # session count is `sessions_active` restricted to that period (ADR-0051).
+        messages = conversation_messages(querysets["messages"]).exclude(
+            chat__experiment_session__status=SessionStatus.SETUP
+        )
 
         trunc_func = self._get_trunc_function(granularity)
 

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -314,7 +314,7 @@ class DashboardService:
 
         # Get participant engagement stats
         date_filter = Q(experimentsession__chat__messages__created_at__gte=querysets["start_date"]) & Q(
-            experimentsession__chat__messages__created_at__lte=querysets["end_date"]
+            experimentsession__chat__messages__created_at__lt=querysets["end_date"]
         )
 
         participant_stats = (

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -241,6 +241,14 @@ class DashboardService:
     def _compute_bot_performance(self, cache_filters: dict, include_cost: bool) -> list[dict[str, Any]]:
         """Build the (uncached, unordered) per-experiment performance rows."""
         querysets = self.get_filtered_queryset_base(**cache_filters)
+        # Conversation turns inside the window, so this column agrees with the
+        # headline message total rather than counting each chat's whole history
+        # (ADR-0051).
+        in_window_turns = Q(
+            chat__messages__message_type__in=CONVERSATION_MESSAGE_TYPES,
+            chat__messages__created_at__gte=querysets["start_date"],
+            chat__messages__created_at__lt=querysets["end_date"],
+        )
         # Pre-compute session stats.
         # The alternative for better performance would be to use a raw SQL Query
         session_stats = (
@@ -250,7 +258,7 @@ class DashboardService:
             .annotate(
                 participants_count=Count("participant", distinct=True),
                 sessions_count=Count("id", distinct=True),
-                messages_count=Count("chat__messages", distinct=True),
+                messages_count=Count("chat__messages", distinct=True, filter=in_window_turns),
             )
         )
         stats_dict = {stat["experiment_id"]: stat for stat in session_stats}

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -14,6 +14,7 @@ from apps.channels.models import ExperimentChannel
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.cost_tracking.services.reporting import CostFilters, costs_by_experiment
 from apps.usage_metrics.dashboard_querysets import filtered_querysets
+from apps.usage_metrics.metrics import CONVERSATION_MESSAGE_TYPES, conversation_message_total
 
 from ..trace.models import Trace
 from .models import DashboardCache
@@ -147,7 +148,7 @@ class DashboardService:
             .annotate(
                 human_messages=Count("id", filter=Q(message_type=ChatMessageType.HUMAN)),
                 ai_messages=Count("id", filter=Q(message_type=ChatMessageType.AI)),
-                total_messages=Count("id"),
+                total_messages=Count("id", filter=Q(message_type__in=CONVERSATION_MESSAGE_TYPES)),
             )
             .order_by("period")
         )
@@ -557,7 +558,7 @@ class DashboardService:
             "total_experiments": querysets["experiments"].count(),
             "total_participants": querysets["participants"].count(),
             "total_sessions": querysets["sessions"].count(),
-            "total_messages": querysets["messages"].count(),
+            "total_messages": conversation_message_total(querysets["messages"]),
             "active_experiments": querysets["experiments"]
             .filter(sessions__in=querysets["sessions"])
             .distinct()

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -1,6 +1,6 @@
 import hashlib
 import json
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any
 
 from django.contrib.contenttypes.models import ContentType
@@ -50,29 +50,12 @@ class DashboardService:
     def __init__(self, team):
         self.team = team
 
-    def get_filtered_queryset_base(
-        self,
-        start_date: datetime | None = None,
-        end_date: datetime | None = None,
-        experiment_ids: list[int] | None = None,
-        platform_names: list[str] | None = None,
-        participant_ids: list[int] | None = None,
-        tag_ids: list[int] | None = None,
-        include_archived: bool = False,
-    ) -> dict[str, Any]:
+    def get_filtered_queryset_base(self, **filters) -> dict[str, Any]:
         """Base querysets with common filters applied. The builder lives in
-        apps.usage_metrics (#3905); this delegation keeps the service API
-        stable for the dashboard's charts and tests."""
-        return filtered_querysets(
-            self.team,
-            start_date=start_date,
-            end_date=end_date,
-            experiment_ids=experiment_ids,
-            platform_names=platform_names,
-            participant_ids=participant_ids,
-            tag_ids=tag_ids,
-            include_archived=include_archived,
-        )
+        apps.usage_metrics (#3905) and owns the filter signature - see
+        `filtered_querysets` for the accepted keywords; this delegation keeps
+        the service API stable for the dashboard's charts and tests."""
+        return filtered_querysets(self.team, **filters)
 
     def get_active_participants_data(self, granularity: str = "daily", **filters) -> list[dict[str, Any]]:
         """Get active participants chart data"""

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -556,7 +556,8 @@ class DashboardService:
             "last_activity": participant.last_activity.isoformat() if participant.last_activity else None,
         }
 
-    def _cache_key(self, filters: dict) -> str:
+    @staticmethod
+    def _cache_key(filters: dict) -> str:
         def normalize(obj):
             if isinstance(obj, dict):
                 return {k: normalize(obj[k]) for k in sorted(obj)}

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -13,6 +13,7 @@ from apps.annotations.models import CustomTaggedItem, TagCategories
 from apps.channels.models import ExperimentChannel
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.cost_tracking.services.reporting import CostFilters, costs_by_experiment
+from apps.experiments.models import Participant
 from apps.usage_metrics.dashboard_querysets import filtered_querysets
 from apps.usage_metrics.filters import HUMAN_AUTHORED
 from apps.usage_metrics.metrics import (
@@ -319,28 +320,35 @@ class DashboardService:
             return cached_data
 
         querysets = self.get_filtered_queryset_base(**filters)
-        participants = querysets["participants"]
 
-        # Get participant engagement stats
-        date_filter = Q(experimentsession__chat__messages__created_at__gte=querysets["start_date"]) & Q(
-            experimentsession__chat__messages__created_at__lt=querysets["end_date"]
-        )
-
-        participant_stats = (
-            participants.annotate(
-                total_messages=Count(
-                    "experimentsession__chat__messages",
-                    filter=Q(experimentsession__chat__messages__message_type=ChatMessageType.HUMAN) & date_filter,
-                ),
-                total_sessions=Count("experimentsession", filter=date_filter, distinct=True),
-                last_activity=Max("experimentsession__last_activity_at"),
+        # Aggregate forward from the canonical message queryset, the same way
+        # `get_active_participants_data` does. Annotating the participant
+        # queryset instead re-enters ExperimentSession from the far side, which
+        # carries none of the SETUP, evaluation or tag exclusions the rest of
+        # the page counts by (ADR-0051).
+        participant_field = "chat__experiment_session__participant"
+        participant_stats = list(
+            querysets["messages"]
+            .filter(HUMAN_AUTHORED)
+            .filter(**{f"{participant_field}__isnull": False})
+            .values(participant_field)
+            .annotate(
+                total_messages=Count("id"),
+                total_sessions=Count("chat__experiment_session", distinct=True),
+                last_activity=Max("created_at"),
             )
-            .filter(total_messages__gt=0)
-            .order_by("-total_messages")
+            .order_by("-total_messages")[:limit]
         )
 
         # Most active participants
-        most_active = [self._format_participant_data(p) for p in participant_stats[:limit]]
+        participants = Participant.objects.filter(team=self.team).in_bulk(
+            [stats[participant_field] for stats in participant_stats]
+        )
+        most_active = [
+            self._format_participant_data(participants[stats[participant_field]], stats)
+            for stats in participant_stats
+            if stats[participant_field] in participants
+        ]
 
         # Session length distribution
         session_lengths = (
@@ -525,8 +533,10 @@ class DashboardService:
         """Format a period object to ISO string"""
         return period.isoformat() if hasattr(period, "isoformat") else str(period)
 
-    def _format_participant_data(self, participant) -> dict[str, Any]:
-        """Format participant data for engagement analysis"""
+    def _format_participant_data(self, participant, stats: dict) -> dict[str, Any]:
+        """Format participant data for engagement analysis. `stats` is one
+        aggregate row keyed on the participant, not annotations on the
+        participant itself."""
         participant_url = reverse(
             "participants:single-participant-home",
             kwargs={"team_slug": self.team.slug, "participant_id": participant.id},
@@ -535,9 +545,9 @@ class DashboardService:
             "participant_id": participant.id,
             "participant_name": participant.name or participant.identifier,
             "participant_url": participant_url,
-            "total_messages": participant.total_messages,
-            "total_sessions": participant.total_sessions,
-            "last_activity": participant.last_activity.isoformat() if participant.last_activity else None,
+            "total_messages": stats["total_messages"],
+            "total_sessions": stats["total_sessions"],
+            "last_activity": stats["last_activity"].isoformat() if stats["last_activity"] else None,
         }
 
     @staticmethod

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -15,7 +15,12 @@ from apps.chat.models import ChatMessage, ChatMessageType
 from apps.cost_tracking.services.reporting import CostFilters, costs_by_experiment
 from apps.experiments.models import SessionStatus
 from apps.usage_metrics.dashboard_querysets import filtered_querysets
-from apps.usage_metrics.metrics import CONVERSATION_MESSAGE_TYPES, conversation_message_total, conversation_messages
+from apps.usage_metrics.metrics import (
+    CONVERSATION_MESSAGE_TYPES,
+    conversation_message_total,
+    conversation_messages,
+    distinct_active_participants,
+)
 
 from ..trace.models import Trace
 from .models import DashboardCache
@@ -120,7 +125,11 @@ class DashboardService:
             .values("period")
             .annotate(
                 total_sessions=Count("chat__experiment_session", distinct=True),
-                unique_participants=Count("chat__experiment_session__participant", distinct=True),
+                unique_participants=Count(
+                    "chat__experiment_session__participant",
+                    distinct=True,
+                    filter=Q(message_type=ChatMessageType.HUMAN),
+                ),
             )
             .order_by("period")
         )
@@ -568,7 +577,7 @@ class DashboardService:
             .filter(sessions__in=querysets["sessions"])
             .distinct()
             .count(),
-            "active_participants": querysets["sessions"].values("participant").distinct().count(),
+            "active_participants": distinct_active_participants(querysets["messages"]),
             "completed_sessions": querysets["sessions"].filter(ended_at__isnull=False).count(),
         }
 

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -14,6 +14,7 @@ from apps.channels.models import ExperimentChannel
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.cost_tracking.services.reporting import CostFilters, costs_by_experiment
 from apps.usage_metrics.dashboard_querysets import filtered_querysets
+from apps.usage_metrics.filters import HUMAN_AUTHORED
 from apps.usage_metrics.metrics import (
     CONVERSATION_MESSAGE_TYPES,
     conversation_message_total,
@@ -130,7 +131,7 @@ class DashboardService:
                 unique_participants=Count(
                     "chat__experiment_session__participant",
                     distinct=True,
-                    filter=Q(message_type=ChatMessageType.HUMAN),
+                    filter=HUMAN_AUTHORED,
                 ),
             )
             .order_by("period")

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -58,6 +58,7 @@ class DashboardService:
         platform_names: list[str] | None = None,
         participant_ids: list[int] | None = None,
         tag_ids: list[int] | None = None,
+        include_archived: bool = False,
     ) -> dict[str, Any]:
         """Base querysets with common filters applied. The builder lives in
         apps.usage_metrics (#3905); this delegation keeps the service API
@@ -70,6 +71,7 @@ class DashboardService:
             platform_names=platform_names,
             participant_ids=participant_ids,
             tag_ids=tag_ids,
+            include_archived=include_archived,
         )
 
     def get_active_participants_data(self, granularity: str = "daily", **filters) -> list[dict[str, Any]]:

--- a/apps/dashboard/services.py
+++ b/apps/dashboard/services.py
@@ -13,7 +13,6 @@ from apps.annotations.models import CustomTaggedItem, TagCategories
 from apps.channels.models import ExperimentChannel
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.cost_tracking.services.reporting import CostFilters, costs_by_experiment
-from apps.experiments.models import SessionStatus
 from apps.usage_metrics.dashboard_querysets import filtered_querysets
 from apps.usage_metrics.metrics import (
     CONVERSATION_MESSAGE_TYPES,
@@ -113,11 +112,12 @@ class DashboardService:
             return cached_data
 
         querysets = self.get_filtered_queryset_base(**filters)
-        # Conversation turns only, SETUP sessions excluded, so each period's
-        # session count is `sessions_active` restricted to that period (ADR-0051).
-        messages = conversation_messages(querysets["messages"]).exclude(
-            chat__experiment_session__status=SessionStatus.SETUP
-        )
+        # Conversation turns only, so each period's session count is
+        # `sessions_active` restricted to that period and each period's
+        # participant count is `active_participants` restricted to it
+        # (ADR-0051). SETUP-session activity is already out of
+        # `querysets["messages"]`.
+        messages = conversation_messages(querysets["messages"])
 
         trunc_func = self._get_trunc_function(granularity)
 

--- a/apps/dashboard/tests/test_cost_tracking_panel.py
+++ b/apps/dashboard/tests/test_cost_tracking_panel.py
@@ -4,6 +4,8 @@ from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from time_machine import travel
 
@@ -295,3 +297,48 @@ class TestBotPerformanceCostColumns:
 
         row = next(r for r in response.json()["results"] if r["experiment_id"] == experiment.id)
         assert row["cost"] == 1.0
+
+
+@pytest.mark.django_db()
+class TestCostPanelCaching:
+    """The cost panel's three reads are cached like every other dashboard
+    metric, accepting the same up-to-30-minutes staleness (#3905)."""
+
+    def _url(self, team):
+        return reverse("dashboard:index", kwargs={"team_slug": team.slug})
+
+    def test_summary_is_served_from_cache_on_the_second_read(self, authenticated_client, team):
+        _enable_flag_for(team)
+        url = self._url(team)
+
+        authenticated_client.get(url)
+        with CaptureQueriesContext(connection) as captured:
+            second = authenticated_client.get(url)
+
+        assert second.status_code == 200
+        summary_queries = [q for q in captured.captured_queries if "usagerecord" in q["sql"].lower()]
+        assert summary_queries == []
+
+    def test_cached_summary_round_trips_its_decimals(self, authenticated_client, team):
+        _enable_flag_for(team)
+        _usage(team, cost="1.23", when=_NOW - timedelta(days=1))
+        url = self._url(team)
+
+        authenticated_client.get(url)
+        response = authenticated_client.get(url)
+
+        summary = response.context["cost_summary"]
+        assert summary.total_cost == Decimal("1.23")
+        assert isinstance(summary.total_cost, Decimal)
+
+    def test_a_different_filter_gets_its_own_cache_entry(self, authenticated_client, team):
+        _enable_flag_for(team)
+        _usage(team, cost="1.23", when=_NOW - timedelta(days=1))
+        experiment = ExperimentFactory.create(team=team)
+        url = self._url(team)
+
+        unfiltered = authenticated_client.get(url).context["cost_summary"]
+        filtered = authenticated_client.get(url, {"experiments": [experiment.id]}).context["cost_summary"]
+
+        assert unfiltered.total_cost == Decimal("1.23")
+        assert filtered.total_cost == Decimal("0.00")

--- a/apps/dashboard/tests/test_cost_tracking_panel.py
+++ b/apps/dashboard/tests/test_cost_tracking_panel.py
@@ -344,21 +344,37 @@ class TestCostPanelCaching:
         assert unfiltered.total_cost == Decimal("1.23")
         assert filtered.total_cost == Decimal("0.00")
 
-    def test_a_stale_cache_shape_recomputes_instead_of_erroring(self, authenticated_client, team):
+    @pytest.mark.parametrize(
+        ("cache_key_prefix", "corrupt"),
+        [
+            pytest.param("cost_", lambda payload: {"written_by": "older code"}, id="unrecognised-shape"),
+            pytest.param("cost_summary", lambda payload: payload | {"total_cost": ""}, id="unparseable-decimal"),
+            pytest.param(
+                "cost_summary", lambda payload: payload | {"period_start": "not-a-timestamp"}, id="unparseable-date"
+            ),
+        ],
+    )
+    def test_a_stale_cache_shape_recomputes_instead_of_erroring(
+        self, authenticated_client, team, cache_key_prefix, corrupt
+    ):
         """A deploy can change the cached payload's shape while entries written
         by the previous code are still inside their TTL. Decoding must fall
         back to recomputing (and overwriting the entry), never surface the
-        KeyError/TypeError to the page."""
+        decode failure to the page or hand the panel a half-built summary."""
         _enable_flag_for(team)
         _usage(team, cost="1.23", when=_NOW - timedelta(days=1))
         url = self._url(team)
 
         authenticated_client.get(url)
-        DashboardCache.objects.filter(cache_key__startswith="cost_").update(data={"written_by": "older code"})
+        for entry in DashboardCache.objects.filter(cache_key__startswith=cache_key_prefix):
+            entry.data = corrupt(entry.data)
+            entry.save()
         response = authenticated_client.get(url)
 
         assert response.status_code == 200
-        assert response.context["cost_summary"].total_cost == Decimal("1.23")
+        summary = response.context["cost_summary"]
+        assert summary.total_cost == Decimal("1.23")
+        assert summary.period_start is not None
 
     def test_an_unknown_granularity_shares_the_daily_cache_entry(self, authenticated_client, team):
         """The timeseries cache key folds in the granularity, which arrives

--- a/apps/dashboard/tests/test_cost_tracking_panel.py
+++ b/apps/dashboard/tests/test_cost_tracking_panel.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from time_machine import travel
 
 from apps.cost_tracking.models import Confidence, UsageSource
+from apps.dashboard.models import DashboardCache
 from apps.teams.models import Flag
 from apps.utils.factories.annotations import CustomTaggedItemFactory, TagFactory
 from apps.utils.factories.cost_tracking import UsageRecordFactory
@@ -342,3 +343,36 @@ class TestCostPanelCaching:
 
         assert unfiltered.total_cost == Decimal("1.23")
         assert filtered.total_cost == Decimal("0.00")
+
+    def test_a_stale_cache_shape_recomputes_instead_of_erroring(self, authenticated_client, team):
+        """A deploy can change the cached payload's shape while entries written
+        by the previous code are still inside their TTL. Decoding must fall
+        back to recomputing (and overwriting the entry), never surface the
+        KeyError/TypeError to the page."""
+        _enable_flag_for(team)
+        _usage(team, cost="1.23", when=_NOW - timedelta(days=1))
+        url = self._url(team)
+
+        authenticated_client.get(url)
+        DashboardCache.objects.filter(cache_key__startswith="cost_").update(data={"written_by": "older code"})
+        response = authenticated_client.get(url)
+
+        assert response.status_code == 200
+        assert response.context["cost_summary"].total_cost == Decimal("1.23")
+
+    def test_an_unknown_granularity_shares_the_daily_cache_entry(self, authenticated_client, team):
+        """The timeseries cache key folds in the granularity, which arrives
+        raw from the query string. An unrecognised value computes the daily
+        series anyway (reporting falls back to TruncDate), so it must reuse
+        the daily key rather than mint an unbounded row per distinct string."""
+        _enable_flag_for(team)
+        _usage(team, cost="1.23", when=_NOW - timedelta(days=1))
+        url = reverse("dashboard:api_cost_timeseries", kwargs={"team_slug": team.slug})
+
+        daily = authenticated_client.get(url, {"granularity": "daily"})
+        bogus = authenticated_client.get(url, {"granularity": "bogus-123"})
+
+        assert daily.status_code == bogus.status_code == 200
+        assert bogus.json() == daily.json()
+        keys = set(DashboardCache.objects.values_list("cache_key", flat=True))
+        assert not any("bogus" in key for key in keys)

--- a/apps/dashboard/tests/test_distinct_usage.py
+++ b/apps/dashboard/tests/test_distinct_usage.py
@@ -21,6 +21,7 @@ from django.utils import timezone
 from apps.annotations.models import Tag
 from apps.channels.models import ChannelPlatform
 from apps.chat.models import ChatMessage, ChatMessageType
+from apps.experiments.models import SessionStatus
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import (
     ExperimentFactory,
@@ -48,6 +49,7 @@ class TestDistinctSessionDuplication:
             experiment=experiment,
             participant=participant,
             team=team,
+            status=SessionStatus.ACTIVE,
         )
 
         # Create 3 messages in the date range for the same session
@@ -169,7 +171,7 @@ class TestDistinctAggregationIssues:
 
     def test_session_analytics_no_duplicate_sessions(self):
         DashboardCache.objects.all().delete()
-        session = ExperimentSessionFactory.create()
+        session = ExperimentSessionFactory.create(status=SessionStatus.ACTIVE)
 
         # Create 3 messages at noon to avoid midnight date boundary issues
         now = timezone.now().replace(hour=12, minute=0, second=0, microsecond=0)
@@ -203,6 +205,7 @@ class TestDistinctAggregationIssues:
             experiment=experiment,
             participant=participant,
             team=team,
+            status=SessionStatus.ACTIVE,
         )
 
         # Create multiple messages
@@ -238,6 +241,7 @@ class TestDistinctAggregationIssues:
             experiment=experiment,
             participant=participant,
             team=team,
+            status=SessionStatus.ACTIVE,
         )
 
         # Create exactly 5 messages
@@ -288,6 +292,7 @@ class TestDistinctComplexFiltering:
             participant=participant,
             team=team,
             experiment_channel=channel,
+            status=SessionStatus.ACTIVE,
         )
 
         # Add messages
@@ -386,6 +391,7 @@ class TestDistinctQueryOptimization:
             experiment=experiment,
             participant=participant,
             team=team,
+            status=SessionStatus.ACTIVE,
         )
 
         # Add messages
@@ -499,6 +505,7 @@ class TestDistinctRegressionCases:
                         experiment=experiment,
                         participant=participant,
                         team=team,
+                        status=SessionStatus.ACTIVE,
                     )
                     sessions.append(session)
 
@@ -549,6 +556,7 @@ class TestDistinctRegressionCases:
             experiment=experiment,
             participant=participant,
             team=team,
+            status=SessionStatus.ACTIVE,
         )
 
         for i in range(4):

--- a/apps/dashboard/tests/test_services.py
+++ b/apps/dashboard/tests/test_services.py
@@ -190,6 +190,31 @@ class TestDashboardService:
             for field in expected_fields:
                 assert field in item
 
+    @pytest.mark.django_db()
+    def test_bot_performance_messages_obey_the_window_and_message_types(self, team, experiment, participant):
+        """The per-chatbot Messages column counts the same rows the headline
+        total does: conversation turns inside the window (ADR-0051)."""
+        now = timezone.now()
+        session = ExperimentSession.objects.create(
+            experiment=experiment, participant=participant, team=team, status="active"
+        )
+        chat = session.chat
+        ChatMessage.objects.create(chat=chat, message_type=ChatMessageType.HUMAN, content="in window")
+        ChatMessage.objects.create(chat=chat, message_type=ChatMessageType.AI, content="in window")
+        ChatMessage.objects.create(chat=chat, message_type=ChatMessageType.SYSTEM, content="not a turn")
+        ChatMessage.objects.create(
+            chat=chat,
+            message_type=ChatMessageType.HUMAN,
+            content="before the window",
+            created_at=now - timedelta(days=90),
+        )
+
+        data = DashboardService(team).get_bot_performance_summary(
+            start_date=now - timedelta(days=1), end_date=now + timedelta(days=1)
+        )
+
+        assert data["results"][0]["messages"] == 2
+
     def test_get_channel_breakdown_data(self, team, experiment, participant, experiment_channel):
         """Test channel breakdown data generation"""
         service = DashboardService(team)

--- a/apps/dashboard/tests/test_services.py
+++ b/apps/dashboard/tests/test_services.py
@@ -144,6 +144,26 @@ class TestDashboardService:
         for key in ["human_messages", "ai_messages", "totals"]:
             assert isinstance(data[key], list)
 
+    def test_get_message_volume_data_total_excludes_system_messages(
+        self, team, experiment, participant, experiment_session, chat
+    ):
+        """The chart's per-period total is human + ai, not every message type
+        (ADR-0051): a SYSTEM message must not inflate it."""
+        service = DashboardService(team)
+
+        ChatMessage.objects.create(chat=chat, message_type=ChatMessageType.HUMAN, content="Human message")
+        ChatMessage.objects.create(chat=chat, message_type=ChatMessageType.AI, content="AI message")
+        ChatMessage.objects.create(chat=chat, message_type=ChatMessageType.SYSTEM, content="System message")
+
+        data = service.get_message_volume_data(granularity="daily")
+
+        assert len(data["totals"]) == 1
+        period = data["totals"][0]
+        assert period["human_messages"] == 1
+        assert period["ai_messages"] == 1
+        assert period["total_messages"] == 2
+        assert period["total_messages"] == period["human_messages"] + period["ai_messages"]
+
     def test_get_bot_performance_summary(self, team, experiment, participant, experiment_session, chat):
         """Test bot performance summary generation"""
         service = DashboardService(team)

--- a/apps/dashboard/tests/test_services.py
+++ b/apps/dashboard/tests/test_services.py
@@ -5,7 +5,7 @@ import pytest
 from django.utils import timezone
 
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
-from apps.experiments.models import Experiment, ExperimentSession
+from apps.experiments.models import Experiment, ExperimentSession, SessionStatus
 from apps.utils.factories.annotations import CustomTaggedItemFactory, TagFactory
 from apps.utils.factories.team import TeamFactory
 
@@ -377,8 +377,10 @@ class TestGetTagAnalyticsDataTeamScoping:
 
 
 def _create_session(experiment, participant, team, message_date):
-    session = ExperimentSession.objects.create(experiment=experiment, participant=participant, team=team)
-    message = ChatMessage.objects.create(chat=session.chat)
+    session = ExperimentSession.objects.create(
+        experiment=experiment, participant=participant, team=team, status=SessionStatus.ACTIVE
+    )
+    message = ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN)
     message.created_at = message_date
     message.save()
     return session

--- a/apps/dashboard/tests/test_services.py
+++ b/apps/dashboard/tests/test_services.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY
 import pytest
 from django.utils import timezone
 
+from apps.channels.models import ChannelPlatform
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
 from apps.experiments.models import Experiment, ExperimentSession, SessionStatus
 from apps.utils.factories.annotations import CustomTaggedItemFactory, TagFactory
@@ -407,6 +408,63 @@ class TestGetTagAnalyticsDataTeamScoping:
 
         assert data["tag_categories"] == {tag.label: {tag.name: 1}}
         assert data["total_tagged_messages"] == 1
+
+
+@pytest.mark.django_db()
+class TestUserEngagementUsesTheCanonicalDefinitions:
+    """The engagement panel sits on the same page as the headline totals, so it
+    counts the same universe: no SETUP sessions, no evaluation-harness sessions,
+    and a tag filter narrows it the same way (ADR-0051)."""
+
+    def _totals(self, data):
+        return [(row["total_messages"], row["total_sessions"]) for row in data["most_active_participants"]]
+
+    def test_setup_sessions_do_not_count(self, team, experiment, participant):
+        _engagement_session(team, experiment, participant, messages=2)
+        _engagement_session(team, experiment, participant, status=SessionStatus.SETUP, messages=3)
+
+        data = DashboardService(team).get_user_engagement_data()
+
+        assert self._totals(data) == [(2, 1)]
+
+    def test_evaluation_sessions_do_not_count(self, team, experiment, participant):
+        _engagement_session(team, experiment, participant, messages=2)
+        _engagement_session(team, experiment, participant, platform=ChannelPlatform.EVALUATIONS, messages=3)
+
+        data = DashboardService(team).get_user_engagement_data()
+
+        assert self._totals(data) == [(2, 1)]
+
+    def test_a_tag_filter_narrows_the_panel(self, team, experiment, participant):
+        tagged = _engagement_session(team, experiment, participant, messages=2)
+        _engagement_session(team, experiment, participant, messages=3)
+        tag = TagFactory.create(team=team)
+        CustomTaggedItemFactory.create(team=team, tag=tag, target=tagged.chat)
+
+        data = DashboardService(team).get_user_engagement_data(tag_ids=[tag.id])
+
+        assert self._totals(data) == [(2, 1)]
+
+    def test_last_activity_comes_from_in_window_activity(self, team, experiment, participant):
+        """`last_activity_at` is the session's own clock and carries no window
+        bound, so reading it directly can report a date outside the range the
+        page is showing."""
+        session = _engagement_session(team, experiment, participant, messages=1)
+        ExperimentSession.objects.filter(id=session.id).update(last_activity_at=timezone.now() + timedelta(days=40))
+
+        data = DashboardService(team).get_user_engagement_data()
+
+        message = ChatMessage.objects.get(chat=session.chat)
+        assert data["most_active_participants"][0]["last_activity"] == message.created_at.isoformat()
+
+
+def _engagement_session(team, experiment, participant, *, status=SessionStatus.ACTIVE, platform="web", messages=1):
+    session = ExperimentSession.objects.create(
+        experiment=experiment, participant=participant, team=team, status=status, platform=platform
+    )
+    for index in range(messages):
+        ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN, content=f"m{index}")
+    return session
 
 
 def _create_session(experiment, participant, team, message_date):

--- a/apps/dashboard/tests/test_services.py
+++ b/apps/dashboard/tests/test_services.py
@@ -352,43 +352,51 @@ class TestGetTagAnalyticsDataTeamScoping:
     cached value from another test can never serve a result here.
     """
 
-    def test_foreign_link_with_foreign_tag_on_local_message_is_excluded(self, team, chat):
+    @pytest.mark.parametrize(
+        "failing_conjunct",
+        [
+            pytest.param("link-team", id="link-team-conjunct"),
+            pytest.param("tag-team", id="tag-team-conjunct"),
+        ],
+    )
+    def test_link_failing_one_scoping_conjunct_is_excluded(self, team, chat, failing_conjunct):
+        """The read scopes tag links with two conjuncts, the link row's
+        `team_id` and its tag's `team_id`. Each case builds a link where
+        exactly one conjunct fails while the other holds, so deleting either
+        predicate turns exactly its named case red. Message links only -
+        this read has no chat leg. Positive control:
+        `test_own_teams_link_and_tag_are_counted`."""
         message = ChatMessage.objects.create(chat=chat, message_type=ChatMessageType.HUMAN, content="hi")
+        foreign_team = TeamFactory.create()
+        link_team = foreign_team if failing_conjunct == "link-team" else team
+        tag = TagFactory.create(team=foreign_team if failing_conjunct == "tag-team" else team)
+        CustomTaggedItemFactory.create(team=link_team, tag=tag, target=message)
+
+        data = DashboardService(team).get_tag_analytics_data()
+
+        assert data["tag_categories"] == {}
+        assert data["total_tagged_messages"] == 0
+
+    def test_foreign_teams_tag_never_renders_in_the_breakdown(self, team, chat):
+        """The reported shape (see the PR demo): a `CustomTaggedItem` owned
+        by another team, carrying that team's tag, points at one of this
+        team's messages. Both conjuncts fail at once, so the conjunct case
+        list above already rejects it; this test pins the user-visible
+        property instead - the breakdown renders the reading team's tags and
+        nothing else, so the foreign tag's user-authored name never appears
+        beside them."""
+        secret = ChatMessage.objects.create(chat=chat, message_type=ChatMessageType.HUMAN, content="hi")
         foreign_team = TeamFactory.create()
         foreign_tag = TagFactory.create(team=foreign_team, name="OTHER-TEAMS-SECRET-TAG")
-        CustomTaggedItemFactory.create(team=foreign_team, tag=foreign_tag, target=message)
+        CustomTaggedItemFactory.create(team=foreign_team, tag=foreign_tag, target=secret)
+        ours = ChatMessage.objects.create(chat=chat, message_type=ChatMessageType.HUMAN, content="ours")
+        local_tag = TagFactory.create(team=team, name="our-own-tag")
+        CustomTaggedItemFactory.create(team=team, tag=local_tag, target=ours)
 
         data = DashboardService(team).get_tag_analytics_data()
 
-        assert data["tag_categories"] == {}
-        assert data["total_tagged_messages"] == 0
-
-    def test_foreign_link_with_local_tag_on_local_message_is_excluded(self, team, chat):
-        """The mirror shape: the link row's `team_id` is foreign even though
-        its tag belongs to the reading team - still must not count."""
-        message = ChatMessage.objects.create(chat=chat, message_type=ChatMessageType.HUMAN, content="hi")
-        foreign_team = TeamFactory.create()
-        local_tag = TagFactory.create(team=team, name="local-tag")
-        CustomTaggedItemFactory.create(team=foreign_team, tag=local_tag, target=message)
-
-        data = DashboardService(team).get_tag_analytics_data()
-
-        assert data["tag_categories"] == {}
-        assert data["total_tagged_messages"] == 0
-
-    def test_local_link_with_foreign_tag_on_local_message_is_excluded(self, team, chat):
-        """Isolates the `tag__team_id` predicate: the link row's own
-        `team_id` already matches the reading team, so only the tag's team
-        membership is left to reject this row."""
-        message = ChatMessage.objects.create(chat=chat, message_type=ChatMessageType.HUMAN, content="hi")
-        foreign_team = TeamFactory.create()
-        foreign_tag = TagFactory.create(team=foreign_team, name="foreign-tag")
-        CustomTaggedItemFactory.create(team=team, tag=foreign_tag, target=message)
-
-        data = DashboardService(team).get_tag_analytics_data()
-
-        assert data["tag_categories"] == {}
-        assert data["total_tagged_messages"] == 0
+        assert data["tag_categories"] == {local_tag.label: {local_tag.name: 1}}
+        assert data["total_tagged_messages"] == 1
 
     def test_own_teams_link_and_tag_are_counted(self, team, chat):
         message = ChatMessage.objects.create(chat=chat, message_type=ChatMessageType.HUMAN, content="hi")

--- a/apps/dashboard/tests/test_views.py
+++ b/apps/dashboard/tests/test_views.py
@@ -1,12 +1,15 @@
 import json
+from datetime import datetime
 
 import pytest
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+from django.utils import timezone
 
 from apps.chat.models import ChatMessage, ChatMessageType
 
 from ...utils.factories.team import MembershipFactory, TeamFactory
+from ..forms import DashboardFilterForm
 from ..models import DashboardFilter
 
 User = get_user_model()
@@ -201,3 +204,20 @@ class TestDashboardSecurity:
 
             # Should redirect to login or return 403
             assert response.status_code in [302, 403]
+
+
+class TestFilterFormWindow:
+    """The form resolves a picked date range to the half-open window the
+    querysets read (ADR-0051): the selected end date stays fully included by
+    windowing up to the start of the following day, exclusive."""
+
+    @pytest.mark.django_db()
+    def test_end_date_resolves_to_the_start_of_the_following_day(self, team):
+        form = DashboardFilterForm(
+            data={"date_range": "custom", "start_date": "2026-06-01", "end_date": "2026-06-15"}, team=team
+        )
+
+        params = form.get_filter_params()
+
+        assert params["start_date"] == timezone.make_aware(datetime(2026, 6, 1, 0, 0))
+        assert params["end_date"] == timezone.make_aware(datetime(2026, 6, 16, 0, 0))

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -1,36 +1,101 @@
 import json
+from dataclasses import asdict
 from datetime import datetime, timedelta
+from decimal import Decimal
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse, JsonResponse
 from django.utils import timezone
+from django.utils.dateparse import parse_datetime
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 from waffle import flag_is_active
 
-from apps.cost_tracking.services.reporting import CostFilters, cost_summary, cost_timeseries, coverage_gaps
+from apps.cost_tracking.services.reporting import (
+    CostFilters,
+    CostSummary,
+    CoverageGaps,
+    ModelCoverageGap,
+    cost_summary,
+    cost_timeseries,
+    coverage_gaps,
+)
 from apps.teams.decorators import login_and_team_required
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 
 from .forms import DashboardFilterForm, SavedFilterForm
-from .models import DashboardFilter
+from .models import DashboardCache, DashboardFilter
 from .services import DashboardService
 
 COST_TRACKING_FLAG = "flag_ai_cost_monitoring"
 DEFAULT_COST_PERIOD_DAYS = 30
 
 
+def _cost_cache_key(prefix: str, filter_form: DashboardFilterForm) -> str:
+    """Key on the form's submitted parameters, not on the resolved window. With
+    no date range submitted the window is `now`-relative and would otherwise
+    change every request, so the entry would never be hit. The window then
+    slides while the cached value stays put for up to the TTL - the same
+    staleness every other dashboard metric already accepts."""
+    params = filter_form.get_filter_params() if filter_form.is_valid() else {}
+    return f"{prefix}_{DashboardService._cache_key(params)}"
+
+
+def _cached(team, cache_key: str, compute, decode):
+    """Serve `compute()` through DashboardCache, encoding via the JSON encoder
+    the cache field expects and rebuilding the dataclass on the way out."""
+    cached_data = DashboardCache.get_cached_data(team, cache_key)
+    if cached_data is not None:
+        return decode(cached_data)
+    value = compute()
+    DashboardCache.set_cached_data(team, cache_key, json.loads(json.dumps(asdict(value), cls=DjangoJSONEncoder)))
+    return value
+
+
+def _cost_summary_from_cache(payload: dict) -> CostSummary:
+    return CostSummary(
+        period_start=parse_datetime(payload["period_start"]),
+        period_end=parse_datetime(payload["period_end"]),
+        total_cost=Decimal(payload["total_cost"]),
+        previous_period_cost=Decimal(payload["previous_period_cost"]),
+        delta_pct=payload["delta_pct"],
+        exact_cost=Decimal(payload["exact_cost"]),
+        estimated_cost=Decimal(payload["estimated_cost"]),
+        unknown_call_count=payload["unknown_call_count"],
+        unpriced_call_count=payload["unpriced_call_count"],
+    )
+
+
+def _coverage_gaps_from_cache(payload: dict) -> CoverageGaps:
+    return CoverageGaps(
+        unpriced=[ModelCoverageGap(**gap) for gap in payload["unpriced"]],
+        unknown=[ModelCoverageGap(**gap) for gap in payload["unknown"]],
+    )
+
+
 def _cost_tracking_context(request, filter_form: DashboardFilterForm) -> dict:
     """Return the cost-tracking panel context. When the flag is off the panel
-    is hidden entirely - no service calls are made.
+    is hidden entirely - no service calls are made. Both reads go through
+    DashboardCache on the same 30-minute TTL as every other dashboard metric
+    (#3905).
     """
     if not flag_is_active(request, COST_TRACKING_FLAG):
         return {"cost_tracking_enabled": False}
     start, end, filters = _cost_panel_scope(filter_form)
     return {
         "cost_tracking_enabled": True,
-        "cost_summary": cost_summary(request.team, start=start, end=end, filters=filters),
-        "cost_coverage_gaps": coverage_gaps(request.team, start=start, end=end, filters=filters),
+        "cost_summary": _cached(
+            request.team,
+            _cost_cache_key("cost_summary", filter_form),
+            lambda: cost_summary(request.team, start=start, end=end, filters=filters),
+            _cost_summary_from_cache,
+        ),
+        "cost_coverage_gaps": _cached(
+            request.team,
+            _cost_cache_key("cost_coverage_gaps", filter_form),
+            lambda: coverage_gaps(request.team, start=start, end=end, filters=filters),
+            _coverage_gaps_from_cache,
+        ),
     }
 
 
@@ -196,9 +261,19 @@ class CostTrackingApiView(DashboardApiView):
     def get(self, request, *args, **kwargs):
         if not flag_is_active(request, COST_TRACKING_FLAG):
             return self.json_response([])
-        start, end, filters = _cost_panel_scope(DashboardFilterForm(data=request.GET, team=request.team))
+        filter_form = DashboardFilterForm(data=request.GET, team=request.team)
+        start, end, filters = _cost_panel_scope(filter_form)
         granularity = request.GET.get("granularity", "daily")
-        data = cost_timeseries(request.team, start=start, end=end, granularity=granularity, filters=filters)
+        cache_key = f"{_cost_cache_key('cost_timeseries', filter_form)}_{granularity}"
+        data = DashboardCache.get_cached_data(request.team, cache_key)
+        if data is None:
+            data = json.loads(
+                json.dumps(
+                    cost_timeseries(request.team, start=start, end=end, granularity=granularity, filters=filters),
+                    cls=DjangoJSONEncoder,
+                )
+            )
+            DashboardCache.set_cached_data(request.team, cache_key, data)
         return self.json_response(data)
 
 

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -41,12 +41,14 @@ def _cost_cache_key(prefix: str, filter_form: DashboardFilterForm) -> str:
     return f"{prefix}_{DashboardService._cache_key(params)}"
 
 
-def _cached(team, cache_key: str, compute, decode):
+def _cached(team, cache_key: str, compute, decode, encode=asdict):
     """Serve `compute()` through DashboardCache, encoding via the JSON encoder
     the cache field expects and rebuilding the dataclass on the way out. A
     payload that no longer decodes - an entry written by an older code shape,
     still inside its TTL after a deploy - falls through to a recompute that
-    overwrites it, rather than surfacing the decode error on every load."""
+    overwrites it, rather than surfacing the decode error on every load.
+    `encode` defaults to dataclass encoding; a payload that is already
+    JSON-shaped passes identity functions for both directions."""
     cached_data = DashboardCache.get_cached_data(team, cache_key)
     if cached_data is not None:
         try:
@@ -54,7 +56,7 @@ def _cached(team, cache_key: str, compute, decode):
         except (KeyError, TypeError, ValueError):
             pass
     value = compute()
-    DashboardCache.set_cached_data(team, cache_key, json.loads(json.dumps(asdict(value), cls=DjangoJSONEncoder)))
+    DashboardCache.set_cached_data(team, cache_key, json.loads(json.dumps(encode(value), cls=DjangoJSONEncoder)))
     return value
 
 
@@ -276,15 +278,16 @@ class CostTrackingApiView(DashboardApiView):
             # so normalise first rather than minting a cache row per string.
             granularity = "daily"
         cache_key = f"{_cost_cache_key('cost_timeseries', filter_form)}_{granularity}"
-        data = DashboardCache.get_cached_data(request.team, cache_key)
-        if data is None:
-            data = json.loads(
-                json.dumps(
-                    cost_timeseries(request.team, start=start, end=end, granularity=granularity, filters=filters),
-                    cls=DjangoJSONEncoder,
-                )
-            )
-            DashboardCache.set_cached_data(request.team, cache_key, data)
+        # The payload is already JSON-shaped (floats + dates), so both cache
+        # directions are identity; the JSON round-trip in _cached normalises
+        # the dates the same way the previous inline encoding did.
+        data = _cached(
+            request.team,
+            cache_key,
+            lambda: cost_timeseries(request.team, start=start, end=end, granularity=granularity, filters=filters),
+            decode=lambda payload: payload,
+            encode=lambda value: value,
+        )
         return self.json_response(data)
 
 

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import asdict
 from datetime import datetime, timedelta
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse, JsonResponse
@@ -53,17 +53,27 @@ def _cached(team, cache_key: str, compute, decode, encode=asdict):
     if cached_data is not None:
         try:
             return decode(cached_data)
-        except (KeyError, TypeError, ValueError):
+        except (KeyError, TypeError, ValueError, InvalidOperation):
             pass
     value = compute()
     DashboardCache.set_cached_data(team, cache_key, json.loads(json.dumps(encode(value), cls=DjangoJSONEncoder)))
     return value
 
 
+def _cached_datetime(value: str) -> datetime:
+    """`parse_datetime` returns None for an unparseable string rather than
+    raising, which would otherwise let a half-built summary pass as a cache
+    hit. Raise instead, so `_cached` recomputes."""
+    parsed = parse_datetime(value)
+    if parsed is None:
+        raise ValueError(f"unparseable cached timestamp: {value!r}")
+    return parsed
+
+
 def _cost_summary_from_cache(payload: dict) -> CostSummary:
     return CostSummary(
-        period_start=parse_datetime(payload["period_start"]),
-        period_end=parse_datetime(payload["period_end"]),
+        period_start=_cached_datetime(payload["period_start"]),
+        period_end=_cached_datetime(payload["period_end"]),
         total_cost=Decimal(payload["total_cost"]),
         previous_period_cost=Decimal(payload["previous_period_cost"]),
         delta_pct=payload["delta_pct"],

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -43,10 +43,16 @@ def _cost_cache_key(prefix: str, filter_form: DashboardFilterForm) -> str:
 
 def _cached(team, cache_key: str, compute, decode):
     """Serve `compute()` through DashboardCache, encoding via the JSON encoder
-    the cache field expects and rebuilding the dataclass on the way out."""
+    the cache field expects and rebuilding the dataclass on the way out. A
+    payload that no longer decodes - an entry written by an older code shape,
+    still inside its TTL after a deploy - falls through to a recompute that
+    overwrites it, rather than surfacing the decode error on every load."""
     cached_data = DashboardCache.get_cached_data(team, cache_key)
     if cached_data is not None:
-        return decode(cached_data)
+        try:
+            return decode(cached_data)
+        except (KeyError, TypeError, ValueError):
+            pass
     value = compute()
     DashboardCache.set_cached_data(team, cache_key, json.loads(json.dumps(asdict(value), cls=DjangoJSONEncoder)))
     return value
@@ -264,6 +270,11 @@ class CostTrackingApiView(DashboardApiView):
         filter_form = DashboardFilterForm(data=request.GET, team=request.team)
         start, end, filters = _cost_panel_scope(filter_form)
         granularity = request.GET.get("granularity", "daily")
+        if granularity not in ("daily", "weekly", "monthly"):
+            # The value arrives raw from the query string and is folded into the
+            # cache key below; reporting falls back to daily for unknown values,
+            # so normalise first rather than minting a cache row per string.
+            granularity = "daily"
         cache_key = f"{_cost_cache_key('cost_timeseries', filter_form)}_{granularity}"
         data = DashboardCache.get_cached_data(request.team, cache_key)
         if data is None:

--- a/apps/experiments/tests/test_session_access_cookie.py
+++ b/apps/experiments/tests/test_session_access_cookie.py
@@ -4,13 +4,16 @@ from django.core import signing
 from django.urls import reverse
 
 from apps.experiments.decorators import CHAT_SESSION_ACCESS_COOKIE, CHAT_SESSION_ACCESS_SALT
-from apps.experiments.models import Participant
+from apps.experiments.models import Participant, SessionStatus
 from apps.utils.factories.experiment import ExperimentSessionFactory
 
 
 @pytest.fixture()
 def session():
-    session = ExperimentSessionFactory.create()
+    # These tests drive the pre-chat flow, which starts at the consent form and
+    # only activates the session once consent is recorded, so the session has to
+    # begin in SETUP rather than the factory's activated default.
+    session = ExperimentSessionFactory.create(status=SessionStatus.SETUP)
     participant = Participant.objects.create(team=session.team, identifier="test@test.com", platform="web")
     session.participant = participant
     session.save()

--- a/apps/usage_metrics/dashboard_querysets.py
+++ b/apps/usage_metrics/dashboard_querysets.py
@@ -1,10 +1,10 @@
 """The dashboard's filtered activity querysets, moved here from
 apps/dashboard/services.py (#3905) so the filter logic has one home. These
 reproduce the dashboard's CURRENT semantics - half-open [start_date, end_date)
-window, sessions = any message in window, message totals include SYSTEM,
-evaluation activity excluded - which differ from the v2 usage API semantics in
-metrics.py. The definition-switch PR converges the two; until then both live
-here side by side.
+window, sessions = a human or AI message in the window, SETUP excluded,
+message totals include SYSTEM, evaluation activity excluded - which differ
+from the v2 usage API semantics in metrics.py. The definition-switch PR
+converges the two; until then both live here side by side.
 
 Evaluation-harness activity is decided on ``ExperimentSession.platform``
 everywhere in this app. ``ExperimentChannel.platform`` is a separate nullable
@@ -28,10 +28,10 @@ from django.utils import timezone
 from apps.annotations.models import CustomTaggedItem
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.models import Chat, ChatMessage
-from apps.experiments.models import Experiment, ExperimentSession, Participant
+from apps.experiments.models import Experiment, ExperimentSession, Participant, SessionStatus
 from apps.teams.models import Team
 
-from .filters import chat_tag_exists_pair
+from .filters import CONVERSATION_MESSAGE_TYPES, chat_tag_exists_pair
 
 
 def filtered_querysets(
@@ -60,6 +60,7 @@ def filtered_querysets(
     msg_exists = Exists(
         ChatMessage.objects.filter(
             chat=OuterRef("chat"),
+            message_type__in=CONVERSATION_MESSAGE_TYPES,
             created_at__gte=start_date,
             created_at__lt=end_date,
         )
@@ -67,6 +68,7 @@ def filtered_querysets(
     sessions = (
         ExperimentSession.objects.filter(team=team)
         .exclude(platform=ChannelPlatform.EVALUATIONS)
+        .exclude(status=SessionStatus.SETUP)
         .annotate(_has_msgs=msg_exists)
         .filter(_has_msgs=True)
     )

--- a/apps/usage_metrics/dashboard_querysets.py
+++ b/apps/usage_metrics/dashboard_querysets.py
@@ -191,21 +191,14 @@ def filtered_querysets(
             Q(_part_tchat=True) | Q(_part_tmsg=True)
         )
 
-        # Messages: the message's own tags carry the tag (both the link row and its tag must
-        # belong to the reading team). Message-only match - a tag on the chat (rather than the
-        # message itself) does not pull the chat's messages in here; that broader chat-or-message
-        # match is what the sessions/experiments/participants legs above use via
-        # `chat_tag_exists_pair`, not this one.
-        msg_tag_on_msg = Exists(
-            CustomTaggedItem.objects.filter(
-                team_id=team.id,
-                tag__team_id=team.id,
-                content_type=message_content_type,
-                object_id=OuterRef("id"),
-                tag_id__in=tag_ids,
-            )
+        # Messages: the same chat-or-message match as every other leg and as
+        # `usage_metrics.messages_queryset`, so a chat-level tag narrows the
+        # message counts to the tagged conversations it narrows the session
+        # counts to, and the dashboard agrees with the API under the filter.
+        msg_tag_on_chat, msg_tag_on_msg = chat_tag_exists_pair(team, tag_ids, "chat_id")
+        messages = messages.annotate(_msg_tchat=msg_tag_on_chat, _msg_tmsg=msg_tag_on_msg).filter(
+            Q(_msg_tchat=True) | Q(_msg_tmsg=True)
         )
-        messages = messages.filter(msg_tag_on_msg)
 
     return {
         "experiments": experiments,

--- a/apps/usage_metrics/dashboard_querysets.py
+++ b/apps/usage_metrics/dashboard_querysets.py
@@ -1,6 +1,6 @@
 """The dashboard's filtered activity querysets, moved here from
 apps/dashboard/services.py (#3905) so the filter logic has one home. These
-reproduce the dashboard's CURRENT semantics - closed [start_date, end_date]
+reproduce the dashboard's CURRENT semantics - half-open [start_date, end_date)
 window, sessions = any message in window, message totals include SYSTEM,
 evaluation activity excluded - which differ from the v2 usage API semantics in
 metrics.py. The definition-switch PR converges the two; until then both live
@@ -49,7 +49,7 @@ def filtered_querysets(
     if not start_date:
         start_date = end_date - timedelta(days=30)
 
-    base_filters = {"created_at__gte": start_date, "created_at__lte": end_date}
+    base_filters = {"created_at__gte": start_date, "created_at__lt": end_date}
 
     experiments = Experiment.objects.filter(team=team, is_archived=False, working_version=None)
     # Use Exists() to avoid join+distinct - prevents row explosion upfront for better performance
@@ -57,7 +57,7 @@ def filtered_querysets(
         ChatMessage.objects.filter(
             chat=OuterRef("chat"),
             created_at__gte=start_date,
-            created_at__lte=end_date,
+            created_at__lt=end_date,
         )
     )
     sessions = (

--- a/apps/usage_metrics/dashboard_querysets.py
+++ b/apps/usage_metrics/dashboard_querysets.py
@@ -43,10 +43,14 @@ def filtered_querysets(
     platform_names: list[str] | None = None,
     participant_ids: list[int] | None = None,
     tag_ids: list[int] | None = None,
+    include_archived: bool = False,
 ) -> dict[str, Any]:
     """Base querysets with the dashboard's common filters applied. Returns
     `experiments`, `sessions`, `messages`, `participants` querysets plus the
-    resolved `start_date`/`end_date` (defaulting to the last 30 days)."""
+    resolved `start_date`/`end_date` (defaulting to the last 30 days).
+
+    `include_archived` applies to the `experiments` enumeration only. The
+    activity querysets count archived-chatbot activity either way (ADR-0051)."""
 
     if not end_date:
         end_date = timezone.now()
@@ -55,7 +59,10 @@ def filtered_querysets(
 
     base_filters = {"created_at__gte": start_date, "created_at__lt": end_date}
 
-    experiments = Experiment.objects.filter(team=team, is_archived=False, working_version=None)
+    # `Experiment.objects` already filters `is_archived=False` (VersionsObjectManagerMixin);
+    # `get_all()` is the archived-inclusive manager.
+    experiment_manager = Experiment.objects.get_all() if include_archived else Experiment.objects.all()
+    experiments = experiment_manager.filter(team=team, working_version=None)
     # Use Exists() to avoid join+distinct - prevents row explosion upfront for better performance
     msg_exists = Exists(
         ChatMessage.objects.filter(

--- a/apps/usage_metrics/dashboard_querysets.py
+++ b/apps/usage_metrics/dashboard_querysets.py
@@ -27,17 +27,15 @@ CodeRabbit finding on PR #4132.
 from datetime import datetime, timedelta
 from typing import Any
 
-from django.contrib.contenttypes.models import ContentType
-from django.db.models import Exists, OuterRef, Q, Subquery
+from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone
 
-from apps.annotations.models import CustomTaggedItem
 from apps.channels.models import ChannelPlatform, ExperimentChannel
-from apps.chat.models import Chat, ChatMessage
+from apps.chat.models import ChatMessage
 from apps.experiments.models import Experiment, ExperimentSession, Participant, SessionStatus
 from apps.teams.models import Team
 
-from .filters import CONVERSATION_MESSAGE_TYPES, chat_tag_exists_pair
+from .filters import CONVERSATION_MESSAGE_TYPES, chat_tag_exists_pair, tagged_conversation_exists_pair
 
 
 def filtered_querysets(
@@ -123,69 +121,21 @@ def filtered_querysets(
         participants = participants.filter(id__in=participant_ids)
 
     if tag_ids:
-        chat_content_type = ContentType.objects.get_for_model(Chat)
-        message_content_type = ContentType.objects.get_for_model(ChatMessage)
-
-        # Sessions: chat or any message in it carries the tag (both the link row and its tag
-        # must belong to the reading team)
+        # One tag-match rule for every leg (chat-or-message, team-scoped links):
+        # sessions and messages resolve it from their chat id, experiments and
+        # participants from their sessions' chats.
         tag_on_chat, tag_on_msg = chat_tag_exists_pair(team, tag_ids, "chat_id")
         sessions = sessions.annotate(_tchat=tag_on_chat, _tmsg=tag_on_msg).filter(Q(_tchat=True) | Q(_tmsg=True))
 
-        # Experiments: any session's chat or messages carry the tag (both the link row and
-        # its tag must belong to the reading team)
-        exp_tag_on_chat = Exists(
-            CustomTaggedItem.objects.filter(
-                team_id=team.id,
-                tag__team_id=team.id,
-                content_type=chat_content_type,
-                object_id__in=Subquery(
-                    Chat.objects.filter(experiment_session__experiment=OuterRef(OuterRef("id"))).values("id")
-                ),
-                tag_id__in=tag_ids,
-            )
-        )
-        exp_tag_on_msg = Exists(
-            CustomTaggedItem.objects.filter(
-                team_id=team.id,
-                tag__team_id=team.id,
-                content_type=message_content_type,
-                object_id__in=Subquery(
-                    ChatMessage.objects.filter(chat__experiment_session__experiment=OuterRef(OuterRef("id"))).values(
-                        "id"
-                    )
-                ),
-                tag_id__in=tag_ids,
-            )
+        exp_tag_on_chat, exp_tag_on_msg = tagged_conversation_exists_pair(
+            team, tag_ids, "experiment_session__experiment"
         )
         experiments = experiments.annotate(_exp_tchat=exp_tag_on_chat, _exp_tmsg=exp_tag_on_msg).filter(
             Q(_exp_tchat=True) | Q(_exp_tmsg=True)
         )
 
-        # Participants: any of their sessions' chats or messages carry the tag (both the
-        # link row and its tag must belong to the reading team)
-        part_tag_on_chat = Exists(
-            CustomTaggedItem.objects.filter(
-                team_id=team.id,
-                tag__team_id=team.id,
-                content_type=chat_content_type,
-                object_id__in=Subquery(
-                    Chat.objects.filter(experiment_session__participant=OuterRef(OuterRef("id"))).values("id")
-                ),
-                tag_id__in=tag_ids,
-            )
-        )
-        part_tag_on_msg = Exists(
-            CustomTaggedItem.objects.filter(
-                team_id=team.id,
-                tag__team_id=team.id,
-                content_type=message_content_type,
-                object_id__in=Subquery(
-                    ChatMessage.objects.filter(chat__experiment_session__participant=OuterRef(OuterRef("id"))).values(
-                        "id"
-                    )
-                ),
-                tag_id__in=tag_ids,
-            )
+        part_tag_on_chat, part_tag_on_msg = tagged_conversation_exists_pair(
+            team, tag_ids, "experiment_session__participant"
         )
         participants = participants.annotate(_part_tchat=part_tag_on_chat, _part_tmsg=part_tag_on_msg).filter(
             Q(_part_tchat=True) | Q(_part_tmsg=True)

--- a/apps/usage_metrics/dashboard_querysets.py
+++ b/apps/usage_metrics/dashboard_querysets.py
@@ -1,10 +1,16 @@
 """The dashboard's filtered activity querysets, moved here from
-apps/dashboard/services.py (#3905) so the filter logic has one home. These
-reproduce the dashboard's CURRENT semantics - half-open [start_date, end_date)
-window, sessions = a human or AI message in the window, SETUP excluded,
-message totals include SYSTEM, evaluation activity excluded - which differ
-from the v2 usage API semantics in metrics.py. The definition-switch PR
-converges the two; until then both live here side by side.
+apps/dashboard/services.py (#3905) so the filter logic has one home.
+
+These are the canonical definitions per ADR-0051, the same ones metrics.py
+computes for the v2 usage API: a half-open [start_date, end_date) window,
+`sessions` = a session with a human or AI message in the window, and
+evaluation-harness and SETUP-session activity excluded from both the session
+and the message querysets.
+
+The `messages` queryset deliberately keeps every message *type*, SYSTEM
+included, because `get_tag_analytics_data` reads it to find tagged messages
+and a SYSTEM message can carry a tag. Narrowing to conversation turns is the
+job of the metrics that count them - see `conversation_messages` in filters.py.
 
 Evaluation-harness activity is decided on ``ExperimentSession.platform``
 everywhere in this app. ``ExperimentChannel.platform`` is a separate nullable
@@ -79,8 +85,10 @@ def filtered_querysets(
         .annotate(_has_msgs=msg_exists)
         .filter(_has_msgs=True)
     )
-    messages = ChatMessage.objects.filter(chat__team=team, **base_filters).exclude(
-        chat__experiment_session__platform=ChannelPlatform.EVALUATIONS
+    messages = (
+        ChatMessage.objects.filter(chat__team=team, **base_filters)
+        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
+        .exclude(chat__experiment_session__status=SessionStatus.SETUP)
     )
     participants = Participant.objects.filter(team=team).exclude(platform=ChannelPlatform.EVALUATIONS)
 

--- a/apps/usage_metrics/dashboard_querysets.py
+++ b/apps/usage_metrics/dashboard_querysets.py
@@ -6,6 +6,10 @@ evaluation activity excluded - which differ from the v2 usage API semantics in
 metrics.py. The definition-switch PR converges the two; until then both live
 here side by side.
 
+Evaluation-harness activity is decided on ``ExperimentSession.platform``
+everywhere in this app. ``ExperimentChannel.platform`` is a separate nullable
+column and the two can disagree on a row (ADR-0051).
+
 One deliberate exception: tag-link matching here is narrower than the
 dashboard's original (unscoped) match. Every `CustomTaggedItem` lookup in this
 module is constrained to the reading team's own rows (`team_id` and
@@ -62,7 +66,7 @@ def filtered_querysets(
     )
     sessions = (
         ExperimentSession.objects.filter(team=team)
-        .exclude(experiment_channel__platform=ChannelPlatform.EVALUATIONS)
+        .exclude(platform=ChannelPlatform.EVALUATIONS)
         .annotate(_has_msgs=msg_exists)
         .filter(_has_msgs=True)
     )

--- a/apps/usage_metrics/filters.py
+++ b/apps/usage_metrics/filters.py
@@ -10,7 +10,7 @@ use.
 from dataclasses import dataclass
 
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Exists, OuterRef, QuerySet, Subquery
+from django.db.models import Exists, OuterRef, Q, QuerySet, Subquery
 
 from apps.annotations.models import CustomTaggedItem
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
@@ -49,6 +49,11 @@ class UsageFilters:
 # bookkeeping and are not counted by any metric (ADR-0051).
 CONVERSATION_MESSAGE_TYPES = (ChatMessageType.HUMAN, ChatMessageType.AI)
 
+# What makes a participant active: they authored a HUMAN message. Receiving AI
+# output is not activity (ADR-0051). Every surface's participant count filters
+# on this one predicate.
+HUMAN_AUTHORED = Q(message_type=ChatMessageType.HUMAN)
+
 
 def conversation_messages(message_queryset: QuerySet[ChatMessage]) -> QuerySet[ChatMessage]:
     """Narrow any team-scoped, windowed message queryset to conversation turns.
@@ -56,6 +61,39 @@ def conversation_messages(message_queryset: QuerySet[ChatMessage]) -> QuerySet[C
     whether the caller starts from ``messages_queryset`` (the API) or from
     ``filtered_querysets`` (the dashboard)."""
     return message_queryset.filter(message_type__in=CONVERSATION_MESSAGE_TYPES)
+
+
+def tagged_conversation_exists_pair(team: Team, tag_ids: list[int], session_path: str) -> tuple[Exists, Exists]:
+    """The (tag-on-chat, tag-on-message) `Exists` pair for querysets one step
+    removed from the chat: an experiment or participant matches when any of
+    its sessions' conversations carries one of `tag_ids`. `session_path` is
+    the ``Chat``-side path back to the outer queryset's row
+    (``"experiment_session__experiment"`` / ``"experiment_session__participant"``).
+    Team scoping is the same as :func:`chat_tag_exists_pair`: both the link
+    row and its tag must belong to the reading team."""
+    chat_content_type = ContentType.objects.get_for_model(Chat)
+    message_content_type = ContentType.objects.get_for_model(ChatMessage)
+    tag_on_chat = Exists(
+        CustomTaggedItem.objects.filter(
+            team_id=team.id,
+            tag__team_id=team.id,
+            content_type=chat_content_type,
+            object_id__in=Subquery(Chat.objects.filter(**{session_path: OuterRef(OuterRef("id"))}).values("id")),
+            tag_id__in=tag_ids,
+        )
+    )
+    tag_on_msg = Exists(
+        CustomTaggedItem.objects.filter(
+            team_id=team.id,
+            tag__team_id=team.id,
+            content_type=message_content_type,
+            object_id__in=Subquery(
+                ChatMessage.objects.filter(**{f"chat__{session_path}": OuterRef(OuterRef("id"))}).values("id")
+            ),
+            tag_id__in=tag_ids,
+        )
+    )
+    return tag_on_chat, tag_on_msg
 
 
 def chat_tag_exists_pair(team: Team, tag_ids: list[int], chat_id_ref: str) -> tuple[Exists, Exists]:

--- a/apps/usage_metrics/filters.py
+++ b/apps/usage_metrics/filters.py
@@ -10,10 +10,10 @@ use.
 from dataclasses import dataclass
 
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Exists, OuterRef, Subquery
+from django.db.models import Exists, OuterRef, QuerySet, Subquery
 
 from apps.annotations.models import CustomTaggedItem
-from apps.chat.models import Chat, ChatMessage
+from apps.chat.models import Chat, ChatMessage, ChatMessageType
 from apps.teams.models import Team
 
 
@@ -46,6 +46,19 @@ class UsageFilters:
     platform: str | None = None
     tag_ids: list[int] | None = None
     include_archived: bool = True
+
+
+# The message types that are conversation turns. `system` messages are internal
+# bookkeeping and are not counted by any metric (ADR-0051).
+CONVERSATION_MESSAGE_TYPES = (ChatMessageType.HUMAN, ChatMessageType.AI)
+
+
+def conversation_messages(message_queryset: QuerySet[ChatMessage]) -> QuerySet[ChatMessage]:
+    """Narrow any team-scoped, windowed message queryset to conversation turns.
+    Both surfaces route through this, so "which messages count" is defined once
+    whether the caller starts from ``messages_queryset`` (the API) or from
+    ``filtered_querysets`` (the dashboard)."""
+    return message_queryset.filter(message_type__in=CONVERSATION_MESSAGE_TYPES)
 
 
 def chat_tag_exists_pair(team: Team, tag_ids: list[int], chat_id_ref: str) -> tuple[Exists, Exists]:

--- a/apps/usage_metrics/filters.py
+++ b/apps/usage_metrics/filters.py
@@ -29,16 +29,13 @@ class UsageFilters:
     message in it carries one of the tags; an empty list is treated as no
     filter.
 
-    `include_archived` is not currently consulted by any function in this
-    module - it is part of the agreed filter shape for surfaces that don't
-    exist yet. The two enumeration paths that exist today each hardcode their
-    own answer instead of reading this flag: `filtered_querysets` in this app
-    hardcodes `is_archived=False, working_version=None` when it builds the
-    `experiments` queryset, while the v2 usage API enumerates experiments with
-    `Experiment.objects.get_all()` (archived and unarchived alike). The
-    default here (`True`) matches the v2 API's behaviour, not the dashboard's
-    - a follow-up that wires this flag into `filtered_querysets` must not
-    assume the default is safe for that path.
+    `include_archived` applies to experiment enumeration only: activity
+    metrics count archived-chatbot activity regardless (ADR-0051). The
+    default (`True`) matches the v2 usage API, which enumerates chatbots with
+    `Experiment.objects.get_all()`; `filtered_querysets` defaults the other
+    way, matching the dashboard's archived-excluding chatbot list. A caller
+    passing `UsageFilters` through to `filtered_querysets` must pass this
+    field explicitly rather than relying on either default.
     """
 
     experiment_ids: list[int] | None = None

--- a/apps/usage_metrics/metrics.py
+++ b/apps/usage_metrics/metrics.py
@@ -43,12 +43,16 @@ from apps.teams.models import Team
 from .dashboard_querysets import filtered_querysets
 from .filters import (
     CONVERSATION_MESSAGE_TYPES,  # noqa: F401 - re-exported for callers importing it from this module
+    HUMAN_AUTHORED,
     UsageFilters,
     chat_tag_exists_pair,
     conversation_messages,
 )
 
-_TRUNC = {
+# DB truncation per bucketed granularity (Django's TruncWeek starts weeks on
+# Monday). The one home of the granularity vocabulary - the v2 usage API's
+# grouped reads import it rather than keeping a copy.
+GRANULARITY_TRUNC = {
     "daily": TruncDate,
     "weekly": TruncWeek,
     "monthly": TruncMonth,
@@ -119,14 +123,14 @@ def active_participants_queryset(
 ) -> QuerySet[ChatMessage]:
     """The message rows behind the active-participants count: HUMAN messages
     only. Receiving AI output is not activity (ADR-0051)."""
-    return messages_queryset(team, start=start, end=end, filters=filters).filter(message_type=ChatMessageType.HUMAN)
+    return messages_queryset(team, start=start, end=end, filters=filters).filter(HUMAN_AUTHORED)
 
 
 def distinct_active_participants(message_queryset: QuerySet[ChatMessage]) -> int:
     """Distinct participants who authored a HUMAN message in an already-scoped
     message queryset. The one definition of the count, callable from either
     surface's starting queryset."""
-    return message_queryset.filter(message_type=ChatMessageType.HUMAN).aggregate(
+    return message_queryset.filter(HUMAN_AUTHORED).aggregate(
         n=Count("chat__experiment_session__participant", distinct=True)
     )["n"]
 
@@ -294,13 +298,16 @@ def _by_bucket(queryset: QuerySet, granularity: str, tz: ZoneInfo, **annotations
     ``annotations``; yields ``(local bucket date, row)``. ``TruncDate`` yields
     a date already; ``TruncWeek``/``TruncMonth`` yield a datetime whose local
     date is the bucket boundary."""
-    trunc = _TRUNC.get(granularity, TruncDate)
+    trunc = GRANULARITY_TRUNC.get(granularity, TruncDate)
     rows = queryset.annotate(bucket=trunc("created_at", tzinfo=tz)).values("bucket").annotate(**annotations)
     for row in rows:
-        yield _bucket_date(row["bucket"], tz), row
+        yield bucket_date(row["bucket"], tz), row
 
 
-def _bucket_date(value, tz: ZoneInfo):
+def bucket_date(value, tz: ZoneInfo):
+    """Normalise a DB truncation result to its local calendar date.
+    ``TruncDate`` yields a ``date`` already; ``TruncWeek``/``TruncMonth``
+    yield a datetime whose local date is the bucket boundary."""
     if isinstance(value, datetime):
         return value.astimezone(tz).date()
     return value

--- a/apps/usage_metrics/metrics.py
+++ b/apps/usage_metrics/metrics.py
@@ -169,15 +169,15 @@ def active_participants(team: Team, *, start: datetime, end: datetime, filters: 
 
 
 def sessions_active(team: Team, *, start: datetime, end: datetime, filters: UsageFilters) -> int:
-    """Sessions with at least one message of any type in the CLOSED interval
-    ``[start, end]`` - the dashboard's current definition, reproduced
-    unchanged (SETUP sessions count; evaluation-channel sessions do not,
-    excluded via ``experiment_channel__platform`` rather than the session's
-    own ``platform`` column that ``sessions_started``/``sessions_in_setup``
-    key on - see ``_session_base``; ``include_archived`` is not consulted).
-    The definition-switch PR moves this to a half-open window over human/AI
-    messages with SETUP excluded; until then this and the API-derived
-    metrics deliberately disagree.
+    """Sessions with at least one message of any type in the half-open
+    interval ``[start, end)`` (SETUP sessions count; evaluation-channel
+    sessions do not, excluded via ``experiment_channel__platform`` rather
+    than the session's own ``platform`` column that
+    ``sessions_started``/``sessions_in_setup`` key on - see
+    ``_session_base``; ``include_archived`` is not consulted). The
+    definition-switch PR moves this further, to human/AI messages only with
+    SETUP excluded; until then this and the API-derived metrics deliberately
+    disagree on which message types and session statuses qualify.
 
     Empty-list filter semantics also differ from the rest of this module: via
     ``filtered_querysets``, an empty ``experiment_ids`` or ``participant_ids``

--- a/apps/usage_metrics/metrics.py
+++ b/apps/usage_metrics/metrics.py
@@ -1,8 +1,9 @@
 """Activity metrics over sessions, messages, and participants (#3905).
 
 Every function here is the canonical definition per ADR-0051: half-open
-`[start, end)` windows, evaluation-harness activity excluded, conversation
-turns are human/AI messages (`system` excluded). `sessions_active` and
+`[start, end)` windows, evaluation-harness and `SETUP`-session activity
+excluded, conversation turns are human/AI messages (`system` excluded).
+`sessions_active` and
 `sessions_started` legitimately differ from each other - they answer
 different questions, not the same one two ways. `sessions_active` is a
 session with a conversation turn in the window (SETUP excluded);
@@ -22,8 +23,11 @@ truthiness semantics), so identical empty-list filters yield opposite
 results on the two functions - see its docstring. `tag_ids` narrows to
 conversations whose chat or any message carries the tag, and an empty list
 always means "no filter" on every function in this module, `sessions_active`
-included. `include_archived` is not consulted here - activity metrics count
-archived-experiment activity on both surfaces today.
+included. `include_archived` is not consulted by any function here: it governs
+experiment *enumeration*, which only `filtered_querysets` returns, and activity
+metrics count archived-chatbot activity either way (ADR-0051). `sessions_active`
+delegates to `filtered_querysets` but reads only its `sessions` queryset, so it
+does not forward the field.
 """
 
 from datetime import datetime
@@ -78,16 +82,25 @@ def conversation_message_total(message_queryset: QuerySet[ChatMessage]) -> int:
 
 
 def messages_queryset(team: Team, *, start: datetime, end: datetime, filters: UsageFilters) -> QuerySet[ChatMessage]:
-    """Team-scoped ``ChatMessage`` in ``[start, end)``, evaluation-harness
-    activity excluded (ADR-0051). ``ChatMessage`` has no direct team FK, so
-    scope via ``chat__team``; participant/chatbot filters hit the session's
-    FK-id columns so no join to the experiment/participant tables. Backed by
-    the ``(chat, message_type, created_at)`` index. Every message type is still
-    in this universe - the human/AI narrowing belongs to the metrics that count
+    """Team-scoped ``ChatMessage`` in ``[start, end)``, with evaluation-harness
+    activity and ``SETUP``-session activity excluded (ADR-0051). ``SETUP`` is
+    excluded on the same universe as ``sessions_active`` drops the session, so
+    a ratio built from a count here over a session count stays on one universe.
+    ``ChatMessage`` has no direct team FK, so scope via ``chat__team``;
+    participant/chatbot filters hit the session's FK-id columns so no join to
+    the experiment/participant tables. Backed by the
+    ``(chat, message_type, created_at)`` index. Every message *type* is still in
+    this universe - the human/AI narrowing belongs to the metrics that count
     conversation turns, not to the scoping.
+
+    Both exclusions cross the nullable session relation, so a message whose
+    chat has no session stays in the universe. That is the dashboard's
+    long-standing behaviour and is deliberate.
     """
-    queryset = ChatMessage.objects.filter(chat__team=team, created_at__gte=start, created_at__lt=end).exclude(
-        chat__experiment_session__platform=ChannelPlatform.EVALUATIONS
+    queryset = (
+        ChatMessage.objects.filter(chat__team=team, created_at__gte=start, created_at__lt=end)
+        .exclude(chat__experiment_session__platform=ChannelPlatform.EVALUATIONS)
+        .exclude(chat__experiment_session__status=SessionStatus.SETUP)
     )
     if filters.participant_ids is not None:
         queryset = queryset.filter(chat__experiment_session__participant_id__in=filters.participant_ids)
@@ -208,12 +221,10 @@ def sessions_active(team: Team, *, start: datetime, end: datetime, filters: Usag
 def sessions_active_queryset(
     team: Team, *, start: datetime, end: datetime, filters: UsageFilters
 ) -> QuerySet[ChatMessage]:
-    """The conversation-turn message rows behind ``sessions_active``, excluding
-    turns belonging to sessions still in ``SETUP`` so the rows agree with the
-    scalar count."""
-    return conversation_messages(messages_queryset(team, start=start, end=end, filters=filters)).exclude(
-        chat__experiment_session__status=SessionStatus.SETUP
-    )
+    """The conversation-turn message rows behind ``sessions_active``.
+    ``messages_queryset`` already drops ``SETUP``-session turns, so these rows
+    agree with the scalar count without a second exclusion here."""
+    return conversation_messages(messages_queryset(team, start=start, end=end, filters=filters))
 
 
 def sessions_active_timeseries(

--- a/apps/usage_metrics/metrics.py
+++ b/apps/usage_metrics/metrics.py
@@ -3,11 +3,11 @@
 Each function reproduces, unchanged, the semantics its consumer computes
 today - this PR extracts, it does not converge. `messages`,
 `sessions_started`, and `active_participants` (and their timeseries) are the
-v2 usage API's current reads: half-open `[start, end)` windows, evaluation
-messages included in `messages`, `total = human + ai`. `sessions_active` is
-the dashboard's current definition (any message in the closed window) via
-`dashboard_querysets`. `sessions_in_setup` is new and has no consumer yet:
-sessions created in the window still in SETUP, so
+v2 usage API's current reads: half-open `[start, end)` windows,
+evaluation-harness activity excluded (ADR-0051), `total = human + ai`.
+`sessions_active` is the dashboard's current definition (any message in the
+closed window) via `dashboard_querysets`. `sessions_in_setup` is new and has
+no consumer yet: sessions created in the window still in SETUP, so
 `sessions_started + sessions_in_setup` is every non-evaluation session
 created in the window. The definition-switch PR converges the dashboard and
 API semantics as one diff against this module; it also adds the
@@ -70,13 +70,17 @@ def message_counts_from_row(row: dict) -> MessageCounts:
 
 
 def messages_queryset(team: Team, *, start: datetime, end: datetime, filters: UsageFilters) -> QuerySet[ChatMessage]:
-    """Team-scoped ``ChatMessage`` in ``[start, end)``, every message type and
-    every session kind (evaluation sessions included). ``ChatMessage`` has no
-    direct team FK, so scope via ``chat__team``; participant/chatbot filters
-    hit the session's FK-id columns so no join to the experiment/participant
-    tables. Backed by the ``(chat, message_type, created_at)`` index.
+    """Team-scoped ``ChatMessage`` in ``[start, end)``, evaluation-harness
+    activity excluded (ADR-0051). ``ChatMessage`` has no direct team FK, so
+    scope via ``chat__team``; participant/chatbot filters hit the session's
+    FK-id columns so no join to the experiment/participant tables. Backed by
+    the ``(chat, message_type, created_at)`` index. Every message type is still
+    in this universe - the human/AI narrowing belongs to the metrics that count
+    conversation turns, not to the scoping.
     """
-    queryset = ChatMessage.objects.filter(chat__team=team, created_at__gte=start, created_at__lt=end)
+    queryset = ChatMessage.objects.filter(chat__team=team, created_at__gte=start, created_at__lt=end).exclude(
+        chat__experiment_session__platform=ChannelPlatform.EVALUATIONS
+    )
     if filters.participant_ids is not None:
         queryset = queryset.filter(chat__experiment_session__participant_id__in=filters.participant_ids)
     if filters.experiment_ids is not None:
@@ -122,12 +126,9 @@ def sessions_in_setup_queryset(
 
 def _session_base(team: Team, *, start: datetime, end: datetime, filters: UsageFilters) -> QuerySet[ExperimentSession]:
     """Shared base for ``sessions_started_queryset``/``sessions_in_setup_queryset``.
-    Evaluation sessions are excluded on the session's own ``platform`` column.
-    This differs from ``sessions_active``, which excludes via
-    ``experiment_channel__platform`` (see ``dashboard_querysets.py``);
-    ``ExperimentSession.platform`` is an independent nullable ``CharField``,
-    so the two exclusions can disagree on a session where the two columns are
-    out of sync."""
+    Evaluation sessions are excluded on the session's own ``platform`` column,
+    the same column ``sessions_active`` now excludes on (see
+    ``dashboard_querysets.py``; ADR-0051)."""
     queryset = ExperimentSession.objects.filter(team=team, created_at__gte=start, created_at__lt=end).exclude(
         platform=ChannelPlatform.EVALUATIONS
     )
@@ -170,14 +171,12 @@ def active_participants(team: Team, *, start: datetime, end: datetime, filters: 
 
 def sessions_active(team: Team, *, start: datetime, end: datetime, filters: UsageFilters) -> int:
     """Sessions with at least one message of any type in the half-open
-    interval ``[start, end)`` (SETUP sessions count; evaluation-channel
-    sessions do not, excluded via ``experiment_channel__platform`` rather
-    than the session's own ``platform`` column that
+    interval ``[start, end)`` (SETUP sessions count; evaluation sessions do
+    not, excluded on the same ``platform`` column
     ``sessions_started``/``sessions_in_setup`` key on - see
-    ``_session_base``; ``include_archived`` is not consulted). The
-    definition-switch PR moves this further, to human/AI messages only with
-    SETUP excluded; until then this and the API-derived metrics deliberately
-    disagree on which message types and session statuses qualify.
+    ``_session_base``; ``include_archived`` is not consulted). This and the
+    API-derived metrics still deliberately disagree on which message types
+    and session statuses qualify a session.
 
     Empty-list filter semantics also differ from the rest of this module: via
     ``filtered_querysets``, an empty ``experiment_ids`` or ``participant_ids``

--- a/apps/usage_metrics/metrics.py
+++ b/apps/usage_metrics/metrics.py
@@ -41,7 +41,12 @@ from apps.experiments.models import ExperimentSession, SessionStatus
 from apps.teams.models import Team
 
 from .dashboard_querysets import filtered_querysets
-from .filters import UsageFilters, chat_tag_exists_pair
+from .filters import (
+    CONVERSATION_MESSAGE_TYPES,  # noqa: F401 - re-exported for callers importing it from this module
+    UsageFilters,
+    chat_tag_exists_pair,
+    conversation_messages,
+)
 
 _TRUNC = {
     "daily": TruncDate,
@@ -67,6 +72,11 @@ MESSAGE_ANNOTATIONS = {
 def message_counts_from_row(row: dict) -> MessageCounts:
     """Build a :class:`MessageCounts` from a row/aggregate carrying ``human``/``ai`` counts."""
     return MessageCounts(human=row["human"], ai=row["ai"], total=row["human"] + row["ai"])
+
+
+def conversation_message_total(message_queryset: QuerySet[ChatMessage]) -> int:
+    """``human + ai`` count over an already-scoped message queryset."""
+    return conversation_messages(message_queryset).count()
 
 
 def messages_queryset(team: Team, *, start: datetime, end: datetime, filters: UsageFilters) -> QuerySet[ChatMessage]:
@@ -100,9 +110,7 @@ def active_participants_queryset(
 ) -> QuerySet[ChatMessage]:
     """The message rows behind the active-participants count: human/AI only,
     the same categories the ``messages`` metric surfaces."""
-    return messages_queryset(team, start=start, end=end, filters=filters).filter(
-        message_type__in=(ChatMessageType.HUMAN, ChatMessageType.AI)
-    )
+    return conversation_messages(messages_queryset(team, start=start, end=end, filters=filters))
 
 
 def sessions_started_queryset(

--- a/apps/usage_metrics/metrics.py
+++ b/apps/usage_metrics/metrics.py
@@ -13,14 +13,12 @@ complement: sessions created in the window still in SETUP, so
 `sessions_started + sessions_in_setup` is every non-evaluation session
 created in the window.
 
-Filter semantics (see `UsageFilters`): for the API-derived reads - `messages`,
-`sessions_started`, `sessions_in_setup`, `active_participants`, and their
-timeseries - `experiment_ids`/`participant_ids` distinguish `None` (no
-filter) from `[]` (matched nobody -> empty result). `sessions_active` does
-NOT follow this rule: it delegates to `filtered_querysets`, which treats an
-empty `experiment_ids`/`participant_ids` list as "no filter" (dashboard
-truthiness semantics), so identical empty-list filters yield opposite
-results on the two functions - see its docstring. `tag_ids` narrows to
+Filter semantics (see `UsageFilters`): `experiment_ids`/`participant_ids`
+distinguish `None` (no filter) from `[]` (matched nobody -> empty result) on
+every function in this module. `sessions_active` delegates to
+`filtered_querysets`, which treats an empty list as "no filter" (dashboard
+truthiness semantics), so it answers the empty-list case itself before
+delegating - see its docstring. `tag_ids` narrows to
 conversations whose chat or any message carries the tag, and an empty list
 always means "no filter" on every function in this module, `sessions_active`
 included. `include_archived` is not consulted by any function here: it governs
@@ -201,11 +199,12 @@ def sessions_active(team: Team, *, start: datetime, end: datetime, filters: Usag
     ``filtered_querysets`` so the dashboard's charts, which read those
     querysets directly, count the same sessions this returns.
 
-    Empty-list filter semantics differ from the rest of this module: via
-    ``filtered_querysets``, an empty ``experiment_ids`` or ``participant_ids``
-    list means "no filter" here (dashboard truthiness semantics), not
-    "matched nobody" as it does on ``sessions_started`` and the other
-    API-derived reads."""
+    ``filtered_querysets`` treats an empty ``experiment_ids``/``participant_ids``
+    list as "no filter" (dashboard truthiness semantics), so the empty-list
+    case is answered here before delegating: ``[]`` means "requested but
+    matched nobody", the same as every other function in this module."""
+    if filters.experiment_ids == [] or filters.participant_ids == []:
+        return 0
     querysets = filtered_querysets(
         team,
         start_date=start,

--- a/apps/usage_metrics/metrics.py
+++ b/apps/usage_metrics/metrics.py
@@ -1,18 +1,16 @@
 """Activity metrics over sessions, messages, and participants (#3905).
 
-Each function reproduces, unchanged, the semantics its consumer computes
-today - this PR extracts, it does not converge. `messages`,
-`sessions_started`, and `active_participants` (and their timeseries) are the
-v2 usage API's current reads: half-open `[start, end)` windows,
-evaluation-harness activity excluded (ADR-0051), `total = human + ai`.
-`sessions_active` is the dashboard's current definition (any message in the
-closed window) via `dashboard_querysets`. `sessions_in_setup` is new and has
-no consumer yet: sessions created in the window still in SETUP, so
+Every function here is the canonical definition per ADR-0051: half-open
+`[start, end)` windows, evaluation-harness activity excluded, conversation
+turns are human/AI messages (`system` excluded). `sessions_active` and
+`sessions_started` legitimately differ from each other - they answer
+different questions, not the same one two ways. `sessions_active` is a
+session with a conversation turn in the window (SETUP excluded);
+`sessions_started` is a session created in the window (also SETUP-excluded,
+via a different mechanism - see `_session_base`). `sessions_in_setup` is the
+complement: sessions created in the window still in SETUP, so
 `sessions_started + sessions_in_setup` is every non-evaluation session
-created in the window. The definition-switch PR converges the dashboard and
-API semantics as one diff against this module; it also adds the
-`sessions_active` timeseries, whose per-period definition is contested today
-(the dashboard has two disagreeing chart implementations).
+created in the window.
 
 Filter semantics (see `UsageFilters`): for the API-derived reads - `messages`,
 `sessions_started`, `sessions_in_setup`, `active_participants`, and their
@@ -178,15 +176,12 @@ def active_participants(team: Team, *, start: datetime, end: datetime, filters: 
 
 
 def sessions_active(team: Team, *, start: datetime, end: datetime, filters: UsageFilters) -> int:
-    """Sessions with at least one message of any type in the half-open
-    interval ``[start, end)`` (SETUP sessions count; evaluation sessions do
-    not, excluded on the same ``platform`` column
-    ``sessions_started``/``sessions_in_setup`` key on - see
-    ``_session_base``; ``include_archived`` is not consulted). This and the
-    API-derived metrics still deliberately disagree on which message types
-    and session statuses qualify a session.
+    """Sessions with at least one human or AI message in ``[start, end)``,
+    ``SETUP`` and evaluation sessions excluded (ADR-0051). Computed through
+    ``filtered_querysets`` so the dashboard's charts, which read those
+    querysets directly, count the same sessions this returns.
 
-    Empty-list filter semantics also differ from the rest of this module: via
+    Empty-list filter semantics differ from the rest of this module: via
     ``filtered_querysets``, an empty ``experiment_ids`` or ``participant_ids``
     list means "no filter" here (dashboard truthiness semantics), not
     "matched nobody" as it does on ``sessions_started`` and the other
@@ -201,6 +196,34 @@ def sessions_active(team: Team, *, start: datetime, end: datetime, filters: Usag
         tag_ids=filters.tag_ids,
     )
     return querysets["sessions"].count()
+
+
+def sessions_active_queryset(
+    team: Team, *, start: datetime, end: datetime, filters: UsageFilters
+) -> QuerySet[ChatMessage]:
+    """The conversation-turn message rows behind ``sessions_active``, excluding
+    turns belonging to sessions still in ``SETUP`` so the rows agree with the
+    scalar count."""
+    return conversation_messages(messages_queryset(team, start=start, end=end, filters=filters)).exclude(
+        chat__experiment_session__status=SessionStatus.SETUP
+    )
+
+
+def sessions_active_timeseries(
+    team: Team, *, start: datetime, end: datetime, granularity: str, tz: ZoneInfo, filters: UsageFilters
+) -> dict:
+    """``{local bucket date: int}`` of distinct sessions with a conversation
+    turn in each bucket. Bucketed on the message's timestamp, not the session's
+    creation - a session spanning three days is active in all three."""
+    return {
+        bucket: row["n"]
+        for bucket, row in _by_bucket(
+            sessions_active_queryset(team, start=start, end=end, filters=filters),
+            granularity,
+            tz,
+            n=Count("chat__experiment_session", distinct=True),
+        )
+    }
 
 
 def messages_timeseries(

--- a/apps/usage_metrics/metrics.py
+++ b/apps/usage_metrics/metrics.py
@@ -106,9 +106,18 @@ def messages_queryset(team: Team, *, start: datetime, end: datetime, filters: Us
 def active_participants_queryset(
     team: Team, *, start: datetime, end: datetime, filters: UsageFilters
 ) -> QuerySet[ChatMessage]:
-    """The message rows behind the active-participants count: human/AI only,
-    the same categories the ``messages`` metric surfaces."""
-    return conversation_messages(messages_queryset(team, start=start, end=end, filters=filters))
+    """The message rows behind the active-participants count: HUMAN messages
+    only. Receiving AI output is not activity (ADR-0051)."""
+    return messages_queryset(team, start=start, end=end, filters=filters).filter(message_type=ChatMessageType.HUMAN)
+
+
+def distinct_active_participants(message_queryset: QuerySet[ChatMessage]) -> int:
+    """Distinct participants who authored a HUMAN message in an already-scoped
+    message queryset. The one definition of the count, callable from either
+    surface's starting queryset."""
+    return message_queryset.filter(message_type=ChatMessageType.HUMAN).aggregate(
+        n=Count("chat__experiment_session__participant", distinct=True)
+    )["n"]
 
 
 def sessions_started_queryset(
@@ -169,10 +178,8 @@ def sessions_in_setup(team: Team, *, start: datetime, end: datetime, filters: Us
 
 
 def active_participants(team: Team, *, start: datetime, end: datetime, filters: UsageFilters) -> int:
-    """Distinct participants with at least one human/AI message in the window."""
-    return active_participants_queryset(team, start=start, end=end, filters=filters).aggregate(
-        n=Count("chat__experiment_session__participant", distinct=True)
-    )["n"]
+    """Distinct participants with at least one HUMAN message in the window."""
+    return distinct_active_participants(messages_queryset(team, start=start, end=end, filters=filters))
 
 
 def sessions_active(team: Team, *, start: datetime, end: datetime, filters: UsageFilters) -> int:
@@ -256,7 +263,7 @@ def sessions_in_setup_timeseries(
 def active_participants_timeseries(
     team: Team, *, start: datetime, end: datetime, granularity: str, tz: ZoneInfo, filters: UsageFilters
 ) -> dict:
-    """``{local bucket date: int}`` of distinct human/AI-message authors per bucket."""
+    """``{local bucket date: int}`` of distinct HUMAN-message authors per bucket."""
     return {
         bucket: row["n"]
         for bucket, row in _by_bucket(

--- a/apps/usage_metrics/tests/test_characterisation.py
+++ b/apps/usage_metrics/tests/test_characterisation.py
@@ -108,6 +108,34 @@ class TestSetupSessionsCountOnNeitherSurface:
         assert metrics.sessions_in_setup(self._team(), start=_START, end=_END, filters=UsageFilters()) == 1
 
 
+class TestSetupSessionActivityCountsNowhere:
+    """A session still in `SETUP` was never engaged, so nothing inside it
+    counts on any metric (ADR-0051) - not its turns, not its author. Counting
+    its messages while `sessions_active` drops the session would put a ratio's
+    numerator and denominator on different universes, which is exactly what
+    the ADR's ratios rule forbids."""
+
+    def _team(self):
+        team = TeamFactory.create()
+        experiment = ExperimentFactory.create(team=team)
+        in_setup = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.SETUP)
+        _message(in_setup, message_type=ChatMessageType.HUMAN)
+        _message(in_setup, message_type=ChatMessageType.AI)
+        return team
+
+    def test_dashboard_messages_exclude_setup_session_turns(self):
+        assert _overview(self._team())["total_messages"] == 0
+
+    def test_dashboard_participants_exclude_setup_session_authors(self):
+        assert _overview(self._team())["active_participants"] == 0
+
+    def test_api_messages_exclude_setup_session_turns(self):
+        assert _api_results(self._team(), ["messages"])["messages"] == {"human": 0, "ai": 0, "total": 0}
+
+    def test_api_participants_exclude_setup_session_authors(self):
+        assert _api_results(self._team(), ["participants"])["participants"] == 0
+
+
 class TestSessionsActiveNeedsAConversationTurn:
     """A session whose only in-window activity is a `system` message was not
     active (ADR-0051)."""

--- a/apps/usage_metrics/tests/test_characterisation.py
+++ b/apps/usage_metrics/tests/test_characterisation.py
@@ -1,8 +1,8 @@
-"""Characterisation tests for #3905: pin what the dashboard and the v2 usage API
-compute TODAY for the same team and window, including where they diverge. The
-extraction PR must keep every one of these green; only the definition-switch PR
-may change an assertion here, and each change there maps to a row in the design's
-divergence table.
+"""Cross-surface definition tests for #3905: the dashboard and the v2 usage API
+compute the same activity metrics the same way (ADR-0051). Each class here
+covers one row of the design's former divergence table, asserting the converged
+behaviour on both surfaces. These started life as characterisation tests pinning
+the divergence; they now pin its absence.
 """
 
 from datetime import UTC, datetime

--- a/apps/usage_metrics/tests/test_characterisation.py
+++ b/apps/usage_metrics/tests/test_characterisation.py
@@ -16,6 +16,8 @@ from apps.channels.models import ChannelPlatform
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.dashboard.services import DashboardService
 from apps.experiments.models import ExperimentSession, SessionStatus
+from apps.usage_metrics import metrics
+from apps.usage_metrics.filters import UsageFilters
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.team import TeamFactory
@@ -56,15 +58,14 @@ def _api_results(team, metrics):
     return api_usage.usage_query(query).results
 
 
-class TestSessionWindowDivergence:
-    """Dashboard sessions = any message in the window; API sessions = created in
-    the window (design section 2, row 1)."""
+class TestSessionMetricsAreTwoNamedDefinitions:
+    """`sessions_active` (a conversation turn in the window) and
+    `sessions_started` (created in the window) are two different questions, so
+    they legitimately differ - but each is now computed one way, and each
+    surface labels which one it shows (ADR-0051). The dashboard shows active;
+    the API's `sessions` metric is started."""
 
     def _team(self):
-        # status=ACTIVE on every session here: the factory default is SETUP, which the API excludes for a
-        # different reason (TestSetupSessionDivergence). Without pinning ACTIVE, `old_but_active` would be
-        # dropped by the status exclusion regardless of its created_at, and this class's API assertion would
-        # pass without actually exercising the created_at window filter it exists to pin.
         team = TeamFactory.create()
         experiment = ExperimentFactory.create(team=team)
         old_but_active = _backdate(
@@ -79,15 +80,16 @@ class TestSessionWindowDivergence:
         )  # created in window, silent
         return team
 
-    def test_dashboard_counts_sessions_with_message_activity_in_window(self):
+    def test_dashboard_shows_sessions_active(self):
         assert _overview(self._team())["total_sessions"] == 1
 
-    def test_api_counts_sessions_created_in_window(self):
+    def test_api_shows_sessions_started(self):
         assert _api_results(self._team(), ["sessions"])["sessions"] == 2
 
 
-class TestSetupSessionDivergence:
-    """The API excludes status=SETUP; the dashboard does not (design section 2, row 2)."""
+class TestSetupSessionsCountOnNeitherSurface:
+    """A session created but never engaged is not active and was not started
+    (ADR-0051); `sessions_in_setup` is where it stays countable."""
 
     def _team(self):
         team = TeamFactory.create()
@@ -96,11 +98,27 @@ class TestSetupSessionDivergence:
         _message(setup_session)
         return team
 
-    def test_dashboard_counts_setup_sessions(self):
-        assert _overview(self._team())["total_sessions"] == 1
+    def test_dashboard_excludes_setup_sessions(self):
+        assert _overview(self._team())["total_sessions"] == 0
 
     def test_api_excludes_setup_sessions(self):
         assert _api_results(self._team(), ["sessions"])["sessions"] == 0
+
+    def test_setup_sessions_stay_countable_as_sessions_in_setup(self):
+        assert metrics.sessions_in_setup(self._team(), start=_START, end=_END, filters=UsageFilters()) == 1
+
+
+class TestSessionsActiveNeedsAConversationTurn:
+    """A session whose only in-window activity is a `system` message was not
+    active (ADR-0051)."""
+
+    def test_system_only_session_is_not_active(self):
+        team = TeamFactory.create()
+        experiment = ExperimentFactory.create(team=team)
+        session = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
+        _message(session, message_type=ChatMessageType.SYSTEM)
+
+        assert _overview(team)["total_sessions"] == 0
 
 
 class TestEvaluationActivityIsExcludedEverywhere:
@@ -199,23 +217,22 @@ class TestWindowBoundaryIsHalfOpen:
 
 
 class TestActiveParticipantsFourImplementations:
-    """The four current implementations define "active participant" differently
-    (design section 2, row 4): the dashboard chart counts HUMAN-message authors
-    only; the dashboard session-analytics series and overview stat count
-    participants with any message type (including SYSTEM-only sessions); the API
-    counts HUMAN+AI. One participant per activity shape (human, AI-only,
-    system-only) pins all four definitions, though this fixture only separates
-    the chart and the API from the other two — session-analytics and overview
-    agree here and diverge only in edge cases this fixture doesn't construct."""
+    """The four current implementations define "active participant" (design
+    section 2, row 4): the dashboard chart counts HUMAN-message authors only;
+    the dashboard session-analytics series, the overview stat, and the API now
+    agree on HUMAN+AI conversation-turn authors, SETUP sessions excluded
+    (ADR-0051). One participant per activity shape (human, AI-only,
+    system-only) pins all four: the chart isolates the HUMAN author, and the
+    other three exclude the system-only participant."""
 
     def _team(self):
         team = TeamFactory.create()
         experiment = ExperimentFactory.create(team=team)
-        human = ExperimentSessionFactory.create(team=team, experiment=experiment)
+        human = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
         _message(human, message_type=ChatMessageType.HUMAN)
-        ai_only = ExperimentSessionFactory.create(team=team, experiment=experiment)
+        ai_only = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
         _message(ai_only, message_type=ChatMessageType.AI)
-        system_only = ExperimentSessionFactory.create(team=team, experiment=experiment)
+        system_only = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
         _message(system_only, message_type=ChatMessageType.SYSTEM)
         return team
 
@@ -225,14 +242,14 @@ class TestActiveParticipantsFourImplementations:
         )
         assert sum(point["active_participants"] for point in data) == 1
 
-    def test_dashboard_session_analytics_counts_any_message_type(self):
+    def test_dashboard_session_analytics_counts_conversation_turn_authors(self):
         data = DashboardService(self._team()).get_session_analytics_data(
             granularity="daily", start_date=_START, end_date=_END
         )
-        assert sum(point["active_participants"] for point in data["participants"]) == 3
+        assert sum(point["active_participants"] for point in data["participants"]) == 2
 
     def test_dashboard_overview_counts_participants_of_active_sessions(self):
-        assert _overview(self._team())["active_participants"] == 3
+        assert _overview(self._team())["active_participants"] == 2
 
     def test_api_counts_human_and_ai_authors(self):
         assert _api_results(self._team(), ["participants"])["participants"] == 2

--- a/apps/usage_metrics/tests/test_characterisation.py
+++ b/apps/usage_metrics/tests/test_characterisation.py
@@ -103,9 +103,9 @@ class TestSetupSessionDivergence:
         assert _api_results(self._team(), ["sessions"])["sessions"] == 0
 
 
-class TestEvaluationMessageDivergence:
-    """The API counts evaluation messages; the dashboard excludes them
-    (design section 2, row 3)."""
+class TestEvaluationActivityIsExcludedEverywhere:
+    """Evaluation-harness activity counts on neither surface (ADR-0051), and
+    the API's grouped rows now sum to its ungrouped total."""
 
     def _team(self):
         team = TeamFactory.create()
@@ -113,6 +113,7 @@ class TestEvaluationMessageDivergence:
         eval_session = ExperimentSessionFactory.create(
             team=team,
             experiment=experiment,
+            status=SessionStatus.ACTIVE,
             experiment_channel=ExperimentChannelFactory(
                 team=team, experiment=experiment, platform=ChannelPlatform.EVALUATIONS
             ),
@@ -123,12 +124,16 @@ class TestEvaluationMessageDivergence:
     def test_dashboard_excludes_evaluation_messages(self):
         assert _overview(self._team())["total_messages"] == 0
 
-    def test_api_counts_evaluation_messages(self):
-        assert _api_results(self._team(), ["messages"])["messages"] == {"human": 1, "ai": 0, "total": 1}
+    def test_api_excludes_evaluation_messages(self):
+        assert _api_results(self._team(), ["messages"])["messages"] == {"human": 0, "ai": 0, "total": 0}
 
-    def test_api_platform_grouping_excludes_evaluations_while_total_counts_them(self):
-        """The API-internal inconsistency the design's problem statement names:
-        grouped rows shrink their universe, the ungrouped total does not."""
+    def test_api_excludes_evaluation_participants(self):
+        assert _api_results(self._team(), ["participants"])["participants"] == 0
+
+    def test_api_platform_grouping_and_total_agree(self):
+        """The API-internal inconsistency the design's problem statement named:
+        grouped rows shrank their universe while the ungrouped total did not.
+        Both now exclude evaluations, so the two reconcile."""
         team = self._team()
         query = api_usage.resolve_query_filters(
             api_usage.UsageQuery(
@@ -141,7 +146,7 @@ class TestEvaluationMessageDivergence:
             )
         )
         assert list(api_usage.group_entities(query)) == []
-        assert _api_results(team, ["messages"])["messages"]["total"] == 1
+        assert _api_results(team, ["messages"])["messages"]["total"] == 0
 
 
 class TestMessageTypeTotalDivergence:

--- a/apps/usage_metrics/tests/test_characterisation.py
+++ b/apps/usage_metrics/tests/test_characterisation.py
@@ -149,21 +149,21 @@ class TestEvaluationActivityIsExcludedEverywhere:
         assert _api_results(team, ["messages"])["messages"]["total"] == 0
 
 
-class TestMessageTypeTotalDivergence:
-    """Dashboard message totals include SYSTEM messages; the API total is
-    human + ai (design section 2, row 7)."""
+class TestMessageTotalIsHumanPlusAi:
+    """`system` messages are internal and are not conversation turns, so both
+    surfaces count human + ai (ADR-0051)."""
 
     def _team(self):
         team = TeamFactory.create()
         experiment = ExperimentFactory.create(team=team)
-        session = ExperimentSessionFactory.create(team=team, experiment=experiment)
+        session = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
         _message(session, message_type=ChatMessageType.HUMAN)
         _message(session, message_type=ChatMessageType.AI)
         _message(session, message_type=ChatMessageType.SYSTEM)
         return team
 
-    def test_dashboard_total_includes_system_messages(self):
-        assert _overview(self._team())["total_messages"] == 3
+    def test_dashboard_total_excludes_system_messages(self):
+        assert _overview(self._team())["total_messages"] == 2
 
     def test_api_total_is_human_plus_ai(self):
         assert _api_results(self._team(), ["messages"])["messages"] == {"human": 1, "ai": 1, "total": 2}

--- a/apps/usage_metrics/tests/test_characterisation.py
+++ b/apps/usage_metrics/tests/test_characterisation.py
@@ -164,23 +164,33 @@ class TestMessageTypeTotalDivergence:
         assert _api_results(self._team(), ["messages"])["messages"] == {"human": 1, "ai": 1, "total": 2}
 
 
-class TestWindowBoundaryDivergence:
-    """Dashboard windows are closed (lte); API windows are half-open (lt)
-    (design section 2, row 6). A message at the boundary instant counts on the
-    dashboard side only."""
+class TestWindowBoundaryIsHalfOpen:
+    """Windows are half-open [start, end) on both surfaces (ADR-0051), so an
+    instant exactly on the boundary belongs to the next period, not this one,
+    and is never counted twice across adjacent periods."""
 
     def _team(self):
         team = TeamFactory.create()
         experiment = ExperimentFactory.create(team=team)
-        session = ExperimentSessionFactory.create(team=team, experiment=experiment)
+        session = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
         _message(session, when=_END)
         return team
 
-    def test_dashboard_includes_the_end_boundary_instant(self):
-        assert _overview(self._team())["total_messages"] == 1
+    def test_dashboard_excludes_the_end_boundary_instant(self):
+        assert _overview(self._team())["total_messages"] == 0
 
     def test_api_excludes_the_end_boundary_instant(self):
         assert _api_results(self._team(), ["messages"])["messages"]["total"] == 0
+
+    def test_both_surfaces_include_the_start_boundary_instant(self):
+        """The other half of half-open: [start is inclusive."""
+        team = TeamFactory.create()
+        experiment = ExperimentFactory.create(team=team)
+        session = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
+        _message(session, when=_START)
+
+        assert _overview(team)["total_messages"] == 1
+        assert _api_results(team, ["messages"])["messages"]["total"] == 1
 
 
 class TestActiveParticipantsFourImplementations:

--- a/apps/usage_metrics/tests/test_characterisation.py
+++ b/apps/usage_metrics/tests/test_characterisation.py
@@ -179,8 +179,15 @@ class TestEvaluationActivityIsExcludedEverywhere:
     def test_api_platform_grouping_and_total_agree(self):
         """The API-internal inconsistency the design's problem statement named:
         grouped rows shrank their universe while the ungrouped total did not.
-        Both now exclude evaluations, so the two reconcile."""
+        Both now exclude evaluations, so the two reconcile. The team here also
+        runs a non-evaluation session, so agreement on a non-zero total is what
+        is under test - an evaluation-only team reconciles trivially."""
         team = self._team()
+        experiment = ExperimentFactory.create(team=team)
+        session = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
+        _message(session, message_type=ChatMessageType.HUMAN)
+        _message(session, message_type=ChatMessageType.AI)
+
         query = api_usage.resolve_query_filters(
             api_usage.UsageQuery(
                 team=team,
@@ -191,8 +198,11 @@ class TestEvaluationActivityIsExcludedEverywhere:
                 group_by=api_usage.GROUP_PLATFORM,
             )
         )
-        assert list(api_usage.group_entities(query)) == []
-        assert _api_results(team, ["messages"])["messages"]["total"] == 0
+        rows = api_usage.group_rows(query, list(api_usage.group_entities(query)))
+
+        total = _api_results(team, ["messages"])["messages"]["total"]
+        assert total == 2
+        assert sum(row["messages"]["total"] for row in rows) == total
 
 
 class TestMessageTotalIsHumanPlusAi:

--- a/apps/usage_metrics/tests/test_characterisation.py
+++ b/apps/usage_metrics/tests/test_characterisation.py
@@ -216,14 +216,11 @@ class TestWindowBoundaryIsHalfOpen:
         assert _api_results(team, ["messages"])["messages"]["total"] == 1
 
 
-class TestActiveParticipantsFourImplementations:
-    """The four current implementations define "active participant" (design
-    section 2, row 4): the dashboard chart counts HUMAN-message authors only;
-    the dashboard session-analytics series, the overview stat, and the API now
-    agree on HUMAN+AI conversation-turn authors, SETUP sessions excluded
-    (ADR-0051). One participant per activity shape (human, AI-only,
-    system-only) pins all four: the chart isolates the HUMAN author, and the
-    other three exclude the system-only participant."""
+class TestActiveParticipantsIsOneDefinition:
+    """What was four implementations is one (ADR-0051): a participant is active
+    when they authored a HUMAN message in the window. Receiving AI output is
+    not activity, and neither is a `system` message. One participant per
+    activity shape pins every surface to the same answer."""
 
     def _team(self):
         team = TeamFactory.create()
@@ -236,23 +233,23 @@ class TestActiveParticipantsFourImplementations:
         _message(system_only, message_type=ChatMessageType.SYSTEM)
         return team
 
-    def test_dashboard_chart_counts_human_authors_only(self):
+    def test_dashboard_chart_counts_human_authors(self):
         data = DashboardService(self._team()).get_active_participants_data(
             granularity="daily", start_date=_START, end_date=_END
         )
         assert sum(point["active_participants"] for point in data) == 1
 
-    def test_dashboard_session_analytics_counts_conversation_turn_authors(self):
+    def test_dashboard_session_analytics_counts_human_authors(self):
         data = DashboardService(self._team()).get_session_analytics_data(
             granularity="daily", start_date=_START, end_date=_END
         )
-        assert sum(point["active_participants"] for point in data["participants"]) == 2
+        assert sum(point["active_participants"] for point in data["participants"]) == 1
 
-    def test_dashboard_overview_counts_participants_of_active_sessions(self):
-        assert _overview(self._team())["active_participants"] == 2
+    def test_dashboard_overview_counts_human_authors(self):
+        assert _overview(self._team())["active_participants"] == 1
 
-    def test_api_counts_human_and_ai_authors(self):
-        assert _api_results(self._team(), ["participants"])["participants"] == 2
+    def test_api_counts_human_authors(self):
+        assert _api_results(self._team(), ["participants"])["participants"] == 1
 
 
 class TestArchivedExperimentActivity:

--- a/apps/usage_metrics/tests/test_dashboard_querysets.py
+++ b/apps/usage_metrics/tests/test_dashboard_querysets.py
@@ -61,80 +61,40 @@ class TestTagFilterTeamScoping:
         assert [e.id for e in querysets["experiments"]] == [experiment.id]
         assert [p.id for p in querysets["participants"]] == [session.participant_id]
 
-    def test_cross_team_tag_link_does_not_qualify_a_local_chat(self):
-        """The inconsistent-link shape: a CustomTaggedItem row carrying a
-        FOREIGN team_id, whose tag is a local tag and whose object_id targets
-        a local chat. The link is not the reading team's, so it must not make
-        the session, experiment, or participant match."""
+    @pytest.mark.parametrize(
+        ("failing_conjunct", "target"),
+        [
+            pytest.param("link-team", "chat", id="link-team-conjunct-on-chat"),
+            pytest.param("tag-team", "chat", id="tag-team-conjunct-on-chat"),
+            pytest.param("tag-team", "msg", id="tag-team-conjunct-on-msg"),
+            pytest.param("link-team", "msg", id="link-team-conjunct-on-msg"),
+        ],
+    )
+    def test_link_failing_one_scoping_conjunct_qualifies_nothing(self, failing_conjunct, target):
+        """Every tag site scopes links with two conjuncts, `team_id` and
+        `tag__team_id`, applied on a chat leg and a message leg
+        (`chat_tag_exists_pair` for sessions, `tagged_conversation_exists_pair`
+        for experiments and participants). Each case builds a link where
+        exactly one conjunct fails on one leg while the other three
+        predicates hold; the legs filter on their own content_type, so a
+        chat-targeted link never reaches the `_on_msg` predicates and vice
+        versa. The three assertions cover the three querysets that consume
+        the predicates. Positive controls:
+        `test_own_teams_tag_link_matches` / `test_own_team_link_on_a_message_matches`."""
         team = TeamFactory.create()
         foreign_team = TeamFactory.create()
         experiment = ExperimentFactory.create(team=team)
         session = _active_session(team, experiment)
-        tag = TagFactory.create(team=team)
-        CustomTaggedItemFactory.create(team=foreign_team, tag=tag, target=session.chat)
-
-        querysets = filtered_querysets(team, start_date=_START, end_date=_END, tag_ids=[tag.id])
-
-        assert list(querysets["sessions"]) == []
-        assert list(querysets["experiments"]) == []
-        assert list(querysets["participants"]) == []
-
-    def test_locally_recorded_link_with_foreign_team_tag_does_not_qualify_a_chat(self):
-        """The mirror inconsistent-link shape: a CustomTaggedItem row with a
-        LOCAL team_id, whose tag belongs to a FOREIGN team, targeting a local
-        chat. The tag isn't the reading team's, so it must not make the
-        session, experiment, or participant match."""
-        team = TeamFactory.create()
-        foreign_team = TeamFactory.create()
-        experiment = ExperimentFactory.create(team=team)
-        session = _active_session(team, experiment)
-        foreign_tag = TagFactory.create(team=foreign_team)
-        CustomTaggedItemFactory.create(team=team, tag=foreign_tag, target=session.chat)
-
-        querysets = filtered_querysets(team, start_date=_START, end_date=_END, tag_ids=[foreign_tag.id])
-
-        assert list(querysets["sessions"]) == []
-        assert list(querysets["experiments"]) == []
-        assert list(querysets["participants"]) == []
-
-    def test_locally_recorded_link_with_foreign_team_tag_does_not_qualify_a_message(self):
-        """Same mirror shape as above, but the link targets a MESSAGE rather
-        than the chat - exercises the `_on_msg` predicates (`tag_on_msg`,
-        `exp_tag_on_msg`, `part_tag_on_msg`), which a chat-targeted tag never
-        reaches."""
-        team = TeamFactory.create()
-        foreign_team = TeamFactory.create()
-        experiment = ExperimentFactory.create(team=team)
-        session = _active_session(team, experiment)
-        message = ChatMessage.objects.create(
-            chat=session.chat, message_type=ChatMessageType.HUMAN, content="tagged", created_at=_MID
+        link_team = foreign_team if failing_conjunct == "link-team" else team
+        tag = TagFactory.create(team=foreign_team if failing_conjunct == "tag-team" else team)
+        link_target = (
+            ChatMessage.objects.create(
+                chat=session.chat, message_type=ChatMessageType.HUMAN, content="tagged", created_at=_MID
+            )
+            if target == "msg"
+            else session.chat
         )
-        foreign_tag = TagFactory.create(team=foreign_team)
-        CustomTaggedItemFactory.create(team=team, tag=foreign_tag, target=message)
-
-        querysets = filtered_querysets(team, start_date=_START, end_date=_END, tag_ids=[foreign_tag.id])
-
-        assert list(querysets["sessions"]) == []
-        assert list(querysets["experiments"]) == []
-        assert list(querysets["participants"]) == []
-
-    def test_foreign_team_link_with_local_tag_does_not_qualify_via_a_message(self):
-        """The remaining inconsistent-link shape: a CustomTaggedItem row with
-        a FOREIGN team_id, whose tag IS local, attached to a MESSAGE rather
-        than the chat. A chat-targeted foreign-team_id link (see
-        `test_cross_team_tag_link_does_not_qualify_a_local_chat`) never
-        reaches `tag_on_msg`/`exp_tag_on_msg`/`part_tag_on_msg`, since those
-        subqueries filter on `content_type=message_content_type` - this is
-        the test that does."""
-        team = TeamFactory.create()
-        foreign_team = TeamFactory.create()
-        experiment = ExperimentFactory.create(team=team)
-        session = _active_session(team, experiment)
-        message = ChatMessage.objects.create(
-            chat=session.chat, message_type=ChatMessageType.HUMAN, content="tagged", created_at=_MID
-        )
-        tag = TagFactory.create(team=team)
-        CustomTaggedItemFactory.create(team=foreign_team, tag=tag, target=message)
+        CustomTaggedItemFactory.create(team=link_team, tag=tag, target=link_target)
 
         querysets = filtered_querysets(team, start_date=_START, end_date=_END, tag_ids=[tag.id])
 
@@ -169,7 +129,17 @@ class TestMessageTagFilterTeamScoping:
     predicate. It now uses a team-scoped `Exists` against `CustomTaggedItem`
     for the message's own tags, matching the other sites' shape."""
 
-    def test_cross_team_link_with_local_tag_on_a_local_message_does_not_qualify(self):
+    @pytest.mark.parametrize(
+        "failing_conjunct",
+        [
+            pytest.param("link-team", id="link-team-conjunct"),
+            pytest.param("tag-team", id="tag-team-conjunct"),
+        ],
+    )
+    def test_link_failing_one_scoping_conjunct_does_not_qualify_a_message(self, failing_conjunct):
+        """Each case builds a message-targeted link where exactly one of the
+        two scoping conjuncts fails while the other holds. Positive control:
+        `test_own_teams_link_on_a_message_matches`."""
         team = TeamFactory.create()
         foreign_team = TeamFactory.create()
         experiment = ExperimentFactory.create(team=team)
@@ -177,25 +147,11 @@ class TestMessageTagFilterTeamScoping:
         message = ChatMessage.objects.create(
             chat=session.chat, message_type=ChatMessageType.HUMAN, content="tagged", created_at=_MID
         )
-        tag = TagFactory.create(team=team)
-        CustomTaggedItemFactory.create(team=foreign_team, tag=tag, target=message)
+        link_team = foreign_team if failing_conjunct == "link-team" else team
+        tag = TagFactory.create(team=foreign_team if failing_conjunct == "tag-team" else team)
+        CustomTaggedItemFactory.create(team=link_team, tag=tag, target=message)
 
         querysets = filtered_querysets(team, start_date=_START, end_date=_END, tag_ids=[tag.id])
-
-        assert list(querysets["messages"]) == []
-
-    def test_local_link_with_foreign_team_tag_on_a_local_message_does_not_qualify(self):
-        team = TeamFactory.create()
-        foreign_team = TeamFactory.create()
-        experiment = ExperimentFactory.create(team=team)
-        session = _active_session(team, experiment)
-        message = ChatMessage.objects.create(
-            chat=session.chat, message_type=ChatMessageType.HUMAN, content="tagged", created_at=_MID
-        )
-        foreign_tag = TagFactory.create(team=foreign_team)
-        CustomTaggedItemFactory.create(team=team, tag=foreign_tag, target=message)
-
-        querysets = filtered_querysets(team, start_date=_START, end_date=_END, tag_ids=[foreign_tag.id])
 
         assert list(querysets["messages"]) == []
 

--- a/apps/usage_metrics/tests/test_dashboard_querysets.py
+++ b/apps/usage_metrics/tests/test_dashboard_querysets.py
@@ -15,6 +15,7 @@ from apps.chat.models import ChatMessage, ChatMessageType
 from apps.experiments.models import ExperimentSession, SessionStatus
 from apps.usage_metrics.dashboard_querysets import filtered_querysets
 from apps.utils.factories.annotations import CustomTaggedItemFactory, TagFactory
+from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.team import TeamFactory
 
@@ -32,7 +33,16 @@ def _frozen_time():
 
 
 def _active_session(team, experiment):
-    session = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
+    # experiment_channel is pinned to `experiment` too: left at its default, ExperimentChannelFactory's
+    # own SubFactory builds an unrelated Experiment for the same team, which would show up as a second,
+    # non-archived experiment and defeat any assertion that counts a team's experiments directly (see the
+    # same fix in test_characterisation.py's TestArchivedExperimentActivity._team).
+    session = ExperimentSessionFactory.create(
+        team=team,
+        experiment=experiment,
+        status=SessionStatus.ACTIVE,
+        experiment_channel=ExperimentChannelFactory(team=team, experiment=experiment),
+    )
     ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN, content="x", created_at=_MID)
     return session
 
@@ -252,3 +262,35 @@ class TestEvaluationExclusionColumn:
         querysets = filtered_querysets(team, start_date=_START, end_date=_END)
 
         assert [s.id for s in querysets["sessions"]] == [web_session.id]
+
+
+class TestIncludeArchived:
+    """`include_archived` applies to experiment enumeration only. Activity
+    metrics count archived-chatbot activity either way - it happened, and the
+    spend was real (ADR-0051)."""
+
+    def _team(self):
+        team = TeamFactory.create()
+        live = ExperimentFactory.create(team=team)
+        _active_session(team, live)
+        archived = ExperimentFactory.create(team=team, is_archived=True)
+        _active_session(team, archived)
+        return team
+
+    def test_enumeration_excludes_archived_by_default(self):
+        querysets = filtered_querysets(self._team(), start_date=_START, end_date=_END)
+
+        assert querysets["experiments"].count() == 1
+
+    def test_enumeration_includes_archived_when_asked(self):
+        querysets = filtered_querysets(self._team(), start_date=_START, end_date=_END, include_archived=True)
+
+        assert querysets["experiments"].count() == 2
+
+    def test_activity_counts_archived_chatbots_either_way(self):
+        team = self._team()
+
+        default = filtered_querysets(team, start_date=_START, end_date=_END)
+        inclusive = filtered_querysets(team, start_date=_START, end_date=_END, include_archived=True)
+
+        assert default["sessions"].count() == inclusive["sessions"].count() == 2

--- a/apps/usage_metrics/tests/test_dashboard_querysets.py
+++ b/apps/usage_metrics/tests/test_dashboard_querysets.py
@@ -8,8 +8,11 @@ from datetime import UTC, datetime
 
 import pytest
 import time_machine
+from field_audit.models import AuditAction
 
+from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.models import ChatMessage, ChatMessageType
+from apps.experiments.models import ExperimentSession
 from apps.usage_metrics.dashboard_querysets import filtered_querysets
 from apps.utils.factories.annotations import CustomTaggedItemFactory, TagFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
@@ -225,3 +228,27 @@ class TestMessageTagFilterTeamScoping:
         # sanity: the chat-level tag does still qualify the session, so the empty messages
         # result above is the message-only leg behaving correctly, not a broken fixture.
         assert [s.id for s in querysets["sessions"]] == [session.id]
+
+
+class TestEvaluationExclusionColumn:
+    """`ExperimentSession.platform` is the sole discriminator for
+    evaluation-harness activity (ADR-0051). The session's channel may carry a
+    different platform - the two are independent nullable columns - and the
+    channel's value must not decide the session's fate either way."""
+
+    def test_session_platform_decides_exclusion_not_the_channels(self):
+        team = TeamFactory.create()
+        experiment = ExperimentFactory.create(team=team)
+        # Session is an evaluation session; its channel says otherwise.
+        eval_session = _active_session(team, experiment)
+        ExperimentSession.objects.filter(pk=eval_session.pk).update(platform=ChannelPlatform.EVALUATIONS)
+        # Session is a real web session; its channel says evaluations.
+        web_session = _active_session(team, experiment)
+        ExperimentSession.objects.filter(pk=web_session.pk).update(platform=ChannelPlatform.WEB)
+        ExperimentChannel.objects.filter(pk=web_session.experiment_channel_id).update(
+            platform=ChannelPlatform.EVALUATIONS, audit_action=AuditAction.IGNORE
+        )
+
+        querysets = filtered_querysets(team, start_date=_START, end_date=_END)
+
+        assert [s.id for s in querysets["sessions"]] == [web_session.id]

--- a/apps/usage_metrics/tests/test_dashboard_querysets.py
+++ b/apps/usage_metrics/tests/test_dashboard_querysets.py
@@ -236,15 +236,17 @@ class TestIncludeArchived:
         _active_session(team, archived)
         return team
 
-    def test_enumeration_excludes_archived_by_default(self):
-        querysets = filtered_querysets(self._team(), start_date=_START, end_date=_END)
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [
+            pytest.param({}, 1, id="excluded-by-default"),
+            pytest.param({"include_archived": True}, 2, id="included-when-asked"),
+        ],
+    )
+    def test_enumeration_honours_include_archived(self, kwargs, expected):
+        querysets = filtered_querysets(self._team(), start_date=_START, end_date=_END, **kwargs)
 
-        assert querysets["experiments"].count() == 1
-
-    def test_enumeration_includes_archived_when_asked(self):
-        querysets = filtered_querysets(self._team(), start_date=_START, end_date=_END, include_archived=True)
-
-        assert querysets["experiments"].count() == 2
+        assert querysets["experiments"].count() == expected
 
     def test_activity_counts_archived_chatbots_either_way(self):
         team = self._team()

--- a/apps/usage_metrics/tests/test_dashboard_querysets.py
+++ b/apps/usage_metrics/tests/test_dashboard_querysets.py
@@ -12,7 +12,7 @@ from field_audit.models import AuditAction
 
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.models import ChatMessage, ChatMessageType
-from apps.experiments.models import ExperimentSession
+from apps.experiments.models import ExperimentSession, SessionStatus
 from apps.usage_metrics.dashboard_querysets import filtered_querysets
 from apps.utils.factories.annotations import CustomTaggedItemFactory, TagFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
@@ -32,7 +32,7 @@ def _frozen_time():
 
 
 def _active_session(team, experiment):
-    session = ExperimentSessionFactory.create(team=team, experiment=experiment)
+    session = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
     ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN, content="x", created_at=_MID)
     return session
 

--- a/apps/usage_metrics/tests/test_dashboard_querysets.py
+++ b/apps/usage_metrics/tests/test_dashboard_querysets.py
@@ -202,7 +202,9 @@ class TestMessageTagFilterTeamScoping:
     def test_own_teams_link_on_a_message_matches(self):
         """Positive control: the reading team's own link on its own tag,
         targeting a message, must qualify - otherwise the two negative
-        assertions above prove nothing."""
+        assertions above prove nothing. The match is chat-or-message, so the
+        tagged message pulls its whole conversation in: the session's other
+        (untagged) message qualifies alongside it."""
         team = TeamFactory.create()
         experiment = ExperimentFactory.create(team=team)
         session = _active_session(team, experiment)
@@ -214,30 +216,31 @@ class TestMessageTagFilterTeamScoping:
 
         querysets = filtered_querysets(team, start_date=_START, end_date=_END, tag_ids=[tag.id])
 
-        assert [m.id for m in querysets["messages"]] == [message.id]
+        assert {m.id for m in querysets["messages"]} == set(
+            ChatMessage.objects.filter(chat=session.chat).values_list("id", flat=True)
+        )
 
-    def test_tag_on_the_chat_does_not_pull_its_messages_into_the_messages_leg(self):
-        """Message-only semantics control: the sessions/experiments/
-        participants legs use the broader chat-or-message match
-        (`chat_tag_exists_pair`), but the messages leg must not - a tag
-        recorded on the chat rather than on a message must not make that
-        chat's messages match here. Widening to chat-or-message would be an
-        unrequested behaviour change."""
+    def test_tag_on_the_chat_pulls_its_messages_into_the_messages_leg(self):
+        """Every leg matches tags chat-or-message (`chat_tag_exists_pair`): a
+        tag recorded on the chat qualifies the conversation's messages the same
+        way it qualifies the session. Without this, a chat-level tag filter
+        counted the session on one card while zeroing the message and
+        participant counts beside it, and the dashboard disagreed with
+        `usage_metrics.messages` under the same filter."""
         team = TeamFactory.create()
         experiment = ExperimentFactory.create(team=team)
         session = _active_session(team, experiment)
-        ChatMessage.objects.create(
-            chat=session.chat, message_type=ChatMessageType.HUMAN, content="untagged", created_at=_MID
-        )
+        untagged_session = _active_session(team, experiment)
         tag = TagFactory.create(team=team)
         CustomTaggedItemFactory.create(team=team, tag=tag, target=session.chat)
 
         querysets = filtered_querysets(team, start_date=_START, end_date=_END, tag_ids=[tag.id])
 
-        assert list(querysets["messages"]) == []
-        # sanity: the chat-level tag does still qualify the session, so the empty messages
-        # result above is the message-only leg behaving correctly, not a broken fixture.
+        assert {m.id for m in querysets["messages"]} == set(
+            ChatMessage.objects.filter(chat=session.chat).values_list("id", flat=True)
+        )
         assert [s.id for s in querysets["sessions"]] == [session.id]
+        assert untagged_session.chat.messages.exists()  # the excluded shape is real, not an empty fixture
 
 
 class TestEvaluationExclusionColumn:

--- a/apps/usage_metrics/tests/test_equality.py
+++ b/apps/usage_metrics/tests/test_equality.py
@@ -1,0 +1,188 @@
+"""Each usage surface equals `usage_metrics` under its own parameterisation,
+and the two surfaces equal each other where their parameters genuinely coincide
+- UTC, no tag filter, identical half-open windows, and the same question asked
+of each (the dashboard shows `sessions_active`, the API's `sessions` metric is
+`sessions_started`, so those two are compared to their own metric function, not
+to one another). Tests here are the standing guard against the two definition
+sets drifting apart again (#3905, ADR-0051).
+"""
+
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+import time_machine
+
+from apps.api.v2.usage import services as api_usage
+from apps.chat.models import ChatMessage, ChatMessageType
+from apps.dashboard.services import DashboardService
+from apps.experiments.models import ExperimentSession, SessionStatus
+from apps.usage_metrics import metrics
+from apps.usage_metrics.filters import UsageFilters
+from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
+from apps.utils.factories.team import TeamFactory
+
+_TZ = ZoneInfo("UTC")
+_START = datetime(2026, 6, 1, tzinfo=UTC)
+_END = datetime(2026, 6, 15, tzinfo=UTC)
+_MID = datetime(2026, 6, 10, 12, 0, tzinfo=UTC)
+_BEFORE = datetime(2026, 5, 20, 12, 0, tzinfo=UTC)
+
+pytestmark = pytest.mark.django_db()
+
+
+@pytest.fixture(autouse=True)
+def _frozen_time():
+    with time_machine.travel(_MID, tick=False):
+        yield
+
+
+def _message(session, *, message_type=ChatMessageType.HUMAN, when=_MID):
+    return ChatMessage.objects.create(chat=session.chat, message_type=message_type, content="x", created_at=when)
+
+
+@pytest.fixture()
+def busy_team():
+    """One team carrying every activity shape the definitions discriminate on,
+    so a single fixture exercises each metric's exclusions at once."""
+    team = TeamFactory.create()
+    experiment = ExperimentFactory.create(team=team)
+
+    started_and_active = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
+    _message(started_and_active, message_type=ChatMessageType.HUMAN)
+    _message(started_and_active, message_type=ChatMessageType.AI)
+
+    # Started before the window, active inside it: counts as active, not as started.
+    old_but_active = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
+    ExperimentSession.objects.filter(pk=old_but_active.pk).update(created_at=_BEFORE)
+    _message(old_but_active, message_type=ChatMessageType.HUMAN)
+
+    # Started inside the window, never engaged: counts as started, not as active.
+    ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
+
+    # Never left setup: counts as neither.
+    in_setup = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.SETUP)
+    _message(in_setup, message_type=ChatMessageType.HUMAN)
+
+    # System-only traffic: not a conversation turn on any metric, but still a
+    # session created (and out of SETUP) in the window, so it counts as started.
+    system_only = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
+    _message(system_only, message_type=ChatMessageType.SYSTEM)
+
+    return team
+
+
+def _overview(team):
+    return DashboardService(team).get_overview_stats(start_date=_START, end_date=_END)
+
+
+def _api_results(team, metric_names):
+    query = api_usage.resolve_query_filters(
+        api_usage.UsageQuery(team=team, metrics=set(metric_names), start=_START, end=_END, tz=_TZ)
+    )
+    return api_usage.usage_query(query).results
+
+
+class TestDashboardEqualsUsageMetrics:
+    def test_overview_sessions_equal_sessions_active(self, busy_team):
+        expected = metrics.sessions_active(busy_team, start=_START, end=_END, filters=UsageFilters())
+
+        assert _overview(busy_team)["total_sessions"] == expected
+
+    def test_overview_messages_equal_the_messages_total(self, busy_team):
+        expected = metrics.messages(busy_team, start=_START, end=_END, filters=UsageFilters())["total"]
+
+        assert _overview(busy_team)["total_messages"] == expected
+
+    def test_overview_participants_equal_active_participants(self, busy_team):
+        expected = metrics.active_participants(busy_team, start=_START, end=_END, filters=UsageFilters())
+
+        assert _overview(busy_team)["active_participants"] == expected
+
+    def test_session_analytics_series_sums_to_sessions_active(self, busy_team):
+        """No session in the fixture spans two days, so the per-bucket series
+        sums to the scalar. A session active across several buckets would count
+        once per bucket by design, which is why this is asserted on a fixture
+        that cannot exercise that case."""
+        data = DashboardService(busy_team).get_session_analytics_data(
+            granularity="daily", start_date=_START, end_date=_END
+        )
+        expected = metrics.sessions_active(busy_team, start=_START, end=_END, filters=UsageFilters())
+
+        assert sum(point["active_sessions"] for point in data["sessions"]) == expected
+
+    def test_participant_chart_sums_to_active_participants(self, busy_team):
+        data = DashboardService(busy_team).get_active_participants_data(
+            granularity="daily", start_date=_START, end_date=_END
+        )
+        expected = metrics.active_participants(busy_team, start=_START, end=_END, filters=UsageFilters())
+
+        assert sum(point["active_participants"] for point in data) == expected
+
+
+class TestApiEqualsUsageMetrics:
+    def test_api_sessions_equal_sessions_started(self, busy_team):
+        expected = metrics.sessions_started(busy_team, start=_START, end=_END, filters=UsageFilters())
+
+        assert _api_results(busy_team, ["sessions"])["sessions"] == expected
+
+    def test_api_messages_equal_the_messages_block(self, busy_team):
+        expected = metrics.messages(busy_team, start=_START, end=_END, filters=UsageFilters())
+
+        assert _api_results(busy_team, ["messages"])["messages"] == expected
+
+    def test_api_participants_equal_active_participants(self, busy_team):
+        expected = metrics.active_participants(busy_team, start=_START, end=_END, filters=UsageFilters())
+
+        assert _api_results(busy_team, ["participants"])["participants"] == expected
+
+
+class TestSurfacesAgreeWhereParametersCoincide:
+    """UTC, no tag filter, no archived divergence, the same half-open window."""
+
+    def test_messages_agree(self, busy_team):
+        assert _overview(busy_team)["total_messages"] == _api_results(busy_team, ["messages"])["messages"]["total"]
+
+    def test_active_participants_agree(self, busy_team):
+        assert _overview(busy_team)["active_participants"] == _api_results(busy_team, ["participants"])["participants"]
+
+    def test_session_metrics_answer_different_questions_and_are_labelled(self, busy_team):
+        """`sessions_active` and `sessions_started` are two named metrics, not
+        one metric counted twice, so they differ on this fixture - and their
+        difference is exactly the sessions that started-but-were-silent and
+        were-active-but-started-earlier."""
+        active = _overview(busy_team)["total_sessions"]
+        started = _api_results(busy_team, ["sessions"])["sessions"]
+
+        assert active == 2  # started_and_active, old_but_active
+        assert started == 3  # started_and_active, the never-engaged one, the system-only one
+
+
+class TestScalarsAndTimeseriesAgree:
+    def test_sessions_active_timeseries_sums_to_the_scalar(self, busy_team):
+        series = metrics.sessions_active_timeseries(
+            busy_team, start=_START, end=_END, granularity="daily", tz=_TZ, filters=UsageFilters()
+        )
+
+        assert sum(series.values()) == metrics.sessions_active(
+            busy_team, start=_START, end=_END, filters=UsageFilters()
+        )
+
+    def test_messages_timeseries_sums_to_the_scalar(self, busy_team):
+        series = metrics.messages_timeseries(
+            busy_team, start=_START, end=_END, granularity="daily", tz=_TZ, filters=UsageFilters()
+        )
+        total = metrics.messages(busy_team, start=_START, end=_END, filters=UsageFilters())
+
+        assert sum(block["total"] for block in series.values()) == total["total"]
+
+    def test_sessions_started_plus_in_setup_is_every_session_created_in_the_window(self, busy_team):
+        started = metrics.sessions_started(busy_team, start=_START, end=_END, filters=UsageFilters())
+        in_setup = metrics.sessions_in_setup(busy_team, start=_START, end=_END, filters=UsageFilters())
+
+        created_in_window = (
+            ExperimentSession.objects.filter(team=busy_team, created_at__gte=_START, created_at__lt=_END)
+            .exclude(platform="evaluations")
+            .count()
+        )
+        assert started + in_setup == created_in_window

--- a/apps/usage_metrics/tests/test_equality.py
+++ b/apps/usage_metrics/tests/test_equality.py
@@ -19,6 +19,7 @@ from apps.dashboard.services import DashboardService
 from apps.experiments.models import ExperimentSession, SessionStatus
 from apps.usage_metrics import metrics
 from apps.usage_metrics.filters import UsageFilters
+from apps.utils.factories.annotations import CustomTaggedItemFactory, TagFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.team import TeamFactory
 
@@ -156,6 +157,51 @@ class TestSurfacesAgreeWhereParametersCoincide:
 
         assert active == 2  # started_and_active, old_but_active
         assert started == 3  # started_and_active, the never-engaged one, the system-only one
+
+
+class TestTagFilteredSurfacesAgree:
+    """A chat-level tag is the common tagging shape (the session-tag UI writes
+    the link against the Chat), and every surface matches it the same way:
+    chat-or-message (`chat_tag_exists_pair`). One tagged and one untagged
+    conversation pin that the filter narrows every count to the tagged one
+    identically - dashboard cards, the bot-performance column, and the API."""
+
+    @pytest.fixture()
+    def tagged_team(self):
+        team = TeamFactory.create()
+        experiment = ExperimentFactory.create(team=team)
+        tagged = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
+        _message(tagged, message_type=ChatMessageType.HUMAN)
+        _message(tagged, message_type=ChatMessageType.AI)
+        untagged = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
+        _message(untagged, message_type=ChatMessageType.HUMAN)
+        tag = TagFactory.create(team=team)
+        CustomTaggedItemFactory.create(team=team, tag=tag, target=tagged.chat)
+        return team, tag
+
+    def test_dashboard_cards_agree_with_each_other_and_the_metrics(self, tagged_team):
+        team, tag = tagged_team
+        overview = DashboardService(team).get_overview_stats(start_date=_START, end_date=_END, tag_ids=[tag.id])
+        filters = UsageFilters(tag_ids=[tag.id])
+
+        assert overview["total_sessions"] == 1
+        assert (
+            overview["total_messages"] == metrics.messages(team, start=_START, end=_END, filters=filters)["total"] == 2
+        )
+        assert (
+            overview["active_participants"]
+            == metrics.active_participants(team, start=_START, end=_END, filters=filters)
+            == 1
+        )
+
+    def test_bot_performance_messages_agree_with_the_headline(self, tagged_team):
+        team, tag = tagged_team
+        overview = DashboardService(team).get_overview_stats(start_date=_START, end_date=_END, tag_ids=[tag.id])
+        performance = DashboardService(team).get_bot_performance_summary(
+            start_date=_START, end_date=_END, tag_ids=[tag.id]
+        )
+
+        assert performance["results"][0]["messages"] == overview["total_messages"] == 2
 
 
 class TestScalarsAndTimeseriesAgree:

--- a/apps/usage_metrics/tests/test_equality.py
+++ b/apps/usage_metrics/tests/test_equality.py
@@ -14,6 +14,7 @@ import pytest
 import time_machine
 
 from apps.api.v2.usage import services as api_usage
+from apps.channels.models import ChannelPlatform
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.dashboard.services import DashboardService
 from apps.experiments.models import ExperimentSession, SessionStatus
@@ -228,7 +229,7 @@ class TestScalarsAndTimeseriesAgree:
 
         created_in_window = (
             ExperimentSession.objects.filter(team=busy_team, created_at__gte=_START, created_at__lt=_END)
-            .exclude(platform="evaluations")
+            .exclude(platform=ChannelPlatform.EVALUATIONS)
             .count()
         )
         assert started + in_setup == created_in_window

--- a/apps/usage_metrics/tests/test_metrics.py
+++ b/apps/usage_metrics/tests/test_metrics.py
@@ -285,11 +285,13 @@ class TestSessionCounts:
 @pytest.mark.django_db()
 @pytest.mark.usefixtures("frozen_time")
 class TestActiveParticipants:
-    def test_counts_distinct_human_or_ai_authors(self):
+    def test_counts_distinct_human_authors_only(self):
         team = TeamFactory.create()
         human = ExperimentSessionFactory.create(team=team)
         _message(human, message_type=ChatMessageType.HUMAN)
         _message(human, message_type=ChatMessageType.AI)
+        ai_only = ExperimentSessionFactory.create(team=team)
+        _message(ai_only, message_type=ChatMessageType.AI)
         system_only = ExperimentSessionFactory.create(team=team)
         _message(system_only, message_type=ChatMessageType.SYSTEM)
 

--- a/apps/usage_metrics/tests/test_metrics.py
+++ b/apps/usage_metrics/tests/test_metrics.py
@@ -267,16 +267,17 @@ class TestSessionCounts:
 
         assert (started, in_setup) == (2, 1)
 
-    def test_sessions_active_counts_any_message_in_half_open_window(self):
-        """The dashboard's current definition: any message type qualifies,
-        SETUP sessions count, the window end is exclusive (ADR-0051)."""
+    def test_sessions_active_needs_a_conversation_turn_in_the_half_open_window(self):
         team = TeamFactory.create()
         experiment = ExperimentFactory.create(team=team)
-        system_only = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.SETUP)
+        system_only = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
         _message(system_only, message_type=ChatMessageType.SYSTEM)
-        at_boundary = ExperimentSessionFactory.create(team=team, experiment=experiment)
-        _message(at_boundary, when=_END)
-        ExperimentSessionFactory.create(team=team, experiment=experiment)  # silent
+        in_setup = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.SETUP)
+        _message(in_setup)
+        boundary = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
+        _message(boundary, when=_END)
+        counted = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.ACTIVE)
+        _message(counted)
 
         assert metrics.sessions_active(team, start=_START, end=_END, filters=UsageFilters()) == 1
 
@@ -362,3 +363,43 @@ class TestTimeseries:
         )
 
         assert series == {date(2026, 6, 10): 1}
+
+
+@pytest.mark.django_db()
+@pytest.mark.usefixtures("frozen_time")
+class TestSessionsActiveTimeseries:
+    def test_buckets_on_message_time_so_one_session_spans_buckets(self):
+        team = TeamFactory.create()
+        session = ExperimentSessionFactory.create(team=team, status=SessionStatus.ACTIVE)
+        _message(session, when=datetime(2026, 6, 9, 12, 0, tzinfo=UTC))
+        _message(session, when=_MID)
+
+        series = metrics.sessions_active_timeseries(
+            team, start=_START, end=_END, granularity="daily", tz=_TZ, filters=UsageFilters()
+        )
+
+        assert series == {date(2026, 6, 9): 1, date(2026, 6, 10): 1}
+
+    def test_system_only_and_setup_sessions_are_absent(self):
+        team = TeamFactory.create()
+        system_only = ExperimentSessionFactory.create(team=team, status=SessionStatus.ACTIVE)
+        _message(system_only, message_type=ChatMessageType.SYSTEM)
+        in_setup = ExperimentSessionFactory.create(team=team, status=SessionStatus.SETUP)
+        _message(in_setup)
+
+        series = metrics.sessions_active_timeseries(
+            team, start=_START, end=_END, granularity="daily", tz=_TZ, filters=UsageFilters()
+        )
+
+        assert series == {}
+
+    def test_sums_to_the_scalar_when_no_session_spans_buckets(self):
+        team = TeamFactory.create()
+        for _ in range(3):
+            _message(ExperimentSessionFactory.create(team=team, status=SessionStatus.ACTIVE))
+
+        series = metrics.sessions_active_timeseries(
+            team, start=_START, end=_END, granularity="daily", tz=_TZ, filters=UsageFilters()
+        )
+
+        assert sum(series.values()) == metrics.sessions_active(team, start=_START, end=_END, filters=UsageFilters())

--- a/apps/usage_metrics/tests/test_metrics.py
+++ b/apps/usage_metrics/tests/test_metrics.py
@@ -52,7 +52,7 @@ def frozen_time():
 @pytest.mark.usefixtures("frozen_time")
 class TestMessages:
     """Reproduces the v2 usage API's current message read: half-open window,
-    every session type (evaluations included), total = human + ai."""
+    evaluation-harness activity excluded (ADR-0051), total = human + ai."""
 
     def test_counts_human_ai_and_total(self):
         team = TeamFactory.create()
@@ -87,7 +87,7 @@ class TestMessages:
         assert counts["total"] == 2
         assert surviving == {_START, _MID}
 
-    def test_includes_evaluation_sessions(self):
+    def test_excludes_evaluation_sessions(self):
         team = TeamFactory.create()
         eval_session = ExperimentSessionFactory.create(
             team=team,
@@ -97,7 +97,7 @@ class TestMessages:
 
         counts = metrics.messages(team, start=_START, end=_END, filters=UsageFilters())
 
-        assert counts["total"] == 1
+        assert counts["total"] == 0
 
     def test_empty_id_list_means_matched_nobody(self):
         team = TeamFactory.create()

--- a/apps/usage_metrics/tests/test_metrics.py
+++ b/apps/usage_metrics/tests/test_metrics.py
@@ -267,6 +267,17 @@ class TestSessionCounts:
 
         assert (started, in_setup) == (2, 1)
 
+    def test_sessions_active_empty_id_list_means_matched_nobody_like_its_siblings(self):
+        """`sessions_active` delegates to `filtered_querysets`, whose truthiness
+        check would silently treat `[]` as "no filter" and return the team-wide
+        count. The module has one empty-list semantic: `[]` matched nobody."""
+        team = TeamFactory.create()
+        session = ExperimentSessionFactory.create(team=team, status=SessionStatus.ACTIVE)
+        _message(session)
+
+        assert metrics.sessions_active(team, start=_START, end=_END, filters=UsageFilters(experiment_ids=[])) == 0
+        assert metrics.sessions_active(team, start=_START, end=_END, filters=UsageFilters(participant_ids=[])) == 0
+
     def test_sessions_active_needs_a_conversation_turn_in_the_half_open_window(self):
         team = TeamFactory.create()
         experiment = ExperimentFactory.create(team=team)

--- a/apps/usage_metrics/tests/test_metrics.py
+++ b/apps/usage_metrics/tests/test_metrics.py
@@ -267,18 +267,18 @@ class TestSessionCounts:
 
         assert (started, in_setup) == (2, 1)
 
-    def test_sessions_active_counts_any_message_in_closed_window(self):
-        """The dashboard's current definition, unchanged: any message type
-        qualifies, SETUP sessions count, the window end is inclusive."""
+    def test_sessions_active_counts_any_message_in_half_open_window(self):
+        """The dashboard's current definition: any message type qualifies,
+        SETUP sessions count, the window end is exclusive (ADR-0051)."""
         team = TeamFactory.create()
         experiment = ExperimentFactory.create(team=team)
         system_only = ExperimentSessionFactory.create(team=team, experiment=experiment, status=SessionStatus.SETUP)
         _message(system_only, message_type=ChatMessageType.SYSTEM)
-        boundary = ExperimentSessionFactory.create(team=team, experiment=experiment)
-        _message(boundary, when=_END)
+        at_boundary = ExperimentSessionFactory.create(team=team, experiment=experiment)
+        _message(at_boundary, when=_END)
         ExperimentSessionFactory.create(team=team, experiment=experiment)  # silent
 
-        assert metrics.sessions_active(team, start=_START, end=_END, filters=UsageFilters()) == 2
+        assert metrics.sessions_active(team, start=_START, end=_END, filters=UsageFilters()) == 1
 
 
 @pytest.mark.django_db()

--- a/apps/utils/factories/experiment.py
+++ b/apps/utils/factories/experiment.py
@@ -121,6 +121,13 @@ class ExperimentSessionFactory(factory.django.DjangoModelFactory):
         "apps.utils.factories.channels.ExperimentChannelFactory", team=factory.SelfAttribute("..team")
     )
     platform = factory.LazyAttribute(lambda obj: obj.experiment_channel.platform)
+    # The model default is SETUP, the state a session occupies only until its
+    # first message: the consent flow moves it to PENDING and then ACTIVE, and
+    # a chatbot without conversational consent activates it straight away. A
+    # session resting at SETUP therefore has no conversation in it, so tests
+    # that give a session messages want ACTIVE. Pass `status` explicitly to
+    # build a pre-conversation session.
+    status = models.SessionStatus.ACTIVE
 
 
 class ChatAttachmentFactory(factory.django.DjangoModelFactory):

--- a/assets/javascript/dashboard/main.js
+++ b/assets/javascript/dashboard/main.js
@@ -402,6 +402,7 @@ function dashboard() {
                     },
                     {
                         label: 'Active Participants',
+                        tooltip: 'Participants who sent a message in the selected date range, out of every participant on this team.',
                         numerator: data.active_participants || 0,
                         denominator: data.total_participants || 0,
                         icon: 'fas fa-users',
@@ -409,6 +410,7 @@ function dashboard() {
                     },
                     {
                         label: 'Completed Sessions',
+                        tooltip: 'Completed sessions out of active sessions - those with at least one message in the selected date range.',
                         numerator: data.completed_sessions || 0,
                         denominator: data.total_sessions || 0,
                         icon: 'fas fa-comments',
@@ -416,6 +418,7 @@ function dashboard() {
                     },
                     {
                         label: 'Total Messages',
+                        tooltip: 'Messages sent and received in the selected date range. Internal system messages are not counted.',
                         numerator: data.total_messages || 0,
                         icon: 'fas fa-envelope',
                         color: 'text-orange-500'

--- a/assets/javascript/dashboard/main.js
+++ b/assets/javascript/dashboard/main.js
@@ -410,7 +410,7 @@ function dashboard() {
                     },
                     {
                         label: 'Completed Sessions',
-                        tooltip: 'Completed sessions out of active sessions - those with at least one message in the selected date range.',
+                        tooltip: 'Completed sessions out of active sessions - those with a message sent or received in the selected date range.',
                         numerator: data.completed_sessions || 0,
                         denominator: data.total_sessions || 0,
                         icon: 'fas fa-comments',

--- a/docs/adr/0051-usage-activity-metric-definitions.md
+++ b/docs/adr/0051-usage-activity-metric-definitions.md
@@ -42,6 +42,7 @@ Numbers visibly change:
 - Dashboard active-participant counts drop participants whose only in-window activity is AI or `system` messages, on the overview stat and the session-analytics series. The active-participants chart already used this definition and does not move.
 - The API's `messages` and `participants` metrics drop evaluation activity, and `participants` drops participants whose only in-window activity is AI messages. Grouped rows now sum to the ungrouped total.
 - Instants on a window boundary stop being counted in two adjacent periods.
+- A tag filter matches whole conversations everywhere: a conversation qualifies when its chat, or any message in it, carries the tag. The dashboard's message counts previously matched a tag filter only against tags placed on individual messages, so a chat-level tag narrowed the session cards but zeroed the message and participant counts beside them.
 
 `sessions_in_setup` is new. It is exposed through `usage_metrics` and has no UI surface in this block.
 

--- a/docs/adr/0051-usage-activity-metric-definitions.md
+++ b/docs/adr/0051-usage-activity-metric-definitions.md
@@ -1,0 +1,54 @@
+# ADR-0051: One set of activity-metric definitions across usage surfaces
+
+<span class="adr-status adr-status-proposed">PROPOSED</span>
+
+<p class="adr-meta">Author: Open Chat Studio · Created: 2026-08-06</p>
+
+## Context
+
+Sessions, messages and participants are computed in two places. The dashboard counts a session as active when any message of any type falls inside a closed `[start, end]` window; the v2 usage API counts sessions created inside a half-open `[start, end)` window and drops sessions still in `SETUP`. Message totals include `system` messages on one surface and not the other. Evaluation-harness activity counts on the API side and not the dashboard side. "Active participant" has four implementations across the two surfaces, disagreeing on whether an AI message or a `system` message makes a participant active.
+
+The result is that the same team and the same window produce different numbers depending on which surface someone reads, with nothing labelling which definition is in play. Within the API itself, platform-grouped message rows exclude evaluations while the ungrouped total includes them, so grouped rows do not sum to the total for teams that run evaluations.
+
+Cost and tokens already share one implementation (`apps/cost_tracking/services/reporting.py`). Activity metrics did not. This ADR is part of the wider convergence tracked in issue #3905.
+
+## Decision
+
+We will define each activity metric once, in `apps/usage_metrics/`, and have every surface read it from there.
+
+- **`sessions_active`** - sessions with at least one human or AI message in the window. Sessions still in `SETUP` and evaluation-harness sessions do not count.
+- **`sessions_started`** - sessions created in the window, on the same two exclusions.
+- **`sessions_in_setup`** - sessions created in the window and still in `SETUP`. `sessions_started + sessions_in_setup` is every non-evaluation session created in the window, so setup drop-off stays countable.
+- **`messages`** - human and AI messages only, evaluation sessions excluded. `total` is `human + ai`; `system` messages are internal and are not conversation turns.
+- **`active_participants`** - distinct participants who authored at least one human message in the window. A participant who only received AI output was not active.
+- **Windows are half-open `[start, end)`** on every surface, so an instant on the boundary is counted exactly once across adjacent periods. A date-range picker whose end date should be fully included resolves that date to the start of the following day.
+- **`ExperimentSession.platform`** is the sole discriminator for evaluation-harness activity. `ExperimentChannel.platform` is a separate nullable column and the two can disagree on a row (the model predates the v2 API's chatbot rename, ADR-0023).
+- **`include_archived`** applies to experiment *enumeration* only. Activity metrics count archived-chatbot activity regardless, because that activity happened and the spend was real.
+
+Two rules govern how these metrics may be combined. Running example: a team spends $100 in June, $80 from chat and $20 from evaluation runs.
+
+- **Ratios.** A ratio's numerator and denominator must describe the same activity. Cost-per-message is the $80 of chat spend over chat messages. Dividing the $100 by chat messages would bill evaluation spend to conversations that did not incur it. Per-message, per-session and per-token ratios always use chat-source spend over chat activity, and a surface showing the $100 inclusive total never captions it "per message" or "per session".
+- **Totals versus breakdowns.** The headline total answers "what did the team spend?" and counts everything. A per-entity breakdown answers "which chatbot spent it?" and only includes spend attributable to that entity. The per-chatbot table for June sums to $80, not $100: the $20 of evaluation spend belongs to the team and not to any chatbot (ADR-0048). Rows from archived chatbots, or with no chatbot recorded, behave the same way. That gap is by design and is not to be closed by hiding it or by spreading evaluation spend across bots.
+
+## Consequences
+
+Both surfaces move to the same numbers in one change, with no flag - a flag would mean maintaining two definitions of the metric it was meant to retire.
+
+Numbers visibly change:
+
+- Dashboard session counts drop sessions whose only in-window activity is a `system` message, and drop sessions still in `SETUP`.
+- Dashboard message totals drop `system` messages.
+- Dashboard active-participant counts drop participants whose only in-window activity is AI or `system` messages, on the overview stat and the session-analytics series. The active-participants chart already used this definition and does not move.
+- The API's `messages` and `participants` metrics drop evaluation activity, and `participants` drops participants whose only in-window activity is AI messages. Grouped rows now sum to the ungrouped total.
+- Instants on a window boundary stop being counted in two adjacent periods.
+
+`sessions_in_setup` is new. It is exposed through `usage_metrics` and has no UI surface in this block.
+
+The usage API has very low, internal-only usage, so the changes ship with a changelog entry listing every visible change rather than a consumer migration.
+
+## Alternatives considered
+
+- **A feature flag over the two definition sets** - rejected: it would keep both definitions alive indefinitely and make "which number is right?" a per-team question.
+- **Keeping `sessions_active` and `sessions_started` as one metric** - rejected: they answer different questions - "who used the product in this period?" versus "how many conversations began in it?" - and a single count would silently serve one question to someone asking the other. Two named metrics, each labelled at its surface, is the point.
+- **A separate "participants reached" metric** counting participants who received AI output - rejected: session counts already answer that, and a second participant metric would reintroduce the ambiguity this ADR removes.
+- **Excluding archived-chatbot activity from the metrics** - rejected: the activity happened and the spend was real; hiding it would make the totals disagree with the cost panel.

--- a/docs/adr/0051-usage-activity-metric-definitions.md
+++ b/docs/adr/0051-usage-activity-metric-definitions.md
@@ -21,8 +21,9 @@ We will define each activity metric once, in `apps/usage_metrics/`, and have eve
 - **`sessions_in_setup`** - sessions created in the window and still in `SETUP`. `sessions_started + sessions_in_setup` is every non-evaluation session created in the window, so setup drop-off stays countable.
 - **`messages`** - human and AI messages only, evaluation sessions excluded. `total` is `human + ai`; `system` messages are internal and are not conversation turns.
 - **`active_participants`** - distinct participants who authored at least one human message in the window. A participant who only received AI output was not active.
+- **Sessions still in `SETUP` are excluded from every activity metric**, not only from the session counts. `SETUP` is the state a session occupies until its first message: the consent flow moves it to `PENDING` and then `ACTIVE`, and a chatbot without conversational consent activates it straight away, so a session resting at `SETUP` has no conversation in it. Counting its turns or its author while `sessions_active` drops the session would put a ratio's numerator and denominator on different universes, which the ratios rule below forbids.
 - **Windows are half-open `[start, end)`** on every surface, so an instant on the boundary is counted exactly once across adjacent periods. A date-range picker whose end date should be fully included resolves that date to the start of the following day.
-- **`ExperimentSession.platform`** is the sole discriminator for evaluation-harness activity. `ExperimentChannel.platform` is a separate nullable column and the two can disagree on a row (the model predates the v2 API's chatbot rename, ADR-0023).
+- **`ExperimentSession.platform`** is the sole discriminator for evaluation-harness activity. `ExperimentChannel.platform` is a separate nullable column, nothing keeps the two aligned, and they can disagree on a row.
 - **`include_archived`** applies to experiment *enumeration* only. Activity metrics count archived-chatbot activity regardless, because that activity happened and the spend was real.
 
 Two rules govern how these metrics may be combined. Running example: a team spends $100 in June, $80 from chat and $20 from evaluation runs.
@@ -37,7 +38,7 @@ Both surfaces move to the same numbers in one change, with no flag - a flag woul
 Numbers visibly change:
 
 - Dashboard session counts drop sessions whose only in-window activity is a `system` message, and drop sessions still in `SETUP`.
-- Dashboard message totals drop `system` messages.
+- Dashboard message totals drop `system` messages, and both surfaces drop turns belonging to sessions still in `SETUP`. In practice a session resting at `SETUP` holds no conversation, so this moves few or no rows; it is what keeps the per-session and per-participant ratios on one universe.
 - Dashboard active-participant counts drop participants whose only in-window activity is AI or `system` messages, on the overview stat and the session-analytics series. The active-participants chart already used this definition and does not move.
 - The API's `messages` and `participants` metrics drop evaluation activity, and `participants` drops participants whose only in-window activity is AI messages. Grouped rows now sum to the ungrouped total.
 - Instants on a window boundary stop being counted in two adjacent periods.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -70,3 +70,4 @@ Where {lowercase-status} is one of: draft, proposed, accepted, rejected, superse
 | [0048](0048-evaluation-spend-is-team-spend-not-entity-spend.md) | <span class="adr-status adr-status-proposed">PROPOSED</span> | Evaluation spend is team spend, never entity spend |
 | [0049](0049-node-rows-own-pipeline-layout.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Node rows own pipeline layout; `Pipeline.data` keeps only edges |
 | [0050](0050-eval-driven-generation-is-evaluation-spend.md) | <span class="adr-status adr-status-proposed">PROPOSED</span> | Eval-driven generation is evaluation spend, billed without a trace |
+| [0051](0051-usage-activity-metric-definitions.md) | <span class="adr-status adr-status-proposed">PROPOSED</span> | One set of activity-metric definitions across usage surfaces |

--- a/docs/architecture/package-map.md
+++ b/docs/architecture/package-map.md
@@ -81,7 +81,7 @@ Features layered on top of the domain, plus supporting services.
 | `trace` | `Trace`/`Span` observability records for requests and pipeline steps. |
 | `events` | Event triggers and scheduled actions. |
 | `cost_tracking` | LLM usage and cost accounting. |
-| `usage_metrics` | Shared activity-metric read path (sessions, messages, participants) for the dashboard and usage API. Models-free. |
+| `usage_metrics` | Shared activity-metric read path (sessions, messages, participants) for the dashboard and usage API. Definitions in ADR-0051. Models-free. |
 | `analysis` | Analysis pipelines over conversation data. |
 | `ocs_notifications` | In-app notifications. |
 | `banners` | Site banners. |

--- a/docs/design/usage-api.md
+++ b/docs/design/usage-api.md
@@ -112,8 +112,8 @@ plus a **max window** relative to granularity (e.g. reject `daily` over a multi-
 | Metric | Source | Shape |
 |---|---|---|
 | `messages` | `ChatMessage` grouped by `message_type`, scoped `chat__team`, participant via `chat__experiment_session__participant` | `{human, ai, total}` |
-| `sessions` | `ExperimentSession` count | integer |
-| `participants` | distinct `Participant` count (only meaningful when **not** grouped by participant) | integer |
+| `sessions` | `sessions_started` - `ExperimentSession` created in the window, SETUP and evaluation sessions excluded | integer |
+| `participants` | `active_participants` - distinct participants who authored a human message in the window (only meaningful when **not** grouped by participant) | integer |
 | `cost` | `reporting.cost_summary` / `cost_timeseries` with `CostFilters` | `{total, currency}` |
 | `tokens` | `UsageRecord.quantity` summed, split by `service_kind` | `{prompt, completion, total}` |
 

--- a/docs/design/usage-api.md
+++ b/docs/design/usage-api.md
@@ -107,6 +107,8 @@ plus a **max window** relative to granularity (e.g. reject `daily` over a multi-
 
 ### Metrics → sources
 
+> The metric *definitions* below are superseded by [ADR-0051](../adr/0051-usage-activity-metric-definitions.md); this table describes the sources they read, not their semantics.
+
 | Metric | Source | Shape |
 |---|---|---|
 | `messages` | `ChatMessage` grouped by `message_type`, scoped `chat__team`, participant via `chat__experiment_session__participant` | `{human, ai, total}` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
       - 0048 Evaluation spend is team spend, never entity spend: adr/0048-evaluation-spend-is-team-spend-not-entity-spend.md
       - 0049 Node rows own pipeline layout; Pipeline.data keeps only edges and viewport: adr/0049-node-rows-own-pipeline-layout.md
       - 0050 Eval-driven generation is evaluation spend: adr/0050-eval-driven-generation-is-evaluation-spend.md
+      - 0051 One set of activity-metric definitions across usage surfaces: adr/0051-usage-activity-metric-definitions.md
   - Developer Guides:
     - Processes:
       - Claude Code Agents: developer_guides/claude_code_agent.md

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -125,7 +125,24 @@
                   <span class="text-2xl font-bold text-gray-500 dark:text-gray-500" x-text="'/ ' + formatNumber(stat.denominator)"></span>
                 </template>
               </div>
-              <div class="stat-label" x-text="stat.label"></div>
+              <div class="flex items-center gap-1">
+                <div class="stat-label" x-text="stat.label"></div>
+                {# Mirrors generic/help.html; inlined because the card list is rendered by Alpine, not Django. #}
+                <template x-if="stat.tooltip">
+                  <div class="dropdown dropdown-top dropdown-hover">
+                    <div role="button" class="btn btn-circle btn-ghost btn-xs text-info">
+                      <i class="text-xs fa-regular fa-circle-question"></i>
+                    </div>
+                    <div
+                      tabindex="0"
+                      class="card card-sm dropdown-content bg-slate-300 dark:bg-slate-700 rounded-box z-1 w-64 shadow-sm">
+                      <div tabindex="0" class="card-body font-medium text-wrap">
+                        <p x-text="stat.tooltip"></p>
+                      </div>
+                    </div>
+                  </div>
+                </template>
+              </div>
             </div>
             <div class="text-2xl" :class="stat.color">
               <i :class="stat.icon"></i>


### PR DESCRIPTION
Closes #3905. Final PR of the three-PR stack (#4132 tag filtering, #4134 extraction, this one): merging this PR completes the convergence for the issue.

### Product Description

The dashboard and the v2 usage API now answer the same question the same way. Every activity metric (sessions, messages, participants) is computed once, in `apps/usage_metrics/`, from the definitions recorded in ADR-0051.

Visible changes:

- Dashboard session counts no longer include sessions whose only activity was an internal system message, or sessions that never left setup.
- Dashboard message totals no longer include internal system messages, and neither surface counts activity belonging to sessions still in setup.
- Dashboard active-participant counts now mean "participants who sent a message", matching the active-participants chart, so the overview stat and the session-analytics series no longer count participants who only received replies.
- The usage API's `messages` and `participants` metrics no longer include evaluation-run activity, so a platform breakdown now sums to the ungrouped total.
- The usage API's `participants` metric now counts participants who sent a message, not those who received a reply.
- Date ranges are half-open everywhere, so an event on a period boundary is counted in one period rather than two. A selected end date is still fully included (it resolves to the start of the following day).
- A tag filter matches whole conversations on every surface: a conversation qualifies when its chat, or any message in it, carries the tag. Previously, a chat-level tag narrowed the session cards but zeroed the message and participant counts beside them.
- The per-chatbot Messages column counts messages in the selected date range only, so it agrees with the headline total on the same page.
- The overview stat cards carry help popovers naming the definition each number uses.
- The cost panel's three reads are now served from the same 30-minute dashboard cache as every other metric, and `cost_summary` no longer scans the team's full usage history per page load.

### Technical Description

The definition switch against `apps/usage_metrics/` (extracted behaviour-preserving in PR 2, #4134): each divergence row from the approved design is one commit that first flips the matching characterisation assertion red, then converges the definition. The commits fall in three groups:

1. **The approved design, one commit per divergence row** - half-open windows, one evaluation-exclusion discriminator (`ExperimentSession.platform`), human+AI message totals, `sessions_active`/`sessions_started` as two named metrics with SETUP excluded, one `active_participants` definition (HUMAN authors), `include_archived` as an explicit enumeration flag, plus the design's two bundled cost fixes (queryset-level window bound on `cost_summary`, `DashboardCache` over the three cost reads) and `test_equality.py` asserting each consumer equals the shared definitions.
2. **Consistency consequences** - SETUP-session activity excluded from the message/participant universes too (so the overview's ratios divide numbers from one universe), stat-card labels, and docs.
3. **Adversarial-review fixes** - tag filters match chat-or-message on every leg (the dashboard's messages leg was message-only, contradicting the one-definition invariant under chat-level tags); a decode guard on the cached cost payloads; one empty-list filter semantic across the module; granularity validated before it reaches a cache key; and the duplication the review found collapsed onto the shared helpers (tag-match `Exists` pairs, tz-bucketing, the HUMAN-authored predicate).

Two items reach beyond the approved design table, kept separately revertible and called out here rather than buried:

- The bot-performance Messages column bound (commit "Bound the bot-performance message count to in-window conversation turns"): the column previously counted each chat's entire history, every message type. Under ADR-0051 it contradicted the headline total on the same page.
- `ExperimentSessionFactory` now defaults `status=ACTIVE` (the model default is SETUP, a state a session leaves on its first message, so sessions that tests give messages to should be ACTIVE). The full suite passes; tests exercising the pre-chat consent flow set `status=SessionStatus.SETUP` explicitly.

ADR-0051 ships in this diff as PROPOSED - sign-off gates merge, not authoring.

No feature flag: a flag would maintain two definitions of the same metric.

### Migrations

- [x] The migrations are backwards compatible

None - `usage_metrics` stays models-free (`makemigrations --check` clean).

### Demo
Stat card pop-over:
<img width="910" height="135" alt="pr4156-demo-1-stat-card-popover" src="https://github.com/user-attachments/assets/0e8a54dc-8e79-481e-9528-fb86948febbc" />

Tag-filtered dashboard
<img width="895" height="620" alt="pr4156-demo-2-tag-filter-narrows-all" src="https://github.com/user-attachments/assets/c51dfc11-d604-4184-82f6-d0f25cce5467" />

Bot-performance Table:
<img width="1568" height="451" alt="pr4156-demo-3-bot-performance-table" src="https://github.com/user-attachments/assets/b682c332-e90e-4378-b4cb-7246f7f8d750" />

### Docs and Changelog

- [x] This PR requires docs/changelog update

The visible-change list above is the changelog source. No manual docs-repo PR - the ocs-agent automation drafts one from the merged PR.

