### PR TITLE
Stable ordering for experiment list API

### DIFF
--- a/apps/api/views/experiments.py
+++ b/apps/api/views/experiments.py
@@ -1,3 +1,4 @@
+from django.db.models import Prefetch
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import mixins
@@ -38,4 +39,11 @@ class ExperimentViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, Generi
 
     def get_queryset(self):
         # Only return working experiments
-        return Experiment.objects.filter(team=self.request.team).filter(working_version__isnull=True)
+        return (
+            Experiment.objects.filter(team=self.request.team)
+            .filter(working_version__isnull=True)
+            # `Experiment.Meta.ordering` is by name, which all versions share, so the DB is free to
+            # return them in any order. Order by version number for a stable response.
+            .prefetch_related(Prefetch("versions", queryset=Experiment.objects.order_by("version_number")))
+            .order_by("name", "id")
+        )


### PR DESCRIPTION
### Product Description
no change

### Technical Description
`test_list_experiments` flakes because the nested `versions` come back in arbitrary order: `Experiment.Meta.ordering` is `["name"]` and every version shares the working version's name, so the tie leaves the DB free to pick any order. Prefetching `versions` with an explicit `order_by("version_number")` pins it (and drops the N+1 on the list endpoint).

`.order_by("name", "id")` on the outer queryset is the same class of bug rather than the reported one — paginating on a non-unique column can duplicate or skip rows across pages.

Verified with a throwaway test that captured the SQL: a 3-version experiment serializes as `[1, 2, 3]` and the ordering lands on the single prefetch query, so the serializer reads the cache rather than issuing its own unordered query.

### Docs and Changelog
- [ ] This PR requires docs/changelog update
