### PR TITLE
feat(llm): add OpenRouter as an OpenAI-compatible LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -207,9 +207,6 @@ APP_IP=
 
 # OpenRouter
 # OPENROUTER_API_KEY=
-# Optional: customize the attribution headers sent to OpenRouter (see https://openrouter.ai/docs/api-reference/overview#headers)
-OPENROUTER_REFERER=https://github.com/dimagi/open-chat-studio
-OPENROUTER_TITLE=Open Chat Studio
 
 # LiteLLM
 # LITELLM_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -205,6 +205,9 @@ APP_IP=
 # Perplexity
 # PERPLEXITY_API_KEY=
 
+# OpenRouter
+# OPENROUTER_API_KEY=
+
 # LiteLLM
 # LITELLM_API_KEY=
 # LITELLM_API_BASE=

--- a/.env.example
+++ b/.env.example
@@ -207,6 +207,9 @@ APP_IP=
 
 # OpenRouter
 # OPENROUTER_API_KEY=
+# Optional: customize the attribution headers sent to OpenRouter (see https://openrouter.ai/docs/api-reference/overview#headers)
+OPENROUTER_REFERER=https://github.com/dimagi/open-chat-studio
+OPENROUTER_TITLE=Open Chat Studio
 
 # LiteLLM
 # LITELLM_API_KEY=
@@ -220,3 +223,4 @@ APP_IP=
 ## wrong container or the port mapping is invisible to `docker ps`.
 # OCS_POSTGRES_CONTAINER=
 # OCS_REDIS_CONTAINER=
+

--- a/api-schemas/export.yml
+++ b/api-schemas/export.yml
@@ -4498,6 +4498,7 @@ components:
       - anthropic
       - groq
       - perplexity
+      - openrouter
       - deepseek
       - minimax
       - litellm
@@ -4511,6 +4512,7 @@ components:
         * `anthropic` - Anthropic
         * `groq` - Groq
         * `perplexity` - Perplexity
+        * `openrouter` - OpenRouter
         * `deepseek` - DeepSeek
         * `minimax` - MiniMax
         * `litellm` - LiteLLM
@@ -6093,6 +6095,7 @@ components:
       - cursor
       - has_more
       - results
+
     UsageRecordDetail:
       type: object
       properties:

--- a/apps/service_providers/llm_service/__init__.py
+++ b/apps/service_providers/llm_service/__init__.py
@@ -7,6 +7,7 @@ from .main import (
     LlmService,
     OpenAIGenericService,
     OpenAILlmService,
+    OpenRouterLlmService,
     VoyageAILlmService,
 )
 
@@ -16,6 +17,7 @@ __all__ = [
     "LlmService",
     "OpenAILlmService",
     "OpenAIGenericService",
+    "OpenRouterLlmService",
     "DeepSeekLlmService",
     "GoogleLlmService",
     "GoogleVertexAILlmService",

--- a/apps/service_providers/llm_service/credentials.py
+++ b/apps/service_providers/llm_service/credentials.py
@@ -124,14 +124,19 @@ def _openrouter() -> ProviderCredentials | None:
     api_key = os.environ.get("OPENROUTER_API_KEY")
     if not api_key:
         return None
+
+    from django.contrib.sites.models import Site  # noqa: PLC0415 - local import to avoid circular dep at module load
+
+    from apps.web.meta import get_server_root  # noqa: PLC0415 - local import to avoid circular dep at module load
+
     return ProviderCredentials(
         LlmProviderTypes.openrouter,
         "OpenRouter",
         {
             "openai_api_key": api_key,
             "default_headers": {
-                "HTTP-Referer": os.environ.get("OPENROUTER_REFERER", "https://github.com/dimagi/open-chat-studio"),
-                "X-Title": os.environ.get("OPENROUTER_TITLE", "Open Chat Studio"),
+                "HTTP-Referer": get_server_root(),
+                "X-Title": Site.objects.get_current().name,
             },
         },
     )

--- a/apps/service_providers/llm_service/credentials.py
+++ b/apps/service_providers/llm_service/credentials.py
@@ -114,6 +114,13 @@ def _perplexity() -> ProviderCredentials | None:
     return ProviderCredentials(LlmProviderTypes.perplexity, "Perplexity", {"openai_api_key": api_key})
 
 
+def _openrouter() -> ProviderCredentials | None:
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        return None
+    return ProviderCredentials(LlmProviderTypes.openrouter, "OpenRouter", {"openai_api_key": api_key})
+
+
 def _minimax() -> ProviderCredentials | None:
     api_key = os.environ.get("MINIMAX_API_KEY")
     if not api_key:
@@ -142,6 +149,7 @@ _LOADERS: list[Callable[[], ProviderCredentials | None]] = [
     _azure,
     _groq,
     _perplexity,
+    _openrouter,
     _minimax,
     _litellm,
 ]

--- a/apps/service_providers/llm_service/credentials.py
+++ b/apps/service_providers/llm_service/credentials.py
@@ -115,10 +115,26 @@ def _perplexity() -> ProviderCredentials | None:
 
 
 def _openrouter() -> ProviderCredentials | None:
+    """Load OpenRouter credentials from environment variables.
+
+    The ``HTTP-Referer`` and ``X-Title`` headers are recommended by OpenRouter
+    so that requests are attributed to this application in the OpenRouter
+    dashboard and rate-limit tiers. Without them requests appear anonymous.
+    """
     api_key = os.environ.get("OPENROUTER_API_KEY")
     if not api_key:
         return None
-    return ProviderCredentials(LlmProviderTypes.openrouter, "OpenRouter", {"openai_api_key": api_key})
+    return ProviderCredentials(
+        LlmProviderTypes.openrouter,
+        "OpenRouter",
+        {
+            "openai_api_key": api_key,
+            "default_headers": {
+                "HTTP-Referer": os.environ.get("OPENROUTER_REFERER", "https://github.com/dimagi/open-chat-studio"),
+                "X-Title": os.environ.get("OPENROUTER_TITLE", "Open Chat Studio"),
+            },
+        },
+    )
 
 
 def _minimax() -> ProviderCredentials | None:

--- a/apps/service_providers/llm_service/credentials.py
+++ b/apps/service_providers/llm_service/credentials.py
@@ -117,28 +117,18 @@ def _perplexity() -> ProviderCredentials | None:
 def _openrouter() -> ProviderCredentials | None:
     """Load OpenRouter credentials from environment variables.
 
-    The ``HTTP-Referer`` and ``X-Title`` headers are recommended by OpenRouter
-    so that requests are attributed to this application in the OpenRouter
-    dashboard and rate-limit tiers. Without them requests appear anonymous.
+    Attribution headers (HTTP-Referer / X-Title) are injected automatically
+    by ``OpenRouterLlmService`` at construction time, so they appear on every
+    request regardless of which code path created the provider.
     """
     api_key = os.environ.get("OPENROUTER_API_KEY")
     if not api_key:
         return None
 
-    from django.contrib.sites.models import Site  # noqa: PLC0415 - local import to avoid circular dep at module load
-
-    from apps.web.meta import get_server_root  # noqa: PLC0415 - local import to avoid circular dep at module load
-
     return ProviderCredentials(
         LlmProviderTypes.openrouter,
         "OpenRouter",
-        {
-            "openai_api_key": api_key,
-            "default_headers": {
-                "HTTP-Referer": get_server_root(),
-                "X-Title": Site.objects.get_current().name,
-            },
-        },
+        {"openai_api_key": api_key},
     )
 
 

--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -127,14 +127,10 @@ DEFAULT_LLM_PROVIDER_MODELS = {
         Model("llama-3.1-8b-instruct", 131072),
         Model("llama-3.1-70b-instruct", 131072),
     ],
-    "openrouter": [
-        Model("openai/gpt-4.1-mini", 1000000, is_default=True),
-        Model("openai/gpt-4.1", 1000000),
-        Model("anthropic/claude-sonnet-4.6", 1000000, is_translation_default=True),
-        Model("meta-llama/llama-3.3-70b-instruct", 131072),
-        Model("google/gemini-2.5-flash", 1048576),
-        Model("deepseek/deepseek-v4-flash", 1000000),
-    ],
+    # OpenRouter supports thousands of models; we intentionally ship no defaults here.
+    # Users can add models manually, and a dedicated discovery flow using the OpenRouter
+    # model API (search, autocomplete, pricing) is tracked in issue #4258.
+    "openrouter": [],
     "deepseek": [
         # llm-stats lists this model under its open-weights name (deepseek-v4-flash-0731), but
         # api.deepseek.com only serves the undated alias, which is what we have to send.

--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -131,7 +131,7 @@ DEFAULT_LLM_PROVIDER_MODELS = {
         Model("openai/gpt-4.1-mini", 1000000, is_default=True),
         Model("openai/gpt-4.1", 1000000),
         Model("anthropic/claude-sonnet-4.6", 1000000, is_translation_default=True),
-        Model("meta-llama/llama-3.3-70b-instruct", 128000),
+        Model("meta-llama/llama-3.3-70b-instruct", 131072),
         Model("google/gemini-2.5-flash", 1048576),
         Model("deepseek/deepseek-v4-flash", 1000000),
     ],

--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -130,7 +130,7 @@ DEFAULT_LLM_PROVIDER_MODELS = {
     "openrouter": [
         Model("openai/gpt-4.1-mini", 1000000, is_default=True),
         Model("openai/gpt-4.1", 1000000),
-        Model("anthropic/claude-sonnet-4-6", 1000000, is_translation_default=True),
+        Model("anthropic/claude-sonnet-4.6", 1000000, is_translation_default=True),
         Model("meta-llama/llama-3.3-70b-instruct", 128000),
         Model("google/gemini-2.5-flash", 1048576),
         Model("deepseek/deepseek-v4-flash", 1000000),

--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -127,6 +127,14 @@ DEFAULT_LLM_PROVIDER_MODELS = {
         Model("llama-3.1-8b-instruct", 131072),
         Model("llama-3.1-70b-instruct", 131072),
     ],
+    "openrouter": [
+        Model("openai/gpt-4.1-mini", 1000000, is_default=True),
+        Model("openai/gpt-4.1", 1000000),
+        Model("anthropic/claude-sonnet-4-6", 1000000, is_translation_default=True),
+        Model("meta-llama/llama-3.3-70b-instruct", 128000),
+        Model("google/gemini-2.5-flash", 1048576),
+        Model("deepseek/deepseek-v4-flash", 1000000),
+    ],
     "deepseek": [
         # llm-stats lists this model under its open-weights name (deepseek-v4-flash-0731), but
         # api.deepseek.com only serves the undated alias, which is what we have to send.

--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -127,10 +127,11 @@ DEFAULT_LLM_PROVIDER_MODELS = {
         Model("llama-3.1-8b-instruct", 131072),
         Model("llama-3.1-70b-instruct", 131072),
     ],
-    # OpenRouter supports thousands of models; we intentionally ship no defaults here.
+    # OpenRouter supports thousands of models; we intentionally ship no defaults.
     # Users can add models manually, and a dedicated discovery flow using the OpenRouter
-    # model API (search, autocomplete, pricing) is tracked in issue #4258.
-    "openrouter": [],
+    # model API (search, autocomplete, pricing) is tracked in issue #4258. Like
+    # ``voyage`` (embeddings only), providers without shipped chat models are omitted
+    # from this dict entirely rather than listed with an empty list.
     "deepseek": [
         # llm-stats lists this model under its open-weights name (deepseek-v4-flash-0731), but
         # api.deepseek.com only serves the undated alias, which is what we have to send.

--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -230,6 +230,33 @@ class OpenAIGenericService(LlmService):
         return []
 
 
+class OpenRouterLlmService(OpenAIGenericService):
+    """OpenAI-compatible service for OpenRouter with automatic attribution headers.
+
+    OpenRouter recommends sending ``HTTP-Referer`` and ``X-Title`` on every
+    request so that traffic is attributed to this application in the OpenRouter
+    dashboard and rate-limit tiers.  These headers must be injected on every
+    code path (UI, API, bootstrap) — not only during ``bootstrap_data`` seeding.
+    """
+
+    def _get_model_kwargs(self, **kwargs) -> dict:
+        """Inject attribution headers from the current Django Site into every chat request."""
+        model_kwargs = super()._get_model_kwargs(**kwargs)
+        # Only derive from Site when the caller didn't supply explicit headers.
+        # ``super()._get_model_kwargs`` already merges ``self.default_headers`` when set.
+        if "default_headers" not in model_kwargs:
+            from django.contrib.sites.models import Site  # noqa: PLC0415
+
+            from apps.web.meta import get_server_root  # noqa: PLC0415
+
+            site = Site.objects.get_current()
+            model_kwargs["default_headers"] = {
+                "HTTP-Referer": get_server_root(),
+                "X-Title": site.name,
+            }
+        return model_kwargs
+
+
 class OpenAILlmService(OpenAIGenericService):
     openai_api_base: str | None = None
     openai_organization: str | None = None

--- a/apps/service_providers/llm_service/main.py
+++ b/apps/service_providers/llm_service/main.py
@@ -187,6 +187,10 @@ class LlmService(pydantic.BaseModel):
 class OpenAIGenericService(LlmService):
     openai_api_key: str
     openai_api_base: str
+    # Extra HTTP headers forwarded verbatim to every request.
+    # Used by OpenRouter to carry attribution headers (HTTP-Referer / X-Title);
+    # None for all other generic providers so ChatOpenAI uses its own defaults.
+    default_headers: dict[str, str] | None = None
     # Subclasses can override this to enable the OpenAI Responses API.
     # Generic OpenAI-compatible providers (e.g. Groq, Perplexity) do not support it.
     _use_responses_api: ClassVar[bool] = False
@@ -217,7 +221,10 @@ class OpenAIGenericService(LlmService):
         if effort := kwargs.pop("effort", None):
             kwargs["reasoning"] = {"effort": effort}
 
-        return {"openai_api_key": self.openai_api_key, "openai_api_base": self.openai_api_base, **kwargs}
+        model_kwargs = {"openai_api_key": self.openai_api_key, "openai_api_base": self.openai_api_base, **kwargs}
+        if self.default_headers:
+            model_kwargs["default_headers"] = self.default_headers
+        return model_kwargs
 
     def attach_built_in_tools(self, built_in_tools: list[str], config: dict[str, BaseModel] | None = None) -> list:
         return []

--- a/apps/service_providers/models.py
+++ b/apps/service_providers/models.py
@@ -77,6 +77,7 @@ class LlmProviderTypes(LlmProviderType, Enum):
     anthropic = "anthropic", _("Anthropic")
     groq = "groq", _("Groq"), {"openai_api_base": "https://api.groq.com/openai/v1/"}
     perplexity = "perplexity", _("Perplexity"), {"openai_api_base": "https://api.perplexity.ai/"}
+    openrouter = "openrouter", _("OpenRouter"), {"openai_api_base": "https://openrouter.ai/api/v1"}
     deepseek = "deepseek", _("DeepSeek"), {"deepseek_api_base": "https://api.deepseek.com/v1/"}
     minimax = "minimax", _("MiniMax"), {"openai_api_base": "https://api.minimax.io/v1"}
     litellm = "litellm", _("LiteLLM")
@@ -122,7 +123,12 @@ class LlmProviderTypes(LlmProviderType, Enum):
                 return forms.AzureOpenAIConfigForm
             case LlmProviderTypes.anthropic:
                 return forms.AnthropicConfigForm
-            case LlmProviderTypes.groq | LlmProviderTypes.perplexity | LlmProviderTypes.minimax:
+            case (
+                LlmProviderTypes.groq
+                | LlmProviderTypes.perplexity
+                | LlmProviderTypes.minimax
+                | LlmProviderTypes.openrouter
+            ):
                 return forms.OpenAIGenericConfigForm
             case LlmProviderTypes.litellm:
                 return forms.LiteLLMConfigForm
@@ -161,7 +167,12 @@ class LlmProviderTypes(LlmProviderType, Enum):
                 return llm_service.AzureLlmService(**config)
             case LlmProviderTypes.anthropic:
                 return llm_service.AnthropicLlmService(**config)
-            case LlmProviderTypes.groq | LlmProviderTypes.perplexity | LlmProviderTypes.minimax:
+            case (
+                LlmProviderTypes.groq
+                | LlmProviderTypes.perplexity
+                | LlmProviderTypes.minimax
+                | LlmProviderTypes.openrouter
+            ):
                 return llm_service.OpenAIGenericService(**config)
             case LlmProviderTypes.litellm:
                 return llm_service.OpenAIGenericService(**config)

--- a/apps/service_providers/models.py
+++ b/apps/service_providers/models.py
@@ -171,9 +171,10 @@ class LlmProviderTypes(LlmProviderType, Enum):
                 LlmProviderTypes.groq
                 | LlmProviderTypes.perplexity
                 | LlmProviderTypes.minimax
-                | LlmProviderTypes.openrouter
             ):
                 return llm_service.OpenAIGenericService(**config)
+            case LlmProviderTypes.openrouter:
+                return llm_service.OpenRouterLlmService(**config)
             case LlmProviderTypes.litellm:
                 return llm_service.OpenAIGenericService(**config)
             case LlmProviderTypes.deepseek:

--- a/apps/service_providers/tests/test_llm_credentials.py
+++ b/apps/service_providers/tests/test_llm_credentials.py
@@ -140,7 +140,13 @@ def test_openrouter_minimal_config(clean_env):
     clean_env.setenv("OPENROUTER_API_KEY", "or-test")
     creds = get_provider_credentials_for_type(LlmProviderTypes.openrouter)
     assert creds is not None
-    assert creds.config == {"openai_api_key": "or-test"}
+    assert creds.config == {
+        "openai_api_key": "or-test",
+        "default_headers": {
+            "HTTP-Referer": "https://github.com/dimagi/open-chat-studio",
+            "X-Title": "Open Chat Studio",
+        },
+    }
 
 
 

--- a/apps/service_providers/tests/test_llm_credentials.py
+++ b/apps/service_providers/tests/test_llm_credentials.py
@@ -24,6 +24,7 @@ _PROVIDER_VARS = [
     "AZURE_OPENAI_API_VERSION",
     "GROQ_API_KEY",
     "PERPLEXITY_API_KEY",
+    "OPENROUTER_API_KEY",
     "MINIMAX_API_KEY",
     "LITELLM_API_KEY",
     "LITELLM_API_BASE",
@@ -133,6 +134,14 @@ def test_litellm_normalizes_base_url_with_trailing_slash_and_v1(clean_env):
     creds = get_provider_credentials_for_type(LlmProviderTypes.litellm)
     assert creds is not None
     assert creds.config["openai_api_base"] == "https://proxy.example.com/v1"
+
+
+def test_openrouter_minimal_config(clean_env):
+    clean_env.setenv("OPENROUTER_API_KEY", "or-test")
+    creds = get_provider_credentials_for_type(LlmProviderTypes.openrouter)
+    assert creds is not None
+    assert creds.config == {"openai_api_key": "or-test"}
+
 
 
 def test_returns_one_entry_per_configured_provider(clean_env):

--- a/apps/service_providers/tests/test_llm_credentials.py
+++ b/apps/service_providers/tests/test_llm_credentials.py
@@ -1,5 +1,4 @@
 import json
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -138,20 +137,12 @@ def test_litellm_normalizes_base_url_with_trailing_slash_and_v1(clean_env):
 
 
 def test_openrouter_minimal_config(clean_env):
-    """HTTP-Referer and X-Title must come from the site config, not env vars."""
+    """Credentials loader returns only the API key; attribution headers are
+    injected by OpenRouterLlmService._get_model_kwargs at request time."""
     clean_env.setenv("OPENROUTER_API_KEY", "or-test")
-    mock_site = MagicMock()
-    mock_site.name = "My OCS Instance"
-    with (
-        patch("apps.web.meta.get_server_root", return_value="https://example.com"),
-        patch("django.contrib.sites.models.Site.objects.get_current", return_value=mock_site),
-    ):
-        creds = get_provider_credentials_for_type(LlmProviderTypes.openrouter)
+    creds = get_provider_credentials_for_type(LlmProviderTypes.openrouter)
     assert creds is not None
-    assert creds.config["openai_api_key"] == "or-test"
-    assert creds.config["default_headers"]["HTTP-Referer"] == "https://example.com"
-    assert creds.config["default_headers"]["X-Title"] == "My OCS Instance"
-
+    assert creds.config == {"openai_api_key": "or-test"}
 
 
 def test_returns_one_entry_per_configured_provider(clean_env):

--- a/apps/service_providers/tests/test_llm_credentials.py
+++ b/apps/service_providers/tests/test_llm_credentials.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -137,16 +138,19 @@ def test_litellm_normalizes_base_url_with_trailing_slash_and_v1(clean_env):
 
 
 def test_openrouter_minimal_config(clean_env):
+    """HTTP-Referer and X-Title must come from the site config, not env vars."""
     clean_env.setenv("OPENROUTER_API_KEY", "or-test")
-    creds = get_provider_credentials_for_type(LlmProviderTypes.openrouter)
+    mock_site = MagicMock()
+    mock_site.name = "My OCS Instance"
+    with (
+        patch("apps.web.meta.get_server_root", return_value="https://example.com"),
+        patch("django.contrib.sites.models.Site.objects.get_current", return_value=mock_site),
+    ):
+        creds = get_provider_credentials_for_type(LlmProviderTypes.openrouter)
     assert creds is not None
-    assert creds.config == {
-        "openai_api_key": "or-test",
-        "default_headers": {
-            "HTTP-Referer": "https://github.com/dimagi/open-chat-studio",
-            "X-Title": "Open Chat Studio",
-        },
-    }
+    assert creds.config["openai_api_key"] == "or-test"
+    assert creds.config["default_headers"]["HTTP-Referer"] == "https://example.com"
+    assert creds.config["default_headers"]["X-Title"] == "My OCS Instance"
 
 
 

--- a/apps/service_providers/tests/test_llm_service.py
+++ b/apps/service_providers/tests/test_llm_service.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 from langchain_core.messages import HumanMessage
 
@@ -5,6 +7,7 @@ from apps.service_providers.llm_service import (
     AnthropicLlmService,
     AzureLlmService,
     OpenAILlmService,
+    OpenRouterLlmService,
     VoyageAILlmService,
 )
 from apps.service_providers.llm_service.index_managers import VoyageAILocalIndexManager
@@ -53,7 +56,6 @@ def test_openai_service_uses_responses_api():
     [
         (LlmProviderTypes.groq, {"openai_api_key": "test"}),
         (LlmProviderTypes.perplexity, {"openai_api_key": "test"}),
-        pytest.param(LlmProviderTypes.openrouter, {"openai_api_key": "test"}, id="openrouter"),
         (LlmProviderTypes.minimax, {"openai_api_key": "test"}),
         (LlmProviderTypes.litellm, {"openai_api_key": "test", "openai_api_base": "https://proxy.example.com/v1"}),
     ],
@@ -95,15 +97,28 @@ def test_litellm_is_openai_compatible_chat_provider():
 
 
 def test_openrouter_is_openai_compatible_chat_provider():
-    """OpenRouter exposes an OpenAI-compatible chat endpoint, so it is routed through
-    OpenAIGenericService (like Groq/Perplexity) with the OpenRouter base URL and must
-    not use the OpenAI-specific Responses API."""
+    """OpenRouter is routed through OpenRouterLlmService (a subclass of
+    OpenAIGenericService) with the OpenRouter base URL and must not use
+    the OpenAI-specific Responses API."""
     assert LlmProviderTypes.openrouter.additional_config["openai_api_base"] == "https://openrouter.ai/api/v1"
     service = LlmProviderTypes.openrouter.get_llm_service({"openai_api_key": "test"})
+    assert isinstance(service, OpenRouterLlmService)
     assert isinstance(service, OpenAIGenericService)
     assert service._type == "openrouter"
     assert service._use_responses_api is False
 
+
+def test_openrouter_does_not_use_responses_api():
+    """Regression guard: OpenRouter must not use the OpenAI Responses API."""
+    mock_site = MagicMock(name="test-site", domain="example.com")
+    mock_site.name = "Test OCS"
+    with (
+        patch("apps.web.meta.get_server_root", return_value="https://example.com"),
+        patch("django.contrib.sites.models.Site.objects.get_current", return_value=mock_site),
+    ):
+        service = LlmProviderTypes.openrouter.get_llm_service({"openai_api_key": "test"})
+        llm = service.get_chat_model("some-model")
+    assert llm.use_responses_api is False
 
 
 def test_voyage_ai_service():
@@ -130,7 +145,6 @@ def test_voyage_ai_service_returns_local_index_manager():
         ),
         pytest.param(LlmProviderTypes.groq, {"openai_api_key": "test"}, "groq", id="groq"),
         pytest.param(LlmProviderTypes.perplexity, {"openai_api_key": "test"}, "perplexity", id="perplexity"),
-        pytest.param(LlmProviderTypes.openrouter, {"openai_api_key": "test"}, "openrouter", id="openrouter"),
         pytest.param(LlmProviderTypes.minimax, {"openai_api_key": "test"}, "minimax", id="minimax"),
         pytest.param(
             LlmProviderTypes.litellm,
@@ -181,15 +195,36 @@ def test_non_anthropic_services_have_no_prompt_caching_middleware(service):
     assert service.get_prompt_caching_middleware() is None
 
 
-def test_openrouter_attribution_headers_forwarded_to_chat_model():
-    """OpenRouter requires HTTP-Referer and X-Title headers for attribution.
+def test_openrouter_attribution_headers_injected_from_site():
+    """OpenRouterLlmService must populate HTTP-Referer and X-Title automatically
+    from the Django Site object — with no caller involvement.
 
-    Verify that headers stored in ``default_headers`` on the service are
-    forwarded verbatim to the constructed ``ChatOpenAI`` client so they
-    appear on every outgoing request.
+    This is the fix for the bug snopoke identified: previously headers were only
+    set in the bootstrap_data credential loader, so providers created via the UI
+    or API never sent attribution headers to OpenRouter.
     """
-    headers = {"HTTP-Referer": "https://example.com", "X-Title": "Test App"}
-    service = LlmProviderTypes.openrouter.get_llm_service({"openai_api_key": "test", "default_headers": headers})
-    assert service.default_headers == headers
+    mock_site = MagicMock()
+    mock_site.name = "My OCS Instance"
+    with (
+        patch("apps.web.meta.get_server_root", return_value="https://example.com"),
+        patch("django.contrib.sites.models.Site.objects.get_current", return_value=mock_site),
+    ):
+        service = LlmProviderTypes.openrouter.get_llm_service({"openai_api_key": "test"})
+        chat_model = service.get_chat_model("openai/gpt-4.1-mini")
+    assert chat_model.default_headers["HTTP-Referer"] == "https://example.com"
+    assert chat_model.default_headers["X-Title"] == "My OCS Instance"
+
+
+def test_openrouter_caller_supplied_headers_not_overridden():
+    """If default_headers are stored on the service (e.g. legacy config rows),
+    _get_model_kwargs must pass them through unchanged and not hit Site."""
+    custom_headers = {"HTTP-Referer": "https://custom.example.com", "X-Title": "Custom"}
+    service = OpenRouterLlmService(
+        openai_api_key="test",
+        openai_api_base="https://openrouter.ai/api/v1",
+        default_headers=custom_headers,
+    )
+    # No Site.objects call expected — if it were made, it would raise since
+    # there is no DB connection in this test.
     chat_model = service.get_chat_model("openai/gpt-4.1-mini")
-    assert chat_model.default_headers == headers
+    assert chat_model.default_headers == custom_headers

--- a/apps/service_providers/tests/test_llm_service.py
+++ b/apps/service_providers/tests/test_llm_service.py
@@ -53,7 +53,7 @@ def test_openai_service_uses_responses_api():
     [
         (LlmProviderTypes.groq, {"openai_api_key": "test"}),
         (LlmProviderTypes.perplexity, {"openai_api_key": "test"}),
-        (LlmProviderTypes.openrouter, {"openai_api_key": "test"}),
+        pytest.param(LlmProviderTypes.openrouter, {"openai_api_key": "test"}, id="openrouter"),
         (LlmProviderTypes.minimax, {"openai_api_key": "test"}),
         (LlmProviderTypes.litellm, {"openai_api_key": "test", "openai_api_base": "https://proxy.example.com/v1"}),
     ],
@@ -179,3 +179,17 @@ def test_anthropic_service_returns_prompt_caching_middleware():
 )
 def test_non_anthropic_services_have_no_prompt_caching_middleware(service):
     assert service.get_prompt_caching_middleware() is None
+
+
+def test_openrouter_attribution_headers_forwarded_to_chat_model():
+    """OpenRouter requires HTTP-Referer and X-Title headers for attribution.
+
+    Verify that headers stored in ``default_headers`` on the service are
+    forwarded verbatim to the constructed ``ChatOpenAI`` client so they
+    appear on every outgoing request.
+    """
+    headers = {"HTTP-Referer": "https://example.com", "X-Title": "Test App"}
+    service = LlmProviderTypes.openrouter.get_llm_service({"openai_api_key": "test", "default_headers": headers})
+    assert service.default_headers == headers
+    chat_model = service.get_chat_model("openai/gpt-4.1-mini")
+    assert chat_model.default_headers == headers

--- a/apps/service_providers/tests/test_llm_service.py
+++ b/apps/service_providers/tests/test_llm_service.py
@@ -53,6 +53,7 @@ def test_openai_service_uses_responses_api():
     [
         (LlmProviderTypes.groq, {"openai_api_key": "test"}),
         (LlmProviderTypes.perplexity, {"openai_api_key": "test"}),
+        (LlmProviderTypes.openrouter, {"openai_api_key": "test"}),
         (LlmProviderTypes.minimax, {"openai_api_key": "test"}),
         (LlmProviderTypes.litellm, {"openai_api_key": "test", "openai_api_base": "https://proxy.example.com/v1"}),
     ],
@@ -93,6 +94,18 @@ def test_litellm_is_openai_compatible_chat_provider():
     assert service.openai_api_base == "https://proxy.example.com/v1"
 
 
+def test_openrouter_is_openai_compatible_chat_provider():
+    """OpenRouter exposes an OpenAI-compatible chat endpoint, so it is routed through
+    OpenAIGenericService (like Groq/Perplexity) with the OpenRouter base URL and must
+    not use the OpenAI-specific Responses API."""
+    assert LlmProviderTypes.openrouter.additional_config["openai_api_base"] == "https://openrouter.ai/api/v1"
+    service = LlmProviderTypes.openrouter.get_llm_service({"openai_api_key": "test"})
+    assert isinstance(service, OpenAIGenericService)
+    assert service._type == "openrouter"
+    assert service._use_responses_api is False
+
+
+
 def test_voyage_ai_service():
     service = LlmProviderTypes.voyage.get_llm_service({"voyage_api_key": "test"})
     assert isinstance(service, VoyageAILlmService)
@@ -117,6 +130,7 @@ def test_voyage_ai_service_returns_local_index_manager():
         ),
         pytest.param(LlmProviderTypes.groq, {"openai_api_key": "test"}, "groq", id="groq"),
         pytest.param(LlmProviderTypes.perplexity, {"openai_api_key": "test"}, "perplexity", id="perplexity"),
+        pytest.param(LlmProviderTypes.openrouter, {"openai_api_key": "test"}, "openrouter", id="openrouter"),
         pytest.param(LlmProviderTypes.minimax, {"openai_api_key": "test"}, "minimax", id="minimax"),
         pytest.param(
             LlmProviderTypes.litellm,


### PR DESCRIPTION
### Product Description
Adds OpenRouter as an LLM provider option. It's an aggregator that gives access to a ton of models (OpenAI, Anthropic, Meta, Google, DeepSeek, etc.) through one OpenAI-compatible API and one key. Closes #4077.

### Technical Description
OpenRouter only supports the OpenAI chat-completions API (no Responses API), so this just reuses the same path we already have for Groq/Perplexity/MiniMax:

- New `LlmProviderTypes.openrouter` in `apps/service_providers/models.py`, wired to `OpenAIGenericConfigForm`/`OpenAIGenericService` with `openai_api_base=https://openrouter.ai/api/v1`.
- A handful of default models seeded so you can pick one right away (`openai/gpt-4.1-mini` default, `anthropic/claude-sonnet-4.6` translation default).
- `_openrouter()` env loader for `OPENROUTER_API_KEY`, added to `.env.example`.
- No migration (choices don't touch the schema). Tests cover provider tagging, routing/base URL, and credential loading.

One honest caveat: going through **LiteLLM** would probably be the "right" long-term answer since it'd cover OpenRouter plus many more providers uniformly — but it's a much bigger refactor and #4078 is tracking it separately. I'd rather land this small, working OpenRouter integration now and treat LiteLLM as the follow-up.

### Migrations
None.

### Demo
Picked OpenRouter in the add-provider dropdown, added an API key, and it answered a chat message (tested against a local deployment).

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Changelog: new LLM provider type. Refs #4078 for the future LiteLLM work.