### PR TITLE
Publish versioned container images to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.git
+.gitignore
 media
 static/css
 static/js

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -1,0 +1,66 @@
+# Publishes a versioned container image for third-party self-hosted operators.
+# Triggered by the release tags described in RELEASING.md. Dimagi's own deploys
+# are unaffected: they build and push to ECR from deploy.yml.
+
+name: Publish Container Image
+
+on:
+  push:
+    tags:
+      # Release tags only. The chat widget's `w_v*` tags do not match.
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and publish image
+    runs-on: ubuntu-latest
+
+    steps:
+      # Audit only: records egress without blocking. Flip to `block` plus an
+      # `allowed-endpoints` list once the recorded traffic looks stable.
+      - name: Harden the runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          # v1.2.3 -> `1.2.3` and `1.2`. `latest` follows automatically, and
+          # metadata-action withholds it from pre-releases (v1.2.3-rc1).
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Deliberately NOT using deploy.yml's zstd-compressed output: zstd
+          # layers need Docker 23+/containerd to pull. Fine for our own ECS,
+          # but this image goes to operators on unknown Docker versions, so
+          # it stays on the default gzip.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bullseye AS build-python
+FROM python:3.13-slim-bookworm AS build-python
 RUN apt-get update \
   # dependencies for building Python packages
   && apt-get install -y build-essential libpq-dev
@@ -50,7 +50,7 @@ COPY assets /code/assets/
 
 RUN corepack pnpm run build
 
-FROM python:3.13-slim-bullseye
+FROM python:3.13-slim-bookworm
 ENV PYTHONUNBUFFERED=1
 ENV DEBUG=0
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bullseye
+FROM python:3.13-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     UV_LINK_MODE=copy \

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,10 +8,15 @@
 # simpler single-server setups.
 
 x-app: &app
+  # Published images: `docker compose pull` fetches the version in OCS_VERSION
+  # (see https://github.com/dimagi/open-chat-studio/pkgs/container/open-chat-studio).
+  # Building from source instead: `docker compose build` tags the local build
+  # under this same name, so both paths work. Pin OCS_VERSION in .env rather
+  # than tracking `latest`, so an upgrade is a deliberate change.
   build:
     context: .
     dockerfile: Dockerfile
-  image: open-chat-studio:latest
+  image: ghcr.io/dimagi/open-chat-studio:${OCS_VERSION:-latest}
   restart: unless-stopped
   env_file:
     # .env is read first so .env.prod values (if present) win on conflicts.


### PR DESCRIPTION
Closes #4282 (partially — see "Left out" below).

### Product Description
No change for product users. Self-hosted operators gain a versioned image to pull instead of building their own.

### Technical Description
Three separable commits, deliberately ordered so the base-image bump can be reviewed and merged on its own if you'd rather not take the rest yet.

**Base image: bullseye → bookworm.** This is the one that needed care. `python:3.13-slim-bullseye` is Debian 11.11 and bullseye's LTS window has closed; publishing a public image on it means shipping unpatched OS CVEs to third parties under Dimagi's name. bookworm is a genuine drop-in — I checked all six installed packages resolve unchanged before touching anything. trixie is *not*: `libasound2` becomes `libasound2t64` and `libmagic1` isn't available at all, so bookworm is the right target today.

**GHCR publish on `v*` tags.** Mirrors `publish_widget.yml`'s tag-triggered shape and reuses the `docker/build-push-action@v7` + GHA-cache config already proven in `deploy.yml:140`. Auth is `GITHUB_TOKEN` + `packages: write` — no new secrets. `v*` does not match the widget's `w_v*` tags.

**Compose** now reads `ghcr.io/dimagi/open-chat-studio:${OCS_VERSION:-latest}`, keeping `build:` so pull-and-run and build-from-source both work.

Two deliberate departures from existing config, both worth a look:

- **No zstd compression.** `deploy.yml` uses `compression=zstd`, which is right for our own ECS but needs Docker 23+/containerd to pull. This image goes to operators on unknown Docker versions, so it stays on default gzip.
- **amd64 only.** arm64 under QEMU would mean compiling Python C extensions *and* a full node asset build under emulation. Wants a native arm runner; worth its own issue rather than blocking this.

ECR and Dimagi's deploy path are untouched — this is purely additive.

### Verification
Built the bookworm image locally (`docker build`, exit 0) and exercised it rather than trusting the build:

- `manage.py check --settings=config.settings_production` — no issues
- Base is `12.15`; `.git` confirmed absent from `/code`; `libasound`/`libmagic` both load; static files collected
- **ffmpeg went 4.x → 5.1**, which is the real behavioural risk since audio goes through pydub. Ran the actual `apps.channels.audio.convert_audio` path inside the image for ogg→mp3, ogg→opus and ogg→wav (the Telegram and WhatsApp targets at `telegram_channel.py:65` and `messaging_service.py:193`). All produce correct-duration mono output.
- `actionlint` clean on the new workflow

The `RequestsDependencyWarning` and transformers/PyTorch notices in container output also reproduce in the local venv — pre-existing and unrelated to the base image.

The publish workflow itself can't be verified without pushing a `v*` tag, which would publish a real public image. Worth reviewing that file closely rather than trusting me on it.

### Left out
The issue's last two checklist items target files that only exist on the unmerged #4280: `docs/hosting/releases.md` and `RELEASING.md`. `docs/hosting/docker.md` exists on `main`, but #4280 already rewrites the exact section that would need editing, so touching it here guarantees a conflict. Once #4280 merges, the pull path and `OCS_VERSION` want documenting in those two files — either as a follow-up or folded into #4280 while it's still a draft.

Also still open from #4282: passing the version through as a build arg, which belongs to #4281.

### Migrations
None.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!-- Operator-facing docs are blocked on #4280; see "Left out". -->

### Operator Impact
- [x] Self-hosted operators must know about or act on this change

<!--
Two things operators act on: a published image to pull instead of building, and
a base-OS change (Debian 11 -> 12, ffmpeg 4.x -> 5.1) in any image they build
themselves. CHANGELOG.md doesn't exist on main yet (#4280), so no entry here —
this needs logging under [Unreleased] once that lands.
-->
