### PR TITLE
[AgentOps] Claude must use `uv sync --locked` (for Supply-chain security)

### DIFF
--- a/.github/workflows/auto-update-models.yml
+++ b/.github/workflows/auto-update-models.yml
@@ -370,7 +370,7 @@ jobs:
             Branch: ${{ steps.branch.outputs.branch_name }} (already created and
             checked out).
           claude_args: |
-            --allowedTools "Bash(uv run:*),Bash(uv sync:*),Bash(python manage.py:*),Bash(pnpm run lint:*),Bash(ls:*),Bash(cat:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git checkout:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh label:*),Read,Write,Edit,Glob,Grep,WebFetch"
+            --allowedTools "Bash(uv run:*),Bash(uv sync --locked --dev),Bash(python manage.py:*),Bash(pnpm run lint:*),Bash(ls:*),Bash(cat:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git checkout:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh label:*),Read,Write,Edit,Glob,Grep,WebFetch"
 
       - name: Append decision report to step summary
         if: always()

--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -94,7 +94,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "dependabot[bot]"
           claude_args: |
-            --allowedTools "Bash(pnpm:*),Bash(uv:*),Bash(git:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Edit,WebFetch,WebSearch"
+            --allowedTools "Bash(pnpm:*),Bash(uv sync --locked --dev),Bash(uv run zensical build --clean),Bash(git:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Edit,WebFetch,WebSearch"
           prompt: |
             You are reviewing PR #${{ steps.pr.outputs.pr_number }}.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ git clone https://github.com/dimagi/open-chat-studio.git
 cd open-chat-studio
 uv venv --python 3.13
 source .venv/bin/activate
-uv sync
+uv sync --locked
 inv setup-dev-env   # installs hooks, starts services, migrates DB, builds frontend, creates superuser
 ./manage.py runserver
 ```

--- a/docs/getting-started/local-setup.md
+++ b/docs/getting-started/local-setup.md
@@ -23,7 +23,7 @@ Open Chat Studio uses [UV](https://docs.astral.sh/uv/getting-started/installatio
     ```bash
     uv venv --python 3.13
     source .venv/bin/activate
-    uv sync
+    uv sync --locked
     ```
 
 3. **Run the automated setup**


### PR DESCRIPTION
### Product Description
None

### Technical Description

GitHub workflows to use: `uv sync --locked `so dependency installs fail closed on lockfile drift instead of silently re-resolving to a newly published (potentially malicious) package version.

Identified this in OCS Docs repo and fixed with this PR https://github.com/dimagi/open-chat-studio-docs/pull/703

### Reviewer NOTES

- In  `claude-depedabot.yml` the Bash(uv:*) was -> `Bash(uv sync --locked --dev),Bash(uv run zensical build --clean)` which tightens permissions

### Docs and Changelog
- [ ] This PR requires docs/changelog update