### PR TITLE
Expire chat session tokens on absolute age

### DIFF
--- a/apps/api/session_tokens.py
+++ b/apps/api/session_tokens.py
@@ -30,11 +30,10 @@ def validate_session_token(token: str, session_external_id: str) -> bool:
 
 
 def session_token_expired(session: ExperimentSession) -> bool:
-    """Sliding inactivity backstop: reject token access to long-inactive sessions.
+    """A session's token stops working a fixed time after the session was created.
 
-    Activity is the session's `last_activity_at` (updated on each user message;
-    polling does not count, so a leaked token cannot keep a session alive),
-    falling back to session creation when there has been no activity yet.
+    The lifetime is absolute: activity does not extend it, so an admitted caller's
+    access is bounded no matter how much they talk. Once it fires the caller must
+    start a new session and be re-admitted under whatever rules apply then.
     """
-    last_activity = session.last_activity_at or session.created_at
-    return timezone.now() - last_activity > settings.CHAT_SESSION_TOKEN_INACTIVITY_WINDOW
+    return timezone.now() - session.created_at > settings.CHAT_SESSION_TOKEN_LIFETIME

--- a/apps/api/tests/test_chat_session_token.py
+++ b/apps/api/tests/test_chat_session_token.py
@@ -9,6 +9,7 @@ from rest_framework.test import APIClient
 
 from apps.api.session_tokens import issue_session_token
 from apps.channels.models import ChannelPlatform
+from apps.chat.models import ChatMessage, ChatMessageType
 from apps.experiments.models import ExperimentSession
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentSessionFactory
@@ -64,8 +65,17 @@ def test_token_for_other_session_denied(api_client, session):
 
 
 @pytest.mark.django_db()
-def test_inactive_session_expired(api_client, session, token):
-    with time_machine.travel(timezone.now() + timedelta(days=7, hours=1)):
+def test_dormant_session_within_lifetime_allowed(api_client, session, token):
+    with time_machine.travel(timezone.now() + timedelta(days=6)):
+        assert api_client.get(poll_url(session), HTTP_X_SESSION_TOKEN=token).status_code == 200
+
+
+@pytest.mark.django_db()
+def test_session_expired_past_lifetime(api_client, session, token):
+    """Chatting does not extend the lifetime: an old session expires however active it is."""
+    with time_machine.travel(timezone.now() + timedelta(days=7, hours=1)) as traveller:
+        ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN, content="hi")
+        traveller.shift(timedelta(minutes=1))
         response = api_client.get(poll_url(session), HTTP_X_SESSION_TOKEN=token)
     assert response.status_code == 403
     assert response.json()["code"] == "session_expired"
@@ -180,6 +190,20 @@ def test_start_session_issues_token_by_default(api_client, experiment):
 
 
 @pytest.mark.django_db()
+def test_expired_session_can_start_a_new_one(api_client, experiment, session, token):
+    """Once the lifetime fires the caller goes back through chat/start/ and is re-admitted."""
+    with time_machine.travel(timezone.now() + timedelta(days=7, hours=1)):
+        assert api_client.get(poll_url(session), HTTP_X_SESSION_TOKEN=token).status_code == 403
+
+        response = start_session(api_client, experiment)
+        assert response.status_code == 201
+        body = response.json()
+        assert body["session_id"] != str(session.external_id)
+        new_url = reverse("api:chat:poll-response", kwargs={"session_id": body["session_id"]})
+        assert api_client.get(new_url, HTTP_X_SESSION_TOKEN=body["session_token"]).status_code == 200
+
+
+@pytest.mark.django_db()
 def test_authenticated_start_then_poll_without_token(api_client, experiment, team_with_users):
     """Authenticated users rely on the auth bypass, not the returned token."""
     user = team_with_users.members.first()
@@ -190,3 +214,18 @@ def test_authenticated_start_then_poll_without_token(api_client, experiment, tea
     assert body["session_token"]  # token still issued
     url = reverse("api:chat:poll-response", kwargs={"session_id": body["session_id"]})
     assert api_client.get(url).status_code == 200  # no token header needed
+
+
+@pytest.mark.django_db()
+def test_participant_user_bypass_outlives_the_lifetime(api_client, experiment, team_with_users):
+    """The lifetime bounds token holders, not the session's own user.
+
+    "Continue Chat" and the logged-in chat page re-mint a token for an arbitrarily old session;
+    they keep working because the participant-user bypass runs before the expiry check.
+    """
+    user = team_with_users.members.first()
+    api_client.force_login(user)
+    body = start_session(api_client, experiment, {"participant_remote_id": user.email}).json()
+    url = reverse("api:chat:poll-response", kwargs={"session_id": body["session_id"]})
+    with time_machine.travel(timezone.now() + timedelta(days=7, hours=1)):
+        assert api_client.get(url, HTTP_X_SESSION_TOKEN=body["session_token"]).status_code == 200

--- a/apps/api/tests/test_session_tokens.py
+++ b/apps/api/tests/test_session_tokens.py
@@ -60,28 +60,38 @@ def test_wrong_salt_rejected():
 
 
 @pytest.mark.django_db()
-def test_session_not_expired_with_recent_activity():
+def test_dormant_session_within_lifetime_not_expired():
+    """Dormancy alone no longer expires anything — only age does."""
     session = ExperimentSessionFactory.create()
-    # The post_save signal on a human message updates last_activity_at on the DB row.
-    ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN, content="hi")
-    session.refresh_from_db()
-    assert session.last_activity_at is not None
-    assert session_token_expired(session) is False
+    assert session.last_activity_at is None
+    with time_machine.travel(timezone.now() + timedelta(days=6)):
+        assert session_token_expired(session) is False
 
 
 @pytest.mark.django_db()
-def test_session_expired_after_inactivity_window():
+def test_session_expired_after_lifetime_despite_recent_activity():
+    """The regression this exists to catch: chatting must not slide the window."""
     session = ExperimentSessionFactory.create()
-    ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN, content="hi")
-    session.refresh_from_db()
+    with time_machine.travel(timezone.now() + timedelta(days=7, hours=1)) as traveller:
+        # The post_save signal on a human message updates last_activity_at on the DB row.
+        ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN, content="hi")
+        session.refresh_from_db()
+        assert session.last_activity_at is not None
+        traveller.shift(timedelta(minutes=1))
+        assert session_token_expired(session) is True
+
+
+@pytest.mark.django_db()
+def test_session_expired_once_older_than_lifetime():
+    session = ExperimentSessionFactory.create()
+    assert session_token_expired(session) is False
     with time_machine.travel(timezone.now() + timedelta(days=7, hours=1)):
         assert session_token_expired(session) is True
 
 
 @pytest.mark.django_db()
-def test_session_with_no_activity_uses_created_at():
+def test_lifetime_setting_drives_expiry(settings):
     session = ExperimentSessionFactory.create()
-    assert session.last_activity_at is None
-    assert session_token_expired(session) is False
-    with time_machine.travel(timezone.now() + timedelta(days=7, hours=1)):
+    settings.CHAT_SESSION_TOKEN_LIFETIME = timedelta(hours=4)
+    with time_machine.travel(timezone.now() + timedelta(hours=5)):
         assert session_token_expired(session) is True

--- a/config/settings.py
+++ b/config/settings.py
@@ -968,8 +968,9 @@ MAX_SUMMARY_LENGTH = 1024
 MAX_FILES_PER_COLLECTION = 1000
 MAX_FILE_SIZE_MB = 50
 
-# How long after the last message a chat session token remains usable.
-CHAT_SESSION_TOKEN_INACTIVITY_WINDOW = timedelta(days=7)
+# How long after a chat session was created its token remains usable. Absolute:
+# activity does not extend it.
+CHAT_SESSION_TOKEN_LIFETIME = timedelta(days=7)
 EMBEDDING_VECTOR_SIZE = 1024
 SUPPORTED_FILE_TYPES = {
     "file_search": (

--- a/docs/adr/0040-stateless-signed-session-tokens-with-inactivity-expiry.md
+++ b/docs/adr/0040-stateless-signed-session-tokens-with-inactivity-expiry.md
@@ -1,10 +1,12 @@
 # ADR-0040: Stateless signed session tokens with server-side inactivity expiry
 
-<span class="adr-status adr-status-accepted">ACCEPTED</span>
+<span class="adr-status adr-status-superseded">SUPERSEDED</span>
 
 <p class="adr-meta">Author: Simon Kelly · Created: 2026-06-09</p>
 
 <p class="adr-meta">Extends: <a href="0039-require-proof-of-possession-for-chat-session-access.md">ADR-0039</a></p>
+
+<p class="adr-meta">Superseded by: <a href="0054-chat-session-tokens-expire-on-absolute-age.md">ADR-0054</a> — the inactivity window is replaced by an absolute lifetime; the stateless signed token below still stands.</p>
 
 ## Context
 

--- a/docs/adr/0054-chat-session-tokens-expire-on-absolute-age.md
+++ b/docs/adr/0054-chat-session-tokens-expire-on-absolute-age.md
@@ -1,0 +1,39 @@
+# ADR-0054: Chat session tokens expire on absolute age, not inactivity
+
+<span class="adr-status adr-status-accepted">ACCEPTED</span>
+
+<p class="adr-meta">Author: Simon Kelly · Created: 2026-08-14</p>
+
+<p class="adr-meta">Supersedes: <a href="0040-stateless-signed-session-tokens-with-inactivity-expiry.md">ADR-0040</a> (its expiry rule; the stateless signed token stands)</p>
+
+## Context
+
+ADR-0039 decides admission once, at session creation. ADR-0040 then expired a session's token on dormancy: a sliding window measured from `last_activity_at`, which advances on every user message. Polling deliberately did not advance it, so a leaked token could not keep a session alive without talking — but a caller who keeps chatting slides the window forever.
+
+The abuse budget of one admitted caller is its rate limit (ADR-0052, a per-session bucket) times its session lifetime. The second factor was unbounded, which made the first one moot: one admission bought chatbot usage at the throttle's rate, indefinitely.
+
+## Decision
+
+We will expire a session's token on **age**. It stops working `CHAT_SESSION_TOKEN_LIFETIME` (default 7 days) after the session was created; activity does not extend it, and `last_activity_at` is no longer read for expiry at all.
+
+This replaces the inactivity window rather than joining it. Since `last_activity_at` is never earlier than `created_at`, any lifetime at or below the old window makes the dormancy branch unreachable. The two only compose when the lifetime is the longer of the two, which nothing wants today.
+
+The lifetime is therefore mandatory. With the window gone, a session without one would have no expiry at all — the outcome ADR-0039 exists to prevent — so there is no "off".
+
+The token mechanism from ADR-0040 is unchanged: a signature check plus a session-ID match, nothing stored, no expiry encoded in the token.
+
+## Consequences
+
+- 7 days is deliberately the old number, and the new rule fires no later than the old one for any session, so no session's life is extended.
+- Sessions currently kept alive past a week by activity now end. An *unbound* widget's existing `session_expired` recovery starts a new conversation, so history stays on the old session and the participant stops seeing it.
+- A *bound* widget — one handed a `session-id` and `session-token` by its host page, which is how the full-page and kiosk chat render — cannot restart a session it does not own. It surfaces "This chat session is no longer available" and the participant has to re-enter through the chatbot's start URL. Under the inactivity window this only befell an already-abandoned session; now a conversation still in daily use dies on its seventh day. Giving those pages a "start a new chat" affordance is the follow-up this decision owes them.
+- Admission becomes recurring rather than one-shot — an expired caller goes back through session start and is re-admitted under whatever rules apply then, which is what makes a short-lived admission credential mean anything.
+- One global value serves every channel, so a channel facing abuse cannot yet tighten below it; 7 days is a floor, not a defence.
+- ADR-0040's care that polling must not advance `last_activity_at` stops mattering for access; the field still orders sessions in the UI.
+
+## Alternatives considered
+
+- **An absolute cap beside the inactivity window** — rejected: the window is unreachable at any lifetime at or below it, and dead code that reads as live policy is worse than no policy.
+- **Per-channel `session_token_lifetime` override** — deferred, not rejected: it is the lever an abuse-facing channel actually needs (hours, not days), and slots in as a nullable field falling back to the global.
+- **Per-session message budget** — rejected: redundant once the lifetime bounds rate × time, and it needs a counter where the lifetime needs nothing.
+- **Per-request credential re-checks on session-bound endpoints** — rejected: a much larger change to ADR-0039's model for a small gain over this.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -61,7 +61,7 @@ Where {lowercase-status} is one of: draft, proposed, accepted, rejected, superse
 | [0037](0037-row-multiplying-filters-use-exists-not-distinct.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Row-multiplying list filters use EXISTS, not a blanket DISTINCT |
 | [0038](0038-redirect-version-snapshot-urls-to-working-version.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Redirect version snapshot URLs to the working version |
 | [0039](0039-require-proof-of-possession-for-chat-session-access.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Require proof of possession for chat session access |
-| [0040](0040-stateless-signed-session-tokens-with-inactivity-expiry.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Stateless signed session tokens with server-side inactivity expiry |
+| [0040](0040-stateless-signed-session-tokens-with-inactivity-expiry.md) | <span class="adr-status adr-status-superseded">SUPERSEDED</span> | Stateless signed session tokens with server-side inactivity expiry |
 | [0041](0041-fail-closed-session-token-enforcement-rollout.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Fail-closed session-token enforcement rollout |
 | [0042](0042-settings-driven-internal-team-metadata.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Settings-driven internal team metadata in a JSON field |
 | [0043](0043-whatsapp-bsuid-participant-identity.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | BSUID participant identity for WhatsApp |
@@ -75,3 +75,4 @@ Where {lowercase-status} is one of: draft, proposed, accepted, rejected, superse
 | [0051](0051-usage-activity-metric-definitions.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | One set of activity-metric definitions across usage surfaces |
 | [0052](0052-app-layer-rate-limiting-mechanism.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | App-layer rate limiting via an in-house fixed-window core |
 | [0053](0053-chat-session-start-requires-membership-or-embed-key.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Starting a chat session requires team membership or the embed key |
+| [0054](0054-chat-session-tokens-expire-on-absolute-age.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Chat session tokens expire on absolute age, not inactivity |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
       - 0051 One set of activity-metric definitions across usage surfaces: adr/0051-usage-activity-metric-definitions.md
       - 0052 App-layer rate limiting: adr/0052-app-layer-rate-limiting-mechanism.md
       - 0053 Starting a chat session requires team membership or the embed key: adr/0053-chat-session-start-requires-membership-or-embed-key.md
+      - 0054 Chat session tokens expire on absolute age, not inactivity: adr/0054-chat-session-tokens-expire-on-absolute-age.md
   - Developer Guides:
     - Processes:
       - Claude GitHub Automation: developer_guides/claude_github_automation.md


### PR DESCRIPTION
Part of #4199 — the global setting only; the per-channel `session_token_lifetime` override, its migration and its form field are left for a follow-up (ADR-0054 records it as deferred, not rejected).

A session's token expired on dormancy, measured from `last_activity_at`, which every user message advanced. Admission is decided once at session creation (ADR-0039), so a caller who kept chatting held an admitted session forever — rate limit × unbounded lifetime. It now expires 7 days after `created_at`, and activity doesn't extend it.

Replacing rather than adding: since `last_activity_at >= created_at`, any lifetime at or below the old window makes the dormancy branch unreachable, so keeping both would have left dead code reading as live policy.

7 days is deliberately today's number — the new rule fires no later than the old one for any session, so nothing's access is extended.

### Worth review attention

**Bound widgets dead-end.** The `session_expired` recovery path starts a new conversation only for *unbound* widgets. A widget handed a `session-id` + `session-token` by its host page — how `web_chat.html` renders the full-page and kiosk chat — refuses to restart a session it doesn't own and shows "This chat session is no longer available". So an anonymous participant on a public chatbot page whose conversation is still in daily use hits a wall on day 7 with no restart affordance on that page. Previously that only befell already-abandoned sessions. Adding the affordance is the follow-up ADR-0054 names; shipping without it is the call to make here.

"Continue Chat" and the logged-in chat page are unaffected — both go through the participant-user bypass, which runs before the expiry check. `test_participant_user_bypass_outlives_the_lifetime` pins that, since this diff makes the bypass load-bearing.

**Announcement.** Sessions currently riding the sliding window past a week end at their next request. Small population, not empty.

### Migrations

None.

### Docs and Changelog
- [x] This PR requires docs/changelog update

The user-visible change is that a conversation now ends a week after it started rather than a week after it went quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
