### PR TITLE
Keep the read-only API key gate on views that override permission_classes

### DIFF
--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -190,6 +190,14 @@ class ReadOnlyAPIKeyPermission(BasePermission):
         return True
 
 
+# The non-scope half of REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] (config/settings.py). Setting
+# ``permission_classes`` on a view replaces the defaults wholesale, which silently drops the
+# read-only API-key gate (ADR-0021), so views that need extra permission classes must build on this
+# list rather than start from an empty one. The OAuth scope class is deliberately excluded: each view
+# pairs its own (TokenHasOAuthScope or TokenHasOAuthResourceScope) with its ``required_scopes``.
+BASE_PERMISSION_CLASSES = [IsAuthenticatedOrMachineToken, ReadOnlyAPIKeyPermission]
+
+
 class ConfigurableKeyParser(KeyParser):
     def __init__(self, keyword: str):
         self.keyword = keyword

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -116,6 +116,16 @@ def test_only_experiments_from_the_scoped_team_is_returned():
 
 
 @pytest.mark.django_db()
+def test_read_only_key_can_read_experiments(experiment):
+    """The experiments endpoints are read-only, so a read-only key keeps full access (ADR-0021)."""
+    user = experiment.team.members.first()
+    client = ApiTestClient(user, experiment.team, read_only=True)
+
+    assert client.get(reverse("api:experiment-list")).status_code == 200
+    assert client.get(reverse("api:experiment-detail", kwargs={"id": experiment.public_id})).status_code == 200
+
+
+@pytest.mark.django_db()
 @pytest.mark.parametrize("auth_method", ["api_key", "oauth"])
 def test_create_and_update_participant_data(auth_method):
     identifier = "part1"

--- a/apps/api/tests/test_permissions.py
+++ b/apps/api/tests/test_permissions.py
@@ -1,0 +1,46 @@
+import pytest
+from django.conf import settings
+
+from apps.api.openai import ChatCompletionsView
+from apps.api.permissions import BASE_PERMISSION_CLASSES, ReadOnlyAPIKeyPermission
+from apps.api.v2.usage.views import UsageView
+from apps.api.v2.views import ChatbotViewSet, MeView
+from apps.api.views.channels import TriggerBotMessageView
+from apps.api.views.experiments import ExperimentViewSet
+from apps.api.views.files import FileContentView
+from apps.api.views.participants import ParticipantView
+from apps.api.views.sessions import ExperimentSessionViewSet
+from apps.oauth.permissions import TokenHasOAuthScope
+
+# Every view that accepts API-key authentication, whether it takes the project defaults or sets its
+# own ``permission_classes``.
+API_KEY_VIEWS = [
+    ChatbotViewSet,
+    ChatCompletionsView,
+    ExperimentSessionViewSet,
+    ExperimentViewSet,
+    FileContentView,
+    MeView,
+    ParticipantView,
+    TriggerBotMessageView,
+    UsageView,
+]
+
+
+def _dotted_path(cls) -> str:
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def test_base_permission_classes_match_project_defaults():
+    """BASE_PERMISSION_CLASSES is the non-scope half of the project defaults; views that override
+    ``permission_classes`` build on it, so it must not drift from settings."""
+    scope_class = _dotted_path(TokenHasOAuthScope)
+    defaults = [p for p in settings.REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] if p != scope_class]
+    assert [_dotted_path(cls) for cls in BASE_PERMISSION_CLASSES] == defaults
+
+
+@pytest.mark.parametrize("view", API_KEY_VIEWS, ids=lambda view: view.__name__)
+def test_api_key_views_keep_the_read_only_gate(view):
+    """Overriding ``permission_classes`` replaces the project defaults, which is how the read-only
+    API-key gate (ADR-0021) gets dropped. Every API-key view must still carry it."""
+    assert ReadOnlyAPIKeyPermission in view.permission_classes

--- a/apps/api/tests/test_session_api.py
+++ b/apps/api/tests/test_session_api.py
@@ -772,3 +772,56 @@ def test_delete_session_tags_does_not_remove_system_tags(auth_method, session):
     # Verify response shows the system tag
     response_data = response.json()
     assert response_data["tags"] == ["important"]
+
+
+def _create_session_request(session):
+    return reverse("api:session-list"), {"experiment": str(session.experiment.public_id)}
+
+
+def _end_session_request(session):
+    return f"/api/sessions/{session.external_id}/end_experiment_session/", None
+
+
+def _update_state_request(session):
+    return f"/api/sessions/{session.external_id}/update_state/", {"state": {"injected": True}}
+
+
+def _tags_request(session):
+    return f"/api/sessions/{session.external_id}/tags/", {"tags": ["injected"]}
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("method", "build_request"),
+    [
+        pytest.param("post", _create_session_request, id="create"),
+        pytest.param("post", _end_session_request, id="end_experiment_session"),
+        pytest.param("patch", _update_state_request, id="update_state"),
+        pytest.param("post", _tags_request, id="add_tags"),
+        pytest.param("delete", _tags_request, id="remove_tags"),
+    ],
+)
+def test_read_only_key_cannot_write_to_sessions(method, build_request, session):
+    """A key issued as read-only must not write through any session endpoint (ADR-0021)."""
+    user = session.team.members.first()
+    client = ApiTestClient(user, session.team, read_only=True)
+    url, data = build_request(session)
+    original_status = session.status
+
+    response = getattr(client, method)(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    session.refresh_from_db()
+    assert session.status == original_status
+    assert session.state == {}
+    assert session.chat.tags.count() == 0
+    assert ExperimentSession.objects.count() == 1
+
+
+@pytest.mark.django_db()
+def test_read_only_key_can_read_sessions(session):
+    user = session.team.members.first()
+    client = ApiTestClient(user, session.team, read_only=True)
+
+    assert client.get(reverse("api:session-list")).status_code == 200
+    assert client.get(reverse("api:session-detail", kwargs={"id": session.external_id})).status_code == 200

--- a/apps/api/v2/tests/test_chatbots_api.py
+++ b/apps/api/v2/tests/test_chatbots_api.py
@@ -47,6 +47,16 @@ def test_list_chatbots(auth_method, experiment):
 
 
 @pytest.mark.django_db()
+def test_read_only_key_can_read_chatbots(experiment):
+    """The chatbots endpoints are read-only, so a read-only key keeps full access (ADR-0021)."""
+    user = experiment.team.members.first()
+    client = ApiTestClient(user, experiment.team, read_only=True)
+
+    assert client.get(reverse("api:v2:chatbot-list")).status_code == 200
+    assert client.get(reverse("api:v2:chatbot-detail", kwargs={"id": experiment.public_id})).status_code == 200
+
+
+@pytest.mark.django_db()
 def test_retrieve_chatbot_by_public_id(experiment):
     user = experiment.team.members.first()
     client = ApiTestClient(user, experiment.team)

--- a/apps/api/v2/tests/test_me_api.py
+++ b/apps/api/v2/tests/test_me_api.py
@@ -51,6 +51,15 @@ def test_me_returns_user_and_team(auth_method):
 
 
 @pytest.mark.django_db()
+def test_me_read_only_key_allowed():
+    """/me is read-only, so a read-only key keeps full access (ADR-0021)."""
+    team = TeamWithUsersFactory.create()
+    client = ApiTestClient(team.members.first(), team, read_only=True)
+
+    assert client.get(reverse("api:v2:me")).status_code == 200
+
+
+@pytest.mark.django_db()
 def test_me_email_verified_true():
     team = TeamWithUsersFactory.create()
     user = team.members.first()

--- a/apps/api/v2/usage/tests/test_usage_messages.py
+++ b/apps/api/v2/usage/tests/test_usage_messages.py
@@ -41,6 +41,17 @@ def test_usage_unauthenticated():
 
 
 @pytest.mark.django_db()
+def test_usage_read_only_key_allowed():
+    """Usage is a read-only endpoint, so a read-only key keeps full access (ADR-0021)."""
+    team = TeamWithUsersFactory.create()
+    client = ApiTestClient(team.members.first(), team, read_only=True)
+
+    response = client.get(reverse(USAGE_URL), {"metric": "messages", "period": "current_month"})
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db()
 @pytest.mark.parametrize("auth_method", ["api_key", "oauth"])
 def test_messages_metric_counts_current_month(auth_method):
     team = TeamWithUsersFactory.create()

--- a/apps/api/v2/usage/views.py
+++ b/apps/api/v2/usage/views.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.api.pagination import CursorPagination
-from apps.api.permissions import IsAuthenticatedOrMachineToken
+from apps.api.permissions import BASE_PERMISSION_CLASSES
 from apps.api.v2.usage import services
 from apps.api.v2.usage.param_serializers import UsageQuerySerializer
 from apps.api.v2.usage.permissions import CanViewUsage
@@ -32,7 +32,7 @@ class UsageView(APIView):
     # and narrowed by participant/chatbot/platform.
     # See docs/design/usage-api.md.
 
-    permission_classes = [IsAuthenticatedOrMachineToken, CanViewUsage, TokenHasOAuthResourceScope]
+    permission_classes = [*BASE_PERMISSION_CLASSES, CanViewUsage, TokenHasOAuthResourceScope]
     required_scopes = ["usage"]
 
     @extend_schema(

--- a/apps/api/v2/views.py
+++ b/apps/api/v2/views.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet
 
-from apps.api.permissions import DjangoModelPermissionsWithView
+from apps.api.permissions import BASE_PERMISSION_CLASSES, DjangoModelPermissionsWithView, ReadOnlyAPIKeyPermission
 from apps.api.v2.inspect.serializers import ChatbotInspectSerializer
 from apps.api.v2.inspect.versioning import InspectVersionError, resolve_inspect_version
 from apps.api.v2.serializers import ChatbotSerializer, MeSerializer
@@ -39,7 +39,7 @@ from apps.oauth.permissions import TokenHasOAuthResourceScope
     ),
 )
 class ChatbotViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, GenericViewSet):
-    permission_classes = [DjangoModelPermissionsWithView, TokenHasOAuthResourceScope]
+    permission_classes = [*BASE_PERMISSION_CLASSES, DjangoModelPermissionsWithView, TokenHasOAuthResourceScope]
     required_scopes = ["chatbots"]
     serializer_class = ChatbotSerializer
     lookup_field = "public_id"
@@ -91,7 +91,9 @@ class ChatbotViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, GenericVi
 class MeView(APIView):
     """Return info about the authenticated user and their scoped team."""
 
-    permission_classes = [IsAuthenticated, TokenHasOAuthResourceScope]
+    # Not BASE_PERMISSION_CLASSES: /me describes a human user, so a machine token (which has no user)
+    # is refused by IsAuthenticated rather than admitted by IsAuthenticatedOrMachineToken.
+    permission_classes = [IsAuthenticated, ReadOnlyAPIKeyPermission, TokenHasOAuthResourceScope]
     required_scopes = []  # Any valid OAuth token is accepted; no specific scope required.
 
     @extend_schema(

--- a/apps/api/views/experiments.py
+++ b/apps/api/views/experiments.py
@@ -3,7 +3,7 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema
 from rest_framework import mixins
 from rest_framework.viewsets import GenericViewSet
 
-from apps.api.permissions import DjangoModelPermissionsWithView
+from apps.api.permissions import BASE_PERMISSION_CLASSES, DjangoModelPermissionsWithView
 from apps.api.serializers import ExperimentSerializer
 from apps.experiments.models import Experiment
 from apps.oauth.permissions import TokenHasOAuthResourceScope
@@ -30,7 +30,7 @@ from apps.oauth.permissions import TokenHasOAuthResourceScope
     ),
 )
 class ExperimentViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, GenericViewSet):
-    permission_classes = [DjangoModelPermissionsWithView, TokenHasOAuthResourceScope]
+    permission_classes = [*BASE_PERMISSION_CLASSES, DjangoModelPermissionsWithView, TokenHasOAuthResourceScope]
     required_scopes = ["chatbots"]
     serializer_class = ExperimentSerializer
     lookup_field = "public_id"

--- a/apps/api/views/sessions.py
+++ b/apps/api/views/sessions.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from apps.annotations.models import CustomTaggedItem, Tag, TagCategories
-from apps.api.permissions import DjangoModelPermissionsWithView
+from apps.api.permissions import BASE_PERMISSION_CLASSES, DjangoModelPermissionsWithView
 from apps.api.serializers import ExperimentSessionCreateSerializer, ExperimentSessionSerializer
 from apps.events.models import StaticTriggerType
 from apps.experiments.models import ExperimentSession
@@ -140,7 +140,7 @@ tags_response_serializer = inline_serializer(
     ),
 )
 class ExperimentSessionViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, GenericViewSet):
-    permission_classes = [DjangoModelPermissionsWithView, TokenHasOAuthResourceScope]
+    permission_classes = [*BASE_PERMISSION_CLASSES, DjangoModelPermissionsWithView, TokenHasOAuthResourceScope]
     serializer_class = ExperimentSessionSerializer
     filter_backends = [filters.OrderingFilter]
     ordering_fields = ["created_at"]


### PR DESCRIPTION
### Product Description
An API key issued as read-only can no longer perform writes on the sessions API.

### Technical Description
`ReadOnlyAPIKeyPermission` — the ADR-0021 "look but don't touch" gate — exists only in `REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"]`. A view that sets `permission_classes` replaces that list wholesale, silently dropping the gate. `ExperimentSessionViewSet` did exactly that while exposing four write endpoints.

This adds `BASE_PERMISSION_CLASSES = [IsAuthenticatedOrMachineToken, ReadOnlyAPIKeyPermission]` in `apps/api/permissions.py` and spreads it into every view that overrides the defaults: `ExperimentSessionViewSet`, `ExperimentViewSet`, v2 `ChatbotViewSet`, v2 `UsageView`, and v2 `MeView` (which keeps its deliberate `IsAuthenticated`). Four of those five have no write endpoints today, so the addition is latent-hole closure there.

The OAuth scope class is deliberately not in the shared list: each view pairs its own (`TokenHasOAuthScope` vs `TokenHasOAuthResourceScope`) with `required_scopes`, and including both would demand two scopes from every OAuth caller.

Found by an automated security review. `apps/api/tests/test_session_api.py` covers all five write entry points and fails without the change; `test_permissions.py` guards against a future override dropping the gate again.

### Migrations
None.

### Demo
n/a

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
