### PR TITLE
Show record counts on tables

### DIFF
--- a/apps/generics/tests/test_table_templates.py
+++ b/apps/generics/tests/test_table_templates.py
@@ -1,0 +1,53 @@
+import django_tables2 as tables
+from django.template import Context
+from django.template.loader import get_template
+from django.test import RequestFactory
+from django_tables2 import RequestConfig
+from django_tables2.paginators import LazyPaginator
+
+
+class NameTable(tables.Table):
+    name = tables.Column()
+
+
+def _render_table(names, *, per_page=20, lazy_pagination=False):
+    request = RequestFactory().get("/")
+    table = NameTable([{"name": name} for name in names])
+    paginate = {"per_page": per_page}
+    if lazy_pagination:
+        paginate["paginator_class"] = LazyPaginator
+    RequestConfig(request, paginate=paginate).configure(table)
+    template = get_template("table/tailwind_js_pagination.html").template
+    return template.render(Context({"table": table, "lazy_pagination": lazy_pagination, "request": request}))
+
+
+def test_single_page_table_shows_record_count():
+    rendered = _render_table(["one", "two", "three"])
+
+    assert "3 records" in rendered
+
+
+def test_record_count_uses_singular_label():
+    rendered = _render_table(["one"])
+
+    assert "1 record" in rendered
+    assert "1 records" not in rendered
+
+
+def test_empty_table_shows_zero_records():
+    rendered = _render_table([])
+
+    assert "0 records" in rendered
+
+
+def test_multi_page_table_shows_total_record_count():
+    rendered = _render_table(["one", "two", "three"], per_page=2)
+
+    assert "3 records" in rendered
+
+
+def test_lazy_pagination_does_not_request_total_count():
+    rendered = _render_table(["one", "two", "three"], per_page=2, lazy_pagination=True)
+
+    assert "3 records" not in rendered
+    assert "Page 1" in rendered

--- a/templates/table/tailwind.html
+++ b/templates/table/tailwind.html
@@ -7,9 +7,20 @@
         {% endblock table %}
 
         {% block pagination %}
-            <div class="flex pagination justify-end">
+            <div class="flex pagination items-center">
+                {% if table.paginator and not lazy_pagination %}
+                    {% with total=table.paginator.count %}
+                        <span class="text-sm text-neutral-500">
+                            {% blocktranslate count total=total %}
+                                {{ total }} record
+                            {% plural %}
+                                {{ total }} records
+                            {% endblocktranslate %}
+                        </span>
+                    {% endwith %}
+                {% endif %}
                 {% if table.page and table.paginator.num_pages > 1 %}
-                    <div class="join">
+                    <div class="join ml-auto">
                         <a class="join-item btn"
                            {% if table.page.has_previous %}
                                {% block prev-page-link-attr %}


### PR DESCRIPTION
### Product Description

Standard table pages now show the total number of matching records below the table. The count remains visible for empty and single-page results, uses singular/plural labels, and updates with applied filters.

### Technical Description

The shared django-tables2 Tailwind footer now renders the normal paginator's exact count. Lazy-paginated tables keep their existing behavior and do not request an expensive exact count.

Template tests cover zero, singular, single-page, multi-page, and lazy-paginator behavior.

Local verification:

- `uv run ruff check`
- `uv run ty check`
- `uv run prek run --files templates/table/tailwind.html apps/generics/tests/test_table_templates.py`
- `uv lock --check`
- `uv run pytest apps/generics/tests apps/chatbots/tests/test_chatbot_views.py -q` — 37 passed
- `pnpm test` — 18 passed
- `pnpm type-check`
- `pnpm build` on Node 24
- Browser smoke: the All Sessions table showed 5 records; filtering to Customer Support Bot showed two rows and 2 records, with no browser console errors.

### Demo

1. Open a standard table such as **All Sessions**.
2. Confirm the footer shows the total record count.
3. Apply a table filter and confirm the footer updates to the number of matching rows.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Closes #4186
