### PR TITLE
Run psql and redis-cli from the dev containers in worktree setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -209,3 +209,12 @@ APP_IP=
 
 # Perplexity
 # PERPLEXITY_API_KEY=
+
+## Worktree development scripts (scripts/setup-worktree.sh, scripts/teardown-worktree.sh)
+## Containers to run the `psql` and `redis-cli` clients in, read straight out of this file
+## rather than through Django settings; an environment variable of the same name wins over
+## the value here. Left unset, the container publishing host port 5432 or 6379 is used,
+## and a client installed on the host is the fallback. Set one when discovery finds the
+## wrong container or the port mapping is invisible to `docker ps`.
+# OCS_POSTGRES_CONTAINER=
+# OCS_REDIS_CONTAINER=

--- a/docs/getting-started/dev-workflow.md
+++ b/docs/getting-started/dev-workflow.md
@@ -65,6 +65,12 @@ automatically on create:
   repository's migrations and says nothing about those shipped by packages in `uv.lock`. Set
   `OCS_DISABLE_DATABASE_TEMPLATES=true` to always build from scratch, and
   `OCS_TEMPLATE_RETENTION` to keep more or fewer than three templates around.
+- Runs `psql` and `redis-cli` inside the containers `docker-compose-dev.yml` defines, located by
+  the host port each publishes, so neither client has to be installed locally. If nothing publishes
+  the port — a Redis on the host, a service container in CI — a host client is used instead, and if
+  neither is available setup says which client is missing rather than failing with
+  `command not found`. `OCS_POSTGRES_CONTAINER` and `OCS_REDIS_CONTAINER` in `.env` pin a container
+  when discovery finds the wrong one.
 - Builds the frontend assets.
 
 On `wt remove` the branch database is dropped, its Redis DB is flushed, and its allocation is

--- a/scripts/teardown-worktree.sh
+++ b/scripts/teardown-worktree.sh
@@ -26,7 +26,7 @@ resource_name=$(ocs_worktree_resource_name "$CURRENT_PATH")
 ocs_drop_database "$resource_name"
 
 if redis_database=$(ocs_lookup_redis_database "$resource_name"); then
-    redis-cli -n "$redis_database" FLUSHDB
+    ocs_redis_cli -n "$redis_database" FLUSHDB
     ocs_release_redis_database "$resource_name" "$redis_database"
 else
     lookup_status=$?

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -574,6 +574,74 @@ def test_psql_recovers_from_a_stale_container_override(
     assert "psql:-h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -c SELECT 1" in command_output
 
 
+@pytest.mark.parametrize(
+    ("env_line", "expected_container"),
+    [
+        pytest.param("OCS_POSTGRES_CONTAINER=ocs_env_postgres", "ocs_env_postgres", id="bare"),
+        pytest.param("OCS_POSTGRES_CONTAINER='ocs_env_postgres'", "ocs_env_postgres", id="quoted"),
+    ],
+)
+def test_psql_reads_its_container_from_the_worktree_env_file(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+    env_line: str,
+    expected_container: str,
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    # Nothing sources `.env` before these scripts run, so a knob set there only works if
+    # they read the file themselves — the way OCS_WORKTREE_ID always has.
+    with (worktree / ".env").open("a") as env_file:
+        env_file.write(f"{env_line}\n")
+
+    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
+
+    assert f"docker-exec:{expected_container}" in command_log.read_text()
+
+
+def test_an_environment_variable_beats_the_worktree_env_file(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    with (worktree / ".env").open("a") as env_file:
+        env_file.write("OCS_POSTGRES_CONTAINER=ocs_env_postgres\n")
+    env["OCS_POSTGRES_CONTAINER"] = "ocs_exported_postgres"
+
+    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
+
+    command_output = command_log.read_text()
+    assert "docker-exec:ocs_exported_postgres" in command_output
+    assert "ocs_env_postgres" not in command_output
+
+
+def test_a_container_override_that_is_not_a_container_name_is_ignored(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    # The value is interpolated into `docker exec`, and `.env` is a file anything can
+    # write, so a name-shaped check is what keeps the rest of a line out of the command.
+    env["OCS_POSTGRES_CONTAINER"] = "nope; rm -rf /"
+
+    result = _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
+
+    assert "is not a container name" in result.stderr
+    assert "docker-exec:ocs_test_postgres" in command_log.read_text()
+
+
+def test_psql_tries_each_container_source_once_when_none_can_run_a_client(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    # Both an override and a discoverable container, neither able to start a client. The
+    # rejection list is what has to end this: an override that stayed eligible after
+    # being rejected would be handed back on the next resolve, forever.
+    env["OCS_POSTGRES_CONTAINER"] = "ocs_stale_postgres"
+    env["OCS_TEST_DOCKER_EXEC_FAILURE"] = "127"
+
+    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
+
+    attempts = [line for line in command_log.read_text().splitlines() if line.startswith("docker-exec:")]
+    assert attempts == ["docker-exec:ocs_stale_postgres", "docker-exec:ocs_test_postgres"]
+
+
 def test_psql_does_not_retry_a_client_that_ran_and_failed(
     worktree_fixture: tuple[Path, Path, dict[str, str], Path],
 ) -> None:

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -31,6 +31,8 @@ printf "bootstrap:%s\n" "$*" >> "$OCS_TEST_COMMAND_LOG"
 FAKE_PSQL_SCRIPT = r"""#!/usr/bin/env bash
 set -euo pipefail
 printf "psql:%s\n" "$*" >> "$OCS_TEST_COMMAND_LOG"
+# Whether it runs in the container or on the host, the client needs its credential.
+: "${PGPASSWORD:?psql was invoked without PGPASSWORD}"
 if [[ "${OCS_TEST_FAIL_PSQL:-false}" == "true" ]]; then exit 1; fi
 
 registry="$OCS_TEST_DATABASE_REGISTRY"
@@ -80,18 +82,32 @@ printf "uv:%s\n" "$*" >> "$OCS_TEST_COMMAND_LOG"
 
 FAKE_DOCKER_SCRIPT = r"""#!/usr/bin/env bash
 set -euo pipefail
-# `docker ps` names the stand-in Redis container, unless the test asked for the
-# no-container case; `docker exec <container> redis-cli ...` hands the rest of the
-# arguments to the redis-cli fake on PATH.
+# `docker ps` lists the stand-in service containers with the port mappings the helpers
+# match on, minus whichever one a test blanked out to exercise the host fallback;
+# `docker exec <container> <client> ...` hands the rest of the arguments to the client
+# fake on PATH.
 if [[ "${1:-}" == "ps" ]]; then
-    container="${OCS_TEST_REDIS_CONTAINER-ocs_test_redis}"
-    printf 'unrelated_container 0.0.0.0:5432->5432/tcp\n'
-    [[ -z "$container" ]] || printf '%s 0.0.0.0:6379->6379/tcp\n' "$container"
+    redis_container="${OCS_TEST_REDIS_CONTAINER-ocs_test_redis}"
+    postgres_container="${OCS_TEST_POSTGRES_CONTAINER-ocs_test_postgres}"
+    [[ -z "$postgres_container" ]] \
+        || printf '%s 0.0.0.0:5432->5432/tcp\n' "$postgres_container"
+    [[ -z "$redis_container" ]] \
+        || printf '%s 0.0.0.0:6379->6379/tcp\n' "$redis_container"
     exit 0
 fi
 
 if [[ "${1:-}" == "exec" ]]; then
     shift
+    while [[ "${1:-}" == -* ]]; do
+        # The environment a real `docker exec -e` would hand the client, kept so the
+        # fakes see what the real commands would.
+        if [[ "$1" == "-e" ]]; then
+            export "${2?docker exec -e needs a value}"
+            shift 2
+            continue
+        fi
+        shift
+    done
     printf "docker-exec:%s\n" "$1" >> "$OCS_TEST_COMMAND_LOG"
     shift
     exec "$@"
@@ -468,19 +484,53 @@ def test_redis_registry_falls_back_to_a_host_client_without_a_container(
     assert "redis-registry:allocate:feature_6:" in command_output
 
 
-def test_redis_client_reports_when_no_client_is_reachable(
-    tmp_path: Path,
+def test_psql_runs_inside_the_postgres_container(
     worktree_fixture: tuple[Path, Path, dict[str, str], Path],
 ) -> None:
+    _, worktree, env, command_log = worktree_fixture
+
+    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
+
+    command_output = command_log.read_text()
+    assert "docker-exec:ocs_test_postgres" in command_output
+    assert "psql:-h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -c SELECT 1" in command_output
+
+
+def test_psql_falls_back_to_a_host_client_without_a_container(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    env["OCS_TEST_POSTGRES_CONTAINER"] = ""
+
+    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
+
+    command_output = command_log.read_text()
+    assert "docker-exec:" not in command_output
+    assert "psql:-h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -c SELECT 1" in command_output
+
+
+@pytest.mark.parametrize(
+    ("helper", "arguments"),
+    [
+        pytest.param("ocs_redis_cli", ("PING",), id="redis"),
+        pytest.param("ocs_psql", ("postgres", "-c", "SELECT 1"), id="postgres"),
+    ],
+)
+def test_service_clients_report_when_no_client_is_reachable(
+    tmp_path: Path,
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+    helper: str,
+    arguments: tuple[str, ...],
+) -> None:
     _, worktree, env, _ = worktree_fixture
-    # A PATH holding neither a container nor a redis-cli -- only the shell that runs the
+    # A PATH holding neither a container nor a client -- only the shell that runs the
     # helper -- so the helper has to say so rather than fail on a missing command.
     bare_bin = tmp_path / "bare-bin"
     bare_bin.mkdir()
     (bare_bin / "bash").symlink_to(shutil.which("bash") or "/bin/bash")
     env["PATH"] = str(bare_bin)
 
-    result = _run_worktree_helper(worktree, "ocs_redis_cli", "PING", env=env, check=False)
+    result = _run_worktree_helper(worktree, helper, *arguments, env=env, check=False)
 
     assert result.returncode != 0
     assert "docker-compose-dev.yml" in result.stderr

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -19,6 +19,60 @@ ENSURE_SETUP_SCRIPT = REPOSITORY_ROOT / "scripts" / "ensure-worktree-setup.sh"
 WORKTREE_ENVIRONMENT_SCRIPT = REPOSITORY_ROOT / "scripts" / "worktree-environment.sh"
 CODEX_HOOKS_FILE = REPOSITORY_ROOT / ".codex" / "hooks.json"
 
+
+# Enough of psql to answer "does this database exist?" and to remember the answer
+# changing, which is what picks between building a worktree database from scratch and
+# copying a template.
+
+
+STALE = "ocs_stale_postgres"
+ENV_NAME = "ocs_env_postgres"
+ENV_LINE = f"OCS_POSTGRES_CONTAINER={ENV_NAME}"
+ENV_QUOTED = f"OCS_POSTGRES_CONTAINER='{ENV_NAME}'"
+PSQL_QUERY_LOG_LINE = "psql:-h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -c SELECT 1"
+
+
+# Where `ocs_psql` is told to find its container, and what should come of it.
+@dataclass(frozen=True)
+class ContainerSourceScenario:
+    exported: str | None = None
+    env_file: str | None = None
+    listed: bool = True
+    expect: str | None = "ocs_test_postgres"
+    absent: str | None = None
+    stderr_fragment: str | None = None
+
+
+@dataclass(frozen=True)
+class SessionGuardScenario:
+    database_name: str
+    thread_id: str
+    setup_script: str
+    expected_log: str | None
+    redis_url: str | None = None
+    python_version: str | None = None
+    migration_path: str | None = None
+
+
+def _run(
+    *command: str | Path,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    process_env = os.environ.copy()
+    if env:
+        process_env.update(env)
+    return subprocess.run(
+        [str(part) for part in command],
+        cwd=cwd,
+        env=process_env,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
 FAKE_BOOTSTRAP_SCRIPT = r"""#!/usr/bin/env bash
 set -euo pipefail
 mkdir -p "$PWD/.venv" "$PWD/node_modules"
@@ -28,6 +82,7 @@ printf "bootstrap:%s\n" "$*" >> "$OCS_TEST_COMMAND_LOG"
 # Enough of psql to answer "does this database exist?" and to remember the answer
 # changing, which is what picks between building a worktree database from scratch and
 # copying a template.
+
 FAKE_PSQL_SCRIPT = r"""#!/usr/bin/env bash
 set -euo pipefail
 printf "psql:%s\n" "$*" >> "$OCS_TEST_COMMAND_LOG"
@@ -126,7 +181,6 @@ fi
 exit 1
 """
 
-
 FAKE_REDIS_CLI_SCRIPT = r"""#!/usr/bin/env bash
 set -euo pipefail
 if [[ "${*: -1}" == "FLUSHDB" ]]; then
@@ -192,36 +246,6 @@ fi
 
 exit 1
 """
-
-
-@dataclass(frozen=True)
-class SessionGuardScenario:
-    database_name: str
-    thread_id: str
-    setup_script: str
-    expected_log: str | None
-    redis_url: str | None = None
-    python_version: str | None = None
-    migration_path: str | None = None
-
-
-def _run(
-    *command: str | Path,
-    cwd: Path,
-    env: dict[str, str] | None = None,
-    check: bool = True,
-) -> subprocess.CompletedProcess[str]:
-    process_env = os.environ.copy()
-    if env:
-        process_env.update(env)
-    return subprocess.run(
-        [str(part) for part in command],
-        cwd=cwd,
-        env=process_env,
-        check=check,
-        capture_output=True,
-        text=True,
-    )
 
 
 def _write_executable(path: Path, contents: str) -> None:
@@ -471,175 +495,129 @@ def test_redis_registry_allocates_distinct_databases_and_reuses_assignments(
     assert repeated_database == first_database
 
 
-def test_redis_registry_runs_inside_the_redis_container(
-    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
-) -> None:
-    _, worktree, env, command_log = worktree_fixture
-
-    _allocate_redis_database(worktree, env, "feature_6")
-
-    command_output = command_log.read_text()
-    assert "docker-exec:ocs_test_redis" in command_output
-    assert "redis-registry:allocate:feature_6:" in command_output
-
-
-def test_redis_registry_falls_back_to_a_host_client_without_a_container(
-    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
-) -> None:
-    _, worktree, env, command_log = worktree_fixture
-    env["OCS_TEST_REDIS_CONTAINER"] = ""
-
-    _allocate_redis_database(worktree, env, "feature_6")
-
-    command_output = command_log.read_text()
-    assert "docker-exec:" not in command_output
-    assert "redis-registry:allocate:feature_6:" in command_output
-
-
-def test_psql_runs_inside_the_postgres_container(
-    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
-) -> None:
-    _, worktree, env, command_log = worktree_fixture
-
-    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
-
-    command_output = command_log.read_text()
-    assert "docker-exec:ocs_test_postgres" in command_output
-    assert "psql:-h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -c SELECT 1" in command_output
-
-
-def test_psql_falls_back_to_a_host_client_without_a_container(
-    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
-) -> None:
-    _, worktree, env, command_log = worktree_fixture
-    env["OCS_TEST_POSTGRES_CONTAINER"] = ""
-
-    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
-
-    command_output = command_log.read_text()
-    assert "docker-exec:" not in command_output
-    assert "psql:-h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -c SELECT 1" in command_output
-
-
+# Every place `ocs_psql` can be told which container to use, and what should come of it.
+# The name-shaped check on the last case matters because the value is interpolated into
+# `docker exec` and `.env` is a file anything can append to.
 @pytest.mark.parametrize(
-    "docker_exec_status",
+    "scenario",
     [
-        pytest.param("125", id="container_unusable"),
-        pytest.param("127", id="client_missing_inside_the_container"),
+        pytest.param(ContainerSourceScenario(), id="discovered_by_published_port"),
+        pytest.param(ContainerSourceScenario(listed=False, expect=None), id="no_container_so_host_client"),
+        pytest.param(ContainerSourceScenario(env_file=ENV_LINE, expect=ENV_NAME), id="named_in_the_env_file"),
+        pytest.param(ContainerSourceScenario(env_file=ENV_QUOTED, expect=ENV_NAME), id="named_in_the_env_file_quoted"),
+        pytest.param(
+            ContainerSourceScenario(env_file=ENV_LINE, exported="ocs_exported", expect="ocs_exported", absent=ENV_NAME),
+            id="environment_beats_the_env_file",
+        ),
+        pytest.param(
+            ContainerSourceScenario(exported="nope; rm -rf /", stderr_fragment="is not a container name"),
+            id="a_value_that_is_not_a_container_name",
+        ),
     ],
 )
-def test_psql_falls_back_to_a_host_client_when_the_container_cannot_run_one(
+def test_where_psql_finds_its_container(
     worktree_fixture: tuple[Path, Path, dict[str, str], Path],
-    docker_exec_status: str,
+    scenario: ContainerSourceScenario,
 ) -> None:
     _, worktree, env, command_log = worktree_fixture
-    env["OCS_TEST_DOCKER_EXEC_FAILURE"] = docker_exec_status
+    # Nothing sources `.env` before these scripts run, so a knob set there only works
+    # because they read the file themselves — the way OCS_WORKTREE_ID always has.
+    if scenario.env_file is not None:
+        with (worktree / ".env").open("a") as env_file:
+            env_file.write(f"{scenario.env_file}\n")
+    if scenario.exported is not None:
+        env["OCS_POSTGRES_CONTAINER"] = scenario.exported
+    if not scenario.listed:
+        env["OCS_TEST_POSTGRES_CONTAINER"] = ""
 
-    # Runs with check=True: the host client is what makes the query succeed at all.
-    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
-
-    command_output = command_log.read_text()
-    assert "docker-exec:ocs_test_postgres" in command_output
-    assert "psql:-h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -c SELECT 1" in command_output
-
-
-def test_redis_registry_falls_back_to_a_host_client_when_the_container_cannot_run_one(
-    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
-) -> None:
-    _, worktree, env, command_log = worktree_fixture
-    env["OCS_TEST_DOCKER_EXEC_FAILURE"] = "127"
-
-    _allocate_redis_database(worktree, env, "feature_6")
-
-    command_output = command_log.read_text()
-    assert "docker-exec:ocs_test_redis" in command_output
-    assert "redis-registry:allocate:feature_6:" in command_output
-
-
-def test_psql_recovers_from_a_stale_container_override(
-    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
-) -> None:
-    _, worktree, env, command_log = worktree_fixture
-    # The shape of a name exported from a `.envrc` and outlived by its container: the
-    # override is unusable, but the container discovery would have found still is.
-    env["OCS_POSTGRES_CONTAINER"] = "ocs_stale_postgres"
-    env["OCS_TEST_DOCKER_EXEC_FAILURE"] = "125"
-    env["OCS_TEST_DOCKER_EXEC_FAILURE_CONTAINER"] = "ocs_stale_postgres"
-
-    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
-
-    command_output = command_log.read_text()
-    assert "docker-exec:ocs_stale_postgres" in command_output
-    assert "docker-exec:ocs_test_postgres" in command_output
-    assert "psql:-h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -c SELECT 1" in command_output
-
-
-@pytest.mark.parametrize(
-    ("env_line", "expected_container"),
-    [
-        pytest.param("OCS_POSTGRES_CONTAINER=ocs_env_postgres", "ocs_env_postgres", id="bare"),
-        pytest.param("OCS_POSTGRES_CONTAINER='ocs_env_postgres'", "ocs_env_postgres", id="quoted"),
-    ],
-)
-def test_psql_reads_its_container_from_the_worktree_env_file(
-    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
-    env_line: str,
-    expected_container: str,
-) -> None:
-    _, worktree, env, command_log = worktree_fixture
-    # Nothing sources `.env` before these scripts run, so a knob set there only works if
-    # they read the file themselves — the way OCS_WORKTREE_ID always has.
-    with (worktree / ".env").open("a") as env_file:
-        env_file.write(f"{env_line}\n")
-
-    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
-
-    assert f"docker-exec:{expected_container}" in command_log.read_text()
-
-
-def test_an_environment_variable_beats_the_worktree_env_file(
-    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
-) -> None:
-    _, worktree, env, command_log = worktree_fixture
-    with (worktree / ".env").open("a") as env_file:
-        env_file.write("OCS_POSTGRES_CONTAINER=ocs_env_postgres\n")
-    env["OCS_POSTGRES_CONTAINER"] = "ocs_exported_postgres"
-
-    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
-
-    command_output = command_log.read_text()
-    assert "docker-exec:ocs_exported_postgres" in command_output
-    assert "ocs_env_postgres" not in command_output
-
-
-def test_a_container_override_that_is_not_a_container_name_is_ignored(
-    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
-) -> None:
-    _, worktree, env, command_log = worktree_fixture
-    # The value is interpolated into `docker exec`, and `.env` is a file anything can
-    # write, so a name-shaped check is what keeps the rest of a line out of the command.
-    env["OCS_POSTGRES_CONTAINER"] = "nope; rm -rf /"
-
+    # check=True throughout: whichever client answers, the query has to succeed.
     result = _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
 
-    assert "is not a container name" in result.stderr
-    assert "docker-exec:ocs_test_postgres" in command_log.read_text()
+    command_output = command_log.read_text()
+    assert PSQL_QUERY_LOG_LINE in command_output
+    if scenario.expect is None:
+        assert "docker-exec:" not in command_output
+    else:
+        assert f"docker-exec:{scenario.expect}" in command_output
+    if scenario.absent is not None:
+        assert scenario.absent not in command_output
+    if scenario.stderr_fragment is not None:
+        assert scenario.stderr_fragment in result.stderr
 
 
-def test_psql_tries_each_container_source_once_when_none_can_run_a_client(
+@pytest.mark.parametrize(
+    ("listed", "expect_container"),
+    [
+        pytest.param(True, True, id="in_the_container"),
+        pytest.param(False, False, id="host_client_without_a_container"),
+    ],
+)
+def test_where_the_redis_registry_finds_its_client(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+    listed: bool,
+    expect_container: bool,
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    if not listed:
+        env["OCS_TEST_REDIS_CONTAINER"] = ""
+
+    _allocate_redis_database(worktree, env, "feature_6")
+
+    command_output = command_log.read_text()
+    assert "redis-registry:allocate:feature_6:" in command_output
+    assert ("docker-exec:ocs_test_redis" in command_output) is expect_container
+
+
+# `docker exec` keeps 125/126/127 for itself: a container it cannot use, or no such
+# executable inside it. Asserting the exact sequence of attempts covers both what gets
+# tried and what does not get tried twice.
+# `docker exec` keeps 125/126/127 for itself: a container it cannot use, or no such
+# executable inside it. The exact sequence of attempts covers both what gets tried and
+# what is not tried twice — a stale override gives way to discovery, and an override that
+# stayed eligible after being rejected would come back forever.
+@pytest.mark.parametrize(
+    ("status", "failing_container", "override", "expected_attempts"),
+    [
+        pytest.param("125", None, None, ["ocs_test_postgres"], id="container_unusable"),
+        pytest.param("127", None, None, ["ocs_test_postgres"], id="no_client_inside_it"),
+        pytest.param("125", STALE, STALE, [STALE, "ocs_test_postgres"], id="a_stale_override_gives_way"),
+        pytest.param("127", None, STALE, [STALE, "ocs_test_postgres"], id="each_source_tried_once_when_none_can"),
+    ],
+)
+def test_psql_moves_on_when_a_container_cannot_run_a_client(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+    status: str,
+    failing_container: str | None,
+    override: str | None,
+    expected_attempts: list[str],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    env["OCS_TEST_DOCKER_EXEC_FAILURE"] = status
+    if failing_container is not None:
+        env["OCS_TEST_DOCKER_EXEC_FAILURE_CONTAINER"] = failing_container
+    if override is not None:
+        env["OCS_POSTGRES_CONTAINER"] = override
+
+    # check=True: whichever client ends up answering, the query has to succeed.
+    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
+
+    command_output = command_log.read_text()
+    attempts = [line for line in command_output.splitlines() if line.startswith("docker-exec:")]
+    assert attempts == [f"docker-exec:{name}" for name in expected_attempts]
+    assert PSQL_QUERY_LOG_LINE in command_output
+
+
+def test_the_redis_registry_moves_on_when_the_container_cannot_run_a_client(
     worktree_fixture: tuple[Path, Path, dict[str, str], Path],
 ) -> None:
     _, worktree, env, command_log = worktree_fixture
-    # Both an override and a discoverable container, neither able to start a client. The
-    # rejection list is what has to end this: an override that stayed eligible after
-    # being rejected would be handed back on the next resolve, forever.
-    env["OCS_POSTGRES_CONTAINER"] = "ocs_stale_postgres"
     env["OCS_TEST_DOCKER_EXEC_FAILURE"] = "127"
 
-    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
+    _allocate_redis_database(worktree, env, "feature_6")
 
-    attempts = [line for line in command_log.read_text().splitlines() if line.startswith("docker-exec:")]
-    assert attempts == ["docker-exec:ocs_stale_postgres", "docker-exec:ocs_test_postgres"]
+    command_output = command_log.read_text()
+    assert "docker-exec:ocs_test_redis" in command_output
+    assert "redis-registry:allocate:feature_6:" in command_output
 
 
 def test_psql_does_not_retry_a_client_that_ran_and_failed(

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import stat
 import subprocess
 from dataclasses import dataclass
@@ -76,6 +77,29 @@ FAKE_UV_SCRIPT = r"""#!/usr/bin/env bash
 set -euo pipefail
 printf "uv:%s\n" "$*" >> "$OCS_TEST_COMMAND_LOG"
 """
+
+FAKE_DOCKER_SCRIPT = r"""#!/usr/bin/env bash
+set -euo pipefail
+# `docker ps` names the stand-in Redis container, unless the test asked for the
+# no-container case; `docker exec <container> redis-cli ...` hands the rest of the
+# arguments to the redis-cli fake on PATH.
+if [[ "${1:-}" == "ps" ]]; then
+    container="${OCS_TEST_REDIS_CONTAINER-ocs_test_redis}"
+    printf 'unrelated_container 0.0.0.0:5432->5432/tcp\n'
+    [[ -z "$container" ]] || printf '%s 0.0.0.0:6379->6379/tcp\n' "$container"
+    exit 0
+fi
+
+if [[ "${1:-}" == "exec" ]]; then
+    shift
+    printf "docker-exec:%s\n" "$1" >> "$OCS_TEST_COMMAND_LOG"
+    shift
+    exec "$@"
+fi
+
+exit 1
+"""
+
 
 FAKE_REDIS_CLI_SCRIPT = r"""#!/usr/bin/env bash
 set -euo pipefail
@@ -304,6 +328,7 @@ def worktree_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[P
     _write_executable(fake_bin / "psql", FAKE_PSQL_SCRIPT)
     _write_executable(fake_bin / "uv", FAKE_UV_SCRIPT)
     _write_executable(fake_bin / "redis-cli", FAKE_REDIS_CLI_SCRIPT)
+    _write_executable(fake_bin / "docker", FAKE_DOCKER_SCRIPT)
 
     env = {
         "OCS_TEST_COMMAND_LOG": str(command_log),
@@ -416,6 +441,49 @@ def test_redis_registry_allocates_distinct_databases_and_reuses_assignments(
 
     assert first_database != second_database
     assert repeated_database == first_database
+
+
+def test_redis_registry_runs_inside_the_redis_container(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+
+    _allocate_redis_database(worktree, env, "feature_6")
+
+    command_output = command_log.read_text()
+    assert "docker-exec:ocs_test_redis" in command_output
+    assert "redis-registry:allocate:feature_6:" in command_output
+
+
+def test_redis_registry_falls_back_to_a_host_client_without_a_container(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    env["OCS_TEST_REDIS_CONTAINER"] = ""
+
+    _allocate_redis_database(worktree, env, "feature_6")
+
+    command_output = command_log.read_text()
+    assert "docker-exec:" not in command_output
+    assert "redis-registry:allocate:feature_6:" in command_output
+
+
+def test_redis_client_reports_when_no_client_is_reachable(
+    tmp_path: Path,
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, _ = worktree_fixture
+    # A PATH holding neither a container nor a redis-cli -- only the shell that runs the
+    # helper -- so the helper has to say so rather than fail on a missing command.
+    bare_bin = tmp_path / "bare-bin"
+    bare_bin.mkdir()
+    (bare_bin / "bash").symlink_to(shutil.which("bash") or "/bin/bash")
+    env["PATH"] = str(bare_bin)
+
+    result = _run_worktree_helper(worktree, "ocs_redis_cli", "PING", env=env, check=False)
+
+    assert result.returncode != 0
+    assert "docker-compose-dev.yml" in result.stderr
 
 
 def test_redis_registry_reports_exhaustion(

--- a/scripts/test_worktree_environment.py
+++ b/scripts/test_worktree_environment.py
@@ -87,6 +87,7 @@ set -euo pipefail
 # `docker exec <container> <client> ...` hands the rest of the arguments to the client
 # fake on PATH.
 if [[ "${1:-}" == "ps" ]]; then
+    printf "docker-ps\n" >> "$OCS_TEST_COMMAND_LOG"
     redis_container="${OCS_TEST_REDIS_CONTAINER-ocs_test_redis}"
     postgres_container="${OCS_TEST_POSTGRES_CONTAINER-ocs_test_postgres}"
     [[ -z "$postgres_container" ]] \
@@ -109,6 +110,15 @@ if [[ "${1:-}" == "exec" ]]; then
         shift
     done
     printf "docker-exec:%s\n" "$1" >> "$OCS_TEST_COMMAND_LOG"
+    # The statuses `docker exec` keeps for itself when it cannot start the client at all:
+    # 125 for a container it cannot use, 126 and 127 for the executable inside it.
+    # Unset, the failure covers every container; set, only the one it names, which is how
+    # a test leaves a working container to be discovered behind a stale override.
+    if [[ -n "${OCS_TEST_DOCKER_EXEC_FAILURE:-}" \
+        && "${OCS_TEST_DOCKER_EXEC_FAILURE_CONTAINER:-$1}" == "$1" ]]; then
+        echo "Error: could not exec in $1" >&2
+        exit "$OCS_TEST_DOCKER_EXEC_FAILURE"
+    fi
     shift
     exec "$@"
 fi
@@ -304,7 +314,9 @@ def worktree_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[P
     # Loading the Django settings reads the developer's own .env, so running these
     # tests from a worktree otherwise leaks that worktree's resource names into every
     # script the fixture starts.
-    for inherited_variable in ("OCS_WORKTREE_ID", "DATABASE_URL", "REDIS_URL"):
+    # PGPASSWORD joins them because the psql fake asserts on it: inheriting one from the
+    # developer's shell would satisfy that guard no matter what the helper passes.
+    for inherited_variable in ("OCS_WORKTREE_ID", "DATABASE_URL", "REDIS_URL", "PGPASSWORD"):
         monkeypatch.delenv(inherited_variable, raising=False)
 
     root = tmp_path / "main"
@@ -507,6 +519,96 @@ def test_psql_falls_back_to_a_host_client_without_a_container(
     command_output = command_log.read_text()
     assert "docker-exec:" not in command_output
     assert "psql:-h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -c SELECT 1" in command_output
+
+
+@pytest.mark.parametrize(
+    "docker_exec_status",
+    [
+        pytest.param("125", id="container_unusable"),
+        pytest.param("127", id="client_missing_inside_the_container"),
+    ],
+)
+def test_psql_falls_back_to_a_host_client_when_the_container_cannot_run_one(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+    docker_exec_status: str,
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    env["OCS_TEST_DOCKER_EXEC_FAILURE"] = docker_exec_status
+
+    # Runs with check=True: the host client is what makes the query succeed at all.
+    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
+
+    command_output = command_log.read_text()
+    assert "docker-exec:ocs_test_postgres" in command_output
+    assert "psql:-h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -c SELECT 1" in command_output
+
+
+def test_redis_registry_falls_back_to_a_host_client_when_the_container_cannot_run_one(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    env["OCS_TEST_DOCKER_EXEC_FAILURE"] = "127"
+
+    _allocate_redis_database(worktree, env, "feature_6")
+
+    command_output = command_log.read_text()
+    assert "docker-exec:ocs_test_redis" in command_output
+    assert "redis-registry:allocate:feature_6:" in command_output
+
+
+def test_psql_recovers_from_a_stale_container_override(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    # The shape of a name exported from a `.envrc` and outlived by its container: the
+    # override is unusable, but the container discovery would have found still is.
+    env["OCS_POSTGRES_CONTAINER"] = "ocs_stale_postgres"
+    env["OCS_TEST_DOCKER_EXEC_FAILURE"] = "125"
+    env["OCS_TEST_DOCKER_EXEC_FAILURE_CONTAINER"] = "ocs_stale_postgres"
+
+    _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env)
+
+    command_output = command_log.read_text()
+    assert "docker-exec:ocs_stale_postgres" in command_output
+    assert "docker-exec:ocs_test_postgres" in command_output
+    assert "psql:-h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -c SELECT 1" in command_output
+
+
+def test_psql_does_not_retry_a_client_that_ran_and_failed(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+    # A statement the server rejects is the client's own failure, not the container's:
+    # running it again against whatever else answers on the host port would send the same
+    # statement to a second server.
+    env["OCS_TEST_FAIL_PSQL"] = "true"
+
+    result = _run_worktree_helper(worktree, "ocs_psql", "postgres", "-c", "SELECT 1", env=env, check=False)
+
+    assert result.returncode == 1
+    assert command_log.read_text().count("psql:") == 1
+
+
+def test_service_container_is_resolved_once_per_shell(
+    worktree_fixture: tuple[Path, Path, dict[str, str], Path],
+) -> None:
+    _, worktree, env, command_log = worktree_fixture
+
+    # Every query would otherwise cost its own `docker ps`, and a single setup runs
+    # dozens of them.
+    _run(
+        "bash",
+        "-c",
+        'source "$1"; ocs_psql postgres -c "SELECT 1"; ocs_psql postgres -c "SELECT 2"',
+        "_",
+        worktree / "scripts" / "worktree-environment.sh",
+        cwd=worktree,
+        env=env,
+    )
+
+    command_output = command_log.read_text()
+    assert command_output.count("psql:") == 2
+    assert command_output.count("docker-ps") == 1
 
 
 @pytest.mark.parametrize(

--- a/scripts/worktree-environment.sh
+++ b/scripts/worktree-environment.sh
@@ -94,7 +94,10 @@ ocs_worktree_resource_name() {
 # clients we reach for are the ones inside those containers. A service is identified by
 # the host port it publishes -- only one container can hold a given port at a time, which
 # makes that unambiguous -- and named directly by `OCS_POSTGRES_CONTAINER` or
-# `OCS_REDIS_CONTAINER` when discovery needs overriding.
+# `OCS_REDIS_CONTAINER` when discovery needs overriding. The ports stay literal, matching
+# the ones `setup-worktree.sh` writes into DATABASE_URL and REDIS_URL: a port knob here
+# and a hardcoded port there would only half-move a service, and the half left behind
+# would be a FLUSHDB against whatever else answers on 6379.
 ocs_container_publishing_port() {
     local port="$1"
     local container
@@ -115,34 +118,82 @@ ocs_container_publishing_port() {
     printf '%s\n' "$container"
 }
 
+# `docker exec` reports its own inability to start anything -- no such container, the
+# container not running, no such executable inside it -- as 125, 126 or 127, and every
+# other status is the client's own. Only the first kind is worth retrying elsewhere:
+# retrying a client that did run would send the same statement to a second server.
+ocs_docker_exec_could_not_start() {
+    case "$1" in
+        125 | 126 | 127) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Left to the caller to turn into a failure, so that the message costs nothing under
+# `set -e`: reporting it with a non-zero status would abort the caller here rather than
+# where it decides what a missing client means.
 ocs_report_missing_client() {
     local client="$1"
     local port="$2"
 
-    echo "No container publishes port $port and no $client is installed on the host." >&2
+    echo "No container serving port $port can run $client, and none is installed on the host." >&2
     echo "Start the development services with: docker compose -f docker-compose-dev.yml up -d" >&2
-    return 1
 }
 
-ocs_redis_container() {
+# The container to exec into is handed back in OCS_RESOLVED_CONTAINER rather than on
+# stdout so that the answer can be kept: resolving it through a command substitution
+# would cache it in a subshell that exits immediately, and `ocs_psql` alone runs dozens
+# of times per setup -- a `docker ps` apiece. A container that turns out to be unable to
+# start a client is disqualified instead of being asked again; a stale name left in
+# `OCS_REDIS_CONTAINER` -- exported from a `.envrc` and outlived by its container -- then
+# gives way to discovery rather than costing the whole run its container.
+OCS_REDIS_CONTAINER_CACHE=""
+OCS_REDIS_CONTAINER_RESOLVED=false
+
+ocs_resolve_redis_container() {
+    OCS_RESOLVED_CONTAINER=""
     if [[ -n "${OCS_REDIS_CONTAINER:-}" ]]; then
-        printf '%s\n' "$OCS_REDIS_CONTAINER"
+        OCS_RESOLVED_CONTAINER=$OCS_REDIS_CONTAINER
         return 0
     fi
-    ocs_container_publishing_port "${OCS_REDIS_PORT:-6379}"
+    if [[ "$OCS_REDIS_CONTAINER_RESOLVED" != "true" ]]; then
+        OCS_REDIS_CONTAINER_CACHE=$(ocs_container_publishing_port 6379 || true)
+        OCS_REDIS_CONTAINER_RESOLVED=true
+    fi
+    OCS_RESOLVED_CONTAINER=$OCS_REDIS_CONTAINER_CACHE
+    [[ -n "$OCS_RESOLVED_CONTAINER" ]]
+}
+
+# Whichever source named the container that could not run a client stops naming it. Each
+# source can be emptied only once, so a run cannot loop over the same container.
+ocs_disqualify_redis_container() {
+    if [[ "${OCS_REDIS_CONTAINER:-}" == "$OCS_RESOLVED_CONTAINER" ]]; then
+        OCS_REDIS_CONTAINER=""
+    elif [[ "$OCS_REDIS_CONTAINER_CACHE" == "$OCS_RESOLVED_CONTAINER" ]]; then
+        OCS_REDIS_CONTAINER_CACHE=""
+    fi
 }
 
 ocs_redis_cli() {
-    local container
+    local status
 
-    if container=$(ocs_redis_container); then
-        docker exec "$container" redis-cli "$@"
-        return
+    if ocs_resolve_redis_container; then
+        status=0
+        docker exec "$OCS_RESOLVED_CONTAINER" redis-cli "$@" || status=$?
+        if [[ "$status" -eq 0 ]] || ! ocs_docker_exec_could_not_start "$status"; then
+            return "$status"
+        fi
+        echo "[ocs] $OCS_RESOLVED_CONTAINER could not run redis-cli; trying elsewhere." >&2
+        ocs_disqualify_redis_container
+        if ocs_resolve_redis_container; then
+            ocs_redis_cli "$@"
+            return
+        fi
     fi
     # A Redis reachable on the host port without a container of its own -- a service
     # container in CI, or a locally installed server -- still answers a host client.
     if ! command -v redis-cli >/dev/null 2>&1; then
-        ocs_report_missing_client redis-cli "${OCS_REDIS_PORT:-6379}"
+        ocs_report_missing_client redis-cli 6379
         return 1
     fi
     redis-cli "$@"
@@ -357,12 +408,29 @@ ocs_templates_are_enabled() {
     [[ "${OCS_DISABLE_DATABASE_TEMPLATES:-false}" != "true" ]]
 }
 
-ocs_postgres_container() {
+OCS_POSTGRES_CONTAINER_CACHE=""
+OCS_POSTGRES_CONTAINER_RESOLVED=false
+
+ocs_resolve_postgres_container() {
+    OCS_RESOLVED_CONTAINER=""
     if [[ -n "${OCS_POSTGRES_CONTAINER:-}" ]]; then
-        printf '%s\n' "$OCS_POSTGRES_CONTAINER"
+        OCS_RESOLVED_CONTAINER=$OCS_POSTGRES_CONTAINER
         return 0
     fi
-    ocs_container_publishing_port "${OCS_POSTGRES_PORT:-5432}"
+    if [[ "$OCS_POSTGRES_CONTAINER_RESOLVED" != "true" ]]; then
+        OCS_POSTGRES_CONTAINER_CACHE=$(ocs_container_publishing_port 5432 || true)
+        OCS_POSTGRES_CONTAINER_RESOLVED=true
+    fi
+    OCS_RESOLVED_CONTAINER=$OCS_POSTGRES_CONTAINER_CACHE
+    [[ -n "$OCS_RESOLVED_CONTAINER" ]]
+}
+
+ocs_disqualify_postgres_container() {
+    if [[ "${OCS_POSTGRES_CONTAINER:-}" == "$OCS_RESOLVED_CONTAINER" ]]; then
+        OCS_POSTGRES_CONTAINER=""
+    elif [[ "$OCS_POSTGRES_CONTAINER_CACHE" == "$OCS_RESOLVED_CONTAINER" ]]; then
+        OCS_POSTGRES_CONTAINER_CACHE=""
+    fi
 }
 
 # Every caller passes its statement inline with -c/-tAc, so nothing here depends on the
@@ -371,7 +439,7 @@ ocs_postgres_container() {
 ocs_psql() {
     local database="$1"
     shift
-    local container
+    local status
     local psql_command=(
         psql
         -h localhost
@@ -381,12 +449,22 @@ ocs_psql() {
         "$@"
     )
 
-    if container=$(ocs_postgres_container); then
-        docker exec -e PGPASSWORD=postgres "$container" "${psql_command[@]}"
-        return
+    if ocs_resolve_postgres_container; then
+        status=0
+        docker exec -e PGPASSWORD=postgres "$OCS_RESOLVED_CONTAINER" \
+            "${psql_command[@]}" || status=$?
+        if [[ "$status" -eq 0 ]] || ! ocs_docker_exec_could_not_start "$status"; then
+            return "$status"
+        fi
+        echo "[ocs] $OCS_RESOLVED_CONTAINER could not run psql; trying elsewhere." >&2
+        ocs_disqualify_postgres_container
+        if ocs_resolve_postgres_container; then
+            ocs_psql "$database" "$@"
+            return
+        fi
     fi
     if ! command -v psql >/dev/null 2>&1; then
-        ocs_report_missing_client psql "${OCS_POSTGRES_PORT:-5432}"
+        ocs_report_missing_client psql 5432
         return 1
     fi
     PGPASSWORD=postgres "${psql_command[@]}"

--- a/scripts/worktree-environment.sh
+++ b/scripts/worktree-environment.sh
@@ -89,6 +89,54 @@ ocs_worktree_resource_name() {
     ocs_sanitize_resource_name "$raw_name"
 }
 
+# Redis for local development runs in the container `docker-compose-dev.yml` defines, and
+# a host redis-cli is not something we can count on being installed, so registry and
+# flush commands go through the client inside that container. Only one container can hold
+# the host Redis port at a time, which is what makes looking it up by published port
+# unambiguous.
+ocs_redis_container() {
+    local port="${OCS_REDIS_PORT:-6379}"
+    local container
+
+    if [[ -n "${OCS_REDIS_CONTAINER:-}" ]]; then
+        printf '%s\n' "$OCS_REDIS_CONTAINER"
+        return 0
+    fi
+
+    command -v docker >/dev/null 2>&1 || return 1
+    # The mapping is read out of `docker ps` rather than asked for with `--filter
+    # publish=`, which podman's docker CLI shim rejects as an invalid filter. awk keeps
+    # reading after the match instead of exiting: closing the pipe early would fail
+    # `docker ps` under `pipefail` and turn a found container into a lookup failure.
+    container=$(
+        docker ps --format '{{.Names}} {{.Ports}}' 2>/dev/null \
+            | awk -v mapping=":$port->" '
+                !found && index($0, mapping) { container = $1; found = 1 }
+                END { if (found) print container }
+            '
+    )
+    [[ -n "$container" ]] || return 1
+    printf '%s\n' "$container"
+}
+
+ocs_redis_cli() {
+    local container
+
+    if container=$(ocs_redis_container); then
+        docker exec "$container" redis-cli "$@"
+        return
+    fi
+    # A Redis reachable on the host port without a container of its own -- a service
+    # container in CI, or a locally installed server -- still answers a host client.
+    if command -v redis-cli >/dev/null 2>&1; then
+        redis-cli "$@"
+        return
+    fi
+    echo "No Redis container publishes port ${OCS_REDIS_PORT:-6379} and no redis-cli is installed." >&2
+    echo "Start the development services with: docker compose -f docker-compose-dev.yml up -d" >&2
+    return 1
+}
+
 ocs_redis_registry_command() {
     local operation="$1"
     local resource_name="$2"
@@ -152,7 +200,7 @@ end
 
 return redis.error_reply("Unknown worktree Redis registry operation")'
 
-    redis-cli \
+    ocs_redis_cli \
         -e \
         -n "$registry_database" \
         --raw \

--- a/scripts/worktree-environment.sh
+++ b/scripts/worktree-environment.sh
@@ -34,22 +34,51 @@ ocs_sanitize_resource_name() {
     printf '%s\n' "$sanitized"
 }
 
-ocs_persisted_worktree_resource_name() {
-    local current_path="$1"
-    local env_file="$current_path/.env"
-    local persisted_name
+# The last assignment of a key in an env file, with the quotes `ocs_set_env_value` never
+# writes but a hand-edited file may carry stripped off. Nothing sources `.env` -- these
+# scripts run before any of it is loaded, and there is no `.envrc` in the repository to do
+# it -- so a value only reaches them by being read out of the file like this.
+ocs_env_file_value() {
+    local env_file="$1"
+    local key="$2"
 
     [[ -f "$env_file" ]] || return 1
-    persisted_name=$(awk '
-        index($0, "OCS_WORKTREE_ID=") == 1 {
-            value = substr($0, length("OCS_WORKTREE_ID=") + 1)
+    awk -v key="$key" '
+        index($0, key "=") == 1 {
+            value = substr($0, length(key) + 2)
+            if (value ~ /^".*"$/ || value ~ /^'"'"'.*'"'"'$/) {
+                value = substr(value, 2, length(value) - 2)
+            }
         }
         END {
             if (value != "") {
                 print value
             }
         }
-    ' "$env_file")
+    ' "$env_file"
+}
+
+# Where the container overrides come from: the environment first, so a one-off invocation
+# can override anything; then the worktree's own `.env`, which is where they are
+# documented and where a per-worktree choice belongs; then the default. The older knobs
+# are environment-only, as they have always been.
+ocs_setting() {
+    local key="$1"
+    local default_value="$2"
+    local value
+
+    value=$(printenv "$key") || value=""
+    if [[ -z "$value" ]]; then
+        value=$(ocs_env_file_value "$(ocs_current_worktree_path)/.env" "$key") || value=""
+    fi
+    printf '%s\n' "${value:-$default_value}"
+}
+
+ocs_persisted_worktree_resource_name() {
+    local current_path="$1"
+    local persisted_name
+
+    persisted_name=$(ocs_env_file_value "$current_path/.env" "OCS_WORKTREE_ID") || return 1
     [[ -n "$persisted_name" ]] || return 1
     if [[ ! "$persisted_name" =~ ^[a-z0-9_]{1,63}$ ]]; then
         echo "Invalid persisted worktree resource name: $persisted_name" >&2
@@ -140,38 +169,60 @@ ocs_report_missing_client() {
     echo "Start the development services with: docker compose -f docker-compose-dev.yml up -d" >&2
 }
 
-# The container to exec into is handed back in OCS_RESOLVED_CONTAINER rather than on
-# stdout so that the answer can be kept: resolving it through a command substitution
-# would cache it in a subshell that exits immediately, and `ocs_psql` alone runs dozens
-# of times per setup -- a `docker ps` apiece. A container that turns out to be unable to
-# start a client is disqualified instead of being asked again; a stale name left in
-# `OCS_REDIS_CONTAINER` -- exported from a `.envrc` and outlived by its container -- then
-# gives way to discovery rather than costing the whole run its container.
-OCS_REDIS_CONTAINER_CACHE=""
-OCS_REDIS_CONTAINER_RESOLVED=false
+# The resolved container is handed back in `_ocs_resolved_container` rather than on stdout
+# so that the answer can be kept: resolving through a command substitution would cache it
+# in a subshell that exits immediately, and `ocs_psql` alone runs dozens of times per
+# setup -- a `docker ps` apiece. The lower case is the distinction the shell already draws
+# and this file follows for locals: an upper-case `OCS_*` name is read from the
+# environment and documented as a knob, a lower-case `_ocs_*` one is private to this file
+# and setting it from outside does nothing. It holds a container only in the moment after
+# a successful resolve; the resolve functions are what to call, never it directly.
+#
+# `_ocs_*_discovered` keeps what `docker ps` reported: a container name, or `none` once a
+# lookup has come up empty, so the lookup happens once either way. `_ocs_*_rejected`
+# lists containers that turned out unable to run a client, which is what stops a source
+# from offering the same one twice and a retry from looping. Rejection is recorded here
+# rather than by clearing `OCS_*_CONTAINER`, because that variable belongs to whoever
+# exported it and every child process inherits what we would have blanked.
+_ocs_resolved_container=""
+_ocs_redis_discovered=""
+_ocs_redis_rejected=""
 
-ocs_resolve_redis_container() {
-    OCS_RESOLVED_CONTAINER=""
-    if [[ -n "${OCS_REDIS_CONTAINER:-}" ]]; then
-        OCS_RESOLVED_CONTAINER=$OCS_REDIS_CONTAINER
-        return 0
-    fi
-    if [[ "$OCS_REDIS_CONTAINER_RESOLVED" != "true" ]]; then
-        OCS_REDIS_CONTAINER_CACHE=$(ocs_container_publishing_port 6379 || true)
-        OCS_REDIS_CONTAINER_RESOLVED=true
-    fi
-    OCS_RESOLVED_CONTAINER=$OCS_REDIS_CONTAINER_CACHE
-    [[ -n "$OCS_RESOLVED_CONTAINER" ]]
+# A container name cannot contain a space, so a space-delimited list needs no more care.
+ocs_container_is_rejected() {
+    local candidate="$1"
+    local rejected="$2"
+
+    [[ " $rejected " == *" $candidate "* ]]
 }
 
-# Whichever source named the container that could not run a client stops naming it. Each
-# source can be emptied only once, so a run cannot loop over the same container.
-ocs_disqualify_redis_container() {
-    if [[ "${OCS_REDIS_CONTAINER:-}" == "$OCS_RESOLVED_CONTAINER" ]]; then
-        OCS_REDIS_CONTAINER=""
-    elif [[ "$OCS_REDIS_CONTAINER_CACHE" == "$OCS_RESOLVED_CONTAINER" ]]; then
-        OCS_REDIS_CONTAINER_CACHE=""
+ocs_resolve_redis_container() {
+    local override
+    override=$(ocs_setting "OCS_REDIS_CONTAINER" "")
+    if [[ -n "$override" && ! "$override" =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$ ]]; then
+        echo "Ignoring OCS_REDIS_CONTAINER: $override is not a container name." >&2
+        override=""
     fi
+
+    _ocs_resolved_container=""
+    if [[ -n "$override" ]] \
+        && ! ocs_container_is_rejected "$override" "$_ocs_redis_rejected"; then
+        _ocs_resolved_container=$override
+        return 0
+    fi
+    if [[ -z "$_ocs_redis_discovered" ]]; then
+        _ocs_redis_discovered=$(ocs_container_publishing_port 6379 || true)
+        _ocs_redis_discovered=${_ocs_redis_discovered:-none}
+    fi
+    if [[ "$_ocs_redis_discovered" == none ]] \
+        || ocs_container_is_rejected "$_ocs_redis_discovered" "$_ocs_redis_rejected"; then
+        return 1
+    fi
+    _ocs_resolved_container=$_ocs_redis_discovered
+}
+
+ocs_disqualify_redis_container() {
+    _ocs_redis_rejected="$_ocs_redis_rejected $_ocs_resolved_container"
 }
 
 ocs_redis_cli() {
@@ -179,11 +230,11 @@ ocs_redis_cli() {
 
     if ocs_resolve_redis_container; then
         status=0
-        docker exec "$OCS_RESOLVED_CONTAINER" redis-cli "$@" || status=$?
+        docker exec "$_ocs_resolved_container" redis-cli "$@" || status=$?
         if [[ "$status" -eq 0 ]] || ! ocs_docker_exec_could_not_start "$status"; then
             return "$status"
         fi
-        echo "[ocs] $OCS_RESOLVED_CONTAINER could not run redis-cli; trying elsewhere." >&2
+        echo "[ocs] $_ocs_resolved_container could not run redis-cli; trying elsewhere." >&2
         ocs_disqualify_redis_container
         if ocs_resolve_redis_container; then
             ocs_redis_cli "$@"
@@ -408,29 +459,36 @@ ocs_templates_are_enabled() {
     [[ "${OCS_DISABLE_DATABASE_TEMPLATES:-false}" != "true" ]]
 }
 
-OCS_POSTGRES_CONTAINER_CACHE=""
-OCS_POSTGRES_CONTAINER_RESOLVED=false
+_ocs_postgres_discovered=""
+_ocs_postgres_rejected=""
 
 ocs_resolve_postgres_container() {
-    OCS_RESOLVED_CONTAINER=""
-    if [[ -n "${OCS_POSTGRES_CONTAINER:-}" ]]; then
-        OCS_RESOLVED_CONTAINER=$OCS_POSTGRES_CONTAINER
+    local override
+    override=$(ocs_setting "OCS_POSTGRES_CONTAINER" "")
+    if [[ -n "$override" && ! "$override" =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$ ]]; then
+        echo "Ignoring OCS_POSTGRES_CONTAINER: $override is not a container name." >&2
+        override=""
+    fi
+
+    _ocs_resolved_container=""
+    if [[ -n "$override" ]] \
+        && ! ocs_container_is_rejected "$override" "$_ocs_postgres_rejected"; then
+        _ocs_resolved_container=$override
         return 0
     fi
-    if [[ "$OCS_POSTGRES_CONTAINER_RESOLVED" != "true" ]]; then
-        OCS_POSTGRES_CONTAINER_CACHE=$(ocs_container_publishing_port 5432 || true)
-        OCS_POSTGRES_CONTAINER_RESOLVED=true
+    if [[ -z "$_ocs_postgres_discovered" ]]; then
+        _ocs_postgres_discovered=$(ocs_container_publishing_port 5432 || true)
+        _ocs_postgres_discovered=${_ocs_postgres_discovered:-none}
     fi
-    OCS_RESOLVED_CONTAINER=$OCS_POSTGRES_CONTAINER_CACHE
-    [[ -n "$OCS_RESOLVED_CONTAINER" ]]
+    if [[ "$_ocs_postgres_discovered" == none ]] \
+        || ocs_container_is_rejected "$_ocs_postgres_discovered" "$_ocs_postgres_rejected"; then
+        return 1
+    fi
+    _ocs_resolved_container=$_ocs_postgres_discovered
 }
 
 ocs_disqualify_postgres_container() {
-    if [[ "${OCS_POSTGRES_CONTAINER:-}" == "$OCS_RESOLVED_CONTAINER" ]]; then
-        OCS_POSTGRES_CONTAINER=""
-    elif [[ "$OCS_POSTGRES_CONTAINER_CACHE" == "$OCS_RESOLVED_CONTAINER" ]]; then
-        OCS_POSTGRES_CONTAINER_CACHE=""
-    fi
+    _ocs_postgres_rejected="$_ocs_postgres_rejected $_ocs_resolved_container"
 }
 
 # Every caller passes its statement inline with -c/-tAc, so nothing here depends on the
@@ -451,12 +509,12 @@ ocs_psql() {
 
     if ocs_resolve_postgres_container; then
         status=0
-        docker exec -e PGPASSWORD=postgres "$OCS_RESOLVED_CONTAINER" \
+        docker exec -e PGPASSWORD=postgres "$_ocs_resolved_container" \
             "${psql_command[@]}" || status=$?
         if [[ "$status" -eq 0 ]] || ! ocs_docker_exec_could_not_start "$status"; then
             return "$status"
         fi
-        echo "[ocs] $OCS_RESOLVED_CONTAINER could not run psql; trying elsewhere." >&2
+        echo "[ocs] $_ocs_resolved_container could not run psql; trying elsewhere." >&2
         ocs_disqualify_postgres_container
         if ocs_resolve_postgres_container; then
             ocs_psql "$database" "$@"

--- a/scripts/worktree-environment.sh
+++ b/scripts/worktree-environment.sh
@@ -89,19 +89,15 @@ ocs_worktree_resource_name() {
     ocs_sanitize_resource_name "$raw_name"
 }
 
-# Redis for local development runs in the container `docker-compose-dev.yml` defines, and
-# a host redis-cli is not something we can count on being installed, so registry and
-# flush commands go through the client inside that container. Only one container can hold
-# the host Redis port at a time, which is what makes looking it up by published port
-# unambiguous.
-ocs_redis_container() {
-    local port="${OCS_REDIS_PORT:-6379}"
+# Postgres and Redis run in the containers `docker-compose-dev.yml` defines, and neither
+# `psql` nor `redis-cli` is something we can count on being installed on the host, so the
+# clients we reach for are the ones inside those containers. A service is identified by
+# the host port it publishes -- only one container can hold a given port at a time, which
+# makes that unambiguous -- and named directly by `OCS_POSTGRES_CONTAINER` or
+# `OCS_REDIS_CONTAINER` when discovery needs overriding.
+ocs_container_publishing_port() {
+    local port="$1"
     local container
-
-    if [[ -n "${OCS_REDIS_CONTAINER:-}" ]]; then
-        printf '%s\n' "$OCS_REDIS_CONTAINER"
-        return 0
-    fi
 
     command -v docker >/dev/null 2>&1 || return 1
     # The mapping is read out of `docker ps` rather than asked for with `--filter
@@ -119,6 +115,23 @@ ocs_redis_container() {
     printf '%s\n' "$container"
 }
 
+ocs_report_missing_client() {
+    local client="$1"
+    local port="$2"
+
+    echo "No container publishes port $port and no $client is installed on the host." >&2
+    echo "Start the development services with: docker compose -f docker-compose-dev.yml up -d" >&2
+    return 1
+}
+
+ocs_redis_container() {
+    if [[ -n "${OCS_REDIS_CONTAINER:-}" ]]; then
+        printf '%s\n' "$OCS_REDIS_CONTAINER"
+        return 0
+    fi
+    ocs_container_publishing_port "${OCS_REDIS_PORT:-6379}"
+}
+
 ocs_redis_cli() {
     local container
 
@@ -128,13 +141,11 @@ ocs_redis_cli() {
     fi
     # A Redis reachable on the host port without a container of its own -- a service
     # container in CI, or a locally installed server -- still answers a host client.
-    if command -v redis-cli >/dev/null 2>&1; then
-        redis-cli "$@"
-        return
+    if ! command -v redis-cli >/dev/null 2>&1; then
+        ocs_report_missing_client redis-cli "${OCS_REDIS_PORT:-6379}"
+        return 1
     fi
-    echo "No Redis container publishes port ${OCS_REDIS_PORT:-6379} and no redis-cli is installed." >&2
-    echo "Start the development services with: docker compose -f docker-compose-dev.yml up -d" >&2
-    return 1
+    redis-cli "$@"
 }
 
 ocs_redis_registry_command() {
@@ -346,16 +357,39 @@ ocs_templates_are_enabled() {
     [[ "${OCS_DISABLE_DATABASE_TEMPLATES:-false}" != "true" ]]
 }
 
+ocs_postgres_container() {
+    if [[ -n "${OCS_POSTGRES_CONTAINER:-}" ]]; then
+        printf '%s\n' "$OCS_POSTGRES_CONTAINER"
+        return 0
+    fi
+    ocs_container_publishing_port "${OCS_POSTGRES_PORT:-5432}"
+}
+
+# Every caller passes its statement inline with -c/-tAc, so nothing here depends on the
+# client sharing a filesystem with the worktree; `localhost` names the server either way,
+# the container's own or the one its published port leads to.
 ocs_psql() {
     local database="$1"
     shift
-
-    PGPASSWORD=postgres psql \
-        -h localhost \
-        -U postgres \
-        -d "$database" \
-        -v ON_ERROR_STOP=1 \
+    local container
+    local psql_command=(
+        psql
+        -h localhost
+        -U postgres
+        -d "$database"
+        -v ON_ERROR_STOP=1
         "$@"
+    )
+
+    if container=$(ocs_postgres_container); then
+        docker exec -e PGPASSWORD=postgres "$container" "${psql_command[@]}"
+        return
+    fi
+    if ! command -v psql >/dev/null 2>&1; then
+        ocs_report_missing_client psql "${OCS_POSTGRES_PORT:-5432}"
+        return 1
+    fi
+    PGPASSWORD=postgres "${psql_command[@]}"
 }
 
 ocs_database_exists() {


### PR DESCRIPTION
### Product Description

Worktree setup and teardown no longer need `psql` or `redis-cli` installed on the host — both run inside the containers `docker-compose-dev.yml` already defines. Without this, setup on such a host dies with `redis-cli: command not found` after having already created the branch database.

### Technical Description

`scripts/worktree-environment.sh` gains `ocs_psql` / `ocs_redis_cli`, and every existing call site goes through them:

- The container is found by the host port it publishes, read out of `docker ps --format '{{.Names}} {{.Ports}}'`. Not `--filter publish=`, which podman's docker CLI shim rejects as an invalid filter.
- No container → the host client, so a locally installed server or a CI service container still works. Neither available → a message naming the missing client, instead of a bare "command not found".
- A container that cannot start a client (`docker exec` 125/126/127) is skipped and the next candidate tried. Any other status is the client's own and is returned untouched, so a statement the server rejected is never replayed elsewhere.
- `OCS_POSTGRES_CONTAINER` / `OCS_REDIS_CONTAINER` pin a container, read from the environment or the worktree's `.env` (nothing sources `.env` for these scripts, so they parse it, as `OCS_WORKTREE_ID` already did). Pre-existing knobs are unchanged.

Safe to run the client in the container because every `ocs_psql` caller passes SQL inline with `-c`/`-tAc` — no `-f`, no stdin, no `\copy`. `-h localhost` is correct either way: the container's own server, or the published port.

Rationale for the individual decisions is in the commit messages.

### Migrations

- [x] The migrations are backwards compatible

None.

### Docs and Changelog

- [x] This PR requires docs/changelog update

Included: `.env.example` documents the two knobs; `docs/getting-started/dev-workflow.md` describes the container clients under *What worktree setup does*. No changelog entry — developer tooling, no user-facing surface.
