### PR TITLE
Port worktree setup hooks to Codex

### DIFF
--- a/.claude/hooks/setup-env.sh
+++ b/.claude/hooks/setup-env.sh
@@ -1,39 +1,10 @@
 #!/usr/bin/env bash
-# Run on SessionStart to set up the development environment.
-# In a worktree: copies env files from the main worktree first.
-# Always: installs dependencies via bootstrap.sh.
+# Claude SessionStart wrapper around the tool-neutral worktree setup.
 
 set -euo pipefail
 
-ROOT_WORKTREE_PATH=$(git worktree list --porcelain | awk '/^worktree/{sub(/^worktree /, ""); print; exit}')
-CURRENT_PATH=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-
-if [ "$CURRENT_PATH" != "$ROOT_WORKTREE_PATH" ]; then
-    echo "[ocs] Setting up worktree at $CURRENT_PATH"
-    export ROOT_WORKTREE_PATH
-
-    [ -f "$ROOT_WORKTREE_PATH/.env" ]   && [ ! -f ".env" ]   && cp "$ROOT_WORKTREE_PATH/.env"   .env
-    [ -f "$ROOT_WORKTREE_PATH/.envrc" ] && [ ! -f ".envrc" ] && cp "$ROOT_WORKTREE_PATH/.envrc" .envrc
-    if [ -f "$ROOT_WORKTREE_PATH/.python-version" ] && [ ! -f ".python-version" ]; then
-        cp "$ROOT_WORKTREE_PATH/.python-version" .python-version
-    fi
-    command -v direnv &>/dev/null        && direnv allow
-fi
-
-# Set UV_PYTHON from .python-version so uv sync uses the pinned version rather
-# than the latest Python satisfying requires-python in pyproject.toml.
-_PV_FILE="${CURRENT_PATH}/.python-version"
-if [ ! -f "$_PV_FILE" ]; then
-    _PV_FILE="$ROOT_WORKTREE_PATH/.python-version"
-fi
-if [ -f "$_PV_FILE" ]; then
-    export UV_PYTHON
-    UV_PYTHON=$(cat "$_PV_FILE")
-fi
-
-"$ROOT_WORKTREE_PATH/scripts/bootstrap.sh" --force --yes
-
-echo "[ocs] Setup complete."
+PROJECT_ROOT=${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
+"$PROJECT_ROOT/scripts/ensure-worktree-setup.sh"
 
 # Ask the user if they want to run Claude Code.
 # Only prompt when stdin/stdout are a TTY (interactive terminal) and guard

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,18 @@
+{
+  "description": "Open Chat Studio development environment setup.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/ensure-worktree-setup.sh\"",
+            "timeout": 1200,
+            "statusMessage": "Setting up the Open Chat Studio worktree"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,19 +1,8 @@
 [[pre-start]]
-bootstrap = ".claude/hooks/setup-env.sh"
-
-[[pre-start]]
-database-url = "if grep -q '^DATABASE_URL=' .env; then sed -i.bak 's|^DATABASE_URL=.*|DATABASE_URL=postgres://postgres:postgres@localhost:5432/{{ branch | sanitize_db }}|' .env && rm -f .env.bak; else echo 'DATABASE_URL=postgres://postgres:postgres@localhost:5432/{{ branch | sanitize_db }}' >> .env; fi"
-
-[[pre-start]]
-redis-url = "REDIS_DB=$(echo '{{ branch | sanitize_db }}' | cksum | awk '{print ($1 % 15) + 1}'); if grep -q '^REDIS_URL=' .env; then sed -i.bak \"s|^REDIS_URL=.*|REDIS_URL=redis://localhost:6379/${REDIS_DB}|\" .env && rm -f .env.bak; else echo \"REDIS_URL=redis://localhost:6379/${REDIS_DB}\" >> .env; fi"
-
-[[pre-start]]
-create-database = "PGPASSWORD=postgres psql -h localhost -U postgres -tAc \"SELECT 1 FROM pg_database WHERE datname='{{ branch | sanitize_db }}'\" | grep -q 1 || PGPASSWORD=postgres psql -h localhost -U postgres -c 'CREATE DATABASE {{ branch | sanitize_db }}'"
+setup = "OCS_WORKTREE_ID='{{ branch | sanitize_db }}' scripts/setup-worktree.sh"
 
 [post-start]
 compile-styles = "pnpm run dev"
-migrate-and-bootstrap = "uv run python manage.py migrate && uv run python manage.py bootstrap_data --email test@example.com --password letmein --superuser"
 
 [post-remove]
-db-remove = "PGPASSWORD=postgres psql -h localhost -U postgres -c \"DROP DATABASE IF EXISTS \\\"{{ branch | sanitize_db }}\\\" WITH (FORCE)\" || true"
-redis-flush = "REDIS_DB=$(echo '{{ branch | sanitize_db }}' | cksum | awk '{print ($1 % 15) + 1}'); redis-cli -n ${REDIS_DB} FLUSHDB || true"
+cleanup = "OCS_WORKTREE_ID='{{ branch | sanitize_db }}' OCS_ALLOW_ROOT_TEARDOWN=true scripts/teardown-worktree.sh"

--- a/docs/getting-started/ai-setup.md
+++ b/docs/getting-started/ai-setup.md
@@ -115,10 +115,42 @@ Defines what happens when `wt` creates a worktree: per-branch database and Redis
 install, migrations and seed data. See
 [What worktree setup does](dev-workflow.md#what-worktree-setup-does).
 
+The underlying setup and cleanup scripts live in `scripts/setup-worktree.sh` and
+`scripts/teardown-worktree.sh` so Claude, Codex and Worktrunk share the same behavior.
+
 ## Other AI coding tools
 
 Other agentic coding tools (Gemini CLI, Codex CLI, OpenCode, Aider, Cline, etc.) can follow the
 same [development workflow](dev-workflow.md). Refer to your tool's documentation for details.
+
+### Codex
+
+Codex reads `AGENTS.md` directly. The checked-in `.codex/hooks.json` also runs a quiet setup guard
+when a Codex session starts or resumes. The first time you open the project in Codex CLI, run
+`/hooks` and trust the project hook, then resume or restart the session. A fresh native Codex
+worktree then receives:
+
+- The root checkout's `.env`, `.envrc` and `.python-version` files.
+- Python and Node dependencies.
+- An isolated PostgreSQL database and Redis database derived from the Codex worktree ID.
+- Migrations and the standard development seed data.
+
+The setup guard exits immediately when `.env`, `.venv` and `node_modules` already exist, their
+dependency fingerprint matches the current lockfiles, and the database URL is correct for the
+worktree. Its full output goes to a temporary log instead of being added to the model context.
+
+Codex Desktop users can additionally create a shared Local Environment in the project settings.
+Use `scripts/setup-worktree.sh` as its setup script and add these actions:
+
+| Action | Command |
+|---|---|
+| Run development environment | `uv run inv dev` |
+| Clean worktree services | `scripts/teardown-worktree.sh` |
+
+Run the cleanup action before deleting a native Codex worktree. Codex session-end hooks are not
+worktree-deletion hooks, so automatically dropping the database there would be unsafe. Worktrees
+created and removed through Worktrunk retain automatic cleanup; use `wtx` from the
+[development workflow](dev-workflow.md#1-create-a-worktree) to launch Codex that way.
 
 ### What works with any AI tool
 

--- a/docs/getting-started/dev-workflow.md
+++ b/docs/getting-started/dev-workflow.md
@@ -38,16 +38,18 @@ a Claude Code session in the new directory.
 
     ```bash
     alias wtc='wt switch --create --execute claude'
+    alias wtx='wt switch --create --execute codex'
     alias wts='wt switch'
     alias wtl='wt list'
     ```
 
-    Then `wtc my-branch-name` is the whole setup step. You can pass an initial prompt through:
-    `wtc my-branch-name -- 'Fix GH #322'`.
+    Then `wtc my-branch-name` starts Claude and `wtx my-branch-name` starts Codex after running the
+    same setup. You can pass an initial prompt through: `wtc my-branch-name -- 'Fix GH #322'`.
 
 ### What worktree setup does
 
-The hooks live in `.config/wt.toml` and run automatically on create:
+The hooks in `.config/wt.toml` delegate to the tool-neutral `scripts/setup-worktree.sh` and run
+automatically on create:
 
 - Copies `.env` (and `.envrc`, `.python-version`) from the main worktree, then runs
   `bootstrap.sh` to install Python and Node dependencies (`uv sync`, `pnpm install`).

--- a/docs/getting-started/dev-workflow.md
+++ b/docs/getting-started/dev-workflow.md
@@ -54,13 +54,14 @@ automatically on create:
 - Copies `.env` (and `.envrc`, `.python-version`) from the main worktree, then runs
   `bootstrap.sh` to install Python and Node dependencies (`uv sync`, `pnpm install`).
 - Points `DATABASE_URL` and `REDIS_URL` at a **per-branch** database and Redis DB, so a migration
-  or a wiped table on one branch can't affect another.
+  or a wiped table on one branch can't affect another. Redis database 15 stores an atomic
+  allocation registry, leaving databases 1–14 for concurrent worktrees without collisions.
 - Creates that database, migrates it, and seeds it with `bootstrap_data` — you get a working
   superuser (`test@example.com` / `letmein`), a team, and sample data rather than an empty app.
 - Builds the frontend assets.
 
-On `wt remove` the branch database is dropped and its Redis DB flushed, so worktrees leave nothing
-behind.
+On `wt remove` the branch database is dropped, its Redis DB is flushed, and its allocation is
+released, so worktrees leave nothing behind.
 
 Once it's set up, run [`inv dev`](local-setup.md#running-the-dev-environment) in the worktree.
 

--- a/scripts/ensure-worktree-setup.sh
+++ b/scripts/ensure-worktree-setup.sh
@@ -19,10 +19,15 @@ if [[ -f "$PROJECT_ROOT/.env" \
     fi
 
     resource_name=$(ocs_worktree_resource_name "$PROJECT_ROOT")
-    if grep -Fqx \
-        "DATABASE_URL=postgres://postgres:postgres@localhost:5432/$resource_name" \
-        "$PROJECT_ROOT/.env"; then
-        exit 0
+    if redis_database=$(ocs_lookup_redis_database "$resource_name"); then
+        if grep -Fqx \
+            "DATABASE_URL=postgres://postgres:postgres@localhost:5432/$resource_name" \
+            "$PROJECT_ROOT/.env" \
+            && grep -Fqx \
+                "REDIS_URL=redis://localhost:6379/$redis_database" \
+                "$PROJECT_ROOT/.env"; then
+            exit 0
+        fi
     fi
 fi
 

--- a/scripts/ensure-worktree-setup.sh
+++ b/scripts/ensure-worktree-setup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Quiet SessionStart guard shared by local coding agents.
+
+set -euo pipefail
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+SCRIPT_DIR="$PROJECT_ROOT/scripts"
+# shellcheck source=scripts/worktree-environment.sh
+source "$SCRIPT_DIR/worktree-environment.sh"
+
+if [[ -f "$PROJECT_ROOT/.env" \
+    && -d "$PROJECT_ROOT/.venv" \
+    && -d "$PROJECT_ROOT/node_modules" ]] \
+    && ocs_dependencies_are_current "$PROJECT_ROOT"; then
+    ROOT_WORKTREE_PATH=$(ocs_root_worktree_path)
+
+    if ocs_is_root_worktree "$PROJECT_ROOT" "$ROOT_WORKTREE_PATH"; then
+        exit 0
+    fi
+
+    resource_name=$(ocs_worktree_resource_name "$PROJECT_ROOT")
+    if grep -Fqx \
+        "DATABASE_URL=postgres://postgres:postgres@localhost:5432/$resource_name" \
+        "$PROJECT_ROOT/.env"; then
+        exit 0
+    fi
+fi
+
+session_id=${CODEX_THREAD_ID:-${CLAUDE_SESSION_ID:-$$}}
+log_file="${TMPDIR:-/tmp}/ocs-worktree-setup-${session_id}.log"
+if ! "$PROJECT_ROOT/scripts/setup-worktree.sh" >"$log_file" 2>&1; then
+    echo "Open Chat Studio setup failed. Full output: $log_file" >&2
+    tail -n 40 "$log_file" >&2
+    exit 1
+fi

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -48,21 +48,14 @@ if [[ ! -f "$CURRENT_PATH/.env" ]]; then
 fi
 
 resource_name=$(ocs_worktree_resource_name "$CURRENT_PATH")
-redis_database=$(ocs_allocate_redis_database "$resource_name")
 database_url="postgres://postgres:postgres@localhost:5432/$resource_name"
-redis_url="redis://localhost:6379/$redis_database"
 
 ocs_set_env_value \
     "$CURRENT_PATH/.env" \
     DATABASE_URL \
     "$database_url"
-ocs_set_env_value \
-    "$CURRENT_PATH/.env" \
-    REDIS_URL \
-    "$redis_url"
 
 export DATABASE_URL="$database_url"
-export REDIS_URL="$redis_url"
 
 if ! PGPASSWORD=postgres psql \
     -h localhost \
@@ -75,6 +68,14 @@ if ! PGPASSWORD=postgres psql \
         -v ON_ERROR_STOP=1 \
         -c "CREATE DATABASE \"$resource_name\""
 fi
+
+redis_database=$(ocs_allocate_redis_database "$resource_name")
+redis_url="redis://localhost:6379/$redis_database"
+ocs_set_env_value \
+    "$CURRENT_PATH/.env" \
+    REDIS_URL \
+    "$redis_url"
+export REDIS_URL="$redis_url"
 
 uv run python manage.py migrate
 uv run python manage.py bootstrap_data \

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -48,7 +48,7 @@ if [[ ! -f "$CURRENT_PATH/.env" ]]; then
 fi
 
 resource_name=$(ocs_worktree_resource_name "$CURRENT_PATH")
-redis_database=$(ocs_redis_database "$resource_name")
+redis_database=$(ocs_allocate_redis_database "$resource_name")
 database_url="postgres://postgres:postgres@localhost:5432/$resource_name"
 redis_url="redis://localhost:6379/$redis_database"
 

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -52,6 +52,10 @@ database_url="postgres://postgres:postgres@localhost:5432/$resource_name"
 
 ocs_set_env_value \
     "$CURRENT_PATH/.env" \
+    OCS_WORKTREE_ID \
+    "$resource_name"
+ocs_set_env_value \
+    "$CURRENT_PATH/.env" \
     DATABASE_URL \
     "$database_url"
 

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Set up dependencies and isolated services for any Git worktree provider.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/worktree-environment.sh
+source "$SCRIPT_DIR/worktree-environment.sh"
+
+ROOT_WORKTREE_PATH=$(ocs_root_worktree_path)
+CURRENT_PATH=$(ocs_current_worktree_path)
+cd "$CURRENT_PATH"
+
+if ! ocs_is_root_worktree "$CURRENT_PATH" "$ROOT_WORKTREE_PATH"; then
+    echo "[ocs] Setting up worktree at $CURRENT_PATH"
+
+    for filename in .env .envrc .python-version; do
+        if [[ -f "$ROOT_WORKTREE_PATH/$filename" && ! -f "$CURRENT_PATH/$filename" ]]; then
+            cp "$ROOT_WORKTREE_PATH/$filename" "$CURRENT_PATH/$filename"
+        fi
+    done
+
+    if command -v direnv >/dev/null 2>&1; then
+        direnv allow "$CURRENT_PATH"
+    fi
+fi
+
+python_version_file="$CURRENT_PATH/.python-version"
+if [[ ! -f "$python_version_file" ]]; then
+    python_version_file="$ROOT_WORKTREE_PATH/.python-version"
+fi
+if [[ -f "$python_version_file" ]]; then
+    export UV_PYTHON
+    UV_PYTHON=$(<"$python_version_file")
+fi
+
+"$CURRENT_PATH/scripts/bootstrap.sh" --force --yes
+
+if ocs_is_root_worktree "$CURRENT_PATH" "$ROOT_WORKTREE_PATH"; then
+    ocs_record_dependency_fingerprint "$CURRENT_PATH"
+    echo "[ocs] Setup complete for root checkout."
+    exit 0
+fi
+
+if [[ ! -f "$CURRENT_PATH/.env" ]]; then
+    echo "[ocs] Cannot configure worktree services because the root checkout has no .env file." >&2
+    exit 1
+fi
+
+resource_name=$(ocs_worktree_resource_name "$CURRENT_PATH")
+redis_database=$(ocs_redis_database "$resource_name")
+database_url="postgres://postgres:postgres@localhost:5432/$resource_name"
+redis_url="redis://localhost:6379/$redis_database"
+
+ocs_set_env_value \
+    "$CURRENT_PATH/.env" \
+    DATABASE_URL \
+    "$database_url"
+ocs_set_env_value \
+    "$CURRENT_PATH/.env" \
+    REDIS_URL \
+    "$redis_url"
+
+export DATABASE_URL="$database_url"
+export REDIS_URL="$redis_url"
+
+if ! PGPASSWORD=postgres psql \
+    -h localhost \
+    -U postgres \
+    -tAc "SELECT 1 FROM pg_database WHERE datname='$resource_name'" \
+    | grep -q 1; then
+    PGPASSWORD=postgres psql \
+        -h localhost \
+        -U postgres \
+        -v ON_ERROR_STOP=1 \
+        -c "CREATE DATABASE \"$resource_name\""
+fi
+
+uv run python manage.py migrate
+uv run python manage.py bootstrap_data \
+    --email test@example.com \
+    --password letmein \
+    --superuser
+
+ocs_record_dependency_fingerprint "$CURRENT_PATH"
+echo "[ocs] Setup complete for $resource_name."

--- a/scripts/teardown-worktree.sh
+++ b/scripts/teardown-worktree.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Remove the isolated PostgreSQL and Redis resources for a worktree.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/worktree-environment.sh
+source "$SCRIPT_DIR/worktree-environment.sh"
+
+ROOT_WORKTREE_PATH=$(ocs_root_worktree_path)
+CURRENT_PATH=$(ocs_current_worktree_path)
+
+if ocs_is_root_worktree "$CURRENT_PATH" "$ROOT_WORKTREE_PATH"; then
+    if [[ "${OCS_ALLOW_ROOT_TEARDOWN:-false}" != "true" ]]; then
+        echo "[ocs] Refusing to clean resources from the root checkout."
+        exit 0
+    fi
+    if [[ -z "${OCS_WORKTREE_ID:-}" ]]; then
+        echo "[ocs] OCS_WORKTREE_ID is required when cleaning from the root checkout." >&2
+        exit 1
+    fi
+fi
+
+resource_name=$(ocs_worktree_resource_name "$CURRENT_PATH")
+redis_database=$(ocs_redis_database "$resource_name")
+
+PGPASSWORD=postgres psql \
+    -h localhost \
+    -U postgres \
+    -v ON_ERROR_STOP=1 \
+    -c "DROP DATABASE IF EXISTS \"$resource_name\" WITH (FORCE)" \
+    || true
+redis-cli -n "$redis_database" FLUSHDB || true
+
+echo "[ocs] Cleaned resources for $resource_name."

--- a/scripts/teardown-worktree.sh
+++ b/scripts/teardown-worktree.sh
@@ -22,14 +22,21 @@ if ocs_is_root_worktree "$CURRENT_PATH" "$ROOT_WORKTREE_PATH"; then
 fi
 
 resource_name=$(ocs_worktree_resource_name "$CURRENT_PATH")
-redis_database=$(ocs_redis_database "$resource_name")
 
 PGPASSWORD=postgres psql \
     -h localhost \
     -U postgres \
     -v ON_ERROR_STOP=1 \
-    -c "DROP DATABASE IF EXISTS \"$resource_name\" WITH (FORCE)" \
-    || true
-redis-cli -n "$redis_database" FLUSHDB || true
+    -c "DROP DATABASE IF EXISTS \"$resource_name\" WITH (FORCE)"
+
+if redis_database=$(ocs_lookup_redis_database "$resource_name"); then
+    redis-cli -n "$redis_database" FLUSHDB
+    ocs_release_redis_database "$resource_name" "$redis_database"
+else
+    lookup_status=$?
+    if [[ "$lookup_status" -ne 1 ]]; then
+        exit "$lookup_status"
+    fi
+fi
 
 echo "[ocs] Cleaned resources for $resource_name."

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -1,0 +1,393 @@
+"""Tests for the tool-neutral worktree setup and teardown scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SETUP_SCRIPT = REPOSITORY_ROOT / "scripts" / "setup-worktree.sh"
+TEARDOWN_SCRIPT = REPOSITORY_ROOT / "scripts" / "teardown-worktree.sh"
+ENSURE_SETUP_SCRIPT = REPOSITORY_ROOT / "scripts" / "ensure-worktree-setup.sh"
+WORKTREE_ENVIRONMENT_SCRIPT = REPOSITORY_ROOT / "scripts" / "worktree-environment.sh"
+CODEX_HOOKS_FILE = REPOSITORY_ROOT / ".codex" / "hooks.json"
+
+
+def _run(
+    *command: str | Path,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    process_env = os.environ.copy()
+    if env:
+        process_env.update(env)
+    return subprocess.run(
+        [str(part) for part in command],
+        cwd=cwd,
+        env=process_env,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _record_dependency_fingerprint(worktree: Path) -> None:
+    _run(
+        "bash",
+        "-c",
+        'source "$1"; ocs_record_dependency_fingerprint "$2"',
+        "_",
+        worktree / "scripts" / "worktree-environment.sh",
+        worktree,
+        cwd=worktree,
+    )
+
+
+@pytest.fixture()
+def worktree_fixture(tmp_path: Path) -> tuple[Path, Path, dict[str, str], Path]:
+    root = tmp_path / "main"
+    worktree = tmp_path / ".codex" / "worktrees" / "a1b2" / "project"
+    fake_bin = tmp_path / "bin"
+    command_log = tmp_path / "commands.log"
+
+    root.mkdir()
+    _run("git", "init", "--initial-branch=main", cwd=root)
+    _run("git", "config", "user.email", "tests@example.com", cwd=root)
+    _run("git", "config", "user.name", "Test User", cwd=root)
+
+    _write_executable(
+        root / "scripts" / "bootstrap.sh",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'mkdir -p "$PWD/.venv" "$PWD/node_modules"\n'
+        'printf "bootstrap:%s\\n" "$*" >> "$OCS_TEST_COMMAND_LOG"\n',
+    )
+    (root / "scripts" / "worktree-environment.sh").write_text(WORKTREE_ENVIRONMENT_SCRIPT.read_text())
+    (root / ".python-version").write_text("3.13\n")
+    (root / "manage.py").write_text("# test fixture\n")
+    _run(
+        "git",
+        "add",
+        "scripts/bootstrap.sh",
+        "scripts/worktree-environment.sh",
+        ".python-version",
+        "manage.py",
+        cwd=root,
+    )
+    _run("git", "commit", "-m", "test fixture", cwd=root)
+
+    (root / ".env").write_text(
+        "SECRET_KEY=test-only\n"
+        "DATABASE_URL=postgres://postgres:postgres@localhost:5432/root_database\n"
+        "REDIS_URL=redis://localhost:6379/0\n"
+    )
+    (root / ".envrc").write_text("export TEST_ONLY=1\n")
+    worktree.parent.mkdir(parents=True)
+    _run("git", "worktree", "add", "--detach", worktree, "HEAD", cwd=root)
+
+    _write_executable(
+        fake_bin / "psql",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'printf "psql:%s\\n" "$*" >> "$OCS_TEST_COMMAND_LOG"\n'
+        'if [[ "$*" == *"SELECT 1 FROM pg_database"* ]]; then exit 0; fi\n',
+    )
+    _write_executable(
+        fake_bin / "uv",
+        '#!/usr/bin/env bash\nset -euo pipefail\nprintf "uv:%s\\n" "$*" >> "$OCS_TEST_COMMAND_LOG"\n',
+    )
+    _write_executable(
+        fake_bin / "redis-cli",
+        '#!/usr/bin/env bash\nset -euo pipefail\nprintf "redis-cli:%s\\n" "$*" >> "$OCS_TEST_COMMAND_LOG"\n',
+    )
+
+    env = {
+        "OCS_TEST_COMMAND_LOG": str(command_log),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+    }
+    return root, worktree, env, command_log
+
+
+def test_setup_configures_a_detached_codex_worktree(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    root, worktree, env, command_log = worktree_fixture
+
+    result = _run(SETUP_SCRIPT, cwd=worktree, env=env)
+
+    worktree_env = (worktree / ".env").read_text()
+    assert "SECRET_KEY=test-only" in worktree_env
+    assert "DATABASE_URL=postgres://postgres:postgres@localhost:5432/codex_a1b2" in worktree_env
+    assert "REDIS_URL=redis://localhost:6379/" in worktree_env
+    assert (worktree / ".envrc").read_text() == "export TEST_ONLY=1\n"
+    assert (root / ".env").read_text().endswith("REDIS_URL=redis://localhost:6379/0\n")
+
+    command_output = command_log.read_text()
+    assert "bootstrap:--force --yes" in command_output
+    assert 'CREATE DATABASE "codex_a1b2"' in command_output
+    assert "uv:run python manage.py migrate" in command_output
+    assert (
+        "uv:run python manage.py bootstrap_data --email test@example.com --password letmein --superuser"
+        in command_output
+    )
+    assert "Setup complete" in result.stdout
+
+
+def test_setup_uses_an_explicit_worktrunk_identifier(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    env["OCS_WORKTREE_ID"] = "feature_database"
+
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+
+    assert "5432/feature_database" in (worktree / ".env").read_text()
+    assert 'CREATE DATABASE "feature_database"' in command_log.read_text()
+
+
+def test_setup_runs_from_the_worktree_root_when_started_in_a_subdirectory(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, _ = worktree_fixture
+    nested_directory = worktree / "apps"
+    nested_directory.mkdir()
+    env["OCS_EXPECTED_CWD"] = str(worktree)
+    _write_executable(
+        worktree / "scripts" / "bootstrap.sh",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        '[[ "$PWD" == "$OCS_EXPECTED_CWD" ]]\n'
+        'mkdir -p "$PWD/.venv" "$PWD/node_modules"\n',
+    )
+
+    _run(SETUP_SCRIPT, cwd=nested_directory, env=env)
+
+
+def test_setup_overrides_inherited_service_urls(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    fake_bin = Path(env["PATH"].split(":", maxsplit=1)[0])
+    env.update(
+        {
+            "DATABASE_URL": "postgres://postgres:postgres@localhost:5432/root_database",
+            "REDIS_URL": "redis://localhost:6379/0",
+        }
+    )
+    _write_executable(
+        fake_bin / "uv",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'printf "uv-env:%s:%s\\n" "$DATABASE_URL" "$REDIS_URL" >> "$OCS_TEST_COMMAND_LOG"\n',
+    )
+
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+
+    worktree_env = (worktree / ".env").read_text().splitlines()
+    database_url = next(line.removeprefix("DATABASE_URL=") for line in worktree_env if line.startswith("DATABASE_URL="))
+    redis_url = next(line.removeprefix("REDIS_URL=") for line in worktree_env if line.startswith("REDIS_URL="))
+    assert f"uv-env:{database_url}:{redis_url}" in command_log.read_text()
+
+
+def test_setup_records_dependencies_only_after_services_are_ready(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, _ = worktree_fixture
+    fake_bin = Path(env["PATH"].split(":", maxsplit=1)[0])
+    _write_executable(fake_bin / "psql", "#!/usr/bin/env bash\nexit 1\n")
+
+    result = _run(SETUP_SCRIPT, cwd=worktree, env=env, check=False)
+
+    assert result.returncode != 0
+    assert not (worktree / ".venv" / ".ocs-dependency-fingerprint").exists()
+
+
+def test_setup_does_not_reconfigure_the_root_checkout(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    root, _, env, command_log = worktree_fixture
+    original_env = (root / ".env").read_text()
+
+    _run(SETUP_SCRIPT, cwd=root, env=env)
+
+    assert (root / ".env").read_text() == original_env
+    assert command_log.read_text() == "bootstrap:--force --yes\n"
+
+
+def test_teardown_removes_only_the_worktree_resources(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+
+    _run(TEARDOWN_SCRIPT, cwd=worktree, env=env)
+
+    command_output = command_log.read_text()
+    assert 'DROP DATABASE IF EXISTS "codex_a1b2" WITH (FORCE)' in command_output
+    assert "redis-cli:-n " in command_output
+    assert " FLUSHDB" in command_output
+
+
+def test_teardown_refuses_to_clean_the_root_checkout(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    root, _, env, command_log = worktree_fixture
+
+    result = _run(TEARDOWN_SCRIPT, cwd=root, env=env)
+
+    assert not command_log.exists()
+    assert "root checkout" in result.stdout
+
+
+def test_teardown_allows_worktrunk_to_clean_after_removal(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    root, _, env, command_log = worktree_fixture
+    env.update(
+        {
+            "OCS_ALLOW_ROOT_TEARDOWN": "true",
+            "OCS_WORKTREE_ID": "feature_database",
+        }
+    )
+
+    _run(TEARDOWN_SCRIPT, cwd=root, env=env)
+
+    command_output = command_log.read_text()
+    assert 'DROP DATABASE IF EXISTS "feature_database" WITH (FORCE)' in command_output
+    assert "redis-cli:-n " in command_output
+
+
+def test_root_teardown_requires_an_explicit_worktree_identifier(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    root, _, env, command_log = worktree_fixture
+    env["OCS_ALLOW_ROOT_TEARDOWN"] = "true"
+
+    result = _run(TEARDOWN_SCRIPT, cwd=root, env=env, check=False)
+
+    assert result.returncode == 1
+    assert not command_log.exists()
+    assert "OCS_WORKTREE_ID" in result.stderr
+
+
+def test_codex_session_setup_keeps_bootstrap_output_out_of_context(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    _write_executable(
+        worktree / "scripts" / "setup-worktree.sh",
+        "#!/usr/bin/env bash\necho 'verbose setup output'\n",
+    )
+    env.update(
+        {
+            "CODEX_THREAD_ID": "test-thread",
+            "TMPDIR": str(command_log.parent),
+        }
+    )
+
+    result = _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
+
+    assert result.stdout == ""
+    assert (command_log.parent / "ocs-worktree-setup-test-thread.log").read_text() == "verbose setup output\n"
+
+
+def test_codex_session_setup_skips_an_initialized_checkout(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    (worktree / ".env").write_text(
+        "SECRET_KEY=test-only\nDATABASE_URL=postgres://postgres:postgres@localhost:5432/codex_a1b2\n"
+    )
+    (worktree / ".venv").mkdir()
+    (worktree / "node_modules").mkdir()
+    _record_dependency_fingerprint(worktree)
+    _write_executable(
+        worktree / "scripts" / "setup-worktree.sh",
+        "#!/usr/bin/env bash\nexit 99\n",
+    )
+    env.update(
+        {
+            "CODEX_THREAD_ID": "initialized-thread",
+            "TMPDIR": str(command_log.parent),
+        }
+    )
+
+    _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
+
+    assert not (command_log.parent / "ocs-worktree-setup-initialized-thread.log").exists()
+
+
+def test_codex_session_setup_refreshes_stale_dependencies(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    (worktree / ".env").write_text(
+        "SECRET_KEY=test-only\nDATABASE_URL=postgres://postgres:postgres@localhost:5432/codex_a1b2\n"
+    )
+    (worktree / ".venv").mkdir()
+    (worktree / "node_modules").mkdir()
+    _record_dependency_fingerprint(worktree)
+    (worktree / ".python-version").write_text("3.14\n")
+    _write_executable(
+        worktree / "scripts" / "setup-worktree.sh",
+        "#!/usr/bin/env bash\necho 'refreshed dependencies'\n",
+    )
+    env.update(
+        {
+            "CODEX_THREAD_ID": "stale-dependencies-thread",
+            "TMPDIR": str(command_log.parent),
+        }
+    )
+
+    _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
+
+    assert (command_log.parent / "ocs-worktree-setup-stale-dependencies-thread.log").read_text() == (
+        "refreshed dependencies\n"
+    )
+
+
+def test_codex_session_setup_repairs_a_shared_database_configuration(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    (worktree / ".env").write_text(
+        "SECRET_KEY=test-only\nDATABASE_URL=postgres://postgres:postgres@localhost:5432/root_database\n"
+    )
+    (worktree / ".venv").mkdir()
+    (worktree / "node_modules").mkdir()
+    _write_executable(
+        worktree / "scripts" / "setup-worktree.sh",
+        "#!/usr/bin/env bash\necho 'reconfigured worktree'\n",
+    )
+    env.update(
+        {
+            "CODEX_THREAD_ID": "shared-database-thread",
+            "TMPDIR": str(command_log.parent),
+        }
+    )
+
+    _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
+
+    assert (command_log.parent / "ocs-worktree-setup-shared-database-thread.log").read_text() == (
+        "reconfigured worktree\n"
+    )
+
+
+def test_codex_hook_runs_when_a_session_resumes() -> None:
+    hooks = json.loads(CODEX_HOOKS_FILE.read_text())
+
+    matcher = hooks["hooks"]["SessionStart"][0]["matcher"]
+
+    assert "startup" in matcher.split("|")
+    assert "resume" in matcher.split("|")

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -284,6 +284,30 @@ def test_setup_uses_an_explicit_worktrunk_identifier(
     assert 'CREATE DATABASE "feature_database"' in command_log.read_text()
 
 
+def test_agent_guard_reuses_the_worktrunk_resource_name(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    env["OCS_WORKTREE_ID"] = "feature_database"
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+    env.pop("OCS_WORKTREE_ID")
+    _write_executable(
+        worktree / "scripts" / "setup-worktree.sh",
+        "#!/usr/bin/env bash\nexit 99\n",
+    )
+    env.update(
+        {
+            "CODEX_THREAD_ID": "worktrunk-resource-thread",
+            "TMPDIR": str(command_log.parent),
+        }
+    )
+
+    _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
+
+    assert "OCS_WORKTREE_ID=feature_database" in (worktree / ".env").read_text()
+    assert not (command_log.parent / "ocs-worktree-setup-worktrunk-resource-thread.log").exists()
+
+
 @pytest.mark.parametrize(
     ("first_identifier", "second_identifier"),
     [

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -43,16 +43,68 @@ def _write_executable(path: Path, contents: str) -> None:
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
 
-def _record_dependency_fingerprint(worktree: Path) -> None:
-    _run(
+def _run_worktree_helper(
+    worktree: Path,
+    function_name: str,
+    *arguments: str | Path,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return _run(
         "bash",
         "-c",
-        'source "$1"; ocs_record_dependency_fingerprint "$2"',
+        f'source "$1"; shift; {function_name} "$@"',
         "_",
         worktree / "scripts" / "worktree-environment.sh",
-        worktree,
+        *arguments,
         cwd=worktree,
+        env=env,
+        check=check,
     )
+
+
+def _record_dependency_fingerprint(worktree: Path) -> None:
+    _run_worktree_helper(worktree, "ocs_record_dependency_fingerprint", worktree)
+
+
+def _allocate_redis_database(worktree: Path, env: dict[str, str], resource_name: str) -> int:
+    result = _run_worktree_helper(
+        worktree,
+        "ocs_allocate_redis_database",
+        resource_name,
+        env=env,
+    )
+    return int(result.stdout)
+
+
+def _prepare_session_guard(
+    worktree: Path,
+    env: dict[str, str],
+    command_log: Path,
+    *,
+    database_name: str,
+    thread_id: str,
+    setup_script: str,
+    redis_url: str | None = None,
+) -> Path:
+    redis_database = _allocate_redis_database(worktree, env, "codex_a1b2")
+    expected_redis_url = redis_url or f"redis://localhost:6379/{redis_database}"
+    (worktree / ".env").write_text(
+        "SECRET_KEY=test-only\n"
+        f"DATABASE_URL=postgres://postgres:postgres@localhost:5432/{database_name}\n"
+        f"REDIS_URL={expected_redis_url}\n"
+    )
+    (worktree / ".venv").mkdir()
+    (worktree / "node_modules").mkdir()
+    _record_dependency_fingerprint(worktree)
+    _write_executable(worktree / "scripts" / "setup-worktree.sh", setup_script)
+    env.update(
+        {
+            "CODEX_THREAD_ID": thread_id,
+            "TMPDIR": str(command_log.parent),
+        }
+    )
+    return command_log.parent / f"ocs-worktree-setup-{thread_id}.log"
 
 
 @pytest.fixture()
@@ -102,6 +154,7 @@ def worktree_fixture(tmp_path: Path) -> tuple[Path, Path, dict[str, str], Path]:
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
         'printf "psql:%s\\n" "$*" >> "$OCS_TEST_COMMAND_LOG"\n'
+        'if [[ "${OCS_TEST_FAIL_PSQL:-false}" == "true" ]]; then exit 1; fi\n'
         'if [[ "$*" == *"SELECT 1 FROM pg_database"* ]]; then exit 0; fi\n',
     )
     _write_executable(
@@ -110,11 +163,64 @@ def worktree_fixture(tmp_path: Path) -> tuple[Path, Path, dict[str, str], Path]:
     )
     _write_executable(
         fake_bin / "redis-cli",
-        '#!/usr/bin/env bash\nset -euo pipefail\nprintf "redis-cli:%s\\n" "$*" >> "$OCS_TEST_COMMAND_LOG"\n',
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'if [[ "${*: -1}" == "FLUSHDB" ]]; then\n'
+        '    printf "redis-cli:%s\\n" "$*" >> "$OCS_TEST_COMMAND_LOG"\n'
+        '    [[ "${OCS_TEST_FAIL_REDIS_FLUSH:-false}" != "true" ]]\n'
+        "    exit 0\n"
+        "fi\n"
+        "operation=\n"
+        "resource_name=\n"
+        "database=\n"
+        'for argument in "$@"; do\n'
+        '    if [[ "$argument" =~ ^(allocate|lookup|release)$ ]]; then\n'
+        "        operation=$argument\n"
+        "        continue\n"
+        "    fi\n"
+        '    if [[ -n "$operation" && -z "$resource_name" ]]; then\n'
+        "        resource_name=$argument\n"
+        '    elif [[ "$operation" == "release" && -n "$resource_name" ]]; then\n'
+        "        database=$argument\n"
+        "    fi\n"
+        "done\n"
+        'printf "redis-registry:%s:%s:%s\\n" "$operation" "$resource_name" "$database" '
+        '>> "$OCS_TEST_COMMAND_LOG"\n'
+        'touch "$OCS_TEST_REDIS_REGISTRY"\n'
+        "existing=$(awk -v resource=\"$resource_name\" '$1 == resource { print $2 }' "
+        '"$OCS_TEST_REDIS_REGISTRY")\n'
+        'if [[ "$operation" == "lookup" ]]; then\n'
+        '    [[ -n "$existing" ]] || exit 1\n'
+        '    printf "%s\\n" "$existing"\n'
+        "    exit 0\n"
+        "fi\n"
+        'if [[ "$operation" == "allocate" ]]; then\n'
+        '    if [[ -n "$existing" ]]; then printf "%s\\n" "$existing"; exit 0; fi\n'
+        "    for candidate in $(seq 1 14); do\n"
+        "        if ! awk -v database=\"$candidate\" '$2 == database { found = 1 } END { exit !found }' "
+        '"$OCS_TEST_REDIS_REGISTRY"; then\n'
+        '            printf "%s %s\\n" "$resource_name" "$candidate" >> "$OCS_TEST_REDIS_REGISTRY"\n'
+        '            printf "%s\\n" "$candidate"\n'
+        "            exit 0\n"
+        "        fi\n"
+        "    done\n"
+        '    echo "Redis database registry exhausted" >&2\n'
+        "    exit 1\n"
+        "fi\n"
+        'if [[ "$operation" == "release" ]]; then\n'
+        '    [[ "$existing" == "$database" ]] || exit 1\n'
+        '    awk -v resource="$resource_name" \'$1 != resource\' "$OCS_TEST_REDIS_REGISTRY" '
+        '> "$OCS_TEST_REDIS_REGISTRY.tmp"\n'
+        '    mv "$OCS_TEST_REDIS_REGISTRY.tmp" "$OCS_TEST_REDIS_REGISTRY"\n'
+        "    echo 1\n"
+        "    exit 0\n"
+        "fi\n"
+        "exit 1\n",
     )
 
     env = {
         "OCS_TEST_COMMAND_LOG": str(command_log),
+        "OCS_TEST_REDIS_REGISTRY": str(tmp_path / "redis-registry"),
         "PATH": f"{fake_bin}:{os.environ['PATH']}",
     }
     return root, worktree, env, command_log
@@ -155,6 +261,68 @@ def test_setup_uses_an_explicit_worktrunk_identifier(
 
     assert "5432/feature_database" in (worktree / ".env").read_text()
     assert 'CREATE DATABASE "feature_database"' in command_log.read_text()
+
+
+@pytest.mark.parametrize(
+    ("first_identifier", "second_identifier"),
+    [
+        pytest.param("feature/a", "feature_a", id="sanitization"),
+        pytest.param(f"{'x' * 63}a", f"{'x' * 63}b", id="truncation"),
+    ],
+)
+def test_resource_names_do_not_collide_after_sanitization(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+    first_identifier: str,
+    second_identifier: str,
+) -> None:
+    _, worktree, _, _ = worktree_fixture
+
+    first_name = _run_worktree_helper(
+        worktree,
+        "ocs_sanitize_resource_name",
+        first_identifier,
+    ).stdout.strip()
+    second_name = _run_worktree_helper(
+        worktree,
+        "ocs_sanitize_resource_name",
+        second_identifier,
+    ).stdout.strip()
+
+    assert first_name != second_name
+    assert len(first_name) <= 63
+    assert len(second_name) <= 63
+
+
+def test_redis_registry_allocates_distinct_databases_and_reuses_assignments(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, _ = worktree_fixture
+
+    first_database = _allocate_redis_database(worktree, env, "feature_6")
+    second_database = _allocate_redis_database(worktree, env, "feature_17")
+    repeated_database = _allocate_redis_database(worktree, env, "feature_6")
+
+    assert first_database != second_database
+    assert repeated_database == first_database
+
+
+def test_redis_registry_reports_exhaustion(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, _ = worktree_fixture
+    for index in range(14):
+        _allocate_redis_database(worktree, env, f"feature_{index}")
+
+    result = _run_worktree_helper(
+        worktree,
+        "ocs_allocate_redis_database",
+        "one_too_many",
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "exhausted" in result.stderr.lower()
 
 
 def test_setup_runs_from_the_worktree_root_when_started_in_a_subdirectory(
@@ -230,6 +398,7 @@ def test_teardown_removes_only_the_worktree_resources(
     worktree_fixture: tuple[Path, Path, dict[str, str], Path],
 ) -> None:
     _, worktree, env, command_log = worktree_fixture
+    redis_database = _allocate_redis_database(worktree, env, "codex_a1b2")
 
     _run(TEARDOWN_SCRIPT, cwd=worktree, env=env)
 
@@ -237,6 +406,15 @@ def test_teardown_removes_only_the_worktree_resources(
     assert 'DROP DATABASE IF EXISTS "codex_a1b2" WITH (FORCE)' in command_output
     assert "redis-cli:-n " in command_output
     assert " FLUSHDB" in command_output
+    lookup = _run_worktree_helper(
+        worktree,
+        "ocs_lookup_redis_database",
+        "codex_a1b2",
+        env=env,
+        check=False,
+    )
+    assert lookup.returncode != 0
+    assert str(redis_database) not in lookup.stdout
 
 
 def test_teardown_refuses_to_clean_the_root_checkout(
@@ -260,12 +438,41 @@ def test_teardown_allows_worktrunk_to_clean_after_removal(
             "OCS_WORKTREE_ID": "feature_database",
         }
     )
+    _allocate_redis_database(root, env, "feature_database")
 
     _run(TEARDOWN_SCRIPT, cwd=root, env=env)
 
     command_output = command_log.read_text()
     assert 'DROP DATABASE IF EXISTS "feature_database" WITH (FORCE)' in command_output
     assert "redis-cli:-n " in command_output
+
+
+@pytest.mark.parametrize(
+    "failure_variable",
+    [
+        pytest.param("OCS_TEST_FAIL_PSQL", id="postgres"),
+        pytest.param("OCS_TEST_FAIL_REDIS_FLUSH", id="redis"),
+    ],
+)
+def test_teardown_propagates_cleanup_failures(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+    failure_variable: str,
+) -> None:
+    _, worktree, env, _ = worktree_fixture
+    _allocate_redis_database(worktree, env, "codex_a1b2")
+    env[failure_variable] = "true"
+
+    result = _run(TEARDOWN_SCRIPT, cwd=worktree, env=env, check=False)
+
+    assert result.returncode != 0
+    assert "Cleaned resources" not in result.stdout
+    lookup = _run_worktree_helper(
+        worktree,
+        "ocs_lookup_redis_database",
+        "codex_a1b2",
+        env=env,
+    )
+    assert lookup.stdout.strip().isdigit()
 
 
 def test_root_teardown_requires_an_explicit_worktree_identifier(
@@ -306,82 +513,74 @@ def test_codex_session_setup_skips_an_initialized_checkout(
     worktree_fixture: tuple[Path, Path, dict[str, str], Path],
 ) -> None:
     _, worktree, env, command_log = worktree_fixture
-    (worktree / ".env").write_text(
-        "SECRET_KEY=test-only\nDATABASE_URL=postgres://postgres:postgres@localhost:5432/codex_a1b2\n"
-    )
-    (worktree / ".venv").mkdir()
-    (worktree / "node_modules").mkdir()
-    _record_dependency_fingerprint(worktree)
-    _write_executable(
-        worktree / "scripts" / "setup-worktree.sh",
-        "#!/usr/bin/env bash\nexit 99\n",
-    )
-    env.update(
-        {
-            "CODEX_THREAD_ID": "initialized-thread",
-            "TMPDIR": str(command_log.parent),
-        }
+    log_file = _prepare_session_guard(
+        worktree,
+        env,
+        command_log,
+        database_name="codex_a1b2",
+        thread_id="initialized-thread",
+        setup_script="#!/usr/bin/env bash\nexit 99\n",
     )
 
     _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
 
-    assert not (command_log.parent / "ocs-worktree-setup-initialized-thread.log").exists()
+    assert not log_file.exists()
 
 
 def test_codex_session_setup_refreshes_stale_dependencies(
     worktree_fixture: tuple[Path, Path, dict[str, str], Path],
 ) -> None:
     _, worktree, env, command_log = worktree_fixture
-    (worktree / ".env").write_text(
-        "SECRET_KEY=test-only\nDATABASE_URL=postgres://postgres:postgres@localhost:5432/codex_a1b2\n"
+    log_file = _prepare_session_guard(
+        worktree,
+        env,
+        command_log,
+        database_name="codex_a1b2",
+        thread_id="stale-dependencies-thread",
+        setup_script="#!/usr/bin/env bash\necho 'refreshed dependencies'\n",
     )
-    (worktree / ".venv").mkdir()
-    (worktree / "node_modules").mkdir()
-    _record_dependency_fingerprint(worktree)
     (worktree / ".python-version").write_text("3.14\n")
-    _write_executable(
-        worktree / "scripts" / "setup-worktree.sh",
-        "#!/usr/bin/env bash\necho 'refreshed dependencies'\n",
-    )
-    env.update(
-        {
-            "CODEX_THREAD_ID": "stale-dependencies-thread",
-            "TMPDIR": str(command_log.parent),
-        }
-    )
 
     _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
 
-    assert (command_log.parent / "ocs-worktree-setup-stale-dependencies-thread.log").read_text() == (
-        "refreshed dependencies\n"
-    )
+    assert log_file.read_text() == "refreshed dependencies\n"
 
 
 def test_codex_session_setup_repairs_a_shared_database_configuration(
     worktree_fixture: tuple[Path, Path, dict[str, str], Path],
 ) -> None:
     _, worktree, env, command_log = worktree_fixture
-    (worktree / ".env").write_text(
-        "SECRET_KEY=test-only\nDATABASE_URL=postgres://postgres:postgres@localhost:5432/root_database\n"
-    )
-    (worktree / ".venv").mkdir()
-    (worktree / "node_modules").mkdir()
-    _write_executable(
-        worktree / "scripts" / "setup-worktree.sh",
-        "#!/usr/bin/env bash\necho 'reconfigured worktree'\n",
-    )
-    env.update(
-        {
-            "CODEX_THREAD_ID": "shared-database-thread",
-            "TMPDIR": str(command_log.parent),
-        }
+    log_file = _prepare_session_guard(
+        worktree,
+        env,
+        command_log,
+        database_name="root_database",
+        thread_id="shared-database-thread",
+        setup_script="#!/usr/bin/env bash\necho 'reconfigured worktree'\n",
     )
 
     _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
 
-    assert (command_log.parent / "ocs-worktree-setup-shared-database-thread.log").read_text() == (
-        "reconfigured worktree\n"
+    assert log_file.read_text() == "reconfigured worktree\n"
+
+
+def test_codex_session_setup_repairs_a_shared_redis_configuration(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    log_file = _prepare_session_guard(
+        worktree,
+        env,
+        command_log,
+        database_name="codex_a1b2",
+        thread_id="shared-redis-thread",
+        setup_script="#!/usr/bin/env bash\necho 'reconfigured worktree'\n",
+        redis_url="redis://localhost:6379/0",
     )
+
+    _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
+
+    assert log_file.read_text() == "reconfigured worktree\n"
 
 
 def test_codex_hook_runs_when_a_session_resumes() -> None:

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -107,6 +107,7 @@ class SessionGuardScenario:
     expected_log: str | None
     redis_url: str | None = None
     python_version: str | None = None
+    migration_path: str | None = None
 
 
 def _run(
@@ -396,6 +397,34 @@ def test_setup_records_dependencies_only_after_services_are_ready(
 
     assert result.returncode != 0
     assert not (worktree / ".venv" / ".ocs-dependency-fingerprint").exists()
+    lookup = _run_worktree_helper(
+        worktree,
+        "ocs_lookup_redis_database",
+        "codex_a1b2",
+        env=env,
+        check=False,
+    )
+    assert lookup.returncode != 0
+
+
+def test_failed_setup_preserves_an_existing_redis_allocation(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, _ = worktree_fixture
+    existing_database = _allocate_redis_database(worktree, env, "codex_a1b2")
+    fake_bin = Path(env["PATH"].split(":", maxsplit=1)[0])
+    _write_executable(fake_bin / "psql", "#!/usr/bin/env bash\nexit 1\n")
+
+    result = _run(SETUP_SCRIPT, cwd=worktree, env=env, check=False)
+
+    assert result.returncode != 0
+    lookup = _run_worktree_helper(
+        worktree,
+        "ocs_lookup_redis_database",
+        "codex_a1b2",
+        env=env,
+    )
+    assert int(lookup.stdout) == existing_database
 
 
 def test_setup_does_not_reconfigure_the_root_checkout(
@@ -549,6 +578,16 @@ def test_codex_session_setup_keeps_bootstrap_output_out_of_context(
         ),
         pytest.param(
             SessionGuardScenario(
+                database_name="codex_a1b2",
+                thread_id="new-migration-thread",
+                setup_script="#!/usr/bin/env bash\necho 'applied migrations'\n",
+                expected_log="applied migrations\n",
+                migration_path="apps/test_app/migrations/0002_new_field.py",
+            ),
+            id="new-migration",
+        ),
+        pytest.param(
+            SessionGuardScenario(
                 database_name="root_database",
                 thread_id="shared-database-thread",
                 setup_script="#!/usr/bin/env bash\necho 'reconfigured worktree'\n",
@@ -576,6 +615,10 @@ def test_codex_session_setup_guard(
     log_file = _prepare_session_guard(worktree, env, scenario)
     if scenario.python_version:
         (worktree / ".python-version").write_text(f"{scenario.python_version}\n")
+    if scenario.migration_path:
+        migration_file = worktree / scenario.migration_path
+        migration_file.parent.mkdir(parents=True)
+        migration_file.write_text("# test migration\n")
 
     _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
 

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -66,6 +66,10 @@ existing=$(awk -v resource="$resource_name" '$1 == resource { print $2 }' \
     "$OCS_TEST_REDIS_REGISTRY")
 
 if [[ "$operation" == "lookup" ]]; then
+    if [[ "${OCS_TEST_FAIL_REDIS_LOOKUP:-false}" == "true" ]]; then
+        echo "Redis registry unavailable" >&2
+        exit 2
+    fi
     [[ -n "$existing" ]] || exit 1
     printf "%s\n" "$existing"
     exit 0
@@ -518,6 +522,27 @@ def test_teardown_propagates_cleanup_failures(
         env=env,
     )
     assert lookup.stdout.strip().isdigit()
+
+
+def test_teardown_propagates_redis_registry_lookup_failures(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, _ = worktree_fixture
+    redis_database = _allocate_redis_database(worktree, env, "codex_a1b2")
+    env["OCS_TEST_FAIL_REDIS_LOOKUP"] = "true"
+
+    result = _run(TEARDOWN_SCRIPT, cwd=worktree, env=env, check=False)
+
+    assert result.returncode == 2
+    assert "Cleaned resources" not in result.stdout
+    env.pop("OCS_TEST_FAIL_REDIS_LOOKUP")
+    lookup = _run_worktree_helper(
+        worktree,
+        "ocs_lookup_redis_database",
+        "codex_a1b2",
+        env=env,
+    )
+    assert int(lookup.stdout) == redis_database
 
 
 def test_root_teardown_requires_an_explicit_worktree_identifier(

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -6,6 +6,7 @@ import json
 import os
 import stat
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,96 @@ TEARDOWN_SCRIPT = REPOSITORY_ROOT / "scripts" / "teardown-worktree.sh"
 ENSURE_SETUP_SCRIPT = REPOSITORY_ROOT / "scripts" / "ensure-worktree-setup.sh"
 WORKTREE_ENVIRONMENT_SCRIPT = REPOSITORY_ROOT / "scripts" / "worktree-environment.sh"
 CODEX_HOOKS_FILE = REPOSITORY_ROOT / ".codex" / "hooks.json"
+
+FAKE_BOOTSTRAP_SCRIPT = r"""#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "$PWD/.venv" "$PWD/node_modules"
+printf "bootstrap:%s\n" "$*" >> "$OCS_TEST_COMMAND_LOG"
+"""
+
+FAKE_PSQL_SCRIPT = r"""#!/usr/bin/env bash
+set -euo pipefail
+printf "psql:%s\n" "$*" >> "$OCS_TEST_COMMAND_LOG"
+if [[ "${OCS_TEST_FAIL_PSQL:-false}" == "true" ]]; then exit 1; fi
+if [[ "$*" == *"SELECT 1 FROM pg_database"* ]]; then exit 0; fi
+"""
+
+FAKE_UV_SCRIPT = r"""#!/usr/bin/env bash
+set -euo pipefail
+printf "uv:%s\n" "$*" >> "$OCS_TEST_COMMAND_LOG"
+"""
+
+FAKE_REDIS_CLI_SCRIPT = r"""#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${*: -1}" == "FLUSHDB" ]]; then
+    printf "redis-cli:%s\n" "$*" >> "$OCS_TEST_COMMAND_LOG"
+    [[ "${OCS_TEST_FAIL_REDIS_FLUSH:-false}" != "true" ]]
+    exit 0
+fi
+
+operation=
+resource_name=
+database=
+for argument in "$@"; do
+    if [[ "$argument" =~ ^(allocate|lookup|release)$ ]]; then
+        operation=$argument
+        continue
+    fi
+    if [[ -n "$operation" && -z "$resource_name" ]]; then
+        resource_name=$argument
+    elif [[ "$operation" == "release" && -n "$resource_name" ]]; then
+        database=$argument
+    fi
+done
+
+printf "redis-registry:%s:%s:%s\n" "$operation" "$resource_name" "$database" \
+    >> "$OCS_TEST_COMMAND_LOG"
+touch "$OCS_TEST_REDIS_REGISTRY"
+existing=$(awk -v resource="$resource_name" '$1 == resource { print $2 }' \
+    "$OCS_TEST_REDIS_REGISTRY")
+
+if [[ "$operation" == "lookup" ]]; then
+    [[ -n "$existing" ]] || exit 1
+    printf "%s\n" "$existing"
+    exit 0
+fi
+
+if [[ "$operation" == "allocate" ]]; then
+    if [[ -n "$existing" ]]; then printf "%s\n" "$existing"; exit 0; fi
+    for candidate in $(seq 1 14); do
+        if ! awk -v database="$candidate" \
+            '$2 == database { found = 1 } END { exit !found }' \
+            "$OCS_TEST_REDIS_REGISTRY"; then
+            printf "%s %s\n" "$resource_name" "$candidate" >> "$OCS_TEST_REDIS_REGISTRY"
+            printf "%s\n" "$candidate"
+            exit 0
+        fi
+    done
+    echo "Redis database registry exhausted" >&2
+    exit 1
+fi
+
+if [[ "$operation" == "release" ]]; then
+    [[ "$existing" == "$database" ]] || exit 1
+    awk -v resource="$resource_name" '$1 != resource' "$OCS_TEST_REDIS_REGISTRY" \
+        > "$OCS_TEST_REDIS_REGISTRY.tmp"
+    mv "$OCS_TEST_REDIS_REGISTRY.tmp" "$OCS_TEST_REDIS_REGISTRY"
+    echo 1
+    exit 0
+fi
+
+exit 1
+"""
+
+
+@dataclass(frozen=True)
+class SessionGuardScenario:
+    database_name: str
+    thread_id: str
+    setup_script: str
+    expected_log: str | None
+    redis_url: str | None = None
+    python_version: str | None = None
 
 
 def _run(
@@ -80,31 +171,27 @@ def _allocate_redis_database(worktree: Path, env: dict[str, str], resource_name:
 def _prepare_session_guard(
     worktree: Path,
     env: dict[str, str],
-    command_log: Path,
-    *,
-    database_name: str,
-    thread_id: str,
-    setup_script: str,
-    redis_url: str | None = None,
+    scenario: SessionGuardScenario,
 ) -> Path:
     redis_database = _allocate_redis_database(worktree, env, "codex_a1b2")
-    expected_redis_url = redis_url or f"redis://localhost:6379/{redis_database}"
+    expected_redis_url = scenario.redis_url or f"redis://localhost:6379/{redis_database}"
     (worktree / ".env").write_text(
         "SECRET_KEY=test-only\n"
-        f"DATABASE_URL=postgres://postgres:postgres@localhost:5432/{database_name}\n"
+        f"DATABASE_URL=postgres://postgres:postgres@localhost:5432/{scenario.database_name}\n"
         f"REDIS_URL={expected_redis_url}\n"
     )
     (worktree / ".venv").mkdir()
     (worktree / "node_modules").mkdir()
     _record_dependency_fingerprint(worktree)
-    _write_executable(worktree / "scripts" / "setup-worktree.sh", setup_script)
+    _write_executable(worktree / "scripts" / "setup-worktree.sh", scenario.setup_script)
+    command_log = Path(env["OCS_TEST_COMMAND_LOG"])
     env.update(
         {
-            "CODEX_THREAD_ID": thread_id,
+            "CODEX_THREAD_ID": scenario.thread_id,
             "TMPDIR": str(command_log.parent),
         }
     )
-    return command_log.parent / f"ocs-worktree-setup-{thread_id}.log"
+    return command_log.parent / f"ocs-worktree-setup-{scenario.thread_id}.log"
 
 
 @pytest.fixture()
@@ -119,13 +206,7 @@ def worktree_fixture(tmp_path: Path) -> tuple[Path, Path, dict[str, str], Path]:
     _run("git", "config", "user.email", "tests@example.com", cwd=root)
     _run("git", "config", "user.name", "Test User", cwd=root)
 
-    _write_executable(
-        root / "scripts" / "bootstrap.sh",
-        "#!/usr/bin/env bash\n"
-        "set -euo pipefail\n"
-        'mkdir -p "$PWD/.venv" "$PWD/node_modules"\n'
-        'printf "bootstrap:%s\\n" "$*" >> "$OCS_TEST_COMMAND_LOG"\n',
-    )
+    _write_executable(root / "scripts" / "bootstrap.sh", FAKE_BOOTSTRAP_SCRIPT)
     (root / "scripts" / "worktree-environment.sh").write_text(WORKTREE_ENVIRONMENT_SCRIPT.read_text())
     (root / ".python-version").write_text("3.13\n")
     (root / "manage.py").write_text("# test fixture\n")
@@ -149,74 +230,9 @@ def worktree_fixture(tmp_path: Path) -> tuple[Path, Path, dict[str, str], Path]:
     worktree.parent.mkdir(parents=True)
     _run("git", "worktree", "add", "--detach", worktree, "HEAD", cwd=root)
 
-    _write_executable(
-        fake_bin / "psql",
-        "#!/usr/bin/env bash\n"
-        "set -euo pipefail\n"
-        'printf "psql:%s\\n" "$*" >> "$OCS_TEST_COMMAND_LOG"\n'
-        'if [[ "${OCS_TEST_FAIL_PSQL:-false}" == "true" ]]; then exit 1; fi\n'
-        'if [[ "$*" == *"SELECT 1 FROM pg_database"* ]]; then exit 0; fi\n',
-    )
-    _write_executable(
-        fake_bin / "uv",
-        '#!/usr/bin/env bash\nset -euo pipefail\nprintf "uv:%s\\n" "$*" >> "$OCS_TEST_COMMAND_LOG"\n',
-    )
-    _write_executable(
-        fake_bin / "redis-cli",
-        "#!/usr/bin/env bash\n"
-        "set -euo pipefail\n"
-        'if [[ "${*: -1}" == "FLUSHDB" ]]; then\n'
-        '    printf "redis-cli:%s\\n" "$*" >> "$OCS_TEST_COMMAND_LOG"\n'
-        '    [[ "${OCS_TEST_FAIL_REDIS_FLUSH:-false}" != "true" ]]\n'
-        "    exit 0\n"
-        "fi\n"
-        "operation=\n"
-        "resource_name=\n"
-        "database=\n"
-        'for argument in "$@"; do\n'
-        '    if [[ "$argument" =~ ^(allocate|lookup|release)$ ]]; then\n'
-        "        operation=$argument\n"
-        "        continue\n"
-        "    fi\n"
-        '    if [[ -n "$operation" && -z "$resource_name" ]]; then\n'
-        "        resource_name=$argument\n"
-        '    elif [[ "$operation" == "release" && -n "$resource_name" ]]; then\n'
-        "        database=$argument\n"
-        "    fi\n"
-        "done\n"
-        'printf "redis-registry:%s:%s:%s\\n" "$operation" "$resource_name" "$database" '
-        '>> "$OCS_TEST_COMMAND_LOG"\n'
-        'touch "$OCS_TEST_REDIS_REGISTRY"\n'
-        "existing=$(awk -v resource=\"$resource_name\" '$1 == resource { print $2 }' "
-        '"$OCS_TEST_REDIS_REGISTRY")\n'
-        'if [[ "$operation" == "lookup" ]]; then\n'
-        '    [[ -n "$existing" ]] || exit 1\n'
-        '    printf "%s\\n" "$existing"\n'
-        "    exit 0\n"
-        "fi\n"
-        'if [[ "$operation" == "allocate" ]]; then\n'
-        '    if [[ -n "$existing" ]]; then printf "%s\\n" "$existing"; exit 0; fi\n'
-        "    for candidate in $(seq 1 14); do\n"
-        "        if ! awk -v database=\"$candidate\" '$2 == database { found = 1 } END { exit !found }' "
-        '"$OCS_TEST_REDIS_REGISTRY"; then\n'
-        '            printf "%s %s\\n" "$resource_name" "$candidate" >> "$OCS_TEST_REDIS_REGISTRY"\n'
-        '            printf "%s\\n" "$candidate"\n'
-        "            exit 0\n"
-        "        fi\n"
-        "    done\n"
-        '    echo "Redis database registry exhausted" >&2\n'
-        "    exit 1\n"
-        "fi\n"
-        'if [[ "$operation" == "release" ]]; then\n'
-        '    [[ "$existing" == "$database" ]] || exit 1\n'
-        '    awk -v resource="$resource_name" \'$1 != resource\' "$OCS_TEST_REDIS_REGISTRY" '
-        '> "$OCS_TEST_REDIS_REGISTRY.tmp"\n'
-        '    mv "$OCS_TEST_REDIS_REGISTRY.tmp" "$OCS_TEST_REDIS_REGISTRY"\n'
-        "    echo 1\n"
-        "    exit 0\n"
-        "fi\n"
-        "exit 1\n",
-    )
+    _write_executable(fake_bin / "psql", FAKE_PSQL_SCRIPT)
+    _write_executable(fake_bin / "uv", FAKE_UV_SCRIPT)
+    _write_executable(fake_bin / "redis-cli", FAKE_REDIS_CLI_SCRIPT)
 
     env = {
         "OCS_TEST_COMMAND_LOG": str(command_log),
@@ -509,78 +525,64 @@ def test_codex_session_setup_keeps_bootstrap_output_out_of_context(
     assert (command_log.parent / "ocs-worktree-setup-test-thread.log").read_text() == "verbose setup output\n"
 
 
-def test_codex_session_setup_skips_an_initialized_checkout(
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        pytest.param(
+            SessionGuardScenario(
+                database_name="codex_a1b2",
+                thread_id="initialized-thread",
+                setup_script="#!/usr/bin/env bash\nexit 99\n",
+                expected_log=None,
+            ),
+            id="initialized-checkout",
+        ),
+        pytest.param(
+            SessionGuardScenario(
+                database_name="codex_a1b2",
+                thread_id="stale-dependencies-thread",
+                setup_script="#!/usr/bin/env bash\necho 'refreshed dependencies'\n",
+                expected_log="refreshed dependencies\n",
+                python_version="3.14",
+            ),
+            id="stale-dependencies",
+        ),
+        pytest.param(
+            SessionGuardScenario(
+                database_name="root_database",
+                thread_id="shared-database-thread",
+                setup_script="#!/usr/bin/env bash\necho 'reconfigured worktree'\n",
+                expected_log="reconfigured worktree\n",
+            ),
+            id="shared-database",
+        ),
+        pytest.param(
+            SessionGuardScenario(
+                database_name="codex_a1b2",
+                thread_id="shared-redis-thread",
+                setup_script="#!/usr/bin/env bash\necho 'reconfigured worktree'\n",
+                expected_log="reconfigured worktree\n",
+                redis_url="redis://localhost:6379/0",
+            ),
+            id="shared-redis",
+        ),
+    ],
+)
+def test_codex_session_setup_guard(
     worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+    scenario: SessionGuardScenario,
 ) -> None:
-    _, worktree, env, command_log = worktree_fixture
-    log_file = _prepare_session_guard(
-        worktree,
-        env,
-        command_log,
-        database_name="codex_a1b2",
-        thread_id="initialized-thread",
-        setup_script="#!/usr/bin/env bash\nexit 99\n",
-    )
+    _, worktree, env, _ = worktree_fixture
+    log_file = _prepare_session_guard(worktree, env, scenario)
+    if scenario.python_version:
+        (worktree / ".python-version").write_text(f"{scenario.python_version}\n")
 
     _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
 
-    assert not log_file.exists()
-
-
-def test_codex_session_setup_refreshes_stale_dependencies(
-    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
-) -> None:
-    _, worktree, env, command_log = worktree_fixture
-    log_file = _prepare_session_guard(
-        worktree,
-        env,
-        command_log,
-        database_name="codex_a1b2",
-        thread_id="stale-dependencies-thread",
-        setup_script="#!/usr/bin/env bash\necho 'refreshed dependencies'\n",
-    )
-    (worktree / ".python-version").write_text("3.14\n")
-
-    _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
-
-    assert log_file.read_text() == "refreshed dependencies\n"
-
-
-def test_codex_session_setup_repairs_a_shared_database_configuration(
-    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
-) -> None:
-    _, worktree, env, command_log = worktree_fixture
-    log_file = _prepare_session_guard(
-        worktree,
-        env,
-        command_log,
-        database_name="root_database",
-        thread_id="shared-database-thread",
-        setup_script="#!/usr/bin/env bash\necho 'reconfigured worktree'\n",
-    )
-
-    _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
-
-    assert log_file.read_text() == "reconfigured worktree\n"
-
-
-def test_codex_session_setup_repairs_a_shared_redis_configuration(
-    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
-) -> None:
-    _, worktree, env, command_log = worktree_fixture
-    log_file = _prepare_session_guard(
-        worktree,
-        env,
-        command_log,
-        database_name="codex_a1b2",
-        thread_id="shared-redis-thread",
-        setup_script="#!/usr/bin/env bash\necho 'reconfigured worktree'\n",
-        redis_url="redis://localhost:6379/0",
-    )
-
-    _run(ENSURE_SETUP_SCRIPT, cwd=worktree, env=env)
-
-    assert log_file.read_text() == "reconfigured worktree\n"
+    if scenario.expected_log is None:
+        assert not log_file.exists()
+    else:
+        assert log_file.read_text() == scenario.expected_log
 
 
 def test_codex_hook_runs_when_a_session_resumes() -> None:

--- a/scripts/worktree-environment.sh
+++ b/scripts/worktree-environment.sh
@@ -168,6 +168,8 @@ ocs_release_redis_database() {
 ocs_dependency_fingerprint() {
     local worktree_path="$1"
     local dependency_file
+    local migration_file
+    local relative_migration_file
     local dependency_files=(
         .python-version
         .npmrc
@@ -178,14 +180,30 @@ ocs_dependency_fingerprint() {
         scripts/bootstrap.sh
     )
 
-    for dependency_file in "${dependency_files[@]}"; do
-        printf '%s:' "$dependency_file"
-        if [[ -f "$worktree_path/$dependency_file" ]]; then
-            cksum < "$worktree_path/$dependency_file"
-        else
-            printf 'missing\n'
+    {
+        for dependency_file in "${dependency_files[@]}"; do
+            printf '%s:' "$dependency_file"
+            if [[ -f "$worktree_path/$dependency_file" ]]; then
+                cksum < "$worktree_path/$dependency_file"
+            else
+                printf 'missing\n'
+            fi
+        done
+
+        if [[ -d "$worktree_path/apps" ]]; then
+            while IFS= read -r -d '' migration_file; do
+                relative_migration_file=${migration_file#"$worktree_path/"}
+                printf '%s:' "$relative_migration_file"
+                cksum < "$migration_file"
+            done < <(
+                find "$worktree_path/apps" \
+                    -type f \
+                    -path '*/migrations/*.py' \
+                    -print0 \
+                    | sort -z
+            )
         fi
-    done | cksum | awk '{print $1 ":" $2}'
+    } | cksum | awk '{print $1 ":" $2}'
 }
 
 ocs_record_dependency_fingerprint() {

--- a/scripts/worktree-environment.sh
+++ b/scripts/worktree-environment.sh
@@ -34,21 +34,55 @@ ocs_sanitize_resource_name() {
     printf '%s\n' "$sanitized"
 }
 
+ocs_persisted_worktree_resource_name() {
+    local current_path="$1"
+    local env_file="$current_path/.env"
+    local persisted_name
+
+    [[ -f "$env_file" ]] || return 1
+    persisted_name=$(awk '
+        index($0, "OCS_WORKTREE_ID=") == 1 {
+            value = substr($0, length("OCS_WORKTREE_ID=") + 1)
+        }
+        END {
+            if (value != "") {
+                print value
+            }
+        }
+    ' "$env_file")
+    [[ -n "$persisted_name" ]] || return 1
+    if [[ ! "$persisted_name" =~ ^[a-z0-9_]{1,63}$ ]]; then
+        echo "Invalid persisted worktree resource name: $persisted_name" >&2
+        return 2
+    fi
+    printf '%s\n' "$persisted_name"
+}
+
 ocs_worktree_resource_name() {
     local current_path="$1"
-    local branch_name parent_name raw_name
+    local branch_name parent_name persisted_status raw_name
 
     if [[ -n "${OCS_WORKTREE_ID:-}" ]]; then
         raw_name=$OCS_WORKTREE_ID
-    elif [[ "$current_path" == */.codex/worktrees/*/* ]]; then
-        parent_name=$(basename "$(dirname "$current_path")")
-        raw_name="codex_${parent_name}"
     else
-        branch_name=$(git -C "$current_path" branch --show-current)
-        if [[ -n "$branch_name" ]]; then
-            raw_name=$branch_name
+        if raw_name=$(ocs_persisted_worktree_resource_name "$current_path"); then
+            :
         else
-            raw_name="worktree_$(printf '%s' "$current_path" | cksum | awk '{print $1}')"
+            persisted_status=$?
+            if [[ "$persisted_status" -ne 1 ]]; then
+                return "$persisted_status"
+            fi
+            if [[ "$current_path" == */.codex/worktrees/*/* ]]; then
+                parent_name=$(basename "$(dirname "$current_path")")
+                raw_name="codex_${parent_name}"
+            else
+                branch_name=$(git -C "$current_path" branch --show-current)
+                if [[ -n "$branch_name" ]]; then
+                    raw_name=$branch_name
+                else
+                    raw_name="worktree_$(printf '%s' "$current_path" | cksum | awk '{print $1}')"
+                fi
+            fi
         fi
     fi
 

--- a/scripts/worktree-environment.sh
+++ b/scripts/worktree-environment.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Shared helpers for configuring isolated development resources per worktree.
+
+set -euo pipefail
+
+ocs_current_worktree_path() {
+    git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+ocs_root_worktree_path() {
+    git worktree list --porcelain | awk '/^worktree/{sub(/^worktree /, ""); print; exit}'
+}
+
+ocs_is_root_worktree() {
+    [[ "$1" == "$2" ]]
+}
+
+ocs_sanitize_resource_name() {
+    local sanitized
+    sanitized=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_]+/_/g; s/^_+//; s/_+$//')
+    sanitized=${sanitized:0:63}
+    if [[ -z "$sanitized" ]]; then
+        echo "Unable to derive a safe worktree resource name." >&2
+        return 1
+    fi
+    printf '%s\n' "$sanitized"
+}
+
+ocs_worktree_resource_name() {
+    local current_path="$1"
+    local branch_name parent_name raw_name
+
+    if [[ -n "${OCS_WORKTREE_ID:-}" ]]; then
+        raw_name=$OCS_WORKTREE_ID
+    elif [[ "$current_path" == */.codex/worktrees/*/* ]]; then
+        parent_name=$(basename "$(dirname "$current_path")")
+        raw_name="codex_${parent_name}"
+    else
+        branch_name=$(git -C "$current_path" branch --show-current)
+        if [[ -n "$branch_name" ]]; then
+            raw_name=$branch_name
+        else
+            raw_name="worktree_$(printf '%s' "$current_path" | cksum | awk '{print $1}')"
+        fi
+    fi
+
+    ocs_sanitize_resource_name "$raw_name"
+}
+
+ocs_redis_database() {
+    printf '%s' "$1" | cksum | awk '{print ($1 % 15) + 1}'
+}
+
+ocs_dependency_fingerprint() {
+    local worktree_path="$1"
+    local dependency_file
+    local dependency_files=(
+        .python-version
+        .npmrc
+        package.json
+        pnpm-lock.yaml
+        pyproject.toml
+        uv.lock
+        scripts/bootstrap.sh
+    )
+
+    for dependency_file in "${dependency_files[@]}"; do
+        printf '%s:' "$dependency_file"
+        if [[ -f "$worktree_path/$dependency_file" ]]; then
+            cksum < "$worktree_path/$dependency_file"
+        else
+            printf 'missing\n'
+        fi
+    done | cksum | awk '{print $1 ":" $2}'
+}
+
+ocs_record_dependency_fingerprint() {
+    local worktree_path="$1"
+    local fingerprint_file="$worktree_path/.venv/.ocs-dependency-fingerprint"
+
+    mkdir -p "$(dirname "$fingerprint_file")"
+    ocs_dependency_fingerprint "$worktree_path" > "$fingerprint_file"
+}
+
+ocs_dependencies_are_current() {
+    local worktree_path="$1"
+    local fingerprint_file="$worktree_path/.venv/.ocs-dependency-fingerprint"
+    local expected_fingerprint
+
+    [[ -f "$fingerprint_file" ]] || return 1
+    expected_fingerprint=$(ocs_dependency_fingerprint "$worktree_path")
+    [[ "$(<"$fingerprint_file")" == "$expected_fingerprint" ]]
+}
+
+ocs_set_env_value() {
+    local env_file="$1"
+    local key="$2"
+    local value="$3"
+    local temp_file
+
+    temp_file=$(mktemp "${env_file}.XXXXXX")
+    awk -v key="$key" -v value="$value" '
+        BEGIN { found = 0 }
+        index($0, key "=") == 1 {
+            print key "=" value
+            found = 1
+            next
+        }
+        { print }
+        END {
+            if (!found) {
+                print key "=" value
+            }
+        }
+    ' "$env_file" > "$temp_file"
+    mv "$temp_file" "$env_file"
+}

--- a/scripts/worktree-environment.sh
+++ b/scripts/worktree-environment.sh
@@ -16,12 +16,20 @@ ocs_is_root_worktree() {
 }
 
 ocs_sanitize_resource_name() {
+    local original="$1"
+    local hash_suffix
+    local prefix_length
     local sanitized
-    sanitized=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_]+/_/g; s/^_+//; s/_+$//')
-    sanitized=${sanitized:0:63}
+    sanitized=$(printf '%s' "$original" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_]+/_/g; s/^_+//; s/_+$//')
     if [[ -z "$sanitized" ]]; then
         echo "Unable to derive a safe worktree resource name." >&2
         return 1
+    fi
+
+    if [[ "$sanitized" != "$original" || ${#sanitized} -gt 63 ]]; then
+        hash_suffix=$(printf '%s' "$original" | cksum | awk '{printf "%08x", $1}')
+        prefix_length=$((63 - ${#hash_suffix} - 1))
+        sanitized="${sanitized:0:prefix_length}_${hash_suffix}"
     fi
     printf '%s\n' "$sanitized"
 }
@@ -47,8 +55,114 @@ ocs_worktree_resource_name() {
     ocs_sanitize_resource_name "$raw_name"
 }
 
-ocs_redis_database() {
-    printf '%s' "$1" | cksum | awk '{print ($1 % 15) + 1}'
+ocs_redis_registry_command() {
+    local operation="$1"
+    local resource_name="$2"
+    local expected_database="${3:-}"
+    local registry_database="${OCS_REDIS_REGISTRY_DATABASE:-15}"
+    local registry_key="ocs:worktree:redis-registry"
+    local registry_script
+
+    registry_script='local operation = ARGV[1]
+local resource = ARGV[2]
+local expected_database = ARGV[3]
+local resource_field = "resource:" .. resource
+
+local function database_field(database)
+    return "database:" .. database
+end
+
+if operation == "lookup" then
+    local database = redis.call("HGET", KEYS[1], resource_field)
+    if not database then
+        return "missing"
+    end
+    if redis.call("HGET", KEYS[1], database_field(database)) ~= resource then
+        return "missing"
+    end
+    return database
+end
+
+
+if operation == "allocate" then
+    local database = redis.call("HGET", KEYS[1], resource_field)
+    if database and redis.call("HGET", KEYS[1], database_field(database)) == resource then
+        return database
+    end
+    redis.call("HDEL", KEYS[1], resource_field)
+
+    for candidate = 1, 14 do
+        local field = database_field(candidate)
+        if not redis.call("HGET", KEYS[1], field) then
+            redis.call("HSET", KEYS[1], field, resource)
+            redis.call("HSET", KEYS[1], resource_field, candidate)
+            return candidate
+        end
+    end
+    return redis.error_reply("No Redis databases available for another worktree")
+end
+
+
+if operation == "release" then
+    local database = redis.call("HGET", KEYS[1], resource_field)
+    if database ~= expected_database then
+        return 0
+    end
+    if redis.call("HGET", KEYS[1], database_field(database)) ~= resource then
+        return 0
+    end
+    redis.call("HDEL", KEYS[1], resource_field, database_field(database))
+    return 1
+end
+
+
+return redis.error_reply("Unknown worktree Redis registry operation")'
+
+    redis-cli \
+        -e \
+        -n "$registry_database" \
+        --raw \
+        EVAL "$registry_script" 1 "$registry_key" \
+        "$operation" "$resource_name" "$expected_database"
+}
+
+ocs_allocate_redis_database() {
+    local resource_name="$1"
+    local database
+
+    database=$(ocs_redis_registry_command allocate "$resource_name")
+    if [[ ! "$database" =~ ^([1-9]|1[0-4])$ ]]; then
+        echo "Unable to allocate a Redis database for $resource_name: ${database:-no response}" >&2
+        return 1
+    fi
+    printf '%s\n' "$database"
+}
+
+ocs_lookup_redis_database() {
+    local resource_name="$1"
+    local database
+
+    database=$(ocs_redis_registry_command lookup "$resource_name") || return 2
+    if [[ "$database" == "missing" ]]; then
+        return 1
+    fi
+    if [[ ! "$database" =~ ^([1-9]|1[0-4])$ ]]; then
+        echo "Invalid Redis database allocation for $resource_name: ${database:-no response}" >&2
+        return 2
+    fi
+    printf '%s\n' "$database"
+}
+
+ocs_release_redis_database() {
+    local resource_name="$1"
+    local database="$2"
+    local released
+
+    released=$(ocs_redis_registry_command release "$resource_name" "$database")
+    if [[ "$released" != "1" ]]; then
+        echo "Unable to release Redis database $database for $resource_name." >&2
+        return 1
+    fi
 }
 
 ocs_dependency_fingerprint() {

--- a/worktrees.json
+++ b/worktrees.json
@@ -1,5 +1,0 @@
-{
-  "setup-worktree": [
-    "bash .claude/hooks/setup-env.sh"
-  ]
-}


### PR DESCRIPTION
### Product Description

No change.

### Technical Description

- Adds a Codex `SessionStart` hook that initializes new and resumed Codex worktrees.
- Shares tool-neutral setup, dependency fingerprinting, database isolation, and cleanup across Claude, Codex, and Worktrunk.
- Derives collision-resistant PostgreSQL resource names while preserving already-safe Worktrunk identifiers.
- Allocates Redis databases 1–14 through an atomic Lua registry stored in database 15, with explicit exhaustion handling and allocation release during teardown.
- Validates both `DATABASE_URL` and `REDIS_URL` before skipping setup, so inherited shared-service configuration is repaired.
- Propagates PostgreSQL and Redis cleanup failures instead of reporting a successful teardown.

### Demo

1. Create a Worktrunk or Codex worktree.
2. Start or resume a Codex task in that worktree (after trusting the project hook through `/hooks`).
3. Confirm setup creates isolated `DATABASE_URL` and `REDIS_URL` values and records the dependency fingerprint.
4. Remove a Worktrunk worktree and confirm its PostgreSQL database, Redis contents, and Redis allocation are cleaned up.

### Docs and Changelog

- [x] This PR requires docs/changelog update

The developer workflow documentation now describes the shared Redis allocation registry and teardown behavior.

### Testing

- `SECRET_KEY=test-only uv run pytest scripts/test_worktree_environment.py -q` (22 passed)
- `uv run inv ruff --paths scripts/test_worktree_environment.py`
- `uv run ty check scripts/test_worktree_environment.py`
- `bash -n` and `shellcheck` for the updated shell scripts
- JSON/TOML parsing and `git diff --check`
