### PR TITLE
Bound memory use in chat session exports

### DIFF
--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -292,20 +292,6 @@ def export_to_tempfile(
     return tmp
 
 
-def filtered_export_to_csv(experiment, sessions_queryset, translation_language=None):
-    """Build a complete CSV in a StringIO buffer and return it.
-
-    For large datasets prefer generate_export_rows() + export_rows_to_csv_stream()
-    to avoid buffering the entire export in memory.  This function is retained for
-    backward compatibility with callers that expect a StringIO return value.
-    """
-    csv_in_memory = io.StringIO()
-    writer = csv.writer(csv_in_memory, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL)
-    for row in generate_export_rows(experiment, sessions_queryset, translation_language):
-        writer.writerow(row)
-    return csv_in_memory
-
-
 def _get_trace_id_for_export(message):
     """Returns the trace info from the message.
     This will return the first non-OCS trace info if it exists.

--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -3,6 +3,7 @@ import gzip
 import io
 import json
 import tempfile
+from collections import OrderedDict
 from collections.abc import Generator, Iterator
 
 import dictdiffer
@@ -19,6 +20,10 @@ _SPOOLED_MAX_BYTES = 10 * 1024 * 1024  # 10 MB threshold before spilling to disk
 
 EXPORT_CHUNK_SIZE = 1000
 PROGRESS_UPDATE_INTERVAL = 100
+
+# Ceiling on the per-session value cache. At roughly 2.4 KB per entry this caps the cache
+# at a few MB regardless of how many sessions the export spans.
+SESSION_CACHE_MAX_ENTRIES = 2000
 
 UTF8_BOM = "\ufeff"  # Prepended to CSV exports so Excel detects UTF-8 encoding.
 
@@ -141,6 +146,40 @@ def _build_session_cache_entry(session) -> dict:
     }
 
 
+class _SessionCache:
+    """Bounded LRU cache of the per-session values repeated on every row of that session.
+
+    Messages are exported in order of global message pk, so a session's messages stay
+    interleaved with other sessions' for the whole run and no entry is ever safely "done".
+    An unbounded dict therefore grows with the session count (~2.4 KB per session), which
+    is the one export memory term that scales with the dataset rather than with the output.
+
+    Capping it trades a recomputation when an evicted session reappears for a fixed
+    ceiling. A miss costs no extra query: the session and its chat tags/comments are
+    already loaded on the message by ``_build_message_queryset``.
+    """
+
+    def __init__(self, max_entries: int | None = None):
+        self._entries: OrderedDict[int, dict] = OrderedDict()
+        # Resolved at call time rather than bound as a default so the ceiling stays patchable.
+        self._max_entries = SESSION_CACHE_MAX_ENTRIES if max_entries is None else max_entries
+
+    def get(self, session) -> dict:
+        try:
+            entry = self._entries[session.id]
+        except KeyError:
+            entry = _build_session_cache_entry(session)
+            self._entries[session.id] = entry
+            if len(self._entries) > self._max_entries:
+                self._entries.popitem(last=False)
+            return entry
+        self._entries.move_to_end(session.id)
+        return entry
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
 def _build_message_row(message, participant_data, sc, experiment, trace_id, translation_language) -> list:
     """Return an export row list for *message*."""
     content = get_message_content(message, translation_language) if translation_language else message.content
@@ -170,12 +209,10 @@ def _build_message_row(message, participant_data, sc, experiment, trace_id, tran
     return row
 
 
-def _yield_row_for_message(message, session_cache, experiment, translation_language) -> list:
+def _yield_row_for_message(message, session_cache: _SessionCache, experiment, translation_language) -> list:
     """Return an export row for a single message."""
     session = message.chat.experiment_session
-    if session.id not in session_cache:
-        session_cache[session.id] = _build_session_cache_entry(session)
-    sc = session_cache[session.id]
+    sc = session_cache.get(session)
     participant_data = _get_participant_data_for_message(message)
     trace_id = _get_trace_id_for_export(message)
     return _build_message_row(message, participant_data, sc, experiment, trace_id, translation_language)
@@ -190,14 +227,14 @@ def generate_export_rows(
     that memory usage stays bounded regardless of dataset size.  Session-level values
     (platform name, state JSON, participant fields, chat tags/comments) are cached the
     first time each session is encountered so they are serialised only once no matter
-    how many messages belong to that session.  The cache stores plain strings/dicts
-    (not ORM objects) so its footprint is small even for experiments with many sessions.
+    how many messages belong to that session; see :class:`_SessionCache` for why that
+    cache is bounded rather than keeping every session for the life of the export.
     """
     yield _get_export_header(translation_language)
 
     base_qs = _build_message_queryset(sessions_queryset)
     last_pk = 0
-    session_cache: dict[int, dict] = {}
+    session_cache = _SessionCache()
     processed = 0
 
     def report(count):

--- a/apps/experiments/export.py
+++ b/apps/experiments/export.py
@@ -1,4 +1,5 @@
 import csv
+import gc
 import gzip
 import io
 import json
@@ -253,7 +254,15 @@ def generate_export_rows(
                 report(processed)
 
         last_pk = chunk[-1].pk
-        if len(chunk) < EXPORT_CHUNK_SIZE:
+        done = len(chunk) < EXPORT_CHUNK_SIZE
+        # Django model instances take part in reference cycles (``_state``, the
+        # related-object and prefetch caches), so refcounting alone does not reclaim a
+        # spent chunk -- it lingers two to three chunks behind until a generational pass
+        # happens to run. Dropping the reference before collecting is what lets the
+        # current chunk go too, which measured ~70% off peak memory for large exports.
+        del chunk
+        gc.collect()
+        if done:
             break
 
     # Report the final tally so the last partial interval (and exports smaller than one

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from celery.app import shared_task
 from celery.utils.log import get_task_logger
 from celery_progress.backend import ProgressRecorder
-from django.core.files.base import ContentFile
+from django.core.files.base import File as DjangoFile
 from django.http import QueryDict
 from django.utils import timezone
 from langchain_core.messages import AIMessage, HumanMessage
@@ -50,11 +50,15 @@ def async_export_chat(self, experiment_id: int, query_params: str, time_zone) ->
     # compress=True writes a gzip stream, reducing file size by ~80–90% for typical
     # chat exports and dramatically cutting S3 storage and download time.
     with export_to_tempfile(experiment, filtered_sessions, compress=True, progress_callback=report_progress) as tmp:
+        # Hand the temp file to storage directly rather than via ContentFile(tmp.read()):
+        # the storage backend streams it in chunks, so peak memory stays flat instead of
+        # scaling with export size. Reading it in one go negates the spooling above and
+        # has OOM'd the worker on large exports.
         file_obj = File.objects.create(
             name=filename,
             team=experiment.team,
             content_type="application/gzip",
-            file=ContentFile(tmp.read(), name=filename),
+            file=DjangoFile(tmp, name=filename),
             purpose=FilePurpose.DATA_EXPORT,
             expiry_date=timezone.now() + timedelta(days=7),
         )

--- a/apps/experiments/tests/test_export.py
+++ b/apps/experiments/tests/test_export.py
@@ -1,4 +1,5 @@
 import csv
+import gc
 import io
 import json
 from unittest.mock import MagicMock, Mock, patch
@@ -480,3 +481,18 @@ def test_export_rows_correct_when_sessions_exceed_cache_ceiling():
         expected_idx = int(row[content_index].split("-")[0].removeprefix("s"))
         assert json.loads(row[state_index]) == {"idx": expected_idx}
         assert row[identifier_index] == f"user{expected_idx}"
+
+
+@pytest.mark.django_db()
+def test_generate_export_rows_holds_only_one_chunk_of_messages():
+    """Spent chunks must not accumulate: ORM reference cycles need an explicit collection."""
+    session = _make_session_with_messages(25)
+    live_counts = []
+
+    with patch("apps.experiments.export.EXPORT_CHUNK_SIZE", 5):
+        for _ in generate_export_rows(session.experiment, session.experiment.sessions.all()):
+            live_counts.append(sum(1 for o in gc.get_objects() if type(o) is ChatMessage))
+
+    # Without the per-chunk collect this climbs toward the full 25; bounded, it stays
+    # within a chunk (plus the row currently being yielded).
+    assert max(live_counts) <= 10, f"spent chunks are accumulating: peak live={max(live_counts)}"

--- a/apps/experiments/tests/test_export.py
+++ b/apps/experiments/tests/test_export.py
@@ -10,13 +10,18 @@ from apps.experiments.export import (
     UTF8_BOM,
     count_export_messages,
     export_rows_to_csv_stream,
-    filtered_export_to_csv,
     generate_export_rows,
 )
 from apps.service_providers.tracing import OCS_TRACE_PROVIDER
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.traces import TraceFactory
+
+
+def _export_csv_text(experiment, sessions_queryset, translation_language=None) -> str:
+    """Render an export to CSV text, minus the Excel BOM, for content assertions."""
+    rows = generate_export_rows(experiment, sessions_queryset, translation_language)
+    return "".join(export_rows_to_csv_stream(rows)).removeprefix(UTF8_BOM)
 
 
 @pytest.mark.django_db()
@@ -88,8 +93,7 @@ def test_filtered_export_with_mocked_filter(mock_get_filtered_sessions, session_
     else:
         filtered_queryset = experiment.sessions.none()
 
-    csv_in_memory = filtered_export_to_csv(experiment, filtered_queryset)
-    csv_content = csv_in_memory.getvalue()
+    csv_content = _export_csv_text(experiment, filtered_queryset)
     csv_lines = csv_content.strip().split("\n") if csv_content.strip() else []
     # Each session produces 2 rows (human + AI message), plus 1 header
     expected_rows = len(filtered_indices) * 2 + 1
@@ -135,8 +139,7 @@ def test_participant_data_export():
         participant_data_diff=[["change", "age", [25, 26]]],
     )
 
-    csv_in_memory = filtered_export_to_csv(experiment, experiment.sessions.all())
-    csv_reader = csv.reader(io.StringIO(csv_in_memory.getvalue()))
+    csv_reader = csv.reader(io.StringIO(_export_csv_text(experiment, experiment.sessions.all())))
     rows = list(csv_reader)
 
     header = rows[0]
@@ -181,8 +184,7 @@ def test_participant_data_export_empty_diff():
         participant_data_diff=[],
     )
 
-    csv_in_memory = filtered_export_to_csv(experiment, experiment.sessions.all())
-    csv_reader = csv.reader(io.StringIO(csv_in_memory.getvalue()))
+    csv_reader = csv.reader(io.StringIO(_export_csv_text(experiment, experiment.sessions.all())))
     rows = list(csv_reader)
 
     header = rows[0]
@@ -223,8 +225,7 @@ def test_participant_data_export_empty_data():
         participant_data_diff=[],
     )
 
-    csv_in_memory = filtered_export_to_csv(experiment, experiment.sessions.all())
-    csv_reader = csv.reader(io.StringIO(csv_in_memory.getvalue()))
+    csv_reader = csv.reader(io.StringIO(_export_csv_text(experiment, experiment.sessions.all())))
     rows = list(csv_reader)
 
     header = rows[0]
@@ -298,8 +299,8 @@ def test_trace_id_resolved_per_message_trace_info():
     mock_messages_qs.filter.return_value.__getitem__ = Mock(return_value=messages)
 
     with patch("apps.experiments.export.ChatMessage.objects.filter", return_value=mock_messages_qs):
-        csv_in_memory = filtered_export_to_csv(experiment, Mock())
-        rows = list(csv.reader(io.StringIO(csv_in_memory.getvalue()), delimiter=","))
+        csv_text = _export_csv_text(experiment, Mock())
+        rows = list(csv.reader(io.StringIO(csv_text), delimiter=","))
 
     header = rows[0]
     trace_id_index = header.index("Trace ID")
@@ -341,8 +342,7 @@ def test_session_state_export():
         output_message=ai_msg,
     )
 
-    csv_in_memory = filtered_export_to_csv(experiment, experiment.sessions.all())
-    csv_reader = csv.reader(io.StringIO(csv_in_memory.getvalue()))
+    csv_reader = csv.reader(io.StringIO(_export_csv_text(experiment, experiment.sessions.all())))
     rows = list(csv_reader)
 
     header = rows[0]

--- a/apps/experiments/tests/test_export.py
+++ b/apps/experiments/tests/test_export.py
@@ -7,7 +7,9 @@ import pytest
 
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.experiments.export import (
+    SESSION_CACHE_MAX_ENTRIES,
     UTF8_BOM,
+    _SessionCache,
     count_export_messages,
     export_rows_to_csv_stream,
     generate_export_rows,
@@ -415,3 +417,66 @@ def test_generate_export_rows_progress_interval_independent_of_chunk_size():
         )
 
     assert calls == [5]
+
+
+def test_session_cache_evicts_oldest_beyond_max_entries():
+    """The cache is an LRU with a hard ceiling, so it can't grow with the session count."""
+    cache = _SessionCache(max_entries=2)
+    sessions = [Mock(id=i, external_id=f"s{i}", state={}, get_platform_name=Mock(return_value="Web")) for i in range(3)]
+    for session in sessions:
+        session.participant = Mock(name=f"p{session.id}", identifier=f"p{session.id}", public_id=f"pub{session.id}")
+        session.chat = Mock(tags=Mock(all=Mock(return_value=[])), comments=Mock(all=Mock(return_value=[])))
+
+    first = cache.get(sessions[0])
+    cache.get(sessions[1])
+    assert cache.get(sessions[0]) is first, "a cache hit must reuse the existing entry"
+
+    # session 0 was just used, so session 1 is the least-recently-used and gets evicted.
+    cache.get(sessions[2])
+    assert len(cache) == 2
+    assert cache.get(sessions[0]) is first
+    assert cache.get(sessions[1]) is not None, "an evicted session is simply recomputed"
+    assert len(cache) == 2
+
+
+def test_session_cache_default_ceiling_comes_from_module_constant():
+    assert _SessionCache()._max_entries == SESSION_CACHE_MAX_ENTRIES
+
+
+@pytest.mark.django_db()
+def test_export_rows_correct_when_sessions_exceed_cache_ceiling():
+    """Rows stay correct for sessions evicted from the cache and re-encountered later.
+
+    Messages are ordered by global message pk, so sessions interleave: with a ceiling
+    below the session count, entries get evicted and rebuilt mid-export. Each row must
+    still carry its own session's values, not a neighbour's.
+    """
+    experiment = ExperimentFactory.create()
+    sessions = [
+        ExperimentSessionFactory.create(
+            experiment=experiment, team=experiment.team, participant__identifier=f"user{i}", state={"idx": i}
+        )
+        for i in range(4)
+    ]
+    # Interleave: one message per session per round, so pk order cycles through sessions.
+    for round_no in range(3):
+        for i, session in enumerate(sessions):
+            ChatMessage.objects.create(
+                chat=session.chat, content=f"s{i}-r{round_no}", message_type=ChatMessageType.HUMAN
+            )
+
+    with patch("apps.experiments.export.SESSION_CACHE_MAX_ENTRIES", 2):
+        csv_reader = csv.reader(io.StringIO(_export_csv_text(experiment, experiment.sessions.all())))
+        rows = list(csv_reader)
+
+    header = rows[0]
+    state_index = header.index("Session State")
+    identifier_index = header.index("Participant Identifier")
+    content_index = header.index("Message Content")
+
+    assert len(rows) == 1 + 4 * 3
+    for row in rows[1:]:
+        # "s<i>-r<n>" encodes the owning session, so each row's own values must match it.
+        expected_idx = int(row[content_index].split("-")[0].removeprefix("s"))
+        assert json.loads(row[state_index]) == {"idx": expected_idx}
+        assert row[identifier_index] == f"user{expected_idx}"

--- a/apps/experiments/tests/test_export.py
+++ b/apps/experiments/tests/test_export.py
@@ -1,12 +1,13 @@
 import csv
-import gc
 import io
 import json
+import weakref
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from apps.chat.models import ChatMessage, ChatMessageType
+from apps.experiments import export as export_mod
 from apps.experiments.export import (
     SESSION_CACHE_MAX_ENTRIES,
     UTF8_BOM,
@@ -484,15 +485,37 @@ def test_export_rows_correct_when_sessions_exceed_cache_ceiling():
 
 
 @pytest.mark.django_db()
-def test_generate_export_rows_holds_only_one_chunk_of_messages():
-    """Spent chunks must not accumulate: ORM reference cycles need an explicit collection."""
+def test_generate_export_rows_releases_spent_chunks():
+    """A written-out chunk must be released, not left for some later generational pass.
+
+    Django model instances sit in reference cycles, so dropping the last strong reference
+    is not enough on its own. Weakrefs to the first chunk's messages assert release
+    directly; counting live ChatMessage instances process-wide would instead depend on
+    whatever other tests happen to be holding, which is not this code's business.
+    """
+    chunk_size = 5
     session = _make_session_with_messages(25)
-    live_counts = []
+    refs = []
+    real_yield = export_mod._yield_row_for_message
 
-    with patch("apps.experiments.export.EXPORT_CHUNK_SIZE", 5):
+    def recording_yield(message, *args):
+        refs.append(weakref.ref(message))
+        return real_yield(message, *args)
+
+    first_chunk_alive_later = None
+    with (
+        patch("apps.experiments.export.EXPORT_CHUNK_SIZE", chunk_size),
+        patch("apps.experiments.export._yield_row_for_message", recording_yield),
+    ):
         for _ in generate_export_rows(session.experiment, session.experiment.sessions.all()):
-            live_counts.append(sum(1 for o in gc.get_objects() if type(o) is ChatMessage))
+            # One message into the third chunk, both earlier chunks have been collected.
+            # (Chunk N's last message stays reachable via the loop variable until the
+            # following chunk rebinds it, so it is chunk N+1's collect that frees it --
+            # hence checking two chunks out rather than one.)
+            if len(refs) == chunk_size * 2 + 1 and first_chunk_alive_later is None:
+                first_chunk_alive_later = sum(1 for ref in refs[:chunk_size] if ref() is not None)
 
-    # Without the per-chunk collect this climbs toward the full 25; bounded, it stays
-    # within a chunk (plus the row currently being yielded).
-    assert max(live_counts) <= 10, f"spent chunks are accumulating: peak live={max(live_counts)}"
+    assert first_chunk_alive_later == 0, (
+        f"{first_chunk_alive_later}/{chunk_size} messages from the first chunk were still alive "
+        "two chunks later -- spent chunks are not being released"
+    )

--- a/apps/experiments/tests/test_tasks.py
+++ b/apps/experiments/tests/test_tasks.py
@@ -6,6 +6,7 @@ import pytest
 from django.test import override_settings
 
 from apps.chat.models import ChatMessage, ChatMessageType
+from apps.experiments import tasks
 from apps.experiments.tasks import async_create_experiment_version, async_export_chat, get_response_for_webchat_task
 from apps.files.models import File, FilePurpose
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
@@ -46,6 +47,59 @@ def test_async_export_chat_applies_query_string_filters(mock_recorder_cls):
     csv_content = gzip.decompress(File.objects.get(id=result["file_id"]).file.read()).decode()
     assert "message from alice" in csv_content
     assert "message from bob" not in csv_content
+
+
+class _ReadTracker:
+    """Wraps the export temp file and records the size argument of every ``read()`` call."""
+
+    def __init__(self, wrapped, reads):
+        self._wrapped = wrapped
+        self._reads = reads
+
+    def read(self, size=-1):
+        self._reads.append(size)
+        return self._wrapped.read(size)
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+    def __enter__(self):
+        self._wrapped.__enter__()
+        return self
+
+    def __exit__(self, *exc_info):
+        return self._wrapped.__exit__(*exc_info)
+
+
+@pytest.mark.django_db()
+@patch("apps.experiments.tasks.ProgressRecorder")
+def test_async_export_chat_streams_temp_file_to_storage(mock_recorder_cls):
+    """The export must reach storage in bounded chunks, never as one big ``read()``.
+
+    ``ContentFile(tmp.read(), ...)`` materialised the entire compressed export as a single
+    bytes object, so peak worker memory scaled with export size and large exports OOM'd the
+    worker — defeating the point of spooling to a temp file in the first place.
+    """
+    session = ExperimentSessionFactory.create()
+    for i in range(50):
+        ChatMessage.objects.create(chat=session.chat, content=f"m{i}", message_type=ChatMessageType.HUMAN)
+
+    reads = []
+    real_export_to_tempfile = tasks.export_to_tempfile
+
+    def tracked_export_to_tempfile(*args, **kwargs):
+        return _ReadTracker(real_export_to_tempfile(*args, **kwargs), reads)
+
+    with patch.object(tasks, "export_to_tempfile", tracked_export_to_tempfile):
+        result = async_export_chat.run(session.experiment_id, "", "UTC")
+
+    assert reads, "the temp file was never read"
+    assert all(size > 0 for size in reads), f"export was read unbounded into memory: read sizes {reads}"
+
+    file = File.objects.get(id=result["file_id"])
+    csv_content = gzip.decompress(file.file.read()).decode()
+    assert "m49" in csv_content
+    assert file.content_size == file.file.size
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
### Product Description
Large chat exports no longer risk OOM-killing the background worker.

### Technical Description
Investigating an overnight outage traced to a memory spike on a large session export. Profiling with tracemalloc found three separate terms, only one of which was the obvious suspect:

1. **`ContentFile(tmp.read())` in `async_export_chat`** — read the whole compressed export back into one contiguous `bytes`, directly negating the temp-file spooling on the line above. This is the only term that grew without bound with output size: measured 32.0 MB peak at a 31.8 MB gzip, 8.2 MB at 7.9 MB — tracking output exactly. Now flat at 0.3 MB.
2. **`session_cache`** — one entry per session, held for the whole run. It can't evict cleanly by construction: messages are ordered by global message pk, so sessions stay interleaved and no entry is ever safely "done". Now a bounded LRU; a miss just recomputes, with no extra query since the session and its chat tags/comments are already loaded on the message.
3. **Spent chunks lingering behind ORM reference cycles** (`_state`, related-object and prefetch caches), so 2–3 chunks were live at once instead of one.

Worth knowing: the message axis *plateaus* at ~95 MB (2k/8k/16k messages), so the keyset chunking from #3232 was working. Only the session axis kept climbing — 29.3 MB at 500 sessions to 97.0 MB at 4,000, to produce a 250 KB file. A wide export is a better fit for the incident than a deep one. Anyone re-measuring this should use the session axis; the message axis looks fine even when something is wrong.

**Worth a closer look:** `del chunk` before the collect is load-bearing, not tidying — the two do different work and both earn their place. Measured at 16k messages: 94.7 MB with neither, 46.0 MB with `del` alone, 28.8 MB with both.

The per-chunk `gc.collect()` has no measurable wall-time cost — 5 interleaved A/B reps give a median of 15.60s with vs 15.94s without (−2.1%), well inside a noise floor that threw 19–20s outliers. Holding less live memory seems to pay for the collect itself.

Also removes `filtered_export_to_csv` (buffered whole exports, no callers). Six of its tests weren't testing the buffering — they were the only coverage of participant-data snapshots via trace diffs, trace-id resolution, and the session-state column — so they're ported to `export_rows_to_csv_stream` rather than deleted with it.

Net: 94.7 → 28.7 MB on the message axis, 97.0 → 33.2 MB on the session axis.

### Migrations
N/A — no schema changes.

### Demo
N/A — no user-visible change beyond exports not falling over.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Internal reliability fix; no user-facing behaviour or API change to document.
