### PR TITLE
Check the participant allowlist before starting a chat session

### DIFF
--- a/apps/api/tests/test_chat_api_anon.py
+++ b/apps/api/tests/test_chat_api_anon.py
@@ -5,11 +5,15 @@ from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
 
+from apps.channels.models import ChannelPlatform
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.experiments.models import ExperimentSession
 from apps.files.models import FilePurpose
+from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentSessionFactory
 from apps.utils.factories.files import FileFactory
+
+WIDGET_TOKEN = "test_widget_token_123456789012"
 
 
 @pytest.fixture()
@@ -179,12 +183,54 @@ def test_session_poll_with_messages(api_client, session):
     }
 
 
-@pytest.mark.skip("This no longer applies to the chat API until we have proper public access implemented.")
 @pytest.mark.django_db()
-def test_start_chat_session_requires_auth_when_not_public(team_with_users, api_client, experiment):
+def test_start_chat_session_not_startable_when_not_public(team_with_users, api_client, experiment):
+    """An allowlist-restricted chatbot is not startable anonymously and leaks no metadata.
+
+    404 (not 403) to match the web entry points, so a non-public chatbot looks the same to a
+    stranger through the API and the UI.
+    """
     url = reverse("api:chat:start-session")
     experiment.participant_allowlist = ["a", "b"]
     experiment.save()
     data = {"chatbot_id": experiment.public_id}
     response = api_client.post(url, data=data, format="json")
-    assert response.status_code == 403
+    assert response.status_code == 404
+    assert experiment.name not in response.content.decode()
+    assert not ExperimentSession.objects.filter(experiment=experiment).exists()
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("participant_allowlist", "status_code"),
+    [
+        pytest.param([], 201, id="public-chatbot-starts"),
+        pytest.param(["someone@example.com"], 404, id="allowlist-restricted-refused"),
+    ],
+)
+def test_start_chat_session_with_embed_key_honours_allowlist(
+    api_client, experiment, participant_allowlist, status_code
+):
+    """The embed key authenticates the widget, not a participant.
+
+    It does not make an allowlist-restricted chatbot startable: the anonymous participant can
+    never be on the allowlist, so the message pipeline would refuse every message in such a
+    session anyway.
+    """
+    experiment.participant_allowlist = participant_allowlist
+    experiment.save(update_fields=["participant_allowlist"])
+    ExperimentChannelFactory.create(
+        experiment=experiment,
+        platform=ChannelPlatform.EMBEDDED_WIDGET,
+        extra_data={"widget_token": WIDGET_TOKEN, "allowed_domains": ["example.com"]},
+    )
+    url = reverse("api:chat:start-session")
+    data = {"chatbot_id": experiment.public_id, "session_data": {"source": "widget"}}
+    response = api_client.post(
+        url,
+        data=data,
+        format="json",
+        HTTP_X_EMBED_KEY=WIDGET_TOKEN,
+        HTTP_ORIGIN="https://example.com",
+    )
+    assert response.status_code == status_code

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -36,6 +36,7 @@ from apps.channels.widget_versions import (
     widget_sunset_headers,
 )
 from apps.chat.models import Chat, ChatAttachment, ChatMessage, ChatMessageType
+from apps.chatbots.version_resolver import resolve_published_or_working
 from apps.experiments.models import Experiment, Participant, ParticipantData
 from apps.experiments.task_utils import get_message_task_response
 from apps.experiments.tasks import get_response_for_webchat_task
@@ -241,6 +242,25 @@ def _resolve_experiment_channel(request, team, session_data):
     return channel
 
 
+def _caller_may_start_session(request, experiment_version) -> bool:
+    """Whether this caller is allowed to chat to `experiment_version`.
+
+    Mirrors the gate the web entry points apply before creating a session
+    (`start_session_public`, `start_session_public_embed`, `start_chatbot_session_public_embed`)
+    and the one the message pipeline applies to every message (`ParticipantValidationStage`):
+    a non-public chatbot only accepts participants on its allowlist (team members included).
+
+    Anonymous callers get an `anon:<uuid>` participant identifier which can never be on an
+    allowlist, so a non-public chatbot is not startable anonymously — matching the fact that
+    such a session could not exchange a single message anyway.
+    """
+    if experiment_version.is_public:
+        return True
+    if request.user.is_authenticated:
+        return experiment_version.is_participant_allowed(request.user.email)
+    return False
+
+
 @extend_schema(
     operation_id="chat_start_session",
     summary="Start a new chat session for a widget",
@@ -350,6 +370,12 @@ def chat_start_session(request):
                 experiment_version = experiment.get_version(version_number)
             except Experiment.DoesNotExist:
                 raise NotFound(f"Experiment with version {version_number} not found") from None
+
+    # Don't create a session on (or disclose the name and version list of) a chatbot the
+    # caller isn't allowed to chat to. The web entry points raise 404 here; match that so a
+    # non-public chatbot looks the same to a stranger through the API and the UI.
+    if not _caller_may_start_session(request, experiment_version or resolve_published_or_working(experiment)):
+        raise NotFound()
 
     team = experiment.team
 


### PR DESCRIPTION
### Product Description
Starting a chat session through the API now respects a chatbot's participant allowlist, the same way every web entry point does.

### Technical Description
`chat_start_session` resolved a chatbot from the request body and went straight to participant creation, session creation, token minting and serialization. Every equivalent web entry point raises `Http404` when the version is not public (`apps/experiments/views/experiment.py:286,374`, `apps/chatbots/views.py:811`); this endpoint had no such gate, so a stranger received a 201 plus the chatbot's name and version list, a `Participant`/`ExperimentSession` row, and the team's `PARTICIPANT_JOINED_EXPERIMENT` / `CONVERSATION_START` triggers fired.

New `_caller_may_start_session` runs immediately after version resolution and before every one of those side effects. It reproduces `ParticipantValidationStage`'s existing rule — public chatbot, or an authenticated caller who is allowlisted or a team member — and refuses with 404 to match the web views. It resolves the same version the message pipeline validates against, so start and message cannot disagree.

No working flow changes: an anonymous caller always gets an `anon:<uuid>` identifier, which can never satisfy an allowlist, so such a session could not exchange a single message today. The refusal simply moves to the handshake.

`apps/api/tests/test_chat_api_anon.py` had a skipped test for this, `"This no longer applies to the chat API until we have proper public access implemented."` It is un-skipped, now asserts 404 rather than the 403 it aspired to, and gains assertions that no chatbot metadata leaks and no session row is created.

Found by an automated security review.

### Migrations
None.

### Demo
n/a

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
