### PR TITLE
Add a binary field type to evaluator and annotation schemas

### DIFF
--- a/apps/assessments/score_writers.py
+++ b/apps/assessments/score_writers.py
@@ -42,6 +42,15 @@ def _score_from_field(
     if schema_type == "choice":
         data_type = Score.DataType.CATEGORICAL
         value_string = sanitize_control_chars(str(raw_value))
+    elif schema_type == "binary":
+        if raw_value not in (0, 1):
+            logger.warning("Score field %s: binary value %r is not 0 or 1; skipping", name, raw_value)
+            return None
+        data_type = Score.DataType.BOOLEAN
+        value_numeric = Decimal(int(raw_value))
+        label_key = "true_label" if int(raw_value) == 1 else "false_label"
+        default = "True" if int(raw_value) == 1 else "False"
+        value_string = sanitize_control_chars(str((schema_field or {}).get(label_key, default)))
     elif isinstance(raw_value, bool):
         data_type = Score.DataType.BOOLEAN
         value_numeric = Decimal(1) if raw_value else Decimal(0)

--- a/apps/assessments/score_writers.py
+++ b/apps/assessments/score_writers.py
@@ -96,6 +96,20 @@ def _score_from_field(
     )
 
 
+def _build_scores(payload: dict, schema: dict, **score_kwargs) -> list[Score]:
+    candidates = (
+        _score_from_field(name=name, raw_value=raw_value, schema_field=schema.get(name), **score_kwargs)
+        for name, raw_value in payload.items()
+    )
+    return [score for score in candidates if score is not None]
+
+
+def _replace_scores(existing_filter: dict, scores: list[Score]) -> None:
+    with transaction.atomic():
+        Score.objects.filter(**existing_filter).delete()
+        Score.objects.bulk_create(scores)
+
+
 def _source_for_evaluator(evaluator) -> str:
     """Map an Evaluator.type to a Score.Source. Defaults to LLM_JUDGE."""
     if evaluator.type == "PythonEvaluator":
@@ -121,26 +135,16 @@ def write_scores_from_evaluation_result(result: EvaluationResult) -> None:
     if not isinstance(result_payload, dict):
         return
 
-    source = _source_for_evaluator(result.evaluator)
     schema = (result.evaluator.params or {}).get("output_schema", {}) or {}
-
-    scores = []
-    for name, raw_value in result_payload.items():
-        score = _score_from_field(
-            team=result.team,
-            target=session,
-            name=name,
-            raw_value=raw_value,
-            source=source,
-            automated_result=result,
-            schema_field=schema.get(name),
-        )
-        if score is not None:
-            scores.append(score)
-
-    with transaction.atomic():
-        Score.objects.filter(automated_result=result).delete()
-        Score.objects.bulk_create(scores)
+    scores = _build_scores(
+        result_payload,
+        schema,
+        team=result.team,
+        target=session,
+        source=_source_for_evaluator(result.evaluator),
+        automated_result=result,
+    )
+    _replace_scores({"automated_result": result}, scores)
 
 
 def write_scores_from_annotation(annotation: Annotation) -> None:
@@ -157,24 +161,13 @@ def write_scores_from_annotation(annotation: Annotation) -> None:
     if target is None:
         return
 
-    schema = item.queue.schema or {}
-    data = annotation.data or {}
-
-    scores = []
-    for name, raw_value in data.items():
-        score = _score_from_field(
-            team=annotation.team,
-            target=target,
-            name=name,
-            raw_value=raw_value,
-            source=Score.Source.HUMAN_REVIEW,
-            review=annotation,
-            author=annotation.reviewer,
-            schema_field=schema.get(name),
-        )
-        if score is not None:
-            scores.append(score)
-
-    with transaction.atomic():
-        Score.objects.filter(review=annotation).delete()
-        Score.objects.bulk_create(scores)
+    scores = _build_scores(
+        annotation.data or {},
+        item.queue.schema or {},
+        team=annotation.team,
+        target=target,
+        source=Score.Source.HUMAN_REVIEW,
+        review=annotation,
+        author=annotation.reviewer,
+    )
+    _replace_scores({"review": annotation}, scores)

--- a/apps/assessments/score_writers.py
+++ b/apps/assessments/score_writers.py
@@ -17,6 +17,49 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+_ScoreValueParts = tuple["Score.DataType", Decimal | None, str | None]
+
+
+def _binary_parts(name: str, raw_value: Any, schema_field: dict | None) -> _ScoreValueParts | None:
+    if raw_value not in (0, 1):
+        logger.warning("Score field %s: binary value %r is not 0 or 1; skipping", name, raw_value)
+        return None
+    is_true = int(raw_value) == 1
+    label = (schema_field or {}).get("true_label" if is_true else "false_label", str(is_true))
+    return Score.DataType.BOOLEAN, Decimal(int(raw_value)), sanitize_control_chars(str(label))
+
+
+def _numeric_parts(name: str, raw_value: Any) -> _ScoreValueParts | None:
+    try:
+        return Score.DataType.NUMERIC, Decimal(str(raw_value)), None
+    except InvalidOperation:
+        logger.warning("Score field %s: cannot convert %r to Decimal; skipping", name, raw_value)
+        return None
+
+
+def _score_value_parts(name: str, raw_value: Any, schema_field: dict | None) -> _ScoreValueParts | None:
+    """Resolve (data_type, value_numeric, value_string) for a field value, or None if unsupported."""
+    schema_type = (schema_field or {}).get("type")
+    # Force categorical when the schema declares a choice — handles numeric-looking
+    # choice values like "0" / "1" without misclassifying them as numeric.
+    if schema_type == "choice":
+        return Score.DataType.CATEGORICAL, None, sanitize_control_chars(str(raw_value))
+    if schema_type == "binary":
+        return _binary_parts(name, raw_value, schema_field)
+    if isinstance(raw_value, bool):
+        return Score.DataType.BOOLEAN, Decimal(1) if raw_value else Decimal(0), None
+    if isinstance(raw_value, int | float | Decimal):
+        return _numeric_parts(name, raw_value)
+    if isinstance(raw_value, str):
+        return Score.DataType.CATEGORICAL, None, sanitize_control_chars(raw_value)
+    logger.warning(
+        "Score field %s: unsupported value type %s; skipping (v1 only supports bool/int/float/str)",
+        name,
+        type(raw_value).__name__,
+    )
+    return None
+
+
 def _score_from_field(
     *,
     team,
@@ -33,44 +76,10 @@ def _score_from_field(
     if raw_value is None:
         return None
 
-    schema_type = (schema_field or {}).get("type")
-    value_numeric: Decimal | None = None
-    value_string: str | None = None
-
-    # Force categorical when the schema declares a choice — handles numeric-looking
-    # choice values like "0" / "1" without misclassifying them as numeric.
-    if schema_type == "choice":
-        data_type = Score.DataType.CATEGORICAL
-        value_string = sanitize_control_chars(str(raw_value))
-    elif schema_type == "binary":
-        if raw_value not in (0, 1):
-            logger.warning("Score field %s: binary value %r is not 0 or 1; skipping", name, raw_value)
-            return None
-        data_type = Score.DataType.BOOLEAN
-        value_numeric = Decimal(int(raw_value))
-        label_key = "true_label" if int(raw_value) == 1 else "false_label"
-        default = "True" if int(raw_value) == 1 else "False"
-        value_string = sanitize_control_chars(str((schema_field or {}).get(label_key, default)))
-    elif isinstance(raw_value, bool):
-        data_type = Score.DataType.BOOLEAN
-        value_numeric = Decimal(1) if raw_value else Decimal(0)
-    elif isinstance(raw_value, int | float | Decimal):
-        try:
-            value_numeric = Decimal(str(raw_value))
-        except InvalidOperation:
-            logger.warning("Score field %s: cannot convert %r to Decimal; skipping", name, raw_value)
-            return None
-        data_type = Score.DataType.NUMERIC
-    elif isinstance(raw_value, str):
-        data_type = Score.DataType.CATEGORICAL
-        value_string = sanitize_control_chars(raw_value)
-    else:
-        logger.warning(
-            "Score field %s: unsupported value type %s; skipping (v1 only supports bool/int/float/str)",
-            name,
-            type(raw_value).__name__,
-        )
+    parts = _score_value_parts(name, raw_value, schema_field)
+    if parts is None:
         return None
+    data_type, value_numeric, value_string = parts
 
     return Score(
         team=team,

--- a/apps/assessments/tests/test_concordance_binary.py
+++ b/apps/assessments/tests/test_concordance_binary.py
@@ -1,0 +1,37 @@
+import pytest
+
+from apps.assessments.models import Score
+from apps.assessments.views import _candidate_categorical_fields, _score_compare_value, _score_value
+from apps.utils.factories.evaluations import EvaluationConfigFactory, EvaluatorFactory
+from apps.utils.factories.human_annotations import AnnotationQueueFactory
+
+
+@pytest.mark.django_db()
+def test_binary_fields_on_both_sides_are_concordance_candidates():
+    evaluator = EvaluatorFactory(binary_schema=True)
+    config = EvaluationConfigFactory(team=evaluator.team, evaluators=[evaluator])
+    queue = AnnotationQueueFactory(team=evaluator.team, binary_schema=True)
+
+    assert _candidate_categorical_fields(config, queue) == ["correct"]
+
+
+@pytest.mark.django_db()
+def test_choice_binary_type_mismatch_is_not_a_candidate():
+    evaluator = EvaluatorFactory(binary_schema=True)
+    config = EvaluationConfigFactory(team=evaluator.team, evaluators=[evaluator])
+    queue = AnnotationQueueFactory(
+        team=evaluator.team,
+        schema={"correct": {"type": "choice", "description": "d", "choices": ["yes", "no"]}},
+    )
+
+    assert _candidate_categorical_fields(config, queue) == []
+
+
+def test_boolean_score_display_prefers_label_and_comparison_uses_boolean():
+    labelled = Score(data_type=Score.DataType.BOOLEAN, value_numeric=1, value_string="Correct")
+    unlabelled = Score(data_type=Score.DataType.BOOLEAN, value_numeric=1, value_string=None)
+
+    assert _score_value(labelled) == "Correct"
+    assert _score_value(unlabelled) is True
+    assert _score_compare_value(labelled) is True
+    assert _score_compare_value(unlabelled) is True

--- a/apps/assessments/tests/test_export.py
+++ b/apps/assessments/tests/test_export.py
@@ -87,6 +87,64 @@ def test_export_concordance_csv(client, concordance_flags):
 
 
 @pytest.mark.django_db()
+def test_export_concordance_csv_neutralizes_formula_label_values(client, concordance_flags):
+    # Binary labels are user-controlled and land in the CSV via Score.value_string;
+    # a label starting with = would execute as a formula when opened in Excel/Sheets.
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    client.force_login(user)
+
+    formula_label = '=HYPERLINK("http://evil.example","open")'
+    schema = {
+        "verdict": {
+            "type": "binary",
+            "description": "x",
+            "true_label": formula_label,
+            "false_label": "No",
+        }
+    }
+    session = ExperimentSessionFactory.create(team=team, experiment__team=team)
+    evaluator = EvaluatorFactory.create(team=team, params={"llm_prompt": "x", "output_schema": schema})
+    eval_config = EvaluationConfigFactory.create(team=team)
+    eval_config.evaluators.add(evaluator)
+    run = EvaluationRunFactory.create(team=team, config=eval_config)
+    message = EvaluationMessageFactory.create(session=session)
+    result = EvaluationResult.objects.create(
+        team=team,
+        evaluator=evaluator,
+        message=message,
+        run=run,
+        output={"result": {"verdict": 1}},
+    )
+    write_scores_from_evaluation_result(result)
+
+    queue = AnnotationQueueFactory.create(team=team, schema=schema)
+    item = AnnotationItemFactory.create(queue=queue, session=session, team=team)
+    Annotation.objects.create(
+        team=team,
+        item=item,
+        reviewer=user,
+        data={"verdict": 1},
+        status=AnnotationStatus.SUBMITTED,
+    )
+
+    url = reverse("assessments:concordance_export", args=[team.slug])
+    response = client.get(url, {"eval": eval_config.id, "queue": queue.id, "field": "verdict", "show": "all"})
+
+    assert response.status_code == 200
+    reader = csv.DictReader(io.StringIO(response.content.decode()))
+    rows = list(reader)
+    assert len(rows) >= 1
+    for row in rows:
+        for value in (row["judge_verdict"], row["human_verdict"]):
+            if value:
+                assert not value.startswith("="), f"unneutralized formula value in CSV: {value!r}"
+    matched = [row for row in rows if row["kind"] == "matched"]
+    assert matched[0]["judge_verdict"] == f"'{formula_label}"
+    assert matched[0]["human_verdict"] == f"'{formula_label}"
+
+
+@pytest.mark.django_db()
 def test_export_concordance_csv_missing_params(client, concordance_flags):
     team = TeamWithUsersFactory.create()
     user = team.members.first()

--- a/apps/assessments/tests/test_score_writers.py
+++ b/apps/assessments/tests/test_score_writers.py
@@ -440,6 +440,49 @@ def test_annotation_save_survives_score_writer_failure(annotation_on_session, ca
     assert any(rec.levelname == "ERROR" and "Failed to write Score rows" in rec.message for rec in caplog.records)
 
 
+def _make_binary_eval_result(raw_value):
+    """Build an EvaluationResult whose evaluator carries the `binary_schema` trait
+    (output_schema: {"correct": {type: binary, true_label: Correct, false_label:
+    Incorrect}}) and whose output is {"result": {"correct": raw_value}}. Mirrors the
+    eval_result_on_session fixture's shape above, parametrized over raw_value."""
+    team = TeamFactory.create()
+    session = ExperimentSessionFactory.create(team=team, experiment__team=team)
+    message = EvaluationMessageFactory.create(session=session)
+    evaluator = EvaluatorFactory.create(team=team, binary_schema=True)
+    run = EvaluationRunFactory.create(team=team)
+    return EvaluationResultFactory.create(
+        team=team,
+        evaluator=evaluator,
+        message=message,
+        run=run,
+        output={"result": {"correct": raw_value}},
+    )
+
+
+@pytest.mark.django_db()
+class TestBinaryScoreWriting:
+    @pytest.mark.parametrize(
+        ("raw_value", "expected_numeric", "expected_string"),
+        [
+            pytest.param(1, Decimal(1), "Correct", id="one-writes-true-label"),
+            pytest.param(0, Decimal(0), "Incorrect", id="zero-writes-false-label"),
+        ],
+    )
+    def test_binary_field_writes_boolean_with_label(self, raw_value, expected_numeric, expected_string):
+        result = _make_binary_eval_result(raw_value)
+        write_scores_from_evaluation_result(result)
+
+        score = Score.objects.get(automated_result=result, name="correct")
+        assert score.data_type == Score.DataType.BOOLEAN
+        assert score.value_numeric == expected_numeric
+        assert score.value_string == expected_string
+
+    def test_non_binary_value_skipped_with_no_score_row(self):
+        result = _make_binary_eval_result(5)
+        write_scores_from_evaluation_result(result)
+        assert not Score.objects.filter(automated_result=result, name="correct").exists()
+
+
 @pytest.mark.django_db()
 @patch("apps.evaluations.models.Evaluator.run")
 def test_evaluation_task_survives_score_writer_failure(evaluator_run_mock, caplog, monkeypatch):

--- a/apps/assessments/views.py
+++ b/apps/assessments/views.py
@@ -14,6 +14,7 @@ from apps.experiments.models import ExperimentSession
 from apps.human_annotations.models import AnnotationItem, AnnotationQueue
 from apps.teams.decorators import login_and_team_required
 from apps.teams.mixins import LoginAndTeamRequiredMixin
+from apps.utils.csv_export import neutralize_csv_formula
 
 _SESSION_MODE = EvaluationMode.SESSION
 
@@ -370,8 +371,8 @@ def export_concordance_csv(request: HttpRequest, team_slug: str) -> HttpResponse
                 row.kind,
                 row.session_external_id,
                 row.experiment_public_id,
-                row.judge_value,
-                row.human_value,
+                neutralize_csv_formula(row.judge_value),
+                neutralize_csv_formula(row.human_value),
                 row.agree,
                 row.eval_run_id,
                 row.eval_result_id,

--- a/apps/assessments/views.py
+++ b/apps/assessments/views.py
@@ -48,7 +48,7 @@ def _candidate_categorical_fields(eval_config: EvaluationConfig, queue: Annotati
     for name in sorted(shared):
         eval_type = eval_fields[name].get("type")
         queue_type = queue_fields[name].get("type")
-        if eval_type == "choice" and queue_type == "choice":
+        if eval_type == queue_type and eval_type in ("choice", "binary"):
             candidates.append(name)
     return candidates
 
@@ -66,7 +66,17 @@ def _latest_score_per_target(scores) -> dict[int, Score]:
 
 
 def _score_value(score: Score) -> Any:
-    """Render the comparable value out of a Score."""
+    """Render the display value out of a Score."""
+    if score.data_type == Score.DataType.CATEGORICAL:
+        return score.value_string
+    if score.data_type == Score.DataType.BOOLEAN:
+        return score.value_string if score.value_string else bool(score.value_numeric)
+    return score.value_numeric
+
+
+def _score_compare_value(score: Score) -> Any:
+    """Value used for agreement comparison. BOOLEAN compares as a boolean so two
+    sides with different display labels still agree on the underlying value."""
     if score.data_type == Score.DataType.CATEGORICAL:
         return score.value_string
     if score.data_type == Score.DataType.BOOLEAN:
@@ -148,6 +158,8 @@ def _make_row(
     ext_id, exp_id = _session_fields(sessions_by_id.get(target_id))
     j_val = _score_value(judge_score) if judge_score is not None else None
     h_val = _score_value(human_score) if human_score is not None else None
+    j_cmp = _score_compare_value(judge_score) if judge_score is not None else None
+    h_cmp = _score_compare_value(human_score) if human_score is not None else None
     # NOTE: the eval results page's `?result_id=` is actually an EvaluationMessage.id
     # (its table rows are keyed by message — multiple evaluator results for the same
     # message merge into one row). Pass the message id, not the EvaluationResult.id,
@@ -160,7 +172,7 @@ def _make_row(
         experiment_public_id=exp_id,
         judge_value=j_val,
         human_value=h_val,
-        agree=(j_val == h_val) if kind == "matched" else None,
+        agree=(j_cmp == h_cmp) if kind == "matched" else None,
         eval_run_id=automated.run_id if automated else None,
         eval_result_id=automated.message_id if automated else None,
         annotation_item_id=item.id if item else None,

--- a/apps/evaluations/aggregation.py
+++ b/apps/evaluations/aggregation.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
-from apps.evaluations.aggregators import aggregate_field, get_aggregators_for_value
-from apps.evaluations.models import EvaluationRun, EvaluationRunAggregate
+from apps.evaluations.aggregators import aggregate_binary_field, aggregate_field, get_aggregators_for_value
+from apps.evaluations.models import EvaluationRun, EvaluationRunAggregate, Evaluator
 
 RESULT_CHUNK_SIZE = 500  # results fetched per round trip when streaming a run's results
 
@@ -24,12 +24,18 @@ def compute_aggregates_for_run(run: EvaluationRun) -> list[EvaluationRunAggregat
         if result_data:  # Skip results with errors
             _collect_aggregatable_values(result_data, field_values_by_evaluator[evaluator_id])
 
+    # One bulk fetch for the schemas; EvaluationResult.evaluator is CASCADE so an id
+    # from results always resolves outside a delete race.
+    evaluators = Evaluator.objects.in_bulk(field_values_by_evaluator)
+
     aggregates = []
     for evaluator_id, field_values in field_values_by_evaluator.items():
+        evaluator = evaluators.get(evaluator_id)
+        schema = (evaluator.params or {}).get("output_schema", {}) or {} if evaluator else {}
         obj, _ = EvaluationRunAggregate.objects.update_or_create(
             run=run,
             evaluator_id=evaluator_id,
-            defaults={"aggregates": _aggregate_fields(field_values)},
+            defaults={"aggregates": _aggregate_fields(field_values, schema)},
         )
         aggregates.append(obj)
 
@@ -43,5 +49,17 @@ def _collect_aggregatable_values(result: dict, field_values: defaultdict[str, li
             field_values[field_name].append(value)
 
 
-def _aggregate_fields(field_values: defaultdict[str, list]) -> dict:
-    return {field_name: aggregate_field(values) for field_name, values in field_values.items()}
+def _aggregate_fields(field_values: defaultdict[str, list], schema: dict) -> dict:
+    """Aggregate each field, dispatching binary fields by schema type.
+
+    A field name present in results but absent from the schema (renamed, removed,
+    or a Python evaluator with no output_schema) falls through to aggregate_field.
+    """
+    return {
+        field_name: (
+            aggregate_binary_field(values)
+            if (schema.get(field_name) or {}).get("type") == "binary"
+            else aggregate_field(values)
+        )
+        for field_name, values in field_values.items()
+    }

--- a/apps/evaluations/aggregators.py
+++ b/apps/evaluations/aggregators.py
@@ -150,3 +150,23 @@ def aggregate_field(values: list) -> dict:
             result[agg.name] = computed
 
     return result
+
+
+def aggregate_binary_field(values: list) -> dict:
+    """Aggregate a binary field's stored 1/0 values as a rate.
+
+    Values other than 0 and 1 (bools count as their integer values) are excluded
+    from count/mean/true_count and reported as excluded_count when present -
+    annotation data is not schema-constrained outside the form.
+    """
+    present = [v for v in values if v is not None]
+    counted = [int(v) for v in present if v in (0, 1)]
+
+    result = {"type": "binary", "count": len(counted)}
+    if counted:
+        result["mean"] = round(sum(counted) / len(counted), 4)
+        result["true_count"] = sum(counted)
+    excluded = len(present) - len(counted)
+    if excluded:
+        result["excluded_count"] = excluded
+    return result

--- a/apps/evaluations/field_definitions.py
+++ b/apps/evaluations/field_definitions.py
@@ -6,7 +6,7 @@ Uses discriminated unions to ensure type-specific constraints are enforced.
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator, model_validator
 
 
 class BaseFieldDefinition(BaseModel):
@@ -80,4 +80,40 @@ class ChoiceFieldDefinition(BaseFieldDefinition):
         return Literal[tuple(self.choices)]
 
 
-FieldDefinition = StringFieldDefinition | IntFieldDefinition | FloatFieldDefinition | ChoiceFieldDefinition
+class BinaryFieldDefinition(BaseFieldDefinition):
+    """Binary field stored as integer 1/0; labels are display vocabulary only."""
+
+    type: Literal["binary"]
+    true_label: str = "True"
+    false_label: str = "False"
+
+    @field_validator("true_label", "false_label")
+    @classmethod
+    def _label_not_blank(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("Binary labels cannot be empty or whitespace-only")
+        return value
+
+    @model_validator(mode="after")
+    def _labels_distinct(self):
+        if self.true_label.strip() == self.false_label.strip():
+            raise ValueError("Binary labels must be distinct")
+        return self
+
+    @property
+    def python_type(self) -> type:
+        return Literal[0, 1]  # ty: ignore[invalid-return-type]
+
+    @property
+    def pydantic_fields(self) -> dict:
+        fields = self.model_dump(
+            exclude={"type", "use_in_aggregations", "required", "true_label", "false_label"},
+            exclude_none=True,
+        )
+        fields["description"] = f"{self.description}. 1 = {self.true_label}, 0 = {self.false_label}"
+        return fields
+
+
+FieldDefinition = (
+    StringFieldDefinition | IntFieldDefinition | FloatFieldDefinition | ChoiceFieldDefinition | BinaryFieldDefinition
+)

--- a/apps/evaluations/field_definitions.py
+++ b/apps/evaluations/field_definitions.py
@@ -92,7 +92,7 @@ class BinaryFieldDefinition(BaseFieldDefinition):
     def _label_not_blank(cls, value: str) -> str:
         if not value or not value.strip():
             raise ValueError("Binary labels cannot be empty or whitespace-only")
-        return value
+        return value.strip()
 
     @model_validator(mode="after")
     def _labels_distinct(self):

--- a/apps/evaluations/forms.py
+++ b/apps/evaluations/forms.py
@@ -476,7 +476,7 @@ class EvaluatorTagRuleForm(forms.ModelForm):
         try:
             coerced = ConditionType.coerce_value(value, field_type)
         except (TypeError, ValueError):
-            msg = "Value must be an integer." if field_type == "int" else "Value must be numeric."
+            msg = "Value must be an integer." if field_type in ("int", "binary") else "Value must be numeric."
             self.add_error("condition_value_single", msg)
             return
         if not self.errors:

--- a/apps/evaluations/rule_validation.py
+++ b/apps/evaluations/rule_validation.py
@@ -42,9 +42,9 @@ class ConditionType(models.TextChoices):
     def coerce_value(raw, field_type: str | None):
         """Coerce a raw equals-value input to the target field's python type.
 
-        Returns the input unchanged when `field_type` isn't numeric; raises
-        (TypeError, ValueError) on failed int/float conversion so the form can
-        surface a user-facing error.
+        Returns the input unchanged when `field_type` isn't numeric or binary;
+        raises (TypeError, ValueError) on failed int/float conversion so the form
+        can surface a user-facing error.
         """
         if field_type == "int":
             return int(raw)

--- a/apps/evaluations/rule_validation.py
+++ b/apps/evaluations/rule_validation.py
@@ -16,6 +16,7 @@ from pydantic import TypeAdapter
 from pydantic import ValidationError as PydanticValidationError
 
 from apps.evaluations.field_definitions import (
+    BinaryFieldDefinition,
     ChoiceFieldDefinition,
     FieldDefinition,
     FloatFieldDefinition,
@@ -49,6 +50,8 @@ class ConditionType(models.TextChoices):
             return int(raw)
         if field_type == "float":
             return float(raw)
+        if field_type == "binary":
+            return int(raw)
         return raw
 
     def matches(self, condition_value: dict, field_value) -> bool:
@@ -68,7 +71,7 @@ class ConditionType(models.TextChoices):
 
 def parse_field_definition(field_def: dict | FieldDefinition) -> FieldDefinition:
     """Parse a raw dict into a typed FieldDefinition, or return as-is if already one."""
-    if isinstance(field_def, (IntFieldDefinition, FloatFieldDefinition, ChoiceFieldDefinition)):
+    if isinstance(field_def, (IntFieldDefinition, FloatFieldDefinition, ChoiceFieldDefinition, BinaryFieldDefinition)):
         return field_def
     return _FIELD_DEFINITION_ADAPTER.validate_python(field_def)
 
@@ -142,6 +145,12 @@ def _validate_equals_condition(condition_value: dict, field_definition: FieldDef
                     )
                 }
             )
+        return
+    if isinstance(field_definition, BinaryFieldDefinition):
+        coerced = _coerce_numeric(condition_value["value"], int)
+        if coerced not in (0, 1):
+            raise ValidationError({"condition_value": "Value must be 0 or 1 for a binary field."})
+        condition_value["value"] = coerced
         return
     if isinstance(field_definition, _NUMERIC_FIELD_TYPES):
         condition_value["value"] = _coerce_numeric(condition_value["value"], field_definition.python_type)

--- a/apps/evaluations/rule_validation.py
+++ b/apps/evaluations/rule_validation.py
@@ -128,6 +128,26 @@ def _coerce_numeric(raw: Any, py_type: type) -> int | float:
         raise ValidationError({"condition_value": f"Value must be coercible to {py_type.__name__}."}) from err
 
 
+def _validate_choice_equals(condition_value: dict, field_definition: ChoiceFieldDefinition) -> None:
+    if not field_definition.choices:
+        raise ValidationError({"condition_value": "Choice field has no 'choices' configured."})
+    if condition_value["value"] not in field_definition.choices:
+        raise ValidationError(
+            {
+                "condition_value": (
+                    f"Value '{condition_value['value']}' is not in the field's choices: {field_definition.choices}"
+                )
+            }
+        )
+
+
+def _validate_binary_equals(condition_value: dict) -> None:
+    coerced = _coerce_numeric(condition_value["value"], int)
+    if coerced not in (0, 1):
+        raise ValidationError({"condition_value": "Value must be 0 or 1 for a binary field."})
+    condition_value["value"] = coerced
+
+
 def _validate_equals_condition(condition_value: dict, field_definition: FieldDefinition) -> None:
     extra = set(condition_value.keys()) - {"value"}
     if extra:
@@ -135,31 +155,16 @@ def _validate_equals_condition(condition_value: dict, field_definition: FieldDef
     if "value" not in condition_value:
         raise ValidationError({"condition_value": "'equals' condition requires a 'value' key."})
     if isinstance(field_definition, ChoiceFieldDefinition):
-        if not field_definition.choices:
-            raise ValidationError({"condition_value": "Choice field has no 'choices' configured."})
-        if condition_value["value"] not in field_definition.choices:
-            raise ValidationError(
-                {
-                    "condition_value": (
-                        f"Value '{condition_value['value']}' is not in the field's choices: {field_definition.choices}"
-                    )
-                }
-            )
-        return
-    if isinstance(field_definition, BinaryFieldDefinition):
-        coerced = _coerce_numeric(condition_value["value"], int)
-        if coerced not in (0, 1):
-            raise ValidationError({"condition_value": "Value must be 0 or 1 for a binary field."})
-        condition_value["value"] = coerced
-        return
-    if isinstance(field_definition, _NUMERIC_FIELD_TYPES):
+        _validate_choice_equals(condition_value, field_definition)
+    elif isinstance(field_definition, BinaryFieldDefinition):
+        _validate_binary_equals(condition_value)
+    elif isinstance(field_definition, _NUMERIC_FIELD_TYPES):
         condition_value["value"] = _coerce_numeric(condition_value["value"], field_definition.python_type)
-        return
-    if isinstance(field_definition, StringFieldDefinition):
+    elif isinstance(field_definition, StringFieldDefinition):
         if not isinstance(condition_value["value"], str):
             raise ValidationError({"condition_value": "Value must be a string."})
-        return
-    raise ValidationError({"condition_type": "'equals' condition is not supported for this field type."})
+    else:
+        raise ValidationError({"condition_type": "'equals' condition is not supported for this field type."})
 
 
 def _validate_range_condition(condition_value: dict, field_definition: FieldDefinition) -> None:

--- a/apps/evaluations/tests/test_aggregations.py
+++ b/apps/evaluations/tests/test_aggregations.py
@@ -244,6 +244,49 @@ class TestBuildTrendData:
         assert categorical_data["points"][0]["value"] == "good"
 
 
+@pytest.mark.django_db()
+class TestBinaryAggregationDispatch:
+    def _make_run_with_results(self, evaluator, outputs):
+        run = EvaluationRunFactory.create(team=evaluator.team)
+        for output in outputs:
+            EvaluationResultFactory.create(
+                team=evaluator.team,
+                run=run,
+                evaluator=evaluator,
+                output={"result": output},
+            )
+        return run
+
+    def test_binary_field_routes_to_binary_aggregator(self):
+        evaluator = EvaluatorFactory.create(binary_schema=True)
+        run = self._make_run_with_results(evaluator, [{"correct": 1}, {"correct": 0}, {"correct": 1}])
+        (aggregate,) = compute_aggregates_for_run(run)
+        assert aggregate.aggregates["correct"] == {
+            "type": "binary",
+            "count": 3,
+            "mean": 0.6667,
+            "true_count": 2,
+        }
+
+    def test_field_absent_from_schema_falls_back_to_value_dispatch(self):
+        # A renamed or removed field aggregates as it does today (numeric for ints).
+        evaluator = EvaluatorFactory.create(binary_schema=True)
+        run = self._make_run_with_results(evaluator, [{"old_name": 1}, {"old_name": 0}])
+        (aggregate,) = compute_aggregates_for_run(run)
+        assert aggregate.aggregates["old_name"]["type"] == "numeric"
+
+    def test_python_evaluator_without_output_schema_unchanged(self):
+        evaluator = EvaluatorFactory.create(
+            type="PythonEvaluator",
+            llm_provider=None,
+            llm_provider_model=None,
+            params={"code": "pass"},
+        )
+        run = self._make_run_with_results(evaluator, [{"score": 1}, {"score": 0}])
+        (aggregate,) = compute_aggregates_for_run(run)
+        assert aggregate.aggregates["score"]["type"] == "numeric"
+
+
 class TestAggregateBinaryField:
     @pytest.mark.parametrize(
         ("values", "expected"),

--- a/apps/evaluations/tests/test_aggregations.py
+++ b/apps/evaluations/tests/test_aggregations.py
@@ -1,7 +1,7 @@
 import pytest
 
 from apps.evaluations.aggregation import compute_aggregates_for_run
-from apps.evaluations.aggregators import aggregate_field, get_aggregators_for_value
+from apps.evaluations.aggregators import aggregate_binary_field, aggregate_field, get_aggregators_for_value
 from apps.evaluations.models import EvaluationRunStatus
 from apps.evaluations.utils import build_trend_data
 from apps.utils.factories.evaluations import EvaluationResultFactory, EvaluationRunFactory, EvaluatorFactory
@@ -242,3 +242,49 @@ class TestBuildTrendData:
         assert categorical_data["type"] == "categorical"
         assert len(categorical_data["points"]) == 1
         assert categorical_data["points"][0]["value"] == "good"
+
+
+class TestAggregateBinaryField:
+    @pytest.mark.parametrize(
+        ("values", "expected"),
+        [
+            pytest.param(
+                [1, 1, 1],
+                {"type": "binary", "count": 3, "mean": 1.0, "true_count": 3},
+                id="all-true",
+            ),
+            pytest.param(
+                [0, 0],
+                {"type": "binary", "count": 2, "mean": 0.0, "true_count": 0},
+                id="all-false-keeps-zero-stats",
+            ),
+            pytest.param(
+                [1, 0, 1, 0],
+                {"type": "binary", "count": 4, "mean": 0.5, "true_count": 2},
+                id="mixed",
+            ),
+            pytest.param(
+                [True, False, 1],
+                {"type": "binary", "count": 3, "mean": 0.6667, "true_count": 2},
+                id="bools-count-as-their-integer-values",
+            ),
+            pytest.param(
+                [1, 2, "yes", 0],
+                {"type": "binary", "count": 2, "mean": 0.5, "true_count": 1, "excluded_count": 2},
+                id="non-binary-values-excluded-and-reported",
+            ),
+            pytest.param(
+                [2, "maybe"],
+                {"type": "binary", "count": 0, "excluded_count": 2},
+                id="all-excluded-returns-count-0-without-mean",
+            ),
+            pytest.param([], {"type": "binary", "count": 0}, id="empty-input"),
+            pytest.param(
+                [None, 1, 0],
+                {"type": "binary", "count": 2, "mean": 0.5, "true_count": 1},
+                id="none-filtered-silently-like-aggregate-field",
+            ),
+        ],
+    )
+    def test_aggregate_binary_field(self, values, expected):
+        assert aggregate_binary_field(values) == expected

--- a/apps/evaluations/tests/test_aggregations.py
+++ b/apps/evaluations/tests/test_aggregations.py
@@ -4,7 +4,12 @@ from apps.evaluations.aggregation import compute_aggregates_for_run
 from apps.evaluations.aggregators import aggregate_binary_field, aggregate_field, get_aggregators_for_value
 from apps.evaluations.models import EvaluationRunStatus
 from apps.evaluations.utils import build_trend_data
-from apps.utils.factories.evaluations import EvaluationResultFactory, EvaluationRunFactory, EvaluatorFactory
+from apps.utils.factories.evaluations import (
+    EvaluationResultFactory,
+    EvaluationRunAggregateFactory,
+    EvaluationRunFactory,
+    EvaluatorFactory,
+)
 
 
 class TestAggregators:
@@ -242,6 +247,26 @@ class TestBuildTrendData:
         assert categorical_data["type"] == "categorical"
         assert len(categorical_data["points"]) == 1
         assert categorical_data["points"][0]["value"] == "good"
+
+    def test_binary_field_uses_mean_points(self):
+        evaluator = EvaluatorFactory.create(binary_schema=True)
+        runs = []
+        for mean, true_count, count in [(1.0, 2, 2), (0.5, 1, 2)]:
+            run = EvaluationRunFactory.create(team=evaluator.team)
+            EvaluationRunAggregateFactory.create(
+                run=run,
+                evaluator=evaluator,
+                aggregates={"correct": {"type": "binary", "count": count, "mean": mean, "true_count": true_count}},
+            )
+            runs.append(run)
+
+        trend_data = build_trend_data(runs)
+
+        field = trend_data[evaluator.name]["correct (binary)"]
+        assert field["type"] == "binary"
+        assert [p["value"] for p in field["points"]] == [1.0, 0.5]
+        assert field["mean"] == 0.75
+        assert "categories" not in field
 
 
 @pytest.mark.django_db()

--- a/apps/evaluations/tests/test_evaluation_utils.py
+++ b/apps/evaluations/tests/test_evaluation_utils.py
@@ -2,7 +2,7 @@ import pytest
 
 from apps.chat.models import ChatMessageType
 from apps.evaluations.exceptions import HistoryParseException
-from apps.evaluations.utils import make_evaluation_messages_from_sessions, parse_history_text
+from apps.evaluations.utils import make_evaluation_messages_from_sessions, merge_binary_labels, parse_history_text
 from apps.utils.factories.experiment import ChatMessageFactory, ExperimentSessionFactory
 from apps.utils.factories.team import TeamFactory
 from apps.utils.factories.traces import TraceFactory
@@ -215,3 +215,23 @@ def test_make_evaluation_messages_from_sessions():
     assert eval_msg_4.metadata["session_id"] == session.external_id
     # History should include all previous messages
     assert len(eval_msg_4.history) == 5  # human1, ai1, human2, human3, ai3
+
+
+class TestMergeBinaryLabels:
+    def test_binary_stats_gain_labels_from_schema(self):
+        stats = {"type": "binary", "count": 3, "mean": 0.6667, "true_count": 2}
+        field_def = {"type": "binary", "true_label": "Correct", "false_label": "Incorrect"}
+        assert merge_binary_labels(stats, field_def) == {
+            **stats,
+            "true_label": "Correct",
+            "false_label": "Incorrect",
+        }
+
+    def test_labels_default_when_schema_omits_them(self):
+        merged = merge_binary_labels({"type": "binary", "count": 1}, {"type": "binary"})
+        assert merged["true_label"] == "True"
+        assert merged["false_label"] == "False"
+
+    def test_non_binary_stats_unchanged(self):
+        stats = {"type": "numeric", "count": 3, "mean": 2.0}
+        assert merge_binary_labels(stats, {"type": "int"}) is stats

--- a/apps/evaluations/tests/test_evaluation_utils.py
+++ b/apps/evaluations/tests/test_evaluation_utils.py
@@ -218,19 +218,24 @@ def test_make_evaluation_messages_from_sessions():
 
 
 class TestMergeBinaryLabels:
-    def test_binary_stats_gain_labels_from_schema(self):
+    def test_binary_stats_gain_labels_and_false_count_from_schema(self):
         stats = {"type": "binary", "count": 3, "mean": 0.6667, "true_count": 2}
         field_def = {"type": "binary", "true_label": "Correct", "false_label": "Incorrect"}
         assert merge_binary_labels(stats, field_def) == {
             **stats,
             "true_label": "Correct",
             "false_label": "Incorrect",
+            "false_count": 1,
         }
 
     def test_labels_default_when_schema_omits_them(self):
         merged = merge_binary_labels({"type": "binary", "count": 1}, {"type": "binary"})
         assert merged["true_label"] == "True"
         assert merged["false_label"] == "False"
+
+    def test_no_false_count_without_true_count(self):
+        merged = merge_binary_labels({"type": "binary", "count": 0}, {"type": "binary"})
+        assert "false_count" not in merged
 
     def test_non_binary_stats_unchanged(self):
         stats = {"type": "numeric", "count": 3, "mean": 2.0}

--- a/apps/evaluations/tests/test_field_definitions.py
+++ b/apps/evaluations/tests/test_field_definitions.py
@@ -1,0 +1,68 @@
+from typing import Literal
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from apps.evaluations.field_definitions import BinaryFieldDefinition, FieldDefinition
+from apps.evaluations.utils import schema_to_pydantic_model
+
+
+class TestBinaryFieldDefinition:
+    def test_python_type_is_literal_0_1(self):
+        defn = BinaryFieldDefinition(type="binary", description="was the answer correct")
+        assert defn.python_type == Literal[0, 1]
+
+    def test_labels_default_to_true_false(self):
+        defn = BinaryFieldDefinition(type="binary", description="d")
+        assert defn.true_label == "True"
+        assert defn.false_label == "False"
+
+    @pytest.mark.parametrize(
+        ("true_label", "false_label"),
+        [
+            pytest.param("", "No", id="empty-true-label"),
+            pytest.param("Yes", "", id="empty-false-label"),
+            pytest.param("   ", "No", id="whitespace-true-label"),
+            pytest.param("Yes", "Yes", id="identical-labels"),
+            pytest.param("Yes", " Yes ", id="identical-after-strip"),
+        ],
+    )
+    def test_invalid_labels_rejected(self, true_label, false_label):
+        with pytest.raises(ValidationError):
+            BinaryFieldDefinition(type="binary", description="d", true_label=true_label, false_label=false_label)
+
+    def test_labels_fold_into_description_not_schema_kwargs(self):
+        defn = BinaryFieldDefinition(
+            type="binary", description="is it correct", true_label="correct", false_label="incorrect"
+        )
+        assert defn.pydantic_fields == {"description": "is it correct. 1 = correct, 0 = incorrect"}
+
+    def test_union_discriminates_binary(self):
+        parsed = TypeAdapter(FieldDefinition).validate_python(
+            {"type": "binary", "description": "d", "true_label": "Yes", "false_label": "No"}
+        )
+        assert isinstance(parsed, BinaryFieldDefinition)
+
+
+class TestBinarySchemaToPydanticModel:
+    def test_model_accepts_only_0_and_1(self):
+        model = schema_to_pydantic_model(
+            {"correct": BinaryFieldDefinition(type="binary", description="was it correct")}
+        )
+        assert model(correct=1).correct == 1
+        assert model(correct=0).correct == 0
+        with pytest.raises(ValidationError):
+            model(correct=2)
+
+    def test_labels_reach_the_judge_via_description(self):
+        model = schema_to_pydantic_model(
+            {
+                "correct": BinaryFieldDefinition(
+                    type="binary", description="was it correct", true_label="Right", false_label="Wrong"
+                )
+            }
+        )
+        schema = model.model_json_schema()
+        assert schema["properties"]["correct"]["description"] == "was it correct. 1 = Right, 0 = Wrong"
+        assert "true_label" not in schema["properties"]["correct"]
+        assert "false_label" not in schema["properties"]["correct"]

--- a/apps/evaluations/tests/test_run_aggregates_view.py
+++ b/apps/evaluations/tests/test_run_aggregates_view.py
@@ -131,6 +131,23 @@ def test_run_with_aggregates_renders_them_and_stops_polling(client_with_user, me
 
 
 @pytest.mark.django_db()
+def test_binary_aggregate_renders_a_count_for_each_label(client_with_user, membership):
+    run = _completed_run(membership.team, finalized=True)
+    EvaluationRunAggregateFactory.create(
+        run=run,
+        evaluator=EvaluatorFactory.create(team=membership.team, binary_schema=True),
+        aggregates={"correct": {"type": "binary", "count": 4, "mean": 0.75, "true_count": 3}},
+    )
+
+    response = client_with_user.get(_aggregates_url(run))
+
+    content = response.content.decode()
+    assert "3/4" in content
+    assert "Incorrect:" in content
+    assert "1/4" in content
+
+
+@pytest.mark.django_db()
 def test_finalized_run_with_no_aggregates_renders_nothing(client_with_user, membership):
     """A run whose results were all errors legitimately has none — and must not poll for them."""
     run = _completed_run(membership.team, finalized=True)

--- a/apps/evaluations/tests/test_tagging_logic.py
+++ b/apps/evaluations/tests/test_tagging_logic.py
@@ -6,12 +6,13 @@ import pytest
 from django.core.exceptions import ValidationError
 
 from apps.evaluations.field_definitions import (
+    BinaryFieldDefinition,
     ChoiceFieldDefinition,
     FloatFieldDefinition,
     IntFieldDefinition,
     StringFieldDefinition,
 )
-from apps.evaluations.rule_validation import validate_condition, validate_field_in_schema
+from apps.evaluations.rule_validation import ConditionType, validate_condition, validate_field_in_schema
 from apps.evaluations.tagging import evaluate_rules, matches, resolve_target
 
 
@@ -113,6 +114,54 @@ class TestValidateFieldInSchema:
     def test_empty_field_name(self):
         with pytest.raises(ValidationError):
             validate_field_in_schema("", {"x": {"type": "int", "description": "d"}})
+
+
+# ---- binary field tag rule conditions --------------------------------------
+
+
+BINARY_FIELD = BinaryFieldDefinition(
+    type="binary", description="was it correct", true_label="Correct", false_label="Incorrect"
+)
+
+
+class TestBinaryTagRuleConditions:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            pytest.param(1, 1, id="int-one"),
+            pytest.param(0, 0, id="int-zero"),
+            pytest.param("1", 1, id="string-one-coerced"),
+            pytest.param("0", 0, id="string-zero-coerced"),
+        ],
+    )
+    def test_equals_accepts_0_and_1(self, raw, expected):
+        condition_value = {"value": raw}
+        validate_condition(ConditionType.EQUALS, condition_value, BINARY_FIELD)
+        assert condition_value["value"] == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            pytest.param(2, id="out-of-range-int"),
+            pytest.param(-1, id="negative"),
+            pytest.param("maybe", id="non-numeric-string"),
+            pytest.param(0.5, id="non-integral-float"),
+        ],
+    )
+    def test_equals_rejects_non_binary_values(self, raw):
+        with pytest.raises(ValidationError):
+            validate_condition(ConditionType.EQUALS, {"value": raw}, BINARY_FIELD)
+
+    def test_range_rejected_for_binary(self):
+        with pytest.raises(ValidationError):
+            validate_condition(ConditionType.RANGE, {"min": 0, "max": 1}, BINARY_FIELD)
+
+    def test_coerce_value_converts_binary_to_int(self):
+        assert ConditionType.coerce_value("1", "binary") == 1
+
+    def test_equals_match_compares_stored_integers(self):
+        assert ConditionType.EQUALS.matches({"value": 1}, 1) is True
+        assert ConditionType.EQUALS.matches({"value": 1}, 0) is False
 
 
 # ---- evaluate_rules --------------------------------------------------------

--- a/apps/evaluations/utils.py
+++ b/apps/evaluations/utils.py
@@ -541,16 +541,20 @@ def get_use_in_aggregations(field_def: dict) -> bool:
 def merge_binary_labels(stats: dict, field_def: dict) -> dict:
     """Copy binary display labels from a field definition into an aggregate blob.
 
-    Labels live only in the schema; the stored blob carries integers. Non-binary
-    blobs pass through unchanged.
+    Labels live only in the schema; the stored blob carries integers. `false_count`
+    is derived here rather than stored so blobs aggregated before it existed still
+    render both counts. Non-binary blobs pass through unchanged.
     """
     if not isinstance(stats, dict) or stats.get("type") != "binary":
         return stats
-    return {
+    merged = {
         **stats,
         "true_label": field_def.get("true_label", "True"),
         "false_label": field_def.get("false_label", "False"),
     }
+    if stats.get("true_count") is not None:
+        merged["false_count"] = stats["count"] - stats["true_count"]
+    return merged
 
 
 def filter_aggregates_for_display(aggregates) -> list[dict]:

--- a/apps/evaluations/utils.py
+++ b/apps/evaluations/utils.py
@@ -538,6 +538,21 @@ def get_use_in_aggregations(field_def: dict) -> bool:
     return field_def.get("type") != "string"
 
 
+def merge_binary_labels(stats: dict, field_def: dict) -> dict:
+    """Copy binary display labels from a field definition into an aggregate blob.
+
+    Labels live only in the schema; the stored blob carries integers. Non-binary
+    blobs pass through unchanged.
+    """
+    if not isinstance(stats, dict) or stats.get("type") != "binary":
+        return stats
+    return {
+        **stats,
+        "true_label": field_def.get("true_label", "True"),
+        "false_label": field_def.get("false_label", "False"),
+    }
+
+
 def filter_aggregates_for_display(aggregates) -> list[dict]:
     """Filter aggregate fields based on use_in_aggregations setting.
 
@@ -547,7 +562,7 @@ def filter_aggregates_for_display(aggregates) -> list[dict]:
     for agg in aggregates:
         output_schema = agg.evaluator.params.get("output_schema", {})
         filtered = {
-            field_name: stats
+            field_name: merge_binary_labels(stats, output_schema.get(field_name) or {})
             for field_name, stats in agg.aggregates.items()
             if get_use_in_aggregations(output_schema.get(field_name, {}))
         }

--- a/apps/evaluations/utils.py
+++ b/apps/evaluations/utils.py
@@ -585,10 +585,10 @@ def build_trend_data(runs: list) -> dict:
         {
             "evaluator_name": {
                 "field_name (type)": {
-                    "type": "numeric" | "categorical",
+                    "type": "numeric" | "categorical" | "binary",
                     "points": [{"run_id": int, "date": str, "value": any, ...}],
                     "categories": ["cat1", "cat2"],  # for categorical only
-                    "mean": float,  # for numeric only
+                    "mean": float,  # for numeric and binary only
                 }
             }
         }
@@ -634,7 +634,7 @@ def build_trend_data(runs: list) -> dict:
                     "date": run.created_at.strftime("%b %d"),
                 }
 
-                if field_type == "numeric":
+                if field_type in ("numeric", "binary"):
                     point["value"] = stats.get("mean")
                 else:
                     point["value"] = stats.get("mode")

--- a/apps/human_annotations/aggregation.py
+++ b/apps/human_annotations/aggregation.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from django.db.models import Prefetch
 
-from apps.evaluations.aggregators import aggregate_field
+from apps.evaluations.aggregators import aggregate_binary_field, aggregate_field
 
 from .models import Annotation, AnnotationQueueAggregate, AnnotationStatus
 
@@ -37,7 +37,14 @@ def compute_aggregates_for_queue(queue) -> AnnotationQueueAggregate:
                 if field_name in aggregatable_fields and value is not None:
                     field_values[field_name].append(value)
 
-    agg_data = {field_name: aggregate_field(values) for field_name, values in field_values.items()}
+    agg_data = {
+        field_name: (
+            aggregate_binary_field(values)
+            if (queue.schema.get(field_name) or {}).get("type") == "binary"
+            else aggregate_field(values)
+        )
+        for field_name, values in field_values.items()
+    }
 
     obj, _ = AnnotationQueueAggregate.objects.update_or_create(
         queue=queue,

--- a/apps/human_annotations/aggregation.py
+++ b/apps/human_annotations/aggregation.py
@@ -16,8 +16,17 @@ def compute_aggregates_for_queue(queue) -> AnnotationQueueAggregate:
     """Compute and store aggregates for all submitted annotations in a queue.
 
     Per item: use authoritative annotation if one exists, else fall back to all
-    submitted annotations. Numeric / categorical aggregators are applied per field.
-    Text (string) fields are excluded from aggregation.
+    submitted annotations. Fields are aggregated per the schema: binary fields
+    dispatch to `aggregate_binary_field`, everything else to the numeric /
+    categorical `aggregate_field`. Text (string) fields are excluded from
+    aggregation.
+
+    Unlike the evaluation-run side (`apps.evaluations.aggregation`), which gates
+    value collection on `get_aggregators_for_value` before dispatch, this function
+    collects any non-None value regardless of shape. A value of an unsupported
+    shape (a dict or list) therefore reaches `aggregate_binary_field` and is
+    counted in `excluded_count`, where the evaluation-run side would have dropped
+    it before it was ever counted.
     """
     aggregatable_fields = _get_aggregatable_fields(queue)
     field_values = defaultdict(list)

--- a/apps/human_annotations/forms.py
+++ b/apps/human_annotations/forms.py
@@ -3,6 +3,7 @@ import json
 from django import forms
 from django.core.exceptions import ValidationError
 from pydantic import TypeAdapter
+from pydantic import ValidationError as PydanticValidationError
 
 from apps.evaluations.field_definitions import (
     BinaryFieldDefinition,
@@ -15,6 +16,21 @@ from apps.evaluations.field_definitions import (
 from apps.evaluations.models import DatasetCreationStatus, EvaluationDataset
 
 from .models import AnnotationQueue
+
+_FIELD_ADAPTER = TypeAdapter(FieldDefinition)
+
+
+def _canonical_field_definition(defn: dict) -> dict:
+    """Return the pydantic-normalized form of a stored field definition.
+
+    Stored schemas may predate normalization or come from non-form writers; a
+    definition that no longer validates is returned as-is so the locked-schema
+    comparison still has something to compare against.
+    """
+    try:
+        return _FIELD_ADAPTER.validate_python(defn).model_dump(exclude_none=True)
+    except PydanticValidationError:
+        return defn
 
 
 class AnnotationQueueForm(forms.ModelForm):
@@ -66,21 +82,26 @@ class AnnotationQueueForm(forms.ModelForm):
         if not data:
             raise ValidationError("Schema must have at least one field")
 
-        adapter = TypeAdapter(FieldDefinition)
+        # Store the pydantic-normalized dump, not the raw submission: a stored dict that
+        # diverges from the builder's serialization (missing label keys, untrimmed labels)
+        # would fail the locked-schema comparison on every subsequent save.
+        normalized = {}
         for name, defn in data.items():
             try:
-                adapter.validate_python(defn)
+                normalized[name] = _FIELD_ADAPTER.validate_python(defn).model_dump(exclude_none=True)
             except Exception as e:
                 raise ValidationError(f"Invalid field '{name}': {e}") from e
 
         if self._schema_locked:
-            self._validate_locked_schema_change(data)
+            self._validate_locked_schema_change(normalized)
 
-        return data
+        return normalized
 
     def _validate_locked_schema_change(self, new_schema):
         """When annotations exist, only the 'required' property may change."""
-        existing = self.instance.schema
+        # The submission is already normalized; canonicalize the stored side too so
+        # schemas stored before normalization compare on structure, not key-set shape.
+        existing = {name: _canonical_field_definition(defn) for name, defn in self.instance.schema.items()}
 
         if set(new_schema.keys()) != set(existing.keys()):
             raise ValidationError("Cannot add or remove fields after annotations have started.")

--- a/apps/human_annotations/forms.py
+++ b/apps/human_annotations/forms.py
@@ -133,6 +133,15 @@ class ImportFromDatasetForm(forms.Form):
         ).order_by("name")
 
 
+def _bounded_number_field(name, defn, field_cls):
+    kwargs = {"label": name, "help_text": defn.description, "required": defn.required}
+    if defn.ge is not None:
+        kwargs["min_value"] = defn.ge
+    if defn.le is not None:
+        kwargs["max_value"] = defn.le
+    return field_cls(**kwargs)
+
+
 def build_annotation_form(queue):
     """Dynamically build a Django form from an AnnotationQueue's field definitions."""
     field_defs = queue.get_field_definitions()
@@ -140,20 +149,10 @@ def build_annotation_form(queue):
 
     for name, defn in field_defs.items():
         if isinstance(defn, IntFieldDefinition):
-            kwargs = {"label": name, "help_text": defn.description, "required": defn.required}
-            if defn.ge is not None:
-                kwargs["min_value"] = defn.ge
-            if defn.le is not None:
-                kwargs["max_value"] = defn.le
-            form_fields[name] = forms.IntegerField(**kwargs)
+            form_fields[name] = _bounded_number_field(name, defn, forms.IntegerField)
 
         elif isinstance(defn, FloatFieldDefinition):
-            kwargs = {"label": name, "help_text": defn.description, "required": defn.required}
-            if defn.ge is not None:
-                kwargs["min_value"] = defn.ge
-            if defn.le is not None:
-                kwargs["max_value"] = defn.le
-            form_fields[name] = forms.FloatField(**kwargs)
+            form_fields[name] = _bounded_number_field(name, defn, forms.FloatField)
 
         elif isinstance(defn, BinaryFieldDefinition):
             choices = [("", "---"), ("1", defn.true_label), ("0", defn.false_label)]

--- a/apps/human_annotations/forms.py
+++ b/apps/human_annotations/forms.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from pydantic import TypeAdapter
 
 from apps.evaluations.field_definitions import (
+    BinaryFieldDefinition,
     ChoiceFieldDefinition,
     FieldDefinition,
     FloatFieldDefinition,
@@ -132,6 +133,17 @@ def build_annotation_form(queue):
             if defn.le is not None:
                 kwargs["max_value"] = defn.le
             form_fields[name] = forms.FloatField(**kwargs)
+
+        elif isinstance(defn, BinaryFieldDefinition):
+            choices = [("", "---"), ("1", defn.true_label), ("0", defn.false_label)]
+            form_fields[name] = forms.TypedChoiceField(
+                label=name,
+                help_text=defn.description,
+                choices=choices,
+                coerce=int,
+                empty_value=None,
+                required=defn.required,
+            )
 
         elif isinstance(defn, ChoiceFieldDefinition):
             choices = [("", "---")] + [(c, c) for c in defn.choices]

--- a/apps/human_annotations/tests/test_aggregation.py
+++ b/apps/human_annotations/tests/test_aggregation.py
@@ -9,6 +9,7 @@ from apps.human_annotations.models import (
     AnnotationStatus,
 )
 from apps.utils.factories.experiment import ExperimentSessionFactory
+from apps.utils.factories.human_annotations import AnnotationQueueFactory
 from apps.utils.factories.team import TeamWithUsersFactory
 
 
@@ -202,3 +203,20 @@ def test_aggregation_falls_back_to_all_when_no_authoritative(team, queue_with_in
     # Both values should contribute when no authoritative pick.
     assert agg.aggregates["score"]["count"] == 2
     assert agg.aggregates["score"]["mean"] == 3.0
+
+
+@pytest.mark.django_db()
+def test_binary_field_aggregates_as_rate(team):
+    queue = AnnotationQueueFactory(binary_schema=True, team=team)
+    reviewer = team.members.first()
+    for value in (1, 0, 1):
+        _make_item_and_annotate(queue, team, reviewer, {"correct": value})
+
+    aggregate = compute_aggregates_for_queue(queue)
+
+    assert aggregate.aggregates["correct"] == {
+        "type": "binary",
+        "count": 3,
+        "mean": 0.6667,
+        "true_count": 2,
+    }

--- a/apps/human_annotations/tests/test_forms.py
+++ b/apps/human_annotations/tests/test_forms.py
@@ -95,7 +95,7 @@ def test_queue_form_preserves_required_false(team):
 
     queue.refresh_from_db()
     assert queue.schema["notes"]["required"] is False
-    assert "required" not in queue.schema["score"]  # not included when true (default)
+    assert queue.schema["score"]["required"] is True  # normalized storage makes the default explicit
 
 
 @pytest.mark.django_db()
@@ -161,6 +161,84 @@ def test_queue_schema_accepts_binary_definition():
                 }
             ),
         }
+    )
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.parametrize(
+    ("submitted", "expected_true", "expected_false"),
+    [
+        pytest.param(
+            {"type": "binary", "description": "Was it correct?"},
+            "True",
+            "False",
+            id="missing-labels-stored-with-defaults",
+        ),
+        pytest.param(
+            {"type": "binary", "description": "Was it correct?", "true_label": " Yes ", "false_label": " No "},
+            "Yes",
+            "No",
+            id="padded-labels-stored-trimmed",
+        ),
+    ],
+)
+@pytest.mark.django_db()
+def test_queue_schema_stores_normalized_binary_definition(submitted, expected_true, expected_false):
+    # The stored schema must be the pydantic-normalized form, not the raw submission:
+    # a raw dict diverging from what the builder serializes makes a locked queue uneditable.
+    form = AnnotationQueueForm(
+        data={
+            "name": "Binary queue",
+            "num_reviews_required": 1,
+            "schema": json.dumps({"correct": submitted}),
+        }
+    )
+    assert form.is_valid(), form.errors
+    stored = form.cleaned_data["schema"]["correct"]
+    assert stored["true_label"] == expected_true
+    assert stored["false_label"] == expected_false
+
+
+@pytest.mark.django_db()
+def test_locked_queue_with_label_free_stored_schema_accepts_builder_schema():
+    # A binary schema stored without label keys (written before normalization, or via a
+    # non-builder client) must still accept the builder's canonical serialization once
+    # locked, otherwise the whole settings form becomes uneditable.
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    queue = AnnotationQueue.objects.create(
+        team=team,
+        name="Queue",
+        schema={"correct": {"type": "binary", "description": "Was it correct?"}},
+        created_by=user,
+    )
+    item = AnnotationItemFactory.create(queue=queue, team=team)
+    Annotation.objects.create(
+        item=item,
+        team=team,
+        reviewer=user,
+        data={"correct": 1},
+        status=AnnotationStatus.SUBMITTED,
+    )
+    item.refresh_from_db()
+    assert item.review_count == 1
+
+    form = AnnotationQueueForm(
+        instance=queue,
+        data={
+            "name": queue.name,
+            "num_reviews_required": queue.num_reviews_required,
+            "schema": json.dumps(
+                {
+                    "correct": {
+                        "type": "binary",
+                        "description": "Was it correct?",
+                        "true_label": "True",
+                        "false_label": "False",
+                    }
+                }
+            ),
+        },
     )
     assert form.is_valid(), form.errors
 

--- a/apps/human_annotations/tests/test_forms.py
+++ b/apps/human_annotations/tests/test_forms.py
@@ -4,8 +4,9 @@ import pytest
 
 from apps.evaluations.models import DatasetCreationStatus
 from apps.human_annotations.forms import AnnotationQueueForm, ImportFromDatasetForm, build_annotation_form
-from apps.human_annotations.models import AnnotationQueue
+from apps.human_annotations.models import Annotation, AnnotationQueue, AnnotationStatus
 from apps.utils.factories.evaluations import EvaluationDatasetFactory
+from apps.utils.factories.human_annotations import AnnotationItemFactory, AnnotationQueueFactory
 from apps.utils.factories.team import TeamWithUsersFactory
 
 
@@ -113,6 +114,86 @@ def test_required_fields_reject_empty_submission(team):
     assert not form.is_valid()
     assert "score" in form.errors
     assert "notes" in form.errors
+
+
+@pytest.mark.django_db()
+class TestBinaryAnnotationForm:
+    def test_binary_field_renders_select_and_cleans_to_int(self):
+        queue = AnnotationQueueFactory(binary_schema=True)
+        form_class = build_annotation_form(queue)
+
+        form = form_class(data={"correct": "1"})
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["correct"] == 1
+
+        form = form_class(data={"correct": "0"})
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["correct"] == 0
+
+    def test_binary_field_shows_labels_not_integers(self):
+        queue = AnnotationQueueFactory(binary_schema=True)
+        form_class = build_annotation_form(queue)
+        choice_labels = [label for _, label in form_class.base_fields["correct"].choices]
+        assert "Correct" in choice_labels
+        assert "Incorrect" in choice_labels
+
+    def test_binary_field_rejects_out_of_range_value(self):
+        queue = AnnotationQueueFactory(binary_schema=True)
+        form_class = build_annotation_form(queue)
+        form = form_class(data={"correct": "2"})
+        assert not form.is_valid()
+
+
+@pytest.mark.django_db()
+def test_queue_schema_accepts_binary_definition():
+    form = AnnotationQueueForm(
+        data={
+            "name": "Binary queue",
+            "num_reviews_required": 1,
+            "schema": json.dumps(
+                {
+                    "correct": {
+                        "type": "binary",
+                        "description": "Was it correct?",
+                        "true_label": "Yes",
+                        "false_label": "No",
+                    }
+                }
+            ),
+        }
+    )
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db()
+def test_locked_binary_schema_roundtrip_is_a_valid_edit():
+    # The exact schema the builder serializes must pass the locked-schema check,
+    # or locked queues become permanently uneditable.
+    team = TeamWithUsersFactory.create()
+    user = team.members.first()
+    queue = AnnotationQueueFactory.create(binary_schema=True, team=team, created_by=user)
+    item = AnnotationItemFactory.create(queue=queue, team=team)
+    # Mirrors the locked-schema setup in test_views.py: a SUBMITTED annotation is what
+    # drives review_count up via Annotation.save(), which is what actually engages the lock.
+    Annotation.objects.create(
+        item=item,
+        team=team,
+        reviewer=user,
+        data={"correct": 1},
+        status=AnnotationStatus.SUBMITTED,
+    )
+    item.refresh_from_db()
+    assert item.review_count == 1
+
+    form = AnnotationQueueForm(
+        instance=queue,
+        data={
+            "name": queue.name,
+            "num_reviews_required": queue.num_reviews_required,
+            "schema": json.dumps(queue.schema),
+        },
+    )
+    assert form.is_valid(), form.errors
 
 
 # === ImportFromDatasetForm ===

--- a/apps/human_annotations/tests/test_views.py
+++ b/apps/human_annotations/tests/test_views.py
@@ -375,6 +375,29 @@ def test_queue_detail_shows_aggregates(client, team_with_users, queue, user):
 
 
 @pytest.mark.django_db()
+def test_queue_detail_shows_a_count_for_each_binary_label(client, team_with_users, user):
+    binary_queue = AnnotationQueueFactory.create(team=team_with_users, created_by=user, binary_schema=True)
+    for value in (1, 1, 1, 0):
+        item = AnnotationItemFactory.create(queue=binary_queue, team=team_with_users)
+        Annotation.objects.create(
+            item=item,
+            team=team_with_users,
+            reviewer=user,
+            data={"correct": value},
+            status=AnnotationStatus.SUBMITTED,
+        )
+    compute_aggregates_for_queue(binary_queue)
+
+    url = reverse("human_annotations:queue_detail", args=[team_with_users.slug, binary_queue.pk])
+    response = client.get(url)
+
+    content = response.content.decode()
+    assert "3/4" in content
+    assert "Incorrect:" in content
+    assert "1/4" in content
+
+
+@pytest.mark.django_db()
 def test_queue_items_table(client, team_with_users, queue):
     AnnotationItemFactory.create(queue=queue, team=team_with_users)
     url = reverse("human_annotations:queue_items_table", args=[team_with_users.slug, queue.pk])

--- a/apps/human_annotations/views/export_views.py
+++ b/apps/human_annotations/views/export_views.py
@@ -8,6 +8,7 @@ from django.shortcuts import get_object_or_404
 from django.views import View
 
 from apps.teams.mixins import LoginAndTeamRequiredMixin
+from apps.utils.csv_export import neutralize_csv_formula
 
 from ..models import Annotation, AnnotationItem, AnnotationItemStatus, AnnotationQueue, AnnotationStatus
 
@@ -15,21 +16,6 @@ from ..models import Annotation, AnnotationItem, AnnotationItemStatus, Annotatio
 def _safe_filename(name: str) -> str:
     """Sanitize a string for use in Content-Disposition filename."""
     return re.sub(r"[^\w\s\-.]", "_", name).strip()
-
-
-_CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
-
-
-def _neutralize_csv_formula(value):
-    """Prefix annotator-controlled values that could execute as a spreadsheet formula.
-
-    csv.DictWriter's quoting protects against delimiter injection but not formula
-    injection: a value starting with =, +, -, or @ runs as a formula when the export
-    is opened in Excel/Sheets. Prepending an apostrophe forces it to be read as text.
-    """
-    if isinstance(value, str) and value.startswith(_CSV_FORMULA_PREFIXES):
-        return f"'{value}"
-    return value
 
 
 class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View):
@@ -132,7 +118,7 @@ class ExportAnnotations(LoginAndTeamRequiredMixin, PermissionRequiredMixin, View
         for field in schema_fields:
             row = dict(base, field=field)
             for email in annotator_emails:
-                row[email] = _neutralize_csv_formula(data_by_email.get(email, {}).get(field, ""))
+                row[email] = neutralize_csv_formula(data_by_email.get(email, {}).get(field, ""))
             rows.append(row)
         return rows
 

--- a/apps/human_annotations/views/queue_views.py
+++ b/apps/human_annotations/views/queue_views.py
@@ -22,6 +22,7 @@ from waffle import flag_is_active
 from apps.annotations.prefetch import attach_chat_tagged_items
 from apps.channels.models import ChannelPlatform
 from apps.chat.models import ChatMessage
+from apps.evaluations.utils import merge_binary_labels
 from apps.experiments.filters import get_filter_context_data
 from apps.experiments.models import ExperimentSession
 from apps.filters.models import FilterSet
@@ -164,7 +165,11 @@ class AnnotationQueueDetail(LoginAndTeamRequiredMixin, PermissionRequiredMixin, 
         context["items_table_url"] = items_table_url
 
         aggregate = getattr(queue, "aggregate", None)
-        context["aggregates"] = aggregate.aggregates if aggregate else {}
+        schema = queue.schema or {}
+        context["aggregates"] = {
+            name: merge_binary_labels(stats, schema.get(name) or {})
+            for name, stats in (aggregate.aggregates if aggregate else {}).items()
+        }
 
         filter_context = get_filter_context_data(
             self.request.team,

--- a/apps/utils/csv_export.py
+++ b/apps/utils/csv_export.py
@@ -1,0 +1,15 @@
+"""Helpers for CSV exports containing user-controlled values."""
+
+CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
+def neutralize_csv_formula(value):
+    """Prefix user-controlled values that could execute as a spreadsheet formula.
+
+    The csv module's quoting protects against delimiter injection but not formula
+    injection: a value starting with =, +, -, or @ runs as a formula when the export
+    is opened in Excel/Sheets. Prepending an apostrophe forces it to be read as text.
+    """
+    if isinstance(value, str) and value.startswith(CSV_FORMULA_PREFIXES):
+        return f"'{value}"
+    return value

--- a/apps/utils/factories/evaluations.py
+++ b/apps/utils/factories/evaluations.py
@@ -27,6 +27,24 @@ class EvaluatorFactory(DjangoModelFactory):
     class Meta:
         model = Evaluator
 
+    class Params:
+        binary_schema = factory.Trait(
+            params=factory.LazyFunction(
+                lambda: {
+                    "llm_prompt": "was the answer correct",
+                    "output_schema": {
+                        "correct": {
+                            "type": "binary",
+                            "description": "was the answer correct",
+                            "true_label": "Correct",
+                            "false_label": "Incorrect",
+                            "use_in_aggregations": True,
+                        },
+                    },
+                }
+            )
+        )
+
     team = factory.SubFactory(TeamFactory)
     type = "LlmEvaluator"
     name = factory.Sequence(lambda n: f"Test Evaluator {n}")

--- a/apps/utils/factories/human_annotations.py
+++ b/apps/utils/factories/human_annotations.py
@@ -11,6 +11,20 @@ class AnnotationQueueFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = AnnotationQueue
 
+    class Params:
+        binary_schema = factory.Trait(
+            schema=factory.LazyFunction(
+                lambda: {
+                    "correct": {
+                        "type": "binary",
+                        "description": "Was the response correct?",
+                        "true_label": "Correct",
+                        "false_label": "Incorrect",
+                    },
+                }
+            )
+        )
+
     team = factory.SubFactory(TeamFactory)
     name = factory.Sequence(lambda n: f"Queue {n}")
     schema = factory.LazyFunction(

--- a/assets/javascript/apps/evaluations/trend-charts.js
+++ b/assets/javascript/apps/evaluations/trend-charts.js
@@ -69,7 +69,7 @@ export function renderTrendCharts(trendData, baseUrl) {
             const canvas = document.getElementById(canvasId);
             if (!canvas) continue;
 
-            if (fieldData.type === 'numeric') {
+            if (fieldData.type === 'numeric' || fieldData.type === 'binary') {
                 renderSparkline(canvas, fieldData, fieldName, buildUrl);
             } else if (fieldData.type === 'categorical') {
                 renderStackedBar(canvas, fieldData, fieldName, buildUrl);

--- a/docs/adr/0055-binary-field-type-extends-the-field-definition-union.md
+++ b/docs/adr/0055-binary-field-type-extends-the-field-definition-union.md
@@ -35,8 +35,11 @@ schema no longer names.
 ## Consequences
 
 - Renaming or swapping labels is free for stored data but changes what
-  historical values display as - the stored integers carry no vocabulary.
-  This is the reverse of `choice` (stored strings, rename orphans history).
+  historical values display as - the stored integers carry no vocabulary -
+  except `Score.value_string`, which snapshots the label at write time so
+  historical concordance rows keep the vocabulary in force when they were
+  scored. This is the reverse of `choice` (stored strings, rename orphans
+  history).
 - Existing two-choice `choice` fields are not converted or retroactively
   rendered as rates (declined on the issue).
 - A schema containing a binary field does not validate on instances that

--- a/docs/adr/0055-binary-field-type-extends-the-field-definition-union.md
+++ b/docs/adr/0055-binary-field-type-extends-the-field-definition-union.md
@@ -1,0 +1,44 @@
+# ADR-0055: Binary field type extends the field definition union
+
+<span class="adr-status adr-status-accepted">ACCEPTED</span>
+
+<p class="adr-meta">Author: Barry Tandy · Created: 2026-08-17</p>
+
+<p class="adr-meta">Extends: <a href="0015-human-annotations-app-with-queue-item-annotation-aggregate-model.md">ADR-0015</a> (the field definition union it describes gains a fifth member; everything else stands)</p>
+
+## Context
+
+ADR-0015 describes `AnnotationQueue.schema` as mapping field names to entries of
+"the int/float/choice/string union `apps.evaluations` uses for evaluator output".
+Issue #2726 adds a boolean-style assessment ("was the answer correct") that judges
+and annotators answer with one of two values and that aggregates as a rate rather
+than a distribution. Modelling it as a two-choice `choice` field leaves polarity
+undefined (which choice counts as true) and aggregates as mode/distribution.
+
+## Decision
+
+The `FieldDefinition` union gains a fifth member, `BinaryFieldDefinition`
+(`type: "binary"`), with two display labels (`true_label`, `false_label`,
+defaulting to True/False; non-blank and distinct). The stored value is the
+integer `1`/`0` everywhere - results, Scores, aggregates, tag-rule conditions,
+CSV exports. Labels are display vocabulary only, resolved from the schema at
+render time, and reach the LLM judge folded into the field description
+("1 = correct, 0 = incorrect") rather than as schema keywords.
+
+Binary fields aggregate through a separate schema-dispatched function,
+`aggregate_binary_field`, emitting `{"type": "binary", "count", "mean",
+"true_count"}` (plus `excluded_count` for out-of-range values). The
+value-dispatched `aggregate_field` (ADR-0017) is unchanged; callers choose the
+function from the schema and fall back to `aggregate_field` for fields the
+schema no longer names.
+
+## Consequences
+
+- Renaming or swapping labels is free for stored data but changes what
+  historical values display as - the stored integers carry no vocabulary.
+  This is the reverse of `choice` (stored strings, rename orphans history).
+- Existing two-choice `choice` fields are not converted or retroactively
+  rendered as rates (declined on the issue).
+- A schema containing a binary field does not validate on instances that
+  predate the union member; cross-instance team import carries it as an
+  opaque blob and fails only where the union is parsed.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -76,3 +76,4 @@ Where {lowercase-status} is one of: draft, proposed, accepted, rejected, superse
 | [0052](0052-app-layer-rate-limiting-mechanism.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | App-layer rate limiting via an in-house fixed-window core |
 | [0053](0053-chat-session-start-requires-membership-or-embed-key.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Starting a chat session requires team membership or the embed key |
 | [0054](0054-chat-session-tokens-expire-on-absolute-age.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Chat session tokens expire on absolute age, not inactivity |
+| [0055](0055-binary-field-type-extends-the-field-definition-union.md) | <span class="adr-status adr-status-accepted">ACCEPTED</span> | Binary field type extends the field definition union |

--- a/docs/design/unified-assessment.md
+++ b/docs/design/unified-assessment.md
@@ -89,7 +89,7 @@ A schema defines the structured fields that scorers (automated or human) produce
 | ID | Requirement | Priority |
 |----|------------|----------|
 | FR-1.1 | Define schemas as named, reusable objects owned by a team | Must |
-| FR-1.2 | Support field types: string, int, float, choice | Must |
+| FR-1.2 | Support field types: string, int, float, choice, binary | Must |
 | FR-1.3 | Support validation constraints per field type (min/max, pattern, choices) | Must |
 | FR-1.4 | Support `required` and `use_in_aggregations` flags per field | Must |
 | FR-1.5 | A schema is reusable across multiple Assessments and is shared by all scorers within an Assessment (both automated and human, with each scorer addressing a subset via `output_fields` — see D-10) | Must |
@@ -390,7 +390,7 @@ A reusable, named schema that all scorers in one or more Assessments share. Lift
 |---|---|
 | `team` | `BaseTeamModel` |
 | `name`, `description` | |
-| `fields` | JSON: `dict[name, FieldDefinition]`. Reuses existing types: `String`, `Int`, `Float`, `Choice`. |
+| `fields` | JSON: `dict[name, FieldDefinition]`. Reuses existing types: `String`, `Int`, `Float`, `Choice`, `Binary`. |
 | `created_at` | Indexed; lets the per-Assessment schema-history chain be queried in order. |
 
 **New table.** Existing inline schemas are migrated lazily — the first time a Score is written referencing an inline schema, an `AssessmentSchema` row is materialised and FK'd.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
       - 0052 App-layer rate limiting: adr/0052-app-layer-rate-limiting-mechanism.md
       - 0053 Starting a chat session requires team membership or the embed key: adr/0053-chat-session-start-requires-membership-or-embed-key.md
       - 0054 Chat session tokens expire on absolute age, not inactivity: adr/0054-chat-session-tokens-expire-on-absolute-age.md
+      - 0055 Binary field type extends the field definition union: adr/0055-binary-field-type-extends-the-field-definition-union.md
   - Developer Guides:
     - Processes:
       - Claude GitHub Automation: developer_guides/claude_github_automation.md

--- a/templates/evaluations/components/aggregates.html
+++ b/templates/evaluations/components/aggregates.html
@@ -48,6 +48,7 @@
                       {% endif %}
                       {% if stats.true_count is not None %}
                         <div>{{ stats.true_label }}: <span class="font-mono">{{ stats.true_count }}/{{ stats.count }}</span></div>
+                        <div>{{ stats.false_label }}: <span class="font-mono">{{ stats.false_count }}/{{ stats.count }}</span></div>
                       {% endif %}
                       {% if stats.excluded_count %}
                         <div class="col-span-2 text-base-content/60">excluded: <span class="font-mono">{{ stats.excluded_count }}</span></div>

--- a/templates/evaluations/components/aggregates.html
+++ b/templates/evaluations/components/aggregates.html
@@ -41,6 +41,18 @@
                         <span class="badge badge-sm badge-outline">{{ value }}: {{ pct }}%</span>
                       {% endfor %}
                     </div>
+                  {% elif stats.type == "binary" %}
+                    <div class="grid grid-cols-2 gap-1 text-sm">
+                      {% if stats.mean is not None %}
+                        <div>mean: <span class="font-mono">{{ stats.mean }}</span></div>
+                      {% endif %}
+                      {% if stats.true_count is not None %}
+                        <div>{{ stats.true_label }}: <span class="font-mono">{{ stats.true_count }}/{{ stats.count }}</span></div>
+                      {% endif %}
+                      {% if stats.excluded_count %}
+                        <div class="col-span-2 text-base-content/60">excluded: <span class="font-mono">{{ stats.excluded_count }}</span></div>
+                      {% endif %}
+                    </div>
                   {% endif %}
                 </div>
               {% endfor %}

--- a/templates/evaluations/components/trend_charts.html
+++ b/templates/evaluations/components/trend_charts.html
@@ -27,6 +27,8 @@
                 <div class="text-right">
                   {% if field_data.type == "numeric" and field_data.mean %}
                     <span class="text-sm">mean: {{ field_data.mean }}</span>
+                  {% elif field_data.type == "binary" and field_data.mean is not None %}
+                    <span class="text-sm">mean: {{ field_data.mean }}</span>
                   {% elif field_data.type == "categorical" and field_data.mode %}
                     <span class="text-sm">mode: {{ field_data.mode }}</span>
                   {% endif %}

--- a/templates/evaluations/evaluator_form.html
+++ b/templates/evaluations/evaluator_form.html
@@ -381,7 +381,7 @@
                             <input type="text"
                                    x-model="pair.true_label"
                                    @input="updateKeyValuePairs(fieldName)"
-                                   placeholder="True"
+                                   placeholder="{% translate "True" %}"
                                    class="input input-bordered w-full input-sm">
                           </div>
                           <div>
@@ -391,7 +391,7 @@
                             <input type="text"
                                    x-model="pair.false_label"
                                    @input="updateKeyValuePairs(fieldName)"
-                                   placeholder="False"
+                                   placeholder="{% translate "False" %}"
                                    class="input input-bordered w-full input-sm">
                           </div>
                         </div>

--- a/templates/evaluations/evaluator_form.html
+++ b/templates/evaluations/evaluator_form.html
@@ -216,6 +216,7 @@
                           <option value="int">{% translate "Integer" %}</option>
                           <option value="float">{% translate "Float" %}</option>
                           <option value="choice">{% translate "Choice" %}</option>
+                          <option value="binary">{% translate "Binary" %}</option>
                         </select>
                       </div>
 
@@ -367,6 +368,35 @@
                         </div>
                       </details>
 
+                      <!-- Binary Labels -->
+                      <details x-show="pair.type === 'binary'" class="mb-2" open>
+                        <summary class="cursor-pointer text-sm font-medium mb-2">
+                          {% translate "Labels" %}
+                        </summary>
+                        <div class="ml-4 grid grid-cols-2 gap-2">
+                          <div>
+                            <label class="label py-0">
+                              <span class="label-text text-xs">{% translate "True label" %}</span>
+                            </label>
+                            <input type="text"
+                                   x-model="pair.true_label"
+                                   @input="updateKeyValuePairs(fieldName)"
+                                   placeholder="True"
+                                   class="input input-bordered w-full input-sm">
+                          </div>
+                          <div>
+                            <label class="label py-0">
+                              <span class="label-text text-xs">{% translate "False label" %}</span>
+                            </label>
+                            <input type="text"
+                                   x-model="pair.false_label"
+                                   @input="updateKeyValuePairs(fieldName)"
+                                   placeholder="False"
+                                   class="input input-bordered w-full input-sm">
+                          </div>
+                        </div>
+                      </details>
+
                       <!-- Aggregations Toggle -->
                       <div class="form-control mt-2">
                         <label class="label cursor-pointer justify-start gap-2">
@@ -502,7 +532,7 @@
       </button>
       {{ available_tags|json_script:"tag-rule-available-tags" }}
       <p class="text-xs text-gray-500 mt-1" x-show="!hasAnyUsableField()">
-        {% translate "Define at least one output field (choice with choices, int, float, or string) before adding tag rules." %}
+        {% translate "Define at least one output field (choice with choices, int, float, string, or binary) before adding tag rules." %}
       </p>
     </div>
   </div>
@@ -652,6 +682,8 @@
               max_length: null,
               pattern: null,
               choices: [],
+              true_label: null,
+              false_label: null,
               use_in_aggregations: false,
             }];
           }
@@ -672,6 +704,8 @@
             max_length: null,
             pattern: null,
             choices: [],
+            true_label: null,
+            false_label: null,
             use_in_aggregations: false,
           });
         },
@@ -755,6 +789,9 @@
                       fieldDef.choices = validChoices;
                     }
                   }
+                } else if (pair.type === 'binary') {
+                  fieldDef.true_label = pair.true_label && pair.true_label.trim() ? pair.true_label.trim() : 'True';
+                  fieldDef.false_label = pair.false_label && pair.false_label.trim() ? pair.false_label.trim() : 'False';
                 }
 
                 fieldDef.use_in_aggregations = pair.use_in_aggregations !== false;
@@ -794,6 +831,8 @@
                       max_length: value.max_length !== undefined ? value.max_length : null,
                       pattern: value.pattern || null,
                       choices: value.choices || [],
+                      true_label: value.true_label !== undefined ? value.true_label : null,
+                      false_label: value.false_label !== undefined ? value.false_label : null,
                       use_in_aggregations: value.use_in_aggregations !== undefined ? value.use_in_aggregations : defaultAgg
                     };
                   });
@@ -828,6 +867,7 @@
             case 'int':
             case 'float': return ['equals', 'range'];
             case 'string': return ['equals'];
+            case 'binary': return ['equals'];
             default: return [];
           }
         },
@@ -842,10 +882,19 @@
           return ((schema[fieldName] || {}).choices || []).filter(c => c && String(c).trim() !== '');
         },
 
+        fieldBinaryLabels(fieldName) {
+          const schema = (this.params && this.params.output_schema) || {};
+          const def = schema[fieldName] || {};
+          return [
+            {value: '1', label: def.true_label || 'True'},
+            {value: '0', label: def.false_label || 'False'},
+          ];
+        },
+
         isUsableField(fieldName) {
           const type = this.fieldType(fieldName);
           if (type === 'choice') return this.fieldChoices(fieldName).length > 0;
-          return ['int', 'float', 'string'].includes(type);
+          return ['int', 'float', 'string', 'binary'].includes(type);
         },
 
         hasAnyUsableField() {

--- a/templates/evaluations/partials/tag_rule_row.html
+++ b/templates/evaluations/partials/tag_rule_row.html
@@ -79,7 +79,17 @@
           </template>
         </select>
       </template>
-      <template x-if="fieldType(fieldName) !== 'choice'">
+      <template x-if="fieldType(fieldName) === 'binary'">
+        <select id="{{ form.condition_value_single.id_for_label }}" name="{{ form.condition_value_single.html_name }}"
+                class="select select-bordered w-full select-sm">
+          <option value="">{% translate "Select a value..." %}</option>
+          <template x-for="option in fieldBinaryLabels(fieldName)" :key="option.value">
+            <option :value="option.value" x-text="option.label"
+                    :selected="option.value === '{{ form.condition_value_single.value|default_if_none:''|escapejs }}'"></option>
+          </template>
+        </select>
+      </template>
+      <template x-if="!['choice', 'binary'].includes(fieldType(fieldName))">
         <input :type="['int','float'].includes(fieldType(fieldName)) ? 'number' : 'text'"
                step="any"
                id="{{ form.condition_value_single.id_for_label }}"

--- a/templates/human_annotations/queue_detail.html
+++ b/templates/human_annotations/queue_detail.html
@@ -96,6 +96,18 @@
                   <span class="badge badge-sm badge-outline">{{ value }}: {{ pct }}%</span>
                 {% endfor %}
               </div>
+            {% elif stats.type == "binary" %}
+              <div class="grid grid-cols-2 gap-1 text-sm">
+                {% if stats.mean is not None %}
+                  <div>mean: <span class="font-mono">{{ stats.mean }}</span></div>
+                {% endif %}
+                {% if stats.true_count is not None %}
+                  <div>{{ stats.true_label }}: <span class="font-mono">{{ stats.true_count }}/{{ stats.count }}</span></div>
+                {% endif %}
+                {% if stats.excluded_count %}
+                  <div class="col-span-2 text-base-content/60">excluded: <span class="font-mono">{{ stats.excluded_count }}</span></div>
+                {% endif %}
+              </div>
             {% endif %}
           </div>
         {% endfor %}

--- a/templates/human_annotations/queue_detail.html
+++ b/templates/human_annotations/queue_detail.html
@@ -103,6 +103,7 @@
                 {% endif %}
                 {% if stats.true_count is not None %}
                   <div>{{ stats.true_label }}: <span class="font-mono">{{ stats.true_count }}/{{ stats.count }}</span></div>
+                  <div>{{ stats.false_label }}: <span class="font-mono">{{ stats.false_count }}/{{ stats.count }}</span></div>
                 {% endif %}
                 {% if stats.excluded_count %}
                   <div class="col-span-2 text-base-content/60">excluded: <span class="font-mono">{{ stats.excluded_count }}</span></div>

--- a/templates/human_annotations/queue_form.html
+++ b/templates/human_annotations/queue_form.html
@@ -73,6 +73,7 @@
                 <option value="int">{% translate "Integer" %}</option>
                 <option value="float">{% translate "Float" %}</option>
                 <option value="choice">{% translate "Choice" %}</option>
+                <option value="binary">{% translate "Binary" %}</option>
               </select>
             </div>
 
@@ -164,6 +165,32 @@
               </div>
             </template>
 
+            <!-- Binary Labels -->
+            <template x-if="field.type === 'binary'">
+              <div class="grid grid-cols-2 gap-2 mb-2">
+                <div>
+                  <label class="label py-0">
+                    <span class="label-text text-xs">{% translate "True label" %}</span>
+                  </label>
+                  <input type="text"
+                         x-model="field.true_label"
+                         placeholder="{% translate "True" %}"
+                         :disabled="locked"
+                         class="input input-bordered w-full input-sm">
+                </div>
+                <div>
+                  <label class="label py-0">
+                    <span class="label-text text-xs">{% translate "False label" %}</span>
+                  </label>
+                  <input type="text"
+                         x-model="field.false_label"
+                         placeholder="{% translate "False" %}"
+                         :disabled="locked"
+                         class="input input-bordered w-full input-sm">
+                </div>
+              </div>
+            </template>
+
             <div class="form-control mt-2" :class="locked && 'bg-base-100 rounded-lg p-2 border border-primary/30'">
               <label class="label cursor-pointer justify-start gap-2">
                 <input type="checkbox"
@@ -247,6 +274,8 @@
               le: def.le !== undefined ? def.le : null,
               max_length: def.max_length !== undefined ? def.max_length : null,
               choices: def.choices || [],
+              true_label: def.true_label !== undefined ? def.true_label : null,
+              false_label: def.false_label !== undefined ? def.false_label : null,
               required: def.required !== undefined ? def.required : true,
             }));
           }
@@ -265,6 +294,8 @@
             le: null,
             max_length: null,
             choices: [],
+            true_label: null,
+            false_label: null,
             required: true,
           });
         },
@@ -279,6 +310,8 @@
           field.le = null;
           field.max_length = null;
           field.choices = [];
+          field.true_label = null;
+          field.false_label = null;
           if (field.type === 'choice') {
             field.choices = [''];
           }
@@ -311,6 +344,9 @@
                 if (validChoices.length > 0) {
                   def.choices = validChoices;
                 }
+              } else if (field.type === 'binary') {
+                def.true_label = field.true_label && field.true_label.trim() ? field.true_label.trim() : 'True';
+                def.false_label = field.false_label && field.false_label.trim() ? field.false_label.trim() : 'False';
               }
               obj[field.name.trim()] = def;
             }


### PR DESCRIPTION
### Product Description

Closes #2726.

Adds a binary field type to evaluator output schemas and annotation queue schemas: a pass/fail field with two configurable display labels, say "Correct" and "Incorrect". The stored value is always the integer `1` or `0`. Labels are display vocabulary only, so renaming or swapping them never touches stored data. The judge still gets the meanings, folded into the field description it receives ("1 = Correct, 0 = Incorrect").

Where the type shows up:

- Both schema builders offer it, with inputs for the two labels (must be non-empty and distinct).
- Annotation forms render a labelled select instead of a 1/0 input.
- Run and queue cards aggregate it as a rate: the mean plus a labelled count ("Correct: 3/4"). Trends draw the mean as a sparkline.
- Tag rules can match a binary field with an equals condition, choosing the value by label.
- Concordance pairs binary evaluator fields with binary annotation fields. Agreement compares the stored booleans; the table and CSV show labels.

Existing two-choice `choice` fields are untouched, and there is no retroactive conversion, per the direction confirmed on the issue.

### Technical Description

`BinaryFieldDefinition` joins the `FieldDefinition` union with `true_label`/`false_label` and a `python_type` of `Literal[0, 1]`. The labels are excluded from the JSON schema sent to the judge, so the schemas emitted for existing field types are unchanged. Aggregation dispatches on schema field type; `aggregate_binary_field` returns count, mean, and true count, excluding (and counting) stored values outside 0/1. Scores are written as `BOOLEAN` with the label snapshotted into `Score.value_string` for concordance display. ADR-0055, added here, records the design.

Two fixes ride along: annotation queue schemas are now stored pydantic-normalized, so any schema that validates also round-trips through the locked settings form, and concordance CSV values pass through `neutralize_csv_formula` (hoisted to `apps/utils/csv_export.py`) because labels are user-controlled text landing in a CSV.

#### Open questions

Four scope calls came out of implementation. Each is currently left out of this PR; direction welcome on whether any of them belongs in scope here.

- The run results table shows `1`/`0`, not labels. The table and the run CSV are built from the same rows, and the CSV must write the stored value, so labels in the table need the two row shapes split. In this PR, or a follow-up?
- The annotate page echoes a submitted answer back as `correct: 1` in its list of existing annotations, which renders raw `ann.data` with no schema lookup. The fix is contained since the view already has the queue. In this PR, or a follow-up?
- Re-typing an existing field to binary reinterprets old runs if they are recomputed (results-CSV upload, finalize retry): aggregation reads the current schema, so historical values are read as pass/fail and out-of-range ones are excluded. Accept as documented behaviour, or add a guard?
- The binary stats block is duplicated across the run and queue card templates, matching the existing numeric and categorical duplication there. Extract all three into a shared include here, or as its own change?

### Migrations

- [x] The migrations are backwards compatible

No migrations: `output_schema` lives in `Evaluator.params`, and the queue schema and aggregate fields are existing `JSONField`s. `makemigrations --check` is clean.

### Demo

The two aggregate-card shots were re-taken after review: the cards now show a count for each label, so earlier screenshots showing only the true-label count are superseded.

| View | Screenshot |
| --- | --- |
| Evaluator builder with a binary field | <img width="1568" height="577" alt="01-evaluator-builder-binary-field" src="https://github.com/user-attachments/assets/167f5fbe-1757-4f88-92e4-c2b4bda31dc0" /> |
| Tag rule condition offering the labels | <img width="1568" height="401" alt="02-tag-rule-label-values" src="https://github.com/user-attachments/assets/ec6e8ba7-62be-441d-9cce-5947a7f77b8b" /> |
| Run results table (aggregate card in this shot predates the per-label counts) | <img width="1269" height="952" alt="03-run-results-aggregates-and-table" src="https://github.com/user-attachments/assets/2924e28c-35c5-4657-af65-ccd09e689f37" /> |
| Run aggregate card with a count per label | <img width="1222" height="216" alt="run-aggregates-binary-dark" src="https://github.com/user-attachments/assets/83b769f0-abe6-4b56-9b14-f21303bb65a0" /> |
| Annotate form labelled selects | <img width="1568" height="415" alt="04-annotate-form-binary-selects" src="https://github.com/user-attachments/assets/7e92541c-c4ed-4356-b80e-5a01ae28dfa9" /> |
| Queue detail aggregate scores, binary beside a numeric field | <img width="1254" height="183" alt="queue-aggregate-scores-dark" src="https://github.com/user-attachments/assets/4fa3acaf-addb-4f83-98b8-78c1de47aae7" /> |
| Concordance at 80% agreement | <img width="1372" height="877" alt="06-concordance-agreement-80pct" src="https://github.com/user-attachments/assets/2f126bfb-95ed-4972-a301-78bce6e09b0d" /> |
| Binary trend sparkline | <img width="1568" height="411" alt="07-trends-binary-sparkline" src="https://github.com/user-attachments/assets/90b99467-0cb3-45f9-b8db-fc080b2d3efb" /> |

### Docs and Changelog

- [x] This PR requires docs/changelog update

ADR-0055 and a design-doc update are included here; user-facing docs will follow via the docs repo.
