### PR TITLE
PythonNode sandbox: security assessment + hardening fixes

### DIFF
--- a/apps/pipelines/nodes/nodes.py
+++ b/apps/pipelines/nodes/nodes.py
@@ -1125,6 +1125,12 @@ class CodeNode(PipelineNode, OutputMessageTagMixin, RestrictedPythonExecutionMix
         def set_session_state_key(key_name: str, value):
             """Sets the value of the session state's key with the given name to the provided data.
             This will override any existing data."""
+            # Enforce reserved keys at runtime. The ``check_reserved_session_state_keys``
+            # source validator only inspects literal calls, so aliasing, computed keys or
+            # star/kwargs unpacking would otherwise bypass it and write reserved keys such
+            # as ``remote_context``, which are populated with trusted server-side context.
+            if key_name in settings.RESERVED_SESSION_STATE_KEYS:
+                raise CodeNodeRunError(f"The key '{key_name}' is a reserved session state key and is read-only.")
             session_state = state.setdefault("session_state", {})
             session_state[key_name] = value
 

--- a/apps/pipelines/tests/test_code_node.py
+++ b/apps/pipelines/tests/test_code_node.py
@@ -599,3 +599,91 @@ def main(input, **kwargs):
     )
     with pytest.raises(CodeNodeRunError, match="'content' must be bytes"):
         node._process(state, NodeContext(state))
+
+
+def _run_sandbox(code, state=None):
+    node = CodeNode(name="test", node_id="123", django_node=None, code=code)
+    node._repo = InMemoryPipelineRepository()
+    if state is None:
+        state = PipelineState(outputs={}, experiment_session=None, last_node_input="hi", node_inputs=["hi"])
+    return node._process(state, NodeContext(state))
+
+
+class TestSandboxHardening:
+    """Regression tests for the RestrictedPython sandbox hardening.
+
+    See docs/developer_guides/security/pythonnode_sandbox_assessment.md.
+    """
+
+    def test_cannot_poison_shared_module_attribute(self):
+        """Assigning to an attribute of an injected module singleton must be blocked.
+
+        Otherwise a node could do ``json.dumps = evil`` and corrupt the shared module
+        for every other execution on the worker process.
+        """
+        code = """
+def main(input, **kwargs):
+    json.dumps = lambda *a, **k: "PWNED"
+    return "patched"
+"""
+        with pytest.raises(CodeNodeRunError):
+            _run_sandbox(code)
+
+    def test_shared_module_not_poisoned_across_executions(self):
+        """A poisoning attempt in one execution must not affect a later execution."""
+        poison = """
+def main(input, **kwargs):
+    json.dumps = lambda *a, **k: "PWNED"
+    return "patched"
+"""
+        with pytest.raises(CodeNodeRunError):
+            _run_sandbox(poison)
+
+        # A subsequent, independent execution must still see a clean json.dumps.
+        use_json = """
+def main(input, **kwargs):
+    return json.dumps({"safe": 1})
+"""
+        output = _run_sandbox(use_json)
+        assert output.update["messages"][-1] == '{"safe": 1}'  # ty: ignore[not-subscriptable]
+
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            pytest.param("def main(input, **kwargs):\n\tx = 1\n\tx += 4\n\treturn str(x)", "5", id="int-iadd"),
+            pytest.param("def main(input, **kwargs):\n\tx = 10\n\tx -= 3\n\treturn str(x)", "7", id="int-isub"),
+            pytest.param("def main(input, **kwargs):\n\tx = 2\n\tx *= 5\n\treturn str(x)", "10", id="int-imul"),
+            pytest.param(
+                "def main(input, **kwargs):\n\txs = [1]\n\txs += [2, 3]\n\treturn str(xs)",
+                "[1, 2, 3]",
+                id="list-iadd",
+            ),
+        ],
+    )
+    def test_augmented_assignment_supported(self, code, expected):
+        """``_inplacevar_`` must make augmented assignment on names work again."""
+        output = _run_sandbox(code)
+        assert output.update["messages"][-1] == expected  # ty: ignore[not-subscriptable]
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            # These forms all evade the source-regex validator but still reach the runtime,
+            # where the reserved-key check must reject them.
+            pytest.param('f = set_session_state_key\n    f("remote_context", "x")', id="aliased"),
+            pytest.param('k = "remote_" + "context"\n    set_session_state_key(k, "x")', id="computed-key"),
+            pytest.param('set_session_state_key("remote_" "context", "x")', id="literal-concat"),
+        ],
+    )
+    def test_reserved_session_state_key_enforced_at_runtime(self, body):
+        """Reserved keys must be rejected at runtime even when the source validator is bypassed."""
+        code = f"def main(input, **kwargs):\n    {body}\n    return input"
+        state = PipelineState(
+            outputs={},
+            experiment_session=ExperimentSessionFactory.build(),
+            last_node_input="hi",
+            node_inputs=["hi"],
+            session_state={},
+        )
+        with pytest.raises(CodeNodeRunError, match="reserved session state key"):
+            _run_sandbox(code, state=state)

--- a/apps/pipelines/tests/test_code_node.py
+++ b/apps/pipelines/tests/test_code_node.py
@@ -629,6 +629,41 @@ def main(input, **kwargs):
         with pytest.raises(CodeNodeRunError):
             _run_sandbox(code)
 
+    def test_can_write_attributes_on_per_execution_objects(self):
+        """Writing an attribute on a per-execution object (e.g. an Attachment) must work.
+
+        The write guard only blocks shared/process-global objects (modules, types); it
+        must not block mutation of ordinary data objects handed to node code.
+        """
+        attachment = Attachment(
+            file_id=1, type="code_interpreter", name="a.txt", size=1, content_type="text/plain", download_link=""
+        )
+        code = """
+def main(input, **kwargs):
+    for att in get_temp_state_key("attachments"):
+        att.send_to_llm = False
+    return str([att.send_to_llm for att in get_temp_state_key("attachments")])
+"""
+        state = PipelineState(
+            outputs={},
+            experiment_session=ExperimentSessionFactory.build(),
+            last_node_input="hi",
+            node_inputs=["hi"],
+            temp_state={"attachments": [attachment]},
+        )
+        output = _run_sandbox(code, state=state)
+        assert output.update["messages"][-1] == "[False]"
+
+    def test_cannot_write_attributes_on_shared_types(self):
+        """Writing an attribute on a class/type (shared, process-global) must be blocked."""
+        code = """
+def main(input, **kwargs):
+    dict.injected = 1
+    return "patched"
+"""
+        with pytest.raises(CodeNodeRunError):
+            _run_sandbox(code)
+
     def test_shared_module_not_poisoned_across_executions(self):
         """A poisoning attempt in one execution must not affect a later execution."""
         poison = """

--- a/apps/pipelines/tests/test_code_node.py
+++ b/apps/pipelines/tests/test_code_node.py
@@ -645,7 +645,7 @@ def main(input, **kwargs):
     return json.dumps({"safe": 1})
 """
         output = _run_sandbox(use_json)
-        assert output.update["messages"][-1] == '{"safe": 1}'  # ty: ignore[not-subscriptable]
+        assert output.update["messages"][-1] == '{"safe": 1}'
 
     @pytest.mark.parametrize(
         ("code", "expected"),
@@ -663,7 +663,7 @@ def main(input, **kwargs):
     def test_augmented_assignment_supported(self, code, expected):
         """``_inplacevar_`` must make augmented assignment on names work again."""
         output = _run_sandbox(code)
-        assert output.update["messages"][-1] == expected  # ty: ignore[not-subscriptable]
+        assert output.update["messages"][-1] == expected
 
     @pytest.mark.parametrize(
         "body",

--- a/apps/utils/python_execution.py
+++ b/apps/utils/python_execution.py
@@ -8,6 +8,7 @@ import re
 import sys
 import time
 import traceback
+import types
 from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
@@ -51,6 +52,23 @@ def restricted_inplacevar(op: str, x: Any, y: Any) -> Any:
     except KeyError:
         raise SyntaxError(f"Augmented assignment operator {op!r} is not supported") from None
     return func(x, y)
+
+
+def restricted_write(obj: Any) -> Any:
+    """Write guard applied by RestrictedPython before attribute/item assignment.
+
+    RestrictedPython compiles ``obj.attr = x`` to ``_write_(obj).attr = x``. We block
+    writes to objects that are *shared across executions* or process-global — module
+    singletons (``json``, ``re``, ``datetime``, ...) and classes/types — because mutating
+    those (e.g. ``json.dumps = evil``) would persist and poison other pipeline executions
+    on the same worker process. Per-execution data objects (``dict``, ``list``, pydantic
+    models such as ``Attachment``, etc.) remain writable so legitimate node code keeps
+    working. Underscore-prefixed attribute names are already rejected at compile time.
+    """
+    if isinstance(obj, (types.ModuleType, type)):
+        # full_write_guard wraps the object so any attribute/item write raises.
+        return full_write_guard(obj)
+    return obj
 
 
 class RestrictedPythonExecutionMixin(BaseModel):
@@ -148,12 +166,11 @@ class RestrictedPythonExecutionMixin(BaseModel):
             "_getiter_": default_guarded_getiter,
             "_iter_unpack_sequence_": guarded_iter_unpack_sequence,
             "_unpack_sequence_": guarded_unpack_sequence,
-            # full_write_guard lets item assignment through on plain dict/list but wraps
-            # every other object so attribute/item writes raise. This prevents sandbox
-            # code from mutating shared objects such as the module singletons injected
-            # below (e.g. ``json.dumps = evil``), which would otherwise persist across
-            # executions on the same worker process.
-            "_write_": full_write_guard,
+            # restricted_write blocks writes to shared/process-global objects (module
+            # singletons injected below, and classes/types) so sandbox code cannot do
+            # e.g. ``json.dumps = evil`` and poison other executions on the same worker,
+            # while still allowing writes to per-execution data (dict, list, Attachment).
+            "_write_": restricted_write,
             "_inplacevar_": restricted_inplacevar,
         }
         return custom_globals

--- a/apps/utils/python_execution.py
+++ b/apps/utils/python_execution.py
@@ -2,6 +2,7 @@ import datetime
 import inspect
 import json
 import logging
+import operator
 import random
 import re
 import sys
@@ -14,9 +15,42 @@ from pydantic_core import PydanticCustomError
 from pydantic_core.core_schema import FieldValidationInfo
 from RestrictedPython import compile_restricted, limited_builtins, safe_builtins, utility_builtins
 from RestrictedPython.Eval import default_guarded_getitem, default_guarded_getiter
-from RestrictedPython.Guards import guarded_iter_unpack_sequence, guarded_unpack_sequence
+from RestrictedPython.Guards import full_write_guard, guarded_iter_unpack_sequence, guarded_unpack_sequence
 
 logger = logging.getLogger("ocs.utils")
+
+# Operators permitted for augmented assignment (``x += 1``). RestrictedPython rewrites
+# augmented assignment to ``_inplacevar_(op, x, y)`` but ships no implementation, so we
+# provide one that only dispatches to a fixed allowlist of in-place operators.
+_INPLACE_OPERATORS = {
+    "+=": operator.iadd,
+    "-=": operator.isub,
+    "*=": operator.imul,
+    "/=": operator.itruediv,
+    "//=": operator.ifloordiv,
+    "%=": operator.imod,
+    "**=": operator.ipow,
+    ">>=": operator.irshift,
+    "<<=": operator.ilshift,
+    "&=": operator.iand,
+    "^=": operator.ixor,
+    "|=": operator.ior,
+    "@=": operator.imatmul,
+}
+
+
+def restricted_inplacevar(op: str, x: Any, y: Any) -> Any:
+    """Implement augmented assignment (``x += y``) for the restricted sandbox.
+
+    RestrictedPython compiles ``x += y`` to ``_inplacevar_('+=', x, y)`` and expects the
+    execution environment to supply ``_inplacevar_``. We restrict it to a known set of
+    operators so sandbox code cannot smuggle arbitrary behaviour through this hook.
+    """
+    try:
+        func = _INPLACE_OPERATORS[op]
+    except KeyError:
+        raise SyntaxError(f"Augmented assignment operator {op!r} is not supported") from None
+    return func(x, y)
 
 
 class RestrictedPythonExecutionMixin(BaseModel):
@@ -114,7 +148,13 @@ class RestrictedPythonExecutionMixin(BaseModel):
             "_getiter_": default_guarded_getiter,
             "_iter_unpack_sequence_": guarded_iter_unpack_sequence,
             "_unpack_sequence_": guarded_unpack_sequence,
-            "_write_": lambda x: x,
+            # full_write_guard lets item assignment through on plain dict/list but wraps
+            # every other object so attribute/item writes raise. This prevents sandbox
+            # code from mutating shared objects such as the module singletons injected
+            # below (e.g. ``json.dumps = evil``), which would otherwise persist across
+            # executions on the same worker process.
+            "_write_": full_write_guard,
+            "_inplacevar_": restricted_inplacevar,
         }
         return custom_globals
 

--- a/docs/developer_guides/security/pythonnode_sandbox_assessment.md
+++ b/docs/developer_guides/security/pythonnode_sandbox_assessment.md
@@ -1,0 +1,270 @@
+# PythonNode Sandbox — Security Assessment
+
+**Date:** 2026-08-20
+**Component:** `CodeNode` (Python Node) — `apps/pipelines/nodes/nodes.py`
+**Sandbox engine:** `RestrictedPythonExecutionMixin` — `apps/utils/python_execution.py`
+**RestrictedPython version:** 8.1
+**Method:** The sandbox's globals/builtins construction was replicated faithfully and
+probed with ~60 escape, resource-exhaustion, and state-tampering test cases. Findings
+below were confirmed by execution against RestrictedPython 8.1; the runtime wiring was
+verified by reading the production code paths.
+
+> **Scope note.** This is a defensive assessment of our own sandbox. It documents
+> where the isolation boundary holds and where it leaks, with reproductions and
+> remediations. No fixes are applied in this document.
+
+---
+
+## Executive summary
+
+The RestrictedPython layer is doing its core job well: arbitrary code execution,
+filesystem access, arbitrary imports, `eval`/`exec`, and the classic
+`__class__ → __subclasses__` breakout chains are all **blocked** (mostly at compile
+time). We found **no way to execute arbitrary native code or read the filesystem** from
+inside the node.
+
+However, the sandbox is **language-level only** — there is no process, container, or
+syscall isolation around it, and no CPU/memory/wall-clock budget. That leaves three
+categories of real weakness:
+
+| # | Finding | Class | Severity | Confirmed |
+|---|---------|-------|----------|-----------|
+| 1 | Shared module singletons (`json`, `re`, `datetime`, `time`, `random`, `math`, `string`) are mutable and poisonable across executions | Cross-tenant integrity / info-leak | **High** | ✅ |
+| 2 | No CPU / memory / wall-clock limit on node execution | Denial of service | **High** | ✅ |
+| 3 | SSRF URL validation is not IP-pinned → DNS-rebinding window | SSRF | **Medium** | ✅ (by inspection) |
+| 4 | Reserved-session-key protection is a source-regex, trivially bypassed and not enforced at runtime | Integrity (weak control) | **Low–Medium** | ✅ |
+| 5 | `_write_` guard is a no-op (`lambda x: x`) — the root cause enabling #1 | Hardening gap | (root cause of #1) | ✅ |
+| 6 | Usability bugs: augmented assignment (`+=`) and `class` definitions are broken | Correctness / UX | Low | ✅ |
+
+The single most important finding is **#1**: one malicious or buggy Python node in *any*
+tenant's pipeline can silently corrupt shared Python modules for *every other* pipeline
+execution running on the same Celery worker process, until that worker restarts.
+
+---
+
+## What the sandbox blocks (the good news)
+
+All of the following were **blocked** (compile-time `SyntaxError` unless noted):
+
+- `import os` / any module outside `{json, re, datetime, time, random}` → `ImportError` at runtime via `guarded_import`.
+- `__import__(...)`, and any name/attribute starting with `_` → compile error ("invalid ... because it starts with `_`"). This kills the whole dunder-walk family: `().__class__.__bases__[0].__subclasses__()`, `main.__globals__`, `x.__init__.__globals__`, `json.__loader__`, etc.
+- `eval(...)`, `exec(...)`, `compile(...)`, `open(...)`, `globals()`, `vars()`, `getattr(...)`, `type(...)`, `breakpoint(...)` → blocked (compile error or `NameError`).
+- `"{0.__class__}".format(x)` → `NotImplementedError` (RestrictedPython blocks `str.format`).
+- `class Foo: ...` → blocked (`__metaclass__` not defined). *(This is also a usability bug — see #6.)*
+- Attribute reads are additionally guarded at **runtime** by `safer_getattr` (present as `_getattr_` inside the builtins), so dunder access is blocked even when it slips past the compiler.
+- `setattr`/`delattr` are the guarded RestrictedPython variants and refuse underscore-prefixed attributes.
+
+The exposed attack surface is a small, curated builtin set (99 names, mostly exception
+types and safe scalars/containers), plus five stdlib modules and the injected helper
+functions (`http`, `get/set_*_state_key`, participant-data helpers, etc.).
+
+---
+
+## Finding 1 — Shared module singletons are poisonable across executions (High)
+
+### Root cause
+`_get_custom_globals()` injects the **actual imported module objects** into every
+execution:
+
+```python
+# apps/utils/python_execution.py
+custom_globals = {
+    "__builtins__": cls._get_custom_builtins(),
+    "json": json, "re": re, "datetime": datetime, "time": time, "random": random,
+    ...
+    "_write_": lambda x: x,   # <-- no-op write guard (Finding 5)
+}
+```
+
+These are process-global singletons. Because `_write_` is a no-op, RestrictedPython's
+attribute-write guard does nothing, so `json.dumps = evil` (a non-underscore attribute
+write) **succeeds** and mutates the shared module object for the whole worker process.
+`utility_builtins` similarly shares `math`, `string`, `random`, `whrandom`.
+
+### Reproduction
+Execution A (tenant X's pipeline):
+```python
+def main(input, **kwargs):
+    def evil(*a, **k):
+        return "PWNED-BY-TENANT-A"
+    json.dumps = evil          # non-underscore attr write, not guarded
+    return "patched"
+```
+Execution B (a *completely separate* pipeline run, fresh globals dict):
+```python
+def main(input, **kwargs):
+    return json.dumps({"safe": 1})
+```
+**Observed:** Execution B returns `"PWNED-BY-TENANT-A"`. The same holds for
+`datetime.MINYEAR = 9999`, `time.sleep = lambda *a: None`, etc.
+
+### Impact
+Celery prefork workers are long-lived and process tasks sequentially, so a poisoned
+module persists across tasks and **across tenants** on that worker until it restarts.
+An attacker can:
+- **Break availability/integrity** for every other pipeline on the worker (corrupt
+  `json`/`datetime`/`re` output).
+- **Exfiltrate data** — a patched `json.dumps`/`json.loads` can capture and stash (e.g.
+  via the exposed `http` client on the next invocation, or into shared module state)
+  every payload other pipelines serialize, including other tenants' data.
+
+This is not a RestrictedPython bug — it is a wiring choice in our harness (sharing live
+singletons + a disabled write guard).
+
+### Remediation
+- Set a real write guard: `"_write_": full_write_guard` (from `RestrictedPython.Guards`),
+  which returns objects that block attribute/item writes on guarded types.
+- Do **not** hand live module singletons to sandboxed code. Expose read-only façades /
+  a curated `SimpleNamespace` of the specific functions needed (e.g. `json.dumps`,
+  `json.loads`) rather than the module object, so attribute assignment can't reach the
+  shared singleton.
+- Add a regression test asserting that mutating an exposed module in one execution does
+  not affect a subsequent execution.
+
+---
+
+## Finding 2 — No CPU / memory / time budget (High)
+
+### Details
+`compile_and_execute_code` calls the user's `main()` directly with no timeout, and there
+is **no** `CELERY_TASK_TIME_LIMIT` / `CELERY_TASK_SOFT_TIME_LIMIT` configured
+(`config/settings.py`) and no per-node watchdog. RestrictedPython caps `range()` to 1000
+elements (`limited_range`) but does not limit loop iterations, string/list
+multiplication, or allocations.
+
+### Reproductions (all confirmed)
+- **CPU:** `while True: x = x + 1` runs unbounded (killed only by an external timeout).
+- **Memory:** `"a" * (50 * 1024 * 1024)` and `[0] * 5_000_000` allocate freely — no
+  memory ceiling; scale up for OOM.
+- **Blocking:** `time.sleep(...)` is available and blocks the worker; combined with the
+  HTTP client (up to 10 requests, each up to a 60s timeout) a node can tie up a worker
+  for minutes per message.
+
+### Impact
+Any user who can author a pipeline can wedge or OOM a shared Celery worker, degrading
+service for all tenants on that worker. `range()` clamping gives a false sense of a
+resource limit that loops/allocations bypass entirely.
+
+### Remediation
+- Set Celery `task_time_limit` / `task_soft_time_limit` for the pipeline/chat queue as a
+  backstop (kills the whole task — coarse but effective).
+- Prefer a per-node budget: run node code in a child process with `resource.setrlimit`
+  (RLIMIT_CPU, RLIMIT_AS) and a wall-clock kill, or an execution-count/instruction guard.
+- Consider removing or capping `time.sleep` for sandboxed code.
+
+---
+
+## Finding 3 — SSRF validation is not IP-pinned (DNS rebinding) (Medium)
+
+### Details
+`RestrictedHttpClient._validate_url` calls `validate_user_input_url`, which resolves the
+hostname and checks every IP is global/public (`apps/utils/urlvalidate.py`). But the
+request itself (`_do_request` → `httpx.Client().stream(...)`) connects **by hostname**
+and performs an **independent second DNS resolution**. The validated IPs are never
+pinned for the actual connection. Additionally, `_validated_hosts` caches by
+`(hostname, port)` and skips validation on subsequent requests to the same host within
+an execution.
+
+### Impact
+A **DNS-rebinding** attacker (low-TTL record they control) can pass validation with a
+public IP, then have httpx resolve the same host to an internal address
+(`169.254.169.254` cloud metadata, `127.0.0.1`, RFC1918) at connection time. In
+production `strict=not settings.DEBUG` is `True`, so HTTP and literal internal IPs are
+blocked and redirects are disabled (`follow_redirects=False`) — good — but the rebinding
+window remains. (In `DEBUG`, `strict=False` disables the IP checks entirely — dev only.)
+
+### Remediation
+- Resolve the host once, validate the resolved IP, then connect to **that IP** (pin it)
+  with the original `Host` header preserved — e.g. a custom httpx transport / resolver,
+  or pass the validated IP as the connect target. This closes the TOCTOU between
+  validation and connection.
+- Re-validate on every request rather than trusting the `(hostname, port)` cache, or key
+  the cache on the resolved IP.
+
+---
+
+## Finding 4 — Reserved-session-key control is source-regex only (Low–Medium)
+
+### Details
+`CodeNode.check_reserved_session_state_keys` blocks reserved keys
+(`user_input`, `outputs`, `attachments`, `remote_context`) by regex-matching the **source
+text** for `set_session_state_key("<key>"...`. The **runtime** `set_session_state_key`
+(`_set_session_state_key`) performs **no** reserved-key check — it writes the key
+unconditionally.
+
+### Reproductions (all bypass the validator)
+```python
+f = set_session_state_key; f("remote_context", 1)          # alias
+k = "remote_" + "context"; set_session_state_key(k, 1)      # computed key
+set_session_state_key(*["remote_context", 1])               # star-args
+set_session_state_key(**{"key_name": "remote_context", "value": 1})  # kwargs
+set_session_state_key("remote_" "context", 1)               # literal concat
+```
+
+### Impact
+`remote_context` is trusted context injected by the API caller (the page/action the user
+is on — `apps/experiments/tasks.py`, `apps/api/serializers.py`) and is intended to be
+read-only from within a pipeline. The bypass lets node code forge/overwrite it, so any
+downstream node that trusts `remote_context` can be fed attacker-chosen values. Impact is
+bounded to the session's own state (the pipeline author is often the same party), which
+is why this is Low–Medium rather than High — but the control as written is effectively
+security theatre.
+
+### Remediation
+Enforce reserved keys at **runtime** inside `_set_session_state_key` (and the
+`temp_state` equivalent), raising on a reserved key regardless of how the call is spelled.
+Keep the source regex only as an early-feedback nicety, not the security boundary.
+
+---
+
+## Finding 5 — `_write_` guard is a no-op (root cause of #1)
+
+`"_write_": lambda x: x` disables RestrictedPython's write-guard entirely. Effects
+observed:
+- `obj.public = 777` on any exposed object succeeds (underscore attrs still compile-block).
+- Enables the shared-module poisoning in Finding 1.
+
+Fix is covered under Finding 1 (use `full_write_guard`). Called out separately because it
+is the underlying mechanism and a one-line change closes the highest-impact vector.
+
+---
+
+## Finding 6 — Usability bugs (Low, correctness)
+
+These break legitimate user code and are worth fixing alongside the security work:
+
+- **Augmented assignment is entirely broken.** `x += 1`, `x -= 1`, `lst += [1]`, etc. all
+  raise `NameError: name '_inplacevar_' is not defined`, because the sandbox globals never
+  define `_inplacevar_`. Users must write `x = x + 1`. Fix: add
+  `"_inplacevar_": protected_inplacevar` (`RestrictedPython.Guards.guarded_inplacevar`,
+  or the library's `Guards.protected_inplacevar`) to the globals.
+- **`class` definitions fail** (`NameError: __metaclass__`). Nested classes are unusable.
+  This happens to close escape vectors, so if classes are intentionally disallowed it
+  should be a *clear, documented error*, not a confusing `__metaclass__` NameError.
+
+`while`/`for`, generators (`yield`), decorators, lambdas, comprehensions, walrus (`:=`),
+`try/except`, `assert`, `global`, and `del` all work as expected.
+
+---
+
+## Architectural observation
+
+The sandbox is **defense-in-depth of one layer**: RestrictedPython in-process, with no
+process/container/seccomp boundary (grep for `nsjail|gvisor|seccomp|subprocess ... python`
+finds nothing) and no resource budget. Consequences:
+
+- Any future RestrictedPython bypass (or a mis-wired global like `_write_`) is an
+  immediate full-worker compromise with cross-tenant blast radius.
+- Resource exhaustion is unmitigated regardless of RestrictedPython correctness.
+
+The highest-leverage hardening is to move node execution into a **budgeted child process**
+(rlimits + wall-clock kill) and stop sharing live singletons — that converts the current
+"single language-level fence" into real isolation and neutralises Findings 1, 2, and 5 at
+once.
+
+## Test coverage gap
+
+There are **no** tests exercising sandbox escapes or resource limits for
+`RestrictedPythonExecutionMixin` (only `apps/utils/tests/test_restricted_http.py` covers
+the HTTP client). Recommend adding an escape/resource regression suite that encodes the
+"blocked" list above plus the Finding-1 cross-execution isolation assertion.

--- a/docs/developer_guides/security/pythonnode_sandbox_assessment.md
+++ b/docs/developer_guides/security/pythonnode_sandbox_assessment.md
@@ -11,7 +11,9 @@ verified by reading the production code paths.
 
 > **Scope note.** This is a defensive assessment of our own sandbox. It documents
 > where the isolation boundary holds and where it leaks, with reproductions and
-> remediations. No fixes are applied in this document.
+> remediations. The tractable fixes (findings 1, 4, 5 and the `+=` half of 6) are
+> implemented in the same PR as this document; the remainder are tracked as issues.
+> See the "Remediation status" callout and per-finding "Remediation" sections.
 
 ---
 

--- a/docs/developer_guides/security/pythonnode_sandbox_assessment.md
+++ b/docs/developer_guides/security/pythonnode_sandbox_assessment.md
@@ -62,7 +62,7 @@ All of the following were **blocked** (compile-time `SyntaxError` unless noted):
 - `f(*args)` / `f(**kwargs)` call unpacking → `NameError: _apply_ is not defined` (RestrictedPython rewrites these to `_apply_(...)`, which the sandbox does not provide). This is why the `*args`/`**kwargs` spellings in Finding 4 fail at runtime even though they slip past the source regex.
 - `class Foo: ...` → fails with `NameError: __metaclass__`. Note this is **missing sandbox setup, not an intentional policy**: RestrictedPython 8.1 rewrites class bodies to reference `__metaclass__` and expects `__name__` in the execution globals, neither of which is provided. It happens to block class-based escape attempts, but should be made an explicit, clearly-messaged policy (see #6 / issue #4243).
 - Attribute reads are additionally guarded at **runtime** by `safer_getattr` (present as `_getattr_` inside the builtins), so dunder access is blocked even when it slips past the compiler.
-- `setattr`/`delattr` are the guarded RestrictedPython variants (`guarded_setattr`/`guarded_delattr`). These do **not** perform an independent underscore-name check — they route the target through `full_write_guard`, which wraps any non-`dict`/`list` object so the write raises. Underscore-prefixed *names* are instead rejected earlier, at compile time. (Before this PR `_write_` was a no-op, so `full_write_guard` was not actually in effect — see Finding 5.)
+- `setattr`/`delattr` are the guarded RestrictedPython variants (`guarded_setattr`/`guarded_delattr`). These do **not** perform an independent underscore-name check — they route the target through `full_write_guard`, which wraps any non-`dict`/`list` object so the write raises. Underscore-prefixed *names* are instead rejected earlier, at compile time. (Direct attribute assignment — `obj.attr = x` — goes through our own `_write_`/`restricted_write` guard instead, which is scoped to block only modules/types; see Findings 1 and 5.)
 
 The exposed attack surface is a small, curated builtin set (99 names, mostly exception
 types and safe scalars/containers), plus five stdlib modules and the injected helper
@@ -123,18 +123,27 @@ This is not a RestrictedPython bug — it is a wiring choice in our harness (sha
 singletons + a disabled write guard).
 
 ### Remediation
-- **✅ Done in this PR.** `_write_` is now `full_write_guard` (from `RestrictedPython.Guards`).
-  It passes plain `dict`/`list` through unchanged — so legitimate item assignment in node
-  code (`d["k"] = v`, `xs[0] = v`) keeps working — but wraps every other object (including
-  the injected module singletons) so `json.dumps = evil` raises `TypeError`. Verified: a
-  poisoning attempt in one execution no longer affects a later execution
-  (`TestSandboxHardening::test_shared_module_not_poisoned_across_executions`).
+- **✅ Done in this PR.** `_write_` is now a small `restricted_write` guard. It blocks
+  attribute/item writes on objects that are *shared across executions or process-global* —
+  module singletons and classes/`type`s (routed through `full_write_guard` so the write
+  raises) — so `json.dumps = evil` or `dict.injected = 1` now raise. Everything else,
+  including per-execution data objects (`dict`, `list`, and pydantic models such as
+  `Attachment`), stays writable, so legitimate node code keeps working
+  (`d["k"] = v`, `att.send_to_llm = False`, etc.).
+  - *Why not plain `full_write_guard`?* It wraps every non-`dict`/`list` object, which
+    also blocks mutating per-execution objects the node is meant to change — e.g.
+    `att.send_to_llm = False` on an `Attachment` from temp state. Scoping the block to
+    modules/types keeps the security property while preserving that behaviour.
+  - Verified: a poisoning attempt in one execution no longer affects a later execution
+    (`TestSandboxHardening::test_shared_module_not_poisoned_across_executions`), type writes
+    are blocked (`::test_cannot_write_attributes_on_shared_types`), and object attribute
+    writes still work (`::test_can_write_attributes_on_per_execution_objects`).
 - **Follow-up ([#4239](https://github.com/dimagi/open-chat-studio/issues/4239)):** as
   defense in depth, stop handing live module singletons to sandboxed code — expose curated
   read-only façades of just the functions needed rather than the module object, and give
   each execution its own `random.Random()` so `random.seed()` can't leak RNG state across
-  runs. (`full_write_guard` already blocks attribute writes, but shared *mutable* state
-  reachable through method calls, like the module-global RNG, is a residual concern.)
+  runs. (`restricted_write` blocks attribute writes, but shared *mutable* state reachable
+  through method calls, like the module-global RNG, is a residual concern.)
 
 ---
 
@@ -258,9 +267,9 @@ observed (before this PR):
 - `obj.public = 777` on any exposed object succeeded (underscore attrs still compile-block).
 - Enabled the shared-module poisoning in Finding 1.
 
-**✅ Done in this PR** — `_write_` is now `full_write_guard` (see Finding 1 remediation).
-Called out separately because it is the underlying mechanism and a one-line change closes
-the highest-impact vector.
+**✅ Done in this PR** — `_write_` is now the `restricted_write` guard (see Finding 1
+remediation). Called out separately because it is the underlying mechanism and closes the
+highest-impact vector.
 
 ---
 

--- a/docs/developer_guides/security/pythonnode_sandbox_assessment.md
+++ b/docs/developer_guides/security/pythonnode_sandbox_assessment.md
@@ -95,7 +95,8 @@ Execution A (tenant X's pipeline):
 def main(input, **kwargs):
     def evil(*a, **k):
         return "PWNED-BY-TENANT-A"
-    json.dumps = evil          # non-underscore attr write, not guarded
+
+    json.dumps = evil  # non-underscore attr write, not guarded
     return "patched"
 ```
 Execution B (a *completely separate* pipeline run, fresh globals dict):

--- a/docs/developer_guides/security/pythonnode_sandbox_assessment.md
+++ b/docs/developer_guides/security/pythonnode_sandbox_assessment.md
@@ -24,21 +24,28 @@ time). We found **no way to execute arbitrary native code or read the filesystem
 inside the node.
 
 However, the sandbox is **language-level only** — there is no process, container, or
-syscall isolation around it, and no CPU/memory/wall-clock budget. That leaves three
-categories of real weakness:
+syscall isolation around it, and no CPU/memory/wall-clock budget. That leaves the
+following real weaknesses:
 
-| # | Finding | Class | Severity | Confirmed |
-|---|---------|-------|----------|-----------|
-| 1 | Shared module singletons (`json`, `re`, `datetime`, `time`, `random`, `math`, `string`) are mutable and poisonable across executions | Cross-tenant integrity / info-leak | **High** | ✅ |
-| 2 | No CPU / memory / wall-clock limit on node execution | Denial of service | **High** | ✅ |
-| 3 | SSRF URL validation is not IP-pinned → DNS-rebinding window | SSRF | **Medium** | ✅ (by inspection) |
-| 4 | Reserved-session-key protection is a source-regex, trivially bypassed and not enforced at runtime | Integrity (weak control) | **Low–Medium** | ✅ |
-| 5 | `_write_` guard is a no-op (`lambda x: x`) — the root cause enabling #1 | Hardening gap | (root cause of #1) | ✅ |
-| 6 | Usability bugs: augmented assignment (`+=`) and `class` definitions are broken | Correctness / UX | Low | ✅ |
+| # | Finding | Class | Severity | Status |
+|---|---------|-------|----------|--------|
+| 1 | Shared module singletons (`json`, `re`, `datetime`, `time`, `random`, `math`, `string`) are mutable and poisonable across executions | Cross-tenant integrity / info-leak | **High** | **Fixed** (attribute-write vector); follow-up [#4239](https://github.com/dimagi/open-chat-studio/issues/4239) |
+| 2 | No CPU / memory / wall-clock limit on node execution | Denial of service | **High** | Open [#4240](https://github.com/dimagi/open-chat-studio/issues/4240) |
+| 3 | SSRF URL validation is not IP-pinned → DNS-rebinding window | SSRF | **Medium** | Open [#4241](https://github.com/dimagi/open-chat-studio/issues/4241) |
+| 4 | Reserved-session-key protection is a source-regex, trivially bypassed and not enforced at runtime | Integrity (weak control) | **Low–Medium** | **Fixed** [#4242](https://github.com/dimagi/open-chat-studio/issues/4242) |
+| 5 | `_write_` guard is a no-op (`lambda x: x`) — the root cause enabling #1 | Hardening gap | (root cause of #1) | **Fixed** |
+| 6 | Usability bugs: augmented assignment (`+=`) is broken; `class` definitions fail | Correctness / UX | Low | `+=` **Fixed**; classes tracked [#4243](https://github.com/dimagi/open-chat-studio/issues/4243) |
 
 The single most important finding is **#1**: one malicious or buggy Python node in *any*
 tenant's pipeline can silently corrupt shared Python modules for *every other* pipeline
 execution running on the same Celery worker process, until that worker restarts.
+
+> **Remediation status.** This PR fixes findings 1 (attribute-write poisoning), 4, 5 and
+> the `+=` half of 6 in code, with regression tests in
+> `apps/pipelines/tests/test_code_node.py::TestSandboxHardening`. Findings 2 and 3, and
+> the residual defense-in-depth work for 1 (not sharing live singletons) and the class
+> policy for 6, are tracked in the linked issues because they need infrastructure/design
+> decisions. See the per-finding "Remediation" sections for what changed.
 
 ---
 
@@ -50,9 +57,10 @@ All of the following were **blocked** (compile-time `SyntaxError` unless noted):
 - `__import__(...)`, and any name/attribute starting with `_` → compile error ("invalid ... because it starts with `_`"). This kills the whole dunder-walk family: `().__class__.__bases__[0].__subclasses__()`, `main.__globals__`, `x.__init__.__globals__`, `json.__loader__`, etc.
 - `eval(...)`, `exec(...)`, `compile(...)`, `open(...)`, `globals()`, `vars()`, `getattr(...)`, `type(...)`, `breakpoint(...)` → blocked (compile error or `NameError`).
 - `"{0.__class__}".format(x)` → `NotImplementedError` (RestrictedPython blocks `str.format`).
-- `class Foo: ...` → blocked (`__metaclass__` not defined). *(This is also a usability bug — see #6.)*
+- `f(*args)` / `f(**kwargs)` call unpacking → `NameError: _apply_ is not defined` (RestrictedPython rewrites these to `_apply_(...)`, which the sandbox does not provide). This is why the `*args`/`**kwargs` spellings in Finding 4 fail at runtime even though they slip past the source regex.
+- `class Foo: ...` → fails with `NameError: __metaclass__`. Note this is **missing sandbox setup, not an intentional policy**: RestrictedPython 8.1 rewrites class bodies to reference `__metaclass__` and expects `__name__` in the execution globals, neither of which is provided. It happens to block class-based escape attempts, but should be made an explicit, clearly-messaged policy (see #6 / issue #4243).
 - Attribute reads are additionally guarded at **runtime** by `safer_getattr` (present as `_getattr_` inside the builtins), so dunder access is blocked even when it slips past the compiler.
-- `setattr`/`delattr` are the guarded RestrictedPython variants and refuse underscore-prefixed attributes.
+- `setattr`/`delattr` are the guarded RestrictedPython variants (`guarded_setattr`/`guarded_delattr`). These do **not** perform an independent underscore-name check — they route the target through `full_write_guard`, which wraps any non-`dict`/`list` object so the write raises. Underscore-prefixed *names* are instead rejected earlier, at compile time. (Before this PR `_write_` was a no-op, so `full_write_guard` was not actually in effect — see Finding 5.)
 
 The exposed attack surface is a small, curated builtin set (99 names, mostly exception
 types and safe scalars/containers), plus five stdlib modules and the injected helper
@@ -112,14 +120,18 @@ This is not a RestrictedPython bug — it is a wiring choice in our harness (sha
 singletons + a disabled write guard).
 
 ### Remediation
-- Set a real write guard: `"_write_": full_write_guard` (from `RestrictedPython.Guards`),
-  which returns objects that block attribute/item writes on guarded types.
-- Do **not** hand live module singletons to sandboxed code. Expose read-only façades /
-  a curated `SimpleNamespace` of the specific functions needed (e.g. `json.dumps`,
-  `json.loads`) rather than the module object, so attribute assignment can't reach the
-  shared singleton.
-- Add a regression test asserting that mutating an exposed module in one execution does
-  not affect a subsequent execution.
+- **✅ Done in this PR.** `_write_` is now `full_write_guard` (from `RestrictedPython.Guards`).
+  It passes plain `dict`/`list` through unchanged — so legitimate item assignment in node
+  code (`d["k"] = v`, `xs[0] = v`) keeps working — but wraps every other object (including
+  the injected module singletons) so `json.dumps = evil` raises `TypeError`. Verified: a
+  poisoning attempt in one execution no longer affects a later execution
+  (`TestSandboxHardening::test_shared_module_not_poisoned_across_executions`).
+- **Follow-up ([#4239](https://github.com/dimagi/open-chat-studio/issues/4239)):** as
+  defense in depth, stop handing live module singletons to sandboxed code — expose curated
+  read-only façades of just the functions needed rather than the module object, and give
+  each execution its own `random.Random()` so `random.seed()` can't leak RNG state across
+  runs. (`full_write_guard` already blocks attribute writes, but shared *mutable* state
+  reachable through method calls, like the module-global RNG, is a residual concern.)
 
 ---
 
@@ -145,11 +157,16 @@ Any user who can author a pipeline can wedge or OOM a shared Celery worker, degr
 service for all tenants on that worker. `range()` clamping gives a false sense of a
 resource limit that loops/allocations bypass entirely.
 
-### Remediation
-- Set Celery `task_time_limit` / `task_soft_time_limit` for the pipeline/chat queue as a
-  backstop (kills the whole task — coarse but effective).
-- Prefer a per-node budget: run node code in a child process with `resource.setrlimit`
+### Remediation (tracked in [#4240](https://github.com/dimagi/open-chat-studio/issues/4240) — needs a design decision)
+- **Per-node budget (preferred):** run node code in a child process with `resource.setrlimit`
   (RLIMIT_CPU, RLIMIT_AS) and a wall-clock kill, or an execution-count/instruction guard.
+- **Celery backstop:** set `task_soft_time_limit` / `task_time_limit` on the pipeline/chat
+  queue. Mind the semantics: the **soft** limit raises `SoftTimeLimitExceeded` *inside* the
+  task, so it must be caught to release resources before deciding to fail or retry; the
+  **hard** limit kills and replaces the worker process, so no in-process cleanup runs. If
+  `task_acks_late` is in play, any task that can be requeued after worker loss must be
+  idempotent. A blanket limit also risks killing legitimately long tasks (LLM calls, evals,
+  syncs), so it must be scoped to the right queue/task rather than applied globally.
 - Consider removing or capping `time.sleep` for sandboxed code.
 
 ---
@@ -173,13 +190,22 @@ production `strict=not settings.DEBUG` is `True`, so HTTP and literal internal I
 blocked and redirects are disabled (`follow_redirects=False`) — good — but the rebinding
 window remains. (In `DEBUG`, `strict=False` disables the IP checks entirely — dev only.)
 
-### Remediation
-- Resolve the host once, validate the resolved IP, then connect to **that IP** (pin it)
-  with the original `Host` header preserved — e.g. a custom httpx transport / resolver,
-  or pass the validated IP as the connect target. This closes the TOCTOU between
-  validation and connection.
-- Re-validate on every request rather than trusting the `(hostname, port)` cache, or key
-  the cache on the resolved IP.
+Related: `_do_request` builds `httpx.Client()` without `trust_env=False`, so httpx honors
+`HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`/`NO_PROXY` from the worker environment by default.
+Whether that is desirable (egress via a controlled proxy) or a risk (bypassing the IP
+checks entirely by routing through a proxy) depends on deployment and should be decided and
+documented explicitly.
+
+### Remediation (tracked in [#4241](https://github.com/dimagi/open-chat-studio/issues/4241))
+- Resolve the host once, validate the resolved IP, then connect to **that IP** (pin it) as
+  the TCP target while preserving the original `Host` header; for HTTPS also set the TLS
+  SNI hostname to the original hostname via httpx request `extensions={"sni_hostname": host}`
+  so certificate verification still works. A custom httpx transport / resolver is the clean
+  way. This closes the TOCTOU between validation and connection.
+- Re-validate on every request rather than trusting the `(hostname, port)` cache, or key the
+  cache on the resolved IP that is actually used for the connection.
+- Decide and document the `trust_env` / proxy behavior (test direct, proxied, and `NO_PROXY`
+  worker environments).
 
 ---
 
@@ -189,16 +215,18 @@ window remains. (In `DEBUG`, `strict=False` disables the IP checks entirely — 
 `CodeNode.check_reserved_session_state_keys` blocks reserved keys
 (`user_input`, `outputs`, `attachments`, `remote_context`) by regex-matching the **source
 text** for `set_session_state_key("<key>"...`. The **runtime** `set_session_state_key`
-(`_set_session_state_key`) performs **no** reserved-key check — it writes the key
-unconditionally.
+(`_set_session_state_key`) performed **no** reserved-key check before this PR — it wrote
+the key unconditionally.
 
-### Reproductions (all bypass the validator)
+### Reproductions
+These forms all evade the source regex. Two are additionally stopped by RestrictedPython
+itself (no `_apply_`), so only the first three actually reach the runtime writer:
 ```python
-f = set_session_state_key; f("remote_context", 1)          # alias
-k = "remote_" + "context"; set_session_state_key(k, 1)      # computed key
-set_session_state_key(*["remote_context", 1])               # star-args
-set_session_state_key(**{"key_name": "remote_context", "value": 1})  # kwargs
-set_session_state_key("remote_" "context", 1)               # literal concat
+f = set_session_state_key; f("remote_context", 1)          # alias        — reaches runtime
+k = "remote_" + "context"; set_session_state_key(k, 1)      # computed key — reaches runtime
+set_session_state_key("remote_" "context", 1)               # literal concat — reaches runtime
+set_session_state_key(*["remote_context", 1])               # star-args  — blocked: _apply_ undefined
+set_session_state_key(**{"key_name": "remote_context", ...})# kwargs     — blocked: _apply_ undefined
 ```
 
 ### Impact
@@ -207,25 +235,29 @@ is on — `apps/experiments/tasks.py`, `apps/api/serializers.py`) and is intende
 read-only from within a pipeline. The bypass lets node code forge/overwrite it, so any
 downstream node that trusts `remote_context` can be fed attacker-chosen values. Impact is
 bounded to the session's own state (the pipeline author is often the same party), which
-is why this is Low–Medium rather than High — but the control as written is effectively
+is why this is Low–Medium rather than High — but the control as written was effectively
 security theatre.
 
 ### Remediation
-Enforce reserved keys at **runtime** inside `_set_session_state_key` (and the
-`temp_state` equivalent), raising on a reserved key regardless of how the call is spelled.
-Keep the source regex only as an early-feedback nicety, not the security boundary.
+**✅ Done in this PR.** `_set_session_state_key` now raises `CodeNodeRunError` when
+`key_name in settings.RESERVED_SESSION_STATE_KEYS`, regardless of how the call is spelled.
+The source regex is kept only as early-feedback UX. Covered by
+`TestSandboxHardening::test_reserved_session_state_key_enforced_at_runtime` (alias, computed
+key, literal concat). Note the `temp_state` setter already enforces its own read-only keys
+(`user_input`, `outputs`, `attachments`) at runtime.
 
 ---
 
 ## Finding 5 — `_write_` guard is a no-op (root cause of #1)
 
-`"_write_": lambda x: x` disables RestrictedPython's write-guard entirely. Effects
-observed:
-- `obj.public = 777` on any exposed object succeeds (underscore attrs still compile-block).
-- Enables the shared-module poisoning in Finding 1.
+`"_write_": lambda x: x` disabled RestrictedPython's write-guard entirely. Effects
+observed (before this PR):
+- `obj.public = 777` on any exposed object succeeded (underscore attrs still compile-block).
+- Enabled the shared-module poisoning in Finding 1.
 
-Fix is covered under Finding 1 (use `full_write_guard`). Called out separately because it
-is the underlying mechanism and a one-line change closes the highest-impact vector.
+**✅ Done in this PR** — `_write_` is now `full_write_guard` (see Finding 1 remediation).
+Called out separately because it is the underlying mechanism and a one-line change closes
+the highest-impact vector.
 
 ---
 
@@ -233,14 +265,21 @@ is the underlying mechanism and a one-line change closes the highest-impact vect
 
 These break legitimate user code and are worth fixing alongside the security work:
 
-- **Augmented assignment is entirely broken.** `x += 1`, `x -= 1`, `lst += [1]`, etc. all
-  raise `NameError: name '_inplacevar_' is not defined`, because the sandbox globals never
-  define `_inplacevar_`. Users must write `x = x + 1`. Fix: add
-  `"_inplacevar_": protected_inplacevar` (`RestrictedPython.Guards.guarded_inplacevar`,
-  or the library's `Guards.protected_inplacevar`) to the globals.
-- **`class` definitions fail** (`NameError: __metaclass__`). Nested classes are unusable.
-  This happens to close escape vectors, so if classes are intentionally disallowed it
-  should be a *clear, documented error*, not a confusing `__metaclass__` NameError.
+- **Augmented assignment was entirely broken.** `x += 1`, `x -= 1`, `lst += [1]`, etc. all
+  raised `NameError: name '_inplacevar_' is not defined`, because the sandbox globals never
+  defined `_inplacevar_` (RestrictedPython rewrites `x += 1` to `_inplacevar_("+=", x, 1)`).
+  **✅ Fixed in this PR:** we register an application-owned `restricted_inplacevar` that
+  allowlists the in-place operators and dispatches to `operator.i*`. RestrictedPython 8.1
+  ships **no** such helper (there is no `guarded_inplacevar`/`protected_inplacevar` in
+  `Guards.py`), so it must be app-owned. Augmented assignment on subscripts/attributes
+  (`d["k"] += 1`) stays blocked by RestrictedPython's own compile-time policy — write
+  `d["k"] = d["k"] + 1`. Covered by `TestSandboxHardening::test_augmented_assignment_supported`.
+- **`class` definitions fail** (`NameError: __metaclass__`). This is missing sandbox setup,
+  not an intentional restriction: RestrictedPython 8.1 rewrites class bodies to reference
+  `__metaclass__` and expects `__name__` in the execution globals. Decision needed
+  ([#4243](https://github.com/dimagi/open-chat-studio/issues/4243)): either support classes
+  by supplying a safe `__metaclass__`/`__name__` and retest, or reject class definitions
+  explicitly at compile time with a clear message. Left as-is pending that decision.
 
 `while`/`for`, generators (`yield`), decorators, lambdas, comprehensions, walrus (`:=`),
 `try/except`, `assert`, `global`, and `del` all work as expected.
@@ -262,9 +301,12 @@ The highest-leverage hardening is to move node execution into a **budgeted child
 "single language-level fence" into real isolation and neutralises Findings 1, 2, and 5 at
 once.
 
-## Test coverage gap
+## Test coverage
 
-There are **no** tests exercising sandbox escapes or resource limits for
-`RestrictedPythonExecutionMixin` (only `apps/utils/tests/test_restricted_http.py` covers
-the HTTP client). Recommend adding an escape/resource regression suite that encodes the
-"blocked" list above plus the Finding-1 cross-execution isolation assertion.
+Before this PR there were **no** tests exercising sandbox escapes for
+`RestrictedPythonExecutionMixin` (only `apps/utils/tests/test_restricted_http.py` covered
+the HTTP client). This PR adds `TestSandboxHardening` in
+`apps/pipelines/tests/test_code_node.py`, covering: module-poisoning is blocked, poisoning
+does not leak across executions, augmented assignment works, and reserved keys are enforced
+at runtime under the validator-bypass spellings. Recommended follow-up: extend it into a
+broader escape/resource regression suite that also encodes the "blocked" list above.


### PR DESCRIPTION
### Product Description
Security assessment of the **PythonNode (`CodeNode`) RestrictedPython sandbox** plus the tractable hardening fixes. The node was probed with ~60 escape, resource-exhaustion, and state-tampering test cases; findings are documented and the safe, well-contained ones are fixed here. Findings that need infrastructure/design decisions are filed as issues (#4239–#4243) for follow-up.

### Technical Description
**Assessment doc:** `docs/developer_guides/security/pythonnode_sandbox_assessment.md`.

**What holds:** No arbitrary code execution or filesystem access. Arbitrary imports, `eval`/`exec`/`compile`/`open`, the `__class__ → __subclasses__` dunder-walk breakouts, `str.format` leaks, and `*args`/`**kwargs` call unpacking (no `_apply_`) are all blocked, with `safer_getattr` as a runtime backstop.

**Fixes in this PR (`apps/utils/python_execution.py`, `apps/pipelines/nodes/nodes.py`):**
| # | Finding | Fix |
|---|---------|-----|
| 1 & 5 | Cross-tenant module poisoning via no-op `_write_` guard | `_write_` is now a scoped `restricted_write` guard: it blocks attribute/item writes on shared/process-global objects (module singletons, classes/types) so `json.dumps = evil` can't persist across executions, while leaving per-execution data objects (`dict`, `list`, pydantic models like `Attachment`) writable so normal node code still works. (#4239) |
| 4 | Reserved session-state keys enforced only by a bypassable source regex | `set_session_state_key` now enforces `RESERVED_SESSION_STATE_KEYS` at runtime, defeating alias/computed-key/literal-concat bypasses. (#4242) |
| 6 (part) | Augmented assignment (`+=`) broken | Added app-owned `restricted_inplacevar` (`_inplacevar_`) with an operator allowlist. (#4243) |

**Regression tests:** `apps/pipelines/tests/test_code_node.py::TestSandboxHardening` — module-poisoning blocked, no cross-execution leak, type-write blocked, per-execution object attribute write allowed, augmented assignment works, reserved keys enforced under bypass spellings.

**Filed for follow-up (need design/infra decisions):** DoS budget #4240, SSRF IP-pinning + `trust_env` #4241, remaining defense-in-depth for #4239 (stop sharing live singletons), class-definition policy #4243.

Reproductions were confirmed against RestrictedPython 8.1; the fixes were verified with the test suite (the affected pipeline/evaluator suites pass locally against a real DB, including the Attachment-mutation test).

### Migrations
- [ ] The migrations are backwards compatible

_(No migrations.)_

### Demo
N/A — see the assessment doc's per-finding reproductions and the new regression tests.

### Docs and Changelog
- [x] This PR requires docs/changelog update _(adds the assessment doc)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)