### PR TITLE
Cache the provisioned worktree database as a PostgreSQL template

### DIFF
--- a/docs/getting-started/dev-workflow.md
+++ b/docs/getting-started/dev-workflow.md
@@ -59,10 +59,12 @@ automatically on create:
 - Creates that database with a working superuser (`test@example.com` / `letmein`), a team, and
   sample data rather than an empty app. Migrating and seeding from scratch takes about ten
   minutes, so the finished database is kept as a PostgreSQL template per migration set and copied
-  in well under a second. A branch that adds migrations copies the closest older template and
+  in a second or two instead. A branch that adds migrations copies the closest older template and
   migrates forward; only a migration set nothing has built yet pays the full cost, and the next
-  worktree copies that result. Set `OCS_DISABLE_DATABASE_TEMPLATES=true` to always build from
-  scratch, and `OCS_TEMPLATE_RETENTION` to keep more or fewer than three templates around.
+  worktree copies that result. `migrate` runs either way, since a template is named for this
+  repository's migrations and says nothing about those shipped by packages in `uv.lock`. Set
+  `OCS_DISABLE_DATABASE_TEMPLATES=true` to always build from scratch, and
+  `OCS_TEMPLATE_RETENTION` to keep more or fewer than three templates around.
 - Builds the frontend assets.
 
 On `wt remove` the branch database is dropped, its Redis DB is flushed, and its allocation is

--- a/docs/getting-started/dev-workflow.md
+++ b/docs/getting-started/dev-workflow.md
@@ -56,8 +56,13 @@ automatically on create:
 - Points `DATABASE_URL` and `REDIS_URL` at a **per-branch** database and Redis DB, so a migration
   or a wiped table on one branch can't affect another. Redis database 15 stores an atomic
   allocation registry, leaving databases 1–14 for concurrent worktrees without collisions.
-- Creates that database, migrates it, and seeds it with `bootstrap_data` — you get a working
-  superuser (`test@example.com` / `letmein`), a team, and sample data rather than an empty app.
+- Creates that database with a working superuser (`test@example.com` / `letmein`), a team, and
+  sample data rather than an empty app. Migrating and seeding from scratch takes about ten
+  minutes, so the finished database is kept as a PostgreSQL template per migration set and copied
+  in well under a second. A branch that adds migrations copies the closest older template and
+  migrates forward; only a migration set nothing has built yet pays the full cost, and the next
+  worktree copies that result. Set `OCS_DISABLE_DATABASE_TEMPLATES=true` to always build from
+  scratch, and `OCS_TEMPLATE_RETENTION` to keep more or fewer than three templates around.
 - Builds the frontend assets.
 
 On `wt remove` the branch database is dropped, its Redis DB is flushed, and its allocation is

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -114,9 +114,12 @@ ocs_set_env_value \
     "$redis_url"
 export REDIS_URL="$redis_url"
 
-if [[ "$provisioning" != copy ]]; then
-    uv run python manage.py migrate
-fi
+# Always migrated, even on an exact template match: the stamp a template is named for
+# covers this repository's migrations, not those of the packages in `uv.lock`. A
+# dependency bump that ships a migration leaves the stamp -- and so the template --
+# byte-identical, and only an unconditional migrate keeps that schema from going stale.
+# It costs a second or two against a database that is already up to date.
+uv run python manage.py migrate
 
 if [[ "$provisioning" == build ]] || ! ocs_database_is_seeded "$resource_name"; then
     # Seeding is not idempotent -- sample sessions, messages, traces and usage records

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -36,8 +36,15 @@ fi
 
 "$CURRENT_PATH/scripts/bootstrap.sh" --force --yes
 
+# Hashing the migrations is the slowest bookkeeping step here, so it happens once and
+# the result is handed to every step that needs it: the template name, the ancestor
+# search and the dependency fingerprint.
+migration_stamp_file=$(mktemp)
+trap 'rm -f "$migration_stamp_file"' EXIT
+ocs_migration_stamp_lines "$CURRENT_PATH" > "$migration_stamp_file"
+
 if ocs_is_root_worktree "$CURRENT_PATH" "$ROOT_WORKTREE_PATH"; then
-    ocs_record_dependency_fingerprint "$CURRENT_PATH"
+    ocs_record_dependency_fingerprint "$CURRENT_PATH" "$migration_stamp_file"
     echo "[ocs] Setup complete for root checkout."
     exit 0
 fi
@@ -61,16 +68,42 @@ ocs_set_env_value \
 
 export DATABASE_URL="$database_url"
 
-if ! PGPASSWORD=postgres psql \
-    -h localhost \
-    -U postgres \
-    -tAc "SELECT 1 FROM pg_database WHERE datname='$resource_name'" \
-    | grep -q 1; then
-    PGPASSWORD=postgres psql \
-        -h localhost \
-        -U postgres \
-        -v ON_ERROR_STOP=1 \
-        -c "CREATE DATABASE \"$resource_name\""
+template_name=$(ocs_template_name "$CURRENT_PATH" "$migration_stamp_file")
+template_source=""
+
+# Copying a template database is milliseconds of work where replaying every migration
+# and seeding the result is minutes of it, so a fresh worktree only builds its database
+# by hand when no template it can start from exists.
+if ocs_database_exists "$resource_name"; then
+    provisioning=migrate
+    echo "[ocs] Migrating the existing $resource_name database."
+elif ocs_templates_are_enabled && ocs_database_exists "$template_name"; then
+    provisioning=copy
+    template_source=$template_name
+    echo "[ocs] Copying $template_name into $resource_name."
+elif ocs_templates_are_enabled \
+    && template_source=$(ocs_find_ancestor_template "$CURRENT_PATH" "$migration_stamp_file"); then
+    provisioning=copy_and_migrate
+    echo "[ocs] Copying $template_source into $resource_name and migrating forward."
+else
+    provisioning=build
+    echo "[ocs] Building $resource_name from scratch; later worktrees copy the result."
+fi
+
+# The database is created before any Redis bookkeeping so that a PostgreSQL failure
+# leaves no Redis allocation behind for a worktree that never finished setting up.
+if [[ -n "$template_source" ]]; then
+    # A template can go away between the check above and the copy: another worktree
+    # prunes stale templates and drops and recreates the one it is snapshotting. That
+    # costs this worktree its head start, not its database, so a copy that will not
+    # succeed falls back to building by hand.
+    if ! ocs_create_database "$resource_name" "$template_source"; then
+        echo "[ocs] Could not copy $template_source; building $resource_name from scratch instead." >&2
+        provisioning=build
+        ocs_create_database "$resource_name"
+    fi
+elif [[ "$provisioning" == build ]]; then
+    ocs_create_database "$resource_name"
 fi
 
 redis_database=$(ocs_allocate_redis_database "$resource_name")
@@ -81,11 +114,30 @@ ocs_set_env_value \
     "$redis_url"
 export REDIS_URL="$redis_url"
 
-uv run python manage.py migrate
-uv run python manage.py bootstrap_data \
-    --email test@example.com \
-    --password letmein \
-    --superuser
+if [[ "$provisioning" != copy ]]; then
+    uv run python manage.py migrate
+fi
 
-ocs_record_dependency_fingerprint "$CURRENT_PATH"
+if [[ "$provisioning" == build ]] || ! ocs_database_is_seeded "$resource_name"; then
+    # Seeding is not idempotent -- sample sessions, messages, traces and usage records
+    # are created outright -- so copies inherit the seed data instead of re-running the
+    # command over data that already exists. An existing database with no users at all
+    # is the exception: a setup that died before finishing the seed left it that way.
+    uv run python manage.py bootstrap_data \
+        --email test@example.com \
+        --password letmein \
+        --superuser
+fi
+
+if [[ "$provisioning" == copy_and_migrate || "$provisioning" == build ]]; then
+    ocs_snapshot_template \
+        "$CURRENT_PATH" \
+        "$template_name" \
+        "$resource_name" \
+        "$migration_stamp_file"
+fi
+
+ocs_prune_template_databases "$CURRENT_PATH" "$template_name"
+
+ocs_record_dependency_fingerprint "$CURRENT_PATH" "$migration_stamp_file"
 echo "[ocs] Setup complete for $resource_name."

--- a/scripts/teardown-worktree.sh
+++ b/scripts/teardown-worktree.sh
@@ -23,11 +23,7 @@ fi
 
 resource_name=$(ocs_worktree_resource_name "$CURRENT_PATH")
 
-PGPASSWORD=postgres psql \
-    -h localhost \
-    -U postgres \
-    -v ON_ERROR_STOP=1 \
-    -c "DROP DATABASE IF EXISTS \"$resource_name\" WITH (FORCE)"
+ocs_drop_database "$resource_name"
 
 if redis_database=$(ocs_lookup_redis_database "$resource_name"); then
     redis-cli -n "$redis_database" FLUSHDB

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -534,7 +534,7 @@ def test_setup_does_not_reconfigure_the_root_checkout(
     assert command_log.read_text() == "bootstrap:--force --yes\n"
 
 
-def test_setup_copies_a_matching_template_instead_of_migrating(
+def test_setup_copies_a_matching_template_instead_of_rebuilding(
     worktree_fixture: tuple[Path, Path, dict[str, str], Path],
 ) -> None:
     _, worktree, env, command_log = worktree_fixture
@@ -548,7 +548,9 @@ def test_setup_copies_a_matching_template_instead_of_migrating(
 
     command_output = command_log.read_text()
     assert f'CREATE DATABASE "second_worktree" TEMPLATE "{template_name}"' in _created_databases(command_log)
-    assert "manage.py migrate" not in command_output
+    # Migrated even though the template matched exactly: the stamp says nothing about
+    # migrations shipped by the packages in `uv.lock`.
+    assert "uv:run python manage.py migrate" in command_output
     assert "bootstrap_data" not in command_output
 
 

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -711,6 +711,37 @@ def test_pruning_keeps_the_retained_template_and_the_newest_few(
     assert (stamp_directory / f"{templates[0]}.stamp").exists()
 
 
+def test_pruning_does_not_spend_a_retention_slot_on_the_retained_template(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    """The retained template is usually the newest one, having just been snapshotted."""
+    _, worktree, env, command_log = worktree_fixture
+    stamp_directory = Path(
+        _run_worktree_helper(worktree, "ocs_template_stamp_directory", worktree, env=env).stdout.strip()
+    )
+    stamp_directory.mkdir(parents=True, exist_ok=True)
+    database_registry = Path(env["OCS_TEST_DATABASE_REGISTRY"])
+    templates = [f"ocs_tmpl_0000000{index}" for index in range(3)]
+    database_registry.write_text("".join(f"{template}\n" for template in templates))
+    for template in templates:
+        (stamp_directory / f"{template}.stamp").write_text("apps/example/migrations/0001_initial.py:1 2\n")
+    env["OCS_TEMPLATE_RETENTION"] = "1"
+
+    _run_worktree_helper(
+        worktree,
+        "ocs_prune_template_databases",
+        worktree,
+        templates[-1],
+        env=env,
+    )
+
+    command_output = command_log.read_text()
+    # The retained newest template, plus one older one on the retention slot it did not take.
+    assert f'DROP DATABASE IF EXISTS "{templates[2]}"' not in command_output
+    assert f'DROP DATABASE IF EXISTS "{templates[1]}"' not in command_output
+    assert f'DROP DATABASE IF EXISTS "{templates[0]}"' in command_output
+
+
 def test_teardown_removes_only_the_worktree_resources(
     worktree_fixture: tuple[Path, Path, dict[str, str], Path],
 ) -> None:

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -24,11 +24,52 @@ mkdir -p "$PWD/.venv" "$PWD/node_modules"
 printf "bootstrap:%s\n" "$*" >> "$OCS_TEST_COMMAND_LOG"
 """
 
+# Enough of psql to answer "does this database exist?" and to remember the answer
+# changing, which is what picks between building a worktree database from scratch and
+# copying a template.
 FAKE_PSQL_SCRIPT = r"""#!/usr/bin/env bash
 set -euo pipefail
 printf "psql:%s\n" "$*" >> "$OCS_TEST_COMMAND_LOG"
 if [[ "${OCS_TEST_FAIL_PSQL:-false}" == "true" ]]; then exit 1; fi
-if [[ "$*" == *"SELECT 1 FROM pg_database"* ]]; then exit 0; fi
+
+registry="$OCS_TEST_DATABASE_REGISTRY"
+statement="${*: -1}"
+touch "$registry"
+
+if [[ "$statement" == *"SELECT 1 FROM pg_database"* ]]; then
+    database=$(sed -E "s/.*datname='([^']*)'.*/\1/" <<< "$statement")
+    grep -Fxq "$database" "$registry" && echo 1
+    exit 0
+fi
+
+if [[ "$statement" == *"FROM pg_database"* ]]; then
+    # Newest first, matching the real ordering by object id.
+    grep '^ocs_tmpl_' "$registry" | tac || true
+    exit 0
+fi
+
+if [[ "$statement" == *"FROM users_customuser"* ]]; then
+    printf '%s\n' "${OCS_TEST_USER_ROW_COUNT:-1}"
+    exit 0
+fi
+
+if [[ "$statement" == CREATE\ DATABASE* ]]; then
+    if [[ -n "${OCS_TEST_REFUSE_TEMPLATE:-}" \
+        && "$statement" == *"TEMPLATE \"$OCS_TEST_REFUSE_TEMPLATE\""* ]]; then
+        echo "source database \"$OCS_TEST_REFUSE_TEMPLATE\" does not exist" >&2
+        exit 1
+    fi
+    database=$(sed -E 's/^CREATE DATABASE "([^"]*)".*/\1/' <<< "$statement")
+    grep -Fxq "$database" "$registry" || printf '%s\n' "$database" >> "$registry"
+    exit 0
+fi
+
+if [[ "$statement" == DROP\ DATABASE* ]]; then
+    database=$(sed -E 's/.*IF EXISTS "([^"]*)".*/\1/' <<< "$statement")
+    grep -Fvx "$database" "$registry" > "$registry.tmp" || true
+    mv "$registry.tmp" "$registry"
+    exit 0
+fi
 """
 
 FAKE_UV_SCRIPT = r"""#!/usr/bin/env bash
@@ -199,8 +240,33 @@ def _prepare_session_guard(
     return command_log.parent / f"ocs-worktree-setup-{scenario.thread_id}.log"
 
 
+def _write_migration(worktree: Path, name: str, contents: str = "# migration\n") -> Path:
+    migration = worktree / "apps" / "example" / "migrations" / name
+    migration.parent.mkdir(parents=True, exist_ok=True)
+    migration.write_text(contents)
+    return migration
+
+
+def _template_name(worktree: Path, env: dict[str, str]) -> str:
+    return _run_worktree_helper(worktree, "ocs_template_name", worktree, env=env).stdout.strip()
+
+
+def _created_databases(command_log: Path) -> list[str]:
+    return [
+        line.split("-c ", maxsplit=1)[1]
+        for line in command_log.read_text().splitlines()
+        if "-c CREATE DATABASE" in line
+    ]
+
+
 @pytest.fixture()
-def worktree_fixture(tmp_path: Path) -> tuple[Path, Path, dict[str, str], Path]:
+def worktree_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path, dict[str, str], Path]:
+    # Loading the Django settings reads the developer's own .env, so running these
+    # tests from a worktree otherwise leaks that worktree's resource names into every
+    # script the fixture starts.
+    for inherited_variable in ("OCS_WORKTREE_ID", "DATABASE_URL", "REDIS_URL"):
+        monkeypatch.delenv(inherited_variable, raising=False)
+
     root = tmp_path / "main"
     worktree = tmp_path / ".codex" / "worktrees" / "a1b2" / "project"
     fake_bin = tmp_path / "bin"
@@ -242,6 +308,7 @@ def worktree_fixture(tmp_path: Path) -> tuple[Path, Path, dict[str, str], Path]:
     env = {
         "OCS_TEST_COMMAND_LOG": str(command_log),
         "OCS_TEST_REDIS_REGISTRY": str(tmp_path / "redis-registry"),
+        "OCS_TEST_DATABASE_REGISTRY": str(tmp_path / "database-registry"),
         "PATH": f"{fake_bin}:{os.environ['PATH']}",
     }
     return root, worktree, env, command_log
@@ -465,6 +532,181 @@ def test_setup_does_not_reconfigure_the_root_checkout(
 
     assert (root / ".env").read_text() == original_env
     assert command_log.read_text() == "bootstrap:--force --yes\n"
+
+
+def test_setup_copies_a_matching_template_instead_of_migrating(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    _write_migration(worktree, "0001_initial.py")
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+    template_name = _template_name(worktree, env)
+    command_log.write_text("")
+    env["OCS_WORKTREE_ID"] = "second_worktree"
+
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+
+    command_output = command_log.read_text()
+    assert f'CREATE DATABASE "second_worktree" TEMPLATE "{template_name}"' in _created_databases(command_log)
+    assert "manage.py migrate" not in command_output
+    assert "bootstrap_data" not in command_output
+
+
+def test_setup_migrates_forward_from_an_ancestor_template(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    _write_migration(worktree, "0001_initial.py")
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+    ancestor_template = _template_name(worktree, env)
+    _write_migration(worktree, "0002_later.py")
+    command_log.write_text("")
+    env["OCS_WORKTREE_ID"] = "second_worktree"
+
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+
+    command_output = command_log.read_text()
+    assert f'CREATE DATABASE "second_worktree" TEMPLATE "{ancestor_template}"' in _created_databases(command_log)
+    assert "uv:run python manage.py migrate" in command_output
+    assert "bootstrap_data" not in command_output
+    # The migrated result becomes the template for the newer migration set.
+    assert f'CREATE DATABASE "{_template_name(worktree, env)}" TEMPLATE "second_worktree"' in _created_databases(
+        command_log
+    )
+
+
+def test_setup_ignores_a_template_holding_unknown_migrations(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    _write_migration(worktree, "0001_initial.py")
+    later_migration = _write_migration(worktree, "0002_later.py")
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+    later_migration.unlink()
+    command_log.write_text("")
+    env["OCS_WORKTREE_ID"] = "second_worktree"
+
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+
+    command_output = command_log.read_text()
+    assert 'CREATE DATABASE "second_worktree"' in _created_databases(command_log)
+    assert "bootstrap_data" in command_output
+
+
+def test_setup_builds_from_scratch_when_templates_are_disabled(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    _write_migration(worktree, "0001_initial.py")
+    env["OCS_DISABLE_DATABASE_TEMPLATES"] = "true"
+
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+
+    command_output = command_log.read_text()
+    assert 'CREATE DATABASE "codex_a1b2"' in _created_databases(command_log)
+    assert "bootstrap_data" in command_output
+    assert "ocs_tmpl_" not in command_output
+
+
+def test_setup_seeds_an_existing_database_that_was_never_seeded(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    # A setup that died between creating the database and finishing the seed leaves an
+    # empty database that every later run would otherwise only migrate.
+    _, worktree, env, command_log = worktree_fixture
+    Path(env["OCS_TEST_DATABASE_REGISTRY"]).write_text("codex_a1b2\n")
+    env["OCS_TEST_USER_ROW_COUNT"] = "0"
+
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+
+    command_output = command_log.read_text()
+    assert _created_databases(command_log) == []
+    assert "uv:run python manage.py migrate" in command_output
+    assert "bootstrap_data" in command_output
+
+
+def test_setup_does_not_reseed_an_existing_database(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    Path(env["OCS_TEST_DATABASE_REGISTRY"]).write_text("codex_a1b2\n")
+
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+
+    command_output = command_log.read_text()
+    assert "uv:run python manage.py migrate" in command_output
+    assert "bootstrap_data" not in command_output
+
+
+def test_setup_builds_from_scratch_when_the_template_copy_fails(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    _write_migration(worktree, "0001_initial.py")
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+    template_name = _template_name(worktree, env)
+    # The template vanishes the way a concurrent worktree's prune would remove it.
+    env["OCS_TEST_REFUSE_TEMPLATE"] = template_name
+    env["OCS_TEMPLATE_COPY_RETRY_DELAY"] = "0"
+    command_log.write_text("")
+    env["OCS_WORKTREE_ID"] = "second_worktree"
+
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+
+    created = _created_databases(command_log)
+    command_output = command_log.read_text()
+    assert f'CREATE DATABASE "second_worktree" TEMPLATE "{template_name}"' in created
+    assert 'CREATE DATABASE "second_worktree"' in created
+    assert "uv:run python manage.py migrate" in command_output
+    assert "bootstrap_data" in command_output
+
+
+def test_setup_creates_the_database_before_allocating_redis(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+
+    _run(SETUP_SCRIPT, cwd=worktree, env=env)
+
+    command_lines = command_log.read_text().splitlines()
+    create_database = next(index for index, line in enumerate(command_lines) if "-c CREATE DATABASE" in line)
+    allocate_redis = next(
+        index for index, line in enumerate(command_lines) if line.startswith("redis-registry:allocate")
+    )
+    assert create_database < allocate_redis
+
+
+def test_pruning_keeps_the_retained_template_and_the_newest_few(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    stamp_directory = Path(
+        _run_worktree_helper(worktree, "ocs_template_stamp_directory", worktree, env=env).stdout.strip()
+    )
+    stamp_directory.mkdir(parents=True, exist_ok=True)
+    database_registry = Path(env["OCS_TEST_DATABASE_REGISTRY"])
+    templates = [f"ocs_tmpl_0000000{index}" for index in range(4)]
+    database_registry.write_text("".join(f"{template}\n" for template in templates))
+    for template in templates:
+        (stamp_directory / f"{template}.stamp").write_text("apps/example/migrations/0001_initial.py:1 2\n")
+    env["OCS_TEMPLATE_RETENTION"] = "1"
+
+    _run_worktree_helper(
+        worktree,
+        "ocs_prune_template_databases",
+        worktree,
+        templates[0],
+        env=env,
+    )
+
+    command_output = command_log.read_text()
+    # The retained template plus the newest one survive; the rest go, stamps and all.
+    assert f'DROP DATABASE IF EXISTS "{templates[0]}"' not in command_output
+    assert f'DROP DATABASE IF EXISTS "{templates[3]}"' not in command_output
+    assert f'DROP DATABASE IF EXISTS "{templates[1]}"' in command_output
+    assert f'DROP DATABASE IF EXISTS "{templates[2]}"' in command_output
+    assert not (stamp_directory / f"{templates[1]}.stamp").exists()
+    assert (stamp_directory / f"{templates[0]}.stamp").exists()
 
 
 def test_teardown_removes_only_the_worktree_resources(

--- a/scripts/worktree-environment.sh
+++ b/scripts/worktree-environment.sh
@@ -419,32 +419,30 @@ ocs_find_ancestor_template() {
     local candidate_stamp
     local missing_migrations
     local size
-    local sorted_candidate
-    local sorted_current
     local template
 
-    missing_migrations=$(mktemp)
-    sorted_candidate=$(mktemp)
-    sorted_current=$(mktemp)
-    LC_ALL=C sort "$stamp_lines_file" > "$sorted_current"
-
+    # Sorted through process substitution rather than temporary files: a `trap` to clean
+    # those up would have to be installed inside this function, where it would replace
+    # the caller's own EXIT trap and leak whatever that was there to remove.
     while IFS= read -r template; do
         [[ -n "$template" ]] || continue
         candidate_stamp=$(ocs_template_stamp_path "$worktree_path" "$template")
         [[ -f "$candidate_stamp" ]] || continue
 
-        LC_ALL=C sort "$candidate_stamp" > "$sorted_candidate"
-        LC_ALL=C comm -23 "$sorted_candidate" "$sorted_current" > "$missing_migrations"
-        [[ -s "$missing_migrations" ]] && continue
+        missing_migrations=$(
+            LC_ALL=C comm -23 \
+                <(LC_ALL=C sort "$candidate_stamp") \
+                <(LC_ALL=C sort "$stamp_lines_file")
+        )
+        [[ -z "$missing_migrations" ]] || continue
 
-        size=$(wc -l < "$sorted_candidate")
+        size=$(wc -l < "$candidate_stamp")
         if [[ "$size" -gt "$best_size" ]]; then
             best_size=$size
             best_template=$template
         fi
     done < <(ocs_list_template_databases "$worktree_path")
 
-    rm -f "$missing_migrations" "$sorted_candidate" "$sorted_current"
     [[ -n "$best_template" ]] || return 1
     printf '%s\n' "$best_template"
 }

--- a/scripts/worktree-environment.sh
+++ b/scripts/worktree-environment.sh
@@ -490,8 +490,10 @@ ocs_prune_template_databases() {
     while IFS= read -r template; do
         [[ -n "$template" ]] || continue
         stamp_path="$stamp_directory/$template.stamp"
+        # Kept without spending a retention slot: this setup's own template would
+        # otherwise take one whenever it is also the newest, leaving the knob to mean
+        # a different total depending on where that template happens to sort.
         if [[ "$template" == "$retained_template" ]]; then
-            kept=$((kept + 1))
             continue
         fi
         if [[ -f "$stamp_path" && "$kept" -lt "$OCS_TEMPLATE_RETENTION" ]]; then

--- a/scripts/worktree-environment.sh
+++ b/scripts/worktree-environment.sh
@@ -199,11 +199,49 @@ ocs_release_redis_database() {
     fi
 }
 
+# One line per migration file, carrying its path and checksum. The lines are both
+# the migration part of the dependency fingerprint and the stamp recorded against a
+# template database, which is why they name the file instead of only checksumming it:
+# comparing two stamps then tells us whether one migration set is an ancestor of the
+# other, not merely that they differ.
+ocs_migration_stamp_lines() {
+    local worktree_path="$1"
+
+    [[ -d "$worktree_path/apps" ]] || return 0
+
+    # Checksumming each migration in its own process costs a fork per file, and there
+    # are hundreds of them; batching the whole set into a handful of `cksum` calls is
+    # an order of magnitude quicker. `cksum` prints "<checksum> <bytes> <path>", which
+    # awk turns back into the "<path>:<checksum> <bytes>" line this function reports.
+    (
+        cd "$worktree_path" || exit 0
+        find apps \
+            -type f \
+            -path '*/migrations/*.py' \
+            -exec cksum {} + \
+            | awk '{ printf "%s:%s %s\n", $3, $1, $2 }' \
+            | LC_ALL=C sort
+    )
+}
+
+# The stamp lines for a worktree, preferring a copy an earlier step already computed.
+# Hashing every migration is expensive enough to be worth doing once per run and
+# handing the result to everything else that needs it.
+ocs_read_migration_stamp() {
+    local worktree_path="$1"
+    local stamp_lines_file="${2:-}"
+
+    if [[ -n "$stamp_lines_file" && -f "$stamp_lines_file" ]]; then
+        cat "$stamp_lines_file"
+    else
+        ocs_migration_stamp_lines "$worktree_path"
+    fi
+}
+
 ocs_dependency_fingerprint() {
     local worktree_path="$1"
+    local stamp_lines_file="${2:-}"
     local dependency_file
-    local migration_file
-    local relative_migration_file
     local dependency_files=(
         .python-version
         .npmrc
@@ -224,28 +262,17 @@ ocs_dependency_fingerprint() {
             fi
         done
 
-        if [[ -d "$worktree_path/apps" ]]; then
-            while IFS= read -r -d '' migration_file; do
-                relative_migration_file=${migration_file#"$worktree_path/"}
-                printf '%s:' "$relative_migration_file"
-                cksum < "$migration_file"
-            done < <(
-                find "$worktree_path/apps" \
-                    -type f \
-                    -path '*/migrations/*.py' \
-                    -print0 \
-                    | sort -z
-            )
-        fi
+        ocs_read_migration_stamp "$worktree_path" "$stamp_lines_file"
     } | cksum | awk '{print $1 ":" $2}'
 }
 
 ocs_record_dependency_fingerprint() {
     local worktree_path="$1"
+    local stamp_lines_file="${2:-}"
     local fingerprint_file="$worktree_path/.venv/.ocs-dependency-fingerprint"
 
     mkdir -p "$(dirname "$fingerprint_file")"
-    ocs_dependency_fingerprint "$worktree_path" > "$fingerprint_file"
+    ocs_dependency_fingerprint "$worktree_path" "$stamp_lines_file" > "$fingerprint_file"
 }
 
 ocs_dependencies_are_current() {
@@ -256,6 +283,227 @@ ocs_dependencies_are_current() {
     [[ -f "$fingerprint_file" ]] || return 1
     expected_fingerprint=$(ocs_dependency_fingerprint "$worktree_path")
     [[ "$(<"$fingerprint_file")" == "$expected_fingerprint" ]]
+}
+
+# Provisioning a worktree database means replaying every migration and then seeding it,
+# which takes minutes and produces the same result every time. Instead we keep that
+# result once per migration set as a template database and let Postgres copy it, which
+# takes milliseconds. Templates are content-addressed by the migration stamp, so a
+# branch that adds migrations gets its own template rather than mutating a shared one.
+OCS_TEMPLATE_NAME_PREFIX="ocs_tmpl_"
+OCS_TEMPLATE_RETENTION="${OCS_TEMPLATE_RETENTION:-3}"
+OCS_TEMPLATE_COPY_RETRY_DELAY="${OCS_TEMPLATE_COPY_RETRY_DELAY:-2}"
+
+ocs_templates_are_enabled() {
+    [[ "${OCS_DISABLE_DATABASE_TEMPLATES:-false}" != "true" ]]
+}
+
+ocs_psql() {
+    local database="$1"
+    shift
+
+    PGPASSWORD=postgres psql \
+        -h localhost \
+        -U postgres \
+        -d "$database" \
+        -v ON_ERROR_STOP=1 \
+        "$@"
+}
+
+ocs_database_exists() {
+    ocs_psql postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$1'" | grep -q 1
+}
+
+ocs_create_database() {
+    local database_name="$1"
+    local template_name="${2:-}"
+    local attempt
+    local statement
+
+    if [[ -z "$template_name" ]]; then
+        ocs_psql postgres -c "CREATE DATABASE \"$database_name\""
+        return
+    fi
+
+    # Postgres refuses to copy a database while anything else is connected to it, so a
+    # second worktree setting itself up at the same moment can lose the race.
+    statement="CREATE DATABASE \"$database_name\" TEMPLATE \"$template_name\""
+    for attempt in 1 2 3; do
+        if ocs_psql postgres -c "$statement"; then
+            return 0
+        fi
+        if [[ "$attempt" -lt 3 ]]; then
+            echo "[ocs] Retrying the copy of $template_name into $database_name." >&2
+            sleep "$OCS_TEMPLATE_COPY_RETRY_DELAY"
+        fi
+    done
+    return 1
+}
+
+ocs_drop_database() {
+    ocs_psql postgres -c "DROP DATABASE IF EXISTS \"$1\" WITH (FORCE)"
+}
+
+# Whether a database already carries the sample data `bootstrap_data` creates. A
+# setup that died between creating the database and finishing the seed would
+# otherwise leave that database empty forever, because every provisioning mode but
+# `build` skips seeding. A query that fails counts as seeded: re-running a seed that
+# is not idempotent over data that already exists is the worse outcome.
+ocs_database_is_seeded() {
+    local user_count
+
+    user_count=$(ocs_psql "$1" -tAc "SELECT count(*) FROM users_customuser" 2>/dev/null) || return 0
+    [[ "$user_count" != "0" ]]
+}
+
+ocs_migration_stamp_id() {
+    ocs_read_migration_stamp "$1" "${2:-}" | cksum | awk '{printf "%08x%08x\n", $1, $2}'
+}
+
+# Templates from one clone are useless to another -- the stamp that says what a
+# template holds lives in the clone that built it -- so each clone gets its own
+# namespace. Sharing the prefix instead would have a second clone of the same
+# repository prune every template it cannot find a stamp for, which is all of them.
+ocs_template_prefix() {
+    local worktree_path="$1"
+
+    printf '%s%s_\n' \
+        "$OCS_TEMPLATE_NAME_PREFIX" \
+        "$(ocs_template_stamp_directory "$worktree_path" | cksum | awk '{printf "%08x", $1}')"
+}
+
+ocs_template_name() {
+    printf '%s%s\n' "$(ocs_template_prefix "$1")" "$(ocs_migration_stamp_id "$1" "${2:-}")"
+}
+
+# Stamps live beside the shared git directory rather than inside the template itself so
+# that reading one costs no database connection: opening a template is exactly what
+# makes a concurrent copy of it fail.
+ocs_template_stamp_directory() {
+    local worktree_path="$1"
+    local git_common_dir
+
+    git_common_dir=$(git -C "$worktree_path" rev-parse --git-common-dir)
+    if [[ "$git_common_dir" != /* ]]; then
+        git_common_dir=$(cd "$worktree_path" && cd "$git_common_dir" && pwd)
+    fi
+    printf '%s/ocs-db-templates\n' "$git_common_dir"
+}
+
+ocs_template_stamp_path() {
+    printf '%s/%s.stamp\n' "$(ocs_template_stamp_directory "$1")" "$2"
+}
+
+ocs_list_template_databases() {
+    local prefix
+    prefix=$(ocs_template_prefix "$1")
+
+    # Newest first: object ids rise with creation order, which is the order we prune in.
+    ocs_psql postgres -tAc "
+        SELECT datname
+        FROM pg_database
+        WHERE left(datname, ${#prefix}) = '$prefix'
+        ORDER BY oid DESC
+    "
+}
+
+# The closest template whose migrations are all still present, unchanged, in this
+# worktree. Such a template can be copied and then migrated forward. One holding a
+# migration this branch does not have would leave schema behind that nothing can
+# unapply, so it is skipped.
+ocs_find_ancestor_template() {
+    local worktree_path="$1"
+    local stamp_lines_file="$2"
+    local best_template=""
+    local best_size=-1
+    local candidate_stamp
+    local missing_migrations
+    local size
+    local sorted_candidate
+    local sorted_current
+    local template
+
+    missing_migrations=$(mktemp)
+    sorted_candidate=$(mktemp)
+    sorted_current=$(mktemp)
+    LC_ALL=C sort "$stamp_lines_file" > "$sorted_current"
+
+    while IFS= read -r template; do
+        [[ -n "$template" ]] || continue
+        candidate_stamp=$(ocs_template_stamp_path "$worktree_path" "$template")
+        [[ -f "$candidate_stamp" ]] || continue
+
+        LC_ALL=C sort "$candidate_stamp" > "$sorted_candidate"
+        LC_ALL=C comm -23 "$sorted_candidate" "$sorted_current" > "$missing_migrations"
+        [[ -s "$missing_migrations" ]] && continue
+
+        size=$(wc -l < "$sorted_candidate")
+        if [[ "$size" -gt "$best_size" ]]; then
+            best_size=$size
+            best_template=$template
+        fi
+    done < <(ocs_list_template_databases "$worktree_path")
+
+    rm -f "$missing_migrations" "$sorted_candidate" "$sorted_current"
+    [[ -n "$best_template" ]] || return 1
+    printf '%s\n' "$best_template"
+}
+
+# Snapshot a freshly provisioned worktree database as the template for its migration
+# set. Failing to do so only costs the next worktree its head start, so it is a
+# warning rather than a setup failure.
+ocs_snapshot_template() {
+    local worktree_path="$1"
+    local template_name="$2"
+    local source_database="$3"
+    local stamp_lines_file="$4"
+    local stamp_path
+
+    ocs_templates_are_enabled || return 0
+
+    if ! ocs_drop_database "$template_name" \
+        || ! ocs_create_database "$template_name" "$source_database"; then
+        echo "[ocs] Could not snapshot $template_name; the next worktree will migrate from scratch." >&2
+        return 0
+    fi
+
+    # A template nothing can read the stamp of is only usable for an exact-name copy
+    # and gets pruned on the next run, so a failed stamp is worth saying out loud --
+    # but not worth failing a setup whose database is already finished.
+    stamp_path=$(ocs_template_stamp_path "$worktree_path" "$template_name")
+    if ! { mkdir -p "$(dirname "$stamp_path")" && cp "$stamp_lines_file" "$stamp_path"; }; then
+        echo "[ocs] Could not record the stamp for $template_name; it will be pruned rather than reused." >&2
+    fi
+}
+
+# Keep the newest few templates plus whichever one this setup relies on, and drop the
+# rest along with any template whose stamp has gone missing.
+ocs_prune_template_databases() {
+    local worktree_path="$1"
+    local retained_template="${2:-}"
+    local kept=0
+    local stamp_directory
+    local stamp_path
+    local template
+
+    ocs_templates_are_enabled || return 0
+    stamp_directory=$(ocs_template_stamp_directory "$worktree_path")
+
+    while IFS= read -r template; do
+        [[ -n "$template" ]] || continue
+        stamp_path="$stamp_directory/$template.stamp"
+        if [[ "$template" == "$retained_template" ]]; then
+            kept=$((kept + 1))
+            continue
+        fi
+        if [[ -f "$stamp_path" && "$kept" -lt "$OCS_TEMPLATE_RETENTION" ]]; then
+            kept=$((kept + 1))
+            continue
+        fi
+        echo "[ocs] Dropping the stale template database $template."
+        ocs_drop_database "$template"
+        rm -f "$stamp_path"
+    done < <(ocs_list_template_databases "$worktree_path")
 }
 
 ocs_set_env_value() {


### PR DESCRIPTION
### Product Description
No change — developer tooling only.

### Technical Description
Creating a worktree spent most of its wall clock replaying every migration and running `bootstrap_data`, which produces the same database every time. That result is now kept as a PostgreSQL template and copied, so a worktree on an already-built migration set is provisioned in a second or two.

Templates are content-addressed by a stamp listing every migration file and its checksum. That stamp is a *list*, not a single hash, so a branch that only adds migrations can find the closest older template (`comm -23` subset test), copy it, and migrate forward rather than paying the full cost. Only a migration set nothing has built yet builds by hand, and the next worktree copies that.

`migrate` still runs unconditionally. A template is named for *this* repository's migrations, so a `uv.lock` bump that ships a package migration (allauth, waffle, oauth2_provider…) leaves the name byte-identical; only an unconditional migrate keeps the copied schema honest. It costs a second or two against an already-current database.

Worth a closer look:

- **Concurrency.** Postgres refuses `CREATE DATABASE … TEMPLATE` while anything is connected to the source, and a template can be dropped or re-snapshotted by another worktree between the existence check and the copy. The copy retries three times and then falls back to building by hand — losing the head start, not the database. Everything about templates is best-effort for the same reason: a failed snapshot or stamp write warns and moves on.
- **Seeding.** `bootstrap_data` isn't idempotent, so copies must not re-run it. Seeding therefore keys off provisioning mode, which would strand a database whose setup died mid-seed (fingerprint never recorded → next run takes the `migrate` path → never seeded). Guarded by an explicit "does this database have any users" check; a failed query counts as seeded, since a spurious re-seed is the worse outcome.
- **Namespacing.** Template names carry a hash of the clone's git common dir. Stamps live next to that git dir, so a second clone sharing the local Postgres cluster would otherwise find no stamp for the first clone's templates and prune all of them.

Known gap left in: the stamp covers `apps/**/migrations/*.py` but not `bootstrap_data.py`, so editing the seed command doesn't invalidate templates and `copy_and_migrate` propagates the old seed forward. Including it would also change the dependency fingerprint, forcing a full `bootstrap.sh --force` on every seed edit — didn't seem worth it, but happy to be argued out of that.

### Demo
`wt add <branch>` on a migration set another worktree has already built.

Tests are in `scripts/test_worktree_environment.py` (35 passing) and drive `setup-worktree.sh` against a fake `psql` that logs its statements, covering each provisioning path: exact-template copy, ancestor + migrate forward, rejecting a template with unknown migrations, templates disabled, copy failure falling back to build, unseeded-existing-database, and pruning.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

`docs/getting-started/dev-workflow.md` updated in-tree; no user-facing changelog entry needed.

