### PR TITLE
[CI Docs] Review & standardise tech docs on GitHub Automation with Claude 

### DIFF
--- a/.github/workflows/README-claude-workflows.md
+++ b/.github/workflows/README-claude-workflows.md
@@ -27,7 +27,7 @@ Check the comment block at the top of each file for what it does, when it is ski
 
 ## Forked PR limitations
 
-`claude-code-review.yml` and `claude-followup.yml` both skip fork-originated PRs — see the `Notes:` in each header comment for why.
+`claude-code-review.yml` and `claude-followup.yml` both skip fork-originated PRs and `claude.yml`'s `claude` job fails with "User does not have write access on this repository". See the `Notes:` in each header comment for why.
 
 ## Concurrency and run cancellation
 
@@ -49,6 +49,7 @@ For the other labels used, see each workflow's header comment.
 
 ## Troubleshooting
 - **Run fails immediately in the `claude-code-action` step** — check that `ANTHROPIC_API_KEY` is set and valid; that's the most common cause across all these workflows.
+- **`claude.yml`'s `claude` job fails with "User does not have write access on this repository"** — expected. That job has no job-level actor check of its own (see its header comment); it relies entirely on claude-code-action's built-in write-access check, so an `@claude` mention or review from anyone without write access — commonly a fork PR's own author — fails the run instead of being skipped. A maintainer commenting `@claude` works normally.
 - **`claude-code-review.yml` didn't run on a PR from a fork** — expected, see Forked PR limitations above. There's no failed job to debug; the run was skipped.
 - **`auto-update-models.yml`'s `reconcile` job fails** — check its header comment's `Requirements:` line for which secret it needs, and confirm it's set and valid.
 - **A Claude-created PR didn't get a second follow-up round** — by design, see `claude-followup.yml`'s header comment for the `claude-followup-done` mechanics. Removing the label doesn't start a run by itself — it only clears the skip for the next "Lint and Test" completion, so push a new commit (or re-run "Lint and Test") after removing it. Commenting `@claude` on the PR works immediately instead, independent of the label.

--- a/.github/workflows/README-claude-workflows.md
+++ b/.github/workflows/README-claude-workflows.md
@@ -6,13 +6,12 @@ These workflows use [`anthropics/claude-code-action`](https://github.com/anthrop
 
 ## Required secrets and permissions
 
-- Secret requirements differ per workflow — check the `Requirements:` line in each workflow file's header comment.
-- Together, `permissions:` and `--allowedTools` are the main safeguard against a compromised or malicious prompt (e.g. a hostile issue/PR body) taking unintended action.
-  - Each workflow's `permissions:` block governs the default `GITHUB_TOKEN`.
-  - Each run is restricted to an explicit allowlist of tools, passed via `--allowedTools` in the `claude_args` field of the workflow file — Claude cannot call anything outside that list.
+Secret requirements differ per workflow — check the `Requirements:` line in each workflow file's header comment.
+
+Two independent mechanisms scope what Claude can do in every run: the `permissions:` block (what the `GITHUB_TOKEN` can access) and `--allowedTools` in `claude_args` (which tools **run without a prompt for permission**). Getting either wrong is the main way a compromised or malicious prompt — e.g. a hostile issue/PR body — could take unintended action, so treat changes to them as security-sensitive. See [claude-code-action's security docs](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md) and the [Claude Code CLI reference](https://code.claude.com/docs/en/cli-reference) for how they actually behave.
 
 > [!WARNING]
-> If Claude tries to use a tool that isn't permitted, that call is denied and it continues without it — **the run won't fail**. A missing tool usually surfaces as an **incomplete result rather than an error**, so check the run transcript for denied tool calls if the output looks truncated.
+> If Claude tries to use a tool that isn't pre-approved, the call is denied and Claude continues without it — **the run won't fail**. A missing tool usually surfaces as an **incomplete result rather than an error**, so check the run transcript for denied tool calls if the output looks truncated.
 
 ## GitHub workflows at a glance
 
@@ -52,6 +51,6 @@ For the other labels used, see each workflow's header comment.
 - **Run fails immediately in the `claude-code-action` step** — check that `ANTHROPIC_API_KEY` is set and valid; that's the most common cause across all these workflows.
 - **`claude-code-review.yml` didn't run on a PR from a fork** — expected, see Forked PR limitations above. There's no failed job to debug; the run was skipped.
 - **`auto-update-models.yml`'s `reconcile` job fails** — check its header comment's `Requirements:` line for which secret it needs, and confirm it's set and valid.
-- **A Claude-created PR didn't get a second follow-up round** — by design, see `claude-followup.yml`'s header comment for the `claude-followup-done` mechanics. Remove the label, or comment `@claude` on the PR, to trigger another pass.
+- **A Claude-created PR didn't get a second follow-up round** — by design, see `claude-followup.yml`'s header comment for the `claude-followup-done` mechanics. Removing the label doesn't start a run by itself — it only clears the skip for the next "Lint and Test" completion, so push a new commit (or re-run "Lint and Test") after removing it. Commenting `@claude` on the PR works immediately instead, independent of the label.
 - **Output looks incomplete, or a step Claude should have taken didn't happen** — check the run transcript for denied tool calls, see Required secrets and permissions above.
 - **Output quality needs improvement** — comment `@claude` on the issue or PR with what to revise, or update the relevant prompt in the workflow file if the issue is systemic.

--- a/.github/workflows/README-claude-workflows.md
+++ b/.github/workflows/README-claude-workflows.md
@@ -2,51 +2,56 @@
 
 For engineers responsible for extending, debugging, or operating the Claude workflows. For day-to-day usage, see [Github automation with Claude](https://developers.openchatstudio.com/developer_guides/claude_github_automation/).
 
-These workflows use [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) to run Claude Code inside GitHub Actions. Claude autonomously reads code, writes changes, runs tests, and opens PRs based on its instructions.
+These workflows use [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) to run Claude Code inside GitHub Actions. Depending on the workflow, Claude reads and reviews code, or writes changes, runs tests, and opens or updates PRs based on its instructions.
 
 ## Required secrets and permissions
 
 - Secret requirements differ per workflow — check the `Requirements:` line in each workflow file's header comment.
-- Each workflow's `permissions:` block governs the default `GITHUB_TOKEN`.
-- Each run is also restricted to an explicit allowlist of tools, passed via `--allowedTools` in the `claude_args` field of the workflow file — Claude cannot call anything outside that list. Together, `permissions:` and `--allowedTools` are the main safeguard against a compromised or malicious prompt (e.g. a hostile issue/PR body) taking unintended action.
+- Together, `permissions:` and `--allowedTools` are the main safeguard against a compromised or malicious prompt (e.g. a hostile issue/PR body) taking unintended action.
+  - Each workflow's `permissions:` block governs the default `GITHUB_TOKEN`.
+  - Each run is restricted to an explicit allowlist of tools, passed via `--allowedTools` in the `claude_args` field of the workflow file — Claude cannot call anything outside that list.
 
 > [!WARNING]
 > If Claude tries to use a tool that isn't permitted, that call is denied and it continues without it — **the run won't fail**. A missing tool usually surfaces as an **incomplete result rather than an error**, so check the run transcript for denied tool calls if the output looks truncated.
 
 ## GitHub workflows at a glance
 
-| File | Actions UI name |
-|---|---|
-| `claude.yml` | Claude Code |
-| `claude-followup.yml` | Claude Followup |
-| `claude-dependabot.yml` | Claude Dependabot PR Review |
-| `claude-code-review.yml` | Claude Code Review |
-| `auto-update-models.yml` | Auto Update LLM Models |
+| File | Actions UI name | Trigger |
+|---|---|---|
+| `claude.yml` | Claude Code | Issue labelled `claude`, `@claude` mention, daily schedule, manual dispatch |
+| `claude-followup.yml` | Claude Followup | CI (i.e. Lint and Test) workflow completes on any `claude/**` branch |
+| `claude-dependabot.yml` | Claude Dependabot PR Review | Dependabot PR opened or updated, manual dispatch |
+| `claude-code-review.yml` | Claude Code Review | PR opened, marked ready for review, or pushed |
+| `auto-update-models.yml` | Auto Update LLM Models | Daily schedule, manual dispatch |
 
-Check the comment block at the top of each file for what it does, when it triggers, and what it needs.
+Check the comment block at the top of each file for what it does, when it is skipped and what it needs.
 
 ## Forked PR limitations
 
-`claude-code-review.yml` skips fork PRs — see the `Notes:` in its header comment for why.
+`claude-code-review.yml` and `claude-followup.yml` both skip fork-originated PRs — see the `Notes:` in each header comment for why.
 
 ## Concurrency and run cancellation
 
-- `claude.yml` and `claude-followup.yml` both use `cancel-in-progress: false`, grouped per issue/PR and per branch respectively — a second trigger for the same issue, PR, or branch waits for the in-progress run to finish rather than replacing it. Runs for different issues, PRs, or branches execute in parallel.
-- `auto-update-models.yml` uses a single global group (`auto-update-models`) instead of one per issue or PR, so only one run of the whole workflow — scheduled or manual — executes at a time across the repository.
-- `claude-code-review.yml` is the exception that cancels: a new push to a PR cancels any in-progress review of that PR (`cancel-in-progress: true`), since a review of stale code is wasted spend.
-- `claude-dependabot.yml` sets no concurrency group at all, so its runs are independent of one another.
+Each workflow's concurrency setup follows one of three patterns, chosen by whether an in-progress run can safely be interrupted:
+
+- **Queue per unit of work** — group by the issue, PR, or branch being acted on, and let a second trigger wait rather than replace the run (`cancel-in-progress: false`). Used when the run does work that shouldn't be interrupted mid-flight.
+- **Cancel superseded work** — group by PR, but cancel an in-progress run when a new one starts (`cancel-in-progress: true`). Used when the in-progress run's output is about to be invalidated anyway, so letting it finish would waste spend.
+- **Serialize globally** — one repo-wide group instead of one per issue/PR, so at most one run of the whole workflow executes at a time, regardless of trigger source. Used when a job mutates shared state that a concurrent run could conflict with.
+
+A workflow can also skip grouping entirely and let every run execute independently, when its runs never touch shared state or overlapping work.
+
+See each workflow's header comment for its specific group key and cancellation setting.
 
 ## GitHub labels used by these workflows
 
-- **`claude` label** — apply to an issue to trigger the one-shot or incremental workflow. Claude also applies it to PRs it opens, including the new-model PR from `auto-update-models.yml`.
-- **`claude-followup-done` label** — one-round limiter for the follow-up workflow; see the header comment in `claude-followup.yml` for the mechanics.
-- **`auto-models` label** — applied by `auto-update-models.yml` to both its new-model PR and to its missing-pricing issue.
-- **`cost-tracking` label** — applied by `auto-update-models.yml` to its missing-pricing issue.
+- **`claude` label** — the one label shared across workflows: `claude.yml` triggers off it (an issue labelled `claude`) and applies it to PRs it opens; `auto-update-models.yml` also applies it to the new-model PR it opens. So any Claude-authored PR carries the same label regardless of which workflow created it.
+
+For the other labels used, see each workflow's header comment.
 
 ## Troubleshooting
 - **Run fails immediately in the `claude-code-action` step** — check that `ANTHROPIC_API_KEY` is set and valid; that's the most common cause across all these workflows.
 - **`claude-code-review.yml` didn't run on a PR from a fork** — expected, see Forked PR limitations above. There's no failed job to debug; the run was skipped.
 - **`auto-update-models.yml`'s `reconcile` job fails** — check its header comment's `Requirements:` line for which secret it needs, and confirm it's set and valid.
-- **A Claude-created PR didn't get a second follow-up round** — by design, see the `claude-followup-done` label above. Remove the label, or comment `@claude` on the PR, to trigger another pass.
+- **A Claude-created PR didn't get a second follow-up round** — by design, see `claude-followup.yml`'s header comment for the `claude-followup-done` mechanics. Remove the label, or comment `@claude` on the PR, to trigger another pass.
 - **Output looks incomplete, or a step Claude should have taken didn't happen** — check the run transcript for denied tool calls, see Required secrets and permissions above.
 - **Output quality needs improvement** — comment `@claude` on the issue or PR with what to revise, or update the relevant prompt in the workflow file if the issue is systemic.

--- a/.github/workflows/README-claude-workflows.md
+++ b/.github/workflows/README-claude-workflows.md
@@ -1,12 +1,13 @@
 # Maintaining Claude Code Agent Workflows
 
-For engineers responsible for extending, debugging, or operating the Claude workflows. For day-to-day usage, see [docs/developer_guides/claude_github_automation.md](../../docs/developer_guides/claude_github_automation.md).
+For engineers responsible for extending, debugging, or operating the Claude workflows. For day-to-day usage, see [Github automation with Claude](https://developers.openchatstudio.com/developer_guides/claude_github_automation/).
 
-These workflows use [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) to run Claude Code inside GitHub Actions. Each run gives Claude access to the repository, a shell, and the GitHub CLI. Claude autonomously reads code, writes changes, runs tests, and opens PRs based on its instructions.
+These workflows use [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) to run Claude Code inside GitHub Actions. Claude autonomously reads code, writes changes, runs tests, and opens PRs based on its instructions.
 
 ## Setup
 
-The `ANTHROPIC_API_KEY` secret must be set under **Settings > Secrets and variables > Actions** in the repository. All Claude workflows require it.
+- **`ANTHROPIC_API_KEY`**: Claude API key.
+- `auto-update-models.yml`'s `reconcile` job needs `LLM_STATS_BEARER_TOKEN`.
 
 ## Workflow files
 
@@ -16,6 +17,7 @@ The `ANTHROPIC_API_KEY` secret must be set under **Settings > Secrets and variab
 | `.github/workflows/claude-followup.yml` | Claude Followup | CI (i.e. Lint and Test) workflow completes on any `claude/**` branch |
 | `.github/workflows/claude-dependabot.yml` | Claude Dependabot PR Review | Dependabot PR opened or updated, manual dispatch |
 | `.github/workflows/claude-code-review.yml` | Claude Code Review | PR opened, marked ready for review, or pushed to (non-Dependabot, non-draft) |
+| `.github/workflows/auto-update-models.yml` | Auto Update LLM Models pricing | Daily schedule, manual dispatch |
 
 ## Forked PRs
 Since fork PRs can't get an OIDC token, these pull requests do **not** run the Claude Code Review workflow.
@@ -36,8 +38,11 @@ The code-review workflow (`claude-code-review.yml`) uses a plugin from an extern
 
 The code review workflow is the exception: a new push to a PR cancels any in-progress review of that PR (`cancel-in-progress: true`), since a review of stale code is wasted spend.
 
+`auto-update-models.yml` uses a single global group (`auto-update-models`) instead of one per issue or PR, so only one run of the whole workflow — scheduled or manual — executes at a time across the repository.
+
 ## Branch and label conventions
 
 - **Branches** — all Claude-created branches are namespaced under `claude/` (e.g. `claude/123-20240518-143022` — issue number, date, time). Easy to target with branch protection rules.
 - **`claude` label** — apply to an issue to trigger the one-shot or incremental workflow. Claude also applies it to PRs it opens.
 - **`claude-followup-done` label** — applied by the follow-up workflow after it runs. Prevents a second round. Remove it manually if you need Claude to re-run follow-up on a PR.
+- **`auto-models` label** — applied by `auto-update-models.yml` to its new-model PR (alongside `claude`) and to its missing-pricing issue (alongside `cost-tracking`). The pricing-update PR from the same workflow gets no labels at all — it's opened by a plain `gh pr create` call in the deterministic `reconcile` job, not by Claude

--- a/.github/workflows/README-claude-workflows.md
+++ b/.github/workflows/README-claude-workflows.md
@@ -6,8 +6,7 @@ These workflows use [`anthropics/claude-code-action`](https://github.com/anthrop
 
 ## Required secrets and permissions
 
-- `ANTHROPIC_API_KEY` for Claude Code.
-- `auto-update-models.yml`'s `reconcile` job needs `LLM_STATS_BEARER_TOKEN`.
+- Secret requirements differ per workflow — check the `Requirements:` line in each workflow file's header comment.
 - Each workflow's `permissions:` block governs the default `GITHUB_TOKEN`.
 - Each run is also restricted to an explicit allowlist of tools, passed via `--allowedTools` in the `claude_args` field of the workflow file — Claude cannot call anything outside that list. Together, `permissions:` and `--allowedTools` are the main safeguard against a compromised or malicious prompt (e.g. a hostile issue/PR body) taking unintended action.
 
@@ -16,20 +15,19 @@ These workflows use [`anthropics/claude-code-action`](https://github.com/anthrop
 
 ## GitHub workflows at a glance
 
-| File | Actions UI name | Trigger |
-|---|---|---|
-| `claude.yml` | Claude Code | Issue labelled `claude`, `@claude` mention, daily schedule, manual dispatch |
-| `claude-followup.yml` | Claude Followup | CI (i.e. Lint and Test) workflow completes on any `claude/**` branch |
-| `claude-dependabot.yml` | Claude Dependabot PR Review | Dependabot PR opened or updated, manual dispatch |
-| `claude-code-review.yml` | Claude Code Review | PR opened, marked ready for review, or pushed (non-Dependabot, non-draft) |
-| `auto-update-models.yml` | Auto Update LLM Models pricing | Daily schedule, manual dispatch |
+| File | Actions UI name |
+|---|---|
+| `claude.yml` | Claude Code |
+| `claude-followup.yml` | Claude Followup |
+| `claude-dependabot.yml` | Claude Dependabot PR Review |
+| `claude-code-review.yml` | Claude Code Review |
+| `auto-update-models.yml` | Auto Update LLM Models |
+
+Check the comment block at the top of each file for what it does, when it triggers, and what it needs.
 
 ## Forked PR limitations
-Since fork PRs can't get an OIDC token, these pull requests do **not** run the Claude Code Review workflow.
 
-## Claude Code plugins
-
-The code-review workflow (`claude-code-review.yml`) uses an official Anthropic plugin.
+`claude-code-review.yml` skips fork PRs — see the `Notes:` in its header comment for why.
 
 ## Concurrency and run cancellation
 
@@ -41,14 +39,14 @@ The code-review workflow (`claude-code-review.yml`) uses an official Anthropic p
 ## GitHub labels used by these workflows
 
 - **`claude` label** — apply to an issue to trigger the one-shot or incremental workflow. Claude also applies it to PRs it opens, including the new-model PR from `auto-update-models.yml`.
-- **`claude-followup-done` label** — applied by the follow-up workflow after it runs. Prevents a second round. Remove it manually if you need Claude to re-run follow-up on a PR.
+- **`claude-followup-done` label** — one-round limiter for the follow-up workflow; see the header comment in `claude-followup.yml` for the mechanics.
 - **`auto-models` label** — applied by `auto-update-models.yml` to both its new-model PR and to its missing-pricing issue.
 - **`cost-tracking` label** — applied by `auto-update-models.yml` to its missing-pricing issue.
 
 ## Troubleshooting
 - **Run fails immediately in the `claude-code-action` step** — check that `ANTHROPIC_API_KEY` is set and valid; that's the most common cause across all these workflows.
-- **`claude-code-review.yml` didn't run on a PR from a fork** — expected, see Forked PRs above. There's no failed job to debug; the run was skipped.
-- **`auto-update-models.yml`'s `reconcile` job fails** — verify `LLM_STATS_BEARER_TOKEN` is set and valid; the job needs it to call the llm-stats.com Stats API.
+- **`claude-code-review.yml` didn't run on a PR from a fork** — expected, see Forked PR limitations above. There's no failed job to debug; the run was skipped.
+- **`auto-update-models.yml`'s `reconcile` job fails** — check its header comment's `Requirements:` line for which secret it needs, and confirm it's set and valid.
 - **A Claude-created PR didn't get a second follow-up round** — by design, see the `claude-followup-done` label above. Remove the label, or comment `@claude` on the PR, to trigger another pass.
-- **Output looks incomplete, or a step Claude should have taken didn't happen** — check the run transcript for denied tool calls, see Tool allowlist above.
+- **Output looks incomplete, or a step Claude should have taken didn't happen** — check the run transcript for denied tool calls, see Required secrets and permissions above.
 - **Output quality needs improvement** — comment `@claude` on the issue or PR with what to revise, or update the relevant prompt in the workflow file if the issue is systemic.

--- a/.github/workflows/README-claude-workflows.md
+++ b/.github/workflows/README-claude-workflows.md
@@ -4,29 +4,28 @@ For engineers responsible for extending, debugging, or operating the Claude work
 
 These workflows use [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) to run Claude Code inside GitHub Actions. Claude autonomously reads code, writes changes, runs tests, and opens PRs based on its instructions.
 
-## Setup
+## Setup secrets and permissions
 
-- **`ANTHROPIC_API_KEY`**: Claude API key.
+- `ANTHROPIC_API_KEY`: Anthropic API key for Claude.
 - `auto-update-models.yml`'s `reconcile` job needs `LLM_STATS_BEARER_TOKEN`.
+- A workflow's `permissions:` block governs the default `GITHUB_TOKEN`.
+- Each run is also restricted to an explicit allowlist of tools, passed via `--allowedTools` in the `claude_args` field of the workflow file — Claude cannot call anything outside that list. Together, `permissions:` and `--allowedTools` are the main safeguard against a compromised or malicious prompt (e.g. a hostile issue/PR body) taking unintended action.
+
+> [!WARNING]
+> If Claude tries to use a tool that isn't permitted, that call is denied and it continues without it — **the run won't fail**. A missing tool usually surfaces as an **incomplete result rather than an error**, so check the run transcript for denied tool calls if the output looks truncated.
 
 ## Workflow files
 
 | File | Actions UI name | Trigger |
 |---|---|---|
-| `.github/workflows/claude.yml` | Claude Code | Issue labelled `claude`, `@claude` mention, daily schedule, manual dispatch |
-| `.github/workflows/claude-followup.yml` | Claude Followup | CI (i.e. Lint and Test) workflow completes on any `claude/**` branch |
-| `.github/workflows/claude-dependabot.yml` | Claude Dependabot PR Review | Dependabot PR opened or updated, manual dispatch |
-| `.github/workflows/claude-code-review.yml` | Claude Code Review | PR opened, marked ready for review, or pushed to (non-Dependabot, non-draft) |
-| `.github/workflows/auto-update-models.yml` | Auto Update LLM Models pricing | Daily schedule, manual dispatch |
+| `claude.yml` | Claude Code | Issue labelled `claude`, `@claude` mention, daily schedule, manual dispatch |
+| `claude-followup.yml` | Claude Followup | CI (i.e. Lint and Test) workflow completes on any `claude/**` branch |
+| `claude-dependabot.yml` | Claude Dependabot PR Review | Dependabot PR opened or updated, manual dispatch |
+| `claude-code-review.yml` | Claude Code Review | PR opened, marked ready for review, or pushed to (non-Dependabot, non-draft) |
+| `auto-update-models.yml` | Auto Update LLM Models pricing | Daily schedule, manual dispatch |
 
 ## Forked PRs
 Since fork PRs can't get an OIDC token, these pull requests do **not** run the Claude Code Review workflow.
-
-## Tool allowlist
-
-Each run is restricted to an explicit allowlist of tools defined in the `claude_args` field of the workflow file. Claude cannot call anything outside that list. If it needs a tool that isn't permitted, the run fails rather than silently taking an unintended action.
-
-For more information on `claude_args`, see [GitHub for claude-code-action usage guide](https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md).
 
 ## Plugins
 

--- a/.github/workflows/README-claude-workflows.md
+++ b/.github/workflows/README-claude-workflows.md
@@ -1,4 +1,4 @@
-# Maintaining Claude Code Agent Workflows
+# GitHub Automation with Claude
 
 For engineers responsible for extending, debugging, or operating the Claude workflows. For day-to-day usage, see [Github automation with Claude](https://developers.openchatstudio.com/developer_guides/claude_github_automation/).
 
@@ -6,22 +6,22 @@ These workflows use [`anthropics/claude-code-action`](https://github.com/anthrop
 
 ## Required secrets and permissions
 
-- `ANTHROPIC_API_KEY`: Anthropic API key for Claude.
+- `ANTHROPIC_API_KEY` for Claude Code.
 - `auto-update-models.yml`'s `reconcile` job needs `LLM_STATS_BEARER_TOKEN`.
-- A workflow's `permissions:` block governs the default `GITHUB_TOKEN`.
+- Each workflow's `permissions:` block governs the default `GITHUB_TOKEN`.
 - Each run is also restricted to an explicit allowlist of tools, passed via `--allowedTools` in the `claude_args` field of the workflow file — Claude cannot call anything outside that list. Together, `permissions:` and `--allowedTools` are the main safeguard against a compromised or malicious prompt (e.g. a hostile issue/PR body) taking unintended action.
 
 > [!WARNING]
 > If Claude tries to use a tool that isn't permitted, that call is denied and it continues without it — **the run won't fail**. A missing tool usually surfaces as an **incomplete result rather than an error**, so check the run transcript for denied tool calls if the output looks truncated.
 
-## Workflows at a glance
+## GitHub workflows at a glance
 
 | File | Actions UI name | Trigger |
 |---|---|---|
 | `claude.yml` | Claude Code | Issue labelled `claude`, `@claude` mention, daily schedule, manual dispatch |
 | `claude-followup.yml` | Claude Followup | CI (i.e. Lint and Test) workflow completes on any `claude/**` branch |
 | `claude-dependabot.yml` | Claude Dependabot PR Review | Dependabot PR opened or updated, manual dispatch |
-| `claude-code-review.yml` | Claude Code Review | PR opened, marked ready for review, or pushed to (non-Dependabot, non-draft) |
+| `claude-code-review.yml` | Claude Code Review | PR opened, marked ready for review, or pushed (non-Dependabot, non-draft) |
 | `auto-update-models.yml` | Auto Update LLM Models pricing | Daily schedule, manual dispatch |
 
 ## Forked PR limitations
@@ -44,3 +44,11 @@ The code-review workflow (`claude-code-review.yml`) uses an official Anthropic p
 - **`claude-followup-done` label** — applied by the follow-up workflow after it runs. Prevents a second round. Remove it manually if you need Claude to re-run follow-up on a PR.
 - **`auto-models` label** — applied by `auto-update-models.yml` to both its new-model PR and to its missing-pricing issue.
 - **`cost-tracking` label** — applied by `auto-update-models.yml` to its missing-pricing issue.
+
+## Troubleshooting
+- **Run fails immediately in the `claude-code-action` step** — check that `ANTHROPIC_API_KEY` is set and valid; that's the most common cause across all these workflows.
+- **`claude-code-review.yml` didn't run on a PR from a fork** — expected, see Forked PRs above. There's no failed job to debug; the run was skipped.
+- **`auto-update-models.yml`'s `reconcile` job fails** — verify `LLM_STATS_BEARER_TOKEN` is set and valid; the job needs it to call the llm-stats.com Stats API.
+- **A Claude-created PR didn't get a second follow-up round** — by design, see the `claude-followup-done` label above. Remove the label, or comment `@claude` on the PR, to trigger another pass.
+- **Output looks incomplete, or a step Claude should have taken didn't happen** — check the run transcript for denied tool calls, see Tool allowlist above.
+- **Output quality needs improvement** — comment `@claude` on the issue or PR with what to revise, or update the relevant prompt in the workflow file if the issue is systemic.

--- a/.github/workflows/README-claude-workflows.md
+++ b/.github/workflows/README-claude-workflows.md
@@ -4,7 +4,7 @@ For engineers responsible for extending, debugging, or operating the Claude work
 
 These workflows use [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) to run Claude Code inside GitHub Actions. Claude autonomously reads code, writes changes, runs tests, and opens PRs based on its instructions.
 
-## Setup secrets and permissions
+## Required secrets and permissions
 
 - `ANTHROPIC_API_KEY`: Anthropic API key for Claude.
 - `auto-update-models.yml`'s `reconcile` job needs `LLM_STATS_BEARER_TOKEN`.
@@ -14,7 +14,7 @@ These workflows use [`anthropics/claude-code-action`](https://github.com/anthrop
 > [!WARNING]
 > If Claude tries to use a tool that isn't permitted, that call is denied and it continues without it — **the run won't fail**. A missing tool usually surfaces as an **incomplete result rather than an error**, so check the run transcript for denied tool calls if the output looks truncated.
 
-## Workflow files
+## Workflows at a glance
 
 | File | Actions UI name | Trigger |
 |---|---|---|
@@ -24,24 +24,23 @@ These workflows use [`anthropics/claude-code-action`](https://github.com/anthrop
 | `claude-code-review.yml` | Claude Code Review | PR opened, marked ready for review, or pushed to (non-Dependabot, non-draft) |
 | `auto-update-models.yml` | Auto Update LLM Models pricing | Daily schedule, manual dispatch |
 
-## Forked PRs
+## Forked PR limitations
 Since fork PRs can't get an OIDC token, these pull requests do **not** run the Claude Code Review workflow.
 
-## Plugins
+## Claude Code plugins
 
-The code-review workflow (`claude-code-review.yml`) uses a plugin from an external marketplace: `https://github.com/anthropics/claude-code.git`
+The code-review workflow (`claude-code-review.yml`) uses an official Anthropic plugin.
 
-## Concurrency
+## Concurrency and run cancellation
 
-`claude.yml` uses `cancel-in-progress: false` — a second trigger for the same issue or PR waits for the in-progress run to finish rather than replacing it. Runs for different issues execute in parallel.
+- `claude.yml` and `claude-followup.yml` both use `cancel-in-progress: false`, grouped per issue/PR and per branch respectively — a second trigger for the same issue, PR, or branch waits for the in-progress run to finish rather than replacing it. Runs for different issues, PRs, or branches execute in parallel.
+- `auto-update-models.yml` uses a single global group (`auto-update-models`) instead of one per issue or PR, so only one run of the whole workflow — scheduled or manual — executes at a time across the repository.
+- `claude-code-review.yml` is the exception that cancels: a new push to a PR cancels any in-progress review of that PR (`cancel-in-progress: true`), since a review of stale code is wasted spend.
+- `claude-dependabot.yml` sets no concurrency group at all, so its runs are independent of one another.
 
-The code review workflow is the exception: a new push to a PR cancels any in-progress review of that PR (`cancel-in-progress: true`), since a review of stale code is wasted spend.
+## GitHub labels used by these workflows
 
-`auto-update-models.yml` uses a single global group (`auto-update-models`) instead of one per issue or PR, so only one run of the whole workflow — scheduled or manual — executes at a time across the repository.
-
-## Branch and label conventions
-
-- **Branches** — all Claude-created branches are namespaced under `claude/` (e.g. `claude/123-20240518-143022` — issue number, date, time). Easy to target with branch protection rules.
-- **`claude` label** — apply to an issue to trigger the one-shot or incremental workflow. Claude also applies it to PRs it opens.
+- **`claude` label** — apply to an issue to trigger the one-shot or incremental workflow. Claude also applies it to PRs it opens, including the new-model PR from `auto-update-models.yml`.
 - **`claude-followup-done` label** — applied by the follow-up workflow after it runs. Prevents a second round. Remove it manually if you need Claude to re-run follow-up on a PR.
-- **`auto-models` label** — applied by `auto-update-models.yml` to its new-model PR (alongside `claude`) and to its missing-pricing issue (alongside `cost-tracking`). The pricing-update PR from the same workflow gets no labels at all — it's opened by a plain `gh pr create` call in the deterministic `reconcile` job, not by Claude
+- **`auto-models` label** — applied by `auto-update-models.yml` to both its new-model PR and to its missing-pricing issue.
+- **`cost-tracking` label** — applied by `auto-update-models.yml` to its missing-pricing issue.

--- a/.github/workflows/auto-update-models.yml
+++ b/.github/workflows/auto-update-models.yml
@@ -1,5 +1,5 @@
-name: Auto Update LLM Models
-
+# Auto Update LLM Models
+#
 # Daily reconciliation against llm-stats.com (via the zeroeval Stats API):
 # scripts/reconcile_models.py runs once and produces three signals:
 #
@@ -15,6 +15,12 @@ name: Auto Update LLM Models
 # docs/developer_guides/managing_models.md.
 #
 # Model metadata is sourced from https://llm-stats.com (via api.zeroeval.com).
+#
+# Triggered on: daily schedule, or manual dispatch
+# Requirements: LLM_STATS_BEARER_TOKEN secret (job 1, reconcile);
+#   ANTHROPIC_API_KEY secret (job 2, new-models-pr)
+
+name: Auto Update LLM Models
 
 on:
   schedule:

--- a/.github/workflows/auto-update-models.yml
+++ b/.github/workflows/auto-update-models.yml
@@ -1,4 +1,4 @@
-# Auto Update LLM Models
+# Auto Update LLM Models Workflow
 #
 # Daily reconciliation against llm-stats.com (via the zeroeval Stats API):
 # scripts/reconcile_models.py runs once and produces three signals:
@@ -19,6 +19,14 @@
 # Triggered on: daily schedule, or manual dispatch
 # Requirements: LLM_STATS_BEARER_TOKEN secret (job 1, reconcile);
 #   ANTHROPIC_API_KEY secret (job 2, new-models-pr)
+#
+# Notes:
+# - The new-model PR (job 2) gets the `claude` and `auto-models` labels.
+# - The missing-pricing issue (job 1) gets the `cost-tracking` and
+#   `auto-models` labels.
+# - Uses a single global concurrency group (not per-issue/PR), so only one
+#   run of the whole workflow — scheduled or manual — executes at a time
+#   across the repository.
 
 name: Auto Update LLM Models
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,8 +13,10 @@
 # - Runs triggered by Dependabot are excluded — Dependabot PRs get their own
 #   review via claude-dependabot.yml when Dependabot is the triggering actor
 # - Draft PRs are skipped; the review runs when the PR is marked ready
-# - sentry[bot] and ocs-agent[bot] PRs are reviewed; the action's
-#   non-human-actor guard is opened for them via allowed_bots
+# - sentry[bot] and ocs-agent[bot] are trusted bot identities allowed via
+#   allowed_bots, which opens the action's non-human-actor guard for them
+#   without verifying repository permissions — it matches by name only, so
+#   keep this list intentionally narrow
 # - A new push cancels any in-progress review of the same PR — a review of
 #   stale code is wasted spend
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,4 +1,4 @@
-# Claude Code Review
+# Claude Code Review Workflow
 #
 # Automated code review on pull requests using the official Anthropic
 # code-review plugin. Findings are verified by the plugin's review agents
@@ -10,12 +10,13 @@
 # Notes:
 # - Fork PRs are skipped — they can't get an OIDC token, so there's no
 #   credential for the review to run with
-# - Dependabot PRs are excluded — they get their own review via
-#   claude-dependabot.yml
+# - Runs triggered by Dependabot are excluded — Dependabot PRs get their own
+#   review via claude-dependabot.yml when Dependabot is the triggering actor
 # - Draft PRs are skipped; the review runs when the PR is marked ready
 # - sentry[bot] and ocs-agent[bot] PRs are reviewed; the action's
 #   non-human-actor guard is opened for them via allowed_bots
-# - A new push cancels any in-progress review of the same PR
+# - A new push cancels any in-progress review of the same PR — a review of
+#   stale code is wasted spend
 
 name: Claude Code Review
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,15 +4,17 @@
 # code-review plugin. Findings are verified by the plugin's review agents
 # and posted as inline comments on the PR diff.
 #
-# Triggered on: PR opened, marked ready for review, or pushed to
+# Triggered on: PR opened, marked ready for review, or pushed
 # Requirements: ANTHROPIC_API_KEY secret must be configured
 #
 # Notes:
+# - Fork PRs are skipped — they can't get an OIDC token, so there's no
+#   credential for the review to run with
 # - Dependabot PRs are excluded — they get their own review via
 #   claude-dependabot.yml
-# - Sentry (Seer) bot PRs are reviewed; the action's non-human-actor guard
-#   is opened for them via allowed_bots
 # - Draft PRs are skipped; the review runs when the PR is marked ready
+# - sentry[bot] and ocs-agent[bot] PRs are reviewed; the action's
+#   non-human-actor guard is opened for them via allowed_bots
 # - A new push cancels any in-progress review of the same PR
 
 name: Claude Code Review

--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -8,6 +8,9 @@
 #
 # Triggered on: Dependabot PRs (opened, synchronize), or manual dispatch
 # Requirements: ANTHROPIC_API_KEY secret must be configured
+#
+# Notes:
+# - No concurrency group is set, so runs are independent of one another.
 
 name: Claude Dependabot PR Review
 

--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -6,7 +6,7 @@
 # - Assess breaking changes and security impacts
 # - Provide actionable recommendations for the development team
 #
-# Triggered on: Dependabot PRs (opened, synchronize)
+# Triggered on: Dependabot PRs (opened, synchronize), or manual dispatch
 # Requirements: ANTHROPIC_API_KEY secret must be configured
 
 name: Claude Dependabot PR Review

--- a/.github/workflows/claude-followup.yml
+++ b/.github/workflows/claude-followup.yml
@@ -1,4 +1,4 @@
-# Claude Followup
+# Claude Followup Workflow
 #
 # Runs a single automatic follow-up pass on PRs from claude/** branches
 # after their CI run completes: fixes CI failures and addresses actionable
@@ -7,6 +7,14 @@
 #
 # Triggered on: "Lint and Test" workflow completing on a claude/** branch
 # Requirements: ANTHROPIC_API_KEY secret must be configured
+#
+# Notes:
+# - Fork PRs are skipped — workflow_run grants this job write permissions
+#   on the base repository, so it only acts on runs whose head branch
+#   lives in this repo, never a fork's.
+# - Runs are grouped per branch (`cancel-in-progress: false`), so a second
+#   trigger for the same branch waits for the in-progress run to finish
+#   rather than replacing it.
 
 name: Claude Followup
 

--- a/.github/workflows/claude-followup.yml
+++ b/.github/workflows/claude-followup.yml
@@ -1,3 +1,13 @@
+# Claude Followup
+#
+# Runs a single automatic follow-up pass on PRs from claude/** branches
+# after their CI run completes: fixes CI failures and addresses actionable
+# PR review feedback, then labels the PR claude-followup-done so it only
+# runs once. Remove that label to allow another round.
+#
+# Triggered on: "Lint and Test" workflow completing on a claude/** branch
+# Requirements: ANTHROPIC_API_KEY secret must be configured
+
 name: Claude Followup
 
 on:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,17 @@
+# Claude Code
+#
+# Runs Claude Code against issues and PR/issue conversations in two modes:
+# - Scheduled/manual (find-work + scheduled jobs): picks the oldest open
+#   issue labelled `claude` that doesn't already have an open PR, and
+#   implements its next unchecked task.
+# - Event-driven (claude job): responds to an `@claude` mention in an issue
+#   comment, PR review comment, or PR review, or to an issue being labelled
+#   `claude`.
+#
+# Triggered on: daily schedule, manual dispatch, `@claude` mention (issue
+# comment, PR review comment, or PR review), or issue labelled `claude`
+# Requirements: ANTHROPIC_API_KEY secret must be configured
+
 name: Claude Code
 
 on:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,4 @@
-# Claude Code
+# Claude Code Workflow
 #
 # Runs Claude Code against issues and PR/issue conversations in two modes:
 # - Scheduled/manual (find-work + scheduled jobs): picks the oldest open
@@ -11,6 +11,13 @@
 # Triggered on: daily schedule, manual dispatch, `@claude` mention (issue
 # comment, PR review comment, or PR review), or issue labelled `claude`
 # Requirements: ANTHROPIC_API_KEY secret must be configured
+#
+# Notes:
+# - Applies the `claude` label to PRs it opens when instructed by the prompt
+#   (the scheduled/manual mode aims to create one PR per completed task).
+# - Runs are grouped per issue/PR (`cancel-in-progress: false`), so a
+#   second trigger for the same issue or PR waits for the in-progress run
+#   to finish rather than replacing it.
 
 name: Claude Code
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,12 @@
 # - Runs are grouped per issue/PR (`cancel-in-progress: false`), so a
 #   second trigger for the same issue or PR waits for the in-progress run
 #   to finish rather than replacing it.
+# - The `claude` job has no actor/permission gate of its own — it relies on
+#   claude-code-action's built-in check that the triggering user has write
+#   access to this repo. A mention or review from anyone without write
+#   access (most fork PR authors included) fails the "Run Claude Code" step
+#   with "Action failed with error: User does not have write access on this
+#   repository" rather than being silently skipped.
 
 name: Claude Code
 

--- a/docs/developer_guides/claude_github_automation.md
+++ b/docs/developer_guides/claude_github_automation.md
@@ -14,9 +14,10 @@ This project has GitHub Actions workflows that use Claude Code for [autonomous i
 
 **Automatic behaviours** (no action needed):
 
+- **PR Code Review** — every non-draft, non-fork, non-Dependabot PR automatically receives a Claude code review with findings posted as inline diff comments. [How it works](#pr-code-review)
 - **Auto-repair** — Claude fixes its own CI failures and addresses reviewer comments automatically, so PRs are in a clean state by the time you review them. [How it works](#automatic-follow-up)
 - **Dependabot review** — every Dependabot PR includes a Claude-written assessment: what changed, whether anything is breaking, and a clear merge recommendation, saving engineers time. [How it works](#dependabot-pr-review)
-- **PR Code Review** — every non-draft, non-fork, non-Dependabot PR automatically receives a Claude code review with findings posted as inline diff comments. [How it works](#pr-code-review)
+
 
 ## How to Use
 
@@ -50,7 +51,11 @@ Use this to ask Claude a question in context, request a specific change to an ex
 - An **inline PR review comment** — to point Claude at a specific line and have it act on that feedback
 - A **PR review body** — to have Claude respond to your review feedback
 
-Claude will push changes to the branch or reply in a new comment. This also works on PRs from a fork, where the automatic PR Code Review doesn't run — it's the fallback for getting Claude's help there.
+Claude will push changes to the branch or reply in a new comment.
+
+!!! note
+
+    This requires write access to the repository. `@claude` only responds to comments and reviews from people with write access or higher — everyone else's mention fails rather than getting a response. If you're an external contributor without write access, ask a maintainer to invoke Claude on your behalf.
 
 **Example prompts:**
 
@@ -130,7 +135,8 @@ Every non-draft, non-fork, non-Dependabot PR triggers an automated Claude code r
 It runs when a PR is opened, when it is marked **ready for review**, and on every push. Drafts are skipped — which is why the [development workflow](../getting-started/dev-workflow.md#then-hand-it-over) has you clean up the PR as a draft first, then flip it to ready to get this review. There is no manual trigger; to get a fresh review, push a new commit.
 
 !!! note
-    Pull requests from a fork do **not** trigger this automatic review — GitHub withholds the permissions this workflow needs from fork-originated PRs. If you're contributing from a fork, comment `@claude review this PR` instead to get the same review on demand — see [Asking or directing Claude with @claude](#3-asking-or-directing-claude-with-claude).
+
+    Pull requests from a fork do **not** trigger this automatic review. Claude Code actions require write access, so an external contributor should ask a maintainer trigger a Claude review.
 
 ## Maintaining These Workflows
 

--- a/docs/developer_guides/claude_github_automation.md
+++ b/docs/developer_guides/claude_github_automation.md
@@ -50,7 +50,7 @@ Use this to ask Claude a question in context, request a specific change to an ex
 - An **inline PR review comment** — to point Claude at a specific line and have it act on that feedback
 - A **PR review body** — to have Claude respond to your review feedback
 
-Claude will push changes to the branch or reply in a new comment.
+Claude will push changes to the branch or reply in a new comment. This also works on PRs from a fork, where the automatic PR Code Review doesn't run — it's the fallback for getting Claude's help there.
 
 **Example prompts:**
 
@@ -130,7 +130,7 @@ Every non-draft, non-fork, non-Dependabot PR triggers an automated Claude code r
 It runs when a PR is opened, when it is marked **ready for review**, and on every push. Drafts are skipped — which is why the [development workflow](../getting-started/dev-workflow.md#then-hand-it-over) has you clean up the PR as a draft first, then flip it to ready to get this review. There is no manual trigger; to get a fresh review, push a new commit.
 
 !!! note
-    For a fork, pull requests do **not** run the Claude Code Review workflow due to permission restrictions.
+    Pull requests from a fork do **not** trigger this automatic review — GitHub withholds the permissions this workflow needs from fork-originated PRs. If you're contributing from a fork, comment `@claude review this PR` instead to get the same review on demand — see [Asking or directing Claude with @claude](#3-asking-or-directing-claude-with-claude).
 
 ## Maintaining These Workflows
 

--- a/docs/developer_guides/claude_github_automation.md
+++ b/docs/developer_guides/claude_github_automation.md
@@ -47,6 +47,7 @@ Use this to ask Claude a question in context, request a specific change to an ex
 
 - An **issue comment** — to ask a question or kick off an implementation
 - A **PR comment** — to request a specific code change
+- An **inline PR review comment** — to point Claude at a specific line and have it act on that feedback
 - A **PR review body** — to have Claude respond to your review feedback
 
 Claude will push changes to the branch or reply in a new comment.


### PR DESCRIPTION
### Product Description

Only technical documentation changes.
Only changes to GitHub workflows **comments** - no changes to code

### Technical Description

The **accuracy and maintainability** of all the GitHub action workflows needs to be validated. These docs can then be used by Claude to double check behavior, maintainability, troubleshooting, permission scope and security.

This work was done based the work done on  OCS Docs workflows: https://github.com/dimagi/open-chat-studio-docs/pull/680 where identified a number of permissions and allowlists that needed tightening.

1. Improved README  **accuracy** (silent failing for denied tool, forked repo, concurrency & troubleshooting) 
2. Improved **workflow file comments** -  consistent & accurate so the README is just an overview with maintenance notes
3. Add recently added `auto-update-models.yml` workflow information to README
4. Clarify secrets, permissions and Claude tool allowlists including warning about tool permissions and failing
5. Clarify how concurrency handled - patterns used 
6. Updated dev guidelines on these workflows for accuracy

#### Not worked on, but noted

- Any permissions that should be reduced ie bash widlcards
- Any Claude allowed tool list potential issues
- Improved job level gate - https://github.com/dimagi/open-chat-studio/issues/4263

### Docs and Changelog
- [ ] This PR requires docs/changelog update