### PR TITLE
fix: WhatsApp template broadcasts rejected by Meta for containing line breaks

### DIFF
--- a/apps/service_providers/messaging_service.py
+++ b/apps/service_providers/messaging_service.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import uuid
 from datetime import datetime, timedelta
 from io import BytesIO
@@ -34,6 +35,20 @@ from apps.service_providers.speech_service import SynthesizedAudio
 logger = logging.getLogger("ocs.messaging")
 
 MEDIA_DOWNLOAD_TIMEOUT = 30
+
+
+_TEMPLATE_PARAM_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _flatten_template_parameter(text: str) -> str:
+    """Collapse every run of whitespace in a template variable down to a single space.
+
+    Meta refuses a template parameter that contains a newline, a tab, or more than four
+    consecutive spaces, so an operator's multi-line message has to go out as one flowing
+    paragraph. Only the substituted variable is flattened -- the template body keeps the
+    line breaks it was approved with.
+    """
+    return _TEMPLATE_PARAM_WHITESPACE_RE.sub(" ", text).strip()
 
 
 def _recipient_kwarg(recipient: str) -> dict:
@@ -582,8 +597,15 @@ class MetaCloudAPIService(HttpMediaDownloadMixin, MessagingService):
 
     def _split_template_message(self, message: str) -> list[str]:
         """Split a message into chunks that fit within the template parameter limit,
-        splitting at word boundaries to avoid cutting words."""
-        return [chunk for chunk in smart_split(message, chars_per_string=self.TEMPLATE_MESSAGE_CHAR_LIMIT) if chunk]
+        splitting at word boundaries to avoid cutting words.
+
+        The message is flattened before it is measured, because that is the text Meta
+        actually receives; flattening only ever shrinks it.
+        """
+        flattened = _flatten_template_parameter(message)
+        if not flattened:
+            return []
+        return [chunk for chunk in smart_split(flattened, chars_per_string=self.TEMPLATE_MESSAGE_CHAR_LIMIT) if chunk]
 
     def send_template_message(self, message: str, from_: str, to: str, platform: ChannelPlatform, **kwargs):
         """Send a WhatsApp template message using the TEMPLATE_NAME template.

--- a/apps/service_providers/tests/test_messaging_providers.py
+++ b/apps/service_providers/tests/test_messaging_providers.py
@@ -868,3 +868,105 @@ class TestMetaCloudAPIServiceBSUIDRecipient:
         assert sent["recipient"] == self.BSUID
         assert sent["recipient_type"] == "individual"
         assert "to" not in sent
+
+
+class TestMetaCloudAPITemplateParameterText:
+    """Meta rejects template parameter values containing newlines, tabs, or more than four
+    consecutive spaces, so the bot message is flattened before it is substituted in."""
+
+    def _make_service(self):
+        return MetaCloudAPIService(access_token="test_token", business_id="123456")
+
+    def _mock_send_response(self):
+        return httpx.Response(
+            200,
+            json={"messages": [{"id": "wamid.test"}]},
+            request=httpx.Request("POST", "https://graph.facebook.com/v25.0/phone123/messages"),
+        )
+
+    def _sent_parameter_texts(self, mock_post) -> list[str]:
+        return [
+            call.kwargs["json"]["template"]["components"][0]["parameters"][0]["text"]
+            for call in mock_post.call_args_list
+        ]
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            pytest.param("Hello\r\n\r\nWorld", "Hello World", id="crlf-paragraph-break"),
+            pytest.param("Hello\nWorld", "Hello World", id="lf-newline"),
+            pytest.param("Hello\rWorld", "Hello World", id="bare-cr"),
+            pytest.param("Hello\tWorld", "Hello World", id="tab"),
+            pytest.param("Hello          World", "Hello World", id="long-space-run"),
+            pytest.param("Hello\r\n  \r\nWorld", "Hello World", id="blank-line-with-spaces"),
+            pytest.param("  Hello World  ", "Hello World", id="leading-and-trailing-whitespace"),
+            pytest.param("Hello World", "Hello World", id="already-clean-is-untouched"),
+        ],
+    )
+    @patch("apps.service_providers.messaging_service.httpx.post")
+    def test_parameter_text_is_flattened(self, mock_post, raw, expected):
+        mock_post.return_value = self._mock_send_response()
+        self._make_service().send_template_message(
+            message=raw, from_="phone123", to="+27826419977", platform=ChannelPlatform.WHATSAPP
+        )
+        assert self._sent_parameter_texts(mock_post) == [expected]
+
+    @patch("apps.service_providers.messaging_service.httpx.post")
+    def test_sentry_broadcast_message_sends_without_newlines(self, mock_post):
+        """The production broadcast that triggered OPEN-CHAT-STUDIO-2DS: a hand-written,
+        multi-paragraph message from a browser textarea, so every break arrives as CRLF."""
+        mock_post.return_value = self._mock_send_response()
+        message = (
+            "Niaje\r\n\r\nTuko na exciting news kutoka kwa MbogiTruu\r\n\r\n"
+            "DJ B - 0704 737 122 [https://bit.ly/DJBShujaaz]\r\n"
+            "Maria Kim - 0704 736 473 [https://bit.ly/MKShujaaz]"
+        )
+        self._make_service().send_template_message(
+            message=message, from_="phone123", to="254714942927", platform=ChannelPlatform.WHATSAPP
+        )
+        (sent,) = self._sent_parameter_texts(mock_post)
+        assert "\n" not in sent
+        assert "\r" not in sent
+        assert "\t" not in sent
+        assert "    " not in sent
+        assert sent.startswith("Niaje Tuko na exciting news")
+
+    @patch("apps.service_providers.messaging_service.httpx.post")
+    def test_flattening_happens_before_splitting(self, mock_post):
+        """Chunks are measured against the flattened text, so no chunk can exceed the limit
+        once the newlines it contained have collapsed."""
+        mock_post.return_value = self._mock_send_response()
+        service = self._make_service()
+        # 1200 words separated by CRLFs -- far over the limit, and every separator is a newline.
+        message = "\r\n".join(["word"] * 1200)
+        service.send_template_message(
+            message=message, from_="phone123", to="+27826419977", platform=ChannelPlatform.WHATSAPP
+        )
+        texts = self._sent_parameter_texts(mock_post)
+        assert len(texts) > 1
+        for text in texts:
+            assert "\n" not in text
+            assert "\r" not in text
+            assert len(text) <= MetaCloudAPIService.TEMPLATE_MESSAGE_CHAR_LIMIT
+
+    @patch("apps.service_providers.messaging_service.httpx.post")
+    def test_whitespace_only_message_sends_nothing(self, mock_post):
+        """A message that flattens to nothing has no parameter value Meta would accept."""
+        self._make_service().send_template_message(
+            message="  \r\n\t  ", from_="phone123", to="+27826419977", platform=ChannelPlatform.WHATSAPP
+        )
+        mock_post.assert_not_called()
+
+    @patch("apps.service_providers.messaging_service.httpx.post")
+    def test_plain_text_message_keeps_its_newlines(self, mock_post):
+        """Flattening is a template-parameter constraint only -- an in-window text send is
+        unaffected and keeps the operator's formatting."""
+        mock_post.return_value = self._mock_send_response()
+        self._make_service().send_text_message(
+            message="Hello\r\n\r\nWorld",
+            from_="phone123",
+            to="+27826419977",
+            platform=ChannelPlatform.WHATSAPP,
+            last_activity_at=timezone.now() - timedelta(hours=1),
+        )
+        assert mock_post.call_args.kwargs["json"]["text"]["body"] == "Hello\r\n\r\nWorld"

--- a/config/sentry.py
+++ b/config/sentry.py
@@ -25,6 +25,8 @@ SENTRY_SECRET_VAR_DENYLIST = [
     "auth_token",
     "secret_key",
     "secret_key_bytes",
+    "access_token",
+    "verify_token",
 ]
 
 # Credential headers the app authenticates with, in the form they appear on a Sentry event.

--- a/config/tests/test_sentry.py
+++ b/config/tests/test_sentry.py
@@ -59,6 +59,8 @@ def _scrubbed_headers(headers: dict) -> dict:
         pytest.param("auth_token", id="auth_token"),
         pytest.param("secret_key", id="secret_key"),
         pytest.param("secret_key_bytes", id="secret_key_bytes"),
+        pytest.param("access_token", id="access_token"),
+        pytest.param("verify_token", id="verify_token"),
         pytest.param("password", id="default-denylist-still-applies"),
     ],
 )

--- a/templates/chatbots/components/broadcast_dialog.html
+++ b/templates/chatbots/components/broadcast_dialog.html
@@ -20,6 +20,10 @@
             message. Make sure the messaging provider used by this channel has a
             <code>new_bot_message</code> template configured.
           {% endblocktranslate %}
+          {% blocktranslate trimmed %}
+            WhatsApp does not allow line breaks inside a template message, so your message is sent
+            to these participants as a single paragraph.
+          {% endblocktranslate %}
           <a class="link" target="_blank"
              href="https://docs.openchatstudio.com/how-to/whatsapp_meta_cloud_api/#create-the-required-template-in-meta-business-manager">
             {% translate "How to create the template" %}


### PR DESCRIPTION
### Product Description

A broadcast to a participant whose last message is more than 24 hours old falls back to a WhatsApp template send. Meta rejected every one of those sends with a 400, so the message never arrived.

The cause: Meta refuses a template parameter containing a newline, a tab, or a run of more than four spaces. Any multi-paragraph broadcast — i.e. most hand-written ones — failed.

Multi-line messages now reach these participants as a single paragraph, and the broadcast dialog says so before you send.

### Technical Description

Sentry: `OPEN-CHAT-STUDIO-2DS`.

- `_flatten_template_parameter` collapses each run of whitespace in the substituted variable to a single space. Only the parameter is flattened — the approved template body keeps the line breaks it was approved with.
- Flattening happens *before* the message is split into chunks, so each chunk is measured against the text Meta actually receives. Flattening only ever shrinks the text.
- A message that flattens to nothing sends no request at all.
- `access_token` and `verify_token` are added to the Sentry scrubbing denylist. The WhatsApp send failure attached the `MetaCloudAPIService` fields as stack-frame locals, so both tokens reached Sentry verbatim.

Out of scope: the denylist matches by variable name, so it cannot reach a token embedded in a string. The pydantic `repr` of the provider models still exposes them; that needs `Field(repr=False)`.

### Migrations

N/A — no schema changes.

### Demo

N/A — the only UI change is a line of explanatory copy in the broadcast dialog.

### Docs and Changelog

- [x] This PR requires docs/changelog update

Changelog: WhatsApp template messages — those sent to participants outside the 24-hour service window — now have their line breaks collapsed to single spaces. Meta rejects a template parameter containing a newline, so the alternative is the send failing outright.
