### PR TITLE
Feat: Adds caching for chatbot usage

### DIFF
--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -1,6 +1,5 @@
 import unicodedata
 import uuid
-from datetime import timedelta
 from functools import cached_property
 
 from django.contrib import messages
@@ -14,7 +13,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.urls import reverse
-from django.utils import timezone
 from django.views.decorators.http import require_GET, require_POST
 from django.views.generic import CreateView, FormView, TemplateView
 from django_htmx.http import HttpResponseClientRedirect
@@ -30,7 +28,7 @@ from apps.chatbots.forms import ChatbotForm, ChatbotSettingsForm, CopyChatbotFor
 from apps.chatbots.tables import ChatbotSessionsTable, ChatbotTable
 from apps.chatbots.tasks import send_bot_message
 from apps.chatbots.version_resolver import resolve_published_or_working
-from apps.cost_tracking.services.reporting import chatbot_usage_summary
+from apps.cost_tracking.services.reporting import get_latest_chatbot_usage_summary
 from apps.events.models import EventLogStatusChoices, StaticTrigger, StaticTriggerType, TimeoutTrigger
 from apps.events.tables import EventsTable
 from apps.experiments.decorators import experiment_session_view, verify_session_access_cookie
@@ -71,7 +69,6 @@ from apps.web.dynamic_filters.datastructures import FilterParams
 from apps.web.waf import WafRule, waf_allow
 
 COST_TRACKING_FLAG = "flag_ai_cost_monitoring"
-USAGE_WIDGET_WINDOW_DAYS = 30
 
 
 def _get_alpine_context(request, experiment=None):
@@ -323,9 +320,7 @@ def single_chatbot_home(request, team_slug: str, experiment_id: int):
     cost_tracking_enabled = flag_is_active(request, COST_TRACKING_FLAG)
     usage_summary = None
     if cost_tracking_enabled:
-        end = timezone.now()
-        start = end - timedelta(days=USAGE_WIDGET_WINDOW_DAYS)
-        usage_summary = chatbot_usage_summary(experiment, start=start, end=end)
+        usage_summary = get_latest_chatbot_usage_summary(request.team, experiment.id)
 
     context = {
         "active_tab": "chatbots",

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -15,7 +15,7 @@ from django.db.models.functions import Coalesce, TruncDate, TruncMonth, TruncWee
 from django.utils import timezone
 
 from apps.cost_tracking.models import Confidence, ServiceKind, UsageRecord, UsageSource
-from apps.experiments.models import Experiment, ExperimentSession
+from apps.experiments.models import ExperimentSession
 from apps.teams.models import Team
 from apps.trace.models import Trace
 from apps.usage_metrics.dashboard_querysets import filtered_querysets
@@ -398,14 +398,18 @@ class ChatbotUsageSummary:
     messages_count: int
 
 
-def chatbot_usage_summary(experiment: Experiment, *, start: datetime, end: datetime) -> ChatbotUsageSummary:
+def chatbot_usage_summary(team: Team, experiment_id: int, *, start: datetime, end: datetime) -> ChatbotUsageSummary:
     """Cost, session count and message count for one chatbot in [start, end), for the chatbot home
     page's usage widget. Session/message counts come from `filtered_querysets` - the same canonical,
     ADR-0051 activity definitions the dashboard's Bot Performance table uses - narrowed to this
     experiment, rather than re-deriving the session base here.
+
+    Takes `team` and `experiment_id` rather than an `Experiment` object - the query below only ever
+    needs those two, and requiring the row would force `get_latest_chatbot_usage_summary` to fetch it
+    even on a cache hit, defeating a chunk of the point of caching this at all.
     """
-    cost = cost_summary(experiment.team, start=start, end=end, filters=CostFilters(experiment_ids=[experiment.id]))
-    querysets = filtered_querysets(experiment.team, start_date=start, end_date=end, experiment_ids=[experiment.id])
+    cost = cost_summary(team, start=start, end=end, filters=CostFilters(experiment_ids=[experiment_id]))
+    querysets = filtered_querysets(team, start_date=start, end_date=end, experiment_ids=[experiment_id])
     sessions_count = querysets["sessions"].count()
     messages_count = conversation_messages(querysets["messages"]).count()
     return ChatbotUsageSummary(cost=cost, sessions_count=sessions_count, messages_count=messages_count)
@@ -421,8 +425,8 @@ def get_latest_chatbot_usage_summary(team: Team, experiment_id: int) -> ChatbotU
 
     This owns both the "latest N days" window and the caching, rather than leaving either to the
     view: the two are coupled (see `chatbot_usage_summary`'s docstring for why a `start`/`end`-taking
-    function can't safely own this cache), and a cache hit here needs no query at all - not even to
-    load the `Experiment` row, since the caller already has `team` and only needs to pass the id.
+    function can't safely own this cache), and a cache hit here needs no query at all, since
+    `chatbot_usage_summary` needs nothing but the `team`/`experiment_id` this function already has.
     Cached in Redis for `_CHATBOT_USAGE_SUMMARY_CACHE_TTL_SECONDS`: short enough that nobody
     watching the page during an active conversation would call the number stale, with no
     signal-based invalidation - `UsageRecord` rows are written continuously, so invalidating on
@@ -435,8 +439,7 @@ def get_latest_chatbot_usage_summary(team: Team, experiment_id: int) -> ChatbotU
 
     end = timezone.now()
     start = end - timedelta(days=_CHATBOT_USAGE_SUMMARY_WINDOW_DAYS)
-    experiment = Experiment.objects.get(id=experiment_id, team=team)
-    usage = chatbot_usage_summary(experiment, start=start, end=end)
+    usage = chatbot_usage_summary(team, experiment_id, start=start, end=end)
 
     cache.set(cache_key, usage, _CHATBOT_USAGE_SUMMARY_CACHE_TTL_SECONDS)
     return usage

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -403,13 +403,6 @@ def chatbot_usage_summary(experiment: Experiment, *, start: datetime, end: datet
     page's usage widget. Session/message counts come from `filtered_querysets` - the same canonical,
     ADR-0051 activity definitions the dashboard's Bot Performance table uses - narrowed to this
     experiment, rather than re-deriving the session base here.
-
-    Uncached and takes an arbitrary window - for a caller that wants a fixed date range. The chatbot
-    home page instead wants "the last 30 days as of now" specifically, cached for a few minutes to
-    cut its query load: see `get_latest_chatbot_usage_summary`, which owns both of those and calls
-    this function on a cache miss. Caching *this* function directly would be wrong - a cache key
-    that doesn't include `start`/`end` would silently serve one caller's window to another's, and a
-    key that does would never hit here since "now"-relative bounds differ on every call.
     """
     cost = cost_summary(experiment.team, start=start, end=end, filters=CostFilters(experiment_ids=[experiment.id]))
     querysets = filtered_querysets(experiment.team, start_date=start, end_date=end, experiment_ids=[experiment.id])

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -5,13 +5,14 @@ hit the `(team, timestamp)` / `(team, experiment, timestamp)` indexes.
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from zoneinfo import ZoneInfo
 
 from django.core.cache import cache
 from django.db.models import Count, DecimalField, F, Q, Sum
 from django.db.models.functions import Coalesce, TruncDate, TruncMonth, TruncWeek
+from django.utils import timezone
 
 from apps.cost_tracking.models import Confidence, ServiceKind, UsageRecord, UsageSource
 from apps.experiments.models import Experiment, ExperimentSession
@@ -36,10 +37,9 @@ _GRANULARITY_TRUNC = {
 # `total` is every LLM kind (so cache-write tokens land in the total but neither sub-count).
 _PROMPT_KINDS = (ServiceKind.LLM_INPUT, ServiceKind.LLM_CACHED_INPUT)
 
-# Short: this bounds staleness, not correctness (like PricingResolver's cache, but with no
-# signal-based invalidation - UsageRecord rows are written continuously, so invalidating on
-# write would defeat the cache). The chatbot home page is the only caller today; a team member
-# watching it during an active conversation will see the number settle within this window.
+# The chatbot home usage widget's rolling window and how long its cached snapshot is trusted for -
+# see `get_latest_chatbot_usage_summary`.
+_CHATBOT_USAGE_SUMMARY_WINDOW_DAYS = 30
 _CHATBOT_USAGE_SUMMARY_CACHE_TTL_SECONDS = 5 * 60
 
 
@@ -398,40 +398,54 @@ class ChatbotUsageSummary:
     messages_count: int
 
 
-def _chatbot_usage_summary_cache_key(experiment: Experiment) -> str:
-    """Keyed on (team, experiment) only, not the resolved window - the chatbot home page always
-    asks for "the last 30 days as of now", so the window changes every request and could never
-    hit a key that included it. The cached value goes stale by at most the TTL instead (same
-    approach as the dashboard's own cost cache: see `apps/dashboard/views.py::_cost_cache_key`).
-    """
-    return f"cost:chatbot_usage_summary:{experiment.team_id}:{experiment.id}"
-
-
-def chatbot_usage_summary(
-    experiment: Experiment, *, start: datetime, end: datetime, use_cache: bool = True
-) -> ChatbotUsageSummary:
+def chatbot_usage_summary(experiment: Experiment, *, start: datetime, end: datetime) -> ChatbotUsageSummary:
     """Cost, session count and message count for one chatbot in [start, end), for the chatbot home
     page's usage widget. Session/message counts come from `filtered_querysets` - the same canonical,
     ADR-0051 activity definitions the dashboard's Bot Performance table uses - narrowed to this
     experiment, rather than re-deriving the session base here.
 
-    Cached in Redis for `_CHATBOT_USAGE_SUMMARY_CACHE_TTL_SECONDS` (see that constant's docstring).
-    Pass `use_cache=False` for a guaranteed-fresh read (e.g. in tests asserting on just-written data).
+    Uncached and takes an arbitrary window - for a caller that wants a fixed date range. The chatbot
+    home page instead wants "the last 30 days as of now" specifically, cached for a few minutes to
+    cut its query load: see `get_latest_chatbot_usage_summary`, which owns both of those and calls
+    this function on a cache miss. Caching *this* function directly would be wrong - a cache key
+    that doesn't include `start`/`end` would silently serve one caller's window to another's, and a
+    key that does would never hit here since "now"-relative bounds differ on every call.
     """
-    cache_key = _chatbot_usage_summary_cache_key(experiment) if use_cache else None
-    if cache_key:
-        cached = cache.get(cache_key)
-        if cached is not None:
-            return cached
-
     cost = cost_summary(experiment.team, start=start, end=end, filters=CostFilters(experiment_ids=[experiment.id]))
     querysets = filtered_querysets(experiment.team, start_date=start, end_date=end, experiment_ids=[experiment.id])
     sessions_count = querysets["sessions"].count()
     messages_count = conversation_messages(querysets["messages"]).count()
-    usage = ChatbotUsageSummary(cost=cost, sessions_count=sessions_count, messages_count=messages_count)
+    return ChatbotUsageSummary(cost=cost, sessions_count=sessions_count, messages_count=messages_count)
 
-    if cache_key:
-        cache.set(cache_key, usage, _CHATBOT_USAGE_SUMMARY_CACHE_TTL_SECONDS)
+
+def _chatbot_usage_summary_cache_key(team_id: int, experiment_id: int) -> str:
+    return f"cost:chatbot_usage_summary:{team_id}:{experiment_id}"
+
+
+def get_latest_chatbot_usage_summary(team: Team, experiment_id: int) -> ChatbotUsageSummary:
+    """Cost, session count and message count for one chatbot over the last
+    `_CHATBOT_USAGE_SUMMARY_WINDOW_DAYS` days, for the chatbot home page's usage widget.
+
+    This owns both the "latest N days" window and the caching, rather than leaving either to the
+    view: the two are coupled (see `chatbot_usage_summary`'s docstring for why a `start`/`end`-taking
+    function can't safely own this cache), and a cache hit here needs no query at all - not even to
+    load the `Experiment` row, since the caller already has `team` and only needs to pass the id.
+    Cached in Redis for `_CHATBOT_USAGE_SUMMARY_CACHE_TTL_SECONDS`: short enough that nobody
+    watching the page during an active conversation would call the number stale, with no
+    signal-based invalidation - `UsageRecord` rows are written continuously, so invalidating on
+    write would defeat the cache (the same tradeoff `PricingResolver`'s cache makes).
+    """
+    cache_key = _chatbot_usage_summary_cache_key(team.id, experiment_id)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    end = timezone.now()
+    start = end - timedelta(days=_CHATBOT_USAGE_SUMMARY_WINDOW_DAYS)
+    experiment = Experiment.objects.get(id=experiment_id, team=team)
+    usage = chatbot_usage_summary(experiment, start=start, end=end)
+
+    cache.set(cache_key, usage, _CHATBOT_USAGE_SUMMARY_CACHE_TTL_SECONDS)
     return usage
 
 

--- a/apps/cost_tracking/services/reporting.py
+++ b/apps/cost_tracking/services/reporting.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from decimal import Decimal
 from zoneinfo import ZoneInfo
 
+from django.core.cache import cache
 from django.db.models import Count, DecimalField, F, Q, Sum
 from django.db.models.functions import Coalesce, TruncDate, TruncMonth, TruncWeek
 
@@ -34,6 +35,12 @@ _GRANULARITY_TRUNC = {
 # Token split for the usage API: `prompt` covers fresh + cached input, `completion` is output, and
 # `total` is every LLM kind (so cache-write tokens land in the total but neither sub-count).
 _PROMPT_KINDS = (ServiceKind.LLM_INPUT, ServiceKind.LLM_CACHED_INPUT)
+
+# Short: this bounds staleness, not correctness (like PricingResolver's cache, but with no
+# signal-based invalidation - UsageRecord rows are written continuously, so invalidating on
+# write would defeat the cache). The chatbot home page is the only caller today; a team member
+# watching it during an active conversation will see the number settle within this window.
+_CHATBOT_USAGE_SUMMARY_CACHE_TTL_SECONDS = 5 * 60
 
 
 @dataclass(frozen=True)
@@ -391,17 +398,41 @@ class ChatbotUsageSummary:
     messages_count: int
 
 
-def chatbot_usage_summary(experiment: Experiment, *, start: datetime, end: datetime) -> ChatbotUsageSummary:
+def _chatbot_usage_summary_cache_key(experiment: Experiment) -> str:
+    """Keyed on (team, experiment) only, not the resolved window - the chatbot home page always
+    asks for "the last 30 days as of now", so the window changes every request and could never
+    hit a key that included it. The cached value goes stale by at most the TTL instead (same
+    approach as the dashboard's own cost cache: see `apps/dashboard/views.py::_cost_cache_key`).
+    """
+    return f"cost:chatbot_usage_summary:{experiment.team_id}:{experiment.id}"
+
+
+def chatbot_usage_summary(
+    experiment: Experiment, *, start: datetime, end: datetime, use_cache: bool = True
+) -> ChatbotUsageSummary:
     """Cost, session count and message count for one chatbot in [start, end), for the chatbot home
     page's usage widget. Session/message counts come from `filtered_querysets` - the same canonical,
     ADR-0051 activity definitions the dashboard's Bot Performance table uses - narrowed to this
     experiment, rather than re-deriving the session base here.
+
+    Cached in Redis for `_CHATBOT_USAGE_SUMMARY_CACHE_TTL_SECONDS` (see that constant's docstring).
+    Pass `use_cache=False` for a guaranteed-fresh read (e.g. in tests asserting on just-written data).
     """
+    cache_key = _chatbot_usage_summary_cache_key(experiment) if use_cache else None
+    if cache_key:
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
+
     cost = cost_summary(experiment.team, start=start, end=end, filters=CostFilters(experiment_ids=[experiment.id]))
     querysets = filtered_querysets(experiment.team, start_date=start, end_date=end, experiment_ids=[experiment.id])
     sessions_count = querysets["sessions"].count()
     messages_count = conversation_messages(querysets["messages"]).count()
-    return ChatbotUsageSummary(cost=cost, sessions_count=sessions_count, messages_count=messages_count)
+    usage = ChatbotUsageSummary(cost=cost, sessions_count=sessions_count, messages_count=messages_count)
+
+    if cache_key:
+        cache.set(cache_key, usage, _CHATBOT_USAGE_SUMMARY_CACHE_TTL_SECONDS)
+    return usage
 
 
 def session_usage(session: ExperimentSession) -> SessionUsage:

--- a/apps/cost_tracking/tests/test_reporting.py
+++ b/apps/cost_tracking/tests/test_reporting.py
@@ -20,6 +20,7 @@ from apps.cost_tracking.services.reporting import (
     cost_total,
     costs_by_experiment,
     coverage_gaps,
+    get_latest_chatbot_usage_summary,
     session_usage,
     token_counts,
     trace_token_usage,
@@ -309,38 +310,56 @@ class TestChatbotUsageSummary:
         assert usage.sessions_count == 1
         assert usage.messages_count == 1
 
+
+@pytest.mark.django_db()
+class TestGetLatestChatbotUsageSummary:
+    """The chatbot home page's cached "last 30 days" read. Caching and window resolution live
+    here rather than on `chatbot_usage_summary` itself - see that function's docstring for why
+    a `start`/`end`-taking function can't safely own this cache. Correctness of the underlying
+    aggregation (scoping, exclusions, the session-window fix) is `TestChatbotUsageSummary`'s job;
+    these tests only cover what this wrapper adds: the window and the cache."""
+
+    def test_computes_last_30_days(self):
+        team = TeamFactory.create()
+        experiment = ExperimentFactory.create(team=team)
+        session = ExperimentSessionFactory.create(experiment=experiment, team=team)
+        UsageRecordFactory.create(team=team, experiment=experiment, session=session, cost=Decimal("1.50"))
+        ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN, content="hi")
+
+        usage = get_latest_chatbot_usage_summary(team, experiment.id)
+
+        assert usage.cost.total_cost == Decimal("1.50000000")
+        assert usage.sessions_count == 1
+        assert usage.messages_count == 1
+
     def test_caches_result_for_short_ttl(self):
         """A second call for the same (team, experiment) within the TTL returns the cached
-        snapshot rather than re-querying - even though new usage was written in between.
-        `end` is padded into the future so the second record would be in-window if this were
-        a fresh read - otherwise "still 1.00" could just mean the window excluded it."""
+        snapshot rather than re-querying - even though new usage was written in between."""
         team = TeamFactory.create()
         experiment = ExperimentFactory.create(team=team)
         session = ExperimentSessionFactory.create(experiment=experiment, team=team)
         UsageRecordFactory.create(team=team, experiment=experiment, session=session, cost=Decimal("1.00"))
-        start = timezone.now() - timedelta(days=30)
-        end = timezone.now() + timedelta(minutes=1)
 
-        first = chatbot_usage_summary(experiment, start=start, end=end)
+        first = get_latest_chatbot_usage_summary(team, experiment.id)
         UsageRecordFactory.create(team=team, experiment=experiment, session=session, cost=Decimal("9.00"))
-        second = chatbot_usage_summary(experiment, start=start, end=end)
+        second = get_latest_chatbot_usage_summary(team, experiment.id)
 
         assert first.cost.total_cost == Decimal("1.00000000")
         assert second.cost.total_cost == Decimal("1.00000000")
 
-    def test_use_cache_false_bypasses_cache(self):
+    def test_cache_hit_needs_no_queries(self):
+        """The whole point of keying on (team, experiment_id) rather than requiring an
+        `Experiment` object: a cache hit doesn't even load the Experiment row."""
         team = TeamFactory.create()
         experiment = ExperimentFactory.create(team=team)
         session = ExperimentSessionFactory.create(experiment=experiment, team=team)
         UsageRecordFactory.create(team=team, experiment=experiment, session=session, cost=Decimal("1.00"))
-        start = timezone.now() - timedelta(days=30)
-        end = timezone.now() + timedelta(minutes=1)
+        get_latest_chatbot_usage_summary(team, experiment.id)  # populate the cache
 
-        chatbot_usage_summary(experiment, start=start, end=end)  # populate the cache
-        UsageRecordFactory.create(team=team, experiment=experiment, session=session, cost=Decimal("9.00"))
-        fresh = chatbot_usage_summary(experiment, start=start, end=end, use_cache=False)
+        with CaptureQueriesContext(connection) as ctx:
+            get_latest_chatbot_usage_summary(team, experiment.id)
 
-        assert fresh.cost.total_cost == Decimal("10.00000000")
+        assert len(ctx.captured_queries) == 0
 
     def test_cache_keyed_per_experiment(self):
         """Two experiments in the same team don't share a cache entry."""
@@ -351,10 +370,9 @@ class TestChatbotUsageSummary:
         session_b = ExperimentSessionFactory.create(experiment=exp_b, team=team)
         UsageRecordFactory.create(team=team, experiment=exp_a, session=session_a, cost=Decimal("1.00"))
         UsageRecordFactory.create(team=team, experiment=exp_b, session=session_b, cost=Decimal("2.00"))
-        start, end = self._window()
 
-        usage_a = chatbot_usage_summary(exp_a, start=start, end=end)
-        usage_b = chatbot_usage_summary(exp_b, start=start, end=end)
+        usage_a = get_latest_chatbot_usage_summary(team, exp_a.id)
+        usage_b = get_latest_chatbot_usage_summary(team, exp_b.id)
 
         assert usage_a.cost.total_cost == Decimal("1.00000000")
         assert usage_b.cost.total_cost == Decimal("2.00000000")

--- a/apps/cost_tracking/tests/test_reporting.py
+++ b/apps/cost_tracking/tests/test_reporting.py
@@ -231,7 +231,7 @@ class TestChatbotUsageSummary:
         experiment = ExperimentFactory.create(team=team)
         start, end = self._window()
 
-        usage = chatbot_usage_summary(experiment, start=start, end=end)
+        usage = chatbot_usage_summary(team, experiment.id, start=start, end=end)
 
         assert usage.cost.total_cost == Decimal(0)
         assert usage.sessions_count == 0
@@ -247,7 +247,7 @@ class TestChatbotUsageSummary:
         ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.SYSTEM, content="sys")
         start, end = self._window()
 
-        usage = chatbot_usage_summary(experiment, start=start, end=end)
+        usage = chatbot_usage_summary(team, experiment.id, start=start, end=end)
 
         assert usage.cost.total_cost == Decimal("1.50000000")
         assert usage.sessions_count == 1
@@ -265,7 +265,7 @@ class TestChatbotUsageSummary:
         UsageRecordFactory.create(team=team, experiment=other_experiment, session=other_session, cost=Decimal("9.00"))
         start, end = self._window()
 
-        usage = chatbot_usage_summary(experiment, start=start, end=end)
+        usage = chatbot_usage_summary(team, experiment.id, start=start, end=end)
 
         assert usage.cost.total_cost == Decimal("1.00000000")
         assert usage.sessions_count == 1
@@ -286,7 +286,7 @@ class TestChatbotUsageSummary:
         ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN, content="hi")
         start, end = self._window()
 
-        usage = chatbot_usage_summary(experiment, start=start, end=end)
+        usage = chatbot_usage_summary(team, experiment.id, start=start, end=end)
 
         assert usage.sessions_count == 0
 
@@ -305,7 +305,7 @@ class TestChatbotUsageSummary:
             chat=session.chat, message_type=ChatMessageType.HUMAN, content="hi", created_at=end - timedelta(days=1)
         )
 
-        usage = chatbot_usage_summary(experiment, start=start, end=end)
+        usage = chatbot_usage_summary(team, experiment.id, start=start, end=end)
 
         assert usage.sessions_count == 1
         assert usage.messages_count == 1

--- a/apps/cost_tracking/tests/test_reporting.py
+++ b/apps/cost_tracking/tests/test_reporting.py
@@ -309,6 +309,56 @@ class TestChatbotUsageSummary:
         assert usage.sessions_count == 1
         assert usage.messages_count == 1
 
+    def test_caches_result_for_short_ttl(self):
+        """A second call for the same (team, experiment) within the TTL returns the cached
+        snapshot rather than re-querying - even though new usage was written in between.
+        `end` is padded into the future so the second record would be in-window if this were
+        a fresh read - otherwise "still 1.00" could just mean the window excluded it."""
+        team = TeamFactory.create()
+        experiment = ExperimentFactory.create(team=team)
+        session = ExperimentSessionFactory.create(experiment=experiment, team=team)
+        UsageRecordFactory.create(team=team, experiment=experiment, session=session, cost=Decimal("1.00"))
+        start = timezone.now() - timedelta(days=30)
+        end = timezone.now() + timedelta(minutes=1)
+
+        first = chatbot_usage_summary(experiment, start=start, end=end)
+        UsageRecordFactory.create(team=team, experiment=experiment, session=session, cost=Decimal("9.00"))
+        second = chatbot_usage_summary(experiment, start=start, end=end)
+
+        assert first.cost.total_cost == Decimal("1.00000000")
+        assert second.cost.total_cost == Decimal("1.00000000")
+
+    def test_use_cache_false_bypasses_cache(self):
+        team = TeamFactory.create()
+        experiment = ExperimentFactory.create(team=team)
+        session = ExperimentSessionFactory.create(experiment=experiment, team=team)
+        UsageRecordFactory.create(team=team, experiment=experiment, session=session, cost=Decimal("1.00"))
+        start = timezone.now() - timedelta(days=30)
+        end = timezone.now() + timedelta(minutes=1)
+
+        chatbot_usage_summary(experiment, start=start, end=end)  # populate the cache
+        UsageRecordFactory.create(team=team, experiment=experiment, session=session, cost=Decimal("9.00"))
+        fresh = chatbot_usage_summary(experiment, start=start, end=end, use_cache=False)
+
+        assert fresh.cost.total_cost == Decimal("10.00000000")
+
+    def test_cache_keyed_per_experiment(self):
+        """Two experiments in the same team don't share a cache entry."""
+        team = TeamFactory.create()
+        exp_a = ExperimentFactory.create(team=team)
+        exp_b = ExperimentFactory.create(team=team)
+        session_a = ExperimentSessionFactory.create(experiment=exp_a, team=team)
+        session_b = ExperimentSessionFactory.create(experiment=exp_b, team=team)
+        UsageRecordFactory.create(team=team, experiment=exp_a, session=session_a, cost=Decimal("1.00"))
+        UsageRecordFactory.create(team=team, experiment=exp_b, session=session_b, cost=Decimal("2.00"))
+        start, end = self._window()
+
+        usage_a = chatbot_usage_summary(exp_a, start=start, end=end)
+        usage_b = chatbot_usage_summary(exp_b, start=start, end=end)
+
+        assert usage_a.cost.total_cost == Decimal("1.00000000")
+        assert usage_b.cost.total_cost == Decimal("2.00000000")
+
 
 @pytest.mark.django_db()
 class TestSessionUsage:


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->

Adds short-lived caching (5 min TTL) to the chatbot home page's usage widget, reducing repeated database load when a chatbot's page is viewed multiple times in quick succession. No visible behavior change.
Spend/session/message counts may lag actual usage by up to 5 minutes. Session and trace-level usage views are unaffected (left uncached, as their queries are already cheap single-row lookups).

Follow up PR for [4179](https://github.com/dimagi/open-chat-studio/pull/4179)


### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->




### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
