### PR TITLE
test: avoid seeded pricing key in evaluation reporting test

### DIFF
--- a/apps/cost_tracking/tests/test_evaluation_reporting.py
+++ b/apps/cost_tracking/tests/test_evaluation_reporting.py
@@ -17,6 +17,11 @@ from apps.cost_tracking.services.reporting import (
 from apps.utils.factories.cost_tracking import PricingRuleFactory, UsageRecordFactory
 from apps.utils.factories.evaluations import EvaluationConfigFactory, EvaluationRunFactory, EvaluatorFactory
 
+# A model name absent from the seed JSON, so a global PricingRule for it can't
+# collide with the rows migration 0062_load_ai_pricing inserts. Tests run with
+# --no-migrations locally and on PRs, so a seeded name only breaks on main.
+_PRICED_MODEL = "test-priced-model"
+
 
 @pytest.mark.django_db()
 def test_evaluation_run_cost_breaks_down_by_evaluator_and_model():
@@ -96,14 +101,14 @@ def test_evaluation_run_cost_confidence_flags_roll_up_from_rows():
     config = EvaluationConfigFactory.create()
     run = EvaluationRunFactory.create(team=config.team, config=config)
     evaluator = EvaluatorFactory.create(team=config.team)
-    priced_rule = PricingRuleFactory.create(provider_type="openai", model_name="gpt-4o-mini")
+    priced_rule = PricingRuleFactory.create(provider_type="openai", model_name=_PRICED_MODEL)
 
     # Priced, exact — the "clean" row, judged by `evaluator`.
     UsageRecordFactory.create(
         team=config.team,
         evaluation_config=config,
         provider_type="openai",
-        model_name="gpt-4o-mini",
+        model_name=_PRICED_MODEL,
         cost=Decimal("0.10"),
         pricing_rule=priced_rule,
         extra={"evaluation_run_id": run.id, "evaluator_id": evaluator.id},
@@ -113,7 +118,7 @@ def test_evaluation_run_cost_confidence_flags_roll_up_from_rows():
         team=config.team,
         evaluation_config=config,
         provider_type="openai",
-        model_name="gpt-4o-mini",
+        model_name=_PRICED_MODEL,
         cost=Decimal("0.05"),
         pricing_rule=priced_rule,
         confidence=Confidence.ESTIMATED,
@@ -138,9 +143,9 @@ def test_evaluation_run_cost_confidence_flags_roll_up_from_rows():
     assert result.has_unknown is True
 
     by_model = {row.model_name: row for row in result.by_model}
-    assert by_model["gpt-4o-mini"].has_unpriced is False
-    assert by_model["gpt-4o-mini"].has_estimated is True
-    assert by_model["gpt-4o-mini"].has_unknown is False
+    assert by_model[_PRICED_MODEL].has_unpriced is False
+    assert by_model[_PRICED_MODEL].has_estimated is True
+    assert by_model[_PRICED_MODEL].has_unknown is False
     assert by_model["claude-3"].has_unpriced is True
     assert by_model["claude-3"].has_unknown is True
 


### PR DESCRIPTION
`test_evaluation_run_cost_confidence_flags_roll_up_from_rows` has been failing on main ([run 32365211286](https://github.com/dimagi/open-chat-studio/actions/runs/32365211286/job/96413226550)) with a `cost_tracking_unique_active_pricing_rule` violation. Not actually flaky — deterministic, but only under the main branch's test config.

The test created a **global** (`team=None`) `PricingRule` for `openai/gpt-4o-mini/llm_input`, a key that `service_providers/0062_load_ai_pricing` seeds from `llm_pricing.json`. `lint_and_test.yml` runs migrations on main and `--no-migrations` on PRs, so the seeded row only exists post-merge — the collision was invisible to the PR that introduced it, and to local runs.

Switched that test to a model name absent from the seed, matching how the sibling tests already dodge this (`test-model` in `test_pricing_resolver.py`, `test-judge-model` in `test_evaluator_usage.py`). The remaining `gpt-4o-mini` references in the file are on `UsageRecord` rows, which carry no such constraint, so they're untouched.

The comment on the new constant is the load-bearing part of the diff: the trap is unobservable under the config everyone develops and reviews against.

### Verification

Before/after across both CI configs, on `test_evaluation_run_cost_confidence_flags_roll_up_from_rows`:

| | `--no-migrations` (PRs) | migrations (main) |
|---|---|---|
| before | pass | **fail** — `UniqueViolation` |
| after | pass | pass |

Also green: `apps/cost_tracking/` against a migrated DB (187 passed), plus the other pricing-touching suites under `--no-migrations` (228 passed).

### Migrations

None.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Test-only change, no user-facing behaviour.