### PR TITLE
Enforce files.view_file on the API file download endpoint

### DIFF
--- a/apps/api/tests/test_file_content_api.py
+++ b/apps/api/tests/test_file_content_api.py
@@ -1,0 +1,76 @@
+"""Authorization tests for the file-download endpoint.
+
+Team scoping alone is not enough: downloading file content requires the ``files.view_file`` model
+permission, the same gate the web view (``apps.files.views.FileView``) enforces.
+"""
+
+import pytest
+from django.urls import reverse
+
+from apps.teams.backends import CHAT_VIEWER_GROUP, EVENT_ADMIN_GROUP, add_user_to_team
+from apps.utils.factories.files import FileFactory
+from apps.utils.factories.team import TeamFactory
+from apps.utils.factories.user import UserFactory
+from apps.utils.tests.clients import ApiTestClient
+
+FILE_CONTENT = b"participant attachment"
+
+
+@pytest.fixture()
+def team(db):
+    return TeamFactory.create()
+
+
+@pytest.fixture()
+def file(team):
+    return FileFactory.create(team=team, file__filename="attachment.txt", file__data=FILE_CONTENT)
+
+
+def _download(client, file):
+    return client.get(reverse("api:file-content", kwargs={"pk": file.id}))
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("auth_method", ["api_key", "oauth"])
+def test_member_with_view_file_permission_can_download(auth_method, team, file):
+    user = UserFactory.create()
+    add_user_to_team(team, user, [CHAT_VIEWER_GROUP])
+    client = ApiTestClient(user, team, auth_method=auth_method)
+
+    response = _download(client, file)
+
+    assert response.status_code == 200
+    assert b"".join(response.streaming_content) == FILE_CONTENT
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("auth_method", ["api_key", "oauth"])
+def test_member_without_view_file_permission_is_forbidden(auth_method, team, file):
+    """Event Admin grants no files permissions, so it cannot download team files by pk."""
+    user = UserFactory.create()
+    add_user_to_team(team, user, [EVENT_ADMIN_GROUP])
+    client = ApiTestClient(user, team, auth_method=auth_method)
+
+    response = _download(client, file)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db()
+def test_machine_token_with_files_scope_can_download(team, file):
+    """A client-credentials token has no user or membership; the OAuth scope is its authorization."""
+    client = ApiTestClient(UserFactory.create(), team, auth_method="oauth_client_credentials", scopes=["files:read"])
+
+    response = _download(client, file)
+
+    assert response.status_code == 200
+    assert b"".join(response.streaming_content) == FILE_CONTENT
+
+
+@pytest.mark.django_db()
+def test_machine_token_without_files_scope_is_forbidden(team, file):
+    client = ApiTestClient(UserFactory.create(), team, auth_method="oauth_client_credentials", scopes=["sessions:read"])
+
+    response = _download(client, file)
+
+    assert response.status_code == 403

--- a/apps/api/views/files.py
+++ b/apps/api/views/files.py
@@ -4,7 +4,13 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.renderers import BaseRenderer
 from rest_framework.views import APIView
 
+from apps.api.permissions import (
+    DjangoModelPermissionsWithView,
+    IsAuthenticatedOrMachineToken,
+    ReadOnlyAPIKeyPermission,
+)
 from apps.files.models import File
+from apps.oauth.permissions import TokenHasOAuthScope
 
 
 class BinaryRenderer(BaseRenderer):
@@ -18,9 +24,19 @@ class BinaryRenderer(BaseRenderer):
 
 
 class FileContentView(APIView):
+    # DjangoModelPermissionsWithView enforces "files.view_file" for GET. It derives that permission
+    # from this queryset's model; the queryset is never used to fetch the file (`get` scopes the
+    # lookup to the request's team). Machine (client-credentials) tokens have no user and are
+    # authorized by the OAuth scope below instead.
+    queryset = File.objects.all()
+    permission_classes = [
+        IsAuthenticatedOrMachineToken,
+        ReadOnlyAPIKeyPermission,
+        DjangoModelPermissionsWithView,
+        TokenHasOAuthScope,
+    ]
     required_scopes = ("files:read",)
     renderer_classes = [BinaryRenderer]
-    permission_required = "files.view_file"
 
     @extend_schema(operation_id="file_content", summary="Download File Content", tags=["Files"], responses=bytes)
     def get(self, request, pk: int):


### PR DESCRIPTION
### Product Description
The API file-download endpoint now respects the same file permission the web UI enforces, so a team role without file access cannot fetch files through the API.

### Technical Description
`FileContentView` declared `permission_required = "files.view_file"`, but that is a Django `PermissionRequiredMixin` attribute on a plain DRF `APIView`, which never reads it — so team scoping was the only authorization on the `pk` path parameter.

The inert attribute is removed and the permission is enforced by `DjangoModelPermissionsWithView`, the class the sibling API views already use. `permission_classes` is now explicit and is a strict superset of the project defaults it overrides, so read-only-key and OAuth-scope behaviour is unchanged. Client-credentials machine tokens are unaffected — they short-circuit that class and stay authorized by the `files:read` scope.

Roles that lose API download access: Team Admin, Event Admin, Evaluation Admin — the same roles `apps/files/views.py` already denies. Every role that can see a `content_url` still holds `files.view_file`.

Found by an automated security review. `apps/api/tests/test_file_content_api.py` covers both sides and fails without the change; the committed OpenAPI snapshots are unchanged.

Human note: I have verified that this API is not needed for anonymous requests e.g. urls included in chat responses.

### Migrations
None.

### Demo
n/a

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
