### PR TITLE
Consistent chip rendering in tables

### DIFF
--- a/apps/chatbots/tables.py
+++ b/apps/chatbots/tables.py
@@ -102,8 +102,8 @@ class ChatbotTable(tables.Table):
             chip_action(
                 label_factory=_name_label_factory,
                 url_factory=_chip_chatbot_url_factory,
-                # Note: Keep the styling consistent with `generic/chip_button.html`
-                button_style="btn-soft btn-primary",
+                button_style=actions.CHIP_BUTTON_STYLE,
+                truncate=True,
             ),
         ],
         align="left",

--- a/apps/chatbots/tables.py
+++ b/apps/chatbots/tables.py
@@ -216,14 +216,14 @@ class ChatbotSessionsTable(tables.Table):
     def render_participant(self, record):
         template = get_template("generic/chip.html")
         chip = record.get_participant_chip(include_link=self._user_has_perm("experiments.view_participant"))
-        return template.render({"chip": chip})
+        return template.render({"chip": chip, "truncate": True})
 
     def render_chatbot(self, record):
         template = get_template("generic/chip.html")
         chatbot = record.experiment
         url = chatbot.get_absolute_url() if self._user_has_perm("experiments.view_experiment") else ""
         chip = chips.Chip(label=str(chatbot), url=url)
-        return template.render({"chip": chip})
+        return template.render({"chip": chip, "truncate": True})
 
     def _user_has_perm(self, perm: str) -> bool:
         # `request` is only set when the table is built via RequestConfig/SingleTableView; guard

--- a/apps/chatbots/tests/test_chatbot_tables.py
+++ b/apps/chatbots/tests/test_chatbot_tables.py
@@ -10,7 +10,7 @@ from time_machine import travel
 from apps.chatbots.tables import ChatbotSessionsTable, ChatbotTable
 from apps.experiments.models import Experiment, ExperimentSession
 from apps.generics.actions import Action, chip_action
-from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
+from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory, ParticipantFactory
 
 
 @pytest.mark.django_db()
@@ -117,3 +117,22 @@ def test_chatbot_chip_action():
         args=[team.slug, experiment.public_id, session.external_id],
     )
     assert url == expected_url
+
+
+@pytest.mark.django_db()
+class TestSessionsTableParticipantColumn:
+    """Long participant labels used to wrap, stretching the chip to fill the cell and giving the
+    column ragged row heights."""
+
+    def _cell(self, session):
+        table = ChatbotSessionsTable(ExperimentSession.objects.filter(id=session.id))
+        return str(list(table.rows)[0].get_cell("participant"))
+
+    def test_chip_stays_on_one_line(self, team_with_users):
+        participant = ParticipantFactory.create(
+            team=team_with_users, name="", identifier="a-very-long-participant@dimagi-associate.com"
+        )
+        session = ExperimentSessionFactory.create(team=team_with_users, participant=participant)
+        cell = self._cell(session)
+        assert "truncate" in cell
+        assert f'title="{participant.identifier}"' in cell

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1156,10 +1156,9 @@ class Participant(BaseTeamModel):
         if self.is_anonymous:
             suffix = str(self.public_id)[:6]
             return f"Anonymous [{suffix}]"
-        if self.name:
-            return f"{self.name} ({self.identifier})"
-        if self.user and self.user.get_full_name():
-            return f"{self.user.get_full_name()} ({self.identifier})"
+        name = self.name or (self.user.get_full_name() if self.user else "")
+        if name and name != self.identifier:
+            return f"{name} ({self.identifier})"
         return self.identifier
 
     def get_platform_display(self):

--- a/apps/experiments/tests/test_models.py
+++ b/apps/experiments/tests/test_models.py
@@ -17,6 +17,7 @@ from apps.experiments.models import (
     ConsentForm,
     Experiment,
     ExperimentSession,
+    Participant,
     SyntheticVoice,
 )
 from apps.pipelines.models import Pipeline
@@ -24,6 +25,7 @@ from apps.service_providers.llm_service.prompt_context import ParticipantDataPro
 from apps.service_providers.tracing import TraceInfo, TracingService
 from apps.teams.utils import get_slug_for_team
 from apps.trace.models import Trace, TraceStatus
+from apps.users.models import CustomUser
 from apps.utils.factories.assistants import OpenAiAssistantFactory
 from apps.utils.factories.events import (
     EventActionFactory,
@@ -1135,3 +1137,35 @@ def test_experiment_get_absolute_url_published_version(team_with_users):
     base_url = reverse("chatbots:single_chatbot_home", args=[get_slug_for_team(team.id), experiment.id])
     expected = f"{base_url}?version_id={snapshot.version_number}#versions"
     assert snapshot.get_absolute_url() == expected
+
+
+class TestParticipantStr:
+    """Chips and other participant labels come from ``__str__``; a name equal to the identifier
+    used to render it twice (e.g. "user@example.com (user@example.com)")."""
+
+    @pytest.mark.parametrize(
+        ("name", "identifier", "expected"),
+        [
+            pytest.param("Jane Doe", "jane@example.com", "Jane Doe (jane@example.com)", id="name-and-identifier"),
+            pytest.param("jane@example.com", "jane@example.com", "jane@example.com", id="name-is-identifier"),
+            pytest.param("", "8778042649", "8778042649", id="identifier-only"),
+        ],
+    )
+    def test_name_variants(self, name, identifier, expected):
+        assert str(Participant(name=name, identifier=identifier)) == expected
+
+    @pytest.mark.parametrize(
+        ("full_name", "identifier", "expected"),
+        [
+            pytest.param("Jane Doe", "jane@example.com", "Jane Doe (jane@example.com)", id="user-name-differs"),
+            pytest.param("jane@example.com", "jane@example.com", "jane@example.com", id="user-name-is-identifier"),
+        ],
+    )
+    def test_falls_back_to_user_full_name(self, full_name, identifier, expected):
+        user = CustomUser(first_name=full_name)
+        assert str(Participant(name="", identifier=identifier, user=user)) == expected
+
+    def test_anonymous(self):
+        participant = Participant(name="")
+        participant.identifier = f"anon:{participant.public_id}"
+        assert str(participant) == f"Anonymous [{str(participant.public_id)[:6]}]"

--- a/apps/generics/actions.py
+++ b/apps/generics/actions.py
@@ -9,6 +9,10 @@ from django.template.loader import get_template
 from django.urls import reverse
 from django_tables2 import TemplateColumn
 
+CHIP_BUTTON_STYLE = "btn-soft btn-primary"
+"""Styling for chips that stand in for the record itself (a name, a participant). Mirrored by
+`generic/chip_button.html`, which renders the same chips outside of an action column."""
+
 
 @dataclasses.dataclass
 class Action:
@@ -68,6 +72,8 @@ class Action:
             "title": self.title or "",
             "disabled": not self.is_enabled(request, record),
             "open_url_in_new_tab": self.open_url_in_new_tab,
+            # set explicitly so an outer context can't turn truncation on for an action
+            "truncate": False,
         }
         if self.button_style:
             ctxt["button_style"] = self.button_style
@@ -180,12 +186,17 @@ def chip_action(
     title: str | None = None,
     button_style: str = "",
     open_url_in_new_tab: bool = False,
+    truncate: bool = False,
 ):
     """Action to display a chip-style link that links to another page.
 
     This must be used with objects that implement the `get_absolute_url` method.
 
-    Note: Keep the styling consistent with `generic/chip_button.html`"""
+    Pass `button_style=CHIP_BUTTON_STYLE` for chips that stand in for the record itself; the
+    default styling suits chips that read as buttons ("Refresh", "View Session").
+
+    Set `truncate` for chips in a table cell, where a wrapped label stretches the chip to the
+    full cell width."""
     if not label and not label_factory:
 
         def label_factory(record, value):
@@ -210,6 +221,7 @@ def chip_action(
         display_condition=display_condition,
         enabled_condition=enabled_condition,
         open_url_in_new_tab=open_url_in_new_tab,
+        extra_context={"truncate": truncate},
     )
 
 

--- a/apps/human_annotations/tables.py
+++ b/apps/human_annotations/tables.py
@@ -23,7 +23,8 @@ class AnnotationQueueTable(tables.Table):
         actions=[
             chip_action(
                 label_factory=lambda record, _: record.name,
-                button_style="btn-soft btn-primary",
+                button_style=actions.CHIP_BUTTON_STYLE,
+                truncate=True,
             ),
         ],
         align="left",
@@ -72,7 +73,7 @@ class AnnotationItemTable(tables.Table):
             chip_action(
                 label="Annotate",
                 url_factory=_item_chip_url,
-                button_style="btn-soft btn-primary",
+                button_style=actions.CHIP_BUTTON_STYLE,
             ),
         ],
         align="left",

--- a/apps/trace/tables.py
+++ b/apps/trace/tables.py
@@ -37,6 +37,8 @@ class TraceTable(tables.Table):
             chip_action(
                 label_factory=lambda record, _: _get_chatbot_name(record),
                 url_factory=_chip_chatbot_url_factory,
+                button_style=actions.CHIP_BUTTON_STYLE,
+                truncate=True,
             ),
         ],
         align="left",
@@ -49,6 +51,8 @@ class TraceTable(tables.Table):
                 label_factory=lambda record, _: record.participant.identifier,
                 url_factory=_chip_session_url_factory,
                 display_condition=lambda request, record: record.session is not None,
+                button_style=actions.CHIP_BUTTON_STYLE,
+                truncate=True,
             ),
         ],
         align="left",

--- a/apps/trace/tests/test_views.py
+++ b/apps/trace/tests/test_views.py
@@ -7,6 +7,7 @@ import pytest
 from django.urls import reverse
 
 from apps.cost_tracking.models import Confidence, PricingRule, ServiceKind
+from apps.generics.actions import CHIP_BUTTON_STYLE
 from apps.teams.models import Flag
 from apps.trace.models import TraceStatus
 from apps.utils.factories.cost_tracking import UsageRecordFactory
@@ -261,3 +262,22 @@ def test_trace_table_view_filters_by_team(client, team_with_users):
     visible_ids = {row.record.id for row in response.context_data["table"].rows}
     assert own_trace.id in visible_ids
     assert foreign_trace.id not in visible_ids
+
+
+@pytest.mark.django_db()
+def test_trace_table_renders_chips_like_other_tables(client, team_with_users):
+    """The bot and session columns stand in for the record, so they carry the shared chip styling
+    and the same one-line truncation as the participant chips in the session tables."""
+    team = team_with_users
+    user = team.members.first()
+    _make_trace(team)
+
+    client.force_login(user)
+    response = client.get(reverse("trace:table", args=[team.slug]))
+
+    chips = re.findall(r'<a [^>]*class="([^"]*)"', response.content.decode())
+    assert chips
+    for classes in chips:
+        assert CHIP_BUTTON_STYLE in classes
+        assert "max-w-xs" in classes
+    assert response.content.decode().count("min-w-0 truncate") == 2

--- a/templates/admin/sections/top_experiments.html
+++ b/templates/admin/sections/top_experiments.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="pg-subtitle">{% translate "Top Experiments" %}</div>
+<div class="pg-subtitle">{% translate "Top Chatbots" %}</div>
 {% if top_experiments %}
 <div class="overflow-x-auto mb-6">
   <table class="table table-zebra table-sm">
@@ -7,7 +7,7 @@
       <tr>
         <th>#</th>
         <th>{% translate "Team" %}</th>
-        <th>{% translate "Experiment" %}</th>
+        <th>{% translate "Chatbot" %}</th>
         <th>{% translate "Messages" %}</th>
         <th>{% translate "Sessions" %}</th>
       </tr>

--- a/templates/admin/sections/whatsapp.html
+++ b/templates/admin/sections/whatsapp.html
@@ -6,7 +6,7 @@
     <thead>
       <tr>
         <th>{% translate "Team" %}</th>
-        <th>{% translate "Experiment" %}</th>
+        <th>{% translate "Chatbot" %}</th>
         <th>{% translate "Channel Number" %}</th>
         <th>{% translate "Human Messages" %}</th>
         <th>{% translate "AI Messages" %}</th>

--- a/templates/admin/usage_chart.html
+++ b/templates/admin/usage_chart.html
@@ -25,7 +25,7 @@
   </a>
   <a class="btn" href="{% url "ocs_admin:export_top_experiments" %}{% querystring %}">
     <i class="fa-solid fa-download"></i>
-    Top Experiments
+    Top Chatbots
   </a>
 </div>
 

--- a/templates/chatbots/components/continue_chat_action.html
+++ b/templates/chatbots/components/continue_chat_action.html
@@ -1,4 +1,4 @@
-<button class="btn btn-sm join-item {{ button_style|default_if_none:"btn-ghost" }}"
+<button class="btn btn-sm join-item {{ button_style }}"
         {% if disabled %}disabled="disabled"{% endif %}
         {% if title %}title="{{ title }}"{% endif %}
         type="button"

--- a/templates/generic/action.html
+++ b/templates/generic/action.html
@@ -1,5 +1,5 @@
 {% if action_url %}
-  <a {% if not disabled %}href="{{ action_url }}"{% endif %} class="btn btn-sm join-item {{ button_style|default_if_none:"btn-ghost" }}{% if truncate %} max-w-xs{% endif %}{% if disabled %} pointer-events-none{% endif %}" {% if disabled %}aria-disabled="true"{% endif %} {% if title %}title="{{ title }}"{% endif %} {% if not disabled and open_url_in_new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>
+  <a {% if not disabled %}href="{{ action_url }}"{% endif %} class="btn btn-sm join-item {{ button_style }}{% if truncate %} max-w-xs{% endif %}{% if disabled %} pointer-events-none{% endif %}" {% if disabled %}aria-disabled="true"{% endif %} {% if title %}title="{{ title }}"{% endif %} {% if not disabled and open_url_in_new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>
     {% include "generic/chip_label.html" %}
     {% if icon_class %}
       <i class="{{ icon_class }}"></i>

--- a/templates/generic/action.html
+++ b/templates/generic/action.html
@@ -1,6 +1,6 @@
 {% if action_url %}
-  <a {% if not disabled %}href="{{ action_url }}"{% endif %} class="btn btn-sm join-item {{ button_style|default_if_none:"btn-ghost" }}{% if disabled %} pointer-events-none{% endif %}" {% if disabled %}aria-disabled="true"{% endif %} {% if title %}title="{{ title }}"{% endif %} {% if not disabled and open_url_in_new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>
-    {{ label }}
+  <a {% if not disabled %}href="{{ action_url }}"{% endif %} class="btn btn-sm join-item {{ button_style|default_if_none:"btn-ghost" }}{% if truncate %} max-w-xs{% endif %}{% if disabled %} pointer-events-none{% endif %}" {% if disabled %}aria-disabled="true"{% endif %} {% if title %}title="{{ title }}"{% endif %} {% if not disabled and open_url_in_new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>
+    {% include "generic/chip_label.html" %}
     {% if icon_class %}
       <i class="{{ icon_class }}"></i>
     {% endif %}

--- a/templates/generic/action_ajax.html
+++ b/templates/generic/action_ajax.html
@@ -1,4 +1,4 @@
-<button @click.stop="" class="btn btn-sm join-item {{ button_style|default_if_none:"btn-ghost" }}"
+<button @click.stop="" class="btn btn-sm join-item {{ button_style }}"
         {% if disabled %}disabled="disabled"{% endif %}
         id="action-{{ action_id }}"
         title="{{ title }}"

--- a/templates/generic/action_modal.html
+++ b/templates/generic/action_modal.html
@@ -1,4 +1,4 @@
-<button class="btn btn-sm join-item {{ button_style|default_if_none:"btn-ghost" }}"
+<button class="btn btn-sm join-item {{ button_style }}"
         {% if disabled %}disabled="disabled"{% endif %}
         id="action-{{ action_id }}"
         title="{{ title }}"

--- a/templates/generic/chip.html
+++ b/templates/generic/chip.html
@@ -1,5 +1,5 @@
 {% if chip.url or chip.label %}
-  {% include "generic/chip_button.html" with url=chip.url label=chip.label %}
+  {% include "generic/chip_button.html" with url=chip.url label=chip.label truncate=truncate %}
 {% else %}
   {{ chip }}
 {% endif %}

--- a/templates/generic/chip_button.html
+++ b/templates/generic/chip_button.html
@@ -1,9 +1,17 @@
-{% with classes="btn btn-sm btn-soft btn-primary" %}
+{% comment %}
+Chip-styled link, or a static badge when `url` is empty.
+
+Params:
+  url, label
+  truncate: keep the chip on one line, ellipsizing overflow with the full label in the tooltip.
+    Use in table cells, where a wrapped label stretches the chip to the full cell width.
+{% endcomment %}
+{% with classes="btn btn-sm btn-soft btn-primary" truncate_classes=truncate|yesno:"max-w-xs," %}
 {% if url %}
-  <a href="{{ url }}" class="{{ classes }}">
-    {{ label }}
+  <a href="{{ url }}" class="{{ classes }} {{ truncate_classes }}">
+    {% include "generic/chip_label.html" %}
   </a>
 {% elif label %}
-  <div class="{{ classes }} no-animation">{{ label }}</div>
+  <div class="{{ classes }} no-animation {{ truncate_classes }}">{% include "generic/chip_label.html" %}</div>
 {% endif %}
 {% endwith %}

--- a/templates/generic/chip_label.html
+++ b/templates/generic/chip_label.html
@@ -1,0 +1,4 @@
+{% if truncate %}
+  {# min-w-0 lets the flex item shrink below the (unbreakable) label width so the ellipsis shows #}
+  <span class="min-w-0 truncate" title="{{ label }}">{{ label }}</span>
+{% else %}{{ label }}{% endif %}

--- a/templates/generic/referenced_objects.html
+++ b/templates/generic/referenced_objects.html
@@ -1,7 +1,7 @@
 <div>
   <p>This {{ object_name }} is still referenced by other objects. Remove or archive those references first.</p>
   {% if experiments %}
-    <h2 class="font-semibold my-2">Experiments</h2>
+    <h2 class="font-semibold my-2">Chatbots</h2>
     <ul class="list-disc list-inside">
       {% for experiment in experiments %}
         <li>{% include "generic/chip.html" with chip=experiment %}</li>
@@ -19,7 +19,7 @@
   {% endif %}
 
   {% if experiments_with_pipeline_nodes %}
-    <h2 class="font-semibold my-2">Experiments referencing Pipeline</h2>
+    <h2 class="font-semibold my-2">Chatbots referencing Pipeline</h2>
     <ul class="list-disc list-inside">
       {% for experiment in experiments_with_pipeline_nodes %}
         <li>{% include "generic/chip.html" with chip=experiment %}</li>
@@ -29,7 +29,7 @@
 
 
   {% if static_trigger_experiments %}
-    <h2 class="font-semibold my-2">Static Trigger Experiments</h2>
+    <h2 class="font-semibold my-2">Static Trigger Chatbots</h2>
     <ul class="list-disc list-inside">
       {% for experiment in static_trigger_experiments %}
         <li>{% include "generic/chip.html" with chip=experiment %}</li>

--- a/templates/participants/partials/participant_experiments.html
+++ b/templates/participants/partials/participant_experiments.html
@@ -3,7 +3,7 @@
 <table class="min-w-full divide-y divide-gray-300">
   <thead>
     <tr>
-      <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">Experiment</th>
+      <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">Chatbot</th>
       <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">Joined on</th>
       <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">Last message received at</th>
       <th scope="col"></th>

--- a/templates/participants/single_participant_home.html
+++ b/templates/participants/single_participant_home.html
@@ -37,7 +37,7 @@
     <div class="max-w-5xl mt-4 border rounded-2xl">
       {% include "participants/partials/participant_summary.html" %}
     </div>
-    <h3 class="text-base font-semibold leading-7 mt-8 pl-4">Experiments</h3>
+    <h3 class="text-base font-semibold leading-7 mt-8 pl-4">Chatbots</h3>
     <div class="max-w-5xl mt-4 border rounded-2xl">
       {% include "participants/partials/participant_experiments.html" %}
     </div>

--- a/templates/teams/manage_team.html
+++ b/templates/teams/manage_team.html
@@ -48,7 +48,7 @@
       {% has_perm "custom_actions" "add_customaction" as allow_new_action %}
       {% url "custom_actions:table" request.team.slug as actions_table_url %}
       {% url "custom_actions:new" request.team.slug as actions_new_url %}
-      {% translate "Allow Experiments to call external services" as actions_subtitle %}
+      {% translate "Allow Chatbots to call external services" as actions_subtitle %}
       {% include "generic/object_home_content.html" with new_object_url=actions_new_url title="Custom Actions" table_url=actions_table_url allow_new=allow_new_action subtitle=actions_subtitle data_cy_title="title-actions" %}
     {% endwith %}
     {% flag "flag_mcp" %}

--- a/templates/trace/trace_detail.html
+++ b/templates/trace/trace_detail.html
@@ -152,7 +152,7 @@
         {% endif %}
         {% if trace.experiment %}
           <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-base-300">
-            <span class="text-xs text-base-content/60">Experiment</span>
+            <span class="text-xs text-base-content/60">Chatbot</span>
             {% include "generic/chip.html" with chip=trace.experiment.as_chatbot_chip %}
             <span class="text-xs text-base-content/60">
               {% if trace.experiment_version_number is not None %}· v{{ trace.experiment_version_number }}{% else %}· unreleased{% endif %}


### PR DESCRIPTION
### Product Description

Participant and record chips in the session, all-sessions and trace tables render consistently: one chip style, one line each, with the full label in a tooltip when it's too long to fit. A participant whose name *is* their email no longer shows it twice (`skelly@dimagi.com (skelly@dimagi.com)`). Separately, the last few user-facing "Experiment" labels now say "Chatbot".

### Technical Description

Chips had two render paths that had drifted apart: `generic/chip.html` (used by `render_*` methods) baked in `btn-soft btn-primary`, while `chip_action` renders through `generic/action.html`, which falls back to `btn-ghost` unless the caller passes `button_style` — `ChatbotTable` did, `TraceTable` didn't. The style is now a single `actions.CHIP_BUTTON_STYLE` constant, and truncation lives in one partial (`generic/chip_label.html`) that both paths include.

Worth knowing for review:

- `chip_action` serves two roles — chips that stand in for the record (trace bot/session, chatbot name, queue name) and chips that read as buttons (`Session Details`, `View Session`, `Refresh`, `Annotate`). I deliberately did **not** change `chip_action`'s default style, so the buttons keep their ghost look; only the identity chips opt in. That's why the constant is passed at the call site rather than defaulted.
- `Action.get_context` now sets `truncate: False` explicitly. Without it, an action inherits whatever `truncate` happens to be in the surrounding template context.
- Truncation caps chips at `max-w-xs`; `min-w-0` on the label span is load-bearing, since a flex item won't shrink below the width of an unbreakable string like an email address.

The "Chatbot" rename is its own commit (`565667ff6`) and is pure label text. One of those edits made a singular per-row column header plural; I made it singular again to match the identical header in `admin/sections/whatsapp.html`.

### Demo

Drove all three tables locally with participants covering each identifier shape — anonymous, bare phone number, email-as-name, name plus email, and a deliberately over-long email. Every chip renders on one line at the same height; the over-long one ellipsizes at 20rem without widening the column.

### Docs and Changelog
- [ ] This PR requires docs/changelog update
