### PR TITLE
[Dev Tooling] Markdownlint checking - quality of dev docs and AI-agent-read markdown

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -64,7 +64,10 @@ MD041:
 MD046: false
 MD049: false
 MD050: false
+
+# TO DO- enable as need link-fragment validation, there can be broken in-document links after heading changes
 MD051: false
+
 MD053: false
 MD054: false
 MD058: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,72 @@
+default: true
+
+# Disable rules that are NOT important for AI agent parsing - structural integrity and link/reference correctness
+
+# List markers can be either - or *
+MD004: false
+
+# Ignore unordered list indentation check
+MD007: false
+
+MD012: false
+
+# Line length — reduce progressively after long lines are fixed
+MD013:
+  line_length: 2000
+  code_blocks: false
+  tables: false
+  headings: false
+
+# Ignore need for blank lines around headings
+MD022: false
+
+MD024:
+  siblings_only: true
+
+# Only one H1 per page (frontmatter title doesn't count, so a real H1 isn't a duplicate)
+MD025:
+  front_matter_title: ""
+
+MD026: false
+MD029: false
+MD030: false
+MD031: false
+
+# Ignore need for blank lines around lists
+MD032: false
+
+# Inline HTML: MkDocs Material uses <br>, <kbd>, attribute lists, etc.
+MD033:
+  allowed_elements:
+    - a
+    - br
+    - details
+    - div
+    - figcaption
+    - figure
+    - iframe
+    - kbd
+    - small
+    - span
+    - sub
+    - summary
+    - sup
+
+MD034: false
+
+# Enable this for fenced-code language as important for AI Agent instructions
+MD040: true
+
+# Every page must open with an H1 (frontmatter title does not substitute)
+MD041:
+  front_matter_title: ""
+
+MD046: false
+MD049: false
+MD050: false
+MD051: false
+MD053: false
+MD054: false
+MD058: false
+MD059: false
+MD060: false

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -7,7 +7,7 @@ CLAUDE.md
 
 # Workflow templates
 .github/templates/
-.github/
+/.github/
 
 # Superpower designs and ADRs
 docs/superpowers
@@ -15,8 +15,8 @@ docs/design
 docs/adr
 
 # Any markdown in the apps or components directory
-apps/
-components/
+/apps/
+/components/
 
 # Build output and virtualenv
 site/

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,23 @@
+# Markdown that is consumed by tooling rather than published to the docs site.
+# A top-level heading would change their meaning, so MD041 must not apply to them.
+
+# Claude Code agent definitions and slash commands (prompt bodies)
+CLAUDE.md
+.claude/skills
+
+# Workflow templates
+.github/templates/
+.github/
+
+# Superpower designs and ADRs
+docs/superpowers
+docs/design
+docs/adr
+
+# Any markdown in the apps or components directory
+apps/
+components/
+
+# Build output and virtualenv
+site/
+.venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,11 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.49.1
+    hooks:
+      - id: markdownlint
+        args: [--config, .markdownlint.yaml]
   - repo: local
     hooks:
       - id: waf-allow-not-first

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -13,7 +13,7 @@ If any of these files don't exist, **proceed silently**. Don't flag their absenc
 
 ## File structure
 
-```
+```text
 /
 ├── CONTEXT.md
 ├── docs/adr/

--- a/docs/design/read-only-chatbot-inspection-api.md
+++ b/docs/design/read-only-chatbot-inspection-api.md
@@ -430,7 +430,7 @@ index — rejected with [D6](#d6-inline-nested-resource-tree-denormalized).
 
 ## Endpoint shape
 
-```
+```http
 GET /api/v2/chatbots/{public_id}/inspect/
 GET /api/v2/chatbots/{public_id}/inspect/?version=<n>        # specific published version
 GET /api/v2/chatbots/{public_id}/inspect/?version=default    # the default published version

--- a/docs/design/unified-assessment.md
+++ b/docs/design/unified-assessment.md
@@ -333,7 +333,7 @@ Where each 2026 backlog item lands, and what state it's in today. "Done" items w
 
 The conceptual model:
 
-```
+```text
                     AssessmentSchema
                         │ (FK, shared catalogue)
                         ▼

--- a/docs/developer_guides/code_systems/feature_flags.md
+++ b/docs/developer_guides/code_systems/feature_flags.md
@@ -153,7 +153,7 @@ python manage.py check_flag_usage --flag-name flag_new_feature
 ```
 
 **Output example:**
-```
+```text
 Found 5 flags in database
 
 Flags found in code (3):

--- a/docs/developer_guides/code_systems/index_managers.md
+++ b/docs/developer_guides/code_systems/index_managers.md
@@ -15,7 +15,7 @@ The system supports two indexing strategies:
 
 The index manager system follows an abstract base class pattern with two main hierarchies:
 
-```
+```text
 RemoteIndexManager (ABC)
 ├── OpenAIRemoteIndexManager
 

--- a/docs/developer_guides/code_systems/meta_cloud_api_integration.md
+++ b/docs/developer_guides/code_systems/meta_cloud_api_integration.md
@@ -36,7 +36,7 @@ Every incoming POST webhook from Meta includes an `X-Hub-Signature-256` header c
 
 The `business_id` is your WhatsApp Business Account ID. During channel creation, when a user enters a phone number, we call the Meta Graph API's Phone Number Management endpoint to list all phone numbers registered under this business account:
 
-```
+```http
 GET https://graph.facebook.com/v25.0/{business_id}/phone_numbers
 ```
 
@@ -68,7 +68,7 @@ This differs from other WhatsApp providers (Twilio, Turn.io) which use the phone
 
 Unlike Turn.io (which uses per-experiment webhook URLs), the Meta Cloud API uses a **single global webhook endpoint**:
 
-```
+```text
 /channels/whatsapp/meta/incoming_message
 ```
 

--- a/docs/developer_guides/code_systems/slack_channel_integration.md
+++ b/docs/developer_guides/code_systems/slack_channel_integration.md
@@ -45,7 +45,7 @@ This guide helps you set up Slack integration with your development environment 
    invoke runserver --public
    ```
 3. This will expose your local server and generate a public HTTPS URL like:
-   ```
+   ```text
    https://abc123.ngrok.io
    ```
 
@@ -54,7 +54,7 @@ This guide helps you set up Slack integration with your development environment 
 1. In your Slack app, go to **OAuth & Permissions**.
 2. Under **Redirect URLs**, add:
 
-   ```
+   ```text
    https://<your-ngrok-subdomain>.ngrok.io/slack/oauth_redirect
    ```
 3. Click **Save URLs**.
@@ -65,7 +65,7 @@ This guide helps you set up Slack integration with your development environment 
 2. Toggle **Enable Events**.
 3. Set the **Request URL** to:
 
-   ```
+   ```text
    https://<your-ngrok-subdomain>.ngrok.io/slack/events
    ```
 4. Under **Subscribe to Bot Events**, add:

--- a/docs/developer_guides/deployment.md
+++ b/docs/developer_guides/deployment.md
@@ -1,12 +1,12 @@
 # Deployment Process
 
-### Continuous Deployment
+## Continuous Deployment
 
 - All changes merged to the `main` branch trigger an automated deployment.
 - Deployment is only triggered by successful completion of the [lint_and_test.yml](https://github.com/dimagi/open-chat-studio/blob/main/.github/workflows/lint_and_test.yml){target="_blank"} GitHub workflow.
 - Deployment is executed by the [deploy.yml](https://github.com/dimagi/open-chat-studio/blob/main/.github/workflows/deploy.yml){target="_blank"} GitHub action.
 
-### Monitoring Deployments
+## Monitoring Deployments
 
 - Deploy notifications are automatically sent to #open-chat-studio-dev Slack channel.
 - Each notification includes:
@@ -14,12 +14,12 @@
     - Changes included in the deployment
     - Deploy completion status
 
-### Best Practices
+## Best Practices
 - Always monitor the Slack channels after merging to main.
 - Watch for successful completion of your deployment.
 - Watch for Sentry errors after deployment.
 
-### Rollback Process
+## Rollback Process
 - Although rollback is possible, we would prefer to roll forward by deploying a fix to the issue.
 - If issues are detected, notify the team in #open-chat-studio-dev.
 - Monitor \#ocs-ops for any related errors.

--- a/docs/developer_guides/testing/help_agent_evals.md
+++ b/docs/developer_guides/testing/help_agent_evals.md
@@ -6,7 +6,7 @@ The `apps/help/evals/` directory contains evaluation tests for the AI agents in 
 
 Eval tests are regular pytest tests marked with `@pytest.mark.eval`. They are automatically skipped if the required API keys are not configured, so they do not break CI for contributors without LLM access.
 
-```
+```text
 apps/help/evals/
 ├── conftest.py              # Shared fixtures, check dispatch, LLM judge
 ├── checks.py                # Deterministic check functions

--- a/docs/getting-started/ai-setup.md
+++ b/docs/getting-started/ai-setup.md
@@ -70,7 +70,7 @@ The OCS [development workflow](dev-workflow.md) follows a design-before-code pro
 each phase — exploring the problem, planning the implementation, executing it, and reviewing the
 result. Install it from the same marketplace:
 
-```
+```text
 /plugins
 ```
 
@@ -81,7 +81,7 @@ Then pick `superpowers`. `/plugins` is also how you'd browse the rest of the mar
 Use Claude Code's **built-in `/code-review`** command. It needs no plugin and takes the working
 diff, a PR number, a branch or a path:
 
-```
+```text
 /code-review          # report findings
 /code-review --fix    # report findings and apply them
 ```

--- a/docs/getting-started/dev-workflow.md
+++ b/docs/getting-started/dev-workflow.md
@@ -148,7 +148,7 @@ readable.
 
 Run Claude Code's built-in `/code-review` command over the working tree — no plugin needed:
 
-```
+```text
 /code-review          # report findings
 /code-review --fix    # report findings and apply them
 ```
@@ -159,7 +159,7 @@ what you touched (see [Everyday commands](#everyday-commands)).
 
 ## 5. Open the PR
 
-```
+```text
 /create-pr
 ```
 
@@ -184,7 +184,7 @@ Open it as a **draft**.
 
 ## 6. Iterate until it's clean
 
-```
+```text
 /iterate-pr
 ```
 

--- a/docs/hosting/cloudflare_tunnel.md
+++ b/docs/hosting/cloudflare_tunnel.md
@@ -155,7 +155,7 @@ networks:
 ### How private hostname resolution works
 Private hostnames like `ocs.your-org` don't exist in public DNS. Here's the full resolution chain:
 
-```
+```text
 1. User types `ocs.your-org` in browser
 2. WARP intercepts the DNS query
 3. WARP checks Local Domain Fallback → matches `ocs.your-org`

--- a/docs/hosting/configuration.md
+++ b/docs/hosting/configuration.md
@@ -75,7 +75,7 @@ One of the following email backends must be configured. Set `DJANGO_EMAIL_BACKEN
 
 ### Mailgun (default)
 
-```
+```env
 DJANGO_EMAIL_BACKEND=anymail.backends.mailgun.EmailBackend
 MAILGUN_API_KEY=your-mailgun-api-key
 MAILGUN_SENDER_DOMAIN=mail.yourdomain.com
@@ -83,7 +83,7 @@ MAILGUN_SENDER_DOMAIN=mail.yourdomain.com
 
 ### Amazon SES
 
-```
+```env
 DJANGO_EMAIL_BACKEND=anymail.backends.amazon_ses.EmailBackend
 # Omit these if using IAM roles:
 AWS_SES_ACCESS_KEY=
@@ -122,7 +122,7 @@ The settings above also work with any S3-compatible service (MinIO, Cloudflare R
 
 MinIO (path-style addressing — note the bucket is included in `AWS_S3_CUSTOM_DOMAIN`):
 
-```
+```env
 USE_S3_STORAGE=True
 AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
@@ -136,7 +136,7 @@ WHATSAPP_S3_AUDIO_BUCKET=whatsapp-audio
 
 Cloudflare R2 (virtual-host addressing):
 
-```
+```env
 USE_S3_STORAGE=True
 AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...


### PR DESCRIPTION
### Product Description

N/A 

### Technical Description

Improve quality of dev docs and **AI-agent-read markdown**
**First step** in bringing agent-read markdown up to standard. Including skills, ADRs, design docs (that create ADRs), READMEs, CLAUDE.md 

1. DevOps markdown lint checking in pre-commit - leaving rules disabled to reduce number of format changes in this PR
2. Ignore AI-agent read markdown files in this PR as can do in another batch
3. Fixes basics like heading levels and fenced blocks 
4. MD040 (fenced-code-language) is  new enforcement, framed explicitly as "important for AI Agent instructions" — directly relevant since this repo's docs are consumed by Claude/agents, not just humans reading

#### Notes

- zero new CI infrastructure
- selectively disables ~20 rules
- Ignore list is documented

#### Testing

`uv run prek run markdownlint --all-files`

### Docs and Changelog
- [ ] This PR requires docs/changelog update
