### PR TITLE
Verify a shared secret on SureAdhere inbound webhooks

### DIFF
--- a/apps/channels/sureadhere_webhook.py
+++ b/apps/channels/sureadhere_webhook.py
@@ -1,0 +1,35 @@
+from django.http.request import HttpHeaders
+from django.utils.crypto import constant_time_compare
+
+SECRET_HEADER = "X-OCS-Webhook-Secret"
+
+
+def get_presented_secret(headers: HttpHeaders) -> str:
+    """Extract the shared secret an inbound SureAdhere webhook presents, or "" if it presents none.
+
+    SureAdhere does not sign its callbacks, so the only credential available is a secret
+    configured on both sides. It is accepted in either the ``X-OCS-Webhook-Secret`` header or
+    as an ``Authorization: Bearer`` token, because the callback is registered in SureAdhere's
+    own configuration and which of the two it can send is not recorded in this repo.
+
+    Lookups go through ``HttpHeaders``, which is case-insensitive, so header casing does not
+    matter. Any other authorization scheme yields "" and is therefore an authentication failure.
+    """
+    presented = headers.get(SECRET_HEADER, "").strip()
+    if presented:
+        return presented
+
+    scheme, _, token = headers.get("Authorization", "").partition(" ")
+    if scheme.lower() == "bearer":
+        return token.strip()
+    return ""
+
+
+def verify_secret(presented: str, expected: str) -> bool:
+    """Compare the presented secret against the configured one in constant time.
+
+    Either value being empty is a failure, so a request presenting no credential can never
+    authenticate against a provider with no secret configured. Whether such a provider is
+    let through at all is the caller's decision, made explicitly.
+    """
+    return bool(presented) and bool(expected) and constant_time_compare(presented, expected)

--- a/apps/channels/tests/test_sureadhere_webhook.py
+++ b/apps/channels/tests/test_sureadhere_webhook.py
@@ -1,0 +1,214 @@
+import json
+from unittest.mock import patch
+
+import pytest
+from django.http.request import HttpHeaders
+from django.urls import reverse
+
+from apps.channels import sureadhere_webhook
+from apps.channels.models import ChannelPlatform
+from apps.channels.tests.message_examples import sureadhere_messages
+from apps.utils.factories.channels import ExperimentChannelFactory
+
+WEBHOOK_SECRET = "sureadhere_test_webhook_secret"
+TENANT_ID = "12"
+
+
+def _headers(**wsgi_headers) -> HttpHeaders:
+    """Build an HttpHeaders from WSGI-style keys, the way Django does for a request."""
+    return HttpHeaders(wsgi_headers)
+
+
+class TestGetPresentedSecret:
+    """Which requests are considered to present a credential at all."""
+
+    def test_custom_header(self):
+        assert sureadhere_webhook.get_presented_secret(_headers(HTTP_X_OCS_WEBHOOK_SECRET="abc")) == "abc"
+
+    def test_header_lookup_is_case_insensitive(self):
+        """HttpHeaders normalises casing, so the sender's choice of casing does not matter."""
+        assert sureadhere_webhook.get_presented_secret(HttpHeaders({"HTTP_X_ocs_Webhook_Secret": "abc"})) == "abc"
+
+    def test_authorization_bearer(self):
+        assert sureadhere_webhook.get_presented_secret(_headers(HTTP_AUTHORIZATION="Bearer abc")) == "abc"
+
+    def test_bearer_scheme_is_case_insensitive(self):
+        assert sureadhere_webhook.get_presented_secret(_headers(HTTP_AUTHORIZATION="bEaReR abc")) == "abc"
+
+    def test_custom_header_wins_over_authorization(self):
+        headers = _headers(HTTP_X_OCS_WEBHOOK_SECRET="abc", HTTP_AUTHORIZATION="Bearer xyz")
+        assert sureadhere_webhook.get_presented_secret(headers) == "abc"
+
+    @pytest.mark.parametrize(
+        "wsgi_headers",
+        [
+            pytest.param({}, id="no_headers"),
+            pytest.param({"HTTP_X_OCS_WEBHOOK_SECRET": ""}, id="empty_custom_header"),
+            pytest.param({"HTTP_X_OCS_WEBHOOK_SECRET": "   "}, id="whitespace_custom_header"),
+            pytest.param({"HTTP_AUTHORIZATION": ""}, id="empty_authorization"),
+            pytest.param({"HTTP_AUTHORIZATION": "Bearer"}, id="bearer_with_no_token"),
+            pytest.param({"HTTP_AUTHORIZATION": "Bearer "}, id="bearer_with_empty_token"),
+            pytest.param({"HTTP_AUTHORIZATION": WEBHOOK_SECRET}, id="bare_token_no_scheme"),
+            pytest.param({"HTTP_AUTHORIZATION": f"Token {WEBHOOK_SECRET}"}, id="token_scheme"),
+            pytest.param({"HTTP_AUTHORIZATION": f"Basic {WEBHOOK_SECRET}"}, id="basic_scheme"),
+        ],
+    )
+    def test_no_credential_presented(self, wsgi_headers):
+        assert sureadhere_webhook.get_presented_secret(HttpHeaders(wsgi_headers)) == ""
+
+
+class TestVerifySecret:
+    def test_matching_secret(self):
+        assert sureadhere_webhook.verify_secret(WEBHOOK_SECRET, WEBHOOK_SECRET) is True
+
+    @pytest.mark.parametrize(
+        ("presented", "expected"),
+        [
+            pytest.param("wrong", WEBHOOK_SECRET, id="wrong_secret"),
+            pytest.param(WEBHOOK_SECRET.upper(), WEBHOOK_SECRET, id="case_changed"),
+            pytest.param(WEBHOOK_SECRET + "x", WEBHOOK_SECRET, id="longer_than_secret"),
+            pytest.param(WEBHOOK_SECRET[:-1], WEBHOOK_SECRET, id="prefix_of_secret"),
+            pytest.param("", WEBHOOK_SECRET, id="nothing_presented"),
+            pytest.param(WEBHOOK_SECRET, "", id="nothing_configured"),
+            pytest.param("", "", id="empty_vs_empty"),
+        ],
+    )
+    def test_rejected(self, presented, expected):
+        assert sureadhere_webhook.verify_secret(presented, expected) is False
+
+
+def _post(client, secret: str | None = None, *, header: str = "HTTP_X_OCS_WEBHOOK_SECRET", body: bytes | None = None):
+    """POST an inbound message to the SureAdhere webhook, omitting the credential when secret is None."""
+    if body is None:
+        body = json.dumps(sureadhere_messages.inbound_message()).encode()
+    headers = {} if secret is None else {header: secret}
+    return client.post(
+        reverse("channels:new_sureadhere_message", kwargs={"sureadhere_tenant_id": TENANT_ID}),
+        data=body,
+        content_type="application/json",
+        **headers,
+    )
+
+
+@pytest.fixture()
+def sureadhere_channel(sureadhere_provider):
+    return ExperimentChannelFactory.create(
+        platform=ChannelPlatform.SUREADHERE,
+        messaging_provider=sureadhere_provider,
+        experiment__team=sureadhere_provider.team,
+        extra_data={"sureadhere_tenant_id": TENANT_ID},
+    )
+
+
+@pytest.fixture()
+def secured_sureadhere_channel(sureadhere_channel):
+    """A SureAdhere channel whose provider has a webhook secret, so verification is enforced."""
+    provider = sureadhere_channel.messaging_provider
+    provider.config = {**provider.config, "webhook_secret": WEBHOOK_SECRET}
+    provider.save()
+    return sureadhere_channel
+
+
+@pytest.mark.django_db()
+class TestNewSureAdhereMessageAuthentication:
+    @pytest.mark.parametrize(
+        "header",
+        [
+            pytest.param("HTTP_X_OCS_WEBHOOK_SECRET", id="custom_header"),
+            pytest.param("HTTP_AUTHORIZATION", id="authorization_bearer"),
+        ],
+    )
+    @patch("apps.channels.tasks.handle_sureadhere_message")
+    def test_correct_secret_is_accepted(self, task, header, client, secured_sureadhere_channel):
+        secret = WEBHOOK_SECRET if header == "HTTP_X_OCS_WEBHOOK_SECRET" else f"Bearer {WEBHOOK_SECRET}"
+        response = _post(client, secret, header=header)
+        assert response.status_code == 200
+        task.delay.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ("header", "secret"),
+        [
+            pytest.param("HTTP_X_OCS_WEBHOOK_SECRET", None, id="no_credential"),
+            pytest.param("HTTP_X_OCS_WEBHOOK_SECRET", "wrong-secret", id="wrong_secret"),
+            pytest.param("HTTP_X_OCS_WEBHOOK_SECRET", "", id="empty_secret"),
+            pytest.param("HTTP_X_OCS_WEBHOOK_SECRET", "   ", id="whitespace_secret"),
+            pytest.param("HTTP_X_OCS_WEBHOOK_SECRET", WEBHOOK_SECRET.upper(), id="case_changed_secret"),
+            pytest.param("HTTP_X_OCS_WEBHOOK_SECRET", WEBHOOK_SECRET + "x", id="longer_than_secret"),
+            pytest.param("HTTP_AUTHORIZATION", f"Bearer {WEBHOOK_SECRET}x", id="bearer_wrong_secret"),
+            pytest.param("HTTP_AUTHORIZATION", "Bearer", id="bearer_with_no_token"),
+            pytest.param("HTTP_AUTHORIZATION", WEBHOOK_SECRET, id="bare_token_no_scheme"),
+            pytest.param("HTTP_AUTHORIZATION", f"Token {WEBHOOK_SECRET}", id="wrong_auth_scheme"),
+        ],
+    )
+    @patch("apps.channels.tasks.handle_sureadhere_message")
+    def test_bad_credential_is_rejected(self, task, header, secret, client, secured_sureadhere_channel):
+        response = _post(client, secret, header=header)
+        assert response.status_code == 401
+        task.delay.assert_not_called()
+
+    @patch("apps.channels.tasks.handle_sureadhere_message")
+    def test_secret_in_the_query_string_is_not_accepted(self, task, client, secured_sureadhere_channel):
+        url = reverse("channels:new_sureadhere_message", kwargs={"sureadhere_tenant_id": TENANT_ID})
+        response = client.post(
+            f"{url}?webhook_secret={WEBHOOK_SECRET}",
+            data=json.dumps(sureadhere_messages.inbound_message()).encode(),
+            content_type="application/json",
+        )
+        assert response.status_code == 401
+        task.delay.assert_not_called()
+
+    @patch("apps.channels.tasks.handle_sureadhere_message")
+    def test_rejected_before_the_body_is_parsed(self, task, client, secured_sureadhere_channel):
+        """The guard runs before json.loads, so an unauthenticated request cannot reach the parser."""
+        response = _post(client, body=b"not json")
+        assert response.status_code == 401
+        task.delay.assert_not_called()
+
+    @patch("apps.channels.tasks.handle_sureadhere_message")
+    def test_unknown_tenant_is_still_a_404(self, task, client, secured_sureadhere_channel):
+        url = reverse("channels:new_sureadhere_message", kwargs={"sureadhere_tenant_id": "9999"})
+        response = client.post(url, data=b"{}", content_type="application/json")
+        assert response.status_code == 404
+        task.delay.assert_not_called()
+
+
+@pytest.mark.django_db()
+class TestNewSureAdhereMessagePassThrough:
+    """Providers with no secret configured yet keep working, unverified. See the summary in
+    _sureadhere_request_is_authorised: enforcing on deploy day would drop live patient traffic
+    for every existing SureAdhere provider."""
+
+    @pytest.mark.parametrize(
+        "stored_secret",
+        [
+            pytest.param("absent", id="key_absent_from_config"),
+            pytest.param("", id="empty_string"),
+            pytest.param("   ", id="whitespace_only"),
+            pytest.param(None, id="none"),
+        ],
+    )
+    @patch("apps.channels.tasks.handle_sureadhere_message")
+    def test_unconfigured_provider_accepts_unauthenticated_webhooks(
+        self, task, stored_secret, client, sureadhere_channel
+    ):
+        if stored_secret != "absent":
+            provider = sureadhere_channel.messaging_provider
+            provider.config = {**provider.config, "webhook_secret": stored_secret}
+            provider.save()
+        response = _post(client)
+        assert response.status_code == 200
+        task.delay.assert_called_once()
+
+    @patch("apps.channels.tasks.handle_sureadhere_message")
+    def test_channel_without_a_messaging_provider_is_unchanged(self, task, client):
+        """messaging_provider is optional on a channel. Such a channel cannot deliver anything
+        (the task only resolves channels with a SureAdhere provider) but the response is a 200,
+        as it was before this guard existed."""
+        ExperimentChannelFactory.create(
+            platform=ChannelPlatform.SUREADHERE,
+            messaging_provider=None,
+            extra_data={"sureadhere_tenant_id": TENANT_ID},
+        )
+        response = _post(client)
+        assert response.status_code == 200
+        task.delay.assert_called_once()

--- a/apps/channels/views.py
+++ b/apps/channels/views.py
@@ -29,7 +29,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.api.permissions import verify_hmac
-from apps.channels import meta_webhook, tasks, turn_webhook
+from apps.channels import meta_webhook, sureadhere_webhook, tasks, turn_webhook
 from apps.channels.datamodels import TwilioMessage, is_non_conversational_whatsapp_message
 from apps.channels.exceptions import ExperimentChannelException
 from apps.channels.forms import ChannelFormWrapper
@@ -121,9 +121,57 @@ def new_sureadhere_message(request, sureadhere_tenant_id: int):
 
     set_current_team(channel.team)
     request.experiment = channel.experiment  # used by RequestLoggingMiddleware
+    if not _sureadhere_request_is_authorised(request, channel):
+        return HttpResponse("Invalid webhook secret.", status=401)
+
     message_data = json.loads(request.body)
     tasks.handle_sureadhere_message.delay(sureadhere_tenant_id=sureadhere_tenant_id, message_data=message_data)
     return HttpResponse()
+
+
+def _sureadhere_request_is_authorised(request, channel: ExperimentChannel) -> bool:
+    """Check whether the SureAdhere webhook request is authorised: True if the provider has no
+    secret configured (fail-open, see below) or if the request presents the matching secret.
+
+    SureAdhere does not sign its callbacks, so the credential is a shared secret configured on
+    both sides. It is optional by design, as for Turn.io above: a provider that has not yet had
+    one registered with SureAdhere is left unverified rather than having live patient traffic
+    dropped. Until an operator sets one, that provider's inbound messages stay unauthenticated.
+    """
+    provider = channel.messaging_provider
+    # The provider is optional on a channel, and a channel without one can never deliver a
+    # message (handle_sureadhere_message only resolves channels with a SureAdhere provider),
+    # so there is nothing to verify against.
+    webhook_secret = (provider.config.get("webhook_secret") or "").strip() if provider else ""
+    if not webhook_secret:
+        log.warning(
+            "SureAdhere webhook NOT VERIFIED: no webhook secret is configured for channel %s (team %s), "
+            "so anyone can post inbound messages for this tenant. Set one on the messaging provider.",
+            channel.id,
+            channel.team.slug,
+        )
+        return True
+
+    presented = sureadhere_webhook.get_presented_secret(request.headers)
+    if sureadhere_webhook.verify_secret(presented, webhook_secret):
+        return True
+
+    if not presented:
+        log.warning(
+            "SureAdhere webhook rejected for provider %s (team %s): no secret presented in the %s "
+            "header or as an Authorization bearer token",
+            channel.messaging_provider_id,
+            channel.team.slug,
+            sureadhere_webhook.SECRET_HEADER,
+        )
+    else:
+        log.warning(
+            "SureAdhere webhook rejected for provider %s (team %s): the presented secret did not "
+            "match, the configured secret may be incorrect",
+            channel.messaging_provider_id,
+            channel.team.slug,
+        )
+    return False
 
 
 @csrf_exempt

--- a/apps/service_providers/forms.py
+++ b/apps/service_providers/forms.py
@@ -310,7 +310,7 @@ class TurnIOMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
 
 
 class SureAdhereMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
-    obfuscate_fields = ["client_secret"]
+    obfuscate_fields = ["client_secret", "webhook_secret"]
     additional_searchable_fields = ["client_id"]
 
     client_id = forms.CharField(
@@ -332,6 +332,22 @@ class SureAdhereMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):
         validators=[URLValidator(schemes=["https"])],
         help_text=_("URL of the SureAdhere backend server"),
     )
+    webhook_secret = forms.CharField(
+        label=_("Inbound Webhook Secret"),
+        required=False,
+        help_text=_(
+            "A secret of your choosing that SureAdhere must send with every inbound message, in "
+            "either an 'X-OCS-Webhook-Secret' header or as an 'Authorization: Bearer' token. "
+            "Requests without it are rejected. Leave blank only while you arrange this with "
+            "SureAdhere: while it is blank, anyone who knows the tenant ID can post messages."
+        ),
+    )
+
+    def clean(self):
+        """Normalise webhook_secret so the stored value is always a string."""
+        cleaned_data = super().clean()
+        cleaned_data["webhook_secret"] = (cleaned_data.get("webhook_secret") or "").strip()
+        return cleaned_data
 
 
 class MetaCloudAPIMessagingConfigForm(ObfuscatingMixin, ProviderTypeConfigForm):

--- a/apps/service_providers/tests/test_sureadhere_config_form.py
+++ b/apps/service_providers/tests/test_sureadhere_config_form.py
@@ -1,0 +1,63 @@
+import pytest
+
+from apps.service_providers.forms import SureAdhereMessagingConfigForm
+
+CONFIG = {
+    "client_id": "client-123",
+    "client_secret": "secret-456",
+    "client_scope": "https://example.onmicrosoft.com/example-app-api/.default",
+    "auth_url": "https://sa.b2clogin.com/sa.onmicrosoft.com/test/oauth2/v2.0/token",
+    "base_url": "https://example.com",
+}
+
+
+class TestSureAdhereMessagingConfigForm:
+    """The webhook_secret is optional so that existing SureAdhere providers keep working after
+    deploy: enforcing it on deploy day would 401 live inbound patient messages for every
+    provider that has not yet had a secret arranged with SureAdhere.
+    """
+
+    def test_webhook_secret_is_optional(self):
+        form = SureAdhereMessagingConfigForm(None, data=CONFIG)
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["webhook_secret"] == ""
+
+    def test_webhook_secret_is_saved_when_supplied(self):
+        form = SureAdhereMessagingConfigForm(None, data={**CONFIG, "webhook_secret": "s3cr3t-value"})
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["webhook_secret"] == "s3cr3t-value"
+
+    def test_webhook_secret_is_stripped(self):
+        form = SureAdhereMessagingConfigForm(None, data={**CONFIG, "webhook_secret": "  s3cr3t-value  "})
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["webhook_secret"] == "s3cr3t-value"
+
+    @pytest.mark.parametrize(
+        "submitted",
+        [pytest.param("", id="left_blank"), pytest.param("   ", id="whitespace_only")],
+    )
+    def test_blank_secret_on_a_pre_existing_provider_normalises_to_empty_string(self, submitted):
+        """A provider saved before this field existed has no webhook_secret in its config.
+
+        ObfuscatingMixin restores the unmasked original for an unchanged field, which would be
+        None here. Storing None would defeat the `not webhook_secret` check in the view.
+        """
+        form = SureAdhereMessagingConfigForm(None, data={**CONFIG, "webhook_secret": submitted}, initial=CONFIG)
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["webhook_secret"] == ""
+
+    def test_unchanged_masked_secret_keeps_the_original_value(self):
+        """Re-saving the provider without touching the masked field must not clobber the secret."""
+        form = SureAdhereMessagingConfigForm(
+            None,
+            data={**CONFIG, "client_secret": "secr...56", "webhook_secret": "s3cr...ue"},
+            initial={**CONFIG, "webhook_secret": "s3cr3t-value"},
+        )
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["webhook_secret"] == "s3cr3t-value"
+        assert form.cleaned_data["client_secret"] == "secret-456"
+
+    def test_secret_is_obfuscated_for_display(self):
+        form = SureAdhereMessagingConfigForm(None, initial={**CONFIG, "webhook_secret": "s3cr3t-value"})
+        assert form["webhook_secret"].value() == "s3cr...ue"
+        assert form["client_secret"].value() == "secr...56"


### PR DESCRIPTION
### Product Description
Adds an optional shared secret to the SureAdhere messaging provider and verifies it on inbound webhooks, so a caller must present a credential rather than just a tenant id.

### Technical Description
`new_sureadhere_message` is `@csrf_exempt` and sits outside auth middleware; its only check was that the path's `sureadhere_tenant_id` matched a channel. A tenant id is an identifier, not a credential. Every sibling webhook in the same file verifies something (Turn.io and Meta by HMAC, Telegram by a high-entropy path token) — this one verified nothing.

- New `apps/channels/sureadhere_webhook.py` with `get_presented_secret` (accepts `X-OCS-Webhook-Secret`, or `Authorization: Bearer`) and `verify_secret` using `constant_time_compare` behind a guard so empty-vs-empty cannot match.
- New optional `webhook_secret` on `SureAdhereMessagingConfigForm`, stored in the already-encrypted `MessagingProvider.config` and masked in the UI.
- The view guard runs before `json.loads` and before the task dispatch; a missing or wrong credential is a 401.

**Verify-when-set, deliberately.** No deployment has this config today, so a provider with no secret is still accepted, now with a `WARNING` per request naming the channel and team. Failing closed in one step would drop real patient messages. Status codes are unchanged for every request except one presenting no/wrong credential to a provider that has a secret set.

**Before this helps anything:** SureAdhere must be configured to send the secret in one of the two accepted locations, and whether its callback registration supports either is not documented anywhere in this repo — worth confirming with the vendor. Until an operator sets a secret per provider, that provider's exposure is unchanged.

Also worth a follow-up: the 401 carries no `WWW-Authenticate` and SureAdhere's retry behaviour is undocumented here, so a mistyped secret could mean silently lost messages.

Found by an automated security review. `apps/channels/tests/test_sureadhere_webhook.py` covers both credential locations, wrong/missing/whitespace/case/scheme variants, rejection before body parsing, and the unconfigured pass-through.

### Migrations
None — `webhook_secret` lands in the existing `config` JSON field.

### Demo
n/a

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
