### PR TITLE
Apply CONN_HEALTH_CHECKS and DISABLE_SERVER_SIDE_CURSORS with DATABASE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,15 @@ DATABASE_URL='postgres://postgres:postgres@localhost:5432/open_chat_studio'
 # DJANGO_DATABASE_PORT=
 
 # Database pool settings
+# DJANGO_DATABASE_USE_POOL=
 # DJANGO_DATABASE_POOL_MIN_SIZE=
 # DJANGO_DATABASE_POOL_MAX_SIZE=
 # DJANGO_DATABASE_POOL_TIMEOUT=
+# DJANGO_DATABASE_CONN_MAX_AGE=
+
+# Applies with DATABASE_URL too. Set to True behind a connection proxy that pins
+# sessions on WITH HOLD cursors (e.g. AWS RDS Proxy).
+# DJANGO_DISABLE_SERVER_SIDE_CURSORS=
 
 ## Cache & Celery queues
 

--- a/config/db.py
+++ b/config/db.py
@@ -1,0 +1,55 @@
+"""Database configuration.
+
+Kept out of ``config.settings`` so that both ways of configuring the connection — a single
+``DATABASE_URL`` or the discrete ``DJANGO_DATABASE_*`` variables — can be exercised by tests.
+
+The two must agree on the Django-level keys. ``env.db()`` only ever emits
+engine/name/user/password/host/port, so any other key has to be applied to whichever config
+the branch produced: a key set inside the ``else`` branch alone is dead in every environment
+that uses ``DATABASE_URL``, which is all of them except a bare local checkout.
+"""
+
+import environ
+
+
+def get_database_config(env: environ.Env, *, debug: bool) -> dict:
+    """Build the ``DATABASES`` setting for the ``default`` connection."""
+    if "DATABASE_URL" in env:
+        config = env.db()
+    else:
+        config = {
+            "ENGINE": "django.db.backends.postgresql_psycopg2",
+            "NAME": env("DJANGO_DATABASE_NAME", default="open_chat_studio"),
+            "USER": env("DJANGO_DATABASE_USER", default="postgres"),
+            "PASSWORD": env("DJANGO_DATABASE_PASSWORD", default="***"),
+            "HOST": env("DJANGO_DATABASE_HOST", default="localhost"),
+            "PORT": env("DJANGO_DATABASE_PORT", default="5432"),
+        }
+
+    config["CONN_HEALTH_CHECKS"] = True
+    # Server-side cursors (Django's implementation of `QuerySet.iterator()` on Postgres) are
+    # declared `WITH HOLD` outside an atomic block, which makes RDS Proxy pin the session to a
+    # backend connection for the life of the client connection. Django reads this key from the
+    # top level of the connection's settings dict, not from OPTIONS, so it cannot be smuggled
+    # in through the DATABASE_URL query string.
+    config["DISABLE_SERVER_SIDE_CURSORS"] = env.bool("DJANGO_DISABLE_SERVER_SIDE_CURSORS", default=False)
+
+    options: dict = config.setdefault("OPTIONS", {})  # ty: ignore[invalid-assignment]
+    if env.bool("DJANGO_DATABASE_USE_POOL", True):
+        config.pop("CONN_MAX_AGE", None)
+        # See https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool
+        options["pool"] = {
+            "min_size": env.int("DJANGO_DATABASE_POOL_MIN_SIZE", default=2),
+            "max_size": env.int("DJANGO_DATABASE_POOL_MAX_SIZE", default=35),
+            "timeout": env.int("DJANGO_DATABASE_POOL_TIMEOUT", default=10),
+        }
+    else:
+        config["CONN_MAX_AGE"] = env.int("DJANGO_DATABASE_CONN_MAX_AGE", 0)
+
+    # RDS Proxy requires TLS. psycopg3 defaults to sslmode=prefer which falls back to
+    # non-SSL on handshake failure, which the proxy rejects. sslmode=require forces SSL
+    # without the non-SSL fallback. Override with DJANGO_DATABASE_SSLMODE if needed
+    # (e.g. set to "prefer" for local dev without TLS).
+    options["sslmode"] = env("DJANGO_DATABASE_SSLMODE", default="prefer" if debug else "require")
+
+    return {"default": config}

--- a/config/settings.py
+++ b/config/settings.py
@@ -23,6 +23,7 @@ from kombu import Queue
 from pythonjsonlogger.json import JsonFormatter
 
 from apps.utils.celery import Queues
+from config.db import get_database_config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -228,39 +229,7 @@ FORMS_URLFIELD_ASSUME_HTTPS = True
 # Database
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
-if "DATABASE_URL" in env:
-    DATABASES = {"default": env.db()}
-else:
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.postgresql_psycopg2",
-            "NAME": env("DJANGO_DATABASE_NAME", default="open_chat_studio"),
-            "USER": env("DJANGO_DATABASE_USER", default="postgres"),
-            "PASSWORD": env("DJANGO_DATABASE_PASSWORD", default="***"),
-            "HOST": env("DJANGO_DATABASE_HOST", default="localhost"),
-            "PORT": env("DJANGO_DATABASE_PORT", default="5432"),
-            "CONN_HEALTH_CHECKS": True,
-            "DISABLE_SERVER_SIDE_CURSORS": env.bool("DJANGO_DISABLE_SERVER_SIDE_CURSORS", default=False),
-        }
-    }
-
-db_options: dict = DATABASES["default"].setdefault("OPTIONS", {})  # ty: ignore[invalid-assignment]
-if env.bool("DJANGO_DATABASE_USE_POOL", True):
-    DATABASES["default"].pop("CONN_MAX_AGE", None)
-    # See https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool
-    db_options["pool"] = {
-        "min_size": env.int("DJANGO_DATABASE_POOL_MIN_SIZE", default=2),
-        "max_size": env.int("DJANGO_DATABASE_POOL_MAX_SIZE", default=35),
-        "timeout": env.int("DJANGO_DATABASE_POOL_TIMEOUT", default=10),
-    }
-else:
-    DATABASES["default"]["CONN_MAX_AGE"] = env.int("DJANGO_DATABASE_CONN_MAX_AGE", 0)
-
-# RDS Proxy requires TLS. psycopg3 defaults to sslmode=prefer which falls back to
-# non-SSL on handshake failure, which the proxy rejects. sslmode=require forces SSL
-# without the non-SSL fallback. Override with DJANGO_DATABASE_SSLMODE if needed
-# (e.g. set to "prefer" for local dev without TLS).
-db_options["sslmode"] = env("DJANGO_DATABASE_SSLMODE", default="prefer" if DEBUG else "require")
+DATABASES = get_database_config(env, debug=DEBUG)
 
 # Auth / login stuff
 

--- a/config/tests/test_database_settings.py
+++ b/config/tests/test_database_settings.py
@@ -1,0 +1,90 @@
+"""Tests for the DATABASES config builder.
+
+Guards against the regression in which ``CONN_HEALTH_CHECKS`` and
+``DISABLE_SERVER_SIDE_CURSORS`` were only set on the discrete-variable branch, leaving them
+unset — and ``DJANGO_DISABLE_SERVER_SIDE_CURSORS`` a silent no-op — wherever ``DATABASE_URL``
+is used, which is every deployed environment (see config/db.py).
+"""
+
+import environ
+import pytest
+
+from config.db import get_database_config
+
+DATABASE_URL = "postgres://user:pw@dbhost:5432/ocs"
+
+
+def _env(**environ_vars: str) -> environ.Env:
+    """An Env reading only ``environ_vars``, so tests don't see the developer's own environment.
+
+    ``ENVIRON`` is a class attribute pointing at ``os.environ``; shadowing it per instance keeps
+    each case isolated without mutating the real process environment.
+    """
+    env = environ.Env()
+    env.ENVIRON = environ_vars  # ty: ignore[invalid-assignment]
+    return env
+
+
+@pytest.fixture(params=["database_url", "discrete_vars"])
+def env(request) -> environ.Env:
+    """Both supported ways of pointing at a database, so every assertion covers both."""
+    if request.param == "database_url":
+        return _env(DATABASE_URL=DATABASE_URL)
+    return _env(DJANGO_DATABASE_HOST="dbhost", DJANGO_DATABASE_NAME="ocs")
+
+
+def test_connection_is_configured(env):
+    config = get_database_config(env, debug=False)["default"]
+    assert "postgresql" in config["ENGINE"]
+    assert config["NAME"] == "ocs"
+    assert config["HOST"] == "dbhost"
+
+
+def test_django_level_keys_are_applied(env):
+    config = get_database_config(env, debug=False)["default"]
+    assert config["CONN_HEALTH_CHECKS"] is True
+    assert config["DISABLE_SERVER_SIDE_CURSORS"] is False
+
+
+def test_server_side_cursors_can_be_disabled(env):
+    """The env var has to reach Django regardless of how the connection was configured."""
+    env.ENVIRON["DJANGO_DISABLE_SERVER_SIDE_CURSORS"] = "True"
+
+    config = get_database_config(env, debug=False)["default"]
+
+    assert config["DISABLE_SERVER_SIDE_CURSORS"] is True
+
+
+def test_pool_is_enabled_by_default(env):
+    config = get_database_config(env, debug=False)["default"]
+
+    assert config["OPTIONS"]["pool"] == {"min_size": 2, "max_size": 35, "timeout": 10}
+    # Persistent connections are the pool's job; leaving CONN_MAX_AGE set would double up on it.
+    assert "CONN_MAX_AGE" not in config
+
+
+def test_conn_max_age_replaces_the_pool_when_it_is_disabled(env):
+    env.ENVIRON["DJANGO_DATABASE_USE_POOL"] = "False"
+    env.ENVIRON["DJANGO_DATABASE_CONN_MAX_AGE"] = "600"
+
+    config = get_database_config(env, debug=False)["default"]
+
+    assert config["CONN_MAX_AGE"] == 600
+    assert "pool" not in config["OPTIONS"]
+
+
+@pytest.mark.parametrize(
+    ("debug", "expected"),
+    [
+        pytest.param(False, "require", id="deployed-requires-tls"),
+        pytest.param(True, "prefer", id="local-dev-may-skip-tls"),
+    ],
+)
+def test_sslmode_follows_debug(env, debug, expected):
+    assert get_database_config(env, debug=debug)["default"]["OPTIONS"]["sslmode"] == expected
+
+
+def test_sslmode_can_be_overridden(env):
+    env.ENVIRON["DJANGO_DATABASE_SSLMODE"] = "disable"
+
+    assert get_database_config(env, debug=False)["default"]["OPTIONS"]["sslmode"] == "disable"

--- a/docs/hosting/configuration.md
+++ b/docs/hosting/configuration.md
@@ -21,9 +21,20 @@ All configuration is via environment variables. In production, set `DJANGO_SETTI
 | `DJANGO_DATABASE_PASSWORD` | — | Database password |
 | `DJANGO_DATABASE_HOST` | `localhost` | Database host |
 | `DJANGO_DATABASE_PORT` | `5432` | Database port |
-| `DJANGO_DATABASE_POOL_MIN_SIZE` | — | Connection pool minimum size |
-| `DJANGO_DATABASE_POOL_MAX_SIZE` | — | Connection pool maximum size |
-| `DJANGO_DATABASE_POOL_TIMEOUT` | — | Connection pool timeout (seconds) |
+
+## Connection behaviour
+
+These apply whether the connection comes from `DATABASE_URL` or the variables above.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DJANGO_DATABASE_USE_POOL` | `True` | Use a psycopg connection pool. When disabled, `DJANGO_DATABASE_CONN_MAX_AGE` applies instead |
+| `DJANGO_DATABASE_POOL_MIN_SIZE` | `2` | Connection pool minimum size |
+| `DJANGO_DATABASE_POOL_MAX_SIZE` | `35` | Connection pool maximum size |
+| `DJANGO_DATABASE_POOL_TIMEOUT` | `10` | Connection pool timeout (seconds) |
+| `DJANGO_DATABASE_CONN_MAX_AGE` | `0` | Persistent connection lifetime, in seconds. Ignored when the pool is enabled |
+| `DJANGO_DATABASE_SSLMODE` | `require` (`prefer` when `DEBUG`) | psycopg `sslmode`. AWS RDS Proxy requires TLS |
+| `DJANGO_DISABLE_SERVER_SIDE_CURSORS` | `False` | Set to `True` to stop Django using server-side cursors for `QuerySet.iterator()`. Behind a connection proxy in transaction-pooling mode (e.g. AWS RDS Proxy) these are declared `WITH HOLD` and pin the session to a backend connection. Disabling them costs memory: each `iterator()` call then buffers its whole result set client-side |
 
 ## Redis (alternative to REDIS_URL)
 


### PR DESCRIPTION
### Product Description
No change.

### Technical Description
`CONN_HEALTH_CHECKS` and `DISABLE_SERVER_SIDE_CURSORS` were set only inside the `else` branch of the `DATABASE_URL` check in `settings.py`, so neither reached Django in any environment that sets `DATABASE_URL` — i.e. all of them. `DJANGO_DISABLE_SERVER_SIDE_CURSORS=True` was a silent no-op, which matters because we need that knob to evaluate the RDS Proxy session pinning in #4176. Django reads both keys from the top level of the connection's settings dict, and django-environ never emits them from a URL, so they can't be smuggled in via the query string either.

No behaviour change intended beyond the two keys now being present: the default stays `False`, so server-side cursors are still enabled until someone sets the var. Verified against the local `.env` (which sets `DATABASE_URL`) that `connection.settings_dict` now carries `CONN_HEALTH_CHECKS: True` and `DISABLE_SERVER_SIDE_CURSORS: False`, where previously both keys were absent.

The config moved to `config/db.py` so both branches can be unit tested — `settings.py` isn't reachable from a test without reloading the module. I confirmed the test fails correctly by reinstating the bug: only the two `[database_url]` cases fail, with `KeyError` on each key.

Also documents `DJANGO_DATABASE_USE_POOL`, `CONN_MAX_AGE`, `SSLMODE` and `DISABLE_SERVER_SIDE_CURSORS`, and moves the pool/TLS knobs out of the "alternative to DATABASE_URL" section of the hosting docs, since they apply either way — the old placement implied the same thing this bug did.

### Docs and Changelog
- [ ] This PR requires docs/changelog update