### PR TITLE
Enforce the channel toggle on session creation and outbound messages

### DIFF
--- a/apps/api/views/channels.py
+++ b/apps/api/views/channels.py
@@ -186,6 +186,14 @@ def handle_trigger_bot_message(request, response_serializer_class):
             status=status.HTTP_400_BAD_REQUEST,
         )
 
+    # Also before _get_or_create_participant_data: this endpoint both opens a session and pushes a
+    # bot message, so a disabled channel has to refuse before either happens.
+    if channel.is_disabled:
+        return JsonResponse(
+            {"detail": f"The {platform} channel is disabled for this experiment."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
     participant_data = _get_or_create_participant_data(
         request, identifier, platform, experiment, data.get("participant_data")
     )

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -269,6 +269,20 @@ def _check_start_session_access(request, experiment, embed_key_channel, version_
     return Response({"error": "You do not have access to this chatbot"}, status=status.HTTP_403_FORBIDDEN)
 
 
+def _channel_disabled_response(experiment_channel) -> Response | None:
+    """A 403 when an admin has switched this channel off, else None.
+
+    Refused here rather than left to the pipeline: the session start is what the widget calls
+    first, and letting it succeed hands back a session and a token on a channel that will not
+    talk. Relays the admin's own static message when they configured one; a silent disable still
+    owes the caller an HTTP body, so it falls back to a generic line.
+    """
+    if not experiment_channel.is_disabled:
+        return None
+    detail = experiment_channel.disabled_message or "This chatbot is currently unavailable."
+    return Response({"error": detail}, status=status.HTTP_403_FORBIDDEN)
+
+
 def _get_requested_version(experiment, version_number):
     """The explicitly requested version, or None to use the working version."""
     if version_number is None or version_number == Experiment.DEFAULT_VERSION_NUMBER:
@@ -400,6 +414,10 @@ def chat_start_session(request):
     team = experiment.team
 
     experiment_channel = _resolve_experiment_channel(request, team, session_data, embed_key_channel)
+
+    # Before the participant work below, which creates records as a side effect.
+    if disabled := _channel_disabled_response(experiment_channel):
+        return disabled
 
     if request.user.is_authenticated:
         user = request.user

--- a/apps/api/views/chat.py
+++ b/apps/api/views/chat.py
@@ -269,6 +269,25 @@ def _check_start_session_access(request, experiment, embed_key_channel, version_
     return Response({"error": "You do not have access to this chatbot"}, status=status.HTTP_403_FORBIDDEN)
 
 
+def _record_participant_name(participant, experiment, team, name: str) -> None:
+    """Store the caller-supplied display name on the participant and their experiment data.
+
+    Written in both places because they are read in different contexts: the participant record
+    labels them across the team, while the ParticipantData copy is what a pipeline sees as
+    ``{participant_data.name}``. Both writes are conditional so a repeat session start with an
+    unchanged name is a no-op rather than a pair of UPDATEs.
+    """
+    if participant.name != name:
+        participant.name = name
+        participant.save(update_fields=["name"])
+    participant_data, _ = ParticipantData.objects.get_or_create(
+        participant=participant, experiment=experiment, team=team, defaults={"data": {}}
+    )
+    if participant_data.data.get("name") != name:
+        participant_data.data["name"] = name
+        participant_data.save(update_fields=["data"])
+
+
 def _channel_disabled_response(experiment_channel) -> Response | None:
     """A 403 when an admin has switched this channel off, else None.
 
@@ -443,15 +462,7 @@ def chat_start_session(request):
         participant = Participant.create_anonymous(team, experiment_channel.platform, remote_id)
 
     if name:
-        if participant.name != name:
-            participant.name = name
-            participant.save(update_fields=["name"])
-        participant_data, _ = ParticipantData.objects.get_or_create(
-            participant=participant, experiment=experiment, team=team, defaults={"data": {}}
-        )
-        if participant_data.data.get("name") != name:
-            participant_data.data["name"] = name
-            participant_data.save(update_fields=["data"])
+        _record_participant_name(participant, experiment, team, name)
 
     metadata = {Chat.MetadataKeys.EMBED_SOURCE: safe_link_url(request.headers.get("referer", None))}
 

--- a/apps/channels/channel_base.py
+++ b/apps/channels/channel_base.py
@@ -261,9 +261,23 @@ class ChannelBase(ABC):
 
         Runs a mini pipeline: ResponseFormattingStage -> terminal stages.
         Voice/text decision, citation formatting, and file handling all apply.
+
+        Nothing is sent on a disabled channel. ``ChannelDisabledStage`` cannot do this job:
+        it answers an inbound message, so on a channel with a static ``disabled_message`` it
+        would swap that text in for the bot's and deliver it -- turning a suppressed reminder
+        into an unsolicited "we are offline" push. Callers usually check first
+        (``ad_hoc_bot_message``); this is the backstop at the door itself.
         """
         if self.experiment_session is None:
             raise ValueError("Cannot send ad hoc message without an experiment session")
+
+        if self.experiment_channel.is_disabled:
+            logger.info(
+                "Not sending message on disabled channel %s (%s)",
+                self.experiment_channel.id,
+                self.experiment_channel.platform,
+            )
+            return
 
         files = files or []
 

--- a/apps/channels/exceptions.py
+++ b/apps/channels/exceptions.py
@@ -8,6 +8,24 @@ class InvalidTelegramChannel(ExperimentChannelException):
         super().__init__(message)
 
 
+class ChannelDisabledException(ExperimentChannelException):
+    """Raised when something tries to open a conversation on a channel an admin has switched off.
+
+    ``ChannelDisabledStage`` covers inbound messages on channels that already have a session.
+    This covers everything that runs *before* a pipeline: every route into
+    ``start_experiment_session``. Callers catch it (or check ``is_disabled`` first) and turn it
+    into whatever refusal suits their surface -- an HTTP error, a form message, or silence.
+
+    ``disabled_message`` is the admin's optional static text, carried here so callers can relay
+    it without re-fetching the channel. It is blank when the admin chose to stay silent.
+    """
+
+    def __init__(self, channel):
+        self.channel = channel
+        self.disabled_message = channel.disabled_message
+        super().__init__(f"Channel {channel.id} ({channel.platform}) is disabled")
+
+
 class EarlyExitResponse(Exception):
     """Raised by any core stage to short-circuit the pipeline.
 

--- a/apps/channels/stages/core.py
+++ b/apps/channels/stages/core.py
@@ -374,6 +374,13 @@ class ChannelDisabledStage(ProcessingStage):
     static ``disabled_message`` is configured it goes back to the user through the
     terminal stages; otherwise the pipeline halts silently.
 
+    This stage only sees traffic that reaches a pipeline. Sessions opened *before* any pipeline
+    runs are refused by ``start_experiment_session``; the routes that would otherwise create
+    participant records on the way there (widget and API session starts, the trigger-bot
+    endpoint, the public web chat, the Slack listener) check ``is_disabled`` themselves first.
+    Bot-initiated sends are refused by ``ad_hoc_bot_message`` and
+    ``ChannelBase.send_message_to_user``.
+
     It deliberately does *not* run first. Delivering the static message needs the same
     groundwork any other reply needs, so it sits behind the participant stages:
 

--- a/apps/channels/tests/channels/test_disabled_channel.py
+++ b/apps/channels/tests/channels/test_disabled_channel.py
@@ -20,6 +20,7 @@ from apps.chat.models import Chat, ChatMessage, ChatMessageType
 from apps.experiments.models import ExperimentSession, Participant
 from apps.experiments.services import start_experiment_session
 from apps.experiments.tasks import get_response_for_webchat_task
+from apps.service_providers.tracing import TraceInfo
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 from apps.utils.factories.team import TeamWithUsersFactory
@@ -240,6 +241,60 @@ class TestDisabledChannelBlocksNewSessions:
         )
 
         assert session.experiment_channel == channel
+
+
+@pytest.mark.django_db()
+class TestDisabledChannelBlocksOutboundMessages:
+    """Bot-initiated sends -- scheduled messages, event actions, API triggers -- never touch a
+    pipeline, so the toggle has to be enforced on the outbound path separately."""
+
+    def test_ad_hoc_bot_message_is_a_no_op(self):
+        """Checked before the LLM runs, so a disabled channel costs nothing and leaves no
+        undelivered AI message behind."""
+        session = ExperimentSessionFactory.create()
+        _disable(session, "We are closed")
+
+        with (
+            patch("apps.chat.bots.EventBot.get_user_message") as get_user_message,
+            patch("apps.experiments.models.ExperimentSession.try_send_message") as try_send_message,
+        ):
+            result = session.ad_hoc_bot_message("check in with the user", TraceInfo(name="test"))
+
+        assert result == {}
+        get_user_message.assert_not_called()
+        try_send_message.assert_not_called()
+        assert not ChatMessage.objects.filter(chat=session.chat).exists()
+
+    def test_direct_message_is_a_no_op(self):
+        session = ExperimentSessionFactory.create()
+        _disable(session)
+
+        with patch("apps.experiments.models.ExperimentSession.try_send_message") as try_send_message:
+            result = session.ad_hoc_bot_message(None, TraceInfo(name="test"), message_text="see you tomorrow")
+
+        assert result == {}
+        try_send_message.assert_not_called()
+        assert not ChatMessage.objects.filter(chat=session.chat).exists()
+
+    def test_send_message_to_user_delivers_nothing(self):
+        """And the static disabled_message is not substituted in: nobody asked us anything, so
+        pushing "we are offline" at them would be worse than staying quiet."""
+        session = ExperimentSessionFactory.create()
+        _disable(session, "We are closed")
+        channel = _make_channel(session)
+
+        channel.send_message_to_user("your appointment is tomorrow")
+
+        assert channel.text_sent == []
+        assert not ChatMessage.objects.filter(chat=session.chat).exists()
+
+    def test_an_enabled_channel_still_sends(self):
+        session = ExperimentSessionFactory.create()
+        channel = _make_channel(session)
+
+        channel.send_message_to_user("your appointment is tomorrow")
+
+        assert channel.text_sent == ["your appointment is tomorrow"]
 
 
 @pytest.mark.django_db()

--- a/apps/channels/tests/channels/test_disabled_channel.py
+++ b/apps/channels/tests/channels/test_disabled_channel.py
@@ -17,7 +17,7 @@ from apps.channels.stages.core import AttachmentHydrationStage, ChannelDisabledS
 from apps.channels.tests.message_examples import base_messages
 from apps.channels.web_channel import WebChannel
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
-from apps.experiments.models import ExperimentSession, Participant
+from apps.experiments.models import ExperimentSession, Participant, SessionStatus
 from apps.experiments.services import start_experiment_session
 from apps.experiments.tasks import get_response_for_webchat_task
 from apps.service_providers.tracing import TraceInfo
@@ -364,6 +364,32 @@ class TestDisabledChannelRefusesSessionStarts:
         for codename in codenames:
             user.user_permissions.add(Permission.objects.get(codename=codename))
         return user
+
+    def test_new_session_from_the_console_is_refused(self, client):
+        """The admin "new session" action reuses the old session's channel, so a disabled one has
+        to refuse -- and refuse before ending the session the participant is already in."""
+        session = ExperimentSessionFactory.create(
+            experiment__team=TeamWithUsersFactory.create(),
+            experiment_channel__platform=ChannelPlatform.TELEGRAM,
+        )
+        experiment = session.experiment
+        session.experiment_channel.enabled = False
+        session.experiment_channel.save()
+        client.force_login(self._console_user(experiment, "change_experimentsession"))
+
+        with patch("apps.chatbots.views.send_bot_message") as send_bot_message:
+            response = client.post(
+                reverse(
+                    "chatbots:chatbot_new_session",
+                    args=[experiment.team.slug, experiment.public_id, session.external_id],
+                )
+            )
+
+        assert response.status_code == 302
+        send_bot_message.delay.assert_not_called()
+        session.refresh_from_db()
+        assert session.status != SessionStatus.COMPLETE
+        assert experiment.sessions.count() == 1
 
     def test_authed_web_session_start_is_refused(self, client):
         """The console's own "chat to this bot" button goes through the same web channel."""

--- a/apps/channels/tests/channels/test_disabled_channel.py
+++ b/apps/channels/tests/channels/test_disabled_channel.py
@@ -365,6 +365,58 @@ class TestDisabledChannelRefusesSessionStarts:
             user.user_permissions.add(Permission.objects.get(codename=codename))
         return user
 
+    def test_public_web_chat_survives_the_channel_going_down_mid_request(self, client):
+        """The check runs before the consent form renders, but an admin can switch the channel off
+        between that check and the session start. A public URL must not 500 for that."""
+        experiment = ExperimentFactory.create(team=TeamWithUsersFactory.create())
+        channel = ExperimentChannel.objects.get_team_web_channel(experiment.team)
+        channel.disabled_message = "Back on Monday"
+        channel.save()  # left enabled, so the up-front check passes
+
+        with patch(
+            "apps.experiments.views.experiment.WebChannel.start_new_session",
+            side_effect=ChannelDisabledException(channel),
+        ):
+            response = client.post(
+                reverse(
+                    "experiments:start_session_public",
+                    kwargs={"team_slug": experiment.team.slug, "experiment_id": experiment.public_id},
+                ),
+                data={
+                    "identifier": "someone@example.com",
+                    "consent_agreement": True,
+                    "experiment_id": str(experiment.id),
+                    "participant_id": "",
+                },
+            )
+
+        assert response.status_code == 503
+        assert "Back on Monday" in response.content.decode()
+
+    def test_console_new_session_survives_the_channel_going_down_mid_request(self, client):
+        """Worse here than on the public page: the old session is already ended by this point, so
+        a 500 would leave the participant with no session at all."""
+        session = ExperimentSessionFactory.create(
+            experiment__team=TeamWithUsersFactory.create(),
+            experiment_channel__platform=ChannelPlatform.TELEGRAM,
+        )
+        experiment = session.experiment
+        client.force_login(self._console_user(experiment, "change_experimentsession"))
+
+        with patch("apps.chatbots.views.get_channel_class_for_platform") as get_channel_class:
+            get_channel_class.return_value.start_new_session.side_effect = ChannelDisabledException(
+                session.experiment_channel
+            )
+            response = client.post(
+                reverse(
+                    "chatbots:chatbot_new_session",
+                    args=[experiment.team.slug, experiment.public_id, session.external_id],
+                )
+            )
+
+        assert response.status_code == 302
+        assert experiment.sessions.count() == 1
+
     def test_new_session_from_the_console_is_refused(self, client):
         """The admin "new session" action reuses the old session's channel, so a disabled one has
         to refuse -- and refuse before ending the session the participant is already in."""

--- a/apps/channels/tests/channels/test_disabled_channel.py
+++ b/apps/channels/tests/channels/test_disabled_channel.py
@@ -3,19 +3,27 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.contrib.auth.models import Permission
+from django.urls import reverse
+from rest_framework.test import APIClient
 
 from apps.channels.api_channel import ApiChannel
 from apps.channels.channel_base import ChannelBase
 from apps.channels.evaluation_channel import EvaluationChannel
-from apps.channels.models import ChannelPlatform
+from apps.channels.exceptions import ChannelDisabledException
+from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.channels.registry import PLATFORM_CHANNEL_CLASSES
 from apps.channels.stages.core import AttachmentHydrationStage, ChannelDisabledStage
 from apps.channels.tests.message_examples import base_messages
 from apps.channels.web_channel import WebChannel
-from apps.chat.models import ChatMessage, ChatMessageType
+from apps.chat.models import Chat, ChatMessage, ChatMessageType
+from apps.experiments.models import ExperimentSession, Participant
+from apps.experiments.services import start_experiment_session
 from apps.experiments.tasks import get_response_for_webchat_task
 from apps.utils.factories.channels import ExperimentChannelFactory
-from apps.utils.factories.experiment import ExperimentSessionFactory
+from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+from apps.utils.tests.clients import ApiTestClient
 
 from .conftest import StubChannel, make_trace_service
 
@@ -179,3 +187,181 @@ class TestDisabledStageIsWired:
         stages = self._core_stages(EvaluationChannel)
 
         assert not any(isinstance(stage, ChannelDisabledStage) for stage in stages)
+
+
+@pytest.mark.django_db()
+class TestDisabledChannelBlocksNewSessions:
+    """The toggle has to mean "no new conversations", not only "no bot replies".
+
+    ChannelDisabledStage can only speak for traffic that reaches a pipeline. Every route that
+    opens a session -- widget and API session starts, the public web chat, the Slack listener,
+    admin "new session" actions -- creates it *before* any pipeline runs, so the guarantee lives
+    in start_experiment_session instead.
+    """
+
+    def _disabled_channel(self, disabled_message=""):
+        return ExperimentChannelFactory.create(enabled=False, disabled_message=disabled_message)
+
+    def test_start_experiment_session_refuses(self):
+        channel = self._disabled_channel("We are closed")
+
+        with pytest.raises(ChannelDisabledException) as exc_info:
+            start_experiment_session(
+                working_experiment=channel.experiment,
+                experiment_channel=channel,
+                participant=Participant(identifier="brand-new"),
+            )
+
+        assert exc_info.value.channel == channel
+        assert exc_info.value.disabled_message == "We are closed"
+
+    def test_refusing_writes_nothing(self):
+        """The refusal precedes every write, so a disabled channel leaves no trace of the attempt."""
+        channel = self._disabled_channel()
+
+        with pytest.raises(ChannelDisabledException):
+            start_experiment_session(
+                working_experiment=channel.experiment,
+                experiment_channel=channel,
+                participant=Participant(identifier="brand-new"),
+            )
+
+        assert not ExperimentSession.objects.filter(experiment_channel=channel).exists()
+        assert not Participant.objects.filter(identifier="brand-new").exists()
+        assert not Chat.objects.exists()
+
+    def test_an_enabled_channel_is_unaffected(self):
+        channel = ExperimentChannelFactory.create()
+
+        session = start_experiment_session(
+            working_experiment=channel.experiment,
+            experiment_channel=channel,
+            participant=Participant(identifier="brand-new"),
+        )
+
+        assert session.experiment_channel == channel
+
+
+@pytest.mark.django_db()
+class TestDisabledChannelRefusesSessionStarts:
+    """The HTTP surfaces that open a session, each turning the refusal into its own idiom."""
+
+    def test_widget_session_start_is_refused(self):
+        """The widget calls this before it can send anything, so letting it through would hand
+        back a session and a token on a channel that will not talk."""
+        experiment = ExperimentFactory.create(team=TeamWithUsersFactory.create())
+        channel = ExperimentChannel.objects.get_team_api_channel(experiment.team)
+        channel.enabled = False
+        channel.disabled_message = "The bot is offline for maintenance"
+        channel.save()
+
+        response = APIClient().post(
+            reverse("api:chat:start-session"),
+            data={"chatbot_id": str(experiment.public_id), "session_data": {}},
+            format="json",
+        )
+
+        assert response.status_code == 403
+        assert response.json() == {"error": "The bot is offline for maintenance"}
+        assert not ExperimentSession.objects.filter(experiment_channel=channel).exists()
+        assert not Participant.objects.filter(team=experiment.team).exists()
+
+    def test_widget_session_start_refusal_has_a_body_when_silent(self):
+        """A silent disable still owes an HTTP caller something to show."""
+        experiment = ExperimentFactory.create(team=TeamWithUsersFactory.create())
+        channel = ExperimentChannel.objects.get_team_api_channel(experiment.team)
+        channel.enabled = False
+        channel.save()
+
+        response = APIClient().post(
+            reverse("api:chat:start-session"),
+            data={"chatbot_id": str(experiment.public_id), "session_data": {}},
+            format="json",
+        )
+
+        assert response.status_code == 403
+        assert response.json() == {"error": "This chatbot is currently unavailable."}
+
+    def test_trigger_bot_message_is_refused(self):
+        """This endpoint opens a session *and* pushes a message, so both have to be refused."""
+        experiment = ExperimentFactory.create(team=TeamWithUsersFactory.create())
+        ExperimentChannelFactory.create(
+            team=experiment.team, experiment=experiment, platform=ChannelPlatform.TELEGRAM, enabled=False
+        )
+        client = ApiTestClient(experiment.team.members.first(), experiment.team)
+
+        response = client.post(
+            reverse("api:trigger_bot"),
+            data={
+                "identifier": "123",
+                "platform": ChannelPlatform.TELEGRAM,
+                "experiment": str(experiment.public_id),
+                "prompt_text": "check in with the user",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert "disabled" in response.json()["detail"]
+        assert not ExperimentSession.objects.filter(experiment=experiment).exists()
+
+    def test_public_web_chat_shows_the_static_message(self, client):
+        experiment = ExperimentFactory.create(team=TeamWithUsersFactory.create())
+        channel = ExperimentChannel.objects.get_team_web_channel(experiment.team)
+        channel.enabled = False
+        channel.disabled_message = "Back on Monday"
+        channel.save()
+
+        response = client.get(
+            reverse(
+                "experiments:start_session_public",
+                kwargs={"team_slug": experiment.team.slug, "experiment_id": experiment.public_id},
+            )
+        )
+
+        assert response.status_code == 503
+        assert "Back on Monday" in response.content.decode()
+        assert not ExperimentSession.objects.filter(experiment_channel=channel).exists()
+
+    def _console_user(self, experiment, *codenames):
+        user = experiment.team.members.first()
+        for codename in codenames:
+            user.user_permissions.add(Permission.objects.get(codename=codename))
+        return user
+
+    def test_authed_web_session_start_is_refused(self, client):
+        """The console's own "chat to this bot" button goes through the same web channel."""
+        experiment = ExperimentFactory.create(team=TeamWithUsersFactory.create())
+        channel = ExperimentChannel.objects.get_team_web_channel(experiment.team)
+        channel.enabled = False
+        channel.save()
+        client.force_login(self._console_user(experiment))
+
+        response = client.post(
+            reverse(
+                "chatbots:start_authed_web_session",
+                args=[experiment.team.slug, experiment.id, experiment.version_number],
+            )
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("chatbots:single_chatbot_home", args=[experiment.team.slug, experiment.id])
+        assert not ExperimentSession.objects.exists()
+
+    def test_invitation_is_refused(self, client):
+        """An invitation to a channel that will not talk is worse than no invitation."""
+        experiment = ExperimentFactory.create(team=TeamWithUsersFactory.create())
+        channel = ExperimentChannel.objects.get_team_web_channel(experiment.team)
+        channel.enabled = False
+        channel.save()
+        client.force_login(self._console_user(experiment, "invite_participants", "view_experiment"))
+
+        with patch("apps.chatbots.views.send_experiment_invitation") as send_invitation:
+            response = client.post(
+                reverse("chatbots:chatbots_invitations", args=[experiment.team.slug, experiment.id]),
+                data={"experiment_id": experiment.id, "email": "someone@example.com", "invite_now": "on"},
+            )
+
+        assert response.status_code == 200
+        send_invitation.assert_not_called()
+        assert not ExperimentSession.objects.exists()

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -671,13 +671,19 @@ def new_chatbot_session(request, team_slug: str, experiment_id: uuid.UUID, sessi
 
     # Create new session using the same channel as the old session
     channel_cls = get_channel_class_for_platform(experiment_channel.platform)
-    new_session = channel_cls.start_new_session(
-        working_experiment=experiment,
-        participant_identifier=participant.identifier,
-        participant_user=participant.user,
-        session_status=SessionStatus.ACTIVE,
-        experiment_channel=experiment_channel,
-    )
+    try:
+        new_session = channel_cls.start_new_session(
+            working_experiment=experiment,
+            participant_identifier=participant.identifier,
+            participant_user=participant.user,
+            session_status=SessionStatus.ACTIVE,
+            experiment_channel=experiment_channel,
+        )
+    except ChannelDisabledException:
+        # Switched off between the check above and here. The old session is already ended, so
+        # say so plainly rather than 500 after a destructive step.
+        messages.error(request, "The channel was disabled while creating the new session.")
+        return redirect("chatbots:chatbot_session_view", team_slug, experiment_id, session_id)
 
     send_bot_message.delay(session_id=new_session.id, instruction_prompt=request.POST.get("prompt", "").strip())
 

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -23,6 +23,7 @@ from waffle import flag_is_active
 
 from apps.annotations.prefetch import attach_chat_tagged_items
 from apps.api.session_tokens import issue_session_token
+from apps.channels.exceptions import ChannelDisabledException
 from apps.channels.models import ChannelPlatform
 from apps.channels.registry import get_channel_class_for_platform
 from apps.channels.web_channel import WebChannel
@@ -662,6 +663,12 @@ def new_chatbot_session(request, team_slug: str, experiment_id: uuid.UUID, sessi
         messages.error(request, "Cannot create a new session from a web session.")
         return redirect("chatbots:chatbot_session_view", team_slug, experiment_id, session_id)
 
+    if experiment_channel.is_disabled:
+        # Checked before ending the old session, so a refusal leaves the participant where they were.
+        platform_label = experiment_channel.get_platform_display()
+        messages.error(request, f"Cannot create a new session: the {platform_label} channel is disabled.")
+        return redirect("chatbots:chatbot_session_view", team_slug, experiment_id, session_id)
+
     _end_session_from_request(old_session, request)
 
     experiment = old_session.experiment
@@ -735,13 +742,17 @@ def chatbot_session_pagination_view(request, team_slug: str, experiment_id: uuid
 @login_and_team_required
 def start_authed_web_session(request, team_slug: str, experiment_id: int, version_number: int):
     experiment = get_object_or_404(Experiment, id=experiment_id, team=request.team)
-    session = WebChannel.start_new_session(
-        working_experiment=experiment,
-        participant_user=request.user,
-        participant_identifier=request.user.email,
-        timezone=request.session.get("detected_tz", None),
-        version=version_number,
-    )
+    try:
+        session = WebChannel.start_new_session(
+            working_experiment=experiment,
+            participant_user=request.user,
+            participant_identifier=request.user.email,
+            timezone=request.session.get("detected_tz", None),
+            version=version_number,
+        )
+    except ChannelDisabledException:
+        messages.error(request, "The web channel is disabled, so no new chat sessions can be started.")
+        return redirect("chatbots:single_chatbot_home", team_slug=team_slug, experiment_id=experiment_id)
     return HttpResponseRedirect(
         reverse("chatbots:chatbot_chat_session", args=[team_slug, experiment_id, version_number, session.id])
     )
@@ -770,15 +781,21 @@ def chatbot_invitations(request, team_slug: str, experiment_id: int):
                 participant_email = post_form.cleaned_data["email"]
                 messages.info(request, f"{participant_email} already has a pending invitation.")
             else:
-                with transaction.atomic():
-                    session = WebChannel.start_new_session(
-                        chatbot,
-                        participant_identifier=post_form.cleaned_data["email"],
-                        session_status=SessionStatus.SETUP,
-                        timezone=request.session.get("detected_tz", None),
-                    )
-                if post_form.cleaned_data["invite_now"]:
-                    send_experiment_invitation(session)
+                try:
+                    with transaction.atomic():
+                        session = WebChannel.start_new_session(
+                            chatbot,
+                            participant_identifier=post_form.cleaned_data["email"],
+                            session_status=SessionStatus.SETUP,
+                            timezone=request.session.get("detected_tz", None),
+                        )
+                except ChannelDisabledException:
+                    # Inviting someone to a channel that will not talk to them is worse than
+                    # refusing the invite.
+                    messages.error(request, "The web channel is disabled, so invitations cannot be sent.")
+                else:
+                    if post_form.cleaned_data["invite_now"]:
+                        send_experiment_invitation(session)
         else:
             form = post_form
 

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1612,6 +1612,19 @@ class ExperimentSession(BaseTeamModel):
         if (instruction_prompt is None) == (message_text is None):
             raise ValueError("Exactly one of instruction_prompt or message_text must be provided")
 
+        if self.experiment_channel and self.experiment_channel.is_disabled:
+            # A disabled channel blocks bot-initiated traffic too -- scheduled messages, event
+            # actions, API triggers. Checked here rather than at the send, so a disabled channel
+            # costs no LLM call and leaves no undelivered AI message in the chat history.
+            # Deliberately not an error: the admin asked for this, so retrying it or logging a
+            # failed attempt against the schedule would both be wrong.
+            log.info(
+                "Not sending bot message to session %s: channel %s is disabled",
+                self.id,
+                self.experiment_channel_id,
+            )
+            return {}
+
         trace_service = None
         try:
             with transaction.atomic(), current_team(self.team):

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1586,6 +1586,15 @@ class ExperimentSession(BaseTeamModel):
         if commit and trigger_type:
             enqueue_static_triggers.delay(self.id, trigger_type)
 
+    @property
+    def channel_is_disabled(self) -> bool:
+        """Whether an admin has switched off the channel this session runs on.
+
+        The FK is nullable, so "no channel" reads as not disabled -- there is nothing to
+        deliver on either way, and the send path fails on its own terms.
+        """
+        return self.experiment_channel is not None and self.experiment_channel.is_disabled
+
     def ad_hoc_bot_message(
         self,
         instruction_prompt: str | None,
@@ -1611,7 +1620,7 @@ class ExperimentSession(BaseTeamModel):
         if (instruction_prompt is None) == (message_text is None):
             raise ValueError("Exactly one of instruction_prompt or message_text must be provided")
 
-        if self.experiment_channel and self.experiment_channel.is_disabled:
+        if self.channel_is_disabled:
             # A disabled channel blocks bot-initiated traffic too -- scheduled messages, event
             # actions, API triggers. Checked here rather than at the send, so a disabled channel
             # costs no LLM call and leaves no undelivered AI message in the chat history.
@@ -1636,12 +1645,9 @@ class ExperimentSession(BaseTeamModel):
                     metadata=trace_info.metadata,
                     notification_config=SpanNotificationConfig(permissions=["experiments.change_experiment"]),
                 ) as span:
-                    if message_text is not None:
-                        bot_message = self._save_direct_bot_message(message_text, experiment, trace_service)
-                    else:
-                        bot_message = self._bot_prompt_for_user(
-                            instruction_prompt, trace_info, use_experiment=use_experiment, trace_service=trace_service
-                        )
+                    bot_message = self._resolve_ad_hoc_message(
+                        instruction_prompt, message_text, experiment, trace_info, use_experiment, trace_service
+                    )
                     self.try_send_message(message=bot_message)
                     span.set_outputs({"response": bot_message})
                     trace_metadata = trace_service.get_trace_metadata()
@@ -1653,6 +1659,26 @@ class ExperimentSession(BaseTeamModel):
                     trace_metadata = trace_service.get_trace_metadata()
                     e.trace_metadata = trace_metadata
                 raise e
+
+    def _resolve_ad_hoc_message(
+        self,
+        instruction_prompt: str | None,
+        message_text: str | None,
+        experiment: Experiment,
+        trace_info: TraceInfo,
+        use_experiment: Experiment | None,
+        trace_service: TracingService,
+    ) -> str:
+        """The text to deliver, recorded in history either way.
+
+        ``message_text`` goes out verbatim; otherwise the LLM writes it from
+        ``instruction_prompt``. Exactly one of the two is set (the caller has already checked).
+        """
+        if message_text is not None:
+            return self._save_direct_bot_message(message_text, experiment, trace_service)
+        return self._bot_prompt_for_user(
+            instruction_prompt, trace_info, use_experiment=use_experiment, trace_service=trace_service
+        )
 
     def _save_direct_bot_message(self, message: str, experiment: Experiment, trace_service: TracingService) -> str:
         """Records a direct (non-LLM) bot message in the chat history and returns it.

--- a/apps/experiments/services.py
+++ b/apps/experiments/services.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 from django.db.models import Q
 
+from apps.channels.exceptions import ChannelDisabledException
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chat.exceptions import VersionedExperimentSessionsNotAllowedException
 from apps.chat.models import Chat
@@ -25,11 +26,25 @@ def start_experiment_session(
     wrapper (``Participant(identifier=...)`` or ``Participant(identifier=..., user=...)``) and it
     is looked up or created here. A stored participant (e.g. one the v2 pipeline already resolved)
     is used as-is.
+
+    Raises ``ChannelDisabledException`` when the channel is switched off. Every participant-facing
+    route that opens a session funnels through here -- widget and API session starts, the public
+    web chat, the Slack listener, admin "new session" actions -- so guarding it here is what makes
+    the admin toggle mean "no new conversations" rather than only "no bot replies". Callers decide
+    how to report the refusal, and several check ``is_disabled`` themselves first so they can
+    refuse before creating participant records.
+
+    Internal routes that build a session row directly (``ExperimentSessionCreateSerializer`` for
+    ``POST /api/sessions/``, eval runs, pipeline test runs) bypass this guard; their traffic is
+    still stopped at the pipeline by ``ChannelDisabledStage``.
     """
     if working_experiment.is_a_version:
         raise VersionedExperimentSessionsNotAllowedException(
             message="A session cannot be linked to an experiment version. "
         )
+
+    if experiment_channel.is_disabled:
+        raise ChannelDisabledException(experiment_channel)
 
     team = working_experiment.team
     participant_identifier = participant.identifier

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -43,7 +43,7 @@ from apps.analysis.const import LANGUAGE_CHOICES
 from apps.analysis.translation import translate_messages_with_llm
 from apps.annotations.models import CustomTaggedItem, Tag
 from apps.channels.datamodels import Attachment
-from apps.channels.models import ChannelPlatform
+from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.channels.web_channel import WebChannel
 from apps.chat.models import ChatAttachment, ChatMessage, ChatMessageType
 from apps.chatbots.version_resolver import resolve_published_or_working
@@ -261,6 +261,21 @@ def start_session_public(request, team_slug: str, experiment_id: uuid.UUID):
     experiment_version = resolve_published_or_working(experiment)
     if not experiment_version.is_public:
         raise Http404
+
+    # Checked once up front rather than around each start_new_session below, so a participant
+    # never fills in the consent form only to be refused on submit. Looked up rather than
+    # created (``get_team_web_channel`` is a get_or_create): this runs on every GET of the
+    # consent page, and a channel that does not exist yet cannot be disabled.
+    web_channel = ExperimentChannel.objects.filter(
+        team=request.team, platform=ChannelPlatform.WEB, deleted=False
+    ).first()
+    if web_channel and web_channel.is_disabled:
+        return TemplateResponse(
+            request,
+            "experiments/channel_disabled.html",
+            {"disabled_message": web_channel.disabled_message},
+            status=503,
+        )
 
     consent = experiment_version.consent_form
     user = get_real_user_or_none(request.user)

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -43,6 +43,7 @@ from apps.analysis.const import LANGUAGE_CHOICES
 from apps.analysis.translation import translate_messages_with_llm
 from apps.annotations.models import CustomTaggedItem, Tag
 from apps.channels.datamodels import Attachment
+from apps.channels.exceptions import ChannelDisabledException
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.channels.web_channel import WebChannel
 from apps.chat.models import ChatAttachment, ChatMessage, ChatMessageType
@@ -249,6 +250,16 @@ def _poll_messages(request):
     return HttpResponse()
 
 
+def _channel_disabled_page(request, disabled_message: str) -> TemplateResponse:
+    """The maintenance page shown when the channel a participant is trying to reach is off."""
+    return TemplateResponse(
+        request,
+        "experiments/channel_disabled.html",
+        {"disabled_message": disabled_message},
+        status=503,
+    )
+
+
 def _disabled_web_channel_response(request) -> TemplateResponse | None:
     """The maintenance page when an admin has switched off the team's web channel, else None.
 
@@ -260,12 +271,7 @@ def _disabled_web_channel_response(request) -> TemplateResponse | None:
     web_channel = ExperimentChannel.objects.filter(team=request.team, platform=ChannelPlatform.WEB).first()
     if not (web_channel and web_channel.is_disabled):
         return None
-    return TemplateResponse(
-        request,
-        "experiments/channel_disabled.html",
-        {"disabled_message": web_channel.disabled_message},
-        status=503,
-    )
+    return _channel_disabled_page(request, web_channel.disabled_message)
 
 
 def _resolve_consent_identifier(consent, form, user, team) -> tuple[str, bool]:
@@ -295,11 +301,20 @@ def start_session_public(request, team_slug: str, experiment_id: uuid.UUID):
     if not experiment_version.is_public:
         raise Http404
 
-    # Checked once up front rather than around each start_new_session below, so a participant
-    # never fills in the consent form only to be refused on submit.
+    # Checked before the consent form is rendered, so a participant never fills it in only to be
+    # refused on submit. The channel is checked again inside start_experiment_session, which is
+    # what the except below catches: an admin switching the channel off mid-request should get
+    # the same maintenance page, not a 500 on a public URL.
     if disabled_response := _disabled_web_channel_response(request):
         return disabled_response
+    try:
+        return _run_public_consent_flow(request, team_slug, experiment, experiment_version)
+    except ChannelDisabledException as e:
+        return _channel_disabled_page(request, e.disabled_message)
 
+
+def _run_public_consent_flow(request, team_slug: str, experiment, experiment_version):
+    """Collect consent if the chatbot asks for it, then start the participant's session."""
     consent = experiment_version.consent_form
     user = get_real_user_or_none(request.user)
     if not consent:

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -249,6 +249,39 @@ def _poll_messages(request):
     return HttpResponse()
 
 
+def _disabled_web_channel_response(request) -> TemplateResponse | None:
+    """The maintenance page when an admin has switched off the team's web channel, else None.
+
+    Looked up rather than fetched via ``get_team_web_channel``, which is a ``get_or_create``:
+    this runs on every anonymous GET of the consent page, so creating here would both write on
+    a read and race two first-time loads against ``unique_global_channel_per_team``. A channel
+    that does not exist yet cannot be disabled, so its absence is not a refusal.
+    """
+    web_channel = ExperimentChannel.objects.filter(team=request.team, platform=ChannelPlatform.WEB).first()
+    if not (web_channel and web_channel.is_disabled):
+        return None
+    return TemplateResponse(
+        request,
+        "experiments/channel_disabled.html",
+        {"disabled_message": web_channel.disabled_message},
+        status=503,
+    )
+
+
+def _resolve_consent_identifier(consent, form, user, team) -> tuple[str, bool]:
+    """The participant identifier from a submitted consent form, and whether to verify it.
+
+    When the form captures an identifier we take theirs and verify it. When it does not, the
+    field was disabled, so we supply one -- the signed-in user's email, or a fresh anonymous
+    identifier -- and there is nothing to verify.
+    """
+    if consent.capture_identifier:
+        return form.cleaned_data.get("identifier", None), True
+    if user:
+        return user.email, False
+    return Participant.create_anonymous(team, ChannelPlatform.WEB).identifier, False
+
+
 @public_chat_rate_limited
 @team_required
 def start_session_public(request, team_slug: str, experiment_id: uuid.UUID):
@@ -263,19 +296,9 @@ def start_session_public(request, team_slug: str, experiment_id: uuid.UUID):
         raise Http404
 
     # Checked once up front rather than around each start_new_session below, so a participant
-    # never fills in the consent form only to be refused on submit. Looked up rather than
-    # created (``get_team_web_channel`` is a get_or_create): this runs on every GET of the
-    # consent page, and a channel that does not exist yet cannot be disabled.
-    web_channel = ExperimentChannel.objects.filter(
-        team=request.team, platform=ChannelPlatform.WEB, deleted=False
-    ).first()
-    if web_channel and web_channel.is_disabled:
-        return TemplateResponse(
-            request,
-            "experiments/channel_disabled.html",
-            {"disabled_message": web_channel.disabled_message},
-            status=503,
-        )
+    # never fills in the consent form only to be refused on submit.
+    if disabled_response := _disabled_web_channel_response(request):
+        return disabled_response
 
     consent = experiment_version.consent_form
     user = get_real_user_or_none(request.user)
@@ -292,16 +315,7 @@ def start_session_public(request, team_slug: str, experiment_id: uuid.UUID):
     if request.method == "POST":
         form = ConsentForm(consent, request.POST, initial={"identifier": user.email if user else None})
         if form.is_valid():
-            verify_user = True
-            if consent.capture_identifier:
-                identifier = form.cleaned_data.get("identifier", None)
-            else:
-                # The identifier field will be disabled, so we must generate one
-                verify_user = False
-                if user:
-                    identifier = user.email
-                else:
-                    identifier = Participant.create_anonymous(request.team, ChannelPlatform.WEB).identifier
+            identifier, verify_user = _resolve_consent_identifier(consent, form, user, request.team)
 
             session = WebChannel.start_new_session(
                 working_experiment=experiment,

--- a/apps/slack/slack_listeners.py
+++ b/apps/slack/slack_listeners.py
@@ -75,6 +75,13 @@ def _respond_to_message(event, channel_id, thread_ts, experiment_channel, experi
     slack_user = event.get("user")
 
     if not session:
+        if experiment_channel.is_disabled:
+            # A new thread has no session, so the pipeline -- and its ChannelDisabledStage --
+            # never runs. Mirror what that stage would have done: the admin's static message,
+            # or silence.
+            if experiment_channel.disabled_message:
+                context.say(experiment_channel.disabled_message, thread_ts=thread_ts)
+            return
         external_id = make_session_external_id(channel_id, thread_ts)
         session = SlackChannel.start_new_session(
             working_experiment=experiment,

--- a/apps/slack/tests/test_listeners.py
+++ b/apps/slack/tests/test_listeners.py
@@ -338,3 +338,34 @@ def test_messages_the_bot_does_not_answer_are_not_counted(bolt_context, rate_lim
         new_message(CHANNEL_MESSAGE_EVENT, bolt_context)
 
     assert _would_block_records(rate_limit_logs) == []
+
+
+@pytest.mark.django_db()
+def test_disabled_channel_replies_with_the_static_message(bolt_context, experiment_channel):
+    """A new thread has no session yet, so the pipeline -- and its ChannelDisabledStage -- never
+    runs. The listener has to mirror that stage itself."""
+    experiment_channel.enabled = False
+    experiment_channel.disabled_message = "The bot is offline for maintenance"
+    experiment_channel.save()
+    bolt_context.client.chat_postMessage = MagicMock()
+
+    new_message(BOT_MENTION_EVENT, bolt_context)
+
+    assert bolt_context.say.call_args_list == [
+        (("The bot is offline for maintenance",), {"thread_ts": BOT_MENTION_EVENT["ts"]})
+    ]
+    bolt_context.client.chat_postMessage.assert_not_called()
+    assert ExperimentSession.objects.count() == 0
+
+
+@pytest.mark.django_db()
+def test_disabled_channel_stays_silent_without_a_static_message(bolt_context, experiment_channel):
+    experiment_channel.enabled = False
+    experiment_channel.save()
+    bolt_context.client.chat_postMessage = MagicMock()
+
+    new_message(BOT_MENTION_EVENT, bolt_context)
+
+    assert bolt_context.say.call_args_list == []
+    bolt_context.client.chat_postMessage.assert_not_called()
+    assert ExperimentSession.objects.count() == 0

--- a/templates/experiments/channel_disabled.html
+++ b/templates/experiments/channel_disabled.html
@@ -1,0 +1,12 @@
+{% extends "error_base.html" %}
+{% load i18n %}
+{% block error_details %}
+  <h1 class="pg-title">{% translate "Temporarily unavailable" %}</h1>
+  <h2 class="pg-subtitle">
+    {% if disabled_message %}
+      {{ disabled_message }}
+    {% else %}
+      {% translate "This chatbot is not accepting new conversations right now. Please try again later." %}
+    {% endif %}
+  </h2>
+{% endblock error_details %}


### PR DESCRIPTION
### Product Description

Disabling a channel now actually blocks access. Before this, #4200's toggle only stopped the bot replying to inbound messages — the widget, the public web chat, Slack and the admin console all still opened new sessions on a disabled channel, and scheduled messages, event actions and API triggers kept pushing messages out.

### Technical Description

`ChannelDisabledStage` can only speak for traffic that reaches a pipeline, but most channels create the session *before* any pipeline runs. The guard therefore lives in `start_experiment_session`, which every session-creating route funnels through; each caller translates `ChannelDisabledException` into its own idiom (403 for the widget/API, 503 page for the public web chat, `messages.error` for the console, static-message-or-silence for Slack). Several also pre-check `is_disabled` so they can refuse before creating participant records.

Worth review attention:

- **The outbound path deliberately does not reuse `ChannelDisabledStage`.** That stage *answers* an inbound message, so on a channel with a static `disabled_message` it would swap that text in and deliver it — turning a suppressed reminder into an unsolicited "we're offline" push. Guarded in `ad_hoc_bot_message` (before the LLM runs, so no cost and no undelivered AI message in history) and again in `send_message_to_user`.
- **`ad_hoc_bot_message` returns `{}` rather than raising.** Raising would give a scheduled message three retries with backoff plus a FAILURE attempt log, against a decision the admin made on purpose. Known wart: the `ScheduledMessage` attempt now records SUCCESS for a message that was deliberately suppressed. Making that precise means widening the return contract — happy to if you'd rather.
- **`start_session_public` uses a non-creating channel lookup.** `get_team_web_channel` is a `get_or_create`, and this runs on every anonymous GET of the consent page; two concurrent first-time loads would race on `unique_global_channel_per_team`.

Deliberately out of scope:

- **`POST /api/sessions/`** builds the session row directly (`ExperimentSessionCreateSerializer.create`) and still bypasses the guard. Guarding it changes a public API contract, and the team-global API channel has no UI toggle, so reaching that state needs DB access. Follow-on messages on such a session are still blocked by `ChannelDisabledStage`. Say the word if you want it closed here.
- **Eval runs and pipeline test runs** also bypass it — both intentional (evals per the rationale already in `EvaluationChannel`, pipeline test sessions are rolled back).
- **The widget never shows `disabled_message`** — `startSession`'s catch in `ocs-chat.tsx` discards the response body, so widget users see "Failed to start chat session" instead of the admin's wording. Needs its own npm release, so it can't ship from here.

The merge from main pulls in #4226, whose `get_trigger_bot_channel` supersedes the guard this branch originally put in `handle_trigger_bot_message` and extends it to the participant detail page; the redundant test here was dropped in favour of main's.

### Demo

To see it: uncheck **Enabled** on a channel, optionally set a disabled message, then try to start a conversation on that channel. Previously a session appeared and only the first reply was blocked.

### Docs and Changelog
- [x] This PR requires docs/changelog update

The toggle itself was documented with #4200; what changed is its scope — it now prevents new sessions and bot-initiated messages, not only bot replies to inbound messages.
