### PR TITLE
Resolve pipeline node inputs by arrival order

### DIFF
--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -107,13 +107,14 @@ class PipelineState(dict):
     # List of (previous, current, next) tuples used for aiding in routing decisions.
     path: Annotated[Sequence[tuple[str | None, str, list[str]]], operator.add]
 
-    # inputs to the current node
+    # Every input delivered to the current node so far, oldest first. One entry per incoming node
+    # run that routed here, so a node on a merge accumulates an entry per branch that reaches it.
     node_inputs: list[str]
 
-    # input from the last executed node prior to this one
+    # The most recently delivered of those inputs: the current node's primary input.
     last_node_input: str
 
-    # source node for the current node
+    # The node that produced `last_node_input`.
     node_source: str
 
     intents: Annotated[list[Intents], _merge_intents]
@@ -204,23 +205,31 @@ class PipelineState(dict):
                 return [out["message"] for out in output]
         return None
 
-    def get_node_inputs(self, node_id: str, incoming_nodes: list[str]) -> dict[str, Any]:
-        """
-        Get the inputs for the given node based on the node's incoming edges.
+    def get_node_inputs(self, node_id: str, incoming_nodes: list[str]) -> list[tuple[str, Any]]:
+        """Every input delivered to ``node_id`` so far, oldest first, as ``(source_node_id, output)``.
 
-        Returns:
-            A dictionary mapping incoming node IDs to their respective outputs in the state.
-            If there is no output for an incoming edge or if that edge was not targeted,
-            the value in the output will be None.
+        An input is delivered when an incoming node runs and routes to this node, so ``path`` — one
+        entry per node run, appended in execution order — is what orders them. Ordering by arrival
+        rather than by the order the edges happen to be stored keeps a node's input independent of
+        how its graph was drawn.
+
+        An incoming node that ran more than once contributes one input per run that targeted this
+        node. A run that produced no output (a Python node that aborted via ``require_node_outputs``)
+        contributes none: it appends neither an output nor a path entry.
         """
-        inputs = {}
-        for incoming_node_id in incoming_nodes:
-            targets = [step[2] for step in self["path"] if step[1] == incoming_node_id]
-            if targets and node_id in targets[0]:
-                # only include outputs from nodes that targeted the current node
-                inputs[incoming_node_id] = self.get_node_outputs(incoming_node_id)
-            else:
-                inputs[incoming_node_id] = None
+        outputs_by_node = {source_id: self.get_node_outputs(source_id) or [] for source_id in set(incoming_nodes)}
+        runs_seen: dict[str, int] = {}
+        inputs = []
+        for _previous, source_id, targets in self["path"]:
+            if source_id not in outputs_by_node:
+                continue
+            # A node's nth path entry and its nth output are written by the same state update, so the
+            # run's own output is the one at that index.
+            run_index = runs_seen.get(source_id, 0)
+            runs_seen[source_id] = run_index + 1
+            outputs = outputs_by_node[source_id]
+            if node_id in targets and run_index < len(outputs):
+                inputs.append((source_id, outputs[run_index]))
         return inputs
 
     @classmethod
@@ -273,18 +282,11 @@ class BasePipelineNode(BaseModel, ABC):
                 Attachment.model_validate(att) for att in state.get("attachments", [])
             ]
         else:
-            for incoming_node_id, outputs in reversed(state.get_node_inputs(node_id, incoming_nodes).items()):
-                if outputs is not None:
-                    # Handle the edge case where a node is downstream of a 'join' node connected to
-                    # multiple parallel nodes. This isn't really a supported workflow, and it's hard to detect
-                    # in the pipeline during the build step.
-                    # By taking the last message, we at least get different outputs for each invocation of
-                    # the node in the case where the parallel branches are of different lengths.
-                    state["last_node_input"] = outputs[-1]
-                    state["node_inputs"] = outputs
-                    state["node_source"] = incoming_node_id
-                    break
-            else:
+            # A node on a merge runs once per branch that reaches it, so it can have several inputs by
+            # the time it runs: all of them are exposed as `node_inputs`, and the one that arrived most
+            # recently is this run's primary input.
+            inputs = state.get_node_inputs(node_id, incoming_nodes)
+            if not inputs:
                 raise PipelineNodeRunError(
                     f"Cannot determine which input to use for node {node_id}",
                     {
@@ -295,6 +297,10 @@ class BasePipelineNode(BaseModel, ABC):
                         "pipeline_path": state["path"],
                     },
                 )
+            source_node_id, last_input = inputs[-1]
+            state["last_node_input"] = last_input
+            state["node_inputs"] = [value for _source_node_id, value in inputs]
+            state["node_source"] = source_node_id
         return state
 
     @property

--- a/apps/pipelines/tests/test_parallel_nodes.py
+++ b/apps/pipelines/tests/test_parallel_nodes.py
@@ -209,13 +209,15 @@ def main(input, **kwargs):
     output_state = PipelineState(output)
     assert PipelineAccessor(output_state).get_node_output("end") == "B: A: Hi,C: Hi"
     assert isinstance(output_state["outputs"]["Code"], dict)
+    # The code node's source is B: of the two branches feeding it, B is the one that delivered last
+    # and so unblocked the merge.
     assert output_state.get_execution_flow() in [
         [
             (None, "start", ["A", "C"]),
             ("start", "C", ["Code"]),
             ("start", "A", ["B"]),
             ("A", "B", ["Code"]),
-            ("C", "Code", ["end"]),
+            ("B", "Code", ["end"]),
             ("Code", "end", []),
         ],
         [
@@ -223,7 +225,7 @@ def main(input, **kwargs):
             ("start", "A", ["B"]),
             ("start", "C", ["Code"]),
             ("A", "B", ["Code"]),
-            ("C", "Code", ["end"]),
+            ("B", "Code", ["end"]),
             ("Code", "end", []),
         ],
     ]
@@ -337,6 +339,176 @@ def test_dangling_node_abort_after(pipeline, experiment_session):
     assert "B" in output_state["outputs"]
     assert "C" in output_state["outputs"]
     assert "Code Abort" not in output_state["outputs"]
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "merge_edges",
+    [
+        pytest.param(["C - D", "B - D"], id="long-branch-edge-first"),
+        pytest.param(["B - D", "C - D"], id="short-branch-edge-first"),
+    ],
+)
+def test_merge_node_inputs_arrive_in_execution_order(pipeline, experiment_session, merge_edges):
+    """A node on an uneven merge runs once per branch that reaches it. Each run's input is the one
+    that arrived most recently, and every input that has arrived is available as `node_inputs` --
+    neither of which may depend on the order the merge edges were drawn.
+
+    start -> A -> C -> D -> end
+          -> B ------^
+    """
+    start = start_node()
+    node_a = render_template_node("A: {{ input }}", "A")
+    node_b = render_template_node("B: {{ input }}", "B")
+    node_c = render_template_node("C: {{ input }}", "C")
+    node_d = code_node(
+        code="""
+def main(input, **kwargs):
+    return f"{input} <- {kwargs['node_inputs']}"
+    """,
+        name="D",
+    )
+    end = end_node()
+    nodes = [start, node_a, node_b, node_c, node_d, end]
+    edges = ["start - A", "start - B", "A - C", *merge_edges, "D - end"]
+    output = create_runnable(pipeline, nodes, edges).invoke(
+        PipelineState(messages=["Hi"], experiment_session=experiment_session),
+        config={"configurable": {"repo": ORMRepository(session=experiment_session)}},
+    )
+    runs = [run["message"] for run in PipelineState(output)["outputs"]["D"]]
+    assert runs == [
+        "B: Hi <- ['B: Hi']",
+        "C: A: Hi <- ['B: Hi', 'C: A: Hi']",
+    ]
+
+
+@pytest.mark.django_db()
+def test_merge_node_waits_for_optional_branch(pipeline, experiment_session):
+    """Only one of the router's branches runs, so the merge node counts its inputs instead of naming
+    the nodes it is waiting for.
+
+    start -> Router -(b)-> B -> Merge -> end
+          -> A ----------------^
+             Router -(c)-> C ---^
+    """
+    start = start_node()
+    router = state_key_router_node(route_key="route", keywords=["b", "c"], name="Router")
+    node_a = render_template_node("A: {{ input }}", "A")
+    node_b = render_template_node("B: {{ input }}", "B")
+    node_c = render_template_node("C: {{ input }}", "C")
+    merge = code_node(
+        code="""
+def main(input, **kwargs):
+    all_inputs = kwargs["node_inputs"]
+    if len(all_inputs) < 2:
+        wait_for_next_input()
+    return ",".join(all_inputs)
+    """,
+        name="Merge",
+    )
+    end = end_node()
+    nodes = [start, router, node_a, node_b, node_c, merge, end]
+    edges = [
+        "start - Router",
+        "start - A",
+        "Router:0 - B",
+        "Router:1 - C",
+        "A - Merge",
+        "B - Merge",
+        "C - Merge",
+        "Merge - end",
+    ]
+    output = create_runnable(pipeline, nodes, edges).invoke(
+        PipelineState(messages=["Hi"], experiment_session=experiment_session, temp_state={"route": "b"}),
+        config={"configurable": {"repo": ORMRepository(session=experiment_session)}},
+    )
+    output_state = PipelineState(output)
+    assert PipelineAccessor(output_state).get_node_output("end") == "A: Hi,B: Hi"
+
+
+@pytest.mark.django_db()
+def test_node_downstream_of_merge_gets_merged_output(pipeline, experiment_session):
+    """A node placed after a merge node receives the merged output.
+
+    start -> A -> B -> Code -> D -> end
+          -> C --------^
+    """
+    start = start_node()
+    node_a = render_template_node("A: {{ input }}", "A")
+    node_b = render_template_node("B: {{ input }}", "B")
+    node_c = render_template_node("C: {{ input }}", "C")
+    code = code_node(
+        code="""
+def main(input, **kwargs):
+    require_node_outputs("B", "C")
+    return f"{get_node_output('B')},{get_node_output('C')}"
+    """,
+        name="Code",
+    )
+    node_d = render_template_node("D: {{ input }}", "D")
+    end = end_node()
+    nodes = [start, node_a, node_b, node_c, code, node_d, end]
+    edges = ["start - A", "start - C", "A - B", "B - Code", "C - Code", "Code - D", "D - end"]
+    output = create_runnable(pipeline, nodes, edges).invoke(
+        PipelineState(messages=["Hi"], experiment_session=experiment_session),
+        config={"configurable": {"repo": ORMRepository(session=experiment_session)}},
+    )
+    output_state = PipelineState(output)
+    assert PipelineAccessor(output_state).get_node_output("D") == "D: B: A: Hi,C: Hi"
+
+
+@pytest.mark.django_db()
+def test_merge_output_not_lost_when_a_branch_arrives_with_it(pipeline, experiment_session):
+    """The merge node and a third branch both reach D in the same step, so D runs once with both
+    inputs. Whichever one becomes `input`, neither may be dropped.
+
+    start -> P -----------> Code -> D -> end
+          -> Q1 -> Q2 -------^      ^
+          -> R1 -> R2 -> R3 --------/
+    """
+    start = start_node()
+    node_p = render_template_node("P: {{ input }}", "P")
+    q1 = render_template_node("Q1: {{ input }}", "Q1")
+    q2 = render_template_node("Q2: {{ input }}", "Q2")
+    r1 = render_template_node("R1: {{ input }}", "R1")
+    r2 = render_template_node("R2: {{ input }}", "R2")
+    r3 = render_template_node("R3: {{ input }}", "R3")
+    code = code_node(
+        code="""
+def main(input, **kwargs):
+    require_node_outputs("P", "Q2")
+    return f"merged:{get_node_output('P')}+{get_node_output('Q2')}"
+    """,
+        name="Code",
+    )
+    node_d = code_node(
+        code="""
+def main(input, **kwargs):
+    return ",".join(sorted(kwargs["node_inputs"]))
+    """,
+        name="D",
+    )
+    end = end_node()
+    nodes = [start, node_p, q1, q2, r1, r2, r3, code, node_d, end]
+    edges = [
+        "start - P",
+        "start - Q1",
+        "start - R1",
+        "P - Code",
+        "Q1 - Q2",
+        "Q2 - Code",
+        "R1 - R2",
+        "R2 - R3",
+        "Code - D",
+        "R3 - D",
+        "D - end",
+    ]
+    output = create_runnable(pipeline, nodes, edges).invoke(
+        PipelineState(messages=["Hi"], experiment_session=experiment_session),
+        config={"configurable": {"repo": ORMRepository(session=experiment_session)}},
+    )
+    output_state = PipelineState(output)
+    assert PipelineAccessor(output_state).get_node_output("D") == "R3: R2: R1: Hi,merged:P: Hi+Q2: Q1: Hi"
 
 
 def static_output(output: str, name: str):


### PR DESCRIPTION
### Product Description
When several branches merge into one node, that node now takes its input from the branch that arrived most recently, and `node_inputs` holds every input that has arrived so far.

Previously the input was chosen by the order the connections happened to be stored, so the same graph could feed a merge node a different branch depending on how it was drawn — sometimes never surfacing a branch's output at all. `node_inputs` only ever held one branch's output, so the documented "wait until I have at least N inputs" pattern never completed and the pipeline silently returned nothing.

### Technical Description
`PipelineState.get_node_inputs` now walks `state["path"]` — one entry per node run, appended in execution order — and returns every input delivered to the node as `(source_node_id, output)` pairs, oldest first. A node that ran more than once contributes one input per run that targeted this node; a run that produced no output (a Python node aborting via `require_node_outputs`) contributes none, since it appends neither an output nor a path entry.

`_prepare_state` sets `last_node_input`/`node_source` from the most recent pair and `node_inputs` from all of them.

This restores the path-order selection that `8edc8de87` replaced with `reversed(incoming_nodes)`, and gives `node_inputs` the semantics `c8c81d263` named it for.

Existing test `test_code_node_wait_for_inputs` changed expectation: the merge node's source is now `B`, the branch that delivered last and unblocked the merge, rather than an edge-order artifact.

### Migrations
None.

- [x] The migrations are backwards compatible

### Demo
On the graph from the [uneven branches docs](https://docs.openchatstudio.com/concepts/pipelines/parallel/#uneven-branches) (`start → A → C → D`, `start → B → D`):

| | before | after |
|---|---|---|
| `D` run 1 | `input=B` | `input=B`, `node_inputs=[B]` |
| `D` run 2 | `input=B` if the C→D edge was drawn first, else `input=C` | `input=C`, `node_inputs=[B, C]` — either way |
| optional-branch merge counting `node_inputs` | pipeline returns nothing | returns the merged value |

Four regression tests added to `test_parallel_nodes.py`, including one where a merge node and a branch reach the same node in the same step — that case previously discarded the merged value outright.

### Docs and Changelog
- [x] This PR requires docs/changelog update

Docs updated in a companion PR: https://github.com/dimagi/open-chat-studio-docs/pull/688 — the pages describing both merge patterns documented behaviour this code did not have.

:warning: Behaviour change for live pipelines: any node with multiple incoming connections may receive a different input than before, and `node_inputs` can now hold more entries.
