### PR TITLE
Deprecate retired Groq models

### DIFF
--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -107,11 +107,11 @@ DEFAULT_LLM_PROVIDER_MODELS = {
     ],
     "groq": [
         Model("whisper-large-v3-turbo", k(8)),
-        Model("gemma2-9b-it", k(8)),
+        Model("gemma2-9b-it", k(8), deprecated=True, replacement="openai/gpt-oss-20b"),
         Model("gemma-7b-it", k(8), deprecated=True),
-        Model("llama-3.3-70b-versatile", k(128), is_default=True, is_translation_default=True),
-        Model("llama-3.1-8b-instant", k(128)),
-        Model("openai/gpt-oss-120b", 131072),
+        Model("llama-3.3-70b-versatile", k(128), deprecated=True, replacement="openai/gpt-oss-120b"),
+        Model("llama-3.1-8b-instant", k(128), deprecated=True, replacement="openai/gpt-oss-20b"),
+        Model("openai/gpt-oss-120b", 131072, is_default=True, is_translation_default=True),
         Model("openai/gpt-oss-20b", 131072),
     ],
     "perplexity": [

--- a/apps/service_providers/migrations/0071_deprecate_vertex_gemini_2_5.py
+++ b/apps/service_providers/migrations/0071_deprecate_vertex_gemini_2_5.py
@@ -1,26 +1,19 @@
 from django.db import migrations
 
-from apps.data_migrations.utils.migrations import RunDataMigration
-
 
 class Migration(migrations.Migration):
     dependencies = [
         ("service_providers", "0070_deepseek_model_updates"),
         # Retained so the graph stays stable for environments that already applied this.
         ("cost_tracking", "0001_initial"),
-        # notify_deprecated_models reads Evaluator through LlmProviderModel.evaluators, so the
-        # Evaluator FK must be in this migration's app state.
+        # Retained so the graph stays stable for environments that already applied this.
         ("evaluations", "0018_evaluator_llm_provider_fks"),
-        # notify_deprecated_models queries Team with live models, so all Team
-        # schema changes must be applied first.
+        # Retained so the graph stays stable for environments that already applied this.
         ("teams", "0013_team_files_export_team_files_export_task_id"),
     ]
 
     operations = [
-        # llm_model_migration() and load_pricing_data() moved to 0072_add_gemini_3_7_flash so they
-        # run only once per deploy. This notification stays here because the deprecations it
-        # announces are this migration's: the deprecated flags come from
-        # DEFAULT_LLM_PROVIDER_MODELS and the google_vertex_ai gemini-2.5 rows it looks up were
-        # seeded by earlier migrations, so it does not depend on the moved llm_model_migration().
-        RunDataMigration("notify_deprecated_models", command_options={"force": True}),
+        # llm_model_migration() and load_pricing_data() moved to 0072_add_gemini_3_7_flash and
+        # notify_deprecated_models moved to 0073_deprecate_groq_models so they run only once per
+        # deploy (the newest migration re-syncs the whole model list and re-scans deprecations).
     ]

--- a/apps/service_providers/migrations/0072_add_gemini_3_7_flash.py
+++ b/apps/service_providers/migrations/0072_add_gemini_3_7_flash.py
@@ -1,7 +1,6 @@
 from django.db import migrations
 
 from apps.cost_tracking.migration_utils import load_pricing_data
-from apps.service_providers.migration_utils import llm_model_migration
 
 
 class Migration(migrations.Migration):
@@ -9,14 +8,13 @@ class Migration(migrations.Migration):
         ("service_providers", "0071_deprecate_vertex_gemini_2_5"),
         # required so the PricingRule table exists for load_pricing_data()
         ("cost_tracking", "0001_initial"),
-        # llm_model_migration() repoints evaluators off any custom model it replaces, so the
-        # Evaluator FK must be in this migration's app state (see _repoint_evaluators).
+        # Retained so the graph stays stable for environments that already applied this.
         ("evaluations", "0018_evaluator_llm_provider_fks"),
     ]
 
     operations = [
-        # Add gemini-3.7-flash for the google and google_vertex_ai providers.
-        llm_model_migration(),
-        # Seed pricing for gemini-3.7-flash.
+        # llm_model_migration() moved to 0073_deprecate_groq_models so it runs only once per deploy
+        # (the newest migration re-syncs the whole model list, which seeds gemini-3.7-flash too).
+        # Seed pricing for gemini-3.7-flash. load_ai_pricing is idempotent, so this stays here.
         load_pricing_data(),
     ]

--- a/apps/service_providers/migrations/0073_deprecate_groq_models.py
+++ b/apps/service_providers/migrations/0073_deprecate_groq_models.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+from apps.data_migrations.utils.migrations import RunDataMigration
+from apps.service_providers.migration_utils import llm_model_migration
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("service_providers", "0072_add_gemini_3_7_flash"),
+        # llm_model_migration() repoints evaluators off any custom model it replaces, so the
+        # Evaluator FK must be in this migration's app state (see _repoint_evaluators).
+        ("evaluations", "0018_evaluator_llm_provider_fks"),
+        # notify_deprecated_models queries Team with live models, so all Team
+        # schema changes must be applied first.
+        ("teams", "0013_team_files_export_team_files_export_task_id"),
+    ]
+
+    operations = [
+        # Re-sync the whole model list, marking the Groq gemma2-9b-it, llama-3.3-70b-versatile and
+        # llama-3.1-8b-instant models deprecated to match Groq's official deprecations.
+        llm_model_migration(),
+        # Notify affected teams about the deprecations and their recommended replacements.
+        RunDataMigration("notify_deprecated_models", command_options={"force": True}),
+    ]

--- a/apps/service_providers/tests/test_llm_integration.py
+++ b/apps/service_providers/tests/test_llm_integration.py
@@ -225,7 +225,6 @@ class TestGroqIntegration:
             team_with_users=team_with_users,
             provider_type=LlmProviderTypes.groq,
             provider_config=groq_credentials,
-            model_name="llama-3.1-8b-instant",  # The current default model has been removed
         )
 
 


### PR DESCRIPTION
### Product Description

OCS's Groq models are being reconciled with Groq's official deprecation schedule. Three models Groq has retired (`gemma2-9b-it`, `llama-3.1-8b-instant`, `llama-3.3-70b-versatile`) are now flagged deprecated in OCS, so existing users see a deprecation warning and a recommended replacement, and the Groq provider default moves to a still-supported model (`openai/gpt-oss-120b`). No models are removed, so existing configurations keep working.

### Technical Description

Reconciles OCS's Groq model list with [Groq's official deprecations page](https://console.groq.com/docs/deprecations), following `docs/developer_guides/managing_models.md`.

- `apps/service_providers/llm_service/default_models.py`: marked `gemma2-9b-it` (replacement `openai/gpt-oss-20b`), `llama-3.1-8b-instant` (replacement `openai/gpt-oss-20b`), and `llama-3.3-70b-versatile` (replacement `openai/gpt-oss-120b`) as `deprecated=True` — all three are on Groq's deprecation schedule with shutdown dates now passed. Moved the Groq `is_default`/`is_translation_default` flags off the now-deprecated `llama-3.3-70b-versatile` onto the recommended survivor `openai/gpt-oss-120b`.
- Added migration `apps/service_providers/migrations/0073_deprecate_groq_models.py` running `llm_model_migration()` + `notify_deprecated_models` (notifies affected teams of the deprecations).
- Stripped the superseded one-shot `llm_model_migration()`/`notify_deprecated_models` calls from earlier migrations `0071`/`0072` (kept idempotent `load_pricing_data()` and dependency chains intact).

### Migrations

This PR adds a data migration (0073). It only sets deprecated flags / sends notifications and removes no models, so it is backwards compatible.

- [x] The migrations are backwards compatible

### Docs and Changelog
- [ ] This PR requires docs/changelog update

---
_Generated by [Claude Code](https://claude.ai/code/session_016yVrzTx9CroEHsAFLbagwJ)_