### PR TITLE
Scrub credential headers from Sentry events

### DIFF
--- a/config/sentry.py
+++ b/config/sentry.py
@@ -13,10 +13,45 @@ from sentry_sdk.scrubber import DEFAULT_DENYLIST, EventScrubber
 #
 # Anything holding raw secret/key material should be named to match one of these entries; prefer
 # the ``encryption_key`` convention for CommCare Connect per-participant keys.
-SENTRY_DENYLIST = [
-    *DEFAULT_DENYLIST,
+SENTRY_SECRET_VAR_DENYLIST = [
     "encryption_key",
     "encryption_key_bytes",
+    "session_token",
+    "embed_key",
+    "widget_token",
+    "hmac_secret",
+    "app_secret",
+    "signing_secret",
+    "auth_token",
+    "secret_key",
+    "secret_key_bytes",
+]
+
+# Credential headers the app authenticates with, in the form they appear on a Sentry event.
+# sentry_sdk derives ``request.headers`` keys from the WSGI environ (``HTTP_X_SESSION_TOKEN`` ->
+# ``X-Session-Token``), so entries here must be the hyphenated name; the scrubber's exact
+# (case-insensitive) match means the underscore spellings in ``DEFAULT_DENYLIST`` never fire for a
+# header. We cannot lean on the SDK's own header filtering either: ``send_default_pii=True`` (needed
+# to identify users on issues) turns ``_filter_headers`` into a no-op. Add any new credential header
+# here at the same time as the code that reads it.
+SENTRY_HEADER_DENYLIST = [
+    "x-api-key",  # hyphen spelling of DEFAULT_DENYLIST's "x_api_key"
+    "x-csrftoken",  # hyphen spelling of DEFAULT_DENYLIST's "x_csrftoken"
+    "x-session-token",
+    "x-embed-key",
+    "x-mac-digest",
+    "x-ocs-webhook-secret",
+    "x-telegram-bot-api-secret-token",
+    "x-twilio-signature",
+    "x-turn-hook-signature",
+    "x-hub-signature-256",
+    "x-slack-signature",
+]
+
+SENTRY_DENYLIST = [
+    *DEFAULT_DENYLIST,
+    *SENTRY_SECRET_VAR_DENYLIST,
+    *SENTRY_HEADER_DENYLIST,
 ]
 
 

--- a/config/tests/test_sentry.py
+++ b/config/tests/test_sentry.py
@@ -1,7 +1,9 @@
 """Tests for Sentry event scrubbing.
 
 Guards against the regression in which the CommCare Connect per-participant encryption key was
-sent to Sentry as a stack-frame local (see config/sentry.py).
+sent to Sentry as a stack-frame local, and against credential headers (API keys, chat session
+tokens, widget embed keys, webhook signatures) being stored verbatim on an event (see
+config/sentry.py).
 """
 
 import pytest
@@ -32,11 +34,31 @@ def _scrubbed_vars(local_vars: dict) -> dict:
     return event["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"]
 
 
+def _scrubbed_headers(headers: dict) -> dict:
+    """Headers as they survive the scrubber, keyed the way sentry_sdk keys them on an event.
+
+    sentry_sdk builds ``request.headers`` from the WSGI environ, title-casing the hyphenated name
+    (``HTTP_X_SESSION_TOKEN`` -> ``X-Session-Token``), so these are the real on-the-wire spellings.
+    """
+    event = {"request": {"headers": dict(headers)}}
+    get_event_scrubber().scrub_event(event)
+    return event["request"]["headers"]
+
+
 @pytest.mark.parametrize(
     "var_name",
     [
         pytest.param("encryption_key", id="encryption_key"),
         pytest.param("encryption_key_bytes", id="encryption_key_bytes"),
+        pytest.param("session_token", id="session_token"),
+        pytest.param("embed_key", id="embed_key"),
+        pytest.param("widget_token", id="widget_token"),
+        pytest.param("hmac_secret", id="hmac_secret"),
+        pytest.param("app_secret", id="app_secret"),
+        pytest.param("signing_secret", id="signing_secret"),
+        pytest.param("auth_token", id="auth_token"),
+        pytest.param("secret_key", id="secret_key"),
+        pytest.param("secret_key_bytes", id="secret_key_bytes"),
         pytest.param("password", id="default-denylist-still-applies"),
     ],
 )
@@ -54,3 +76,32 @@ def test_non_sensitive_frame_locals_are_preserved():
 def test_secret_nested_in_a_dict_is_scrubbed():
     scrubbed = _scrubbed_vars({"payload": {"encryption_key": "super-secret-value"}})
     assert scrubbed["payload"]["encryption_key"] != "super-secret-value"
+
+
+@pytest.mark.parametrize(
+    "header_name",
+    [
+        pytest.param("X-Api-Key", id="rest-api-key"),
+        pytest.param("Authorization", id="bearer-api-key-or-oauth-token"),
+        pytest.param("X-Session-Token", id="chat-session-token"),
+        pytest.param("X-Embed-Key", id="widget-embed-key"),
+        pytest.param("X-Mac-Digest", id="commcare-connect-hmac"),
+        pytest.param("X-Ocs-Webhook-Secret", id="sureadhere-webhook-secret"),
+        pytest.param("X-Telegram-Bot-Api-Secret-Token", id="telegram-webhook-secret"),
+        pytest.param("X-Twilio-Signature", id="twilio-webhook-signature"),
+        pytest.param("X-Turn-Hook-Signature", id="turn-webhook-signature"),
+        pytest.param("X-Hub-Signature-256", id="meta-webhook-signature"),
+        pytest.param("X-Slack-Signature", id="slack-webhook-signature"),
+        pytest.param("X-Csrftoken", id="csrf-token"),
+        pytest.param("Cookie", id="default-denylist-still-applies"),
+    ],
+)
+def test_credential_headers_are_scrubbed(header_name):
+    scrubbed = _scrubbed_headers({header_name: "super-secret-value"})
+    assert scrubbed[header_name] != "super-secret-value"
+
+
+def test_non_sensitive_headers_are_preserved():
+    scrubbed = _scrubbed_headers({"Content-Type": "application/json", "X-Ocs-Widget-Version": "2"})
+    assert scrubbed["Content-Type"] == "application/json"
+    assert scrubbed["X-Ocs-Widget-Version"] == "2"


### PR DESCRIPTION
### Product Description
Credential headers are now redacted before an error event leaves the deployment for Sentry.

### Technical Description
Two mechanisms were both missing the app's own credentials:

- `send_default_pii=True` makes `sentry_sdk`'s own header filter a no-op (`_wsgi_common.py` returns headers untouched);
- `EventScrubber` matches keys by exact lowercased name (`scrubber.py`: `k.lower() in self.denylist`), while WSGI header keys arrive hyphenated (`HTTP_X_SESSION_TOKEN` → `X-Session-Token`). So `DEFAULT_DENYLIST`'s underscore spellings such as `x_api_key` could never match a header, and the project's two extra entries were variable names only.

`SENTRY_DENYLIST` is now composed from two named sublists — `SENTRY_HEADER_DENYLIST` (the hyphenated wire names of every credential header the app reads, enumerated by grepping `apps/`) and `SENTRY_SECRET_VAR_DENYLIST` (the frame-local names those secrets appear under). The result is a strict superset of the previous list; nothing loses coverage.

`send_default_pii=True` is left alone — flipping it would also drop cookies and client IP from every event, and buys only the SDK's six-name filter, which does not include these headers.

Expect one collateral effect: received webhook signatures and `X-Csrftoken` will read `[Filtered]` in Sentry, so debugging a signature mismatch from the event payload alone gets harder.

Found by an automated security review. `config/tests/test_sentry.py` runs the real configured scrubber over a realistically shaped event and fails against the previous denylist.

### Migrations
None.

### Demo
n/a

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
