### PR TITLE
Adopt chat widget 0.12.0

### DIFF
--- a/apps/channels/migrations/0034_notify_widget_version_release_0_12_0.py
+++ b/apps/channels/migrations/0034_notify_widget_version_release_0_12_0.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+
+from apps.data_migrations.utils.migrations import RunDataMigration
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bot_channels", "0033_experimentchannel_credential_mode_and_more"),
+        ("data_migrations", "0001_initial"),
+        ("teams", "0012_team_metadata"),
+    ]
+
+    operations = [
+        # Announce the 0.12.0 widget release to every team with an embedded-widget
+        # channel. force=True because the command's run-once slug is fixed; Django
+        # tracks this migration's single run. See docs/developer_guides/widget_versioning.md
+        RunDataMigration(
+            "notify_widget_version_release",
+            command_options={
+                "force": True,
+                "widget_version": "0.12.0",
+                "notes": (
+                    'New: persistent-session="tab" keeps a conversation across reloads but clears it '
+                    "when the tab closes. "
+                    "New: kiosk mode offers a restart once a session has ended. "
+                    "New: auth-token-provider supplies an OAuth bearer token for chatbots whose channel "
+                    "requires one. "
+                    "Changed: the device time zone is sent on session start, and .xlsm attachments are "
+                    "accepted while .bmp and .svg are not."
+                ),
+            },
+        ),
+    ]

--- a/apps/channels/migrations/0034_notify_widget_version_release_0_12_0.py
+++ b/apps/channels/migrations/0034_notify_widget_version_release_0_12_0.py
@@ -19,6 +19,7 @@ class Migration(migrations.Migration):
             command_options={
                 "force": True,
                 "widget_version": "0.12.0",
+                "changelog_url": "https://docs.openchatstudio.com/chat_widget/changelog/#v0120-2026-08-27",
                 "notes": (
                     'New: persistent-session="tab" keeps a conversation across reloads but clears it '
                     "when the tab closes. "

--- a/apps/channels/widget_versions.py
+++ b/apps/channels/widget_versions.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.utils.http import http_date
 from packaging.version import InvalidVersion, Version
 
-LATEST_VERSION = "0.11.0"
+LATEST_VERSION = "0.12.0"
 
 # Widgets older than 0.5.1 (Sept 2025) do not send the x-ocs-widget-version
 # header, so a missing/unparseable version is treated as older than everything.

--- a/docs/developer_guides/widget_versioning.md
+++ b/docs/developer_guides/widget_versioning.md
@@ -113,7 +113,11 @@ details dialog shows the current minimum required version and any pending upgrad
    changelog. The command slug is fixed; Django tracks each migration's single
    run, so `force=True` is required and nothing needs bumping. Preview with:
 
-        python manage.py notify_widget_version_release --dry-run --widget-version 0.10.0
+        python manage.py notify_widget_version_release --force --dry-run --widget-version 0.10.0
+
+   `--force` is needed alongside `--dry-run` because the fixed slug is already
+   marked applied from an earlier release, and the applied check runs before the
+   dry-run branch. `--dry-run` still writes nothing.
 
 ## Deprecating old versions
 
@@ -150,9 +154,10 @@ Keep the sunset date consistent across all three places — the `WidgetDeprecati
 entry, the changelog tag, and the `Sunset` header (which is derived from the
 entry automatically).
 
-To preview who would be notified before deploying, run the command manually:
+To preview who would be notified before deploying, run the command manually
+(`--force` for the same reason as above; `--dry-run` still writes nothing):
 
-        python manage.py notify_deprecated_widget_versions --dry-run
+        python manage.py notify_deprecated_widget_versions --force --dry-run
 
 To size up the impact before choosing a `below_version` and sunset date, see
 [which versions are actually in use](#auditing-which-versions-are-in-use).

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "js-cookie": "^3.0.8",
     "js-tiktoken": "^1.0.21",
     "lodash": "^4.17.23",
-    "open-chat-studio-widget": "^0.11.0",
+    "open-chat-studio-widget": "^0.12.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-error-boundary": "^6.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^4.17.23
         version: 4.18.1
       open-chat-studio-widget:
-        specifier: ^0.11.0
-        version: 0.11.0
+        specifier: ^0.12.0
+        version: 0.12.0
       react:
         specifier: ^19.2.3
         version: 19.2.8
@@ -1261,8 +1261,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@stencil/core@4.43.5':
-    resolution: {integrity: sha512-cgWD+GeuvJpTe1WQn40p02+BJ2j0j1YJ17GdkF2qKIQ23s2e3Zivq5yISXS3dcuV6oUJFN93jprdk+nk/sq99Q==}
+  '@stencil/core@4.44.1':
+    resolution: {integrity: sha512-OaFtMODcDcKswPbJC6An6xAcNmeuBggxyUTVKSX1UY7bPtWgIR5mGy1jZ6JkyFGgIxZCj/9wp2r97KBQow9wOQ==}
     engines: {node: '>=16.0.0', npm: '>=7.10.0'}
     hasBin: true
 
@@ -2570,9 +2570,9 @@ packages:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
 
-  marked@4.3.0:
-    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
-    engines: {node: '>= 12'}
+  marked@18.0.10:
+    resolution: {integrity: sha512-FJeH4bRpYoXiggcgriCGItKCSv3xkngJc4QCZ/rkQCogU3VYaLxYJoZl8Nw/b4+x7iij/pd+09mZ6A1dXzpL0A==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -2693,10 +2693,6 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
-  npmrc@1.1.1:
-    resolution: {integrity: sha512-uBbR8YNnIvKhMCDyz27Ffvnm2bLntMesFcwiz6Yp0DYSQB+JqgM1MocewFwMlItKCex+1ytii/+vmLhigO1qhg==}
-    hasBin: true
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2708,8 +2704,8 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  open-chat-studio-widget@0.11.0:
-    resolution: {integrity: sha512-eifYu/Hyinup5Zk0oSn2x+Fx4/ZWvICDKtyQH3aLKe1lK4MVD8s2xd0M+I15TlsyfBuarvNeOxpEAgssmZM4zA==}
+  open-chat-studio-widget@0.12.0:
+    resolution: {integrity: sha512-9WzaR7pe0MsW0Nr4W91UufpAWMuVPmhFIMf3FyLWQpkB5SnXT0TxqNMF4CDxoCevme8Ol0+aVv5+9JzfQGa1Fw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -4700,7 +4696,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@stencil/core@4.43.5':
+  '@stencil/core@4.44.1':
     optionalDependencies:
       '@rollup/rollup-darwin-arm64': 4.44.0
       '@rollup/rollup-darwin-x64': 4.44.0
@@ -6015,7 +6011,7 @@ snapshots:
       pify: 4.0.1
       semver: 5.7.2
 
-  marked@4.3.0: {}
+  marked@18.0.10: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -6076,8 +6072,6 @@ snapshots:
   normalize-path@3.0.0:
     optional: true
 
-  npmrc@1.1.1: {}
-
   object-assign@4.1.1: {}
 
   obug@2.1.4: {}
@@ -6086,13 +6080,12 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  open-chat-studio-widget@0.11.0:
+  open-chat-studio-widget@0.12.0:
     dependencies:
-      '@stencil/core': 4.43.5
+      '@stencil/core': 4.44.1
       dompurify: 3.4.13
       js-cookie: 3.0.8
-      marked: 4.3.0
-      npmrc: 1.1.1
+      marked: 18.0.10
 
   optionator@0.9.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,10 @@
 # To take an urgent release inside the window, add it to minimumReleaseAgeExclude
 # (supports `pkg@version` and `@scope/*` patterns) rather than lowering the floor.
 minimumReleaseAge: 4320
+
+# First-party package: published from this repo by .github/workflows/publish_widget.yml
+# via npm OIDC trusted publishing. The cooldown guards against third-party registry
+# compromise, which does not apply here, and would otherwise stall adoption of our own
+# widget releases for three days.
+minimumReleaseAgeExclude:
+  - open-chat-studio-widget


### PR DESCRIPTION
### Product Description
Adopts chat widget 0.12.0 across the app: the embed snippet (`{% widget_script_url %}`) starts handing out 0.12.0, channels still on 0.11.0 get an "update available" badge, and every team with an embedded-widget channel gets an in-app release notification on deploy.

Release notes sent to teams:
- `persistent-session="tab"` — session kept in `sessionStorage`, survives reload, cleared on tab close
- Kiosk mode offers a restart once a session has ended
- `auth-token-provider` supplies an OAuth bearer token for channels that require one
- Device time zone sent on session start; `.xlsm` accepted, `.bmp`/`.svg` dropped

### Technical Description
- Root `package.json` `open-chat-studio-widget` ^0.11.0 → ^0.12.0, so OCS's own pages
  (support widget, web chat, share page — bundled via `assets/javascript/site.js`) run 0.12.0.
- `pnpm-workspace.yaml`: added `minimumReleaseAgeExclude: [open-chat-studio-widget]`. The 3-day
  `minimumReleaseAge` cooldown otherwise blocks our own release for three days. The widget is
  first-party, published from this repo by `publish_widget.yml` over npm OIDC trusted publishing,
  so the cooldown's threat model (third-party registry compromise) does not apply. Using the
  documented exclude rather than lowering the floor, as the file's comment directs.
- `LATEST_VERSION` in `apps/channels/widget_versions.py` 0.11.0 → 0.12.0. This was bumped in #4279 and then deliberately reverted by `f18bd5995` ("Leave LATEST_VERSION at 0.11.0 until the widget is published") — this is that deferred half.
- `0034_notify_widget_version_release_0_12_0` announces the release.
- Drive-by docs fix: the preview commands in `widget_versioning.md` needed `--force`. The already-applied check in `IdempotentCommand.handle` (`apps/data_migrations/management/commands/base.py:125`) returns before the dry-run branch, and the slug is fixed, so `--dry-run` alone has been a silent no-op since 0.10.0.

### Release gate — satisfied

`open-chat-studio-widget@0.12.0` is live on npm, so this is safe to merge:

- #4301 merged as `6dd38ee9e`
- `w_v0.12.0` tagged on that commit; published to npm 2026-08-27T12:49:38Z (`latest = 0.12.0`)
- https://unpkg.com/open-chat-studio-widget@0.12.0/dist/open-chat-studio-widget/open-chat-studio-widget.esm.js → HTTP 200
- Changelog anchor `#v0120-2026-08-27` is live, so the notification deep-links correctly
- `pnpm install --frozen-lockfile` clean; webpack build compiles against 0.12.0

### Migrations
- [x] The migrations are backwards compatible

### Demo
n/a

### Docs and Changelog
- [x] This PR requires docs/changelog update
