### PR TITLE
Require team membership or the embed key to start a chat session

### DIFF
--- a/apps/admin/forms.py
+++ b/apps/admin/forms.py
@@ -6,6 +6,7 @@ from django.db.models import TextChoices
 from django.utils import timezone
 
 from apps.admin.models import ChatWidgetConfig, OcsConfiguration, SiteConfig
+from apps.channels.utils import clear_widget_embed_key_cache, fetch_widget_embed_key
 from apps.service_providers.utils import ServiceProvider
 from apps.teams.models import Team
 
@@ -120,7 +121,10 @@ class OcsConfigurationForm(forms.Form):
         max_length=255,
         required=False,
         label="Chatbot ID",
-        help_text="ID of the chatbot to use for the widget",
+        help_text=(
+            "ID of the chatbot to use for the widget. The chatbot needs an 'Embedded Widget' channel "
+            "that allows this site's domain — the widget authorizes itself with that channel's embed key."
+        ),
         widget=forms.TextInput(attrs={"placeholder": "Enter chatbot ID"}),
     )
 
@@ -175,6 +179,15 @@ class OcsConfigurationForm(forms.Form):
             self.fields["starter_questions"].initial = "\n".join(chat_widget.starter_questions)
             self.fields["position"].initial = chat_widget.position
 
+    def clean_chatbot_id(self):
+        chatbot_id = self.cleaned_data["chatbot_id"].strip()
+        if chatbot_id and not fetch_widget_embed_key(chatbot_id):
+            raise forms.ValidationError(
+                "No embedded widget channel with an embed key was found for this chatbot. Add an "
+                "'Embedded Widget' channel to the chatbot, and allow this site's domain on it."
+            )
+        return chatbot_id
+
     def save(self):
         welcome_messages = [msg.strip() for msg in self.cleaned_data["welcome_messages"].split("\n") if msg.strip()]
         starter_questions = [q.strip() for q in self.cleaned_data["starter_questions"].split("\n") if q.strip()]
@@ -200,5 +213,9 @@ class OcsConfigurationForm(forms.Form):
 
         config_instance.config = site_config
         config_instance.save()
+
+        # The embed key is cached per chatbot; drop it so a newly configured (or re-pointed)
+        # widget picks up its key on the next render instead of waiting out the TTL.
+        clear_widget_embed_key_cache(chat_widget_config.chatbot_id)
 
         return config_instance

--- a/apps/admin/models.py
+++ b/apps/admin/models.py
@@ -8,6 +8,8 @@ from django_pydantic_field import SchemaField
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field
 
+from apps.channels.utils import get_widget_embed_key
+
 SITE_CONFIG_CACHE_KEY = "ocs_site_config"
 SITE_CONFIG_CACHE_TIMEOUT = 60 * 60 * 24
 
@@ -36,6 +38,12 @@ class ChatWidgetConfig(PydanticBaseModel):
             "starter-questions": json.dumps(self.starter_questions),
             "position": self.position,
         }
+        # This widget is rendered for every logged-in user, who is generally not a member of the
+        # support bot's team, so it authorizes itself with the bot's embed key like any other
+        # embedded widget (see `apps.api.views.chat.chat_start_session`). The key is looked up from
+        # the configured chatbot rather than stored on the config so there is nothing to keep in sync.
+        if embed_key := get_widget_embed_key(self.chatbot_id):
+            attrs["embed-key"] = embed_key
         return attrs
 
 

--- a/apps/admin/tests/test_forms.py
+++ b/apps/admin/tests/test_forms.py
@@ -1,0 +1,72 @@
+import pytest
+
+from apps.admin.forms import OcsConfigurationForm
+from apps.admin.models import OcsConfiguration
+from apps.channels.models import ChannelPlatform
+from apps.channels.utils import clear_widget_embed_key_cache, get_widget_embed_key
+from apps.utils.factories.channels import ExperimentChannelFactory
+from apps.utils.factories.experiment import ExperimentFactory
+
+
+def form_data(**overrides):
+    data = {
+        "chat_widget_enabled": True,
+        "chatbot_id": "",
+        "button_text": "Ask me!",
+        "welcome_messages": "Hi!",
+        "starter_questions": "How do I create a bot?",
+        "position": "right",
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.fixture()
+def widget_channel():
+    channel = ExperimentChannelFactory.create(
+        platform=ChannelPlatform.EMBEDDED_WIDGET,
+        extra_data={"widget_token": "site-widget-token", "allowed_domains": ["example.com"]},
+    )
+    chatbot_id = str(channel.experiment.public_id)
+    clear_widget_embed_key_cache(chatbot_id)
+    yield channel
+    clear_widget_embed_key_cache(chatbot_id)
+
+
+@pytest.mark.django_db()
+class TestOcsConfigurationFormChatbotId:
+    """The site widget authorizes itself with the chatbot's embed key, so a chatbot without one
+    would render a widget that cannot start a session."""
+
+    def test_accepts_a_chatbot_with_a_widget_channel(self, widget_channel):
+        form = OcsConfigurationForm(data=form_data(chatbot_id=str(widget_channel.experiment.public_id)))
+        assert form.is_valid(), form.errors
+
+    def test_accepts_an_empty_chatbot_id(self):
+        form = OcsConfigurationForm(data=form_data())
+        assert form.is_valid(), form.errors
+
+    def test_rejects_a_chatbot_without_a_widget_channel(self):
+        experiment = ExperimentFactory.create()
+        form = OcsConfigurationForm(data=form_data(chatbot_id=str(experiment.public_id)))
+        assert not form.is_valid()
+        assert "No embedded widget channel" in form.errors["chatbot_id"][0]
+
+    def test_rejects_an_unknown_chatbot_id(self):
+        form = OcsConfigurationForm(data=form_data(chatbot_id="not-a-chatbot"))
+        assert not form.is_valid()
+        assert "No embedded widget channel" in form.errors["chatbot_id"][0]
+
+    def test_saving_refreshes_the_cached_embed_key(self, widget_channel):
+        """A freshly configured chatbot must not be shadowed by a cached miss."""
+        chatbot_id = str(widget_channel.experiment.public_id)
+        assert get_widget_embed_key(chatbot_id) == "site-widget-token"
+        widget_channel.extra_data["widget_token"] = "rotated-token"
+        widget_channel.save()
+
+        form = OcsConfigurationForm(data=form_data(chatbot_id=chatbot_id))
+        assert form.is_valid(), form.errors
+        form.save()
+
+        assert get_widget_embed_key(chatbot_id) == "rotated-token"
+        assert OcsConfiguration.objects.get().config.chat_widget.chatbot_id == chatbot_id

--- a/apps/admin/tests/test_models.py
+++ b/apps/admin/tests/test_models.py
@@ -9,6 +9,10 @@ from apps.admin.models import (
     clear_site_config_cache,
     get_site_config,
 )
+from apps.channels.models import ChannelPlatform
+from apps.channels.utils import clear_widget_embed_key_cache
+from apps.utils.factories.channels import ExperimentChannelFactory
+from apps.utils.factories.experiment import ExperimentFactory
 
 
 class TestChatWidgetConfig:
@@ -28,6 +32,34 @@ class TestChatWidgetConfig:
         attrs = config.get_widget_attributes()
         assert attrs["welcome-messages"] == '["Message with \\"quotes\\" and \\\\backslashes"]'
         assert attrs["starter-questions"] == "[\"Question with 'quotes'\"]"
+
+    def test_get_widget_attributes_without_a_chatbot_has_no_embed_key(self):
+        assert "embed-key" not in ChatWidgetConfig().get_widget_attributes()
+
+    @pytest.mark.django_db()
+    def test_get_widget_attributes_includes_the_chatbots_embed_key(self):
+        channel = ExperimentChannelFactory.create(
+            platform=ChannelPlatform.EMBEDDED_WIDGET,
+            extra_data={"widget_token": "site-widget-token", "allowed_domains": ["example.com"]},
+        )
+        chatbot_id = str(channel.experiment.public_id)
+        clear_widget_embed_key_cache(chatbot_id)
+        try:
+            attrs = ChatWidgetConfig(chatbot_id=chatbot_id).get_widget_attributes()
+        finally:
+            clear_widget_embed_key_cache(chatbot_id)
+        assert attrs["embed-key"] == "site-widget-token"
+
+    @pytest.mark.django_db()
+    def test_get_widget_attributes_omits_embed_key_when_the_chatbot_has_no_widget_channel(self):
+        experiment = ExperimentFactory.create()
+        chatbot_id = str(experiment.public_id)
+        clear_widget_embed_key_cache(chatbot_id)
+        try:
+            attrs = ChatWidgetConfig(chatbot_id=chatbot_id).get_widget_attributes()
+        finally:
+            clear_widget_embed_key_cache(chatbot_id)
+        assert "embed-key" not in attrs
 
 
 class TestSiteConfig:

--- a/apps/api/authentication.py
+++ b/apps/api/authentication.py
@@ -86,14 +86,35 @@ class EmbeddedWidgetAuthentication(authentication.BaseAuthentication):
         return "X-Embed-Key"
 
 
-def get_embed_key_channel(request, experiment) -> ExperimentChannel | None:
-    """Return the widget channel of `experiment` that this request's X-Embed-Key proves access to.
+def embed_key_authorizes_channel(request, channel: ExperimentChannel | None) -> bool:
+    """Whether this request's X-Embed-Key proves access to `channel`.
 
     `EmbeddedWidgetAuthentication` only runs when no earlier authenticator matched, so a caller
     that also has a Django session cookie never authenticates as the channel — which is exactly
     the site help widget, embedded in OCS for a logged-in user. This runs the same key and origin
-    checks as that class plus `WidgetDomainPermission`, so a view can treat a valid embed key as
-    authorization no matter which class authenticated the request.
+    checks as that class plus `WidgetDomainPermission`, so a view or permission class can treat a
+    valid embed key as authorization no matter which class authenticated the request.
+
+    Takes the channel rather than looking it up, so callers that already hold one (a session's
+    `experiment_channel`, say) spend no query and are not tied to the channel's experiment being
+    the working version.
+    """
+    embed_key = request.headers.get("X-Embed-Key")
+    if not embed_key or channel is None:
+        return False
+    if channel.platform != ChannelPlatform.EMBEDDED_WIDGET:
+        return False
+    if embed_key != channel.extra_data.get("widget_token"):
+        return False
+
+    origin_domain = extract_domain_from_headers(request)
+    if not origin_domain:
+        return False
+    return validate_domain(origin_domain, channel.extra_data.get("allowed_domains", []))
+
+
+def get_embed_key_channel(request, experiment) -> ExperimentChannel | None:
+    """Return the widget channel of `experiment` that this request's X-Embed-Key proves access to.
 
     Returns None (rather than raising) for every failure mode; the caller decides the response.
     """
@@ -101,17 +122,13 @@ def get_embed_key_channel(request, experiment) -> ExperimentChannel | None:
     if not embed_key:
         return None
 
-    channel = ExperimentChannel.objects.filter(
-        experiment=experiment,
-        platform=ChannelPlatform.EMBEDDED_WIDGET,
-        extra_data__widget_token=embed_key,
-    ).first()
-    if channel is None:
-        return None
-
-    origin_domain = extract_domain_from_headers(request)
-    if not origin_domain:
-        return None
-    if not validate_domain(origin_domain, channel.extra_data.get("allowed_domains", [])):
-        return None
-    return channel
+    channel = (
+        ExperimentChannel.objects.select_related("experiment", "team")
+        .filter(
+            experiment=experiment,
+            platform=ChannelPlatform.EMBEDDED_WIDGET,
+            extra_data__widget_token=embed_key,
+        )
+        .first()
+    )
+    return channel if embed_key_authorizes_channel(request, channel) else None

--- a/apps/api/authentication.py
+++ b/apps/api/authentication.py
@@ -5,7 +5,7 @@ from rest_framework import authentication
 from rest_framework.exceptions import AuthenticationFailed, ParseError
 
 from apps.channels.models import ChannelPlatform, ExperimentChannel
-from apps.channels.utils import get_experiment_session_cached
+from apps.channels.utils import extract_domain_from_headers, get_experiment_session_cached, validate_domain
 
 
 class EmbeddedWidgetAuthentication(authentication.BaseAuthentication):
@@ -84,3 +84,34 @@ class EmbeddedWidgetAuthentication(authentication.BaseAuthentication):
         Return the authentication scheme for 401 responses.
         """
         return "X-Embed-Key"
+
+
+def get_embed_key_channel(request, experiment) -> ExperimentChannel | None:
+    """Return the widget channel of `experiment` that this request's X-Embed-Key proves access to.
+
+    `EmbeddedWidgetAuthentication` only runs when no earlier authenticator matched, so a caller
+    that also has a Django session cookie never authenticates as the channel — which is exactly
+    the site help widget, embedded in OCS for a logged-in user. This runs the same key and origin
+    checks as that class plus `WidgetDomainPermission`, so a view can treat a valid embed key as
+    authorization no matter which class authenticated the request.
+
+    Returns None (rather than raising) for every failure mode; the caller decides the response.
+    """
+    embed_key = request.headers.get("X-Embed-Key")
+    if not embed_key:
+        return None
+
+    channel = ExperimentChannel.objects.filter(
+        experiment=experiment,
+        platform=ChannelPlatform.EMBEDDED_WIDGET,
+        extra_data__widget_token=embed_key,
+    ).first()
+    if channel is None:
+        return None
+
+    origin_domain = extract_domain_from_headers(request)
+    if not origin_domain:
+        return None
+    if not validate_domain(origin_domain, channel.extra_data.get("allowed_domains", [])):
+        return None
+    return channel

--- a/apps/api/authentication.py
+++ b/apps/api/authentication.py
@@ -104,6 +104,10 @@ def embed_key_authorizes_channel(request, channel: ExperimentChannel | None) -> 
         return False
     if channel.platform != ChannelPlatform.EMBEDDED_WIDGET:
         return False
+    # Callers that reach a channel by FK traversal (`session.experiment_channel`) bypass the
+    # default manager's `deleted=False`, so deleting a widget would otherwise not revoke its key.
+    if channel.deleted:
+        return False
     if embed_key != channel.extra_data.get("widget_token"):
         return False
 

--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -12,6 +12,7 @@ from rest_framework.authentication import BaseAuthentication
 from rest_framework.permissions import SAFE_METHODS, BasePermission, DjangoModelPermissions, IsAuthenticated
 from rest_framework_api_key.permissions import KeyParser
 
+from apps.api.authentication import embed_key_authorizes_channel
 from apps.api.session_tokens import session_token_expired, validate_session_token
 from apps.channels.models import ExperimentChannel, WidgetAuthLevel
 from apps.channels.utils import extract_domain_from_headers, get_experiment_session_cached, validate_domain
@@ -130,6 +131,14 @@ class SessionAccessPermission(BasePermission):
             # A valid embed key + domain check satisfies EMBED_KEY and NONE channels. It
             # never satisfies a SESSION_TOKEN channel — that always requires the token,
             # even if the session was (mis)configured with session_token_required=False.
+            return level != WidgetAuthLevel.SESSION_TOKEN
+
+        # ADR-0052: a Django session cookie preempts EmbeddedWidgetAuthentication, so a
+        # same-origin widget's embed key never reaches `request.auth`. Honour a key that
+        # rode along with another authenticator, under the same channel and origin checks
+        # as the branch above — otherwise the site help widget could start a session on an
+        # EMBED_KEY channel and then be denied every follow-up request.
+        if embed_key_authorizes_channel(request, channel):
             return level != WidgetAuthLevel.SESSION_TOKEN
 
         # No embed key. At EMBED_KEY and above a valid embed key is mandatory, so the

--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -133,7 +133,7 @@ class SessionAccessPermission(BasePermission):
             # even if the session was (mis)configured with session_token_required=False.
             return level != WidgetAuthLevel.SESSION_TOKEN
 
-        # ADR-0052: a Django session cookie preempts EmbeddedWidgetAuthentication, so a
+        # ADR-0053: a Django session cookie preempts EmbeddedWidgetAuthentication, so a
         # same-origin widget's embed key never reaches `request.auth`. Honour a key that
         # rode along with another authenticator, under the same channel and origin checks
         # as the branch above — otherwise the site help widget could start a session on an

--- a/apps/api/tests/test_chat_api_authed.py
+++ b/apps/api/tests/test_chat_api_authed.py
@@ -3,28 +3,66 @@
 When access is authenticated, it implies that the chat widget is being hosted on the same
 OCS instance as the bot (to allow the session cookie to work). In this case, we should enforce
 that the `remote_id` matches the authenticated user's email address.
+
+Being logged in is not access to every chatbot: the caller must also either belong to the
+chatbot's team or present its widget embed key (the site help widget's route — its users are
+logged in but are not members of the support bot's team). Every test here runs over both.
 """
 
 import pytest
 from django.urls import reverse
 from rest_framework.test import APIClient
 
+from apps.channels.models import ChannelPlatform
 from apps.experiments.models import ExperimentSession, Participant, ParticipantData
+from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentSessionFactory
 from apps.utils.factories.team import TeamWithUsersFactory
 
+WIDGET_TOKEN = "test_widget_token_123456789012"
+WIDGET_DOMAIN = "ocs.example.com"
+
 
 @pytest.fixture()
-def authed_user():
+def widget_channel(experiment):
+    return ExperimentChannelFactory.create(
+        experiment=experiment,
+        team=experiment.team,
+        platform=ChannelPlatform.EMBEDDED_WIDGET,
+        extra_data={"widget_token": WIDGET_TOKEN, "allowed_domains": [WIDGET_DOMAIN]},
+    )
+
+
+@pytest.fixture(params=["team_member", "embed_key"])
+def auth_route(request):
+    """The two ways a session-authenticated caller may be authorized for a chatbot."""
+    return request.param
+
+
+@pytest.fixture()
+def authed_user(auth_route, experiment):
+    if auth_route == "team_member":
+        return experiment.team.members.first()
     other_team = TeamWithUsersFactory.create()
     return other_team.members.first()
 
 
 @pytest.fixture()
-def authed_client(authed_user):
+def authed_client(auth_route, authed_user, widget_channel):
     client = APIClient()
     client.login(username=authed_user.email, password="password")
+    if auth_route == "embed_key":
+        client.credentials(HTTP_X_EMBED_KEY=WIDGET_TOKEN, HTTP_ORIGIN=f"https://{WIDGET_DOMAIN}")
     return client
+
+
+@pytest.fixture()
+def non_member_client():
+    """A logged-in user with no relationship to the chatbot's team and no embed key."""
+    user = TeamWithUsersFactory.create().members.first()
+    client = APIClient()
+    client.login(username=user.email, password="password")
+    return client, user
 
 
 @pytest.fixture()
@@ -116,3 +154,137 @@ def test_start_chat_session_with_name(authed_user, authed_client, experiment):
 
     session = ExperimentSession.objects.get(external_id=response_json["session_id"])
     assert session.state == session_state
+
+
+@pytest.mark.django_db()
+def test_embed_key_route_keeps_the_authenticated_user_as_the_participant(experiment, widget_channel):
+    """The embed key authorizes; it does not downgrade the caller to an anonymous participant."""
+    user = TeamWithUsersFactory.create().members.first()
+    client = APIClient()
+    client.login(username=user.email, password="password")
+    client.credentials(HTTP_X_EMBED_KEY=WIDGET_TOKEN, HTTP_ORIGIN=f"https://{WIDGET_DOMAIN}")
+
+    url = reverse("api:chat:start-session")
+    data = {"chatbot_id": experiment.public_id, "participant_remote_id": user.email}
+    response = client.post(url, data=data, format="json")
+
+    assert response.status_code == 201
+    session = ExperimentSession.objects.get(external_id=response.json()["session_id"])
+    assert session.participant.user_id == user.id
+    assert session.participant.identifier == user.email
+
+
+@pytest.mark.django_db()
+class TestChannelAttribution:
+    """A widget's own channel owns the session whenever its embed key rides along, so the same
+    widget cannot produce two channels — and two participants — depending on who is looking."""
+
+    def _start(self, user, experiment, **extra):
+        client = APIClient()
+        client.login(username=user.email, password="password")
+        url = reverse("api:chat:start-session")
+        data = {"chatbot_id": experiment.public_id, "participant_remote_id": user.email}
+        response = client.post(url, data=data, format="json", **extra)
+        assert response.status_code == 201, response.json()
+        return ExperimentSession.objects.get(external_id=response.json()["session_id"])
+
+    def test_non_member_with_embed_key_lands_on_the_widget_channel(self, experiment, widget_channel):
+        user = TeamWithUsersFactory.create().members.first()
+        session = self._start(user, experiment, HTTP_X_EMBED_KEY=WIDGET_TOKEN, HTTP_ORIGIN=f"https://{WIDGET_DOMAIN}")
+        assert session.experiment_channel == widget_channel
+        assert session.participant.platform == ChannelPlatform.EMBEDDED_WIDGET
+
+    def test_team_member_with_embed_key_lands_on_the_same_channel(self, experiment, widget_channel):
+        """Membership short-circuits authorization, but it must not change attribution."""
+        member = experiment.team.members.first()
+        session = self._start(member, experiment, HTTP_X_EMBED_KEY=WIDGET_TOKEN, HTTP_ORIGIN=f"https://{WIDGET_DOMAIN}")
+        assert session.experiment_channel == widget_channel
+        assert session.participant.platform == ChannelPlatform.EMBEDDED_WIDGET
+
+    def test_team_member_without_embed_key_stays_on_the_api_channel(self, experiment, widget_channel):
+        member = experiment.team.members.first()
+        session = self._start(member, experiment)
+        assert session.experiment_channel.platform == ChannelPlatform.API
+        assert session.participant.platform == ChannelPlatform.API
+
+    def test_an_invalid_key_does_not_attribute_to_the_widget_channel(self, experiment, widget_channel):
+        """A member gets in on membership alone; a key that fails its checks attributes nothing."""
+        member = experiment.team.members.first()
+        session = self._start(member, experiment, HTTP_X_EMBED_KEY=WIDGET_TOKEN, HTTP_ORIGIN="https://evil.com")
+        assert session.experiment_channel.platform == ChannelPlatform.API
+
+    def test_widget_version_is_recorded_for_the_site_widget(self, experiment, widget_channel):
+        """The site widget is now visible to the version telemetry that drives the auth-level ratchet."""
+        user = TeamWithUsersFactory.create().members.first()
+        self._start(
+            user,
+            experiment,
+            HTTP_X_EMBED_KEY=WIDGET_TOKEN,
+            HTTP_ORIGIN=f"https://{WIDGET_DOMAIN}",
+            HTTP_X_OCS_WIDGET_VERSION="0.9.0",
+        )
+        widget_channel.refresh_from_db()
+        assert widget_channel.widget_version == "0.9.0"
+
+
+@pytest.mark.django_db()
+class TestNonMemberAccess:
+    """A logged-in user may not start a session on another team's chatbot without its embed key."""
+
+    def _start(self, client, experiment, user, **extra):
+        url = reverse("api:chat:start-session")
+        data = {"chatbot_id": experiment.public_id, "participant_remote_id": user.email}
+        return client.post(url, data=data, format="json", **extra)
+
+    def test_no_embed_key(self, non_member_client, experiment, widget_channel):
+        client, user = non_member_client
+        response = self._start(client, experiment, user)
+        assert response.status_code == 403
+        assert response.json()["error"] == "You do not have access to this chatbot"
+
+    def test_wrong_embed_key(self, non_member_client, experiment, widget_channel):
+        client, user = non_member_client
+        response = self._start(
+            client, experiment, user, HTTP_X_EMBED_KEY="wrong_token", HTTP_ORIGIN=f"https://{WIDGET_DOMAIN}"
+        )
+        assert response.status_code == 403
+
+    def test_embed_key_of_another_chatbot(self, non_member_client, experiment, widget_channel):
+        """A key is only good for the chatbot it belongs to."""
+        other_channel = ExperimentChannelFactory.create(
+            platform=ChannelPlatform.EMBEDDED_WIDGET,
+            extra_data={"widget_token": "someone_elses_token", "allowed_domains": [WIDGET_DOMAIN]},
+        )
+        client, user = non_member_client
+        response = self._start(
+            client,
+            experiment,
+            user,
+            HTTP_X_EMBED_KEY=other_channel.extra_data["widget_token"],
+            HTTP_ORIGIN=f"https://{WIDGET_DOMAIN}",
+        )
+        assert response.status_code == 403
+
+    def test_embed_key_from_disallowed_domain(self, non_member_client, experiment, widget_channel):
+        client, user = non_member_client
+        response = self._start(client, experiment, user, HTTP_X_EMBED_KEY=WIDGET_TOKEN, HTTP_ORIGIN="https://evil.com")
+        assert response.status_code == 403
+
+    def test_embed_key_without_origin_or_referer(self, non_member_client, experiment, widget_channel):
+        client, user = non_member_client
+        response = self._start(client, experiment, user, HTTP_X_EMBED_KEY=WIDGET_TOKEN)
+        assert response.status_code == 403
+
+    def test_embed_key_does_not_grant_version_selection(self, non_member_client, experiment, widget_channel):
+        """Choosing a chatbot version stays a team-member capability."""
+        client, user = non_member_client
+        url = reverse("api:chat:start-session")
+        data = {
+            "chatbot_id": experiment.public_id,
+            "participant_remote_id": user.email,
+            "version_number": 0,
+        }
+        response = client.post(
+            url, data=data, format="json", HTTP_X_EMBED_KEY=WIDGET_TOKEN, HTTP_ORIGIN=f"https://{WIDGET_DOMAIN}"
+        )
+        assert response.status_code == 403

--- a/apps/api/tests/test_chat_api_authed.py
+++ b/apps/api/tests/test_chat_api_authed.py
@@ -242,11 +242,19 @@ class TestNonMemberAccess:
         assert response.status_code == 403
         assert response.json()["error"] == "You do not have access to this chatbot"
 
-    def test_wrong_embed_key(self, non_member_client, experiment, widget_channel):
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            pytest.param(
+                {"HTTP_X_EMBED_KEY": "wrong_token", "HTTP_ORIGIN": f"https://{WIDGET_DOMAIN}"}, id="wrong_key"
+            ),
+            pytest.param({"HTTP_X_EMBED_KEY": WIDGET_TOKEN, "HTTP_ORIGIN": "https://evil.com"}, id="disallowed_domain"),
+            pytest.param({"HTTP_X_EMBED_KEY": WIDGET_TOKEN}, id="no_origin_or_referer"),
+        ],
+    )
+    def test_embed_key_rejected(self, non_member_client, experiment, widget_channel, extra):
         client, user = non_member_client
-        response = self._start(
-            client, experiment, user, HTTP_X_EMBED_KEY="wrong_token", HTTP_ORIGIN=f"https://{WIDGET_DOMAIN}"
-        )
+        response = self._start(client, experiment, user, **extra)
         assert response.status_code == 403
 
     def test_embed_key_of_another_chatbot(self, non_member_client, experiment, widget_channel):
@@ -263,16 +271,6 @@ class TestNonMemberAccess:
             HTTP_X_EMBED_KEY=other_channel.extra_data["widget_token"],
             HTTP_ORIGIN=f"https://{WIDGET_DOMAIN}",
         )
-        assert response.status_code == 403
-
-    def test_embed_key_from_disallowed_domain(self, non_member_client, experiment, widget_channel):
-        client, user = non_member_client
-        response = self._start(client, experiment, user, HTTP_X_EMBED_KEY=WIDGET_TOKEN, HTTP_ORIGIN="https://evil.com")
-        assert response.status_code == 403
-
-    def test_embed_key_without_origin_or_referer(self, non_member_client, experiment, widget_channel):
-        client, user = non_member_client
-        response = self._start(client, experiment, user, HTTP_X_EMBED_KEY=WIDGET_TOKEN)
         assert response.status_code == 403
 
     def test_embed_key_does_not_grant_version_selection(self, non_member_client, experiment, widget_channel):

--- a/apps/api/tests/test_widget_auth_level.py
+++ b/apps/api/tests/test_widget_auth_level.py
@@ -16,6 +16,7 @@ from apps.channels.models import ChannelPlatform, WidgetAuthLevel
 from apps.experiments.models import ExperimentSession
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentSessionFactory
+from apps.utils.factories.team import TeamWithUsersFactory
 
 WIDGET_TOKEN = "test_widget_token_123456789012"
 
@@ -200,6 +201,28 @@ def test_embed_key_for_other_channel_denied(api_client, experiment):
         HTTP_ORIGIN="https://b.example.com",
     )
     assert allowed.status_code == 200
+
+
+@pytest.mark.django_db()
+def test_embed_key_riding_along_with_a_session_cookie_grants_access(api_client, experiment):
+    """ADR-0052: the site help widget is cookie-authenticated, so its embed key never reaches
+    `request.auth`. An EMBED_KEY channel must still accept it, or the widget starts a session and
+    is then denied every follow-up request."""
+    experiment.participant_allowlist = ["someone-else@example.com"]
+    experiment.save(update_fields=["participant_allowlist"])
+    channel = _widget_channel(experiment, WidgetAuthLevel.EMBED_KEY)
+    session = ExperimentSessionFactory.create(
+        experiment=experiment, experiment_channel=channel, session_token_required=False
+    )
+    user = TeamWithUsersFactory.create().members.first()
+    api_client.login(username=user.email, password="password")
+
+    allowed = api_client.get(poll_url(session), HTTP_X_EMBED_KEY=WIDGET_TOKEN, HTTP_ORIGIN="https://example.com")
+    assert allowed.status_code == 200
+
+    # the ride-along key is held to the same origin check
+    denied = api_client.get(poll_url(session), HTTP_X_EMBED_KEY=WIDGET_TOKEN, HTTP_ORIGIN="https://evil.com")
+    assert denied.status_code == 403
 
 
 # --- migration version → level mapping -------------------------------------------------

--- a/apps/api/tests/test_widget_auth_level.py
+++ b/apps/api/tests/test_widget_auth_level.py
@@ -205,7 +205,7 @@ def test_embed_key_for_other_channel_denied(api_client, experiment):
 
 @pytest.mark.django_db()
 def test_embed_key_riding_along_with_a_session_cookie_grants_access(api_client, experiment):
-    """ADR-0052: the site help widget is cookie-authenticated, so its embed key never reaches
+    """ADR-0053: the site help widget is cookie-authenticated, so its embed key never reaches
     `request.auth`. An EMBED_KEY channel must still accept it, or the widget starts a session and
     is then denied every follow-up request."""
     experiment.participant_allowlist = ["someone-else@example.com"]

--- a/apps/api/tests/test_widget_auth_level.py
+++ b/apps/api/tests/test_widget_auth_level.py
@@ -225,6 +225,22 @@ def test_embed_key_riding_along_with_a_session_cookie_grants_access(api_client, 
     assert denied.status_code == 403
 
 
+@pytest.mark.django_db()
+def test_deleting_the_channel_revokes_a_riding_along_embed_key(api_client, experiment):
+    """Deleting a widget must revoke its key. `session.experiment_channel` is a FK traversal, so it
+    returns the soft-deleted channel where the manager would have filtered it out."""
+    channel = _widget_channel(experiment, WidgetAuthLevel.EMBED_KEY)
+    session = ExperimentSessionFactory.create(
+        experiment=experiment, experiment_channel=channel, session_token_required=False
+    )
+    channel.soft_delete()
+    user = TeamWithUsersFactory.create().members.first()
+    api_client.login(username=user.email, password="password")
+
+    denied = api_client.get(poll_url(session), HTTP_X_EMBED_KEY=WIDGET_TOKEN, HTTP_ORIGIN="https://example.com")
+    assert denied.status_code == 403
+
+
 # --- migration version → level mapping -------------------------------------------------
 
 _migration = importlib.import_module("apps.channels.migrations.0029_experimentchannel_required_auth_level")

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -225,8 +225,20 @@ def _issue_or_opt_out_session_token(session, channel):
     return _opt_out_session_token(session)
 
 
-def _may_start_session(request, is_team_member, embed_key_channel) -> bool:
-    """Whether this caller may start a session against the chatbot at all.
+def _resolve_embed_key_channel(request, experiment) -> ExperimentChannel | None:
+    """The widget channel this request's embed key proves, if any.
+
+    Resolved once: it both authorizes the caller and owns the session. `request.auth` already
+    holds it when the key did the authenticating, so this only queries for keys that rode along
+    with another authenticator.
+    """
+    if isinstance(request.auth, ExperimentChannel):
+        return request.auth
+    return get_embed_key_channel(request, experiment)
+
+
+def _check_start_session_access(request, experiment, embed_key_channel, version_number) -> Response | None:
+    """A 403 response if this caller may not start the session they asked for, else None.
 
     ADR-0052: being logged in to OCS is not, on its own, access to every chatbot. A
     session-authenticated caller needs either team membership or the chatbot's embed key — the
@@ -236,8 +248,23 @@ def _may_start_session(request, is_team_member, embed_key_channel) -> bool:
     Anonymous callers are unaffected; the permission classes are the only gate on that path.
     """
     if not request.user.is_authenticated:
-        return True
-    return is_team_member or embed_key_channel is not None
+        return None
+    if experiment.team.members.filter(id=request.user.id).exists():
+        return None
+    # Not a member: the embed key is the only other proof, and it does not grant version selection.
+    if embed_key_channel is not None and version_number is None:
+        return None
+    return Response({"error": "You do not have access to this chatbot"}, status=status.HTTP_403_FORBIDDEN)
+
+
+def _get_requested_version(experiment, version_number):
+    """The explicitly requested version, or None to use the working version."""
+    if version_number is None or version_number == Experiment.DEFAULT_VERSION_NUMBER:
+        return None
+    try:
+        return experiment.get_version(version_number)
+    except Experiment.DoesNotExist:
+        raise NotFound(f"Experiment with version {version_number} not found") from None
 
 
 def _resolve_experiment_channel(request, team, session_data, embed_key_channel):
@@ -356,36 +383,13 @@ def chat_start_session(request):
     # Always look up the working version by public_id
     experiment = get_object_or_404(Experiment, public_id=experiment_id, working_version_id__isnull=True)
 
-    # The widget channel this request's embed key proves, if any. Resolved once: it both
-    # authorizes the caller below and owns the session. `request.auth` already holds it when the
-    # key did the authenticating, so this only queries for keys that rode along with another
-    # authenticator.
-    embed_key_channel = (
-        request.auth if isinstance(request.auth, ExperimentChannel) else get_embed_key_channel(request, experiment)
-    )
+    embed_key_channel = _resolve_embed_key_channel(request, experiment)
 
-    is_team_member = request.user.is_authenticated and experiment.team.members.filter(id=request.user.id).exists()
+    denied = _check_start_session_access(request, experiment, embed_key_channel, version_number)
+    if denied:
+        return denied
 
-    if not _may_start_session(request, is_team_member, embed_key_channel):
-        return Response(
-            {"error": "You do not have access to this chatbot"},
-            status=status.HTTP_403_FORBIDDEN,
-        )
-
-    experiment_version = None
-    if version_number is not None:
-        # Choosing a version is a team-member capability; an embed key does not grant it.
-        if not is_team_member:
-            return Response(
-                {"error": "You do not have access to this chatbot"},
-                status=status.HTTP_403_FORBIDDEN,
-            )
-
-        if version_number != Experiment.DEFAULT_VERSION_NUMBER:
-            try:
-                experiment_version = experiment.get_version(version_number)
-            except Experiment.DoesNotExist:
-                raise NotFound(f"Experiment with version {version_number} not found") from None
+    experiment_version = _get_requested_version(experiment, version_number)
 
     team = experiment.team
 

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -225,6 +225,21 @@ def _issue_or_opt_out_session_token(session, channel):
     return _opt_out_session_token(session)
 
 
+def _may_start_session(request, is_team_member, embed_key_channel) -> bool:
+    """Whether this caller may start a session against the chatbot at all.
+
+    ADR-0052: being logged in to OCS is not, on its own, access to every chatbot. A
+    session-authenticated caller needs either team membership or the chatbot's embed key — the
+    same proof an anonymous embedder must present. The key path is what keeps the site help
+    widget working, since its users are logged in but are not members of the support bot's team.
+
+    Anonymous callers are unaffected; the permission classes are the only gate on that path.
+    """
+    if not request.user.is_authenticated:
+        return True
+    return is_team_member or embed_key_channel is not None
+
+
 def _resolve_experiment_channel(request, team, session_data, embed_key_channel):
     """Return the ExperimentChannel that owns this session.
 
@@ -351,11 +366,7 @@ def chat_start_session(request):
 
     is_team_member = request.user.is_authenticated and experiment.team.members.filter(id=request.user.id).exists()
 
-    # ADR-0052: being logged in to OCS is not, on its own, access to every chatbot. A
-    # session-authenticated caller needs either team membership or the chatbot's embed key — the
-    # same proof an anonymous embedder must present. The key path is what keeps the site help
-    # widget working, since its users are logged in but are not members of the support bot's team.
-    if request.user.is_authenticated and not is_team_member and embed_key_channel is None:
+    if not _may_start_session(request, is_team_member, embed_key_channel):
         return Response(
             {"error": "You do not have access to this chatbot"},
             status=status.HTTP_403_FORBIDDEN,

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -245,10 +245,14 @@ def _check_start_session_access(request, experiment, embed_key_channel, version_
     same proof an anonymous embedder must present. The key path is what keeps the site help
     widget working, since its users are logged in but are not members of the support bot's team.
 
-    Anonymous callers are unaffected; the permission classes are the only gate on that path.
+    Selecting a version is narrower still: only a team member may do it, so `version_number` must
+    be None on every other route through here. `chat_send_message` gates it the same way.
     """
     if not request.user.is_authenticated:
-        return None
+        # Otherwise unaffected: the permission classes are the only gate on the anonymous path.
+        if version_number is None:
+            return None
+        return Response({"error": "Version number requires authentication"}, status=status.HTTP_403_FORBIDDEN)
     if experiment.team.members.filter(id=request.user.id).exists():
         return None
     # Not a member: the embed key is the only other proof, and it does not grant version selection.
@@ -372,13 +376,6 @@ def chat_start_session(request):
     # so deprecated old widgets still receive RFC 8594 sunset headers.
     if is_widget_request(request, session_data):
         mark_widget_request(request)
-
-    # Security check: Only authenticated users can specify version numbers
-    if version_number is not None and not request.user.is_authenticated:
-        return Response(
-            {"error": "Version number requires authentication"},
-            status=status.HTTP_403_FORBIDDEN,
-        )
 
     # Always look up the working version by public_id
     experiment = get_object_or_404(Experiment, public_id=experiment_id, working_version_id__isnull=True)

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -240,7 +240,7 @@ def _resolve_embed_key_channel(request, experiment) -> ExperimentChannel | None:
 def _check_start_session_access(request, experiment, embed_key_channel, version_number) -> Response | None:
     """A 403 response if this caller may not start the session they asked for, else None.
 
-    ADR-0052: being logged in to OCS is not, on its own, access to every chatbot. A
+    ADR-0053: being logged in to OCS is not, on its own, access to every chatbot. A
     session-authenticated caller needs either team membership or the chatbot's embed key — the
     same proof an anonymous embedder must present. The key path is what keeps the site help
     widget working, since its users are logged in but are not members of the support bot's team.
@@ -274,7 +274,7 @@ def _get_requested_version(experiment, version_number):
 def _resolve_experiment_channel(request, team, session_data, embed_key_channel):
     """Return the ExperimentChannel that owns this session.
 
-    ADR-0052: a widget's own channel owns the session whenever the request carries that widget's
+    ADR-0053: a widget's own channel owns the session whenever the request carries that widget's
     embed key, whether the key authenticated the request (an anonymous embed) or merely
     accompanied it (the site help widget, where a Django session cookie authenticates first).
     Attribution therefore tracks the widget, not the authenticator, so one widget cannot produce

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -239,12 +239,11 @@ def _resolve_experiment_channel(request, team, session_data, embed_key_channel):
     caller using an embed key isn't tagged with a placeholder version. Everything else
     (authenticated users with no key) falls back to the team API channel.
     """
-    channel = request.auth if isinstance(request.auth, ExperimentChannel) else embed_key_channel
-    if channel is None:
+    if embed_key_channel is None:
         return ExperimentChannel.objects.get_team_api_channel(team)
     if is_widget_request(request, session_data):
-        channel.record_widget_version(request.headers.get(WIDGET_VERSION_HEADER))
-    return channel
+        embed_key_channel.record_widget_version(request.headers.get(WIDGET_VERSION_HEADER))
+    return embed_key_channel
 
 
 @extend_schema(

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -14,7 +14,7 @@ from rest_framework.exceptions import NotFound
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 
-from apps.api.authentication import EmbeddedWidgetAuthentication
+from apps.api.authentication import EmbeddedWidgetAuthentication, get_embed_key_channel
 from apps.api.permissions import SessionAccessPermission, WidgetDomainPermission
 from apps.api.serializers import (
     ChatPollResponse,
@@ -225,18 +225,23 @@ def _issue_or_opt_out_session_token(session, channel):
     return _opt_out_session_token(session)
 
 
-def _resolve_experiment_channel(request, team, session_data):
-    """Return the ExperimentChannel for this request.
+def _resolve_experiment_channel(request, team, session_data, embed_key_channel):
+    """Return the ExperimentChannel that owns this session.
 
-    Embed-key auth resolves to the widget's own channel; for widget traffic we also
-    record the reported version (or a placeholder for pre-0.5.1 widgets that send no
-    header). Recording is gated on `is_widget_request` so a non-widget caller using an
-    embed key isn't tagged with a placeholder version. Everything else (authenticated
-    users) falls back to the team API channel.
+    ADR-0052: a widget's own channel owns the session whenever the request carries that widget's
+    embed key, whether the key authenticated the request (an anonymous embed) or merely
+    accompanied it (the site help widget, where a Django session cookie authenticates first).
+    Attribution therefore tracks the widget, not the authenticator, so one widget cannot produce
+    two channels — and two participants — depending on who is looking at the page.
+
+    For widget traffic we also record the reported version (or a placeholder for pre-0.5.1
+    widgets that send no header). Recording is gated on `is_widget_request` so a non-widget
+    caller using an embed key isn't tagged with a placeholder version. Everything else
+    (authenticated users with no key) falls back to the team API channel.
     """
-    if not isinstance(request.auth, ExperimentChannel):
+    channel = request.auth if isinstance(request.auth, ExperimentChannel) else embed_key_channel
+    if channel is None:
         return ExperimentChannel.objects.get_team_api_channel(team)
-    channel = request.auth
     if is_widget_request(request, session_data):
         channel.record_widget_version(request.headers.get(WIDGET_VERSION_HEADER))
     return channel
@@ -337,10 +342,30 @@ def chat_start_session(request):
     # Always look up the working version by public_id
     experiment = get_object_or_404(Experiment, public_id=experiment_id, working_version_id__isnull=True)
 
+    # The widget channel this request's embed key proves, if any. Resolved once: it both
+    # authorizes the caller below and owns the session. `request.auth` already holds it when the
+    # key did the authenticating, so this only queries for keys that rode along with another
+    # authenticator.
+    embed_key_channel = (
+        request.auth if isinstance(request.auth, ExperimentChannel) else get_embed_key_channel(request, experiment)
+    )
+
+    is_team_member = request.user.is_authenticated and experiment.team.members.filter(id=request.user.id).exists()
+
+    # ADR-0052: being logged in to OCS is not, on its own, access to every chatbot. A
+    # session-authenticated caller needs either team membership or the chatbot's embed key — the
+    # same proof an anonymous embedder must present. The key path is what keeps the site help
+    # widget working, since its users are logged in but are not members of the support bot's team.
+    if request.user.is_authenticated and not is_team_member and embed_key_channel is None:
+        return Response(
+            {"error": "You do not have access to this chatbot"},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+
     experiment_version = None
     if version_number is not None:
-        # Verify the authenticated user belongs to the experiment's team
-        if not experiment.team.members.filter(id=request.user.id).exists():
+        # Choosing a version is a team-member capability; an embed key does not grant it.
+        if not is_team_member:
             return Response(
                 {"error": "You do not have access to this chatbot"},
                 status=status.HTTP_403_FORBIDDEN,
@@ -354,7 +379,7 @@ def chat_start_session(request):
 
     team = experiment.team
 
-    experiment_channel = _resolve_experiment_channel(request, team, session_data)
+    experiment_channel = _resolve_experiment_channel(request, team, session_data, embed_key_channel)
 
     if request.user.is_authenticated:
         user = request.user

--- a/apps/channels/tests/test_utils.py
+++ b/apps/channels/tests/test_utils.py
@@ -1,7 +1,16 @@
 import pytest
+from django.core.cache import cache
 from django.test import override_settings
 
-from apps.channels.utils import get_allowed_email_domains, is_email_domain_allowed
+from apps.channels.models import ChannelPlatform
+from apps.channels.utils import (
+    clear_widget_embed_key_cache,
+    fetch_widget_embed_key,
+    get_allowed_email_domains,
+    get_widget_embed_key,
+    is_email_domain_allowed,
+)
+from apps.utils.factories.channels import ExperimentChannelFactory
 
 
 class TestIsEmailDomainAllowed:
@@ -39,3 +48,83 @@ class TestGetAllowedEmailDomains:
     @override_settings(EMAIL_CHANNEL_ALLOWED_DOMAINS=[])
     def test_returns_empty_list_when_unset(self):
         assert get_allowed_email_domains() == []
+
+
+@pytest.fixture()
+def widget_channel():
+    return ExperimentChannelFactory.create(
+        platform=ChannelPlatform.EMBEDDED_WIDGET,
+        extra_data={"widget_token": "a-widget-token", "allowed_domains": ["example.com"]},
+    )
+
+
+@pytest.mark.django_db()
+class TestFetchWidgetEmbedKey:
+    def test_returns_the_channel_token(self, widget_channel):
+        assert fetch_widget_embed_key(str(widget_channel.experiment.public_id)) == "a-widget-token"
+
+    def test_ignores_deleted_channels(self, widget_channel):
+        widget_channel.soft_delete()
+        assert fetch_widget_embed_key(str(widget_channel.experiment.public_id)) == ""
+
+    def test_ignores_other_platforms(self):
+        channel = ExperimentChannelFactory.create(
+            platform=ChannelPlatform.TELEGRAM, extra_data={"widget_token": "not-a-widget"}
+        )
+        assert fetch_widget_embed_key(str(channel.experiment.public_id)) == ""
+
+    @pytest.mark.parametrize(
+        "chatbot_id",
+        [
+            pytest.param("", id="empty"),
+            pytest.param("not-a-uuid", id="not_a_uuid"),
+            pytest.param("6d2f0b1e-0000-0000-0000-000000000000", id="unknown_chatbot"),
+        ],
+    )
+    def test_returns_empty_string_without_a_channel(self, chatbot_id):
+        assert fetch_widget_embed_key(chatbot_id) == ""
+
+
+@pytest.mark.django_db()
+class TestGetWidgetEmbedKey:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self, widget_channel):
+        chatbot_id = str(widget_channel.experiment.public_id)
+        clear_widget_embed_key_cache(chatbot_id)
+        yield
+        clear_widget_embed_key_cache(chatbot_id)
+
+    def test_caches_the_token(self, widget_channel, django_assert_num_queries):
+        chatbot_id = str(widget_channel.experiment.public_id)
+        with django_assert_num_queries(1):
+            assert get_widget_embed_key(chatbot_id) == "a-widget-token"
+        with django_assert_num_queries(0):
+            assert get_widget_embed_key(chatbot_id) == "a-widget-token"
+
+    def test_caches_misses(self, django_assert_num_queries):
+        chatbot_id = "6d2f0b1e-0000-0000-0000-000000000000"
+        try:
+            with django_assert_num_queries(1):
+                assert get_widget_embed_key(chatbot_id) == ""
+            with django_assert_num_queries(0):
+                assert get_widget_embed_key(chatbot_id) == ""
+        finally:
+            clear_widget_embed_key_cache(chatbot_id)
+
+    def test_clearing_the_cache_forces_a_refresh(self, widget_channel):
+        chatbot_id = str(widget_channel.experiment.public_id)
+        assert get_widget_embed_key(chatbot_id) == "a-widget-token"
+
+        widget_channel.extra_data["widget_token"] = "rotated-token"
+        widget_channel.save()
+        assert get_widget_embed_key(chatbot_id) == "a-widget-token"
+
+        clear_widget_embed_key_cache(chatbot_id)
+        assert get_widget_embed_key(chatbot_id) == "rotated-token"
+
+    def test_empty_chatbot_id_does_not_touch_the_cache(self):
+        cache.set("WIDGET_EMBED_KEY:", "should-not-be-read")
+        try:
+            assert get_widget_embed_key("") == ""
+        finally:
+            cache.delete("WIDGET_EMBED_KEY:")

--- a/apps/channels/utils.py
+++ b/apps/channels/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -7,11 +8,12 @@ from django.core.cache import cache
 from django.core.validators import validate_domain_name  # ty: ignore[unresolved-import]
 
 from apps.channels.exceptions import ExperimentChannelException
-from apps.channels.models import ChannelPlatform
+from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.experiments.models import Experiment, ExperimentSession
 
 ALL_DOMAINS = "*"
 WIDGET_SESSION_CACHE_TTL = 300
+WIDGET_EMBED_KEY_CACHE_TTL = 300
 
 
 def match_domain_pattern(origin_domain: str, allowed_pattern: str) -> bool:
@@ -118,3 +120,49 @@ def get_experiment_session_cached(session_id: str) -> ExperimentSession | None:
         return session
     except ExperimentSession.DoesNotExist:
         return None
+
+
+def _get_widget_embed_key_cache_key(chatbot_id: str) -> str:
+    return f"WIDGET_EMBED_KEY:{chatbot_id}"
+
+
+def get_widget_embed_key(chatbot_id: str) -> str:
+    """Cached variant of `fetch_widget_embed_key`, for the page-render path.
+
+    The site help widget resolves its embed key on every page render, so the lookup is cached.
+    Misses are cached too, so a chatbot without a widget channel doesn't cost a query per render.
+    A rotated token propagates within the TTL; `clear_widget_embed_key_cache` shortens that for
+    changes we know about.
+    """
+    if not chatbot_id:
+        return ""
+
+    cache_key = _get_widget_embed_key_cache_key(chatbot_id)
+    embed_key = cache.get(cache_key)
+    if embed_key is None:
+        embed_key = fetch_widget_embed_key(chatbot_id)
+        cache.set(cache_key, embed_key, WIDGET_EMBED_KEY_CACHE_TTL)
+    return embed_key
+
+
+def fetch_widget_embed_key(chatbot_id: str) -> str:
+    """Return the embed key of the chatbot's embedded widget channel, or "" if it has none.
+
+    `chatbot_id` is an experiment's `public_id`; anything that isn't a UUID has no channel.
+    """
+    try:
+        uuid.UUID(str(chatbot_id))
+    except (ValueError, TypeError):
+        return ""
+
+    widget_token = (
+        ExperimentChannel.objects.filter(experiment__public_id=chatbot_id, platform=ChannelPlatform.EMBEDDED_WIDGET)
+        .values_list("extra_data__widget_token", flat=True)
+        .first()
+    )
+    return widget_token or ""
+
+
+def clear_widget_embed_key_cache(chatbot_id: str) -> None:
+    if chatbot_id:
+        cache.delete(_get_widget_embed_key_cache_key(chatbot_id))

--- a/docs/adr/0052-chat-session-start-requires-membership-or-embed-key.md
+++ b/docs/adr/0052-chat-session-start-requires-membership-or-embed-key.md
@@ -1,0 +1,42 @@
+# ADR-0052: Starting a chat session requires team membership or the embed key
+
+<span class="adr-status adr-status-accepted">ACCEPTED</span>
+
+<p class="adr-meta">Author: Simon Kelly · Created: 2026-08-11</p>
+
+<p class="adr-meta">Extends: <a href="0039-require-proof-of-possession-for-chat-session-access.md">ADR-0039</a></p>
+
+## Context
+
+ADR-0039 required proof of possession on the four session endpoints but left the start endpoint (`chat_start_session`) alone. There, an authenticated Django session was sufficient on its own: any logged-in OCS user who knew a chatbot's `public_id` could start a session against any team's chatbot, and only version selection checked team membership. Chatbot `public_id`s are not secret — they ship in every embed snippet.
+
+Closing that hole by requiring team membership would have broken OCS's own site help widget, which `templates/web/app/app_base.html` renders for every logged-in user from `ChatWidgetConfig`. Its users are logged in but are generally not members of the support bot's team, so it worked only because the endpoint accepted a bare session cookie. The config already names the chatbot, so the chatbot's embed key is derivable from it — the widget can present the same proof an external embedder does.
+
+The two credentials then collide. DRF stops at the first authenticator that matches, and `SessionAuthentication` precedes `EmbeddedWidgetAuthentication`, so a same-origin widget's cookie always wins and `request.auth` is never the channel. The embed key has to be consulted by the view rather than inferred from `request.auth`, and once it is, the channel that owns the resulting session is an open question.
+
+## Decision
+
+We will treat being logged in as identity, not as access to every chatbot.
+
+- A session-authenticated caller may start a session only if they belong to the chatbot's team **or** the request carries that chatbot's widget embed key, validated against the channel's `allowed_domains` exactly as `WidgetDomainPermission` validates it. Anonymous callers are unaffected.
+- Selecting a chatbot version stays a team-member capability; an embed key does not grant it.
+- The embed key authorizes without changing identity: the caller stays the authenticated user, so the participant remains user-linked and session state is still recorded.
+- A widget's own channel owns the session whenever that widget's embed key accompanies the request, whether the key authenticated it or merely rode along. Attribution tracks the widget, not the authenticator.
+- `ChatWidgetConfig` derives the embed key from its configured `chatbot_id` rather than storing one; site config cannot name a chatbot that has no embedded widget channel.
+
+## Consequences
+
+- A leaked `public_id` no longer lets an arbitrary logged-in user consume another team's chatbot.
+- The site help widget is no longer a special case: it is an embedded widget that authorizes like any other, so widget version telemetry and the ADR-0045 auth-level ratchet finally see it, and its sessions inherit that channel's ADR-0044 policy.
+- Attribution follows the widget rather than the viewer, so a support-team member and an ordinary user on the same page produce one channel and one participant identity, not two.
+- Help-widget participants move from `platform=api` to `platform=embedded_widget`. Because `Participant` is keyed on `(team, platform, identifier)`, existing users get a second participant record and their prior conversations stay under the old one.
+- The support bot's widget channel must list the OCS host in `allowed_domains` in every environment, or the help widget cannot start a session. The admin configuration form refuses a chatbot without a widget channel, but cannot check the domain.
+- Any future same-origin embed of an OCS chatbot must carry its embed key; a session cookie alone is no longer enough.
+
+## Alternatives considered
+
+- **Store an `embed_key` field on `ChatWidgetConfig`** — rejected: a copy of a value the chatbot already owns, silently stale after a token rotation.
+- **Order `EmbeddedWidgetAuthentication` before `SessionAuthentication`** — rejected: the key would win over the cookie and downgrade help-widget users to anonymous participants, losing user linkage and the page context that is only saved for authenticated callers.
+- **Accept the key as authorization but keep sessions on the team API channel** — rejected: attribution would depend on which credential happened to be consulted, and the site widget would stay invisible to widget telemetry.
+- **Switch to the widget channel only when the key was needed** — rejected: membership short-circuits the authorization check, so staff and non-staff on the same page would land on different channels and different participants.
+- **Restrict the start endpoint to team members outright** — rejected: it breaks the site help widget with no replacement, and the embed key is the proof external embedders already present.

--- a/docs/adr/0053-chat-session-start-requires-membership-or-embed-key.md
+++ b/docs/adr/0053-chat-session-start-requires-membership-or-embed-key.md
@@ -33,7 +33,8 @@ We will treat being logged in as identity, not as access to every chatbot.
 - Attribution follows the widget rather than the viewer, so a support-team member and an ordinary user on the same page produce one channel and one participant identity, not two.
 - Help-widget participants move from `platform=api` to `platform=embedded_widget`. Because `Participant` is keyed on `(team, platform, identifier)`, existing users get a second participant record and their prior conversations stay under the old one.
 - The support bot's widget channel must list the OCS host in `allowed_domains` in every environment, or the help widget cannot start a session. The admin configuration form refuses a chatbot without a widget channel, but cannot check the domain.
-- Any future same-origin embed of an OCS chatbot must carry its embed key *if it leans on the viewer's session cookie*; that cookie alone is no longer enough.
+- A same-origin embed inside OCS may still run on the session cookie alone, as long as its viewers are members of the chatbot's team. `templates/chatbots/single_chatbot_home.html` is exactly that — no `embed-key`, and it picks a version through `openChatWidget(...)`, which only a member may do anyway. The site help widget is the outlier that needs a key, because it renders for every logged-in user regardless of team. An embed whose audience is not guaranteed to be team members must carry the key.
+- Embeds that attach to an already-started session by passing `session-id` and `session-token` — `chatbots/chat/web_chat.html` and `chatbots/components/session_chat_widget_launcher.html` — never reach `chat_start_session`, so nothing here applies to them. Their access is ADR-0039's proof-of-possession, not this ADR's.
 
 ## Alternatives considered
 

--- a/docs/adr/0053-chat-session-start-requires-membership-or-embed-key.md
+++ b/docs/adr/0053-chat-session-start-requires-membership-or-embed-key.md
@@ -1,4 +1,4 @@
-# ADR-0052: Starting a chat session requires team membership or the embed key
+# ADR-0053: Starting a chat session requires team membership or the embed key
 
 <span class="adr-status adr-status-accepted">ACCEPTED</span>
 

--- a/docs/adr/0053-chat-session-start-requires-membership-or-embed-key.md
+++ b/docs/adr/0053-chat-session-start-requires-membership-or-embed-key.md
@@ -18,20 +18,22 @@ The two credentials then collide. DRF stops at the first authenticator that matc
 
 We will treat being logged in as identity, not as access to every chatbot.
 
-- A session-authenticated caller may start a session only if they belong to the chatbot's team **or** the request carries that chatbot's widget embed key, validated against the channel's `allowed_domains` exactly as `WidgetDomainPermission` validates it. Anonymous callers are unaffected.
-- Selecting a chatbot version stays a team-member capability; an embed key does not grant it.
+- A session-authenticated caller may start a session only if they belong to the chatbot's team **or** the request carries that chatbot's widget embed key, validated against the channel's `allowed_domains` exactly as `WidgetDomainPermission` validates it.
+- **This binds session-authenticated callers only. Anonymous callers are not required to present an embed key.** A request carrying no credentials at all may still start a session on any chatbot whose `public_id` it knows, exactly as before this ADR. What is being withdrawn is a privilege the Django session cookie was granting on its own — nothing is being added to the anonymous path, which stays governed by the channel's widget auth level (ADR-0045) and the permission classes.
+- Selecting a chatbot version stays a team-member capability; an embed key does not grant it. An anonymous caller may not select one either, which predates this ADR.
 - The embed key authorizes without changing identity: the caller stays the authenticated user, so the participant remains user-linked and session state is still recorded.
 - A widget's own channel owns the session whenever that widget's embed key accompanies the request, whether the key authenticated it or merely rode along. Attribution tracks the widget, not the authenticator.
 - `ChatWidgetConfig` derives the embed key from its configured `chatbot_id` rather than storing one; site config cannot name a chatbot that has no embedded widget channel.
 
 ## Consequences
 
-- A leaked `public_id` no longer lets an arbitrary logged-in user consume another team's chatbot.
+- A leaked `public_id` no longer lets an arbitrary *logged-in* user consume another team's chatbot. It does not turn `public_id` into a secret: the same request without a session cookie is still accepted, so this raises the bar against accidental and in-browser misuse, not against a determined caller.
+- The anonymous-without-a-key path stays open for now because widgets older than 0.5.1 predate the embed key and cannot send one (`EMBED_KEY_INTRODUCED` in `apps/channels/widget_versions.py`). Closing it is queued behind the deprecation schedule in that module: the current entry deprecates everything below 0.6.0 with a sunset of 1 October 2026, past which no supported widget lacks a key. Those `sunset_at` dates are RFC 8594 declarations of intent rather than enforcement, so dropping the path will be its own change — gated on that date and on the ADR-0045 ratchet having moved live channels off `NONE`.
 - The site help widget is no longer a special case: it is an embedded widget that authorizes like any other, so widget version telemetry and the ADR-0045 auth-level ratchet finally see it, and its sessions inherit that channel's ADR-0044 policy.
 - Attribution follows the widget rather than the viewer, so a support-team member and an ordinary user on the same page produce one channel and one participant identity, not two.
 - Help-widget participants move from `platform=api` to `platform=embedded_widget`. Because `Participant` is keyed on `(team, platform, identifier)`, existing users get a second participant record and their prior conversations stay under the old one.
 - The support bot's widget channel must list the OCS host in `allowed_domains` in every environment, or the help widget cannot start a session. The admin configuration form refuses a chatbot without a widget channel, but cannot check the domain.
-- Any future same-origin embed of an OCS chatbot must carry its embed key; a session cookie alone is no longer enough.
+- Any future same-origin embed of an OCS chatbot must carry its embed key *if it leans on the viewer's session cookie*; that cookie alone is no longer enough.
 
 ## Alternatives considered
 
@@ -40,3 +42,4 @@ We will treat being logged in as identity, not as access to every chatbot.
 - **Accept the key as authorization but keep sessions on the team API channel** — rejected: attribution would depend on which credential happened to be consulted, and the site widget would stay invisible to widget telemetry.
 - **Switch to the widget channel only when the key was needed** — rejected: membership short-circuits the authorization check, so staff and non-staff on the same page would land on different channels and different participants.
 - **Restrict the start endpoint to team members outright** — rejected: it breaks the site help widget with no replacement, and the embed key is the proof external embedders already present.
+- **Require the embed key from anonymous callers in the same change** — deferred, not rejected: widgets below 0.5.1 have no key to send, so it would have broken every such embed on deploy. It becomes available once the 0.6.0 sunset above has passed, and is the natural follow-up to this ADR.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -71,3 +71,4 @@ Where {lowercase-status} is one of: draft, proposed, accepted, rejected, superse
 | [0049](0049-node-rows-own-pipeline-layout.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Node rows own pipeline layout; `Pipeline.data` keeps only edges |
 | [0050](0050-eval-driven-generation-is-evaluation-spend.md) | <span class="adr-status adr-status-proposed">PROPOSED</span> | Eval-driven generation is evaluation spend, billed without a trace |
 | [0051](0051-usage-activity-metric-definitions.md) | <span class="adr-status adr-status-proposed">PROPOSED</span> | One set of activity-metric definitions across usage surfaces |
+| [0052](0052-chat-session-start-requires-membership-or-embed-key.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Starting a chat session requires team membership or the embed key |

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -71,4 +71,4 @@ Where {lowercase-status} is one of: draft, proposed, accepted, rejected, superse
 | [0049](0049-node-rows-own-pipeline-layout.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Node rows own pipeline layout; `Pipeline.data` keeps only edges |
 | [0050](0050-eval-driven-generation-is-evaluation-spend.md) | <span class="adr-status adr-status-proposed">PROPOSED</span> | Eval-driven generation is evaluation spend, billed without a trace |
 | [0051](0051-usage-activity-metric-definitions.md) | <span class="adr-status adr-status-proposed">PROPOSED</span> | One set of activity-metric definitions across usage surfaces |
-| [0052](0052-chat-session-start-requires-membership-or-embed-key.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Starting a chat session requires team membership or the embed key |
+| [0053](0053-chat-session-start-requires-membership-or-embed-key.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Starting a chat session requires team membership or the embed key |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,7 +127,7 @@ nav:
       - 0049 Node rows own pipeline layout; Pipeline.data keeps only edges and viewport: adr/0049-node-rows-own-pipeline-layout.md
       - 0050 Eval-driven generation is evaluation spend: adr/0050-eval-driven-generation-is-evaluation-spend.md
       - 0051 One set of activity-metric definitions across usage surfaces: adr/0051-usage-activity-metric-definitions.md
-      - 0052 Starting a chat session requires team membership or the embed key: adr/0052-chat-session-start-requires-membership-or-embed-key.md
+      - 0053 Starting a chat session requires team membership or the embed key: adr/0053-chat-session-start-requires-membership-or-embed-key.md
   - Developer Guides:
     - Processes:
       - Claude Code Agents: developer_guides/claude_code_agent.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - 0049 Node rows own pipeline layout; Pipeline.data keeps only edges and viewport: adr/0049-node-rows-own-pipeline-layout.md
       - 0050 Eval-driven generation is evaluation spend: adr/0050-eval-driven-generation-is-evaluation-spend.md
       - 0051 One set of activity-metric definitions across usage surfaces: adr/0051-usage-activity-metric-definitions.md
+      - 0052 Starting a chat session requires team membership or the embed key: adr/0052-chat-session-start-requires-membership-or-embed-key.md
   - Developer Guides:
     - Processes:
       - Claude Code Agents: developer_guides/claude_code_agent.md


### PR DESCRIPTION
### Product Description

Being logged in to OCS is no longer, on its own, access to every chatbot. `chat_start_session` now requires that a session-authenticated caller either belongs to the chatbot's team or presents that chatbot's widget embed key.

### Technical Description

ADR-0039 put proof-of-possession on the four session endpoints but left the start endpoint alone, where a bare session cookie was sufficient — and `public_id`s ship in every embed snippet. Full reasoning and rejected alternatives in [ADR-0053](docs/adr/0053-chat-session-start-requires-membership-or-embed-key.md).

The interesting part is the credential collision. DRF stops at the first matching authenticator and `SessionAuthentication` precedes `EmbeddedWidgetAuthentication`, so the site help widget's cookie always wins and `request.auth` is never the channel. The embed key therefore has to be consulted explicitly rather than inferred from `request.auth` — `embed_key_authorizes_channel` exists for that, and is called from both the view and `SessionAccessPermission`. The permission-class caller matters: since the widget channel now owns the session, its `required_auth_level` decides whether a session token is issued, so an `EMBED_KEY`-level channel would otherwise hand out a `201` and then 403 every follow-up poll.

Worth knowing beyond the diff:

- **Deploy prerequisite.** The support bot's widget channel must list the OCS host in `allowed_domains` in every environment, or the help widget cannot start a session at all. The admin form refuses a chatbot with no widget channel but cannot check the domain.
- **Help-widget participants move from `platform=api` to `platform=embedded_widget`.** `Participant` is keyed on `(team, platform, identifier)`, so existing help-widget users get a second participant record and their prior conversations stay under the old one.
- **Deleting a widget channel now revokes its embed key.** `session.experiment_channel` is a FK traversal, so it hands back soft-deleted channels that the default manager filters out, and the ride-along path was honouring them. A holder of the revoked key kept access to every session that channel already owned.
- **Anonymous + `version_number` + an unknown `chatbot_id` now returns 404 rather than 403.** The "only authenticated users may select a version" gate moved into the authorization helper, which runs after the chatbot lookup, so the whole rule lives in one place (matching `chat_send_message`). Known chatbots are unaffected.

Scope, so it reads as no more than it is: the gate binds cookie-bearing callers only. An anonymous request with a known `public_id` and no embed key still gets a `201` — widgets below 0.5.1 have no key to send. ADR-0053 now states that explicitly and points at the 0.6.0 sunset (1 Oct 2026) in `apps/channels/widget_versions.py` that unblocks closing it. In-OCS embeds running on cookie + team membership (`single_chatbot_home.html`) keep working without a key, and the `session-token` embeds never reach this endpoint at all.

Also note the ADR is numbered 0053 — main took 0051 and 0052 while this branch was open.

### Migrations

None.

### Docs and Changelog
- [x] This PR requires docs/changelog update

Changelog angle: `chat_start_session` tightened — a logged-in caller now needs team membership or the chatbot's embed key. Anonymous callers are unaffected. Separately, deleting a chatbot's embedded-widget channel now revokes that embed key for sessions the channel already owns.
