### PR TITLE
Require 2FA for staff and superusers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,10 @@ TASKBADGER_ORG=
 TASKBADGER_PROJECT=
 TASKBADGER_API_KEY=
 
+## Staff and superusers must set up 2FA before they can use the app. On unless DEBUG is set,
+## so uncomment this to exercise it in development.
+# REQUIRE_MFA_FOR_STAFF=True
+
 ## Production Email Config (Uncomment the one you are using)
 ACCOUNT_EMAIL_VERIFICATION=mandatory
 

--- a/apps/users/middleware.py
+++ b/apps/users/middleware.py
@@ -1,0 +1,124 @@
+from urllib.parse import urlparse
+
+from allauth.account.models import EmailAddress
+from allauth.mfa import app_settings as mfa_settings
+from allauth.mfa.utils import is_mfa_enabled
+from django.conf import settings
+from django.contrib import messages
+from django.http import HttpResponse, HttpResponseRedirect
+from django.urls import reverse
+from django.utils.deprecation import MiddlewareMixin
+from django.utils.translation import gettext_lazy as _
+from django_htmx.http import HttpResponseClientRedirect
+
+
+def _path_of(url: str | None) -> str:
+    return urlparse(url).path if url else ""
+
+
+class RequireMfaForStaffMiddleware(MiddlewareMixin):
+    """Confine staff and superusers without MFA to the MFA setup flow.
+
+    allauth's ``mfa`` app ships no enforcement hook, so this follows the ``BaseRequire2FAMiddleware``
+    pattern documented by django-allauth-2fa:
+    https://django-allauth-2fa.readthedocs.io/en/latest/advanced/
+
+    Only the session-authenticated web UI is gated. The API and webhook surfaces authenticate per
+    request (API key, OAuth token, platform signature) and can't act on a redirect, so a redirect
+    there would break integrations rather than prompt anyone to enrol.
+    """
+
+    MESSAGE = _("Two-factor authentication is required for staff accounts. Please set it up to continue.")
+
+    VERIFY_EMAIL_MESSAGE = _(
+        "Two-factor authentication is required for staff accounts, and it can only be set up once "
+        "your email address is verified."
+    )
+
+    ALLOWED_VIEW_NAMES = frozenset({"set_language"})
+
+    #: ``/accounts/`` is where config.urls mounts allauth (plus the OCS SSO views): the MFA setup
+    #: flow itself, login/logout, password and email management, and the social provider
+    #: login/callback URLs. All of it stays open, for two reasons. Gating any of it breaks the very
+    #: flows a user needs to enrol -- an SSO login can't complete if the provider callback is
+    #: redirected away, and the IdP's front-channel logout would leave the session alive. It also
+    #: keeps the gate loop-free: ``/accounts/login/`` bounces an authenticated user to
+    #: ``LOGIN_REDIRECT_URL``, which the gate sends back here, so any gated URL under ``/accounts/``
+    #: is a redirect cycle waiting to happen.
+    #:
+    #: The remaining prefixes are surfaces that don't use session auth (they authenticate per
+    #: request with an API key, OAuth token, or platform signature), where redirecting the caller
+    #: achieves nothing -- plus ``/__reload__/``, whose event stream the dev server's browser-reload
+    #: worker reconnects to and reloads the page over if it is ever redirected.
+    EXEMPT_PATH_PREFIXES = (
+        "/accounts/",
+        "/api/",
+        "/channels/",
+        "/anymail/",
+        "/celery-progress/",
+        "/tz_detect/",
+        "/__reload__/",
+    )
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        if not settings.REQUIRE_MFA_FOR_STAFF:
+            return None
+
+        user = getattr(request, "user", None)
+        if user is None or not user.is_authenticated:
+            return None
+
+        if not (user.is_staff or user.is_superuser):
+            return None
+
+        if is_mfa_enabled(user) or self._is_exempt(request):
+            return None
+
+        if request.htmx and self._is_exempt_path(_path_of(request.htmx.current_url)):
+            # This is a background request fired by a page the gate already lets through -- the
+            # banner poll on the setup page, say. Telling htmx to navigate would send the browser
+            # to the page it is already on, which fires the request again: an endless reload loop.
+            # 204 leaves the fragment unswapped, and unlike a 403 it doesn't log a warning per
+            # page load.
+            return HttpResponse(status=204)
+
+        target, message = self._next_step(user)
+        messages.error(request, message)
+        if request.htmx:
+            # Swapping the setup form into a fragment would strand the user, so move the whole page.
+            return HttpResponseClientRedirect(target)
+        return HttpResponseRedirect(target)
+
+    @staticmethod
+    def _next_step(user) -> tuple[str, str]:
+        """Where the user has to go to satisfy the requirement, and why.
+
+        allauth refuses to enable MFA while any of the user's email addresses is unverified, and
+        bounces the setup page straight back to the MFA overview (see
+        ``allauth.mfa.internal.flows.add.validate_can_add_authenticator``). Sending those users to
+        the setup page would leave them with no way to satisfy the requirement, so point them at
+        their email addresses instead.
+        """
+
+        if (
+            not mfa_settings.ALLOW_UNVERIFIED_EMAIL
+            and EmailAddress.objects.filter(user_id=user.pk, verified=False).exists()
+        ):
+            return reverse("account_email"), RequireMfaForStaffMiddleware.VERIFY_EMAIL_MESSAGE
+        return reverse("mfa_activate_totp"), RequireMfaForStaffMiddleware.MESSAGE
+
+    def _is_exempt(self, request) -> bool:
+        if self._is_exempt_path(request.path):
+            return True
+
+        view_name = request.resolver_match.view_name if request.resolver_match else None
+        return view_name in self.ALLOWED_VIEW_NAMES
+
+    def _is_exempt_path(self, path: str) -> bool:
+        if not path:
+            return False
+        if path.startswith(self.EXEMPT_PATH_PREFIXES):
+            return True
+        # Assets are served ahead of this middleware in production, but not by the dev server.
+        asset_prefixes = tuple(url for url in (settings.STATIC_URL, settings.MEDIA_URL) if url and url != "/")
+        return path.startswith(asset_prefixes)

--- a/apps/users/middleware.py
+++ b/apps/users/middleware.py
@@ -61,19 +61,24 @@ class RequireMfaForStaffMiddleware(MiddlewareMixin):
     )
 
     def process_view(self, request, view_func, view_args, view_kwargs):
-        if not settings.REQUIRE_MFA_FOR_STAFF:
+        if not self._must_enrol(request):
             return None
+        return self._gate(request)
+
+    def _must_enrol(self, request) -> bool:
+        if not settings.REQUIRE_MFA_FOR_STAFF:
+            return False
 
         user = getattr(request, "user", None)
         if user is None or not user.is_authenticated:
-            return None
+            return False
 
         if not (user.is_staff or user.is_superuser):
-            return None
+            return False
 
-        if is_mfa_enabled(user) or self._is_exempt(request):
-            return None
+        return not (is_mfa_enabled(user) or self._is_exempt(request))
 
+    def _gate(self, request):
         if request.htmx and self._is_exempt_path(_path_of(request.htmx.current_url)):
             # This is a background request fired by a page the gate already lets through -- the
             # banner poll on the setup page, say. Telling htmx to navigate would send the browser
@@ -82,7 +87,7 @@ class RequireMfaForStaffMiddleware(MiddlewareMixin):
             # page load.
             return HttpResponse(status=204)
 
-        target, message = self._next_step(user)
+        target, message = self._next_step(request.user)
         messages.error(request, message)
         if request.htmx:
             # Swapping the setup form into a fragment would strand the user, so move the whole page.

--- a/apps/users/middleware.py
+++ b/apps/users/middleware.py
@@ -5,7 +5,7 @@ from allauth.mfa import app_settings as mfa_settings
 from allauth.mfa.utils import is_mfa_enabled
 from django.conf import settings
 from django.contrib import messages
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseForbidden, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import gettext_lazy as _
@@ -23,9 +23,10 @@ class RequireMfaForStaffMiddleware(MiddlewareMixin):
     pattern documented by django-allauth-2fa:
     https://django-allauth-2fa.readthedocs.io/en/latest/advanced/
 
-    Only the session-authenticated web UI is gated. The API and webhook surfaces authenticate per
-    request (API key, OAuth token, platform signature) and can't act on a redirect, so a redirect
-    there would break integrations rather than prompt anyone to enrol.
+    The gate keys off the session, which is the only thing ``AuthenticationMiddleware`` populates
+    ``request.user`` from. API-key, OAuth-token and webhook callers are anonymous here -- DRF
+    authenticates them inside the view, long after this runs -- so integrations never reach the gate
+    and keep working while their owner enrols.
     """
 
     MESSAGE = _("Two-factor authentication is required for staff accounts. Please set it up to continue.")
@@ -46,18 +47,24 @@ class RequireMfaForStaffMiddleware(MiddlewareMixin):
     #: ``LOGIN_REDIRECT_URL``, which the gate sends back here, so any gated URL under ``/accounts/``
     #: is a redirect cycle waiting to happen.
     #:
-    #: The remaining prefixes are surfaces that don't use session auth (they authenticate per
-    #: request with an API key, OAuth token, or platform signature), where redirecting the caller
-    #: achieves nothing -- plus ``/__reload__/``, whose event stream the dev server's browser-reload
-    #: worker reconnects to and reloads the page over if it is ever redirected.
+    #: ``/__reload__/`` is the dev server's browser-reload event stream: redirect it and the reload
+    #: worker reconnects and reloads the page, forever. ``/tz_detect/`` records a timezone from every
+    #: page load, including the setup page, and refusing it would log a warning each time.
     EXEMPT_PATH_PREFIXES = (
         "/accounts/",
+        "/tz_detect/",
+        "/__reload__/",
+    )
+
+    #: Gated, but answered with a 403 rather than a redirect: the caller is code, and a redirect to
+    #: an HTML setup page is no use to it. These are *not* exempt, because a staff user's session
+    #: authenticates some of them -- ``/api/chat/`` enables DRF's ``SessionAuthentication``
+    #: (apps/api/views/chat.py) -- and exempting them would leave a way around the requirement.
+    PROGRAMMATIC_PATH_PREFIXES = (
         "/api/",
         "/channels/",
         "/anymail/",
         "/celery-progress/",
-        "/tz_detect/",
-        "/__reload__/",
     )
 
     def process_view(self, request, view_func, view_args, view_kwargs):
@@ -79,6 +86,9 @@ class RequireMfaForStaffMiddleware(MiddlewareMixin):
         return not (is_mfa_enabled(user) or self._is_exempt(request))
 
     def _gate(self, request):
+        if request.path.startswith(self.PROGRAMMATIC_PATH_PREFIXES):
+            return HttpResponseForbidden(str(self.MESSAGE))
+
         if request.htmx and self._is_exempt_path(_path_of(request.htmx.current_url)):
             # This is a background request fired by a page the gate already lets through -- the
             # banner poll on the setup page, say. Telling htmx to navigate would send the browser

--- a/apps/users/tests/test_require_mfa_middleware.py
+++ b/apps/users/tests/test_require_mfa_middleware.py
@@ -15,6 +15,7 @@ from django.urls import reverse
 
 from apps.users.middleware import RequireMfaForStaffMiddleware
 from apps.utils.factories.team import TeamWithUsersFactory
+from apps.utils.tests.clients import ApiTestClient
 
 PASSWORD = "sekr1t-passw0rd"
 
@@ -282,12 +283,35 @@ def test_returning_user_can_reauthenticate_and_enrol(client, user, gated_page):
     assert resumed.redirect_chain[-1][0] == reverse("mfa_activate_totp")
 
 
-def test_api_requests_are_not_redirected(client, user):
-    """API callers authenticate per request and can't act on a redirect, so the gate skips them."""
+@pytest.mark.parametrize(
+    ("method", "url_name"),
+    [
+        pytest.param("get", "api:experiment-list", id="experiments"),
+        # /api/chat/ enables DRF's SessionAuthentication, so a staff session really does authenticate
+        # here -- exempting the prefix would have been a way around the requirement.
+        pytest.param("post", "api:chat:start-session", id="chat"),
+    ],
+)
+def test_session_authenticated_api_requests_are_refused(client, user, method, url_name):
+    """Gated, but with a 403: an API caller can't act on a redirect to an HTML setup page."""
     user.is_superuser = True
     user.save()
     client.force_login(user)
 
-    response = client.get(reverse("api:experiment-list"))
+    response = getattr(client, method)(reverse(url_name))
 
-    assert response.status_code != 302
+    assert response.status_code == 403
+
+
+def test_api_key_requests_are_unaffected(db, user):
+    """The gate reads the session; DRF authenticates keys inside the view, long after it runs.
+
+    So a staff user's integrations keep working while they enrol -- only their browser is gated.
+    """
+    user.is_superuser = True
+    user.save()
+    api_client = ApiTestClient(user, user.teams.first())
+
+    response = api_client.get(reverse("api:experiment-list"))
+
+    assert response.status_code == 200

--- a/apps/users/tests/test_require_mfa_middleware.py
+++ b/apps/users/tests/test_require_mfa_middleware.py
@@ -1,0 +1,293 @@
+"""Tests for the staff MFA requirement (apps.users.middleware.RequireMfaForStaffMiddleware).
+
+``REQUIRE_MFA_FOR_STAFF`` defaults off in development and under test (see config/settings.py), so
+every test here switches it on explicitly.
+"""
+
+import time
+
+import pytest
+from allauth.account.models import EmailAddress
+from allauth.mfa.totp.internal import auth as totp_auth
+from allauth.socialaccount.models import SocialApp
+from django.contrib.sites.models import Site
+from django.urls import reverse
+
+from apps.users.middleware import RequireMfaForStaffMiddleware
+from apps.utils.factories.team import TeamWithUsersFactory
+
+PASSWORD = "sekr1t-passw0rd"
+
+
+@pytest.fixture(autouse=True)
+def _require_mfa(settings):
+    settings.REQUIRE_MFA_FOR_STAFF = True
+
+
+@pytest.fixture()
+def user(db):
+    user = TeamWithUsersFactory.create().members.first()
+    user.set_password(PASSWORD)
+    user.save()
+    return user
+
+
+@pytest.fixture()
+def gated_page():
+    """A page with no bearing on MFA, which a gated user must not reach."""
+    return reverse("users:user_profile")
+
+
+def _login(client, user):
+    """Log in for real: the MFA views require a recent authentication record in the session."""
+    response = client.post(reverse("account_login"), {"login": user.email, "password": PASSWORD})
+    assert response.status_code == 302, "login failed"
+    return client
+
+
+@pytest.mark.parametrize(
+    ("is_staff", "is_superuser"),
+    [
+        pytest.param(True, False, id="staff"),
+        pytest.param(False, True, id="superuser"),
+        pytest.param(True, True, id="staff-and-superuser"),
+    ],
+)
+def test_privileged_user_without_mfa_is_sent_to_setup(client, user, gated_page, is_staff, is_superuser):
+    user.is_staff = is_staff
+    user.is_superuser = is_superuser
+    user.save()
+    client.force_login(user)
+
+    response = client.get(gated_page)
+
+    assert response.status_code == 302
+    assert response["Location"] == reverse("mfa_activate_totp")
+
+
+def test_redirect_explains_itself(client, user, gated_page):
+    user.is_superuser = True
+    user.save()
+    client.force_login(user)
+
+    response = client.get(gated_page, follow=True)
+
+    assert [str(message) for message in response.context["messages"]] == [
+        "Two-factor authentication is required for staff accounts. Please set it up to continue."
+    ]
+
+
+def test_htmx_requests_get_a_client_redirect(client, user, gated_page):
+    """A 302 would be swapped into the page fragment; the browser has to navigate instead."""
+    user.is_superuser = True
+    user.save()
+    client.force_login(user)
+
+    response = client.get(gated_page, headers={"hx-request": "true"})
+
+    assert response.status_code == 200
+    assert response["HX-Redirect"] == reverse("mfa_activate_totp")
+
+
+def test_background_htmx_request_from_the_setup_page_is_dropped_not_redirected(client, user):
+    """The reload loop: every page fires the banner poll, so an HX-Redirect here never settles.
+
+    htmx would navigate the browser to the setup page, whose own banner poll would be redirected
+    again -- the page reloads forever. 204 also keeps a warning per page load out of the log.
+    """
+    user.is_superuser = True
+    user.save()
+    client.force_login(user)
+
+    response = client.get(
+        reverse("banners:load_banners"),
+        headers={"hx-request": "true", "hx-current-url": f"http://testserver{reverse('mfa_activate_totp')}"},
+    )
+
+    assert response.status_code == 204
+    assert "HX-Redirect" not in response.headers
+
+
+def test_browser_reload_stream_is_not_gated(client, user):
+    """A redirected event stream makes the dev server's reload worker reload the page in a loop."""
+    middleware = RequireMfaForStaffMiddleware(lambda request: None)
+
+    assert middleware._is_exempt_path("/__reload__/events/")
+    assert not middleware._is_exempt_path(reverse("users:user_profile"))
+
+
+def test_unprivileged_user_without_mfa_is_not_gated(client, user, gated_page):
+    client.force_login(user)
+
+    assert client.get(gated_page).status_code == 200
+
+
+def test_privileged_user_with_mfa_is_not_gated(client, user, gated_page):
+    user.is_superuser = True
+    user.save()
+    totp_auth.TOTP.activate(user, totp_auth.generate_totp_secret())
+    client.force_login(user)
+
+    assert client.get(gated_page).status_code == 200
+
+
+def test_requirement_can_be_switched_off(client, user, gated_page, settings):
+    settings.REQUIRE_MFA_FOR_STAFF = False
+    user.is_superuser = True
+    user.save()
+    client.force_login(user)
+
+    assert client.get(gated_page).status_code == 200
+
+
+def test_anonymous_users_are_not_gated(client, gated_page):
+    response = client.get(gated_page)
+
+    assert reverse("mfa_activate_totp") not in response["Location"]
+
+
+@pytest.mark.parametrize(
+    "url_name",
+    [
+        pytest.param("mfa_index", id="mfa-overview"),
+        pytest.param("mfa_activate_totp", id="mfa-setup"),
+        pytest.param("account_email", id="email-addresses"),
+        pytest.param("account_change_password", id="change-password"),
+    ],
+)
+def test_enrolment_and_account_pages_stay_reachable(client, user, url_name):
+    user.is_superuser = True
+    user.save()
+    _login(client, user)
+
+    assert client.get(reverse(url_name)).status_code == 200
+
+
+def test_logout_stays_reachable(client, user):
+    user.is_superuser = True
+    user.save()
+    client.force_login(user)
+
+    response = client.get(reverse("account_logout"))
+
+    assert response["Location"] != reverse("mfa_activate_totp")
+    assert not client.session.get("_auth_user_id")
+
+
+def test_sso_front_channel_logout_stays_reachable(client, user):
+    """The IdP calls this with the user's cookies; a redirect would leave the session alive."""
+    user.is_superuser = True
+    user.save()
+    client.force_login(user)
+
+    response = client.get(reverse("sso:logout"))
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param("/accounts/microsoft/login/", id="provider-login"),
+        pytest.param("/accounts/microsoft/login/callback/", id="provider-callback"),
+    ],
+)
+def test_sso_login_round_trip_is_not_gated(client, user, url):
+    """Gating the provider round trip leaves an SSO login unable to complete."""
+    app = SocialApp.objects.create(provider="microsoft", name="Microsoft", client_id="id", secret="secret")
+    app.sites.add(Site.objects.get_current())
+    user.is_superuser = True
+    user.set_unusable_password()
+    user.save()
+    client.force_login(user)
+
+    response = client.get(url)
+
+    assert response.get("Location") != reverse("mfa_activate_totp")
+
+
+@pytest.mark.parametrize(
+    ("has_password", "email_state"),
+    [
+        pytest.param(True, "verified", id="password-verified-email"),
+        pytest.param(True, "unverified", id="password-unverified-email"),
+        pytest.param(True, "none", id="password-no-email-row"),
+        pytest.param(False, "verified", id="sso-only-verified-email"),
+        pytest.param(False, "unverified", id="sso-only-unverified-email"),
+        pytest.param(False, "none", id="sso-only-no-email-row"),
+    ],
+)
+def test_gated_user_always_lands_somewhere(client, user, gated_page, has_password, email_state):
+    """No account state may leave the browser bouncing between the gate and the setup flow.
+
+    ``/accounts/login/`` sends an authenticated user to ``LOGIN_REDIRECT_URL``, which the gate
+    redirects back to the setup page -- so a gated URL anywhere in the enrolment flow loops.
+    """
+    user.is_superuser = True
+    if not has_password:
+        user.set_unusable_password()
+    user.save()
+    if email_state != "none":
+        EmailAddress.objects.create(user=user, email=user.email, verified=email_state == "verified", primary=True)
+    client.force_login(user)
+
+    url = gated_page
+    visited = []
+    for _ in range(10):
+        response = client.get(url)
+        visited.append(url)
+        if response.status_code != 302:
+            break
+        url = response["Location"]
+    else:
+        pytest.fail(f"redirect loop: {visited}")
+
+    assert response.status_code == 200
+
+
+def test_unverified_email_is_sent_to_verify_it_first(client, user, gated_page):
+    """allauth refuses to enable MFA with an unverified address, so the setup page is a dead end."""
+    user.is_superuser = True
+    user.save()
+    EmailAddress.objects.create(user=user, email=user.email, verified=False, primary=True)
+    _login(client, user)
+
+    response = client.get(gated_page)
+
+    assert response["Location"] == reverse("account_email")
+    # Pin the allauth behaviour this branch exists for: the setup page refuses to serve the form.
+    assert client.get(reverse("mfa_activate_totp"))["Location"] == reverse("mfa_index")
+
+
+def test_returning_user_can_reauthenticate_and_enrol(client, user, gated_page):
+    """A session with no recent authentication has to pass through allauth's reauthentication."""
+    user.is_superuser = True
+    user.save()
+    EmailAddress.objects.create(user=user, email=user.email, verified=True, primary=True)
+    _login(client, user)
+    session = client.session
+    session["account_authentication_methods"] = [{"method": "password", "at": time.time() - 100_000}]
+    session.save()
+
+    setup = client.get(gated_page, follow=True)
+    assert setup.redirect_chain[-1][0].startswith(reverse("account_reauthenticate"))
+
+    resumed = client.post(
+        setup.redirect_chain[-1][0],
+        {"password": PASSWORD},
+        follow=True,
+    )
+
+    assert resumed.status_code == 200
+    assert resumed.redirect_chain[-1][0] == reverse("mfa_activate_totp")
+
+
+def test_api_requests_are_not_redirected(client, user):
+    """API callers authenticate per request and can't act on a redirect, so the gate skips them."""
+    user.is_superuser = True
+    user.save()
+    client.force_login(user)
+
+    response = client.get(reverse("api:experiment-list"))
+
+    assert response.status_code != 302

--- a/apps/users/tests/test_require_mfa_middleware.py
+++ b/apps/users/tests/test_require_mfa_middleware.py
@@ -10,6 +10,7 @@ import pytest
 from allauth.account.models import EmailAddress
 from allauth.mfa.totp.internal import auth as totp_auth
 from allauth.socialaccount.models import SocialApp
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.urls import reverse
 
@@ -144,7 +145,8 @@ def test_requirement_can_be_switched_off(client, user, gated_page, settings):
 def test_anonymous_users_are_not_gated(client, gated_page):
     response = client.get(gated_page)
 
-    assert reverse("mfa_activate_totp") not in response["Location"]
+    assert response.status_code == 302
+    assert response["Location"].startswith(reverse(settings.LOGIN_URL))
 
 
 @pytest.mark.parametrize(

--- a/config/settings.py
+++ b/config/settings.py
@@ -159,6 +159,7 @@ MIDDLEWARE = list(
             "django.middleware.csrf.CsrfViewMiddleware",
             "django.contrib.auth.middleware.AuthenticationMiddleware",
             "django_htmx.middleware.HtmxMiddleware",
+            "apps.users.middleware.RequireMfaForStaffMiddleware",
             "apps.teams.middleware.TeamsMiddleware",
             "apps.web.scope_middleware.RequestContextMiddleware",
             "apps.web.locale_middleware.UserLocaleMiddleware",
@@ -291,6 +292,11 @@ MFA_ADAPTER = "apps.users.adapter.MfaAdapter"
 MFA_RECOVERY_CODE_COUNT = 10
 MFA_RECOVERY_CODES_SHOW_ONCE = True
 MFA_TOTP_ISSUER = "Open Chat Studio"
+# Staff and superusers are confined to the MFA setup flow until they enrol
+# (apps.users.middleware.RequireMfaForStaffMiddleware). Off by default in development and under
+# test: local superusers shouldn't have to enrol, and the existing staff-view tests would each need
+# to. Set REQUIRE_MFA_FOR_STAFF=True to exercise it locally; the middleware's own tests switch it on.
+REQUIRE_MFA_FOR_STAFF = env.bool("REQUIRE_MFA_FOR_STAFF", default=not (DEBUG or IS_TESTING))
 
 # User signup configuration: change to "mandatory" to require users to confirm email before signing in.
 # or "optional" to send confirmation emails but not require them


### PR DESCRIPTION
### Product Description
Staff and superusers can't use the app until they've set up 2FA — every page redirects them to the TOTP setup flow. Everyone else is unaffected.

### Technical Description
`allauth.mfa` ships no enforcement hook, so this is the [`BaseRequire2FAMiddleware` pattern](https://django-allauth-2fa.readthedocs.io/en/latest/advanced/) from django-allauth-2fa, reimplemented against `allauth.mfa`.

Enabled by default outside `DEBUG` and tests, so **existing staff accounts get gated on their next request after deploy**, and anyone without an authenticator has to enrol before they can do anything else. `REQUIRE_MFA_FOR_STAFF=False` is the escape hatch. It's off under test because the existing staff-view tests would each have to enrol first.

The gate keys off the session, since that's the only thing `AuthenticationMiddleware` populates `request.user` from. API-key and OAuth callers are anonymous at that point — DRF authenticates them inside the view — so **integrations keep working while their owner enrols**; only the browser is gated.

What to look at, since each of these is here because it broke something:

- **All of `/accounts/` is exempt**, rather than an allow-list of view names. The Microsoft provider URLs (`microsoft_login`, `microsoft_callback`) don't match an `account_*`/`socialaccount_*` prefix, so an SSO login couldn't complete — and since `/accounts/login/` bounces an authenticated user to `LOGIN_REDIRECT_URL`, which the gate sends back to the setup page, any gated URL under `/accounts/` is a redirect cycle. The front-channel `sso:logout` callback would also have silently left the session alive.
- **`/api/` and the webhook prefixes are gated, but answered with a 403** instead of a redirect. They were exempt at first; `/api/chat/` enables DRF's `SessionAuthentication` (`apps/api/views/chat.py:60`), so exempting the prefix left a staff session able to use those endpoints without enrolling.
- **HTMX background requests get `204`, not `HX-Redirect`,** when the calling page is already exempt. The banner poll fires on every page, including the setup page: htmx obeyed the redirect header, navigated, and the new page polled again — an endless reload loop. `204` over `403` keeps a `Forbidden` warning out of the log on every page load.
- **`/__reload__/` is exempt** — a redirected event stream makes the dev server's browser-reload worker reload the page in a loop.

Users with an unverified email address are sent to `/accounts/email/` instead: allauth refuses enrolment in that state, so the setup page is a dead end for them and the requirement would be unsatisfiable.

### Demo
Verified on a dev server: gated pages redirect to setup, completing TOTP activation lifts the gate. `test_gated_user_always_lands_somewhere` walks the redirect chain to a 200 across password/SSO-only × verified/unverified/absent email, since termination is the property that kept breaking.

### Docs and Changelog
- [ ] This PR requires docs/changelog update
