### PR TITLE
Escape JSON rendered by the to_json filter

### DIFF
--- a/apps/web/templatetags/json_tags.py
+++ b/apps/web/templatetags/json_tags.py
@@ -38,20 +38,20 @@ def pygments_json_css() -> str:
 
 @register.filter
 def to_json(obj):
-    """Source: https://gist.github.com/czue/90e287c9818ae726f73f5850c1b00f7f"""
+    """Render a Python value as indented JSON text.
 
-    def escape_script_tags(unsafe_str):
-        # seriously: http://stackoverflow.com/a/1068548/8207
-        return unsafe_str.replace("</script>", '<" + "/script>')
-
+    The returned string is deliberately *not* marked safe: the data may contain
+    attacker-controlled values (e.g. participant data or session state supplied
+    through the API), so Django's autoescaping must run over the JSON to prevent
+    stored HTML from being parsed by the browser.
+    """
     # json.dumps does not properly convert QueryDict array parameter to json
     if isinstance(obj, QueryDict):
         obj = dict(obj)
     try:
-        json_string = json.dumps(obj, indent=2, cls=DjangoJSONEncoder)
-        return mark_safe(escape_script_tags(json_string))
+        return json.dumps(obj, indent=2, cls=DjangoJSONEncoder)
     except JSONDecodeError:
-        return mark_safe("Unable to decode JSON data")
+        return "Unable to decode JSON data"
 
 
 @register.filter

--- a/apps/web/templatetags/json_tags.py
+++ b/apps/web/templatetags/json_tags.py
@@ -1,5 +1,4 @@
 import json
-from json import JSONDecodeError
 
 from django import template
 from django.core.serializers.json import DjangoJSONEncoder
@@ -50,8 +49,9 @@ def to_json(obj):
         obj = dict(obj)
     try:
         return json.dumps(obj, indent=2, cls=DjangoJSONEncoder)
-    except JSONDecodeError:
-        return "Unable to decode JSON data"
+    except (TypeError, ValueError):
+        # TypeError: value is not serializable; ValueError: circular reference
+        return "Unable to encode JSON data"
 
 
 @register.filter

--- a/apps/web/tests/test_json_tags.py
+++ b/apps/web/tests/test_json_tags.py
@@ -12,6 +12,12 @@ def _render_to_json(value):
     return Template("{% load json_tags %}{{ value|to_json }}").render(Context({"value": value}))
 
 
+def _circular_dict():
+    data = {}
+    data["self"] = data
+    return data
+
+
 class TestToJson:
     def test_output_is_not_marked_safe(self):
         # unsafe output means Django's autoescaping runs over the JSON when it is rendered
@@ -43,6 +49,18 @@ class TestToJson:
         # what the browser displays is unchanged: entities decode back to the original JSON
         rendered = _render_to_json({"greeting": "<b>hi</b>", "count": 2})
         assert json.loads(html.unescape(rendered)) == {"greeting": "<b>hi</b>", "count": 2}
+
+    @pytest.mark.parametrize(
+        "make_value",
+        [
+            pytest.param(lambda: {1, 2}, id="set-is-not-serializable"),
+            pytest.param(lambda: {"obj": object()}, id="arbitrary-object"),
+            pytest.param(_circular_dict, id="circular-reference"),
+        ],
+    )
+    def test_unserializable_value_returns_message(self, make_value):
+        # json.dumps raises TypeError for unsupported types and ValueError for circular data
+        assert to_json(make_value()) == "Unable to encode JSON data"
 
 
 class TestHighlightJson:

--- a/apps/web/tests/test_json_tags.py
+++ b/apps/web/tests/test_json_tags.py
@@ -1,6 +1,48 @@
+import html
+import json
+
+import pytest
+from django.template import Context, Template
 from django.utils.safestring import SafeData
 
-from apps.web.templatetags.json_tags import format_participant_data_diff, highlight_json, readable_value
+from apps.web.templatetags.json_tags import format_participant_data_diff, highlight_json, readable_value, to_json
+
+
+def _render_to_json(value):
+    return Template("{% load json_tags %}{{ value|to_json }}").render(Context({"value": value}))
+
+
+class TestToJson:
+    def test_output_is_not_marked_safe(self):
+        # unsafe output means Django's autoescaping runs over the JSON when it is rendered
+        assert not isinstance(to_json({"key": "value"}), SafeData)
+
+    def test_dumps_indented_json(self):
+        assert to_json({"key": "value"}) == '{\n  "key": "value"\n}'
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            pytest.param('<img src=x onerror="alert(1)">', id="img-onerror"),
+            pytest.param("</script><script>alert(1)</script>", id="script-breakout"),
+            pytest.param("<svg/onload=alert(1)>", id="svg-onload"),
+        ],
+    )
+    def test_html_in_values_is_escaped_when_rendered(self, payload):
+        rendered = _render_to_json({"participant_name": payload})
+        assert "<" not in rendered
+        assert ">" not in rendered
+        assert "&lt;" in rendered
+
+    def test_html_in_keys_is_escaped_when_rendered(self):
+        rendered = _render_to_json({"<img src=x onerror=alert(1)>": "value"})
+        assert "<" not in rendered
+        assert "&lt;" in rendered
+
+    def test_rendered_output_is_readable_json(self):
+        # what the browser displays is unchanged: entities decode back to the original JSON
+        rendered = _render_to_json({"greeting": "<b>hi</b>", "count": 2})
+        assert json.loads(html.unescape(rendered)) == {"greeting": "<b>hi</b>", "count": 2}
 
 
 class TestHighlightJson:


### PR DESCRIPTION
### Product Description
Data a chat participant supplies can no longer inject markup into the team-facing session detail, annotation and trace pages.

### Technical Description
The `to_json` template filter wrapped raw `json.dumps` output in `mark_safe`, which switches off autoescaping. `json.dumps` does not escape `<`, `>` or `&`, and the local `escape_script_tags` helper only rewrote a literal `</script>`, so stored values reached the browser as markup rather than text.

The filter now returns a plain string and lets the template engine escape it. All nine call sites render display-identical output; the one site that chains `|force_escape` inside an `x-data` attribute is byte-identical.

Found by an automated security review. `apps/web/tests/test_json_tags.py` covers the escaping through the real template engine and fails without the change.

### Migrations
None.

### Demo
n/a

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
