### PR TITLE
Provider spend reporting: tracing volume and project-based team joins

### DIFF
--- a/apps/admin/provider_keys.py
+++ b/apps/admin/provider_keys.py
@@ -22,7 +22,7 @@ import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
 
-from apps.service_providers.models import LlmProvider, TraceProvider
+from apps.service_providers.models import LlmProvider, LlmProviderTypes, TraceProvider
 from apps.teams.metadata import get_team_metadata_fields
 
 logger = logging.getLogger("ocs.admin")
@@ -144,17 +144,32 @@ def _cloud_project(provider) -> str | None:
     ``mask_secret`` has nothing to fingerprint and the key→team join can never fire for
     it. Its GCP project id is the join instead — that is what the Cloud Billing export
     keys cost by — and it is an identifier, not a credential.
+
+    Gated on the provider type rather than on the presence of ``credentials_json``:
+    ``config`` is a free-form JSON blob, so any provider could carry that key, and a
+    stray one would hand a spend report a project id to attribute cost by — quietly
+    billing the wrong team.
     """
-    credentials = provider.config.get("credentials_json")
-    if isinstance(credentials, str):
-        try:
-            credentials = json.loads(credentials)
-        except ValueError:
-            logger.warning("Provider id=%s has unparseable credentials_json", provider.pk)
-            return None
-    if not isinstance(credentials, dict):
+    if provider.type != str(LlmProviderTypes.google_vertex_ai):
         return None
-    return credentials.get("project_id") or None
+    credentials = provider.config.get("credentials_json")
+    project = _as_dict(credentials).get("project_id") or None
+    if credentials and not project:
+        # Configured but unusable -- malformed JSON, or a document with no project_id.
+        # Either way this team's Vertex spend cannot be joined, so say so rather than
+        # letting it silently fall through to the pro-rata bucket.
+        logger.warning("Vertex provider id=%s has no usable project_id in credentials_json", provider.pk)
+    return project
+
+
+def _as_dict(value) -> dict:
+    """``value`` as a dict, whether it is stored as one or as a JSON string."""
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except ValueError:
+            return {}
+    return value if isinstance(value, dict) else {}
 
 
 def _secret_field_for(provider) -> str | None:

--- a/apps/admin/provider_keys.py
+++ b/apps/admin/provider_keys.py
@@ -29,6 +29,9 @@ logger = logging.getLogger("ocs.admin")
 
 _LAST = 4
 
+# Tracing-provider metadata a spend report joins on, copied through verbatim.
+_TRACE_METADATA_KEYS = ("project_id", "project_name", "organization_id", "organization_name")
+
 
 @dataclass(frozen=True)
 class _MaskRule:
@@ -115,7 +118,6 @@ def get_trace_provider_records(metadata_fields: list[dict] | None = None) -> Ite
         metadata_fields = get_team_metadata_fields()
     providers = TraceProvider.objects.select_related("team").order_by("team__name", "type", "name")
     for provider in providers.iterator():
-        provider_metadata = provider.metadata or {}
         yield {
             "team_id": provider.team_id,
             "team_name": provider.team.name,
@@ -125,16 +127,24 @@ def get_trace_provider_records(metadata_fields: list[dict] | None = None) -> Ite
             "provider_type": provider.type,
             "name": provider.name,
             "host": provider.config.get("host") or "",
-            "project_id": provider_metadata.get("project_id") or "",
-            "project_name": provider_metadata.get("project_name") or "",
-            "organization_id": provider_metadata.get("organization_id") or "",
-            "organization_name": provider_metadata.get("organization_name") or "",
+            **_trace_metadata(provider),
         }
 
 
 def _team_metadata(team, metadata_fields) -> dict:
     metadata = team.metadata or {}
     return {field["key"]: metadata.get(field["key"], "") for field in metadata_fields}
+
+
+def _trace_metadata(provider) -> dict:
+    """The provider-side project/organization ids, blank where not yet recorded.
+
+    Metadata is best-effort at save time — a tracing-service outage leaves it empty —
+    so every key is always present and a missing one reads as "nothing to join on"
+    rather than being absent from the record.
+    """
+    metadata = provider.metadata or {}
+    return {key: metadata.get(key) or "" for key in _TRACE_METADATA_KEYS}
 
 
 def _cloud_project(provider) -> str | None:

--- a/apps/admin/provider_keys.py
+++ b/apps/admin/provider_keys.py
@@ -6,16 +6,23 @@ provider-assigned id. We reproduce each provider's own redaction format (e.g.
 ``sk-...JrYA`` for OpenAI, ``sk-ant-api03-cLV...lAAA`` for Anthropic) so the
 masked key here can be matched against what the provider console/API shows.
 
+Not every provider bills against something a key can identify. Vertex authenticates
+with a service-account document rather than an API key, and it bills by GCP project;
+tracing services bill by their own project inside an organization. Those providers
+carry a non-secret project identifier instead, which is the join their cost export
+actually keys on.
+
 Provider ``config`` is encrypted at rest, so we decrypt-on-access per row.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
 
-from apps.service_providers.models import LlmProvider
+from apps.service_providers.models import LlmProvider, TraceProvider
 from apps.teams.metadata import get_team_metadata_fields
 
 logger = logging.getLogger("ocs.admin")
@@ -61,30 +68,93 @@ def mask_secret(secret: str, provider_type: str) -> str:
     return f"{rule.header}{body[: rule.lead]}...{last}"
 
 
-def get_provider_key_fingerprints() -> Iterator[dict]:
+def get_provider_key_fingerprints(metadata_fields: list[dict] | None = None) -> Iterator[dict]:
     """Yield one masked-key record per LLM provider across all teams.
 
     Each record carries the owning team's `metadata` and `slug` so a report can
     label a team even when it has no usage in the reporting window (and so is
     absent from the usage report, which is keyed on recorded usage).
+
+    ``metadata_fields`` is accepted so a caller emitting several of these listings in
+    one response validates the setting once instead of per listing.
     """
-    metadata_fields = get_team_metadata_fields()
+    if metadata_fields is None:
+        metadata_fields = get_team_metadata_fields()
     providers = LlmProvider.objects.select_related("team").order_by("team__name", "type", "name")
     for provider in providers.iterator():
         secret_field = _secret_field_for(provider)
         secret = (provider.config.get(secret_field) or "") if secret_field else ""
-        metadata = provider.team.metadata or {}
         yield {
             "team_id": provider.team_id,
             "team_name": provider.team.name,
             "team_slug": provider.team.slug,
-            "metadata": {field["key"]: metadata.get(field["key"], "") for field in metadata_fields},
+            "metadata": _team_metadata(provider.team, metadata_fields),
             "provider_id": provider.id,
             "provider_type": provider.type,
             "name": provider.name,
             "masked_key": mask_secret(secret, provider.type),
             "organization": provider.config.get("openai_organization") or None,
+            "cloud_project": _cloud_project(provider),
         }
+
+
+def get_trace_provider_records(metadata_fields: list[dict] | None = None) -> Iterator[dict]:
+    """Yield one record per tracing provider across all teams.
+
+    Tracing bills per ingested unit at the *organization* level, so the join a spend
+    report needs is project → team rather than key → team. ``TraceProvider.metadata``
+    already holds the Langfuse project and organization — recorded on save, or by the
+    ``backfill_langfuse_metadata`` command — and is deliberately unencrypted so usage
+    can be aggregated by it. ``host`` and ``organization_id`` are what distinguish a
+    team tracing into our own organization (and so onto our invoice) from one bringing
+    its own account, which no report of ours should charge for.
+
+    Carries no secret: the key pair stays in the encrypted config.
+    """
+    if metadata_fields is None:
+        metadata_fields = get_team_metadata_fields()
+    providers = TraceProvider.objects.select_related("team").order_by("team__name", "type", "name")
+    for provider in providers.iterator():
+        provider_metadata = provider.metadata or {}
+        yield {
+            "team_id": provider.team_id,
+            "team_name": provider.team.name,
+            "team_slug": provider.team.slug,
+            "metadata": _team_metadata(provider.team, metadata_fields),
+            "provider_id": provider.id,
+            "provider_type": provider.type,
+            "name": provider.name,
+            "host": provider.config.get("host") or "",
+            "project_id": provider_metadata.get("project_id") or "",
+            "project_name": provider_metadata.get("project_name") or "",
+            "organization_id": provider_metadata.get("organization_id") or "",
+            "organization_name": provider_metadata.get("organization_name") or "",
+        }
+
+
+def _team_metadata(team, metadata_fields) -> dict:
+    metadata = team.metadata or {}
+    return {field["key"]: metadata.get(field["key"], "") for field in metadata_fields}
+
+
+def _cloud_project(provider) -> str | None:
+    """The cloud project ``provider`` bills to, or None if it doesn't bill by project.
+
+    Vertex authenticates with a service-account document rather than an API key, so
+    ``mask_secret`` has nothing to fingerprint and the key→team join can never fire for
+    it. Its GCP project id is the join instead — that is what the Cloud Billing export
+    keys cost by — and it is an identifier, not a credential.
+    """
+    credentials = provider.config.get("credentials_json")
+    if isinstance(credentials, str):
+        try:
+            credentials = json.loads(credentials)
+        except ValueError:
+            logger.warning("Provider id=%s has unparseable credentials_json", provider.pk)
+            return None
+    if not isinstance(credentials, dict):
+        return None
+    return credentials.get("project_id") or None
 
 
 def _secret_field_for(provider) -> str | None:

--- a/apps/admin/queries.py
+++ b/apps/admin/queries.py
@@ -16,6 +16,7 @@ from apps.evaluations.models import EvaluationConfig, EvaluationDataset, Evaluat
 from apps.experiments.models import Experiment, ExperimentSession, Participant
 from apps.teams.metadata import get_team_metadata_fields
 from apps.teams.models import Team
+from apps.trace.models import Trace
 
 _ZERO = Decimal(0)
 _COST_FIELD = DecimalField(max_digits=14, decimal_places=8)
@@ -162,6 +163,57 @@ def build_usage_report(start: datetime, end: datetime) -> dict:
         "metadata_fields": metadata_fields,
         "teams": result,
     }
+
+
+def build_tracing_volume_report(start: datetime, end: datetime) -> dict:
+    """Per-team tracing volume: how many traces each team recorded, and how many LLM
+    turns and tool calls happened inside them.
+
+    Reports the three counts separately and combines none of them. A consumer
+    apportioning a tracing bill needs a single weight, but what that weight should be is
+    a question about how the tracing service prices ingestion, not about OCS — so it
+    belongs to whoever is reading the invoice.
+
+    What the counts do and don't cover is an OCS fact, and worth knowing before
+    weighting them: a trace records its LLM turns and tool calls, but not its pipeline
+    node steps. A tracing service that bills per observation is therefore billing for
+    spans no column here counts, and a team running wide pipelines will look cheaper
+    than it is.
+
+    Counts every team's traces, including teams tracing to their own account rather
+    than ours. Which teams belong on our invoice is a question about *providers*, and
+    the caller answers it from the tracing-provider records in the provider-keys API.
+    """
+    rows = (
+        Trace.objects.filter(timestamp__gte=start, timestamp__lt=end, team_id__isnull=False)
+        .values("team_id")
+        .annotate(
+            traces=Count("id"),
+            turns=Coalesce(Sum("n_turns"), 0),
+            toolcalls=Coalesce(Sum("n_toolcalls"), 0),
+        )
+    )
+    by_team = {row["team_id"]: row for row in rows}
+    # Name and slug fetched by PK rather than grouped on, as in `get_usage_data`: both
+    # are per-team so neither affects the grouping, and it keeps the team join off the
+    # high-volume Trace scan.
+    teams = Team.objects.filter(id__in=list(by_team)).values_list("id", "name", "slug")
+
+    result = [
+        {
+            "team_id": team_id,
+            "team_name": name,
+            "team_slug": slug,
+            "traces": by_team[team_id]["traces"],
+            "turns": by_team[team_id]["turns"],
+            "toolcalls": by_team[team_id]["toolcalls"],
+        }
+        for team_id, name, slug in teams
+    ]
+    # Busiest first on the primary count, so the raw JSON reads sensibly. Ordering on a
+    # sum of the three would be the same editorial choice this report declines to make.
+    result.sort(key=lambda team: (-team["traces"], team["team_name"] or ""))
+    return {"start": start.isoformat(), "end": end.isoformat(), "teams": result}
 
 
 def get_whatsapp_numbers():

--- a/apps/admin/tests/conftest.py
+++ b/apps/admin/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+from apps.users.models import CustomUser
+
+
+@pytest.fixture()
+def superuser_client(client):
+    """A logged-in superuser, which is what the staff-only admin views and the
+    cross-team reporting APIs all require."""
+    user = CustomUser.objects.create(username="admin@acme.com", is_staff=True, is_superuser=True)
+    client.force_login(user)
+    return client

--- a/apps/admin/tests/test_provider_keys.py
+++ b/apps/admin/tests/test_provider_keys.py
@@ -1,21 +1,16 @@
+import json
+
 import pytest
 from django.urls import reverse
 
 from apps.admin.provider_keys import mask_secret
 from apps.service_providers.models import LlmProviderTypes
 from apps.users.models import CustomUser
-from apps.utils.factories.service_provider_factories import LlmProviderFactory
+from apps.utils.factories.service_provider_factories import LlmProviderFactory, TraceProviderFactory
 from apps.utils.factories.team import TeamFactory
 
 OPENAI_KEY = "sk-abcdefghijklJrYA"
 ANTHROPIC_KEY = "sk-ant-api03-cLVxxxxxxxxxxlAAA"
-
-
-@pytest.fixture()
-def superuser_client(client):
-    user = CustomUser.objects.create(username="admin@acme.com", is_staff=True, is_superuser=True)
-    client.force_login(user)
-    return client
 
 
 @pytest.mark.parametrize(
@@ -105,3 +100,70 @@ def test_vertex_dict_credentials_do_not_crash(superuser_client):
     assert response.status_code == 200
     vertex = {p["provider_type"]: p for p in response.json()["providers"]}["google_vertex_ai"]
     assert vertex["masked_key"] == ""
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("credentials", "expected"),
+    [
+        pytest.param({"type": "service_account", "project_id": "ocs-vertex"}, "ocs-vertex", id="dict"),
+        pytest.param('{"project_id": "ocs-vertex"}', "ocs-vertex", id="json-string"),
+        pytest.param({"type": "service_account"}, None, id="no-project-id"),
+        pytest.param("not json", None, id="unparseable"),
+        pytest.param(None, None, id="missing"),
+    ],
+)
+def test_vertex_exposes_gcp_project(superuser_client, credentials, expected):
+    """Vertex has no key fingerprint to join on, so the GCP project is the join key
+    against Cloud Billing. It is an identifier, not a credential."""
+    LlmProviderFactory(
+        type=str(LlmProviderTypes.google_vertex_ai),
+        config={"credentials_json": credentials},
+    )
+    response = superuser_client.get(reverse("ocs_admin:provider_keys_api"))
+
+    vertex = {p["provider_type"]: p for p in response.json()["providers"]}["google_vertex_ai"]
+    assert vertex["cloud_project"] == expected
+
+
+@pytest.mark.django_db()
+def test_lists_trace_providers_with_project_mapping(superuser_client):
+    team = TeamFactory(name="Alpha")
+    TraceProviderFactory(
+        team=team,
+        name="Langfuse",
+        config={"public_key": "pk-lf-1", "secret_key": "sk-lf-1", "host": "https://cloud.langfuse.com"},
+        metadata={
+            "project_id": "proj-123",
+            "project_name": "alpha-bot",
+            "organization_id": "org-dimagi",
+            "organization_name": "Dimagi",
+        },
+    )
+
+    response = superuser_client.get(reverse("ocs_admin:provider_keys_api"))
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload["trace_providers"]) == 1
+    record = payload["trace_providers"][0]
+    assert record["team_name"] == "Alpha"
+    assert record["project_id"] == "proj-123"
+    assert record["organization_id"] == "org-dimagi"
+    assert record["host"] == "https://cloud.langfuse.com"
+    # The key pair is the whole reason config is encrypted; it must not ride along.
+    assert "secret_key" not in json.dumps(record)
+    assert "pk-lf-1" not in json.dumps(record)
+
+
+@pytest.mark.django_db()
+def test_trace_provider_without_metadata_reports_blank_project(superuser_client):
+    """Metadata is best-effort at save time (a Langfuse outage leaves it empty), so the
+    record still appears — with no project to join on — rather than vanishing."""
+    TraceProviderFactory(team=TeamFactory(name="Alpha"), metadata={})
+
+    response = superuser_client.get(reverse("ocs_admin:provider_keys_api"))
+
+    record = response.json()["trace_providers"][0]
+    assert record["project_id"] == ""
+    assert record["organization_id"] == ""

--- a/apps/admin/tests/test_provider_keys.py
+++ b/apps/admin/tests/test_provider_keys.py
@@ -127,6 +127,21 @@ def test_vertex_exposes_gcp_project(superuser_client, credentials, expected):
 
 
 @pytest.mark.django_db()
+def test_non_vertex_provider_never_reports_a_cloud_project(superuser_client):
+    """`config` is a free-form JSON blob, so any provider could carry a
+    `credentials_json`. Only Vertex bills by project, and handing a spend report a
+    project id for anything else would attribute that cost to the wrong team."""
+    LlmProviderFactory(
+        type=str(LlmProviderTypes.openai),
+        config={"openai_api_key": OPENAI_KEY, "credentials_json": {"project_id": "not-vertex"}},
+    )
+    response = superuser_client.get(reverse("ocs_admin:provider_keys_api"))
+
+    openai = {p["provider_type"]: p for p in response.json()["providers"]}["openai"]
+    assert openai["cloud_project"] is None
+
+
+@pytest.mark.django_db()
 def test_lists_trace_providers_with_project_mapping(superuser_client):
     team = TeamFactory(name="Alpha")
     TraceProviderFactory(

--- a/apps/admin/tests/test_provider_usage_api.py
+++ b/apps/admin/tests/test_provider_usage_api.py
@@ -15,13 +15,6 @@ INVALID_RANGE = {"range_type": "custom", "start": "not-a-date", "end": "2026-05-
 WHEN = timezone.make_aware(datetime(2026, 5, 15, 12, 0))
 
 
-@pytest.fixture()
-def superuser_client(client):
-    user = CustomUser.objects.create(username="admin@acme.com", is_staff=True, is_superuser=True)
-    client.force_login(user)
-    return client
-
-
 def _usage(team, **kwargs):
     kwargs.setdefault("at", WHEN)
     return UsageRecordFactory(team=team, **kwargs)

--- a/apps/admin/tests/test_tracing_usage_api.py
+++ b/apps/admin/tests/test_tracing_usage_api.py
@@ -1,0 +1,133 @@
+from datetime import datetime
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.users.models import CustomUser
+from apps.utils.factories.team import TeamFactory
+from apps.utils.factories.traces import TraceFactory
+
+DATE_RANGE = {"range_type": "custom", "start": "2026-05-01", "end": "2026-05-31"}
+INVALID_RANGE = {"range_type": "custom", "start": "not-a-date", "end": "2026-05-31"}
+WHEN = timezone.make_aware(datetime(2026, 5, 15, 12, 0))
+
+
+def _trace(team, **kwargs):
+    kwargs.setdefault("at", WHEN)
+    return TraceFactory(team=team, **kwargs)
+
+
+def _teams(response):
+    return {team["team_name"]: team for team in response.json()["teams"]}
+
+
+@pytest.mark.django_db()
+def test_non_superuser_blocked(client):
+    client.force_login(CustomUser.objects.create(username="staff@acme.com", is_staff=True))
+    response = client.get(reverse("ocs_admin:tracing_usage_api"), DATE_RANGE)
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db()
+def test_invalid_range_returns_400(superuser_client):
+    response = superuser_client.get(reverse("ocs_admin:tracing_usage_api"), INVALID_RANGE)
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("params", "expected_status"),
+    [
+        pytest.param({"range_type": "custom", "start": "2026-05-01", "end": "2026-05-31"}, 200, id="custom"),
+        pytest.param({"range_type": "d30", "start": "2026-05-01", "end": "2026-05-31"}, 200, id="named-range"),
+        pytest.param({"range_type": "30d", "start": "2026-05-01", "end": "2026-05-31"}, 400, id="transposed-slug"),
+        # `_get_form` only binds the form when all three are present; an unbound form is
+        # never valid, so every parameter is required even for a named range that
+        # computes its own dates.
+        pytest.param({"range_type": "d30"}, 400, id="named-range-without-dates"),
+        pytest.param({"start": "2026-05-01", "end": "2026-05-31"}, 400, id="no-range-type"),
+        pytest.param({}, 400, id="nothing"),
+    ],
+)
+def test_date_range_params_are_all_required(superuser_client, params, expected_status):
+    response = superuser_client.get(reverse("ocs_admin:tracing_usage_api"), params)
+    assert response.status_code == expected_status
+
+
+@pytest.mark.django_db()
+def test_reporting_token_grants_access(client, settings):
+    settings.PROVIDER_REPORTING_API_TOKEN = "s3cret-token"
+    response = client.get(reverse("ocs_admin:tracing_usage_api"), DATE_RANGE, HTTP_AUTHORIZATION="Bearer s3cret-token")
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db()
+def test_reports_the_three_counts_separately(superuser_client):
+    """Traces, turns and tool calls stay unmixed: how to weight them against a tracing
+    invoice is the consumer's decision, not this endpoint's."""
+    team = TeamFactory(name="Alpha")
+    _trace(team, n_turns=3, n_toolcalls=2)
+    _trace(team, n_turns=1, n_toolcalls=0)
+
+    response = superuser_client.get(reverse("ocs_admin:tracing_usage_api"), DATE_RANGE)
+
+    assert response.status_code == 200
+    alpha = _teams(response)["Alpha"]
+    assert alpha["traces"] == 2
+    assert alpha["turns"] == 4
+    assert alpha["toolcalls"] == 2
+    assert "units" not in alpha
+
+
+@pytest.mark.django_db()
+def test_null_turn_counts_report_as_zero(superuser_client):
+    """`n_turns`/`n_toolcalls` are nullable; the sums must coalesce so a consumer can
+    add them without null-checking every field."""
+    team = TeamFactory(name="Alpha")
+    _trace(team, n_turns=None, n_toolcalls=None)
+    _trace(team, n_turns=2, n_toolcalls=None)
+
+    response = superuser_client.get(reverse("ocs_admin:tracing_usage_api"), DATE_RANGE)
+
+    alpha = _teams(response)["Alpha"]
+    assert alpha["traces"] == 2
+    assert alpha["turns"] == 2
+    assert alpha["toolcalls"] == 0
+
+
+@pytest.mark.django_db()
+def test_teams_ordered_by_trace_count(superuser_client):
+    small = TeamFactory(name="Small")
+    big = TeamFactory(name="Big")
+    _trace(small, n_turns=99)
+    for _ in range(3):
+        _trace(big, n_turns=1)
+
+    response = superuser_client.get(reverse("ocs_admin:tracing_usage_api"), DATE_RANGE)
+
+    assert [team["team_name"] for team in response.json()["teams"]] == ["Big", "Small"]
+
+
+@pytest.mark.django_db()
+def test_excludes_traces_outside_the_range(superuser_client):
+    team = TeamFactory(name="Alpha")
+    _trace(team, n_turns=1)
+    _trace(team, n_turns=99, at=timezone.make_aware(datetime(2026, 4, 30, 23, 59)))
+
+    alpha = _teams(superuser_client.get(reverse("ocs_admin:tracing_usage_api"), DATE_RANGE))["Alpha"]
+
+    assert alpha["traces"] == 1
+    assert alpha["turns"] == 1
+
+
+@pytest.mark.django_db()
+def test_teamless_traces_are_skipped(superuser_client):
+    """`Trace.team` is SET_NULL, so a deleted team leaves orphan rows with nothing to
+    apportion cost to."""
+    _trace(None, n_turns=5)
+    _trace(TeamFactory(name="Alpha"), n_turns=1)
+
+    response = superuser_client.get(reverse("ocs_admin:tracing_usage_api"), DATE_RANGE)
+
+    assert list(_teams(response)) == ["Alpha"]

--- a/apps/admin/urls.py
+++ b/apps/admin/urls.py
@@ -37,4 +37,5 @@ urlpatterns = [
     # Cross-team LLM usage / provider-key reporting (consumed by external scripts)
     path("api/provider-usage/", views.provider_usage_api, name="provider_usage_api"),
     path("api/provider-keys/", views.provider_keys_api, name="provider_keys_api"),
+    path("api/tracing-usage/", views.tracing_usage_api, name="tracing_usage_api"),
 ]

--- a/apps/admin/views.py
+++ b/apps/admin/views.py
@@ -1,6 +1,7 @@
 import functools
 import hmac
 import logging
+from collections.abc import Callable
 from datetime import datetime, time, timedelta
 from urllib.parse import urlencode
 
@@ -568,6 +569,19 @@ def users_api(request):
     return JsonResponse(data, safe=False)
 
 
+def _range_report(request, build: Callable[[datetime, datetime], dict]) -> JsonResponse:
+    """Run a reporting query over the requested date range, or 400 if it isn't valid.
+
+    Shared by the cross-team reporting APIs: they differ only in which report they
+    build, and the range is the whole of their request contract.
+    """
+    result = _validated_range(request)
+    if result is None:
+        return JsonResponse({"error": "Invalid or missing date range (range_type, start, end)"}, status=400)
+    _, _, start_timestamp, end_timestamp = result
+    return JsonResponse(build(start_timestamp, end_timestamp))
+
+
 @rate_limited("admin_api", key_fn=admin_api_key)
 @superuser_or_reporting_token
 def provider_usage_api(request):
@@ -575,11 +589,7 @@ def provider_usage_api(request):
     per-model detail, all read from recorded UsageRecords. Requires `range_type`,
     `start`, and `end` query params (as the dashboard date-range form).
     """
-    result = _validated_range(request)
-    if result is None:
-        return JsonResponse({"error": "Invalid or missing date range (range_type, start, end)"}, status=400)
-    _, _, start_timestamp, end_timestamp = result
-    return JsonResponse(build_usage_report(start_timestamp, end_timestamp))
+    return _range_report(request, build_usage_report)
 
 
 @rate_limited("admin_api", key_fn=admin_api_key)
@@ -609,11 +619,7 @@ def tracing_usage_api(request):
     that arrives with no per-team breakdown. Requires `range_type`, `start`, and `end`
     query params (as the dashboard date-range form).
     """
-    result = _validated_range(request)
-    if result is None:
-        return JsonResponse({"error": "Invalid or missing date range (range_type, start, end)"}, status=400)
-    _, _, start_timestamp, end_timestamp = result
-    return JsonResponse(build_tracing_volume_report(start_timestamp, end_timestamp))
+    return _range_report(request, build_tracing_volume_report)
 
 
 @is_superuser

--- a/apps/admin/views.py
+++ b/apps/admin/views.py
@@ -28,7 +28,7 @@ from apps.admin.forms import (
 )
 from apps.admin.imports import import_team_metadata_from_csv
 from apps.admin.models import OcsConfiguration
-from apps.admin.provider_keys import get_provider_key_fingerprints
+from apps.admin.provider_keys import get_provider_key_fingerprints, get_trace_provider_records
 from apps.admin.queries import (
     build_usage_report,
     get_message_stats,
@@ -587,9 +587,17 @@ def provider_keys_api(request):
     """Masked API-key fingerprint → team mapping across all LLM providers, so a
     report can attribute provider-side cost (keyed by the provider's redacted
     key) back to the owning team. Never returns the raw secret.
+
+    `trace_providers` is the same mapping for tracing, which bills by project inside
+    an organization rather than by key, so it joins on `project_id` instead.
     """
+    metadata_fields = get_team_metadata_fields()
     return JsonResponse(
-        {"providers": list(get_provider_key_fingerprints()), "metadata_fields": get_team_metadata_fields()}
+        {
+            "providers": list(get_provider_key_fingerprints(metadata_fields)),
+            "trace_providers": list(get_trace_provider_records(metadata_fields)),
+            "metadata_fields": metadata_fields,
+        }
     )
 
 

--- a/apps/admin/views.py
+++ b/apps/admin/views.py
@@ -30,6 +30,7 @@ from apps.admin.imports import import_team_metadata_from_csv
 from apps.admin.models import OcsConfiguration
 from apps.admin.provider_keys import get_provider_key_fingerprints, get_trace_provider_records
 from apps.admin.queries import (
+    build_tracing_volume_report,
     build_usage_report,
     get_message_stats,
     get_participant_stats,
@@ -599,6 +600,20 @@ def provider_keys_api(request):
             "metadata_fields": metadata_fields,
         }
     )
+
+
+@rate_limited("admin_api", key_fn=admin_api_key)
+@superuser_or_reporting_token
+def tracing_usage_api(request):
+    """Cross-team tracing volume over a date range, for apportioning a tracing bill
+    that arrives with no per-team breakdown. Requires `range_type`, `start`, and `end`
+    query params (as the dashboard date-range form).
+    """
+    result = _validated_range(request)
+    if result is None:
+        return JsonResponse({"error": "Invalid or missing date range (range_type, start, end)"}, status=400)
+    _, _, start_timestamp, end_timestamp = result
+    return JsonResponse(build_tracing_volume_report(start_timestamp, end_timestamp))
 
 
 @is_superuser

--- a/apps/utils/factories/traces.py
+++ b/apps/utils/factories/traces.py
@@ -7,5 +7,15 @@ from apps.trace.models import Trace
 class TraceFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Trace
+        skip_postgeneration_save = True
 
     duration = 1000
+
+    @factory.post_generation
+    def at(self, create, extracted, **kwargs):
+        """Stamp `timestamp` to a specific moment after creation. Skips when
+        not provided; tests that don't care about timing get auto_now_add."""
+        if not create or extracted is None:
+            return
+        Trace.objects.filter(pk=self.pk).update(timestamp=extracted)
+        self.refresh_from_db()


### PR DESCRIPTION
### Product Description

No change. Staff-only reporting APIs, consumed by the provider spend reconciliation script.

### Technical Description

Monthly provider spend is attributed back to OCS teams by joining each provider's cost report against OCS's key registry. Two providers can't be joined that way, and this adds what they need:

- **`provider-keys` gains `trace_providers` and `cloud_project`.** Tracing bills per project inside an organization, and Vertex authenticates with a service-account document rather than an API key, so neither has a key fingerprint to match a team on — the project id is the only join available. `TraceProvider.metadata` already recorded the Langfuse project/org, so this mostly just exposes it. Vertex's project id comes out of `credentials_json`; it's an identifier, not a credential, and no secret is returned by either block.

- **New `/admin/api/tracing-usage/`** returning per-team `traces`, `turns` and `toolcalls`. It combines none of them: a tracing invoice needs a single weight, but what counts as a billable unit is a fact about the vendor's pricing rather than about OCS, so the consumer decides. Worth knowing before weighting them — a trace records its LLM turns and tool calls but not its pipeline node steps, so anything billing per observation is billing for spans no column here counts.

Both endpoints reuse the existing `superuser_or_reporting_token` + rate-limit decorators and the dashboard date-range form, so all three of `range_type`, `start` and `end` are required — `_get_form` leaves the form unbound otherwise. Tests pin that down since it's easy to trip over.

### Demo

```
$ curl -H "Authorization: Bearer $TOKEN" \
    "$OCS/admin/api/tracing-usage/?range_type=custom&start=2026-07-01&end=2026-07-31"

{"start": "...", "end": "...",
 "teams": [{"team_id": 1, "team_name": "...", "team_slug": "...",
            "traces": 412, "turns": 1103, "toolcalls": 87}]}
```

### Docs and Changelog
- [ ] This PR requires docs/changelog update
