### PR TITLE
fix(docker, channels): support optional .env fallbacks, add build context, and fix Telegram webhook token validation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ node_modules
 npm-debug.log
 pnpm-debug.log
 .env
+.env.prod
 .direnv
 .pytest_cache
 .venv

--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,11 @@ SLACK_CLIENT_SECRET=
 SLACK_SIGNING_SECRET=
 SLACK_BOT_NAME=
 
+## Optional: Telegram Webhook Secret Token
+# Secret token for verifying webhook request authenticity (sent in X-Telegram-Bot-Api-Secret-Token header).
+# Leave commented out / blank if not enforcing webhook secret token validation.
+# TELEGRAM_SECRET_TOKEN=
+
 ## Google Analytics (optional)
 GOOGLE_ANALYTICS_ID=
 

--- a/apps/channels/tests/test_webhooks.py
+++ b/apps/channels/tests/test_webhooks.py
@@ -1,8 +1,12 @@
 from unittest.mock import patch
 
-from django.conf import settings
+import pytest
+from django.test import override_settings
+from django.urls import reverse
 
+from apps.channels.models import ChannelPlatform
 from apps.channels.webhooks import TelegramWebhookManager
+from apps.utils.factories.channels import ExperimentChannelFactory
 
 
 @patch("apps.channels.webhooks.TeleBot")
@@ -10,11 +14,24 @@ def test_set_incoming_webhook_sets_webhook_and_commands(mock_telebot):
     bot = mock_telebot.return_value
     manager = TelegramWebhookManager()
 
-    manager.set_incoming_webhook({"bot_token": "tok"}, "https://example.com/hook")
+    with override_settings(TELEGRAM_SECRET_TOKEN="my-secret-token"):
+        manager.set_incoming_webhook({"bot_token": "tok"}, "https://example.com/hook")
 
     mock_telebot.assert_called_once_with("tok", threaded=False)
-    bot.set_webhook.assert_called_once_with("https://example.com/hook", secret_token=settings.TELEGRAM_SECRET_TOKEN)
+    bot.set_webhook.assert_called_once_with("https://example.com/hook", secret_token="my-secret-token")
     bot.set_my_commands.assert_called_once()
+
+
+@patch("apps.channels.webhooks.TeleBot")
+def test_set_incoming_webhook_passes_none_when_secret_unset(mock_telebot):
+    bot = mock_telebot.return_value
+    manager = TelegramWebhookManager()
+
+    with override_settings(TELEGRAM_SECRET_TOKEN=""):
+        manager.set_incoming_webhook({"bot_token": "tok"}, "https://example.com/hook")
+
+    mock_telebot.assert_called_once_with("tok", threaded=False)
+    bot.set_webhook.assert_called_once_with("https://example.com/hook", secret_token=None)
 
 
 @patch("apps.channels.webhooks.TeleBot")
@@ -30,3 +47,61 @@ def test_remove_incoming_webhook_clears_webhook(mock_telebot):
 
 def test_supports_webhook_management():
     assert TelegramWebhookManager.supports_webhook_management is True
+
+
+@pytest.fixture()
+def telegram_channel(db):
+    return ExperimentChannelFactory.create(platform=ChannelPlatform.TELEGRAM)
+
+
+@pytest.mark.django_db()
+@patch("apps.channels.tasks.handle_telegram_message.delay")
+def test_telegram_message_accepted_when_secret_unset(mock_handle, client, telegram_channel):
+    with override_settings(TELEGRAM_SECRET_TOKEN=""):
+        response = client.post(
+            reverse("channels:new_telegram_message", args=[telegram_channel.external_id]),
+            data="{}",
+            content_type="application/json",
+        )
+    assert response.status_code == 200
+    mock_handle.assert_called_once()
+
+
+@pytest.mark.django_db()
+@patch("apps.channels.tasks.handle_telegram_message.delay")
+def test_telegram_message_accepted_with_valid_secret(mock_handle, client, telegram_channel):
+    with override_settings(TELEGRAM_SECRET_TOKEN="valid-secret"):
+        response = client.post(
+            reverse("channels:new_telegram_message", args=[telegram_channel.external_id]),
+            data="{}",
+            content_type="application/json",
+            headers={"x-telegram-bot-api-secret-token": "valid-secret"},
+        )
+    assert response.status_code == 200
+    mock_handle.assert_called_once()
+
+
+@pytest.mark.django_db()
+def test_telegram_message_rejected_with_invalid_secret(client, telegram_channel):
+    with override_settings(TELEGRAM_SECRET_TOKEN="valid-secret"):
+        response = client.post(
+            reverse("channels:new_telegram_message", args=[telegram_channel.external_id]),
+            data="{}",
+            content_type="application/json",
+            headers={"x-telegram-bot-api-secret-token": "wrong-secret"},
+        )
+    assert response.status_code == 400
+    assert response.content == b"Invalid request."
+
+
+@pytest.mark.django_db()
+def test_telegram_message_rejected_when_secret_missing_but_required(client, telegram_channel):
+    with override_settings(TELEGRAM_SECRET_TOKEN="valid-secret"):
+        response = client.post(
+            reverse("channels:new_telegram_message", args=[telegram_channel.external_id]),
+            data="{}",
+            content_type="application/json",
+        )
+    assert response.status_code == 400
+    assert response.content == b"Invalid request."
+

--- a/apps/channels/tests/test_webhooks.py
+++ b/apps/channels/tests/test_webhooks.py
@@ -104,4 +104,3 @@ def test_telegram_message_rejected_when_secret_missing_but_required(client, tele
         )
     assert response.status_code == 400
     assert response.content == b"Invalid request."
-

--- a/apps/channels/views.py
+++ b/apps/channels/views.py
@@ -61,9 +61,10 @@ log = logging.getLogger("ocs.channels")
 @csrf_exempt
 @require_POST
 def new_telegram_message(request, channel_external_id: uuid):
-    token = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
-    if token != settings.TELEGRAM_SECRET_TOKEN:
-        return HttpResponseBadRequest("Invalid request.")
+    if settings.TELEGRAM_SECRET_TOKEN:
+        token = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
+        if token != settings.TELEGRAM_SECRET_TOKEN:
+            return HttpResponseBadRequest("Invalid request.")
 
     channel = tasks.get_experiment_channel(ChannelPlatform.TELEGRAM, external_id=channel_external_id)
     if not channel:

--- a/apps/channels/webhooks.py
+++ b/apps/channels/webhooks.py
@@ -27,7 +27,7 @@ class TelegramWebhookManager:
 
     def set_incoming_webhook(self, extra_data: dict, webhook_url: str) -> None:
         bot = TeleBot(extra_data.get("bot_token", ""), threaded=False)
-        bot.set_webhook(webhook_url, secret_token=settings.TELEGRAM_SECRET_TOKEN)
+        bot.set_webhook(webhook_url, secret_token=settings.TELEGRAM_SECRET_TOKEN or None)
         bot.set_my_commands(commands=[types.BotCommand(ExperimentChannel.RESET_COMMAND, "Restart chat")])
 
     def remove_incoming_webhook(self, extra_data: dict, webhook_url: str) -> None:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,10 +8,16 @@
 # simpler single-server setups.
 
 x-app: &app
+  build:
+    context: .
+    dockerfile: Dockerfile
   image: open-chat-studio:latest
   restart: unless-stopped
   env_file:
-    - .env.prod
+    - path: .env.prod
+      required: false
+    - path: .env
+      required: false
   depends_on:
     db:
       condition: service_healthy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,9 +14,10 @@ x-app: &app
   image: open-chat-studio:latest
   restart: unless-stopped
   env_file:
-    - path: .env.prod
-      required: false
+    # .env is read first so .env.prod values (if present) win on conflicts.
     - path: .env
+      required: false
+    - path: .env.prod
       required: false
   depends_on:
     db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
 
   web:
     <<: *app
-    command: python manage.py runserver
+    command: python manage.py runserver 0.0.0.0:8000
     ports:
       - "8000:8000"
     environment:

--- a/docs/hosting/configuration.md
+++ b/docs/hosting/configuration.md
@@ -165,6 +165,12 @@ Required only if you want users to connect Slack channels to their chatbots.
 | `SLACK_SIGNING_SECRET` | Slack app signing secret |
 | `SLACK_BOT_NAME` | Display name for the Slack bot |
 
+### Telegram
+
+| Variable | Description |
+|----------|-------------|
+| `TELEGRAM_SECRET_TOKEN` | Optional. Secret token for verifying inbound webhook authenticity via the `X-Telegram-Bot-Api-Secret-Token` header. When configured, OCS registers it with Telegram's `setWebhook` API and rejects requests without matching tokens. |
+
 ## Observability
 
 | Variable | Description |

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -59,6 +59,9 @@ CRYPTOGRAPHY_SALT=<generate a random salt>
 
 See [Configuration Reference](./configuration.md) for all available options.
 
+!!! note "Environment file fallback"
+    `docker-compose.prod.yml` reads both `.env` and `.env.prod` (either may be absent; `.env.prod` values take precedence when both define the same variable). This keeps the compose file working on platforms that only supply a standard `.env` file, such as **Dokploy, Coolify, and Portainer**. The optional `required: false` `env_file` entries require Docker Compose **v2.24+** (Docker Engine 24+ ships with a compatible Compose). The bundled PostgreSQL container requires `POSTGRES_PASSWORD` to be present for interpolation — either in `.env`, `.env.prod`, or the shell (see Step 3).
+
 ## Step 3: Start the Services
 
 If using the bundled PostgreSQL container, also set `POSTGRES_PASSWORD` (it must match the password in `DATABASE_URL`):


### PR DESCRIPTION
### Product Description

Improves the self-hosting experience for Docker Compose users:

- **Dokploy / Coolify / Portainer compatibility:** the production compose file no longer hard-crashes with `stat .env.prod: no such file or directory` when only a standard `.env` file is provided. Both `.env` and `.env.prod` are loaded, and either may be absent.
- **Build from source:** `docker compose -f docker-compose.prod.yml up --build` now builds the Dockerfile directly from the repository, instead of failing when pre-tagged `open-chat-studio:latest` images aren't present locally.
- **Dev port binding fix:** the dev `web` service binds `runserver` to `0.0.0.0:8000` so the app is reachable from the host when running `docker compose up` locally.
- **Telegram webhook secret token made optional:** when `TELEGRAM_SECRET_TOKEN` is unset, inbound Telegram messages are accepted instead of being rejected (previously an unset token rejected *every* message, silently breaking self-hosted installs). When set, the token is enforced on incoming webhooks and registered with Telegram's `setWebhook` API.

### Technical Description

`docker-compose.prod.yml`:

- Adds `build: context: .` (Dockerfile) to the `x-app` anchor so `--build` works against the bundled `Dockerfile`.
- Switches `env_file` to the Compose v2 `path`/`required: false` syntax, loading both `.env` and `.env.prod`. `.env` is listed **first** so `.env.prod` values win on conflicts ? a stray dev variable can never override a production value.
- Adds `.env.prod` to `.dockerignore`: the Dockerfile copies the full build context (`COPY . /code`), so without this a `.env.prod` sitting in the repo root would be baked into the image.
- Note: `required: false` requires Docker Compose v2.24+ (Docker Engine 24+ ships with a compatible Compose version). Documented in `docs/hosting/docker.md`.

`apps/channels/`:

- `views.py`: only validate the `X-Telegram-Bot-Api-Secret-Token` header when `TELEGRAM_SECRET_TOKEN` is configured; otherwise accept the request. Previously an empty token rejected every inbound message (`None != ""` was always true).
- `webhooks.py`: pass `secret_token=settings.TELEGRAM_SECRET_TOKEN or None` so an unset token omits the secret rather than registering an empty one.
- Added unit tests covering unset / valid / invalid / missing secret token cases.

`docker-compose.yml`:

- `web` command changed to `runserver 0.0.0.0:8000` so the dev server is reachable from the host.

### Migrations

No migrations.

### Demo

Tested locally: `docker compose config` validates; `docker compose up --build` builds and starts with only `.env.prod` or only `.env`. Telegram webhook tests cover the token matrix.

### Docs and Changelog

- [x] This PR requires docs/changelog update

Updated `docs/hosting/docker.md` (environment-file fallback + Compose version note) and `docs/hosting/configuration.md` (Telegram secret token variable).
