### PR TITLE
Broadcast message support

### DIFF
--- a/apps/chatbots/forms.py
+++ b/apps/chatbots/forms.py
@@ -119,17 +119,29 @@ class CopyChatbotForm(forms.Form):
     )
 
 
+# Platforms with no way to push a message at a participant out of band. API and web sessions
+# have no address to deliver to and evaluation sessions have no human on the other end; the
+# chat widget routes through `ApiChannel`, whose sender is a `NoOpSender`, so a broadcast there
+# would land in the chat history and be delivered nowhere.
+#
+# Listed out rather than derived from `ChannelPlatform.team_global_platforms()`, which answers a
+# different question -- which platforms allow only one channel per team -- and no longer matches.
+NON_BROADCASTABLE_PLATFORMS = [
+    ChannelPlatform.API,
+    ChannelPlatform.WEB,
+    ChannelPlatform.EVALUATIONS,
+    ChannelPlatform.EMBEDDED_WIDGET,
+]
+
+
 def get_broadcast_channels(experiment: Experiment):
     """The channels a broadcast can go out on.
 
-    The team-global platforms are excluded: API and web sessions have no address to push a
-    message to, and evaluation sessions have no human on the other end. Disabled channels are
-    excluded too -- the send path drops bot-initiated traffic on them, so offering one would
+    Disabled channels are excluded alongside the platforms that can't be pushed to at all --
+    the send path drops bot-initiated traffic on a disabled channel, so offering one would
     only ever be a broadcast that silently goes nowhere.
     """
-    return experiment.experimentchannel_set.exclude(platform__in=ChannelPlatform.team_global_platforms()).exclude(
-        enabled=False
-    )
+    return experiment.experimentchannel_set.exclude(platform__in=NON_BROADCASTABLE_PLATFORMS).exclude(enabled=False)
 
 
 class BroadcastChannelWidget(forms.CheckboxSelectMultiple):

--- a/apps/chatbots/forms.py
+++ b/apps/chatbots/forms.py
@@ -132,6 +132,28 @@ def get_broadcast_channels(experiment: Experiment):
     )
 
 
+class BroadcastChannelWidget(forms.CheckboxSelectMultiple):
+    """Checkboxes tagged with their platform so the dialog can react to what is ticked.
+
+    The `data-platform` attribute is what arms the WhatsApp template warning; `x-model` feeds
+    the same selection to the send button.
+    """
+
+    def __init__(self, attrs=None):
+        super().__init__(attrs={"x-model": "selectedChannels", **(attrs or {})})
+
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
+        option = super().create_option(name, value, label, selected, index, subindex, attrs)
+        # `value` is a ModelChoiceIteratorValue wrapping the channel's pk; the instance is on it.
+        option["attrs"]["data-platform"] = value.instance.platform
+        return option
+
+
+class BroadcastChannelField(forms.ModelMultipleChoiceField):
+    def label_from_instance(self, obj):
+        return f"{obj.platform_enum.label} — {obj.name}"
+
+
 class BroadcastMessageForm(forms.Form):
     """A one-off message sent to every participant of a chatbot on the chosen channels."""
 
@@ -140,16 +162,21 @@ class BroadcastMessageForm(forms.Form):
     # all of the selected channels rather than being silently split on one of them.
     MESSAGE_CHAR_LIMIT = MetaCloudAPIService.TEMPLATE_MESSAGE_CHAR_LIMIT
 
-    channels = forms.ModelMultipleChoiceField(
+    channels = BroadcastChannelField(
         queryset=ExperimentChannel.objects.none(),
-        widget=forms.CheckboxSelectMultiple,
+        widget=BroadcastChannelWidget,
         error_messages={"required": "Select at least one channel to broadcast on."},
     )
     message = forms.CharField(
         max_length=MESSAGE_CHAR_LIMIT,
-        widget=forms.Textarea(attrs={"rows": 4}),
+        widget=forms.Textarea(attrs={"rows": 5, "x-model": "message"}),
     )
 
     def __init__(self, experiment: Experiment, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["channels"].queryset = get_broadcast_channels(experiment)
+
+    @property
+    def eligible_channels(self):
+        """The channels on offer. Empty means there is nothing to broadcast on, so no dialog."""
+        return self.fields["channels"].queryset

--- a/apps/chatbots/forms.py
+++ b/apps/chatbots/forms.py
@@ -142,8 +142,8 @@ class BroadcastChannelWidget(forms.CheckboxSelectMultiple):
     def __init__(self, attrs=None):
         super().__init__(attrs={"x-model": "selectedChannels", **(attrs or {})})
 
-    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
-        option = super().create_option(name, value, label, selected, index, subindex, attrs)
+    def create_option(self, name, value, *args, **kwargs):
+        option = super().create_option(name, value, *args, **kwargs)
         # `value` is a ModelChoiceIteratorValue wrapping the channel's pk; the instance is on it.
         option["attrs"]["data-platform"] = value.instance.platform
         return option

--- a/apps/chatbots/forms.py
+++ b/apps/chatbots/forms.py
@@ -173,10 +173,8 @@ class BroadcastMessageForm(forms.Form):
     # all of the selected channels rather than being silently split on one of them.
     MESSAGE_CHAR_LIMIT = MetaCloudAPIService.TEMPLATE_MESSAGE_CHAR_LIMIT
 
-    DEFAULT_ACTIVE_WITHIN_DAYS = 90
-    # Bounds the audience query's lookback so a broadcast can't be pointed at years of stale
-    # sessions -- three years comfortably covers any real "recently active" cutoff.
-    MAX_ACTIVE_WITHIN_DAYS = 365 * 3
+    DEFAULT_ACTIVE_WITHIN_DAYS = 14
+    MAX_ACTIVE_WITHIN_DAYS = 90
 
     channels = BroadcastChannelField(
         queryset=ExperimentChannel.objects.none(),

--- a/apps/chatbots/forms.py
+++ b/apps/chatbots/forms.py
@@ -2,8 +2,10 @@ from django import forms
 from django.db import transaction
 from waffle import flag_is_active
 
+from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.experiments.models import ConsentForm, Experiment, SyntheticVoice
 from apps.pipelines.models import Pipeline
+from apps.service_providers.messaging_service import MetaCloudAPIService
 from apps.service_providers.utils import get_first_llm_provider_by_team, get_first_llm_provider_model
 
 
@@ -115,3 +117,39 @@ class CopyChatbotForm(forms.Form):
         max_length=255,
         required=True,
     )
+
+
+def get_broadcast_channels(experiment: Experiment):
+    """The channels a broadcast can go out on.
+
+    The team-global platforms are excluded: API and web sessions have no address to push a
+    message to, and evaluation sessions have no human on the other end. Disabled channels are
+    excluded too -- the send path drops bot-initiated traffic on them, so offering one would
+    only ever be a broadcast that silently goes nowhere.
+    """
+    return experiment.experimentchannel_set.exclude(platform__in=ChannelPlatform.team_global_platforms()).exclude(
+        enabled=False
+    )
+
+
+class BroadcastMessageForm(forms.Form):
+    """A one-off message sent to every participant of a chatbot on the chosen channels."""
+
+    # The limit is WhatsApp's: a broadcast lands outside the 24-hour service window, so it goes
+    # out as a template message. Applied to every platform so the same text is deliverable on
+    # all of the selected channels rather than being silently split on one of them.
+    MESSAGE_CHAR_LIMIT = MetaCloudAPIService.TEMPLATE_MESSAGE_CHAR_LIMIT
+
+    channels = forms.ModelMultipleChoiceField(
+        queryset=ExperimentChannel.objects.none(),
+        widget=forms.CheckboxSelectMultiple,
+        error_messages={"required": "Select at least one channel to broadcast on."},
+    )
+    message = forms.CharField(
+        max_length=MESSAGE_CHAR_LIMIT,
+        widget=forms.Textarea(attrs={"rows": 4}),
+    )
+
+    def __init__(self, experiment: Experiment, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["channels"].queryset = get_broadcast_channels(experiment)  # ty: ignore[unresolved-attribute]

--- a/apps/chatbots/forms.py
+++ b/apps/chatbots/forms.py
@@ -166,17 +166,28 @@ class BroadcastChannelField(forms.ModelMultipleChoiceField):
 
 
 class BroadcastMessageForm(forms.Form):
-    """A one-off message sent to every participant of a chatbot on the chosen channels."""
+    """A one-off message sent to the recently active participants of a chatbot on the chosen channels."""
 
     # The limit is WhatsApp's: a broadcast lands outside the 24-hour service window, so it goes
     # out as a template message. Applied to every platform so the same text is deliverable on
     # all of the selected channels rather than being silently split on one of them.
     MESSAGE_CHAR_LIMIT = MetaCloudAPIService.TEMPLATE_MESSAGE_CHAR_LIMIT
 
+    DEFAULT_ACTIVE_WITHIN_DAYS = 90
+
     channels = BroadcastChannelField(
         queryset=ExperimentChannel.objects.none(),
         widget=BroadcastChannelWidget,
         error_messages={"required": "Select at least one channel to broadcast on."},
+    )
+    active_within_days = forms.IntegerField(
+        label="Active in the last (days)",
+        initial=DEFAULT_ACTIVE_WITHIN_DAYS,
+        min_value=1,
+        help_text=(
+            "Only participants whose last activity falls inside this many days are messaged. "
+            "A participant who has not chatted since then is left alone."
+        ),
     )
     message = forms.CharField(
         max_length=MESSAGE_CHAR_LIMIT,

--- a/apps/chatbots/forms.py
+++ b/apps/chatbots/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.db import transaction
 from waffle import flag_is_active
 
-from apps.channels.models import ChannelPlatform, ExperimentChannel
+from apps.channels.models import ExperimentChannel
 from apps.experiments.models import ConsentForm, Experiment, SyntheticVoice
 from apps.pipelines.models import Pipeline
 from apps.service_providers.messaging_service import MetaCloudAPIService
@@ -119,29 +119,21 @@ class CopyChatbotForm(forms.Form):
     )
 
 
-# Platforms with no way to push a message at a participant out of band. API and web sessions
-# have no address to deliver to and evaluation sessions have no human on the other end; the
-# chat widget routes through `ApiChannel`, whose sender is a `NoOpSender`, so a broadcast there
-# would land in the chat history and be delivered nowhere.
-#
-# Listed out rather than derived from `ChannelPlatform.team_global_platforms()`, which answers a
-# different question -- which platforms allow only one channel per team -- and no longer matches.
-NON_BROADCASTABLE_PLATFORMS = [
-    ChannelPlatform.API,
-    ChannelPlatform.WEB,
-    ChannelPlatform.EVALUATIONS,
-    ChannelPlatform.EMBEDDED_WIDGET,
-]
-
-
 def get_broadcast_channels(experiment: Experiment):
-    """The channels a broadcast can go out on.
+    """Every channel of this chatbot a broadcast can go out on.
 
-    Disabled channels are excluded alongside the platforms that can't be pushed to at all --
-    the send path drops bot-initiated traffic on a disabled channel, so offering one would
-    only ever be a broadcast that silently goes nowhere.
+    A broadcast runs through `ad_hoc_bot_message`, the same path as a scheduled message, so any
+    channel that can carry one can carry the other. On the chat widget that means the message
+    is written to the chat history and picked up by the widget's polling rather than pushed,
+    which is how a scheduled message reaches a widget participant too.
+
+    Nothing filters by platform. The API, web and evaluations channels belong to the team
+    rather than a chatbot (`ExperimentChannel.objects.get_team_*_channel` leaves `experiment`
+    null), so they are already absent from this set and their sessions are unreachable through
+    it. Disabled channels are excluded because `ad_hoc_bot_message` refuses to send on one --
+    offering it would only ever be a broadcast that silently goes nowhere.
     """
-    return experiment.experimentchannel_set.exclude(platform__in=NON_BROADCASTABLE_PLATFORMS).exclude(enabled=False)
+    return experiment.experimentchannel_set.exclude(enabled=False)
 
 
 class BroadcastChannelWidget(forms.CheckboxSelectMultiple):

--- a/apps/chatbots/forms.py
+++ b/apps/chatbots/forms.py
@@ -152,4 +152,4 @@ class BroadcastMessageForm(forms.Form):
 
     def __init__(self, experiment: Experiment, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["channels"].queryset = get_broadcast_channels(experiment)  # ty: ignore[unresolved-attribute]
+        self.fields["channels"].queryset = get_broadcast_channels(experiment)

--- a/apps/chatbots/forms.py
+++ b/apps/chatbots/forms.py
@@ -174,6 +174,9 @@ class BroadcastMessageForm(forms.Form):
     MESSAGE_CHAR_LIMIT = MetaCloudAPIService.TEMPLATE_MESSAGE_CHAR_LIMIT
 
     DEFAULT_ACTIVE_WITHIN_DAYS = 90
+    # Bounds the audience query's lookback so a broadcast can't be pointed at years of stale
+    # sessions -- three years comfortably covers any real "recently active" cutoff.
+    MAX_ACTIVE_WITHIN_DAYS = 365 * 3
 
     channels = BroadcastChannelField(
         queryset=ExperimentChannel.objects.none(),
@@ -184,6 +187,7 @@ class BroadcastMessageForm(forms.Form):
         label="Active in the last (days)",
         initial=DEFAULT_ACTIVE_WITHIN_DAYS,
         min_value=1,
+        max_value=MAX_ACTIVE_WITHIN_DAYS,
         help_text=(
             "Only participants whose last activity falls inside this many days are messaged. "
             "A participant who has not chatted since then is left alone."

--- a/apps/chatbots/forms.py
+++ b/apps/chatbots/forms.py
@@ -163,7 +163,14 @@ class BroadcastChannelWidget(forms.CheckboxSelectMultiple):
 
 class BroadcastChannelField(forms.ModelMultipleChoiceField):
     def label_from_instance(self, obj):
-        return f"{obj.platform_enum.label} — {obj.name}"
+        """The platform is the whole label.
+
+        `ExperimentChannel.__str__` would add the channel's name, which defaults to the
+        chatbot's -- the same on every row, so it only tells the reader which chatbot they are
+        already looking at. A chatbot can hold only one channel per platform
+        (`validate_platform_availability`), so the platform on its own is unambiguous.
+        """
+        return obj.platform_enum.label
 
 
 class BroadcastMessageForm(forms.Form):

--- a/apps/chatbots/tasks.py
+++ b/apps/chatbots/tasks.py
@@ -1,5 +1,9 @@
+from datetime import timedelta
+
 from celery import shared_task
 from celery.utils.log import get_task_logger
+from django.db.models import Q
+from django.utils import timezone
 
 from apps.experiments.models import ExperimentSession, SessionStatus
 from apps.service_providers.tracing import TraceInfo
@@ -18,19 +22,24 @@ def send_bot_message(session_id: int, instruction_prompt: str):
 
 
 @shared_task(queue=Queues.BACKGROUND)
-def send_broadcast_message(experiment_id: int, channel_ids: list[int], message: str):
-    """Deliver `message` to every participant of this chatbot on the given channels.
+def send_broadcast_message(experiment_id: int, channel_ids: list[int], message: str, active_within_days: int):
+    """Deliver `message` to the recently active participants of this chatbot on the given channels.
 
     Runs on the background queue and fans out one send per session, so a broadcast to a
     large audience can't hold up the latency-sensitive chat queue while it walks the list.
     """
-    session_ids = get_broadcast_session_ids(experiment_id, channel_ids)
-    log.info("Broadcasting to %s session(s) for experiment %s", len(session_ids), experiment_id)
+    session_ids = get_broadcast_session_ids(experiment_id, channel_ids, active_within_days)
+    log.info(
+        "Broadcasting to %s session(s) active in the last %s day(s) for experiment %s",
+        len(session_ids),
+        active_within_days,
+        experiment_id,
+    )
     for session_id in session_ids:
         send_broadcast_message_to_session.delay(session_id=session_id, message=message)
 
 
-def get_broadcast_session_ids(experiment_id: int, channel_ids: list[int]) -> list[int]:
+def get_broadcast_session_ids(experiment_id: int, channel_ids: list[int], active_within_days: int) -> list[int]:
     """The most recent active session per (participant, channel) for a broadcast.
 
     A participant is reachable only through a session they already have -- that is what holds
@@ -39,16 +48,25 @@ def get_broadcast_session_ids(experiment_id: int, channel_ids: list[int]) -> lis
 
     Only `ACTIVE` sessions count. A session resting at `SETUP` or `PENDING` has no conversation
     in it yet, and one that has been ended sits at `PENDING_REVIEW` or `COMPLETE` -- broadcasting
-    into either would push a message at someone who is not in a conversation with the bot. The
-    status is filtered before the newest-per-group pick, so a participant whose newest session
-    has been ended is still reached on an older one that is still active.
+    into either would push a message at someone who is not in a conversation with the bot.
+
+    `active_within_days` is the audience cutoff the sender chose in the broadcast dialog: a
+    participant who has been quiet for longer than that is left alone rather than pulled back
+    into a conversation they walked away from weeks ago. Activity is measured the way the
+    sessions table and its "Last Activity" filter measure it -- `last_activity_at`, falling
+    back to `created_at` for a session that never received a participant message.
+
+    Both filters run before the newest-per-group pick, so a participant whose newest session
+    has been ended, or has gone quiet, is still reached on an older session that qualifies.
     """
+    cutoff = timezone.now() - timedelta(days=active_within_days)
     return list(
         ExperimentSession.objects.filter(
             experiment_id=experiment_id,
             experiment_channel_id__in=channel_ids,
             status=SessionStatus.ACTIVE,
         )
+        .filter(Q(last_activity_at__gte=cutoff) | Q(last_activity_at__isnull=True, created_at__gte=cutoff))
         # `-id` breaks ties on `created_at` so the newest session is picked deterministically.
         .order_by("participant_id", "experiment_channel_id", "-created_at", "-id")
         .distinct("participant_id", "experiment_channel_id")

--- a/apps/chatbots/tasks.py
+++ b/apps/chatbots/tasks.py
@@ -1,7 +1,7 @@
 from celery import shared_task
 from celery.utils.log import get_task_logger
 
-from apps.experiments.models import ExperimentSession
+from apps.experiments.models import ExperimentSession, SessionStatus
 from apps.service_providers.tracing import TraceInfo
 from apps.utils.celery import Queues
 
@@ -31,16 +31,23 @@ def send_broadcast_message(experiment_id: int, channel_ids: list[int], message: 
 
 
 def get_broadcast_session_ids(experiment_id: int, channel_ids: list[int]) -> list[int]:
-    """The most recent session per (participant, channel) for a broadcast.
+    """The most recent active session per (participant, channel) for a broadcast.
 
     A participant is reachable only through a session they already have -- that is what holds
     the address to deliver to -- and only their latest session on a channel is the live
     conversation, so older ones are skipped. Someone on two channels is messaged on both.
+
+    Only `ACTIVE` sessions count. A session resting at `SETUP` or `PENDING` has no conversation
+    in it yet, and one that has been ended sits at `PENDING_REVIEW` or `COMPLETE` -- broadcasting
+    into either would push a message at someone who is not in a conversation with the bot. The
+    status is filtered before the newest-per-group pick, so a participant whose newest session
+    has been ended is still reached on an older one that is still active.
     """
     return list(
         ExperimentSession.objects.filter(
             experiment_id=experiment_id,
             experiment_channel_id__in=channel_ids,
+            status=SessionStatus.ACTIVE,
         )
         # `-id` breaks ties on `created_at` so the newest session is picked deterministically.
         .order_by("participant_id", "experiment_channel_id", "-created_at", "-id")

--- a/apps/chatbots/tasks.py
+++ b/apps/chatbots/tasks.py
@@ -1,8 +1,11 @@
 from celery import shared_task
+from celery.utils.log import get_task_logger
 
 from apps.experiments.models import ExperimentSession
 from apps.service_providers.tracing import TraceInfo
 from apps.utils.celery import Queues
+
+log = get_task_logger("ocs.chatbots")
 
 
 @shared_task(queue=Queues.CHAT)
@@ -11,4 +14,50 @@ def send_bot_message(session_id: int, instruction_prompt: str):
     session.ad_hoc_bot_message(
         instruction_prompt=instruction_prompt,
         trace_info=TraceInfo(name="Manual Session Start"),
+    )
+
+
+@shared_task(queue=Queues.BACKGROUND)
+def send_broadcast_message(experiment_id: int, channel_ids: list[int], message: str):
+    """Deliver `message` to every participant of this chatbot on the given channels.
+
+    Runs on the background queue and fans out one send per session, so a broadcast to a
+    large audience can't hold up the latency-sensitive chat queue while it walks the list.
+    """
+    session_ids = get_broadcast_session_ids(experiment_id, channel_ids)
+    log.info("Broadcasting to %s session(s) for experiment %s", len(session_ids), experiment_id)
+    for session_id in session_ids:
+        send_broadcast_message_to_session.delay(session_id=session_id, message=message)
+
+
+def get_broadcast_session_ids(experiment_id: int, channel_ids: list[int]) -> list[int]:
+    """The most recent session per (participant, channel) for a broadcast.
+
+    A participant is reachable only through a session they already have -- that is what holds
+    the address to deliver to -- and only their latest session on a channel is the live
+    conversation, so older ones are skipped. Someone on two channels is messaged on both.
+    """
+    return list(
+        ExperimentSession.objects.filter(
+            experiment_id=experiment_id,
+            experiment_channel_id__in=channel_ids,
+        )
+        .order_by("participant_id", "experiment_channel_id", "-created_at")
+        .distinct("participant_id", "experiment_channel_id")
+        .values_list("id", flat=True)
+    )
+
+
+@shared_task(queue=Queues.CHAT)
+def send_broadcast_message_to_session(session_id: int, message: str):
+    """Deliver one broadcast message verbatim, bypassing the LLM.
+
+    `ad_hoc_bot_message` swallows delivery failures and skips disabled channels, so one
+    unreachable participant never aborts the rest of the broadcast.
+    """
+    session = ExperimentSession.objects.get(id=session_id)
+    session.ad_hoc_bot_message(
+        instruction_prompt=None,
+        message_text=message,
+        trace_info=TraceInfo(name="Broadcast Message"),
     )

--- a/apps/chatbots/tasks.py
+++ b/apps/chatbots/tasks.py
@@ -42,7 +42,8 @@ def get_broadcast_session_ids(experiment_id: int, channel_ids: list[int]) -> lis
             experiment_id=experiment_id,
             experiment_channel_id__in=channel_ids,
         )
-        .order_by("participant_id", "experiment_channel_id", "-created_at")
+        # `-id` breaks ties on `created_at` so the newest session is picked deterministically.
+        .order_by("participant_id", "experiment_channel_id", "-created_at", "-id")
         .distinct("participant_id", "experiment_channel_id")
         .values_list("id", flat=True)
     )

--- a/apps/chatbots/tests/test_broadcast.py
+++ b/apps/chatbots/tests/test_broadcast.py
@@ -1,16 +1,29 @@
 from unittest.mock import patch
 
 import pytest
+from django.urls import reverse
 
 from apps.channels.models import ChannelPlatform
+from apps.chatbots.forms import BroadcastMessageForm
 from apps.chatbots.tasks import send_broadcast_message
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory, ParticipantFactory
+from apps.utils.factories.team import TeamWithUsersFactory
 
 
 @pytest.fixture()
 def experiment():
-    return ExperimentFactory()
+    return ExperimentFactory(team=TeamWithUsersFactory())
+
+
+@pytest.fixture()
+def logged_in_client(client, experiment):
+    client.force_login(experiment.team.members.first())
+    return client
+
+
+def _broadcast_url(experiment):
+    return reverse("chatbots:broadcast_message", args=[experiment.team.slug, experiment.id])
 
 
 @pytest.mark.django_db()
@@ -41,3 +54,47 @@ def test_broadcast_reaches_each_participant_once_per_selected_channel(delay, exp
     messaged = {call.kwargs["session_id"] for call in delay.call_args_list}
     assert messaged == {latest_telegram.id, on_whatsapp_too.id, other_participant.id}
     assert {call.kwargs["message"] for call in delay.call_args_list} == {"Hi all"}
+
+
+@pytest.mark.django_db()
+@patch("apps.chatbots.views.send_broadcast_message.delay")
+def test_broadcast_view_queues_the_selected_channels(delay, experiment, logged_in_client):
+    telegram = ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.TELEGRAM)
+
+    response = logged_in_client.post(
+        _broadcast_url(experiment), data={"channels": [telegram.id], "message": "We're back online"}
+    )
+
+    assert response.status_code == 302
+    delay.assert_called_once_with(experiment_id=experiment.id, channel_ids=[telegram.id], message="We're back online")
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("channel", "message"),
+    [
+        pytest.param(None, "Hi", id="no-channel-selected"),
+        pytest.param("other-chatbot", "Hi", id="channel-of-another-chatbot"),
+        pytest.param("disabled", "Hi", id="disabled-channel"),
+        pytest.param("own", "", id="empty-message"),
+        pytest.param("own", "x" * (BroadcastMessageForm.MESSAGE_CHAR_LIMIT + 1), id="message-over-char-limit"),
+    ],
+)
+@patch("apps.chatbots.views.send_broadcast_message.delay")
+def test_broadcast_view_rejects_invalid_input(delay, channel, message, experiment, logged_in_client):
+    """Nothing is queued unless a live channel of *this* chatbot and a message within the limit are given."""
+    channels = {
+        "own": ExperimentChannelFactory(team=experiment.team, experiment=experiment),
+        "other-chatbot": ExperimentChannelFactory(team=experiment.team),
+        "disabled": ExperimentChannelFactory(
+            team=experiment.team, experiment=experiment, platform=ChannelPlatform.WHATSAPP, enabled=False
+        ),
+    }
+    data = {"message": message}
+    if channel:
+        data["channels"] = [channels[channel].id]
+
+    response = logged_in_client.post(_broadcast_url(experiment), data=data)
+
+    assert response.status_code == 302
+    delay.assert_not_called()

--- a/apps/chatbots/tests/test_broadcast.py
+++ b/apps/chatbots/tests/test_broadcast.py
@@ -1,13 +1,15 @@
 import re
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
 from django.urls import reverse
+from django.utils import timezone
 
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chatbots.forms import BroadcastMessageForm
 from apps.chatbots.tasks import send_broadcast_message
-from apps.experiments.models import SessionStatus
+from apps.experiments.models import ExperimentSession, SessionStatus
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory, ParticipantFactory
 from apps.utils.factories.team import TeamWithUsersFactory
@@ -26,6 +28,11 @@ def logged_in_client(client, experiment):
 
 def _broadcast_url(experiment):
     return reverse("chatbots:broadcast_message", args=[experiment.team.slug, experiment.id])
+
+
+def _dialog(content: str) -> str:
+    start = content.index('id="broadcast_message_modal"')
+    return content[start : content.index("</dialog>", start)]
 
 
 @pytest.mark.django_db()
@@ -51,7 +58,12 @@ def test_broadcast_reaches_each_participant_once_per_selected_channel(delay, exp
     # A participant of a different chatbot is not part of this broadcast.
     ExperimentSessionFactory(experiment=ExperimentFactory(team=team), experiment_channel=telegram)
 
-    send_broadcast_message(experiment_id=experiment.id, channel_ids=[telegram.id, whatsapp.id], message="Hi all")
+    send_broadcast_message(
+        experiment_id=experiment.id,
+        channel_ids=[telegram.id, whatsapp.id],
+        message="Hi all",
+        active_within_days=30,
+    )
 
     messaged = {call.kwargs["session_id"] for call in delay.call_args_list}
     assert delay.call_count == 3, "each (participant, channel) pair must be messaged exactly once"
@@ -76,7 +88,7 @@ def test_broadcast_skips_a_session_that_is_not_active(delay, status, experiment)
     channel = ExperimentChannelFactory(team=experiment.team, experiment=experiment)
     ExperimentSessionFactory(experiment=experiment, experiment_channel=channel, status=status)
 
-    send_broadcast_message(experiment_id=experiment.id, channel_ids=[channel.id], message="Hi")
+    send_broadcast_message(experiment_id=experiment.id, channel_ids=[channel.id], message="Hi", active_within_days=30)
 
     delay.assert_not_called()
 
@@ -95,9 +107,69 @@ def test_broadcast_falls_back_to_an_older_session_that_is_still_active(delay, ex
         status=SessionStatus.PENDING_REVIEW,
     )
 
-    send_broadcast_message(experiment_id=experiment.id, channel_ids=[channel.id], message="Hi")
+    send_broadcast_message(experiment_id=experiment.id, channel_ids=[channel.id], message="Hi", active_within_days=30)
 
     delay.assert_called_once_with(session_id=still_active.id, message="Hi")
+
+
+@pytest.mark.django_db()
+@patch("apps.chatbots.tasks.send_broadcast_message_to_session.delay")
+def test_broadcast_skips_a_session_quiet_for_longer_than_the_activity_window(delay, experiment):
+    """The window is what makes a broadcast go to *recently* active participants only."""
+    channel = ExperimentChannelFactory(team=experiment.team, experiment=experiment)
+    recently_active = ExperimentSessionFactory(
+        experiment=experiment, experiment_channel=channel, last_activity_at=timezone.now() - timedelta(days=6)
+    )
+    ExperimentSessionFactory(
+        experiment=experiment, experiment_channel=channel, last_activity_at=timezone.now() - timedelta(days=8)
+    )
+
+    send_broadcast_message(experiment_id=experiment.id, channel_ids=[channel.id], message="Hi", active_within_days=7)
+
+    delay.assert_called_once_with(session_id=recently_active.id, message="Hi")
+
+
+@pytest.mark.django_db()
+@patch("apps.chatbots.tasks.send_broadcast_message_to_session.delay")
+def test_broadcast_measures_the_window_from_creation_when_no_activity_was_recorded(delay, experiment):
+    """`last_activity_at` is only written when the participant sends a message.
+
+    A session that never received one falls back to `created_at`, the same fallback the
+    sessions table and its "Last Activity" filter use.
+    """
+    channel = ExperimentChannelFactory(team=experiment.team, experiment=experiment)
+    just_created = ExperimentSessionFactory(experiment=experiment, experiment_channel=channel, last_activity_at=None)
+    long_dormant = ExperimentSessionFactory(experiment=experiment, experiment_channel=channel, last_activity_at=None)
+    # `created_at` is `auto_now_add`, so it can only be backdated after the fact.
+    ExperimentSession.objects.filter(id=long_dormant.id).update(created_at=timezone.now() - timedelta(days=8))
+
+    send_broadcast_message(experiment_id=experiment.id, channel_ids=[channel.id], message="Hi", active_within_days=7)
+
+    delay.assert_called_once_with(session_id=just_created.id, message="Hi")
+
+
+@pytest.mark.django_db()
+@patch("apps.chatbots.tasks.send_broadcast_message_to_session.delay")
+def test_broadcast_falls_back_to_an_older_session_inside_the_activity_window(delay, experiment):
+    """The window is applied before the newest-per-group pick, as the status filter is."""
+    channel = ExperimentChannelFactory(team=experiment.team, experiment=experiment)
+    participant = ParticipantFactory(team=experiment.team)
+    inside_window = ExperimentSessionFactory(
+        experiment=experiment,
+        participant=participant,
+        experiment_channel=channel,
+        last_activity_at=timezone.now() - timedelta(days=2),
+    )
+    ExperimentSessionFactory(
+        experiment=experiment,
+        participant=participant,
+        experiment_channel=channel,
+        last_activity_at=timezone.now() - timedelta(days=8),
+    )
+
+    send_broadcast_message(experiment_id=experiment.id, channel_ids=[channel.id], message="Hi", active_within_days=7)
+
+    delay.assert_called_once_with(session_id=inside_window.id, message="Hi")
 
 
 @pytest.mark.django_db()
@@ -136,10 +208,27 @@ def test_broadcast_channel_is_labelled_by_platform_alone(experiment, logged_in_c
         reverse("chatbots:single_chatbot_home", args=[experiment.team.slug, experiment.id])
     ).content.decode()
 
-    start = content.index('id="broadcast_message_modal"')
-    dialog = content[start : content.index("</dialog>", start)]
+    dialog = _dialog(content)
     assert "WhatsApp" in dialog
     assert experiment.name not in dialog
+
+
+@pytest.mark.django_db()
+def test_broadcast_dialog_offers_the_activity_window(experiment, logged_in_client):
+    """The cutoff is the sender's to choose, pre-filled and floored at a single day."""
+    ExperimentChannelFactory(team=experiment.team, experiment=experiment)
+
+    dialog = _dialog(
+        logged_in_client.get(
+            reverse("chatbots:single_chatbot_home", args=[experiment.team.slug, experiment.id])
+        ).content.decode()
+    )
+
+    window = re.search(r'<input[^>]*name="active_within_days"[^>]*>', dialog)
+    assert window, dialog
+    assert 'min="1"' in window.group()
+    assert f'value="{BroadcastMessageForm.DEFAULT_ACTIVE_WITHIN_DAYS}"' in window.group()
+    assert f'max="{BroadcastMessageForm.MAX_ACTIVE_WITHIN_DAYS}"' in window.group()
 
 
 @pytest.mark.django_db()
@@ -172,11 +261,17 @@ def test_broadcast_view_queues_the_selected_channels(delay, experiment, logged_i
     telegram = ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.TELEGRAM)
 
     response = logged_in_client.post(
-        _broadcast_url(experiment), data={"channels": [telegram.id], "message": "We're back online"}
+        _broadcast_url(experiment),
+        data={"channels": [telegram.id], "message": "We're back online", "active_within_days": 14},
     )
 
     assert response.status_code == 302
-    delay.assert_called_once_with(experiment_id=experiment.id, channel_ids=[telegram.id], message="We're back online")
+    delay.assert_called_once_with(
+        experiment_id=experiment.id,
+        channel_ids=[telegram.id],
+        message="We're back online",
+        active_within_days=14,
+    )
 
 
 @pytest.mark.django_db()
@@ -186,7 +281,10 @@ def test_broadcast_view_rejects_a_chatbot_that_is_not_editable(delay, experiment
     telegram = ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.TELEGRAM)
     experiment.archive()
 
-    response = logged_in_client.post(_broadcast_url(experiment), data={"channels": [telegram.id], "message": "Hi"})
+    response = logged_in_client.post(
+        _broadcast_url(experiment),
+        data={"channels": [telegram.id], "message": "Hi", "active_within_days": 30},
+    )
 
     assert response.status_code == 404
     delay.assert_not_called()
@@ -194,18 +292,29 @@ def test_broadcast_view_rejects_a_chatbot_that_is_not_editable(delay, experiment
 
 @pytest.mark.django_db()
 @pytest.mark.parametrize(
-    ("channel", "message"),
+    ("channel", "message", "days"),
     [
-        pytest.param(None, "Hi", id="no-channel-selected"),
-        pytest.param("other-chatbot", "Hi", id="channel-of-another-chatbot"),
-        pytest.param("disabled", "Hi", id="disabled-channel"),
-        pytest.param("own", "", id="empty-message"),
-        pytest.param("own", "x" * (BroadcastMessageForm.MESSAGE_CHAR_LIMIT + 1), id="message-over-char-limit"),
+        pytest.param(None, "Hi", "30", id="no-channel-selected"),
+        pytest.param("other-chatbot", "Hi", "30", id="channel-of-another-chatbot"),
+        pytest.param("disabled", "Hi", "30", id="disabled-channel"),
+        pytest.param("own", "", "30", id="empty-message"),
+        pytest.param("own", "x" * (BroadcastMessageForm.MESSAGE_CHAR_LIMIT + 1), "30", id="message-over-char-limit"),
+        pytest.param("own", "Hi", "", id="no-activity-window"),
+        pytest.param("own", "Hi", "0", id="activity-window-under-a-day"),
+        pytest.param("own", "Hi", "-7", id="negative-activity-window"),
+        pytest.param(
+            "own",
+            "Hi",
+            str(BroadcastMessageForm.MAX_ACTIVE_WITHIN_DAYS + 1),
+            id="activity-window-over-the-cap",
+        ),
+        pytest.param("own", "Hi", "seven", id="non-numeric-activity-window"),
     ],
 )
 @patch("apps.chatbots.views.send_broadcast_message.delay")
-def test_broadcast_view_rejects_invalid_input(delay, channel, message, experiment, logged_in_client):
-    """Nothing is queued unless a live channel of *this* chatbot and a message within the limit are given."""
+def test_broadcast_view_rejects_invalid_input(delay, channel, message, days, experiment, logged_in_client):
+    """Nothing is queued unless a live channel of *this* chatbot, a message within the limit and a
+    window of at least one day are given."""
     channels = {
         "own": ExperimentChannelFactory(team=experiment.team, experiment=experiment),
         "other-chatbot": ExperimentChannelFactory(team=experiment.team),
@@ -213,7 +322,7 @@ def test_broadcast_view_rejects_invalid_input(delay, channel, message, experimen
             team=experiment.team, experiment=experiment, platform=ChannelPlatform.WHATSAPP, enabled=False
         ),
     }
-    data = {"message": message}
+    data = {"message": message, "active_within_days": days}
     if channel:
         data["channels"] = [channels[channel].id]
 

--- a/apps/chatbots/tests/test_broadcast.py
+++ b/apps/chatbots/tests/test_broadcast.py
@@ -102,11 +102,12 @@ def test_broadcast_falls_back_to_an_older_session_that_is_still_active(delay, ex
 
 @pytest.mark.django_db()
 def test_chatbot_home_offers_only_the_broadcastable_channels(experiment, logged_in_client):
-    """The API, web and evaluation channels can't be broadcast on, so they aren't offered."""
+    """Nothing can be pushed at a participant on the API, web, evaluation or widget channels."""
     telegram = ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.TELEGRAM)
     ExperimentChannel.objects.get_team_api_channel(experiment.team)
     ExperimentChannel.objects.get_team_web_channel(experiment.team)
     ExperimentChannel.objects.get_team_evaluations_channel(experiment.team)
+    ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.EMBEDDED_WIDGET)
 
     response = logged_in_client.get(reverse("chatbots:single_chatbot_home", args=[experiment.team.slug, experiment.id]))
 
@@ -174,6 +175,7 @@ def test_broadcast_view_rejects_a_chatbot_that_is_not_editable(delay, experiment
         pytest.param(None, "Hi", id="no-channel-selected"),
         pytest.param("other-chatbot", "Hi", id="channel-of-another-chatbot"),
         pytest.param("disabled", "Hi", id="disabled-channel"),
+        pytest.param("widget", "Hi", id="chat-widget-channel"),
         pytest.param("own", "", id="empty-message"),
         pytest.param("own", "x" * (BroadcastMessageForm.MESSAGE_CHAR_LIMIT + 1), id="message-over-char-limit"),
     ],
@@ -186,6 +188,9 @@ def test_broadcast_view_rejects_invalid_input(delay, channel, message, experimen
         "other-chatbot": ExperimentChannelFactory(team=experiment.team),
         "disabled": ExperimentChannelFactory(
             team=experiment.team, experiment=experiment, platform=ChannelPlatform.WHATSAPP, enabled=False
+        ),
+        "widget": ExperimentChannelFactory(
+            team=experiment.team, experiment=experiment, platform=ChannelPlatform.EMBEDDED_WIDGET
         ),
     }
     data = {"message": message}

--- a/apps/chatbots/tests/test_broadcast.py
+++ b/apps/chatbots/tests/test_broadcast.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+import pytest
+
+from apps.channels.models import ChannelPlatform
+from apps.chatbots.tasks import send_broadcast_message
+from apps.utils.factories.channels import ExperimentChannelFactory
+from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory, ParticipantFactory
+
+
+@pytest.fixture()
+def experiment():
+    return ExperimentFactory()
+
+
+@pytest.mark.django_db()
+@patch("apps.chatbots.tasks.send_broadcast_message_to_session.delay")
+def test_broadcast_reaches_each_participant_once_per_selected_channel(delay, experiment):
+    """One send per (participant, channel), against the participant's live session."""
+    team = experiment.team
+    telegram = ExperimentChannelFactory(team=team, experiment=experiment, platform=ChannelPlatform.TELEGRAM)
+    whatsapp = ExperimentChannelFactory(team=team, experiment=experiment, platform=ChannelPlatform.WHATSAPP)
+    unselected = ExperimentChannelFactory(team=team, experiment=experiment, platform=ChannelPlatform.SLACK)
+
+    participant = ParticipantFactory(team=team)
+    # An older session on the same channel: superseded, so it must not be messaged.
+    ExperimentSessionFactory(experiment=experiment, participant=participant, experiment_channel=telegram)
+    latest_telegram = ExperimentSessionFactory(
+        experiment=experiment, participant=participant, experiment_channel=telegram
+    )
+    on_whatsapp_too = ExperimentSessionFactory(
+        experiment=experiment, participant=participant, experiment_channel=whatsapp
+    )
+    other_participant = ExperimentSessionFactory(experiment=experiment, experiment_channel=whatsapp)
+    ExperimentSessionFactory(experiment=experiment, experiment_channel=unselected)
+    # A participant of a different chatbot is not part of this broadcast.
+    ExperimentSessionFactory(experiment=ExperimentFactory(team=team), experiment_channel=telegram)
+
+    send_broadcast_message(experiment_id=experiment.id, channel_ids=[telegram.id, whatsapp.id], message="Hi all")
+
+    messaged = {call.kwargs["session_id"] for call in delay.call_args_list}
+    assert messaged == {latest_telegram.id, on_whatsapp_too.id, other_participant.id}
+    assert {call.kwargs["message"] for call in delay.call_args_list} == {"Hi all"}

--- a/apps/chatbots/tests/test_broadcast.py
+++ b/apps/chatbots/tests/test_broadcast.py
@@ -101,18 +101,25 @@ def test_broadcast_falls_back_to_an_older_session_that_is_still_active(delay, ex
 
 
 @pytest.mark.django_db()
-def test_chatbot_home_offers_only_the_broadcastable_channels(experiment, logged_in_client):
-    """Nothing can be pushed at a participant on the API, web, evaluation or widget channels."""
+def test_chatbot_home_offers_every_enabled_channel(experiment, logged_in_client):
+    """Anything a scheduled message can go out on can carry a broadcast, the chat widget included."""
     telegram = ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.TELEGRAM)
+    widget = ExperimentChannelFactory(
+        team=experiment.team, experiment=experiment, platform=ChannelPlatform.EMBEDDED_WIDGET
+    )
+    ExperimentChannelFactory(
+        team=experiment.team, experiment=experiment, platform=ChannelPlatform.WHATSAPP, enabled=False
+    )
+    # The API, web and evaluations channels hang off the team, not the chatbot, so they can't
+    # appear here -- there is no per-chatbot channel for a broadcast to select.
     ExperimentChannel.objects.get_team_api_channel(experiment.team)
     ExperimentChannel.objects.get_team_web_channel(experiment.team)
     ExperimentChannel.objects.get_team_evaluations_channel(experiment.team)
-    ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.EMBEDDED_WIDGET)
 
     response = logged_in_client.get(reverse("chatbots:single_chatbot_home", args=[experiment.team.slug, experiment.id]))
 
     assert response.status_code == 200
-    assert list(response.context["broadcast_form"].eligible_channels) == [telegram]
+    assert set(response.context["broadcast_form"].eligible_channels) == {telegram, widget}
     content = response.content.decode()
     assert "Broadcast message" in content
     assert _broadcast_url(experiment) in content
@@ -192,7 +199,6 @@ def test_broadcast_view_rejects_a_chatbot_that_is_not_editable(delay, experiment
         pytest.param(None, "Hi", id="no-channel-selected"),
         pytest.param("other-chatbot", "Hi", id="channel-of-another-chatbot"),
         pytest.param("disabled", "Hi", id="disabled-channel"),
-        pytest.param("widget", "Hi", id="chat-widget-channel"),
         pytest.param("own", "", id="empty-message"),
         pytest.param("own", "x" * (BroadcastMessageForm.MESSAGE_CHAR_LIMIT + 1), id="message-over-char-limit"),
     ],
@@ -205,9 +211,6 @@ def test_broadcast_view_rejects_invalid_input(delay, channel, message, experimen
         "other-chatbot": ExperimentChannelFactory(team=experiment.team),
         "disabled": ExperimentChannelFactory(
             team=experiment.team, experiment=experiment, platform=ChannelPlatform.WHATSAPP, enabled=False
-        ),
-        "widget": ExperimentChannelFactory(
-            team=experiment.team, experiment=experiment, platform=ChannelPlatform.EMBEDDED_WIDGET
         ),
     }
     data = {"message": message}

--- a/apps/chatbots/tests/test_broadcast.py
+++ b/apps/chatbots/tests/test_broadcast.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chatbots.forms import BroadcastMessageForm
 from apps.chatbots.tasks import send_broadcast_message
+from apps.experiments.models import SessionStatus
 from apps.utils.factories.channels import ExperimentChannelFactory
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory, ParticipantFactory
 from apps.utils.factories.team import TeamWithUsersFactory
@@ -56,6 +57,47 @@ def test_broadcast_reaches_each_participant_once_per_selected_channel(delay, exp
     assert delay.call_count == 3, "each (participant, channel) pair must be messaged exactly once"
     assert messaged == {latest_telegram.id, on_whatsapp_too.id, other_participant.id}
     assert {call.kwargs["message"] for call in delay.call_args_list} == {"Hi all"}
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "status",
+    [
+        pytest.param(SessionStatus.SETUP, id="setup"),
+        pytest.param(SessionStatus.PENDING, id="pending"),
+        pytest.param(SessionStatus.PENDING_REVIEW, id="pending-review"),
+        pytest.param(SessionStatus.COMPLETE, id="complete"),
+        pytest.param(SessionStatus.UNKNOWN, id="unknown"),
+    ],
+)
+@patch("apps.chatbots.tasks.send_broadcast_message_to_session.delay")
+def test_broadcast_skips_a_session_that_is_not_active(delay, status, experiment):
+    """Only a live conversation is broadcast into -- anything else has no participant in it."""
+    channel = ExperimentChannelFactory(team=experiment.team, experiment=experiment)
+    ExperimentSessionFactory(experiment=experiment, experiment_channel=channel, status=status)
+
+    send_broadcast_message(experiment_id=experiment.id, channel_ids=[channel.id], message="Hi")
+
+    delay.assert_not_called()
+
+
+@pytest.mark.django_db()
+@patch("apps.chatbots.tasks.send_broadcast_message_to_session.delay")
+def test_broadcast_falls_back_to_an_older_session_that_is_still_active(delay, experiment):
+    """Status is filtered before the newest-per-group pick, so an ended newer session is stepped over."""
+    channel = ExperimentChannelFactory(team=experiment.team, experiment=experiment)
+    participant = ParticipantFactory(team=experiment.team)
+    still_active = ExperimentSessionFactory(experiment=experiment, participant=participant, experiment_channel=channel)
+    ExperimentSessionFactory(
+        experiment=experiment,
+        participant=participant,
+        experiment_channel=channel,
+        status=SessionStatus.PENDING_REVIEW,
+    )
+
+    send_broadcast_message(experiment_id=experiment.id, channel_ids=[channel.id], message="Hi")
+
+    delay.assert_called_once_with(session_id=still_active.id, message="Hi")
 
 
 @pytest.mark.django_db()

--- a/apps/chatbots/tests/test_broadcast.py
+++ b/apps/chatbots/tests/test_broadcast.py
@@ -1,9 +1,10 @@
+import re
 from unittest.mock import patch
 
 import pytest
 from django.urls import reverse
 
-from apps.channels.models import ChannelPlatform
+from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.chatbots.forms import BroadcastMessageForm
 from apps.chatbots.tasks import send_broadcast_message
 from apps.utils.factories.channels import ExperimentChannelFactory
@@ -54,6 +55,46 @@ def test_broadcast_reaches_each_participant_once_per_selected_channel(delay, exp
     messaged = {call.kwargs["session_id"] for call in delay.call_args_list}
     assert messaged == {latest_telegram.id, on_whatsapp_too.id, other_participant.id}
     assert {call.kwargs["message"] for call in delay.call_args_list} == {"Hi all"}
+
+
+@pytest.mark.django_db()
+def test_chatbot_home_offers_only_the_broadcastable_channels(experiment, logged_in_client):
+    """The API, web and evaluation channels can't be broadcast on, so they aren't offered."""
+    telegram = ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.TELEGRAM)
+    ExperimentChannel.objects.get_team_api_channel(experiment.team)
+    ExperimentChannel.objects.get_team_web_channel(experiment.team)
+    ExperimentChannel.objects.get_team_evaluations_channel(experiment.team)
+
+    response = logged_in_client.get(reverse("chatbots:single_chatbot_home", args=[experiment.team.slug, experiment.id]))
+
+    assert response.status_code == 200
+    assert list(response.context["broadcast_channels"]) == [telegram]
+    content = response.content.decode()
+    assert "Broadcast message" in content
+    assert _broadcast_url(experiment) in content
+
+
+@pytest.mark.django_db()
+def test_broadcast_modal_arms_the_whatsapp_template_warning(experiment, logged_in_client):
+    """The warning is driven by which of the rendered channels are WhatsApp ones."""
+    ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.TELEGRAM)
+    whatsapp = ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.WHATSAPP)
+
+    content = logged_in_client.get(
+        reverse("chatbots:single_chatbot_home", args=[experiment.team.slug, experiment.id])
+    ).content.decode()
+
+    assert re.search(rf"whatsappChannels:\s*\[\s*'{whatsapp.id}',\s*\]", content)
+    assert "new_bot_message" in content
+    assert "whatsapp_meta_cloud_api/#create-the-required-template-in-meta-business-manager" in content
+
+
+@pytest.mark.django_db()
+def test_chatbot_home_hides_the_broadcast_button_without_a_channel(experiment, logged_in_client):
+    response = logged_in_client.get(reverse("chatbots:single_chatbot_home", args=[experiment.team.slug, experiment.id]))
+
+    assert response.status_code == 200
+    assert "Broadcast message" not in response.content.decode()
 
 
 @pytest.mark.django_db()

--- a/apps/chatbots/tests/test_broadcast.py
+++ b/apps/chatbots/tests/test_broadcast.py
@@ -53,6 +53,7 @@ def test_broadcast_reaches_each_participant_once_per_selected_channel(delay, exp
     send_broadcast_message(experiment_id=experiment.id, channel_ids=[telegram.id, whatsapp.id], message="Hi all")
 
     messaged = {call.kwargs["session_id"] for call in delay.call_args_list}
+    assert delay.call_count == 3, "each (participant, channel) pair must be messaged exactly once"
     assert messaged == {latest_telegram.id, on_whatsapp_too.id, other_participant.id}
     assert {call.kwargs["message"] for call in delay.call_args_list} == {"Hi all"}
 
@@ -108,6 +109,19 @@ def test_broadcast_view_queues_the_selected_channels(delay, experiment, logged_i
 
     assert response.status_code == 302
     delay.assert_called_once_with(experiment_id=experiment.id, channel_ids=[telegram.id], message="We're back online")
+
+
+@pytest.mark.django_db()
+@patch("apps.chatbots.views.send_broadcast_message.delay")
+def test_broadcast_view_rejects_a_chatbot_that_is_not_editable(delay, experiment, logged_in_client):
+    """An archived chatbot can't be broadcast on, even by POSTing the endpoint directly."""
+    telegram = ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.TELEGRAM)
+    experiment.archive()
+
+    response = logged_in_client.post(_broadcast_url(experiment), data={"channels": [telegram.id], "message": "Hi"})
+
+    assert response.status_code == 404
+    delay.assert_not_called()
 
 
 @pytest.mark.django_db()

--- a/apps/chatbots/tests/test_broadcast.py
+++ b/apps/chatbots/tests/test_broadcast.py
@@ -119,6 +119,23 @@ def test_chatbot_home_offers_only_the_broadcastable_channels(experiment, logged_
 
 
 @pytest.mark.django_db()
+def test_broadcast_channel_is_labelled_by_platform_alone(experiment, logged_in_client):
+    """The channel name defaults to the chatbot's, so it says nothing the reader doesn't know."""
+    ExperimentChannelFactory(
+        team=experiment.team, experiment=experiment, platform=ChannelPlatform.WHATSAPP, name=experiment.name
+    )
+
+    content = logged_in_client.get(
+        reverse("chatbots:single_chatbot_home", args=[experiment.team.slug, experiment.id])
+    ).content.decode()
+
+    start = content.index('id="broadcast_message_modal"')
+    dialog = content[start : content.index("</dialog>", start)]
+    assert "WhatsApp" in dialog
+    assert experiment.name not in dialog
+
+
+@pytest.mark.django_db()
 def test_broadcast_modal_arms_the_whatsapp_template_warning(experiment, logged_in_client):
     """Each checkbox carries its platform, which is what the warning keys off."""
     telegram = ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.TELEGRAM)

--- a/apps/chatbots/tests/test_broadcast.py
+++ b/apps/chatbots/tests/test_broadcast.py
@@ -69,7 +69,7 @@ def test_chatbot_home_offers_only_the_broadcastable_channels(experiment, logged_
     response = logged_in_client.get(reverse("chatbots:single_chatbot_home", args=[experiment.team.slug, experiment.id]))
 
     assert response.status_code == 200
-    assert list(response.context["broadcast_channels"]) == [telegram]
+    assert list(response.context["broadcast_form"].eligible_channels) == [telegram]
     content = response.content.decode()
     assert "Broadcast message" in content
     assert _broadcast_url(experiment) in content
@@ -77,15 +77,16 @@ def test_chatbot_home_offers_only_the_broadcastable_channels(experiment, logged_
 
 @pytest.mark.django_db()
 def test_broadcast_modal_arms_the_whatsapp_template_warning(experiment, logged_in_client):
-    """The warning is driven by which of the rendered channels are WhatsApp ones."""
-    ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.TELEGRAM)
+    """Each checkbox carries its platform, which is what the warning keys off."""
+    telegram = ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.TELEGRAM)
     whatsapp = ExperimentChannelFactory(team=experiment.team, experiment=experiment, platform=ChannelPlatform.WHATSAPP)
 
     content = logged_in_client.get(
         reverse("chatbots:single_chatbot_home", args=[experiment.team.slug, experiment.id])
     ).content.decode()
 
-    assert re.search(rf"whatsappChannels:\s*\[\s*'{whatsapp.id}',\s*\]", content)
+    assert re.search(rf'value="{whatsapp.id}"[^>]*data-platform="whatsapp"', content)
+    assert re.search(rf'value="{telegram.id}"[^>]*data-platform="telegram"', content)
     assert "new_bot_message" in content
     assert "whatsapp_meta_cloud_api/#create-the-required-template-in-meta-business-manager" in content
 

--- a/apps/chatbots/urls.py
+++ b/apps/chatbots/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
         views.revert_chatbot_version,
         name="revert-version",
     ),
+    path("<int:experiment_id>/broadcast/", views.broadcast_message, name="broadcast_message"),
     path("<int:experiment_id>/events/", include("apps.events.urls")),
     path(
         "<int:experiment_id>/versions/status",

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -25,9 +25,15 @@ from apps.channels.exceptions import ChannelDisabledException
 from apps.channels.models import ChannelPlatform
 from apps.channels.registry import get_channel_class_for_platform
 from apps.channels.web_channel import WebChannel
-from apps.chatbots.forms import ChatbotForm, ChatbotSettingsForm, CopyChatbotForm
+from apps.chatbots.forms import (
+    BroadcastMessageForm,
+    ChatbotForm,
+    ChatbotSettingsForm,
+    CopyChatbotForm,
+    get_broadcast_channels,
+)
 from apps.chatbots.tables import ChatbotSessionsTable, ChatbotTable
-from apps.chatbots.tasks import send_bot_message
+from apps.chatbots.tasks import send_bot_message, send_broadcast_message
 from apps.chatbots.version_resolver import resolve_published_or_working
 from apps.cost_tracking.services.reporting import get_latest_chatbot_usage_summary
 from apps.events.models import EventLogStatusChoices, StaticTrigger, StaticTriggerType, TimeoutTrigger
@@ -335,6 +341,8 @@ def single_chatbot_home(request, team_slug: str, experiment_id: int):
         "highlight_version_id": request.GET.get("version_id"),
         "cost_tracking_enabled": cost_tracking_enabled,
         "usage_summary": usage_summary,
+        "broadcast_channels": get_broadcast_channels(experiment),
+        "broadcast_char_limit": BroadcastMessageForm.MESSAGE_CHAR_LIMIT,
         **_get_events_context(experiment, team_slug),
     }
     session_table_url = reverse("chatbots:sessions-list", args=(team_slug, experiment_id))
@@ -351,6 +359,28 @@ def single_chatbot_home(request, team_slug: str, experiment_id: int):
     context.update(filter_context)
 
     return TemplateResponse(request, "chatbots/single_chatbot_home.html", context)
+
+
+@require_POST
+@login_and_team_required
+@permission_required("experiments.invite_participants", raise_exception=True)
+def broadcast_message(request, team_slug: str, experiment_id: int):
+    """Queue a message for every participant of this chatbot on the selected channels."""
+    experiment = get_object_or_404(Experiment, id=experiment_id, team=request.team)
+    form = BroadcastMessageForm(experiment, data=request.POST)
+    if not form.is_valid():
+        for error in form.errors.values():
+            messages.error(request, error[0])
+    else:
+        channels = form.cleaned_data["channels"]
+        send_broadcast_message.delay(
+            experiment_id=experiment.id,
+            channel_ids=[channel.id for channel in channels],
+            message=form.cleaned_data["message"],
+        )
+        platforms = ", ".join(sorted(channel.platform_enum.label for channel in channels))
+        messages.success(request, f"Your message is being sent to all participants on {platforms}.")
+    return redirect("chatbots:single_chatbot_home", team_slug=team_slug, experiment_id=experiment.id)
 
 
 class EditChatbot(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateView):

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -25,13 +25,7 @@ from apps.channels.exceptions import ChannelDisabledException
 from apps.channels.models import ChannelPlatform
 from apps.channels.registry import get_channel_class_for_platform
 from apps.channels.web_channel import WebChannel
-from apps.chatbots.forms import (
-    BroadcastMessageForm,
-    ChatbotForm,
-    ChatbotSettingsForm,
-    CopyChatbotForm,
-    get_broadcast_channels,
-)
+from apps.chatbots.forms import BroadcastMessageForm, ChatbotForm, ChatbotSettingsForm, CopyChatbotForm
 from apps.chatbots.tables import ChatbotSessionsTable, ChatbotTable
 from apps.chatbots.tasks import send_bot_message, send_broadcast_message
 from apps.chatbots.version_resolver import resolve_published_or_working
@@ -341,8 +335,7 @@ def single_chatbot_home(request, team_slug: str, experiment_id: int):
         "highlight_version_id": request.GET.get("version_id"),
         "cost_tracking_enabled": cost_tracking_enabled,
         "usage_summary": usage_summary,
-        "broadcast_channels": get_broadcast_channels(experiment),
-        "broadcast_char_limit": BroadcastMessageForm.MESSAGE_CHAR_LIMIT,
+        "broadcast_form": BroadcastMessageForm(experiment),
         **_get_events_context(experiment, team_slug),
     }
     session_table_url = reverse("chatbots:sessions-list", args=(team_slug, experiment_id))

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -358,7 +358,7 @@ def single_chatbot_home(request, team_slug: str, experiment_id: int):
 @login_and_team_required
 @permission_required("experiments.invite_participants", raise_exception=True)
 def broadcast_message(request, team_slug: str, experiment_id: int):
-    """Queue a message for every participant of this chatbot on the selected channels."""
+    """Queue a message for the recently active participants of this chatbot on the selected channels."""
     experiment = get_object_or_404(Experiment, id=experiment_id, team=request.team)
     form = BroadcastMessageForm(experiment, data=request.POST)
     if not form.is_valid():
@@ -366,13 +366,19 @@ def broadcast_message(request, team_slug: str, experiment_id: int):
             messages.error(request, error[0])
     else:
         channels = form.cleaned_data["channels"]
+        days = form.cleaned_data["active_within_days"]
         send_broadcast_message.delay(
             experiment_id=experiment.id,
             channel_ids=[channel.id for channel in channels],
             message=form.cleaned_data["message"],
+            active_within_days=days,
         )
         platforms = ", ".join(sorted(channel.platform_enum.label for channel in channels))
-        messages.success(request, f"Your message is being sent to all participants on {platforms}.")
+        messages.success(
+            request,
+            f"Your message is being sent to participants on {platforms} "
+            f"who were active in the last {days} {'day' if days == 1 else 'days'}.",
+        )
     return redirect("chatbots:single_chatbot_home", team_slug=team_slug, experiment_id=experiment.id)
 
 

--- a/templates/chatbots/components/broadcast_dialog.html
+++ b/templates/chatbots/components/broadcast_dialog.html
@@ -1,12 +1,7 @@
-{% load i18n %}
+{% load form_tags i18n %}
 <dialog id="broadcast_message_modal" class="modal">
-  {# `whatsappChannels` is the subset of the rendered channels that needs the template warning below. #}
-  <div class="modal-box" x-data="{
-         selectedChannels: [],
-         whatsappChannels: [{% for channel in broadcast_channels %}{% if channel.platform == 'whatsapp' %}'{{ channel.id }}',{% endif %}{% endfor %}],
-         message: '',
-         get whatsappSelected() { return this.selectedChannels.some(id => this.whatsappChannels.includes(id)) },
-       }">
+  <div class="modal-box" x-data="{ selectedChannels: [], message: '', whatsappSelected: false }"
+       x-on:change="whatsappSelected = !!$el.querySelectorAll('input[data-platform=whatsapp]:checked').length">
     <h3 class="font-bold text-lg">{% translate "Broadcast message" %}</h3>
     <p class="text-sm pg-text-muted mt-1">
       {% translate "Send a message to everyone who has chatted to this bot on the channels you pick." %}
@@ -15,16 +10,7 @@
     <form id="broadcast-message-form" method="post"
           action="{% url 'chatbots:broadcast_message' request.team.slug experiment.id %}">
       {% csrf_token %}
-      <fieldset class="fieldset">
-        <legend class="fieldset-legend">{% translate "Channels" %}</legend>
-        {% for channel in broadcast_channels %}
-          <label class="label cursor-pointer justify-start gap-2">
-            <input type="checkbox" name="channels" value="{{ channel.id }}" x-model="selectedChannels"
-                   class="checkbox checkbox-sm checkbox-primary">
-            <span class="label-text">{{ channel.platform_enum.label }} — {{ channel.name }}</span>
-          </label>
-        {% endfor %}
-      </fieldset>
+      {% render_field broadcast_form.channels %}
 
       <div role="alert" class="alert alert-warning text-sm my-2" x-show="whatsappSelected" x-cloak>
         <i class="fa-solid fa-triangle-exclamation"></i>
@@ -41,14 +27,8 @@
         </span>
       </div>
 
-      <fieldset class="fieldset">
-        <legend class="fieldset-legend">{% translate "Message" %}</legend>
-        <textarea required rows="5" name="message" x-model="message"
-                  maxlength="{{ broadcast_char_limit }}"
-                  class="textarea textarea-bordered w-full"
-                  placeholder="{% translate 'The message to send to every participant' %}"></textarea>
-        <p class="label" x-text="`${message.length} / {{ broadcast_char_limit }}`"></p>
-      </fieldset>
+      {% render_field broadcast_form.message %}
+      <p class="label" x-text="`${message.length} / {{ broadcast_form.fields.message.max_length }}`"></p>
     </form>
 
     <div class="modal-action">

--- a/templates/chatbots/components/broadcast_dialog.html
+++ b/templates/chatbots/components/broadcast_dialog.html
@@ -4,7 +4,7 @@
        x-on:change="whatsappSelected = !!$el.querySelectorAll('input[data-platform=whatsapp]:checked').length">
     <h3 class="font-bold text-lg">{% translate "Broadcast message" %}</h3>
     <p class="text-sm pg-text-muted mt-1">
-      {% translate "Send a message to everyone who has chatted to this bot on the channels you pick." %}
+      {% translate "Send a message to the participants who have chatted to this bot recently on the channels you pick." %}
     </p>
 
     <form id="broadcast-message-form" method="post"
@@ -26,6 +26,8 @@
           </a>
         </span>
       </div>
+
+      {% render_field broadcast_form.active_within_days %}
 
       {% render_field broadcast_form.message %}
       <p class="label" x-text="`${message.length} / {{ broadcast_form.fields.message.max_length }}`"></p>

--- a/templates/chatbots/components/broadcast_dialog.html
+++ b/templates/chatbots/components/broadcast_dialog.html
@@ -21,7 +21,7 @@
           <label class="label cursor-pointer justify-start gap-2">
             <input type="checkbox" name="channels" value="{{ channel.id }}" x-model="selectedChannels"
                    class="checkbox checkbox-sm checkbox-primary">
-            <span class="label-text">{{ channel.platform_enum.label }} &mdash; {{ channel.name }}</span>
+            <span class="label-text">{{ channel.platform_enum.label }} — {{ channel.name }}</span>
           </label>
         {% endfor %}
       </fieldset>

--- a/templates/chatbots/components/broadcast_dialog.html
+++ b/templates/chatbots/components/broadcast_dialog.html
@@ -1,0 +1,67 @@
+{% load i18n %}
+<dialog id="broadcast_message_modal" class="modal">
+  {# `whatsappChannels` is the subset of the rendered channels that needs the template warning below. #}
+  <div class="modal-box" x-data="{
+         selectedChannels: [],
+         whatsappChannels: [{% for channel in broadcast_channels %}{% if channel.platform == 'whatsapp' %}'{{ channel.id }}',{% endif %}{% endfor %}],
+         message: '',
+         get whatsappSelected() { return this.selectedChannels.some(id => this.whatsappChannels.includes(id)) },
+       }">
+    <h3 class="font-bold text-lg">{% translate "Broadcast message" %}</h3>
+    <p class="text-sm pg-text-muted mt-1">
+      {% translate "Send a message to everyone who has chatted to this bot on the channels you pick." %}
+    </p>
+
+    <form id="broadcast-message-form" method="post"
+          action="{% url 'chatbots:broadcast_message' request.team.slug experiment.id %}">
+      {% csrf_token %}
+      <fieldset class="fieldset">
+        <legend class="fieldset-legend">{% translate "Channels" %}</legend>
+        {% for channel in broadcast_channels %}
+          <label class="label cursor-pointer justify-start gap-2">
+            <input type="checkbox" name="channels" value="{{ channel.id }}" x-model="selectedChannels"
+                   class="checkbox checkbox-sm checkbox-primary">
+            <span class="label-text">{{ channel.platform_enum.label }} &mdash; {{ channel.name }}</span>
+          </label>
+        {% endfor %}
+      </fieldset>
+
+      <div role="alert" class="alert alert-warning text-sm my-2" x-show="whatsappSelected" x-cloak>
+        <i class="fa-solid fa-triangle-exclamation"></i>
+        <span>
+          {% blocktranslate trimmed %}
+            Broadcasts land outside WhatsApp's 24-hour service window, so they go out as a template
+            message. Make sure the messaging provider used by this channel has a
+            <code>new_bot_message</code> template configured.
+          {% endblocktranslate %}
+          <a class="link" target="_blank"
+             href="https://docs.openchatstudio.com/how-to/whatsapp_meta_cloud_api/#create-the-required-template-in-meta-business-manager">
+            {% translate "How to create the template" %}
+          </a>
+        </span>
+      </div>
+
+      <fieldset class="fieldset">
+        <legend class="fieldset-legend">{% translate "Message" %}</legend>
+        <textarea required rows="5" name="message" x-model="message"
+                  maxlength="{{ broadcast_char_limit }}"
+                  class="textarea textarea-bordered w-full"
+                  placeholder="{% translate 'The message to send to every participant' %}"></textarea>
+        <p class="label" x-text="`${message.length} / {{ broadcast_char_limit }}`"></p>
+      </fieldset>
+    </form>
+
+    <div class="modal-action">
+      <form method="dialog">
+        <button class="btn">{% translate "Cancel" %}</button>
+      </form>
+      <button form="broadcast-message-form" type="submit" class="btn btn-primary"
+              x-bind:disabled="!selectedChannels.length || !message.trim()">
+        {% translate "Send" %}
+      </button>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>{% translate "close" %}</button>
+  </form>
+</dialog>

--- a/templates/chatbots/single_chatbot_home.html
+++ b/templates/chatbots/single_chatbot_home.html
@@ -50,7 +50,7 @@
         {% endif %}
       </div>
       <div class="justify-self-end flex items-center gap-2">
-        {% if experiment.is_editable and broadcast_channels and perms.experiments.invite_participants %}
+        {% if experiment.is_editable and broadcast_form.eligible_channels and perms.experiments.invite_participants %}
           <button class="btn btn-sm btn-outline btn-primary" onclick="broadcast_message_modal.showModal()">
             <i class="fa-solid fa-bullhorn"></i> Broadcast message
           </button>
@@ -137,7 +137,7 @@
       {% endif %}
     </div>
     {% if experiment.is_editable %}
-      {% if broadcast_channels and perms.experiments.invite_participants %}
+      {% if broadcast_form.eligible_channels and perms.experiments.invite_participants %}
         {% include "chatbots/components/broadcast_dialog.html" %}
       {% endif %}
       {% include "chatbots/chatbot_copy_dialog.html" with chatbot_id=experiment.id team_slug=request.team.slug name=experiment.name %}

--- a/templates/chatbots/single_chatbot_home.html
+++ b/templates/chatbots/single_chatbot_home.html
@@ -49,7 +49,12 @@
           </div>
         {% endif %}
       </div>
-      <div class="justify-self-end">
+      <div class="justify-self-end flex items-center gap-2">
+        {% if experiment.is_editable and broadcast_channels and perms.experiments.invite_participants %}
+          <button class="btn btn-sm btn-outline btn-primary" onclick="broadcast_message_modal.showModal()">
+            <i class="fa-solid fa-bullhorn"></i> Broadcast message
+          </button>
+        {% endif %}
         <div class="join">
           {% if experiment.is_editable %}
             <div class="tooltip" data-tip="Chat to the bot">
@@ -132,6 +137,9 @@
       {% endif %}
     </div>
     {% if experiment.is_editable %}
+      {% if broadcast_channels and perms.experiments.invite_participants %}
+        {% include "chatbots/components/broadcast_dialog.html" %}
+      {% endif %}
       {% include "chatbots/chatbot_copy_dialog.html" with chatbot_id=experiment.id team_slug=request.team.slug name=experiment.name %}
       {% if experiment.is_public %}
         {% include "experiments/share/dialog.html" %}


### PR DESCRIPTION
### Product Description

Bot builders can now send a one-off broadcast message to every participant of a chatbot. A "Broadcast message" button on the chatbot home page opens a modal where they pick the channels to send on (multi-select) and type the message. Sending queues a background task that delivers the message to every participant on the selected channels.

If a WhatsApp channel is ticked, the modal warns that the provider needs a `new_bot_message` template configured (broadcasts land outside the 24-hour service window) and links to the docs page explaining how to create it.

### Technical Description

Three commits:

1. **Background task** (`apps/chatbots/tasks.py`) — `send_broadcast_message` resolves the latest session per `(participant, channel)` and fans out one `send_broadcast_message_to_session` per session, which calls `ExperimentSession.ad_hoc_bot_message(message_text=...)` to deliver the text verbatim. The coordinator runs on the `background` queue so walking a large audience can't hold up inbound chat; individual sends stay on the chat queue. A broadcast reaches a participant through a session they already have — that session holds the platform address to deliver to.

2. **Form, view, URL** — `BroadcastMessageForm` offers the chatbot's own channels, excluding `team_global_platforms()` (API/Web/Evaluations) and disabled channels (the send path drops bot-initiated traffic on those). Message capped at `MetaCloudAPIService.TEMPLATE_MESSAGE_CHAR_LIMIT` on every platform, so one message is deliverable on all selected channels rather than being split on one. `POST chatbots/<id>/broadcast/` is gated on `experiments.invite_participants`.

3. **UI** — daisyUI modal with channel checkboxes, textarea with a live character counter, Cancel + Send (Send disabled until a channel and message are chosen), and the Alpine-driven WhatsApp template warning.

### Migrations

No migrations.

- [x] The migrations are backwards compatible

### Demo

<img width="1287" height="842" alt="image" src="https://github.com/user-attachments/assets/9bdc4798-ea10-4032-9f92-e19a622f0ab8" />


### Docs and Changelog

- [x] This PR requires docs/changelog update

Resolves #4252

Generated with [Claude Code](https://claude.ai/code)