### PR TITLE
Fix Trigger Bot 500 on the participant detail page

### DIFF
--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -864,9 +864,9 @@ paths:
                   the bot/LLM.
               ExperimentChannelNotFound:
                 value:
-                  detail: Experiment cannot send messages on the connect_messaging
-                    channel
-                summary: Experiment cannot send messages on the specified channel
+                  detail: Chatbot cannot send messages on the connect_messaging channel.
+                    Create the channel first.
+                summary: Chatbot cannot send messages on the specified channel
               ConsentNotGiven:
                 value:
                   detail: User has not given consent
@@ -915,6 +915,11 @@ paths:
               schema:
                 description: Bad Request
               examples:
+                ExperimentChannelNotFound:
+                  value:
+                    detail: Chatbot cannot send messages on the connect_messaging
+                      channel. Create the channel first.
+                  summary: Chatbot cannot send messages on the specified channel
                 ConsentNotGiven:
                   value:
                     detail: User has not given consent
@@ -931,12 +936,6 @@ paths:
             application/json:
               schema:
                 description: Not Found
-              examples:
-                ExperimentChannelNotFound:
-                  value:
-                    detail: Experiment cannot send messages on the connect_messaging
-                      channel
-                  summary: Experiment cannot send messages on the specified channel
           description: ''
   /channels/api/{experiment_id}/incoming_message:
     post:

--- a/api-schemas/v2.yml
+++ b/api-schemas/v2.yml
@@ -199,9 +199,9 @@ paths:
               examples:
                 ChannelNotConfigured:
                   value:
-                    detail: Experiment cannot send messages on the whatsapp channel.
+                    detail: Chatbot cannot send messages on the whatsapp channel.
                       Create the channel first.
-                  summary: Experiment cannot send messages on the specified channel
+                  summary: Chatbot cannot send messages on the specified channel
                 ConsentNotGiven:
                   value:
                     detail: User has not given consent

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -1092,7 +1092,7 @@ def test_trigger_bot_on_disabled_channel(trigger_bot_message_task, experiment):
     response = client.post(reverse("api:trigger_bot"), json.dumps(data), content_type="application/json")
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "The email channel for this experiment is disabled."
+    assert response.json()["detail"] == "The email channel for this chatbot is disabled."
     trigger_bot_message_task.delay_on_commit.assert_not_called()
     assert not ExperimentSession.objects.filter(experiment=experiment).exists()
 

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -1069,8 +1069,37 @@ def test_generate_bot_message_for_email_channel(experiment, django_capture_on_co
 
 
 @pytest.mark.django_db()
+@patch("apps.api.views.channels.trigger_bot_message_task")
+def test_trigger_bot_on_disabled_channel(trigger_bot_message_task, experiment):
+    """The channel kill-switch blocks outbound triggers too: no session is opened, nothing is sent."""
+    ExperimentChannelFactory.create(
+        team=experiment.team,
+        experiment=experiment,
+        platform=ChannelPlatform.EMAIL,
+        extra_data={"email_address": "bot@chat.openchatstudio.com"},
+        enabled=False,
+    )
+
+    api_user = experiment.team.members.first()
+    client = ApiTestClient(api_user, experiment.team)
+
+    data = {
+        "identifier": "user@example.com",
+        "platform": ChannelPlatform.EMAIL,
+        "experiment": str(experiment.public_id),
+        "prompt_text": "Say hello",
+    }
+    response = client.post(reverse("api:trigger_bot"), json.dumps(data), content_type="application/json")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "The email channel for this experiment is disabled."
+    trigger_bot_message_task.delay_on_commit.assert_not_called()
+    assert not ExperimentSession.objects.filter(experiment=experiment).exists()
+
+
+@pytest.mark.django_db()
 @override_settings(COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123")
-@patch("apps.api.views.channels.CommCareConnectClient")
+@patch("apps.api.trigger_bot.CommCareConnectClient")
 def test_trigger_bot_duplicate_channel_id_conflict(ConnectClientView, experiment):
     """A duplicate channel_id during enrollment surfaces as a 409, not a misleading consent error."""
     duplicate_channel_id = uuid.uuid4().hex
@@ -1120,7 +1149,7 @@ def test_trigger_bot_duplicate_channel_id_conflict(ConnectClientView, experiment
 @override_settings(
     CELERY_TASK_ALWAYS_EAGER=True, COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123"
 )
-@patch("apps.api.views.channels.CommCareConnectClient")
+@patch("apps.api.trigger_bot.CommCareConnectClient")
 @patch("apps.channels.connect_channel.CommCareConnectClient")
 @pytest.mark.parametrize("auth_method", ["api_key", "oauth"])
 def test_trigger_bot_direct_message(
@@ -1217,7 +1246,7 @@ def test_trigger_bot_direct_message_for_email_channel(experiment, django_capture
 @override_settings(
     CELERY_TASK_ALWAYS_EAGER=True, COMMCARE_CONNECT_SERVER_SECRET="123", COMMCARE_CONNECT_SERVER_ID="123"
 )
-@patch("apps.api.views.channels.CommCareConnectClient")
+@patch("apps.api.trigger_bot.CommCareConnectClient")
 @patch("apps.channels.connect_channel.CommCareConnectClient")
 def test_trigger_bot_direct_message_consent_required(ConnectClientChat, ConnectClientView, experiment, httpx_mock):
     """

--- a/apps/api/tests/test_application_chatbot_allowlist.py
+++ b/apps/api/tests/test_application_chatbot_allowlist.py
@@ -214,7 +214,7 @@ def test_non_machine_callers_are_unaffected(handle_api_message, _trigger_task, p
 @pytest.mark.django_db()
 @patch("apps.api.views.channels.trigger_bot_message_task")
 def test_denied_trigger_bot_creates_no_participant_data(trigger_bot_message_task, experiment):
-    """The check runs before `_get_or_create_participant_data`, which creates data as a side effect."""
+    """The check runs before `prepare_trigger_bot_message`, which creates data as a side effect."""
     response = _post_trigger_bot(_machine_client(experiment.team), experiment)
 
     assert response.status_code == 403, response.content

--- a/apps/api/trigger_bot.py
+++ b/apps/api/trigger_bot.py
@@ -1,0 +1,145 @@
+"""Shared setup for the bot-initiated ("trigger bot") message flow.
+
+Before ``trigger_bot_message_task`` can be dispatched, someone has to resolve the channel, the
+participant data and the session the message will be sent in. That used to live only in the API
+view, so the participant detail page kept calling the task with the dict argument it took before
+the session moved into the caller, and 500'd (#4221). It lives here so both callers share it.
+
+Callers dispatch the task themselves -- they differ in whether they can send ``message_text`` --
+and map :class:`TriggerBotMessageError` onto their own error surface (a JSON body for the API, a
+form error for the web view).
+"""
+
+import httpx
+from rest_framework import status
+
+from apps.api.tasks import (
+    DuplicateConnectChannelError,
+    connect_channel_error_details,
+    create_connect_channel_for_participant,
+)
+from apps.channels.clients.connect_client import CommCareConnectClient
+from apps.channels.models import ChannelPlatform, ExperimentChannel
+from apps.channels.registry import get_channel_class_for_platform
+from apps.chatbots.version_resolver import resolve_published_or_working
+from apps.experiments.models import Experiment, ExperimentSession, Participant, ParticipantData
+from apps.teams.models import Team
+from apps.teams.utils import current_team
+
+
+class TriggerBotMessageError(Exception):
+    """A bot message cannot be triggered. ``detail`` is safe to show the caller."""
+
+    def __init__(self, detail: str, status_code: int = status.HTTP_400_BAD_REQUEST):
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+def prepare_trigger_bot_message(
+    team: Team,
+    experiment: Experiment,
+    identifier: str,
+    platform: str,
+    *,
+    start_new_session: bool = False,
+    session_data: dict | None = None,
+    incoming_participant_data: dict | None = None,
+) -> tuple[ExperimentSession, ParticipantData]:
+    """Resolve everything ``trigger_bot_message_task`` needs and return the session to send in.
+
+    The session is created synchronously (rather than in the task) so that callers can report it
+    back to the user before the task runs. Raises :class:`TriggerBotMessageError` when the message
+    cannot be triggered at all: no channel for the platform, a channel an admin has switched off,
+    a CommCare Connect channel that could not be created, or a participant who has not consented.
+    """
+    identifier = ChannelPlatform(platform).normalize_identifier(identifier)
+    channel = get_trigger_bot_channel(experiment, platform)
+    participant_data = get_or_create_participant_data(team, identifier, platform, experiment, incoming_participant_data)
+
+    if platform == ChannelPlatform.COMMCARE_CONNECT:
+        ensure_commcare_connect_ready(channel, identifier, participant_data)
+
+    target_experiment = resolve_published_or_working(experiment)
+    ChannelClass = get_channel_class_for_platform(platform)
+    bot_channel = ChannelClass(experiment=target_experiment, experiment_channel=channel)
+    with current_team(experiment.team):
+        bot_channel.ensure_session_exists_for_participant(identifier, new_session=start_new_session)
+        session = bot_channel.experiment_session
+        assert session is not None
+        if session_data:
+            session.state = {**session.state, **session_data}
+            session.save(update_fields=["state"])
+
+    return session, participant_data
+
+
+def get_trigger_bot_channel(experiment: Experiment, platform: str) -> ExperimentChannel:
+    """Return the channel ``experiment`` may send ``platform`` messages on.
+
+    A channel an admin has switched off must not open a session or push a message out, mirroring
+    ``ChannelDisabledStage`` on the inbound path.
+    """
+    channel = ExperimentChannel.objects.filter(platform=platform, experiment=experiment).first()
+    if not channel:
+        raise TriggerBotMessageError(
+            f"Experiment cannot send messages on the {platform} channel. Create the channel first."
+        )
+    if channel.is_disabled:
+        raise TriggerBotMessageError(f"The {platform} channel for this experiment is disabled.")
+    return channel
+
+
+def get_or_create_participant_data(
+    team: Team,
+    identifier: str,
+    platform: str,
+    experiment: Experiment,
+    incoming_participant_data: dict | None = None,
+) -> ParticipantData:
+    """Get or create a participant and their ParticipantData for an experiment.
+
+    If ``incoming_participant_data`` is provided it is merged into any existing data.
+    Returns the (possibly newly created) ``ParticipantData`` instance.
+    """
+    participant_data = ParticipantData.objects.filter(
+        participant__identifier=identifier,
+        participant__platform=platform,
+        experiment=experiment.id,
+    ).first()
+
+    if not participant_data:
+        participant, _ = Participant.objects.get_or_create(identifier=identifier, platform=platform, team=team)
+        participant_data, created = ParticipantData.objects.get_or_create(
+            participant=participant,
+            experiment=experiment,
+            defaults={"team": team, "data": incoming_participant_data or {}},
+        )
+        if created:
+            return participant_data
+
+    if incoming_participant_data:
+        merged_data = {**participant_data.data, **incoming_participant_data}
+        if merged_data != participant_data.data:
+            participant_data.data = merged_data
+            participant_data.save(update_fields=["data"])
+
+    return participant_data
+
+
+def ensure_commcare_connect_ready(channel: ExperimentChannel, identifier: str, participant_data: ParticipantData):
+    """Ensure a CommCare Connect channel exists for the participant and that they have consented.
+
+    Raises :class:`TriggerBotMessageError` if the channel cannot be created or consent has not
+    been given.
+    """
+    if not participant_data.system_metadata.get("commcare_connect_channel_id"):
+        connect_client = CommCareConnectClient()
+        try:
+            create_connect_channel_for_participant(channel, connect_client, identifier, participant_data)
+        except (DuplicateConnectChannelError, httpx.HTTPError) as e:
+            status_code, detail = connect_channel_error_details(e, identifier)
+            raise TriggerBotMessageError(detail, status_code) from e
+
+    if not participant_data.has_consented():
+        raise TriggerBotMessageError("User has not given consent")

--- a/apps/api/trigger_bot.py
+++ b/apps/api/trigger_bot.py
@@ -83,10 +83,10 @@ def get_trigger_bot_channel(experiment: Experiment, platform: str) -> Experiment
     channel = ExperimentChannel.objects.filter(platform=platform, experiment=experiment).first()
     if not channel:
         raise TriggerBotMessageError(
-            f"Experiment cannot send messages on the {platform} channel. Create the channel first."
+            f"Chatbot cannot send messages on the {platform} channel. Create the channel first."
         )
     if channel.is_disabled:
-        raise TriggerBotMessageError(f"The {platform} channel for this experiment is disabled.")
+        raise TriggerBotMessageError(f"The {platform} channel for this chatbot is disabled.")
     return channel
 
 

--- a/apps/api/trigger_bot.py
+++ b/apps/api/trigger_bot.py
@@ -37,7 +37,6 @@ class TriggerBotMessageError(Exception):
 
 
 def prepare_trigger_bot_message(
-    team: Team,
     experiment: Experiment,
     identifier: str,
     platform: str,
@@ -48,6 +47,9 @@ def prepare_trigger_bot_message(
 ) -> tuple[ExperimentSession, ParticipantData]:
     """Resolve everything ``trigger_bot_message_task`` needs and return the session to send in.
 
+    The participant is created on ``experiment.team``; callers resolve the experiment through the
+    requesting team, so there is no second team to pass in.
+
     The session is created synchronously (rather than in the task) so that callers can report it
     back to the user before the task runs. Raises :class:`TriggerBotMessageError` when the message
     cannot be triggered at all: no channel for the platform, a channel an admin has switched off,
@@ -55,7 +57,9 @@ def prepare_trigger_bot_message(
     """
     identifier = ChannelPlatform(platform).normalize_identifier(identifier)
     channel = get_trigger_bot_channel(experiment, platform)
-    participant_data = get_or_create_participant_data(team, identifier, platform, experiment, incoming_participant_data)
+    participant_data = get_or_create_participant_data(
+        experiment.team, identifier, platform, experiment, incoming_participant_data
+    )
 
     if platform == ChannelPlatform.COMMCARE_CONNECT:
         ensure_commcare_connect_ready(channel, identifier, participant_data)

--- a/apps/api/v2/channels.py
+++ b/apps/api/v2/channels.py
@@ -86,8 +86,8 @@ class TriggerBotMessageView(APIView):
             ),
             OpenApiExample(
                 name="ChannelNotConfigured",
-                summary="Experiment cannot send messages on the specified channel",
-                value={"detail": "Experiment cannot send messages on the whatsapp channel. Create the channel first."},
+                summary="Chatbot cannot send messages on the specified channel",
+                value={"detail": "Chatbot cannot send messages on the whatsapp channel. Create the channel first."},
                 response_only=True,
                 status_codes=[400],
             ),

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -20,19 +20,10 @@ from apps.api.permissions import (
     verify_hmac,
 )
 from apps.api.serializers import TriggerBotMessageRequest, TriggerBotMessageResponse
-from apps.api.tasks import (
-    DuplicateConnectChannelError,
-    connect_channel_error_details,
-    create_connect_channel_for_participant,
-    trigger_bot_message_task,
-)
-from apps.channels.clients.connect_client import CommCareConnectClient
-from apps.channels.models import ChannelPlatform, ExperimentChannel
-from apps.channels.registry import get_channel_class_for_platform
-from apps.chatbots.version_resolver import resolve_published_or_working
-from apps.experiments.models import Experiment, Participant, ParticipantData
+from apps.api.tasks import trigger_bot_message_task
+from apps.api.trigger_bot import TriggerBotMessageError, prepare_trigger_bot_message
+from apps.experiments.models import Experiment, ParticipantData
 from apps.oauth.permissions import TokenHasOAuthScope, enforce_application_chatbot_access
-from apps.teams.utils import current_team
 from apps.utils.rate_limit import rate_limited
 
 connect_logger = logging.getLogger("api.connect_channel")
@@ -103,107 +94,39 @@ def consent(request: Request):
     return HttpResponse()
 
 
-def _get_or_create_participant_data(request, identifier, platform, experiment, incoming_participant_data):
-    """Get or create a participant and their ParticipantData for an experiment.
-
-    If ``incoming_participant_data`` is provided it is merged into any existing data.
-    Returns the (possibly newly created) ``ParticipantData`` instance.
-    """
-    participant_data = ParticipantData.objects.filter(
-        participant__identifier=identifier,
-        participant__platform=platform,
-        experiment=experiment.id,
-    ).first()
-
-    if not participant_data:
-        participant, _ = Participant.objects.get_or_create(identifier=identifier, platform=platform, team=request.team)
-        participant_data, created = ParticipantData.objects.get_or_create(
-            participant=participant,
-            experiment=experiment,
-            defaults={"team": request.team, "data": incoming_participant_data or {}},
-        )
-        if not created and incoming_participant_data:
-            merged_data = {**participant_data.data, **incoming_participant_data}
-            if merged_data != participant_data.data:
-                participant_data.data = merged_data
-                participant_data.save(update_fields=["data"])
-    elif incoming_participant_data:
-        merged_data = {**participant_data.data, **incoming_participant_data}
-        if merged_data != participant_data.data:
-            participant_data.data = merged_data
-            participant_data.save(update_fields=["data"])
-
-    return participant_data
-
-
-def _ensure_commcare_connect_ready(channel, identifier, participant_data):
-    """Ensure a CommCare Connect channel exists for the participant and that they have consented.
-
-    Returns a ``JsonResponse`` error response if the channel cannot be created or consent has
-    not been given, or ``None`` if everything is in order.
-    """
-    if not participant_data.system_metadata.get("commcare_connect_channel_id"):
-        connect_client = CommCareConnectClient()
-        try:
-            create_connect_channel_for_participant(channel, connect_client, identifier, participant_data)
-        except (DuplicateConnectChannelError, httpx.HTTPError) as e:
-            status_code, detail = connect_channel_error_details(e, identifier)
-            return JsonResponse({"detail": detail}, status=status_code)
-
-    if not participant_data.has_consented():
-        return JsonResponse({"detail": "User has not given consent"}, status=status.HTTP_400_BAD_REQUEST)
-
-    return None
-
-
 def handle_trigger_bot_message(request, response_serializer_class):
     """Run the trigger-bot flow shared by all API versions and build the response.
 
-    Validates the request, resolves the experiment/channel, ensures CommCare Connect enrollment and
-    consent where relevant, creates or reuses the session, and dispatches the async bot-message task.
-    The session is then serialised with ``response_serializer_class`` (which differs per API version).
+    Validates the request, resolves the experiment, then hands off to ``prepare_trigger_bot_message``
+    (channel, CommCare Connect enrollment and consent, session) before dispatching the async
+    bot-message task. The session is then serialised with ``response_serializer_class`` (which
+    differs per API version).
 
     Returns the final response to hand back from the view: a 200 ``Response`` on success, or an error
-    response (bad channel, failed enrollment, missing consent) to return as-is.
+    response (bad or disabled channel, failed enrollment, missing consent) to return as-is.
     """
     serializer = TriggerBotMessageRequest(data=request.data)
     serializer.is_valid(raise_exception=True)
 
     data = serializer.data
-    platform = data["platform"]
-    identifier = ChannelPlatform(platform).normalize_identifier(data["identifier"])
-    # Propagate the normalized identifier so the async task uses a consistent value
-    data = dict(data)
-    data["identifier"] = identifier
     experiment = get_object_or_404(Experiment, public_id=data["experiment"], team=request.team)
-    # Before _get_or_create_participant_data below, which creates participant data as a side effect.
+    # Before prepare_trigger_bot_message below, which creates participant data as a side effect.
     enforce_application_chatbot_access(request, experiment)
 
-    channel = ExperimentChannel.objects.filter(platform=platform, experiment=experiment).first()
-    if not channel:
-        return JsonResponse(
-            {"detail": f"Experiment cannot send messages on the {platform} channel. Create the channel first."},
-            status=status.HTTP_400_BAD_REQUEST,
+    # Returning (rather than raising) keeps the atomic block committing what got as far as being
+    # created -- the Connect auto-consent flow relies on the participant data surviving the error.
+    try:
+        session, participant_data = prepare_trigger_bot_message(
+            request.team,
+            experiment,
+            data["identifier"],
+            data["platform"],
+            start_new_session=data["start_new_session"],
+            session_data=data.get("session_data"),
+            incoming_participant_data=data.get("participant_data"),
         )
-
-    participant_data = _get_or_create_participant_data(
-        request, identifier, platform, experiment, data.get("participant_data")
-    )
-
-    if platform == ChannelPlatform.COMMCARE_CONNECT:
-        if error := _ensure_commcare_connect_ready(channel, identifier, participant_data):
-            return error
-
-    target_experiment = resolve_published_or_working(experiment)
-    ChannelClass = get_channel_class_for_platform(platform)
-    bot_channel = ChannelClass(experiment=target_experiment, experiment_channel=channel)
-    with current_team(experiment.team):
-        bot_channel.ensure_session_exists_for_participant(identifier, new_session=data["start_new_session"])
-        session = bot_channel.experiment_session
-        assert session is not None
-        if data.get("session_data"):
-            session.state = {**session.state, **data["session_data"]}
-            session.save(update_fields=["state"])
+    except TriggerBotMessageError as error:
+        return JsonResponse({"detail": error.detail}, status=error.status_code)
 
     trigger_bot_message_task.delay_on_commit(
         str(session.external_id), data.get("prompt_text"), data.get("message_text")

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -117,7 +117,6 @@ def handle_trigger_bot_message(request, response_serializer_class):
     # created -- the Connect auto-consent flow relies on the participant data surviving the error.
     try:
         session, participant_data = prepare_trigger_bot_message(
-            request.team,
             experiment,
             data["identifier"],
             data["platform"],

--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -189,9 +189,11 @@ class TriggerBotMessageView(APIView):
             ),
             OpenApiExample(
                 name="ExperimentChannelNotFound",
-                summary="Experiment cannot send messages on the specified channel",
-                value={"detail": "Experiment cannot send messages on the connect_messaging channel"},
-                status_codes=[404],
+                summary="Chatbot cannot send messages on the specified channel",
+                value={
+                    "detail": "Chatbot cannot send messages on the connect_messaging channel. Create the channel first."
+                },
+                status_codes=[400],
             ),
             OpenApiExample(
                 name="ConsentNotGiven",

--- a/apps/participants/tests/test_views.py
+++ b/apps/participants/tests/test_views.py
@@ -3,10 +3,11 @@ from unittest.mock import patch
 
 import pytest
 from django.http import QueryDict
+from django.test import override_settings
 from django.urls import reverse
 
 from apps.channels.models import ChannelPlatform
-from apps.experiments.models import Participant, ParticipantData
+from apps.experiments.models import ExperimentSession, Participant, ParticipantData
 from apps.participants.forms import TriggerBotForm
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory, ParticipantFactory
@@ -68,9 +69,14 @@ def test_single_participant_home_with_experiment_renders_session_table(client, t
 
 
 @pytest.mark.django_db()
-@patch("apps.participants.views.trigger_bot_message_task")
-def test_trigger_bot(mock_task, client, team_with_users):
-    """Test that a bot can be triggered for a participant"""
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+@patch.object(ExperimentSession, "ad_hoc_bot_message", autospec=True)
+def test_trigger_bot(mock_ad_hoc_bot_message, client, team_with_users, django_capture_on_commit_callbacks):
+    """Test that a bot can be triggered for a participant.
+
+    The task runs for real (eagerly) rather than being mocked: mocking it let this view keep calling
+    the task with its old dict argument long after the signature changed (#4221).
+    """
     participant = ParticipantFactory.create(team=team_with_users, platform=ChannelPlatform.WHATSAPP)
     experiment = ExperimentFactory.create(team=team_with_users, working_version=None)
     ExperimentChannelFactory.create(team=team_with_users, experiment=experiment, platform=ChannelPlatform.WHATSAPP)
@@ -92,18 +98,56 @@ def test_trigger_bot(mock_task, client, team_with_users):
         "session_data": '{"key": "value"}',
     }
 
-    response = client.post(url, data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = client.post(url, data)
     assert response.status_code == 302
 
-    # Verify the task was called with correct data
-    mock_task.delay.assert_called_once()
-    call_args = mock_task.delay.call_args[0][0]
-    assert call_args["identifier"] == participant.identifier
-    assert call_args["platform"] == participant.platform
-    assert call_args["experiment"] == str(experiment.public_id)
-    assert call_args["prompt_text"] == "Hello, this is a test message"
-    assert call_args["start_new_session"] is True
-    assert call_args["session_data"] == {"key": "value"}
+    # The view creates the session up front so the task can look it up by external ID
+    session = ExperimentSession.objects.get(participant__identifier=participant.identifier, experiment=experiment)
+    assert session.experiment_channel.platform == ChannelPlatform.WHATSAPP
+    assert session.state == {"key": "value"}
+
+    mock_ad_hoc_bot_message.assert_called_once()
+    called_session, prompt_text = mock_ad_hoc_bot_message.call_args.args[:2]
+    assert called_session == session
+    assert prompt_text == "Hello, this is a test message"
+    assert mock_ad_hoc_bot_message.call_args.kwargs["message_text"] is None
+
+
+@pytest.mark.django_db()
+@patch("apps.participants.views.trigger_bot_message_task")
+def test_trigger_bot_on_disabled_channel(mock_task, client, team_with_users):
+    """The channel kill-switch blocks outbound triggers too: no session is opened, nothing is sent."""
+    participant = ParticipantFactory.create(team=team_with_users, platform=ChannelPlatform.WHATSAPP)
+    experiment = ExperimentFactory.create(team=team_with_users, working_version=None)
+    ExperimentChannelFactory.create(
+        team=team_with_users, experiment=experiment, platform=ChannelPlatform.WHATSAPP, enabled=False
+    )
+    user = team_with_users.members.first()
+    client.login(username=user.username, password="password")
+
+    url = reverse(
+        "participants:trigger_bot",
+        kwargs={
+            "team_slug": team_with_users.slug,
+            "participant_id": participant.id,
+        },
+    )
+
+    response = client.post(
+        url,
+        {
+            "prompt_text": "Hello, this is a test message",
+            "experiment": experiment.id,
+            "start_new_session": True,
+            "session_data": "{}",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "channel for this experiment is disabled" in response.content.decode()
+    mock_task.delay_on_commit.assert_not_called()
+    assert not ExperimentSession.objects.filter(experiment=experiment).exists()
 
 
 @pytest.mark.django_db()
@@ -133,7 +177,7 @@ def test_trigger_bot_with_invalid_json(mock_task, client, team_with_users):
 
     response = client.post(url, data)
     assert response.status_code == 200
-    mock_task.delay.assert_not_called()
+    mock_task.delay_on_commit.assert_not_called()
 
 
 @pytest.mark.django_db()

--- a/apps/participants/tests/test_views.py
+++ b/apps/participants/tests/test_views.py
@@ -145,7 +145,7 @@ def test_trigger_bot_on_disabled_channel(mock_task, client, team_with_users):
     )
 
     assert response.status_code == 200
-    assert "channel for this experiment is disabled" in response.content.decode()
+    assert "channel for this chatbot is disabled" in response.content.decode()
     mock_task.delay_on_commit.assert_not_called()
     assert not ExperimentSession.objects.filter(experiment=experiment).exists()
 

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -13,6 +13,7 @@ from django_tables2 import RequestConfig, SingleTableView
 
 from apps.annotations.prefetch import chat_tagged_items_prefetch
 from apps.api.tasks import trigger_bot_message_task
+from apps.api.trigger_bot import TriggerBotMessageError, prepare_trigger_bot_message
 from apps.channels.models import ChannelPlatform
 from apps.chatbots.tables import ChatbotSessionsTable
 from apps.experiments.models import Experiment, ExperimentSession, Participant, ParticipantData
@@ -347,25 +348,32 @@ def trigger_bot(request, team_slug: str, participant_id: int):
 
     if not form.is_valid():
         messages.error(request, "Please check the form for errors")
-        context = single_participant_home_context(request, {}, participant_id=participant_id)
-        context["trigger_bot_form"] = form
-        return render(request, "participants/single_participant_home.html", context=context)
+        return _render_trigger_bot_form(request, participant_id, form)
 
-    experiment = form.cleaned_data["experiment"]
-    prompt_text = form.cleaned_data["prompt_text"]
-    start_new_session = form.cleaned_data["start_new_session"]
-    session_data = form.cleaned_data.get("session_data", {})
+    try:
+        # Shared with the API's trigger-bot endpoint: the session has to exist before the task runs,
+        # and both callers must agree on the task's arguments (#4221).
+        session, _ = prepare_trigger_bot_message(
+            request.team,
+            form.cleaned_data["experiment"],
+            participant.identifier,
+            participant.platform,
+            start_new_session=form.cleaned_data["start_new_session"],
+            session_data=form.cleaned_data.get("session_data"),
+        )
+    except TriggerBotMessageError as error:
+        form.add_error(None, error.detail)
+        return _render_trigger_bot_form(request, participant_id, form)
 
-    data = {
-        "identifier": participant.identifier,
-        "platform": participant.platform,
-        "experiment": str(experiment.public_id),
-        "prompt_text": prompt_text,
-        "start_new_session": start_new_session,
-        "session_data": session_data,
-    }
-
-    trigger_bot_message_task.delay(data)
+    # No message_text: this form only sends prompts through the bot, never verbatim messages.
+    trigger_bot_message_task.delay_on_commit(str(session.external_id), form.cleaned_data["prompt_text"], None)
 
     messages.success(request, f"Bot message triggered for {participant}")
     return redirect("participants:single-participant-home", team_slug=team_slug, participant_id=participant_id)
+
+
+def _render_trigger_bot_form(request, participant_id: int, form: TriggerBotForm):
+    """Re-render the participant page with the errored form (the template reopens the dialog)."""
+    context = single_participant_home_context(request, {}, participant_id=participant_id)
+    context["trigger_bot_form"] = form
+    return render(request, "participants/single_participant_home.html", context=context)

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -354,7 +354,6 @@ def trigger_bot(request, team_slug: str, participant_id: int):
         # Shared with the API's trigger-bot endpoint: the session has to exist before the task runs,
         # and both callers must agree on the task's arguments (#4221).
         session, _ = prepare_trigger_bot_message(
-            request.team,
             form.cleaned_data["experiment"],
             participant.identifier,
             participant.platform,


### PR DESCRIPTION
### Product Description
The "Trigger Bot Message" button on the participant detail page returned a 500 and enqueued nothing, so the form was entirely non-functional. It now works: the session is created, the bot message is dispatched, and the success message renders.

### Technical Description
`apps/participants/views.trigger_bot` still called `trigger_bot_message_task` with the dict argument it took before `94f3af571` moved session creation into the caller. Celery's `typing` check raised synchronously in the request:

```
TypeError: trigger_bot_message_task() missing 2 required positional arguments: 'prompt_text' and 'message_text'
```

The API view's session-resolution flow is extracted into `apps/api/trigger_bot.py` (`prepare_trigger_bot_message`) and used by both callers so they cannot drift apart again: channel resolution, get-or-create participant data, CommCare Connect enrollment/consent, session creation and `session_data` merge. Failures raise `TriggerBotMessageError(detail, status_code); the API maps it to a JSON body and the web view to a non-field form error.

**Behaviour change to flag**: the disabled-channel guard the issue asked me to carry over did not actually exist on the API path. It now lives in the shared helper, so triggering on a channel an admin switched off returns 400 on both paths instead of opening a session and sending — mirroring `ChannelDisabledStage` on the inbound path. This is a new failure mode for API callers.

`test_trigger_bot` no longer mocks the task (which is how it pinned the old contract): it runs eagerly against the real signature. Reverting the fix reproduces the reported TypeError. Added disabled-channel tests on both paths.

Fixes #4221

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Generated with [Claude Code](https://claude.ai/code)