### PR TITLE
docs: document global (team-less) OAuth applications

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -118,9 +118,10 @@ A Team-scoped, versioned wrapper around a resource in OpenAI's Assistants API. P
 _Avoid_: bare "Assistant" — it overloads with the colloquial sense ("the chatbot as an assistant").
 
 **OAuth Application**:
-A Team-scoped registration that lets an external system authenticate to OCS. Two kinds, fixed at registration: **machine** applications (client credentials — no human, no login, a synthetic service identity acting for the Team) and **user-facing** applications (authorization code — a real User signs in and consents).
+A registration that lets an external system authenticate to OCS. Two kinds, fixed at registration: **machine** applications (client credentials — no human, no login, a synthetic service identity acting for the Team) and **user-facing** applications (authorization code — a real User signs in and consents).
 A machine application also names the Chatbots it may **reach**; naming none means it may reach none. The allowlist gates every door the machine scope opens — chat completions, message ingress and outbound bot messages (ADR-0056) — with chat-session admission as one more consumer.
-_Avoid_: "API key" (a separate, user-scoped credential), and "the OAuth app's user" for a machine application — it has none.
+Usually **Team-scoped**: the Team is pinned at registration and every token the application issues is scoped to it. A **global** application is instead registered with no Team — superusers only, from the site admin area, and authorization-code only, since deriving a Team needs a User to ask. Any User may authorize one, in any of *their* Teams. The application spans Teams; **a token never does** — each is scoped to the one Team chosen at authorization time and carries it through code → access token → refresh. See [oauth_applications.md](docs/admin_guides/oauth_applications.md).
+_Avoid_: "API key" (a separate, user-scoped credential), "the OAuth app's user" for a machine application — it has none — and "a global token": global is a property of the *application*, never of a token.
 
 **Custom Action**:
 A Team-scoped HTTP API that a Chatbot can call, described by an OpenAPI schema. Provides one or more **Custom Action Operations**.

--- a/docs/admin_guides/index.md
+++ b/docs/admin_guides/index.md
@@ -6,6 +6,7 @@ This section contains documentation for features that are typically used by syst
 
 - [Banners System](banners.md) - Create and manage system-wide notification banners
 - [Feature Flags](feature_flags.md) - Manage access to [feature flags](../developer_guides/code_systems/feature_flags.md)
+- [OAuth Applications](oauth_applications.md) - Register global (team-less) OAuth applications
 
 ## Overview
 

--- a/docs/admin_guides/oauth_applications.md
+++ b/docs/admin_guides/oauth_applications.md
@@ -1,0 +1,88 @@
+# OAuth Applications
+
+An OAuth application is a registration that lets an external system authenticate to Open Chat Studio.
+Most are registered by team admins and belong to a single team. A **global** application belongs to no
+team and can be registered only by a superuser — that is what this guide covers.
+
+## Team-scoped vs. global applications
+
+|  | Team-scoped | Global |
+| --- | --- | --- |
+| Registered from | Team Settings > OAuth Applications (`/a/<team-slug>/oauth/applications/`) | Global Admin > OAuth Apps (`/o/global-applications/`) |
+| Who can register it | Team admins | Superusers only |
+| Grant types | Authorization code, or client credentials | **Authorization code only** |
+| Who can authorize it | Members of that one team | Any user, in any of *their* teams |
+| Team a token is scoped to | Always the application's team | The team the authorizing user picks |
+
+Register a global application when one external integration needs to serve users across many teams —
+a partner portal, or a system that signs users in through OCS — and you do not want a separate
+client ID and secret per team.
+
+Everything else should be team-scoped. A team-scoped application is self-service, and it keeps the
+blast radius of a leaked secret inside one team.
+
+## Why global applications are authorization-code only
+
+A global application has no team of its own, so something has to decide which team a token may reach.
+For the authorization-code grant that is the user: they sign in, and the consent screen asks them to
+pick one of their teams.
+
+The client-credentials grant has no user — nobody to ask — so a global client-credentials application
+would have no team at all, and no way to derive one. The registration form therefore offers only the
+authorization-code grant, and the choice is locked.
+
+## Registering one
+
+1. Sign in as a superuser and go to **Global Admin** (`/admin/`).
+2. Click **OAuth Apps**. This button is only rendered for superusers, and the pages behind it return
+   404 to everyone else rather than a permission error.
+3. Click **Register**, then fill in:
+    - **Name** — what the user sees on the consent screen. Make it recognisable; the user is
+      consenting to hand this application access to their team's data.
+    - **Redirect URIs** — one per line. Required. Only these URIs can receive an authorization code.
+    - **Post logout redirect URIs** and **Allowed origins** (CORS) — optional.
+    - **Client ID** and **Client secret** are pre-filled with generated values.
+4. **Copy the client secret before saving.** It is hashed on save and cannot be retrieved afterwards.
+   The edit form does not show it, so there is no way to look it up or rotate it later — if it is
+   lost, delete the application and register a new one.
+
+Grant type, algorithm (RS256) and client type (confidential) are fixed and not editable.
+
+## What a token is scoped to
+
+This is the part most easily misread. The *application* is global; a *token* is not.
+
+Each access token is scoped to exactly one team — the one selected when it was authorized — and that
+scoping is carried through the whole chain: the authorization code, the access token, and every
+refresh of it. An API request made with the token sees only that team's data.
+
+So one global application serves every team, but a client that needs a second team's data must send
+the user through the authorization flow again and have them pick that team. There is no token that
+spans teams.
+
+Team membership is checked at authorization time, and again when the consent form is submitted. A
+user can never scope a token to a team they do not belong to.
+
+## Preselecting the team
+
+Add a `team` query parameter to the authorize URL to preselect the team and hide the picker:
+
+```text
+/o/authorize/?client_id=<client-id>&response_type=code&team=<team-slug>&scope=...
+```
+
+This is the right thing to do when the client already knows which team the user is acting in — it
+removes a decision the user cannot get right without context. If the user is not a member of the
+named team, the parameter is ignored and the picker is shown as usual.
+
+## Related settings
+
+Global applications use the same provider configuration as every other OAuth application:
+
+- `OIDC_RSA_PRIVATE_KEY` must be set for token issuance to work at all.
+- `OAUTH_PKCE_REQUIRED` defaults to `True`.
+- Available scopes are listed under `OAUTH2_PROVIDER["SCOPES"]`; the `openid` and `profile` scopes
+  exist only when OIDC is enabled.
+
+See [Configuration](../hosting/configuration.md) for these, and
+[Rate Limiting](../hosting/rate_limiting.md) for the limits on `/o/token/`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -178,3 +178,4 @@ nav:
     - Overview: admin_guides/index.md
     - Banners System: admin_guides/banners.md
     - Feature Flags: admin_guides/feature_flags.md
+    - OAuth Applications: admin_guides/oauth_applications.md


### PR DESCRIPTION
### Product Description
No user-facing change. Documents an existing superuser feature: OAuth applications registered with no team, from Global Admin > OAuth Apps.

### Technical Description
Global applications have been supported since the team-scoping work, but the only documentation was code comments in `apps/oauth/`, and `CONTEXT.md` actively contradicted them — the glossary entry opened "A **Team-scoped** registration", which reads as ruling the team-less case out.

Two things worth checking as domain claims rather than prose:

- The guide leans hard on **application-is-global / token-never-is**, since that's the part most likely to be misread by anyone wiring up a client. `CONTEXT.md` gets a matching `_Avoid_` entry for "a global token".
- It states the client secret **cannot be rotated** — `RegisterApplicationForm` swaps the field for a `HiddenInput` once the app exists, and `ClientSecretField.pre_save` hashes it. Deliberately omitted: it *is* settable via `/django-admin/`, which I'd rather not document as a supported path.

`allowed_chatbots` isn't mentioned — client-credentials only, which global apps can't be.

Still absent, and out of scope: an ADR for the authorization-code-only decision and the `prompt=none` open-redirect guard in `_refuse_non_member`. Happy to follow up.

### Demo
N/A — docs only. `zensical build --clean` passes with no new warnings.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Internal developer/admin docs, already in this repo — nothing for the public changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
