### PR TITLE
Release process for third-party self-hosters

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,3 +43,22 @@ Note: When this PR is merged and the checkbox above is checked, Claude will auto
 
 Add any notes here that will help Claude write the changelog and docs.
 -->
+
+### Operator Impact
+- [ ] Self-hosted operators must know about or act on this change
+
+<!--
+Check the box above if a self-hosted operator has to do something, or would be
+surprised on upgrade: migrations, new/renamed/removed settings or env vars, a
+change in deployment shape (process types, queues, backing-service versions),
+a deprecation or removal, or a security fix needing operator action.
+
+This is separate from the docs/changelog checkbox above, which covers the
+user-facing product changelog. If checked, add an entry under `[Unreleased]` in
+the repo-root `CHANGELOG.md` in this PR. See RELEASING.md.
+
+Leave unchecked for a change that is purely a feature, improvement or bug fix
+with none of the above — those reach operators through the user-facing
+changelog. A feature PR that also carries a migration or a settings change is
+still operator-impacting: check the box and log the migration.
+-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,109 @@
+# Operator Changelog
+
+Changes that a **self-hosted operator must know about or act on** when upgrading
+Open Chat Studio: migrations, configuration, deployment shape, deprecations and
+removals, and security fixes.
+
+This is **not** the product changelog. New features, improvements and bug fixes
+are described for end users at
+<https://docs.openchatstudio.com/changelog/>, and summarised in the
+[docs-repo release notes](https://github.com/dimagi/open-chat-studio-docs/releases).
+Each version section below links to the user-facing notes covering the same
+range, so an operator reads the product story there and the upgrade mechanics
+here.
+
+Versioning is [SemVer](https://semver.org/); see `RELEASING.md` for how this
+file is maintained and cut. Widget versions are a separate train — see
+[widget versioning](docs/developer_guides/widget_versioning.md).
+
+## [Unreleased]
+
+Operator-impacting entries land here as they merge to `main`, and move into a
+version section when a release is cut.
+
+### Upgrading
+<!-- Manual steps, in the order they must run relative to the deploy. Omit if
+     the upgrade is "pull the new tag and deploy". -->
+
+### Migrations
+<!-- One line per migration. Omit the section if there are none. -->
+
+### Configuration
+<!-- New, renamed, retyped or removed environment variables and settings.
+     State the default and whether it is required. -->
+
+### Deployment
+<!-- Changes to the shape of a deployment: process types, Celery queues,
+     backing-service versions, resource requirements, new external
+     dependencies. -->
+
+### Deprecated
+<!-- Signals intent to remove. Every entry names the earliest version in which
+     removal may land, and links its deprecation tracking issue. -->
+
+### Removed
+
+### Security
+<!-- Also list here anything requiring operator action, e.g. credential
+     rotation. -->
+
+---
+
+## [X.Y.Z] - YYYY-MM-DD
+<!-- Template. Delete any section with no entries; delete this comment block. -->
+
+User-facing changes in this release: link to the docs-repo release notes
+covering the same commit range.
+
+Bundled chat widget: `LATEST_VERSION` from `apps/channels/widget_versions.py`.
+
+### Upgrading
+- Exact commands and their order relative to the deploy. (#PR)
+
+### Migrations
+- `NNNN_migration_name`: reversible yes/no; locking yes/no (expected duration on
+  a representative table size); manual steps none/described. (#PR)
+
+### Configuration
+- `OCS_EXAMPLE_SETTING`: new, optional, defaults to `x`. (#PR)
+
+### Deployment
+- Deployment-shape change and what an operator must do about it. (#PR)
+
+### Deprecated
+- Feature X is deprecated; removal no earlier than vN.0.0 and no sooner than
+  `YYYY-MM-DD`. Use Y instead. (#issue)
+
+### Removed
+- Feature X, deprecated in vA.B.C on `YYYY-MM-DD`. (#PR)
+
+### Security
+- Fix description; avoid exploit detail if disclosure timing matters. (#PR)
+
+---
+
+<!-- Filled-out example for reference; delete once real releases exist.
+
+## [1.1.0] - 2026-10-01
+
+User-facing changes in this release:
+https://github.com/dimagi/open-chat-studio-docs/releases/tag/...
+
+Bundled chat widget: 0.11.0
+
+### Migrations
+- `0142_add_index_filechunkembedding`: reversible, non-locking (uses
+  `CONCURRENTLY`), no manual steps. On tables over 5M rows expect 10-15 min
+  build time; no maintenance window required. (#812)
+
+### Configuration
+- `OCS_EVAL_QUEUE_NAME`: new, optional, defaults to `evaluations`. Only
+  relevant if you run per-queue Celery workers. (#799)
+
+### Deployment
+- The `evaluations` queue can now be consumed by a dedicated worker. Existing
+  single-worker deployments need no change — a worker started without `-Q`
+  still consumes every queue. See the
+  [hosting overview](docs/hosting/index.md). (#799)
+
+-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,25 @@ version section when a release is cut.
 ### Configuration
 <!-- New, renamed, retyped or removed environment variables and settings.
      State the default and whether it is required. -->
+- `OCS_VERSION`: new, optional, defaults to `latest`. Read by
+  `docker-compose.prod.yml` to select which published image tag to run. Pin it
+  to the release you intend to run rather than tracking `latest`. (#4283)
 
 ### Deployment
 <!-- Changes to the shape of a deployment: process types, Celery queues,
      backing-service versions, resource requirements, new external
      dependencies. -->
+- Container images are now published to
+  `ghcr.io/dimagi/open-chat-studio` on each release tag, so an upgrade is a
+  pull rather than a local build. Images are `linux/amd64` only; arm64
+  operators still build from source. The first image is published with the
+  first release tag. (#4283)
+- The base image moved from Debian 11 (bullseye) to Debian 12 (bookworm),
+  because bullseye's LTS window has closed. This affects you only if you build
+  the image yourself: ffmpeg goes 4.x to 5.1 and the bundled `psql` client goes
+  13 to 15. Audio conversion was verified against ffmpeg 5.1 across the mp3,
+  opus and wav paths. No action required if you pull the published image. (#4283)
+- Container images no longer contain the `.git` directory. (#4283)
 
 ### Deprecated
 <!-- Signals intent to remove. Every entry names the earliest version in which

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,203 @@
+# OCS Release Process
+
+How to cut a tagged release of Open Chat Studio for third-party self-hosted
+operators.
+
+This is the internal procedure. The **operator-facing contract** — what a
+version number means, cadence, support window, how to upgrade, how to subscribe
+— lives in [docs/hosting/releases.md](docs/hosting/releases.md) and is published
+at <https://developers.openchatstudio.com/hosting/releases/>. Any change here
+that an operator can observe must be reflected there too.
+
+## Scope
+
+This governs the tagged, external-facing release train only. It does not change:
+
+- **Our own deploys.** `deploy.yml` continues to ship every green `main` commit
+  straight to prod (dev deploys are a manual `workflow_dispatch`) — see
+  [deployment process](docs/developer_guides/deployment.md). Tags are cut from
+  commits that have already been through that path; they do not gate it.
+- **The user-facing changelog.** Per-PR entries continue to flow to the docs
+  repo via the "This PR requires docs/changelog update" checkbox and
+  `docs-changelog-dispatch.yml`. See
+  [user docs and changelog process](docs/developer_guides/user_docs.md).
+- **The weekly docs-repo release notes.** The Monday workflow in the docs repo
+  still publishes the user-subscribed release feed, on its own cadence.
+- **The chat widget train.** The widget is versioned, published to npm and
+  deprecated independently, under `w_v*` tags. See
+  [widget versioning](docs/developer_guides/widget_versioning.md). An app
+  release records which widget `LATEST_VERSION` it bundles, but does not
+  version it.
+
+### How the pieces fit
+
+| Surface | Repo | Audience | Cadence |
+|---|---|---|---|
+| `docs.openchatstudio.com/changelog/` | docs | product users | per merged PR |
+| Docs-repo GitHub Releases | docs | users on the release feed | weekly (Mon) |
+| `CHANGELOG.md` + `vX.Y.Z` tags | this | self-host operators | monthly |
+| [Chat widget changelog](https://docs.openchatstudio.com/chat_widget/) + `w_v*` tags | docs / this | widget embedders | per widget release |
+
+An operator release note therefore has two halves: **what changed** (link to the
+docs-repo notes for the same commit range) and **what you must do about it**
+(this repo's `CHANGELOG.md`). Nothing is written twice.
+
+## Choosing the version
+
+The bump rules and their rationale are the operator contract — see
+[what a version number means](docs/hosting/releases.md#what-a-version-number-means).
+In short: PATCH for fixes, MINOR for backward-compatible change and additive
+migrations, MAJOR for anything requiring operator action.
+
+Two calls that need judgement at cut time:
+
+- **Removal of an unused feature is MINOR, not MAJOR.**
+  [Feature deprecation](docs/developer_guides/feature_deprecation.md) puts
+  features with no active usage on a fast path with no grace period, so treating
+  every removal as breaking would force a major bump for routine cleanup and
+  destroy the signal MAJOR carries. Ship it as MINOR with a `Removed` entry
+  naming the audit. A feature with active usage is the MAJOR case, and only
+  after its 60-day lifecycle.
+- **The bump follows the highest-impact change in the batch**, not the most
+  interesting one. One locking migration makes a release of bug fixes a MAJOR.
+
+`vX.Y.Z` does not collide with the widget's `w_vX.Y.Z` namespace. Do not use
+CalVer or build numbers — operators need to reason about compatibility, not
+dates.
+
+## Cadence
+
+- **Monthly**, on the first Thursday, cut a release from `main`.
+- **Out of cadence** for security fixes and critical regressions affecting
+  self-hosters. These are patch releases and ship as soon as the fix is
+  verified.
+
+## Cut criteria
+
+Do not tag the tip of `main`. Tag the most recent commit that has been running
+in **our** production for at least 24-48 hours with no rollback or hotfix.
+
+Find the candidates from the prod deployment record. `deploy.yml` creates the
+deployment record *before* the ECS rollout runs, so a record on its own is not
+evidence the deploy succeeded — a deployment needs a `success` status. Check for
+`success` anywhere in a deployment's status history, not just its latest status:
+statuses are returned newest-first, and every superseded deployment ends up
+`inactive,success,pending`, so reading only the newest status hides exactly the
+soaked commits you are looking for.
+
+    gh api "repos/dimagi/open-chat-studio/deployments?environment=aws-prod&per_page=10" \
+      --jq '.[] | "\(.id) \(.created_at) \(.sha)"' |
+    while read -r id created sha; do
+      states=$(gh api "repos/dimagi/open-chat-studio/deployments/$id/statuses" \
+        --jq '[.[].state] | join(",")')
+      case ",$states," in *,success,*) echo "$created ${sha:0:9}  [$states]" ;; esac
+    done
+
+`inactive` on an older deployment is normal — it means a later deploy superseded
+it, not that anything went wrong. A deployment with no `success` in its history
+failed or is still in flight; skip it.
+
+If a rollback or hotfix occurred in the soak window, move to the fixed commit and
+restart its soak clock.
+
+## Release steps
+
+1. Identify the candidate commit per "Cut criteria".
+2. Move `CHANGELOG.md` `[Unreleased]` entries into a new version section. Verify
+   them against the actual diff since the last tag — in particular, that every
+   migration in the range has a line, and every changed setting is listed:
+
+       git log --oneline <last-tag>..<sha>
+       git diff --stat <last-tag>..<sha> -- '*/migrations/*' 'config/settings*.py' .env.example
+
+3. Record the bundled widget version (`LATEST_VERSION` in
+   `apps/channels/widget_versions.py`).
+4. Link the docs-repo release notes covering the same commit range.
+5. Confirm the bump matches the highest-impact change in the batch (see
+   "Choosing the version").
+6. If anything in the range is breaking, confirm it completed the
+   [feature deprecation](docs/developer_guides/feature_deprecation.md)
+   lifecycle. If not, hold it and ship the deprecation notice instead.
+7. Tag and push: `git tag vX.Y.Z <sha> && git push origin vX.Y.Z`.
+8. Publish a GitHub Release in **this** repo with the changelog section as the
+   body. Title it `vX.Y.Z` so it is not confused with the docs-repo release
+   feed.
+9. Post to
+   [Discussions → Announcements](https://github.com/dimagi/open-chat-studio/discussions/categories/announcements)
+   and link it from the Release body — see
+   [Announcing a release](#announcing-a-release).
+
+## Writing migration notes
+
+For each Django migration in the release, state:
+
+- **Reversible?** Yes/No.
+- **Long-running or locking?** If yes, expected duration on a representative
+  table size, and whether a maintenance window is advised.
+- **Manual steps?** Exact commands and their order relative to the deploy.
+- **Data backfill?** Automatic post-deploy, or a manual management command.
+
+If there are none, say "No migrations in this release."
+
+Write these for someone with a database you cannot see. "Fast on our data" is
+not a note; a row count and a duration is.
+
+## Breaking changes
+
+Removals and breaking changes follow
+[feature deprecation](docs/developer_guides/feature_deprecation.md), which is
+the authority on audit, comms and timing — including the **60-day minimum**
+between announcement and removal for features with active usage. This process
+adds only the release-train mapping:
+
+- A breaking change appears as **Deprecated** in a release before it appears as
+  **Removed**, and its Deprecated entry names the earliest version in which
+  removal may land.
+- With a monthly cadence, the 60-day window spans at least two releases — one
+  release cycle is not sufficient notice.
+- Major releases carry an "Upgrading to vX.0.0" section summarising every
+  breaking change and the required action.
+
+## Announcing a release
+
+Announcements go to **GitHub Discussions** in this repo, in the
+[Announcements](https://github.com/dimagi/open-chat-studio/discussions/categories/announcements)
+category — the channel operators are told to watch in
+[releases.md](docs/hosting/releases.md#staying-informed).
+
+- **Every release** gets a post: the version, a one-line summary, and links to
+  the GitHub Release and the docs-repo notes for the same range. Keep it short —
+  the release body is the detail.
+- **Security releases and breaking changes** get their own post, titled so the
+  severity is legible in a notification email (e.g. `Security release v1.2.1 —
+  action required`). Lead with what an operator must do, not with what changed.
+- **Deprecations** are announced when the notice ships, not when the removal
+  does, naming the earliest version removal may land in. This is the same
+  announcement the
+  [feature deprecation](docs/developer_guides/feature_deprecation.md) comms
+  levers call for, aimed at self-hosters.
+
+Post from the release manager account via **New discussion** in the
+Announcements category, and link the discussion from the GitHub Release body so
+the two are navigable in both directions. When this gets automated (see
+[Known gaps](#known-gaps)), it is the GraphQL `createDiscussion` mutation
+against category `Announcements` — there is no supported REST create endpoint.
+
+## Known gaps
+
+Deliberately unresolved at the time this process was written:
+
+1. **No published container image.** Operators clone and build from the tag. A
+   workflow publishing `ghcr.io/dimagi/open-chat-studio:vX.Y.Z` on tag push
+   would make upgrades a pull instead of a build, and commits us to maintaining
+   a public image.
+2. **No version surfaced in the app.** `pyproject.toml` says `0.1.0` and is
+   unused. An operator cannot tell what they are running. Needs a single source
+   of truth, bumped at tag time and exposed (footer, health endpoint, or both).
+3. **Announcement posts are manual.** Step 9 is a hand-written Discussions post.
+   Worth automating off the tag push once the cadence has settled.
+
+## Ownership
+
+Release manager: **[define rotation]**. The release manager for a cycle owns
+steps 1-9.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -85,13 +85,23 @@ statuses are returned newest-first, and every superseded deployment ends up
 `inactive,success,pending`, so reading only the newest status hides exactly the
 soaked commits you are looking for.
 
-    gh api "repos/dimagi/open-chat-studio/deployments?environment=aws-prod&per_page=10" \
+    gh api "repos/dimagi/open-chat-studio/deployments?environment=aws-prod&per_page=100" \
       --jq '.[] | "\(.id) \(.created_at) \(.sha)"' |
     while read -r id created sha; do
       states=$(gh api "repos/dimagi/open-chat-studio/deployments/$id/statuses" \
         --jq '[.[].state] | join(",")')
-      case ",$states," in *,success,*) echo "$created ${sha:0:9}  [$states]" ;; esac
+      case ",$states," in
+        *,success,*)
+          age=$(( ( $(date -u +%s) - $(date -u -d "$created" +%s) ) / 3600 ))
+          [ "$age" -ge 24 ] && soaked="soaked" || soaked="too new"
+          printf '%s  %3sh  %-8s %s\n' "$created" "$age" "$soaked" "${sha:0:9}" ;;
+      esac
     done
+
+`per_page=100` is not arbitrary: prod takes roughly 5 deploys per 48 hours, so a
+single page covers about a month. A smaller page can push the commit you want
+off the end during a busy spell, and since failed and in-flight deploys are
+filtered out afterwards, the page holds fewer candidates than it looks.
 
 `inactive` on an older deployment is normal — it means a later deploy superseded
 it, not that anything went wrong. A deployment with no `success` in its history
@@ -102,30 +112,58 @@ restart its soak clock.
 
 ## Release steps
 
-1. Identify the candidate commit per "Cut criteria".
-2. Move `CHANGELOG.md` `[Unreleased]` entries into a new version section. Verify
+The tag must contain the changelog section describing its own release —
+[releases.md](docs/hosting/releases.md#what-changed-in-a-release) sends operators
+to `CHANGELOG.md` *at that tag*. Since the changelog is written after the
+candidate commit is chosen, the tag goes on a short release branch, not on the
+soaked commit itself.
+
+1. Identify the candidate commit per "Cut criteria". Call it `<sha>`.
+2. Branch from it, so `main` moving on doesn't drag the release forward:
+
+       git fetch origin main
+       git switch -c release/vX.Y.Z <sha>
+
+3. Move `CHANGELOG.md` `[Unreleased]` entries into a new version section. Verify
    them against the actual diff since the last tag — in particular, that every
    migration in the range has a line, and every changed setting is listed:
 
        git log --oneline <last-tag>..<sha>
        git diff --stat <last-tag>..<sha> -- '*/migrations/*' 'config/settings*.py' .env.example
 
-3. Record the bundled widget version (`LATEST_VERSION` in
-   `apps/channels/widget_versions.py`).
-4. Link the docs-repo release notes covering the same commit range.
+4. Record the bundled widget version (`LATEST_VERSION` in
+   `apps/channels/widget_versions.py`) and link the docs-repo release notes
+   covering the same commit range.
 5. Confirm the bump matches the highest-impact change in the batch (see
    "Choosing the version").
 6. If anything in the range is breaking, confirm it completed the
    [feature deprecation](docs/developer_guides/feature_deprecation.md)
    lifecycle. If not, hold it and ship the deprecation notice instead.
-7. Tag and push: `git tag vX.Y.Z <sha> && git push origin vX.Y.Z`.
-8. Publish a GitHub Release in **this** repo with the changelog section as the
-   body. Title it `vX.Y.Z` so it is not confused with the docs-repo release
-   feed.
-9. Post to
-   [Discussions → Announcements](https://github.com/dimagi/open-chat-studio/discussions/categories/announcements)
-   and link it from the Release body — see
-   [Announcing a release](#announcing-a-release).
+7. Commit, and check the commit is documentation only — this is what lets it
+   skip the soak. If anything outside `CHANGELOG.md` appears here, stop: code on
+   a release branch has not been through production and must not be tagged.
+
+       git commit -m "docs: changelog for vX.Y.Z" CHANGELOG.md
+       git diff --name-only <sha>..HEAD    # must print CHANGELOG.md and nothing else
+
+8. Tag the release branch, not `<sha>`:
+
+       git push origin release/vX.Y.Z
+       git tag vX.Y.Z && git push origin vX.Y.Z
+
+   The tagged tree is now soaked code plus a changelog-only delta.
+9. Open a PR merging the same changelog change back to `main`, so `[Unreleased]`
+   is emptied there too. Without this the next release re-ships these entries.
+10. Publish a GitHub Release in **this** repo with the changelog section as the
+    body. Title it `vX.Y.Z` so it is not confused with the docs-repo release
+    feed.
+11. Post to
+    [Discussions → Announcements](https://github.com/dimagi/open-chat-studio/discussions/categories/announcements)
+    and link it from the Release body — see
+    [Announcing a release](#announcing-a-release).
+
+A patch release for an older supported minor branches from that minor's tag
+instead of from `main`, and cherry-picks the fix; everything else is unchanged.
 
 ## Writing migration notes
 
@@ -193,7 +231,7 @@ against category `Announcements` — there is no supported REST create endpoint.
 2. **amd64 only.** `publish_image.yml` builds a single architecture. Operators
    on arm64 still build their own. Needs a native arm runner; QEMU would mean
    compiling C extensions and the node asset build under emulation.
-3. **Announcement posts are manual.** Step 9 is a hand-written Discussions post.
+3. **Announcement posts are manual.** The Announcements post is written by hand.
    Worth automating off the tag push once the cadence has settled.
 4. **Publishing a public image is an ongoing commitment.** Base-image CVEs are
    now ours to patch on a schedule rather than whenever we happen to rebuild,
@@ -202,4 +240,4 @@ against category `Announcements` — there is no supported REST create endpoint.
 ## Ownership
 
 Release manager: **[define rotation]**. The release manager for a cycle owns
-steps 1-9.
+every step above.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -185,17 +185,19 @@ against category `Announcements` — there is no supported REST create endpoint.
 
 ## Known gaps
 
-Deliberately unresolved at the time this process was written:
-
-1. **No published container image.** Operators clone and build from the tag. A
-   workflow publishing `ghcr.io/dimagi/open-chat-studio:vX.Y.Z` on tag push
-   would make upgrades a pull instead of a build, and commits us to maintaining
-   a public image.
-2. **No version surfaced in the app.** `pyproject.toml` says `0.1.0` and is
-   unused. An operator cannot tell what they are running. Needs a single source
-   of truth, bumped at tag time and exposed (footer, health endpoint, or both).
+1. **The image publish path has never run.** `publish_image.yml` builds and
+   pushes `ghcr.io/dimagi/open-chat-studio` on `v*` tag push, but no `v*` tag
+   exists yet, so no image has been published. The first release cut is also the
+   first live exercise of that workflow — expect to babysit it, and confirm the
+   package is public before pointing operators at it.
+2. **amd64 only.** `publish_image.yml` builds a single architecture. Operators
+   on arm64 still build their own. Needs a native arm runner; QEMU would mean
+   compiling C extensions and the node asset build under emulation.
 3. **Announcement posts are manual.** Step 9 is a hand-written Discussions post.
    Worth automating off the tag push once the cadence has settled.
+4. **Publishing a public image is an ongoing commitment.** Base-image CVEs are
+   now ours to patch on a schedule rather than whenever we happen to rebuild,
+   and operators will pin to `latest` whether we want them to or not.
 
 ## Ownership
 

--- a/docs/contributing/pull_requests.md
+++ b/docs/contributing/pull_requests.md
@@ -50,6 +50,7 @@ The OCS team automates most of steps 3–6 — see the [Development Workflow](..
 
 - **User-facing changes** follow these [guidelines](../developer_guides/user_docs.md)
 - **API changes**: If your changes affect the REST API schema, update the `api-schemas/v1.yml` file. See the [API Documentation guide](../developer_guides/api_documentation.md) for details.
+- **Operator-impacting changes** (migrations, new or changed settings, deployment shape, deprecations, removals, security fixes): check the "Self-hosted operators must know about or act on this change" box and add an entry under `[Unreleased]` in the repo-root `CHANGELOG.md`. See [two changelogs, two checkboxes](../developer_guides/user_docs.md#two-changelogs-two-checkboxes).
 
 ## Communication
 

--- a/docs/developer_guides/user_docs.md
+++ b/docs/developer_guides/user_docs.md
@@ -22,7 +22,8 @@ The PR template has two independent checkboxes, for two audiences:
 
 Most user-facing PRs need only the first. Check the second when an operator has
 to *do* something on upgrade — a migration, a new or changed setting, a change
-in deployment shape, a deprecation or removal. Some PRs need both, and a purely
+in deployment shape, a deprecation or removal, or a security fix that needs
+operator action such as rotating a credential. Some PRs need both, and a purely
 internal migration needs only the second. See [`RELEASING.md`](https://github.com/dimagi/open-chat-studio/blob/main/RELEASING.md)
 for how those entries are cut into a tagged release.
 

--- a/docs/developer_guides/user_docs.md
+++ b/docs/developer_guides/user_docs.md
@@ -11,6 +11,23 @@ LLM-based automation (with Claude) helps draft changelog entries **and** user do
 All user-facing changes should ideally be accompanied by documentation and changelog updates. However, use discretion: purely internal changes or very minor updates may not require docs. In general, treat documentation as part of the feature — this avoids shipping UI that points users to outdated or missing documentation.
 
 
+## Two changelogs, two checkboxes
+
+The PR template has two independent checkboxes, for two audiences:
+
+| Checkbox | Audience | Where the entry goes |
+|---|---|---|
+| "This PR requires docs/changelog update" | product users | docs repo, written for you by the automation below |
+| "Self-hosted operators must know about or act on this change" | self-host operators | `CHANGELOG.md` at the root of this repo, written by you in the PR |
+
+Most user-facing PRs need only the first. Check the second when an operator has
+to *do* something on upgrade — a migration, a new or changed setting, a change
+in deployment shape, a deprecation or removal. Some PRs need both, and a purely
+internal migration needs only the second. See [`RELEASING.md`](https://github.com/dimagi/open-chat-studio/blob/main/RELEASING.md)
+for how those entries are cut into a tagged release.
+
+The rest of this page covers the user-facing changelog.
+
 ## Changelog process
 
 The easiest way to trigger a docs/changelog update is to check the **"This PR requires docs/changelog update"** checkbox in the PR description.

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -22,8 +22,13 @@ compose file and `.env`:
 ```bash
 git clone https://github.com/dimagi/open-chat-studio.git
 cd open-chat-studio
+git fetch --tags
 git checkout v1.0.0
 ```
+
+On a clone you already have, `git fetch --tags` is what makes a newly published
+release visible — without it `git checkout` fails on a tag created after you
+cloned.
 
 Set `OCS_VERSION` in your `.env` to the release you want (see
 [Releases and Upgrades](./releases.md)), then pull:
@@ -172,12 +177,18 @@ docker compose -f docker-compose.prod.yml logs -f celery_worker
 # Run a management command
 docker compose -f docker-compose.prod.yml run --rm web python manage.py <command>
 
-# Apply migrations after an upgrade
-docker compose -f docker-compose.prod.yml run --rm migrate
-
-# Upgrade to a new release: bump OCS_VERSION in .env, then
+# Upgrade to a new release, in this order. Migrations must run on the new
+# image, so the pull comes first; running them before it applies the old
+# image's migrations and misses everything the new release added.
+git fetch --tags                      # make the new tag visible
+git checkout v1.1.0                   # compose file and .env for the release
+# bump OCS_VERSION in .env to 1.1.0
 docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
+
+# `up -d` runs the migrate service before web starts, so migrations are
+# already applied. Run it by hand only to re-check or after a manual rollback:
+docker compose -f docker-compose.prod.yml run --rm migrate
 ```
 
 ## Scaling

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -13,28 +13,47 @@ This guide covers deploying Open Chat Studio on a single server or small cluster
 - A domain name with DNS pointing to your server
 - A reverse proxy (nginx, Caddy, Traefik) handling TLS termination
 
-## Step 1: Build the Image
+## Step 1: Get the Image
 
-Clone the repository, check out the release you want to run, and build the
-production image.
+Releases are published to `ghcr.io/dimagi/open-chat-studio`, which
+`docker-compose.prod.yml` pulls by default. You only need the repository for the
+compose file and `.env`:
 
 ```bash
 git clone https://github.com/dimagi/open-chat-studio.git
 cd open-chat-studio
 git checkout v1.0.0
-
-docker build -t open-chat-studio:latest .
 ```
 
-The checked-out tag determines the version you run; `docker-compose.prod.yml`
-refers to the image as `open-chat-studio:latest` regardless. To upgrade, check
-out the new tag and rebuild.
+Set `OCS_VERSION` in your `.env` to the release you want (see
+[Releases and Upgrades](./releases.md)), then pull:
+
+```bash
+# .env
+OCS_VERSION=1.0.0
+```
+
+```bash
+docker compose -f docker-compose.prod.yml pull
+```
+
+Pin an exact release rather than tracking `latest`, so an upgrade is always a
+change you chose.
+
+### Building it yourself
+
+Published images are `linux/amd64`, so arm64 hosts build from source. `docker
+compose build` tags the local build under the same name the compose file
+expects, so nothing else changes:
+
+```bash
+docker compose -f docker-compose.prod.yml build
+```
 
 !!! warning "Don't build from `main`"
     `main` is Dimagi's continuous-deployment branch — it moves several times a
     day, has not been through the release soak, and carries no migration notes.
-    See [Releases and Upgrades](./releases.md) for the tagged release train and
-    the supported upgrade path.
+    Always build from a release tag.
 
 ## Step 2: Create the Environment File
 
@@ -156,9 +175,8 @@ docker compose -f docker-compose.prod.yml run --rm web python manage.py <command
 # Apply migrations after an upgrade
 docker compose -f docker-compose.prod.yml run --rm migrate
 
-# Upgrade to a new release
-git checkout v1.1.0
-docker build -t open-chat-studio:latest .
+# Upgrade to a new release: bump OCS_VERSION in .env, then
+docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
 ```
 

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -15,14 +15,26 @@ This guide covers deploying Open Chat Studio on a single server or small cluster
 
 ## Step 1: Build the Image
 
-Clone the repository and build the production image.
+Clone the repository, check out the release you want to run, and build the
+production image.
 
 ```bash
 git clone https://github.com/dimagi/open-chat-studio.git
 cd open-chat-studio
+git checkout v1.0.0
 
 docker build -t open-chat-studio:latest .
 ```
+
+The checked-out tag determines the version you run; `docker-compose.prod.yml`
+refers to the image as `open-chat-studio:latest` regardless. To upgrade, check
+out the new tag and rebuild.
+
+!!! warning "Don't build from `main`"
+    `main` is Dimagi's continuous-deployment branch — it moves several times a
+    day, has not been through the release soak, and carries no migration notes.
+    See [Releases and Upgrades](./releases.md) for the tagged release train and
+    the supported upgrade path.
 
 ## Step 2: Create the Environment File
 
@@ -144,7 +156,8 @@ docker compose -f docker-compose.prod.yml run --rm web python manage.py <command
 # Apply migrations after an upgrade
 docker compose -f docker-compose.prod.yml run --rm migrate
 
-# Rebuild after a code update
+# Upgrade to a new release
+git checkout v1.1.0
 docker build -t open-chat-studio:latest .
 docker compose -f docker-compose.prod.yml up -d
 ```

--- a/docs/hosting/index.md
+++ b/docs/hosting/index.md
@@ -110,3 +110,11 @@ python manage.py createsuperuser
 ```
 
 You will then need to create a Team in the Django admin before the app is usable.
+
+## Staying Current
+
+Deploy a tagged release rather than `main`, and watch
+[Announcements](https://github.com/dimagi/open-chat-studio/discussions/categories/announcements)
+so you hear about security releases. See
+[Releases and Upgrades](./releases.md) for what version numbers mean, how long
+each release is supported, and how to upgrade.

--- a/docs/hosting/releases.md
+++ b/docs/hosting/releases.md
@@ -1,0 +1,135 @@
+# Releases, Versions and Upgrades
+
+What Open Chat Studio's version numbers mean, how often releases happen, how
+long each one is supported, and how to hear about them. This is the contract
+for self-hosted operators.
+
+If you are cutting a release rather than consuming one, see
+[RELEASING.md](https://github.com/dimagi/open-chat-studio/blob/main/RELEASING.md)
+in the repository root.
+
+## What a version number means
+
+Releases are tagged `vMAJOR.MINOR.PATCH` and follow
+[SemVer](https://semver.org/). The first release is `v1.0.0`.
+
+| Bump | What it means for you |
+|------|----------------------|
+| PATCH | Bug and security fixes. Nothing to act on: no schema, config or behaviour change. |
+| MINOR | New features and backward-compatible changes. May include additive migrations, which run automatically with no manual steps. |
+| MAJOR | Requires action. Manual migration steps, removed or renamed configuration, breaking API or webhook changes, or the removal of a feature that was in use. |
+
+Two things worth knowing:
+
+- **A MINOR release can remove a feature** — but only one that a usage audit
+  found nobody was using. Anything with real usage goes through the full
+  [deprecation lifecycle](#deprecations) and its removal is a MAJOR release.
+- **The chat widget is versioned separately** under `w_vX.Y.Z` tags, with its
+  own [changelog](https://docs.openchatstudio.com/chat_widget/) and deprecation
+  schedule. Each app release records which widget version it bundles, but
+  upgrading the app does not change the widget your sites embed — that is pinned
+  in your embed snippet.
+
+## Cadence
+
+- A release is cut **monthly**, on the first Thursday.
+- **Security fixes and critical regressions** ship out of cadence, as patch
+  releases, as soon as they are verified.
+
+Releases are never cut from the tip of `main`. Every tag points at a commit that
+has already run in Dimagi's own production for at least 24-48 hours without a
+rollback.
+
+## What changed in a release
+
+Each release has two sets of notes, for two different questions:
+
+| Question | Where |
+|---|---|
+| What's new, improved or fixed? | [Product changelog](https://docs.openchatstudio.com/changelog/) |
+| What do I have to *do* about it? | [`CHANGELOG.md`](https://github.com/dimagi/open-chat-studio/blob/main/CHANGELOG.md) in the repository |
+
+`CHANGELOG.md` is the operator-facing one: migrations, configuration changes,
+changes to the shape of a deployment, deprecations, removals, and security
+fixes. Read that one before upgrading. Each version section links the product
+notes covering the same range, so start there and follow the link for the
+feature story.
+
+The [GitHub Release](https://github.com/dimagi/open-chat-studio/releases) for a
+tag carries the same operator notes as its body.
+
+## Getting a release
+
+There is currently no published container image, so a release is consumed as a
+git tag and built locally. Following
+[Docker Compose deployment](docker.md), check out the tag before building:
+
+```bash
+git clone https://github.com/dimagi/open-chat-studio.git
+cd open-chat-studio
+git checkout v1.0.0
+
+docker build -t open-chat-studio:latest .
+```
+
+The checked-out tag is what determines the version you run. Record which tag a
+deployment was built from — without a published image or an in-app version
+string, that note is the only way to tell later.
+
+Do not deploy from `main`. It is Dimagi's continuous-deployment branch: it moves
+several times a day, has not been through the release soak, and carries no
+migration notes.
+
+## Upgrading
+
+1. Read the `CHANGELOG.md` sections for **every** version between yours and the
+   target — not just the target's.
+2. Check the **Migrations** notes for anything long-running or locking, and
+   whether a maintenance window is advised.
+3. Check the **Configuration** notes and update your environment before
+   deploying.
+4. For a MAJOR release, work through its "Upgrading to vX.0.0" section, which
+   lists every breaking change and the action each requires.
+5. Back up your database. Some migrations are not reversible, and the notes say
+   which.
+6. Check out the tag, build, deploy, and run `python manage.py migrate`.
+
+**Upgrade one minor at a time.** Upgrading from the immediately preceding minor
+release is what gets tested. Skipping versions is unsupported — if you are
+several minors behind, upgrade through each intermediate minor rather than
+jumping straight to the newest.
+
+## Support window
+
+The current minor release (N) and the one before it (N-1) receive patch and
+security fixes. Because a monthly release may be a patch rather than a minor,
+that is *at least* two months of cover.
+
+Older minors do not receive fixes, including security fixes, and we do not
+backport further back. If you are behind, upgrading is the fix.
+
+## Deprecations
+
+A `Deprecated` entry in `CHANGELOG.md` is a warning with a deadline. It names
+the earliest version in which the feature may be removed, and links a tracking
+issue where you can object or ask for a migration path.
+
+For anything with active usage, removal is at least **60 days** after the
+deprecation is announced, which spans at least two releases. Removal itself
+appears as a `Removed` entry in a later release. If a deprecation affects you,
+the tracking issue is the place to say so — that window exists to be used.
+
+## Staying informed
+
+Release announcements go to **GitHub Discussions** in the
+[Announcements](https://github.com/dimagi/open-chat-studio/discussions/categories/announcements)
+category. Watching that category is the supported way to hear about a release.
+
+To subscribe: open the
+[Announcements category](https://github.com/dimagi/open-chat-studio/discussions/categories/announcements)
+and use **Watch** (or watch the repository and enable Discussions
+notifications). Every release gets a post; security releases and breaking
+changes get their own, titled so the urgency is visible in a notification email.
+
+Running a self-hosted deployment without watching Announcements means you will
+not hear about security releases.

--- a/docs/hosting/releases.md
+++ b/docs/hosting/releases.md
@@ -15,7 +15,7 @@ Releases are tagged `vMAJOR.MINOR.PATCH` and follow
 
 | Bump | What it means for you |
 |------|----------------------|
-| PATCH | Bug and security fixes. Nothing to act on: no schema, config or behaviour change. |
+| PATCH | Bug and security fixes. *Usually* nothing to act on — no schema, config or behaviour change. Always read the release's **Security** section: a security fix ships as a PATCH and can still require action, such as rotating a credential. |
 | MINOR | New features and backward-compatible changes. May include additive migrations, which run automatically with no manual steps. |
 | MAJOR | Requires action. Manual migration steps, removed or renamed configuration, breaking API or webhook changes, or the removal of a feature that was in use. |
 

--- a/docs/hosting/releases.md
+++ b/docs/hosting/releases.md
@@ -60,25 +60,34 @@ tag carries the same operator notes as its body.
 
 ## Getting a release
 
-There is currently no published container image, so a release is consumed as a
-git tag and built locally. Following
-[Docker Compose deployment](docker.md), check out the tag before building:
+Each release is published as a container image to
+[`ghcr.io/dimagi/open-chat-studio`](https://github.com/dimagi/open-chat-studio/pkgs/container/open-chat-studio),
+tagged `1.2.3`, `1.2`, and `latest`. Set `OCS_VERSION` to the release you want
+and pull it:
 
 ```bash
-git clone https://github.com/dimagi/open-chat-studio.git
-cd open-chat-studio
-git checkout v1.0.0
-
-docker build -t open-chat-studio:latest .
+# .env
+OCS_VERSION=1.2.3
 ```
 
-The checked-out tag is what determines the version you run. Record which tag a
-deployment was built from — without a published image or an in-app version
-string, that note is the only way to tell later.
+```bash
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
+```
 
-Do not deploy from `main`. It is Dimagi's continuous-deployment branch: it moves
-several times a day, has not been through the release soak, and carries no
-migration notes.
+**Pin `OCS_VERSION` to an exact release** rather than tracking `latest`. It
+makes an upgrade a change you chose, keeps the previous image on disk to roll
+back to, and means `docker compose up` on a rebuilt host doesn't silently jump
+versions.
+
+Images are `linux/amd64`. On arm64, build from source instead.
+
+### Building from source
+
+Still supported, and required on arm64. Check out the tag first — see
+[Docker Compose deployment](docker.md). Do not build from `main`: it is Dimagi's
+continuous-deployment branch, moves several times a day, has not been through
+the release soak, and carries no migration notes.
 
 ## Upgrading
 
@@ -92,7 +101,8 @@ migration notes.
    lists every breaking change and the action each requires.
 5. Back up your database. Some migrations are not reversible, and the notes say
    which.
-6. Check out the tag, build, deploy, and run `python manage.py migrate`.
+6. Bump `OCS_VERSION`, then `docker compose -f docker-compose.prod.yml pull`
+   and `up -d`. The `migrate` service runs migrations before `web` starts.
 
 **Upgrade one minor at a time.** Upgrading from the immediately preceding minor
 release is what gets tested. Skipping versions is unsupported — if you are

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,6 +164,7 @@ nav:
       - Help Agent Evals: developer_guides/testing/help_agent_evals.md
   - Self-Hosting:
     - Overview: hosting/index.md
+    - Releases and Upgrades: hosting/releases.md
     - Configuration: hosting/configuration.md
     - Rate Limiting: hosting/rate_limiting.md
     - Docker Compose: hosting/docker.md


### PR DESCRIPTION
### Product Description
No change — process and docs only.

### Technical Description
There's no way for a third-party operator to consume OCS today. This adds a tagged monthly SemVer train on top of the existing continuous deploy, without disturbing it.

The load-bearing decisions, none of which are visible in the diff:

- **The operator changelog carries only operator-relevant content** — migrations, config, deployment shape, deprecations, removals, security. Feature narrative stays in the docs-repo changelog and is linked per version section. The alternative was a full parallel Keep-a-Changelog here, which would mean two entries per PR in two repos for two audiences. That's the decision most worth arguing with, since it shapes the PR-template checkbox and the per-cut work.
- **Monthly, not fortnightly, with N/N-1 support.** A 2-week cadence with N/N-1 gives operators ~4 weeks of cover and forces ~6 upgrade hops per quarter under the sequential-upgrade rule.
- **Starts at v1.0.0.** Under SemVer, 0.x lets MINOR break, which would defeat the point for operators.
- **Removing an unused feature is MINOR, not MAJOR.** `feature_deprecation.md` fast-paths features with zero measured usage; treating every removal as breaking would burn a major version on routine cleanup. Features with real usage keep the 60-day lifecycle and a MAJOR bump.

`RELEASING.md` and `docs/hosting/releases.md` are deliberately split by audience: the cut procedure stays at the repo root, and the contract operators rely on (version meanings, support window, upgrade path, how to subscribe) is on the docs site next to the hosting guides. They cross-reference, so operator-observable changes have to land in both.

Two existing docs were contradicting the new policy and are corrected here: the draft's "one release cycle" deprecation notice (`feature_deprecation.md` mandates 60 days, per ADR-0034), and the Docker guide's default-branch clone.

### Superseded since this PR was opened
It originally proposed **tag-only, no published image**, with image publishing recorded as a known gap. #4283 has since merged and closed that gap, so the last commit rewrites the artifact story: operators pull a pinned `OCS_VERSION` from `ghcr.io/dimagi/open-chat-studio`, and building from source is documented as the arm64 path rather than the default. `CHANGELOG.md` now carries #4283's operator entries, since #4283 merged before this file existed and couldn't log itself.

The known-gaps list is rewritten accordingly. Two of the four are new and are the ones worth reading:

- **The publish path has never run.** No `v*` tag exists and `ghcr.io/dimagi/open-chat-studio` currently 404s. The first release cut is also the first live exercise of that workflow, and the package needs confirming public before operators are pointed at it.
- **Publishing a public image is an ongoing commitment**, not a one-off workflow — base-image CVEs are now ours to patch on a schedule.

### Merge order
Merge this **before** #4287. #4287 adds `manage.py ocs_version`, which wants documenting in `releases.md` and `docker.md` and an entry in `CHANGELOG.md` — none of which exist until this lands. I deliberately left those references out here rather than have the docs name a command that doesn't exist yet; they belong to #4287 once it rebases onto this.

### Still open
The release-manager rotation is a `[define rotation]` placeholder.

### Verification
`uv run --no-project zensical build --clean` is clean for these files — the new page is in nav and every cross-document anchor resolves. The one remaining warning is pre-existing in `architecture/index.md:25`.

The soak-clock command in the cut criteria was run against the live repo. Worth noting for anyone reviewing that section: the obvious form of it is wrong. Deployment statuses come back newest-first and every superseded deployment ends `inactive,success,pending`, so filtering on the *latest* status returns only the newest deploy — precisely the commit the soak rule forbids tagging. It checks for `success` anywhere in the history instead.

The new checkbox was checked against `docs-changelog-dispatch.yml`'s regex; it can't false-trigger the docs automation.

### Migrations
None.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!-- Unchecked: no user-facing product change, and these paths don't trigger the dispatch workflow. -->

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change

<!--
Unchecked for this PR's own changes: it adds process and docs, not software
behaviour. The CHANGELOG entries it carries describe #4283's changes, which
were operator-impacting and merged before this file existed.
-->
