### PR TITLE
widget: accept .xlsm attachments

### DIFF
--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.spec.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.spec.tsx
@@ -888,5 +888,9 @@ describe('ocs-chat', () => {
     it('keeps the supported image formats', () => {
       expect(extensions).toEqual(expect.arrayContaining(['.jpg', '.jpeg', '.png', '.gif', '.webp']));
     });
+
+    it('includes the spreadsheet formats', () => {
+      expect(extensions).toEqual(expect.arrayContaining(['.xls', '.xlsx', '.xlsm', '.csv', '.tsv']));
+    });
   });
 });

--- a/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
+++ b/components/chat_widget/src/components/ocs-chat/ocs-chat.tsx
@@ -63,6 +63,7 @@ export class OcsChat {
     '.docx',
     '.xls',
     '.xlsx',
+    '.xlsm',
     '.csv',
     '.jpg',
     '.jpeg',


### PR DESCRIPTION
Refs #4297

### Product Description
Macro-enabled Excel workbooks (`.xlsm`) can be attached in the chat widget.

### Technical Description
Adds `.xlsm` to the widget's `SUPPORTED_FILE_EXTENSIONS`. Text extraction already handles xlsm — markitdown receives raw bytes, so magic sniffing puts it in the xlsx family and openpyxl reads it natively.

This is the widget half of #4297; the server-side allowlist (`config/settings.py`) and the Django chat page `accept` attribute follow separately. Nothing ships until the widget is released and the npm dependency bumped.

### Migrations
- [x] The migrations are backwards compatible

### Demo
n/a

### Docs and Changelog
- [ ] This PR requires docs/changelog update