### PR TITLE
Bump the chat widget to 0.12.0

### DIFF
--- a/components/chat_widget/package.json
+++ b/components/chat_widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-chat-studio-widget",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Chat component for Open Chat Studio",
   "packageManager": "pnpm@10.30.1",
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
### Product Description
Bumps the chat widget package to 0.12.0 so it can be published to npm. No user-visible change on its own — nothing in the app points at 0.12.0 yet.

Widget changes since 0.11.0 (all already on main):
- `persistent-session="tab"` — session kept in `sessionStorage`, survives reload, cleared on tab close
- Kiosk mode offers a restart once a session has ended
- `auth-token-provider` supplies an OAuth bearer token at `chat/start/` for channels that require one
- Device time zone sent on session start
- `.xlsm` accepted as an attachment; `.bmp` and `.svg` dropped
- Widget build version exposed on the element
- Visitor ids from `crypto.randomUUID`
- Provider exception text no longer written to the persisted transcript

### Technical Description
One line: `components/chat_widget/package.json` 0.11.0 → 0.12.0.

**After merging, push the tag** — that is what publishes to npm (`.github/workflows/publish_widget.yml` triggers on `w_v*`):

    git tag w_v0.12.0 <merge-sha> && git push origin w_v0.12.0

The server-side release (`LATEST_VERSION`, the announcement migration) is deliberately split into a follow-up PR that merges only *after* 0.12.0 is live on npm. Merging them together would make `{% widget_script_url %}` emit a 404 unpkg URL and show an "update available" badge for a version nobody could install.

Follow-up: #4302

### Migrations
- [ ] The migrations are backwards compatible

### Demo
n/a

### Docs and Changelog
- [ ] This PR requires docs/changelog update
