### PR TITLE
Add missing OpenAPI schema updates

### DIFF
--- a/api-schemas/v1.yml
+++ b/api-schemas/v1.yml
@@ -1999,6 +1999,8 @@ components:
             participants:read: Read Participant Data
             participants:write: Update Participant Data
             usage:read: Read usage and activity data
+            openid: OpenID Connect scope
+            profile: User Profile
     apiKeyAuth:
       type: apiKey
       in: header

--- a/api-schemas/v2.yml
+++ b/api-schemas/v2.yml
@@ -2877,6 +2877,8 @@ components:
             participants:read: Read Participant Data
             participants:write: Update Participant Data
             usage:read: Read usage and activity data
+            openid: OpenID Connect scope
+            profile: User Profile
     apiKeyAuth:
       type: apiKey
       in: header


### PR DESCRIPTION
### Product Description
No user-facing behaviour change. This syncs the checked-in OpenAPI schema artifacts with the current API surface so the published API docs list the OAuth scopes that the server actually supports.

### Technical Description
Regenerated `api-schemas/v1.yml` and `api-schemas/v2.yml` via `uv run inv schema`. The only delta is the addition of the `openid` and `profile` OAuth2 scopes under the `oauth2` security scheme in both files — these were introduced with the OIDC support but the generated schemas were never regenerated.

Note: these two scopes are only merged into `OAUTH2_PROVIDER["SCOPES"]` when `OIDC_RSA_PRIVATE_KEY` is set (`config/settings.py`). That variable is present locally but not in the `update-generated-files` workflow, so as-is CI will regenerate the schemas without these lines and revert them. Follow-up needed before merge: either make the two scopes unconditional in `SCOPES`, or set `OIDC_RSA_PRIVATE_KEY` in the workflow's schema-generation step.

### Migrations
- [x] The migrations are backwards compatible

No migrations.

### Demo
N/A — generated artifact only.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

Changes to `api-schemas/**.yml` on `main` automatically dispatch to `dimagi/open-chat-studio-docs`.