### PR TITLE
Require experiments.change_participant on the trigger_bot endpoints

### DIFF
--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -214,6 +214,25 @@ class DjangoModelPermissionsWithView(DjangoModelPermissions):
         return super().has_permission(request, view)
 
 
+class CanTriggerBotMessage(BasePermission):
+    """Sending a message to a participant as the bot is the API twin of the ``participants:trigger_bot``
+    UI view, which requires ``experiments.change_participant``. Gate the API on the same permission so a
+    role that cannot message a participant from the UI cannot do it through the API either.
+
+    ``has_perm`` resolves against the team the credential is scoped to (the auth layer calls
+    ``set_current_team``), and applies to every auth type — including API keys, which the OAuth scope
+    check alone does not gate.
+
+    Client-credentials (machine) tokens have no user, so authorization is delegated to the OAuth scope
+    (chatbots:interact), enforced by TokenHasOAuthScope.
+    """
+
+    def has_permission(self, request, view):
+        if is_client_credentials_request(request):
+            return True
+        return bool(request.user and request.user.has_perm("experiments.change_participant"))
+
+
 def verify_hmac(view_func):
     """Match the HMAC signature in the request to the calculated HMAC using the request payload."""
 

--- a/apps/api/tests/test_trigger_bot_permissions.py
+++ b/apps/api/tests/test_trigger_bot_permissions.py
@@ -1,0 +1,127 @@
+"""Authorization tests for the trigger_bot endpoints (v1 and v2).
+
+Triggering a bot message is the API twin of the participants UI view
+(``apps.participants.views.trigger_bot``), which requires ``experiments.change_participant``. The API
+endpoints previously relied on the default permission stack alone, which checks team membership and
+the OAuth scope but no role, so any team member could message participants on the team's channels.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+
+from apps.channels.models import ChannelPlatform
+from apps.experiments.models import ExperimentSession
+from apps.teams.backends import (
+    ANNOTATION_REVIEWER_GROUP,
+    CHAT_VIEWER_GROUP,
+    CHATBOT_ADMIN_GROUP,
+    EVENT_ADMIN_GROUP,
+    TEAM_ADMIN_GROUP,
+    add_user_to_team,
+    create_default_groups,
+)
+from apps.utils.factories.channels import ExperimentChannelFactory
+from apps.utils.factories.experiment import ExperimentFactory
+from apps.utils.factories.team import TeamFactory
+from apps.utils.factories.user import UserFactory
+from apps.utils.tests.clients import ApiTestClient
+
+URL_NAMES = [pytest.param("api:trigger_bot", id="v1"), pytest.param("api:v2:trigger_bot", id="v2")]
+
+
+@pytest.fixture()
+def email_experiment(db):
+    """An experiment with an email channel, so trigger_bot has a channel to dispatch on.
+
+    ``create_default_groups()`` is called explicitly so the DB-backed groups reflect the current
+    backends.py definition even though pytest runs with --reuse-db.
+    """
+    create_default_groups()
+    experiment = ExperimentFactory.create(team=TeamFactory.create())
+    ExperimentChannelFactory.create(
+        team=experiment.team,
+        experiment=experiment,
+        platform=ChannelPlatform.EMAIL,
+        extra_data={"email_address": "bot@chat.openchatstudio.com"},
+    )
+    return experiment
+
+
+def _request_data(experiment):
+    return {
+        "identifier": "participant@example.com",
+        "platform": ChannelPlatform.EMAIL,
+        "experiment": str(experiment.public_id),
+        "message_text": "Your clinic appointment is cancelled, call +1555000000 to rebook",
+    }
+
+
+def _post(client, url_name, experiment):
+    return client.post(reverse(url_name), json.dumps(_request_data(experiment)), content_type="application/json")
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("url_name", URL_NAMES)
+@pytest.mark.parametrize(
+    ("group_name", "auth_method"),
+    [
+        pytest.param(CHAT_VIEWER_GROUP, "api_key", id="chat-viewer-api-key"),
+        pytest.param(CHAT_VIEWER_GROUP, "oauth", id="chat-viewer-oauth-token"),
+        pytest.param(TEAM_ADMIN_GROUP, "api_key", id="team-admin-api-key"),
+        pytest.param(EVENT_ADMIN_GROUP, "api_key", id="event-admin-api-key"),
+        pytest.param(ANNOTATION_REVIEWER_GROUP, "api_key", id="annotation-reviewer-api-key"),
+    ],
+)
+@patch("apps.api.views.channels.trigger_bot_message_task")
+def test_trigger_bot_denied_without_change_participant(
+    trigger_bot_message_task, email_experiment, group_name, auth_method, url_name
+):
+    """A member whose role lacks experiments.change_participant cannot dispatch a message."""
+    user = UserFactory.create()
+    add_user_to_team(email_experiment.team, user, groups=[group_name])
+    client = ApiTestClient(user, email_experiment.team, auth_method=auth_method)
+
+    response = _post(client, url_name, email_experiment)
+
+    assert response.status_code == 403, response.content
+    trigger_bot_message_task.delay_on_commit.assert_not_called()
+    assert not ExperimentSession.objects.filter(experiment=email_experiment).exists()
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("url_name", URL_NAMES)
+@pytest.mark.parametrize("auth_method", ["api_key", "oauth"])
+@patch("apps.api.views.channels.trigger_bot_message_task")
+def test_trigger_bot_allowed_with_change_participant(trigger_bot_message_task, email_experiment, auth_method, url_name):
+    """A role holding experiments.change_participant (Chatbot Admin) still succeeds."""
+    user = UserFactory.create()
+    add_user_to_team(email_experiment.team, user, groups=[CHATBOT_ADMIN_GROUP])
+    client = ApiTestClient(user, email_experiment.team, auth_method=auth_method)
+
+    response = _post(client, url_name, email_experiment)
+
+    assert response.status_code == 200, response.content
+    trigger_bot_message_task.delay_on_commit.assert_called_once()
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("url_name", URL_NAMES)
+@patch("apps.api.views.channels.trigger_bot_message_task")
+def test_trigger_bot_allowed_for_machine_token_with_scope(trigger_bot_message_task, email_experiment, url_name):
+    """Machine tokens have no user, so they keep relying on the chatbots:interact scope."""
+    # The app owner is deliberately a non-member of the team to prove access does not depend on a
+    # membership row or on a role.
+    client = ApiTestClient(
+        UserFactory.create(),
+        email_experiment.team,
+        auth_method="oauth_client_credentials",
+        scopes=["chatbots:interact"],
+    )
+
+    response = _post(client, url_name, email_experiment)
+
+    assert response.status_code == 200, response.content
+    trigger_bot_message_task.delay_on_commit.assert_called_once()

--- a/apps/api/v2/channels.py
+++ b/apps/api/v2/channels.py
@@ -2,12 +2,22 @@ from django.db import transaction
 from drf_spectacular.utils import OpenApiExample, extend_schema
 from rest_framework.views import APIView
 
+from apps.api.permissions import CanTriggerBotMessage, IsAuthenticatedOrMachineToken, ReadOnlyAPIKeyPermission
 from apps.api.serializers import TriggerBotMessageRequest
 from apps.api.v2.serializers import TriggerBotMessageResponse
 from apps.api.views.channels import handle_trigger_bot_message
+from apps.oauth.permissions import TokenHasOAuthScope
 
 
 class TriggerBotMessageView(APIView):
+    # Same explicit permission stack as the v1 view: the role check (CanTriggerBotMessage) is not part
+    # of DEFAULT_PERMISSION_CLASSES, so it has to be named here too.
+    permission_classes = [
+        IsAuthenticatedOrMachineToken,
+        ReadOnlyAPIKeyPermission,
+        CanTriggerBotMessage,
+        TokenHasOAuthScope,
+    ]
     required_scopes = ("chatbots:interact",)
 
     @extend_schema(

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -13,7 +13,12 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView, Request
 
-from apps.api.permissions import verify_hmac
+from apps.api.permissions import (
+    CanTriggerBotMessage,
+    IsAuthenticatedOrMachineToken,
+    ReadOnlyAPIKeyPermission,
+    verify_hmac,
+)
 from apps.api.serializers import TriggerBotMessageRequest, TriggerBotMessageResponse
 from apps.api.tasks import (
     DuplicateConnectChannelError,
@@ -26,6 +31,7 @@ from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.channels.registry import get_channel_class_for_platform
 from apps.chatbots.version_resolver import resolve_published_or_working
 from apps.experiments.models import Experiment, Participant, ParticipantData
+from apps.oauth.permissions import TokenHasOAuthScope
 from apps.teams.utils import current_team
 
 connect_logger = logging.getLogger("api.connect_channel")
@@ -199,6 +205,15 @@ def handle_trigger_bot_message(request, response_serializer_class):
 
 
 class TriggerBotMessageView(APIView):
+    # Spelled out rather than inherited from DEFAULT_PERMISSION_CLASSES so the role check is explicit:
+    # the default stack gates on team membership and the OAuth scope only, which for API-key callers
+    # left this endpoint open to any member regardless of their role.
+    permission_classes = [
+        IsAuthenticatedOrMachineToken,
+        ReadOnlyAPIKeyPermission,
+        CanTriggerBotMessage,
+        TokenHasOAuthScope,
+    ]
     required_scopes = ("chatbots:interact",)
 
     @extend_schema(


### PR DESCRIPTION
### Product Description
`trigger_bot` now requires the same permission through the API as it does in the app, so a role that cannot press the "send message" button cannot call the endpoint either.

### Technical Description
`TriggerBotMessageView` (v1 and its v2 twin) declared only `required_scopes` and inherited the project default permission classes, none of which consults the caller's team role. `TokenHasOAuthScope` skips scope enforcement for non-OAuth tokens, so for API-key callers the whole authorization decision was "the key is not read-only and the user has a `Membership` row in the token's team".

The UI equivalent establishes the intended permission unambiguously — `apps/participants/views.py` carries `@permission_required(["experiments.change_participant"])` and the template gates the button on `perms.experiments.change_participant`. New `CanTriggerBotMessage` asserts exactly that, and nothing stricter, on both endpoints.

`permission_classes` is now explicit on both views and contains all three settings defaults plus the new class, so read-only-key and scope behaviour is unchanged. Client-credentials machine tokens short-circuit as they do in `CanViewUsage` and `DjangoModelPermissionsWithView`, staying authorized by `chatbots:interact`.

Roles that lose API access: Team Admin, Chat Viewer, Assistant Admin, Event Admin, Evaluation Admin, Annotation Reviewer — the same six the UI gate already denies. Super Admin and Chatbot Admin keep it.

Operational note: an integration whose API key belongs to a Team-Admin-only member will start receiving 403 and needs a key owned by a Chatbot Admin or Super Admin.

Found by an automated security review. `apps/api/tests/test_trigger_bot_permissions.py` covers both API versions and all three auth types, and fails without the change.

### Migrations
None.

### Demo
n/a

### Docs and Changelog
- [ ] This PR requires docs/changelog update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
