### PR TITLE
Keep the Connect HMAC secret out of logged stack frames

### DIFF
--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -221,24 +221,41 @@ def verify_hmac(view_func):
     @wraps(view_func)
     def _inner(request, *args, **kwargs):
         expected_digest = convert_to_bytestring_if_unicode(request.headers.get("X-Mac-Digest"))
-        secret_key_bytes = convert_to_bytestring_if_unicode(settings.COMMCARE_CONNECT_SERVER_SECRET)
+        # Only the fact that a key is configured may be bound here, never the key itself: the views
+        # this wraps are unauthenticated, so any caller can drive the rejection logging below, and
+        # Sentry attaches this frame's locals to the events it builds (`attach_stacktrace=True`).
+        has_secret_key = bool(settings.COMMCARE_CONNECT_SERVER_SECRET)
 
-        if not (expected_digest and secret_key_bytes):
-            logger.exception(
+        if not (expected_digest and has_secret_key):
+            # Warning, not exception/error: there is no live exception here, and an unauthenticated
+            # caller can trigger this at request rate, which at ERROR would become Sentry events.
+            logger.warning(
                 "Request rejected reason=%s request=%s",
-                "hmac:missing_key" if not secret_key_bytes else "hmac:missing_header",
+                "hmac:missing_key" if not has_secret_key else "hmac:missing_header",
                 request.path,
             )
             return HttpResponse(_("Missing HMAC signature or shared key"), status=401)
 
-        data_digest = get_hmac_digest(key=secret_key_bytes, data_bytes=request.body)
+        data_digest = _get_connect_secret_digest(request.body)
 
         if not hmac.compare_digest(data_digest, expected_digest):
-            logger.exception("Calculated HMAC does not match expected HMAC")
+            logger.warning("Calculated HMAC does not match expected HMAC")
             return HttpResponse(_("Invalid payload"), status=401)
         return view_func(request, *args, **kwargs)
 
     return _inner
+
+
+def _get_connect_secret_digest(data_bytes: bytes) -> bytes:
+    """HMAC ``data_bytes`` with the CommCare Connect shared secret.
+
+    The secret is read and consumed within this frame so that it does not outlive the digest
+    computation. Callers must not hold it themselves: this frame is gone by the time they log a
+    rejection, so the raw secret cannot end up in a stack-frame dump.
+    """
+    return get_hmac_digest(
+        key=convert_to_bytestring_if_unicode(settings.COMMCARE_CONNECT_SERVER_SECRET), data_bytes=data_bytes
+    )
 
 
 def get_hmac_digest(key: bytes, data_bytes: bytes) -> bytes:

--- a/apps/api/tests/test_verify_hmac.py
+++ b/apps/api/tests/test_verify_hmac.py
@@ -1,0 +1,111 @@
+import base64
+import hashlib
+import hmac
+import json
+import logging
+
+import pytest
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+from sentry_sdk.utils import current_stacktrace
+
+from apps.api.permissions import verify_hmac
+
+SHARED_SECRET = "connect-shared-secret-value"
+
+
+@verify_hmac
+def hmac_protected_view(request):
+    return HttpResponse("ok")
+
+
+class StacktraceCapture(logging.Handler):
+    """Record what the Sentry logging integration would ship for each log record.
+
+    Sentry builds an event from a log record and, because the SDK is initialised with
+    ``attach_stacktrace=True``, attaches ``current_stacktrace(include_local_variables=True)``
+    while the emitting frames are still live. Capturing it from a handler therefore sees exactly
+    the frame locals that would leave the process.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+        self.stacktraces: list[dict] = []
+
+    def emit(self, record):
+        self.records.append(record)
+        self.stacktraces.append(current_stacktrace(include_local_variables=True, include_source_context=False))
+
+
+@pytest.fixture()
+def sentry_frames():
+    handler = StacktraceCapture()
+    logger = logging.getLogger("ocs.api")
+    logger.addHandler(handler)
+    try:
+        yield handler
+    finally:
+        logger.removeHandler(handler)
+
+
+def _make_request(body: bytes, digest_header: str | None):
+    headers = {"X-Mac-Digest": digest_header} if digest_header is not None else {}
+    return RequestFactory().post(
+        "/api/commcare_connect/consent", body, content_type="application/json", headers=headers
+    )
+
+
+def _valid_digest(body: bytes) -> bytes:
+    return base64.b64encode(hmac.new(SHARED_SECRET.encode(), body, hashlib.sha256).digest())
+
+
+def _dump_locals_of_module_under_test(stacktrace: dict) -> str:
+    """Serialise the locals of the ``apps.api.permissions`` frames only.
+
+    The test harness legitimately holds the secret in its own frames; in production the frames
+    above the decorator are Django's request handling, which never sees it.
+    """
+    frames = [frame for frame in stacktrace["frames"] if frame.get("module") == "apps.api.permissions"]
+    assert frames, "no apps.api.permissions frames were captured"
+    return json.dumps(frames, default=repr)
+
+
+@pytest.mark.parametrize(
+    ("digest_header", "configured_secret"),
+    [
+        pytest.param("AAAA", SHARED_SECRET, id="digest-mismatch"),
+        pytest.param(None, SHARED_SECRET, id="missing-header"),
+        pytest.param("AAAA", "", id="missing-secret"),
+    ],
+)
+def test_rejected_request_does_not_expose_the_shared_secret(sentry_frames, digest_header, configured_secret):
+    request = _make_request(json.dumps({"channel_id": "abc"}).encode(), digest_header)
+
+    with override_settings(COMMCARE_CONNECT_SERVER_SECRET=configured_secret):
+        response = hmac_protected_view(request)
+
+    assert response.status_code == 401
+    [record] = sentry_frames.records
+    [stacktrace] = sentry_frames.stacktraces
+    frame_dump = _dump_locals_of_module_under_test(stacktrace)
+    # Sanity check that the dump really does hold the locals of the rejecting frame, so the
+    # assertions below cannot pass vacuously.
+    assert "_inner" in frame_dump
+    assert "expected_digest" in frame_dump
+    assert SHARED_SECRET not in frame_dump
+    # Below Sentry's default ``event_level`` so a bad signature does not create an event at all,
+    # and no bogus "NoneType: None" traceback from ``logger.exception`` outside an except block.
+    assert record.levelno == logging.WARNING
+    assert record.exc_info is None
+
+
+def test_correct_digest_is_accepted():
+    body = json.dumps({"channel_id": "abc"}).encode()
+    request = _make_request(body, _valid_digest(body).decode())
+
+    with override_settings(COMMCARE_CONNECT_SERVER_SECRET=SHARED_SECRET):
+        response = hmac_protected_view(request)
+
+    assert response.status_code == 200
+    assert response.content == b"ok"


### PR DESCRIPTION
### Product Description
The CommCare Connect shared secret can no longer be carried out of the deployment in an error report.

### Technical Description
`verify_hmac._inner` bound the raw `COMMCARE_CONNECT_SERVER_SECRET` to a local (`secret_key_bytes`) that was still live when its two rejection log calls fired, and both used `logger.exception` despite there being no active exception. With `attach_stacktrace=True`, an ERROR-level record makes Sentry attach frame locals.

- The digest now computes in a new module-level `_get_connect_secret_digest`, which passes the setting straight into `get_hmac_digest` without binding it to a name. That frame is popped before any logging happens, so the value cannot appear in a frame dump regardless of what the scrubber denylist covers.
- `_inner` binds only `has_secret_key = bool(...)`.
- Both calls now log at `WARNING`, which also removes the spurious `NoneType: None` traceback they were emitting.

Level choice: the default `LoggingIntegration` turns ERROR into a Sentry event, and both branches are reachable at request rate by an unauthenticated caller, so ERROR would be a quota lever. The records still reach the normal log handlers with their `reason=` labels, and a deployment that intends Connect enabled still gets an ERROR from `CommCareConnectClient.__init__` the moment any Connect operation runs.

Verification semantics are untouched: correct digest verifies, wrong is refused, `compare_digest` still constant-time, and the header-absent short-circuit still avoids hashing the body.

Found by an automated security review. `apps/api/tests/test_verify_hmac.py` captures frame locals at emit time via the same call the Sentry integration makes and fails without the change.

### Migrations
None.

### Demo
n/a

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
