### PR TITLE
Expose participant_data and session_state to evaluators

### DIFF
--- a/apps/evaluations/const.py
+++ b/apps/evaluations/const.py
@@ -1,4 +1,6 @@
+import re
 from datetime import timedelta
+from string import Formatter
 
 PREVIEW_SAMPLE_SIZE = 10
 
@@ -57,3 +59,16 @@ def evaluator_prompt_variable_hints(evaluation_mode: str) -> list[str]:
     """Display forms for `evaluation_mode`, e.g. ``{context.[key]}``, for the form's help text."""
     variables = EVALUATOR_PROMPT_VARIABLES.get(evaluation_mode, EVALUATOR_PROMPT_VARIABLES["message"])
     return [f"{{{name}.[key]}}" if dotted else f"{{{name}}}" for name, dotted in variables]
+
+
+def prompt_variable_roots(prompt: str) -> set[str]:
+    """Root names of the format fields in `prompt`, e.g. ``{context[key]}`` -> ``context``.
+
+    Escaped literal braces yield no field. A malformed template yields nothing, so callers
+    surface it as a missing variable rather than an unhandled ``ValueError``.
+    """
+    try:
+        fields = [field for _, field, _, _ in Formatter().parse(prompt) if field]
+    except ValueError:
+        return set()
+    return {re.split(r"[.\[]", field, maxsplit=1)[0] for field in fields}

--- a/apps/evaluations/const.py
+++ b/apps/evaluations/const.py
@@ -16,3 +16,44 @@ EVALUATION_RUN_FIXED_HEADERS = [
     "Dataset Output",
     "Generated Response",
 ]
+
+
+# Variables an evaluator can interpolate, and the single source of truth for the prompt field
+# description, the validator, and the form's autocomplete and hints. Add one here and in the
+# corresponding evaluator's ``run()`` -- nowhere else. ``dotted`` marks a dict, useful only with
+# a trailing key. Keyed by ``EvaluationMode`` value, since ``models`` imports this module.
+EVALUATOR_PROMPT_VARIABLES = {
+    "message": [
+        ("input.content", False),
+        ("output.content", False),
+        ("context", True),
+        ("participant_data", True),
+        ("session_state", True),
+        ("full_history", False),
+        ("generated_response", False),
+    ],
+    "session": [
+        ("context", True),
+        ("participant_data", True),
+        ("session_state", True),
+        ("full_history", False),
+    ],
+}
+
+# Roots only (``input``, not ``input.content``), so the validator keeps accepting unadvertised
+# sub-keys like ``{input.role}``. Params carry no evaluation mode, so it cannot be mode-aware.
+ALL_EVALUATOR_PROMPT_VARIABLE_ROOTS = {
+    name.split(".")[0] for variables in EVALUATOR_PROMPT_VARIABLES.values() for name, _ in variables
+}
+
+
+def evaluator_prompt_variable_names(evaluation_mode: str) -> list[str]:
+    """Autocomplete entries for `evaluation_mode`, falling back to message mode."""
+    variables = EVALUATOR_PROMPT_VARIABLES.get(evaluation_mode, EVALUATOR_PROMPT_VARIABLES["message"])
+    return [name for name, _ in variables]
+
+
+def evaluator_prompt_variable_hints(evaluation_mode: str) -> list[str]:
+    """Display forms for `evaluation_mode`, e.g. ``{context.[key]}``, for the form's help text."""
+    variables = EVALUATOR_PROMPT_VARIABLES.get(evaluation_mode, EVALUATOR_PROMPT_VARIABLES["message"])
+    return [f"{{{name}.[key]}}" if dotted else f"{{{name}}}" for name, dotted in variables]

--- a/apps/evaluations/evaluators.py
+++ b/apps/evaluations/evaluators.py
@@ -6,6 +6,7 @@ from pydantic_core import ValidationError
 from apps.evaluations.const import (
     ALL_EVALUATOR_PROMPT_VARIABLE_ROOTS,
     evaluator_prompt_variable_hints,
+    prompt_variable_roots,
 )
 from apps.evaluations.exceptions import EvaluationRunException
 from apps.evaluations.field_definitions import FieldDefinition
@@ -97,8 +98,8 @@ class LlmEvaluator(LLMResponseMixin, BaseEvaluator):
     @field_validator("prompt")
     @classmethod
     def prompt_must_contain_variable(cls, v: str) -> str:
-        # Not exhaustive: an unknown variable still surfaces as an error result at run time.
-        if not any(f"{{{name}" in v for name in ALL_EVALUATOR_PROMPT_VARIABLE_ROOTS):
+        # Roots only: an unknown sub-key still surfaces as an error result at run time.
+        if not prompt_variable_roots(v) & ALL_EVALUATOR_PROMPT_VARIABLE_ROOTS:
             raise ValueError(
                 "The prompt must include at least one variable so the evaluator has context to work with. "
                 f"Available variables: {', '.join(evaluator_prompt_variable_hints('message'))}"

--- a/apps/evaluations/evaluators.py
+++ b/apps/evaluations/evaluators.py
@@ -3,6 +3,10 @@ from pydantic import BaseModel, Field, field_validator
 from pydantic.config import ConfigDict
 from pydantic_core import ValidationError
 
+from apps.evaluations.const import (
+    ALL_EVALUATOR_PROMPT_VARIABLE_ROOTS,
+    evaluator_prompt_variable_hints,
+)
 from apps.evaluations.exceptions import EvaluationRunException
 from apps.evaluations.field_definitions import FieldDefinition
 from apps.evaluations.models import EvaluationMessage, EvaluationMessageContent
@@ -84,9 +88,8 @@ class LlmEvaluator(LLMResponseMixin, BaseEvaluator):
 
     prompt: str = Field(
         description=(
-            "The prompt template to use for evaluation. "
-            "Available variables: {input.content}, {output.content}, {context.[context_parameter]}, {full_history} "
-            "{generated_response}"
+            "The prompt template to use for evaluation. Available variables: "
+            f"{', '.join(evaluator_prompt_variable_hints('message'))}"
         ),
         json_schema_extra=UiSchema(widget=Widgets.text_editor),
     )
@@ -94,12 +97,11 @@ class LlmEvaluator(LLMResponseMixin, BaseEvaluator):
     @field_validator("prompt")
     @classmethod
     def prompt_must_contain_variable(cls, v: str) -> str:
-        required_prefixes = ["{input", "{output", "{context.", "{full_history}", "{generated_response}"]
-        if not any(prefix in v for prefix in required_prefixes):
+        # Not exhaustive: an unknown variable still surfaces as an error result at run time.
+        if not any(f"{{{name}" in v for name in ALL_EVALUATOR_PROMPT_VARIABLE_ROOTS):
             raise ValueError(
                 "The prompt must include at least one variable so the evaluator has context to work with. "
-                "Available variables: {input.content}, {output.content}, {context.[name]}, {full_history}, "
-                "{generated_response}"
+                f"Available variables: {', '.join(evaluator_prompt_variable_hints('message'))}"
             )
         return v
 
@@ -138,6 +140,8 @@ class LlmEvaluator(LLMResponseMixin, BaseEvaluator):
             input=SafeAccessWrapper(input),
             output=SafeAccessWrapper(output),
             context=SafeAccessWrapper(message.context),
+            participant_data=SafeAccessWrapper(message.participant_data or {}),
+            session_state=SafeAccessWrapper(message.session_state or {}),
             full_history=message.full_history,
             generated_response=generated_response,
         )
@@ -158,6 +162,8 @@ def main(input: dict, output: dict, context: dict, full_history: str, generated_
         context: Additional context of the message (e.g., {'current_datetime': '2025-06-02T18:51:55.334974+00:00'})
         full_history: Complete conversation history as a string (e.g., "user: hello!\nassistant: hello!\n")
         generated_response: The AI-generated response being evaluated, if enabled
+        **kwargs: Carries participant_data and session_state, both dicts captured at the time
+              of the message (e.g., kwargs['session_state'].get('current_step'))
 
     Returns:
         dict: Evaluation results where keys become columns in the output
@@ -214,6 +220,10 @@ class PythonEvaluator(BaseEvaluator, RestrictedPythonExecutionMixin):
                 context=message.context,
                 full_history=message.full_history,
                 generated_response=generated_response,
+                # Via **kwargs: _validate_function_signature demands an exact positional match,
+                # so widening _get_function_args would invalidate every saved evaluator.
+                participant_data=message.participant_data or {},
+                session_state=message.session_state or {},
             )
             if not isinstance(result, dict):
                 raise EvaluationRunException("The python function did not return a dictionary")

--- a/apps/evaluations/tests/test_evaluator_views.py
+++ b/apps/evaluations/tests/test_evaluator_views.py
@@ -12,7 +12,11 @@ from apps.evaluations.models import ConditionType
 from apps.evaluations.views.evaluator_views import _get_evaluator_schema
 from apps.service_providers.llm_service.default_models import get_default_model
 from apps.service_providers.models import LlmProviderModel, LlmProviderTypes
-from apps.utils.factories.evaluations import EvaluatorFactory, EvaluatorTagRuleFactory
+from apps.utils.factories.evaluations import (
+    EvaluationMessageFactory,
+    EvaluatorFactory,
+    EvaluatorTagRuleFactory,
+)
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 from apps.utils.factories.team import TeamWithUsersFactory
 
@@ -323,3 +327,52 @@ class TestEvaluatorLlmProviderSelection:
         evaluator.refresh_from_db()
         assert evaluator.llm_provider_id is None
         assert evaluator.llm_provider_model_id is None
+
+
+class TestPromptVariables:
+    """The form's autocomplete and help text are derived from the evaluators' actual kwargs."""
+
+    def test_both_modes_are_shipped_to_the_form(self, client_with_user, team):
+        response = client_with_user.get(reverse("evaluations:evaluator_new", args=[team.slug]))
+
+        by_mode = response.context_data["prompt_variables_by_mode"]
+        assert set(by_mode) == {"message", "session"}
+
+    @pytest.mark.parametrize("mode", ["message", "session"])
+    def test_participant_data_and_session_state_are_offered(self, client_with_user, team, mode):
+        """Both are captured on every message, so neither mode should hide them."""
+        response = client_with_user.get(reverse("evaluations:evaluator_new", args=[team.slug]))
+
+        variables = response.context_data["prompt_variables_by_mode"][mode]
+        assert {"participant_data", "session_state"} <= set(variables["autocomplete"])
+        assert "{session_state.[key]}" in variables["hints"]
+
+    def test_session_mode_omits_the_per_message_variables(self, client_with_user, team):
+        """A session-mode dataset holds a whole conversation, not one input/output pair."""
+        response = client_with_user.get(reverse("evaluations:evaluator_new", args=[team.slug]))
+
+        session_vars = response.context_data["prompt_variables_by_mode"]["session"]["autocomplete"]
+        assert not {"input.content", "output.content", "generated_response"} & set(session_vars)
+
+    def test_every_offered_variable_is_actually_interpolated(self, client_with_user, team):
+        """A variable the form offers but run() omits raises KeyError, which evaluate_message
+        buries in a per-message error result -- nothing else would catch the drift."""
+        response = client_with_user.get(reverse("evaluations:evaluator_new", args=[team.slug]))
+        by_mode = response.context_data["prompt_variables_by_mode"]
+        offered = {name for mode in by_mode for name in by_mode[mode]["autocomplete"]}
+
+        message = EvaluationMessageFactory.create()
+        evaluator = evaluators.LlmEvaluator.model_construct(
+            prompt=" ".join(f"{{{name}}}" for name in sorted(offered)),
+            output_schema={},
+        )
+        with patch.object(evaluators.LlmEvaluator, "get_chat_model") as get_chat_model:
+            get_chat_model.return_value.with_structured_output.return_value.with_retry.return_value.invoke.return_value = (  # noqa: E501
+                _StubResult()
+            )
+            evaluator.run(message, "a response")  # no KeyError => every offered variable is supplied
+
+
+class _StubResult:
+    def model_dump(self):
+        return {}

--- a/apps/evaluations/tests/test_llm_evaluator.py
+++ b/apps/evaluations/tests/test_llm_evaluator.py
@@ -30,6 +30,16 @@ _VALID_PROMPTS = [
     # Unadvertised sub-keys stay valid: the validator matches on the root.
     "Role: {input.role}",
     "Role: {output.role}",
+    "Bracket access: {context[my param]}",
+]
+
+_INVALID_PROMPTS = [
+    pytest.param("Evaluate this conversation please.", id="no-variables"),
+    # A root that merely starts with an advertised one is not one.
+    pytest.param("Evaluate {contextual.value}", id="prefix-of-a-root"),
+    # Escaped literal braces are text, not a variable.
+    pytest.param("Evaluate {{context.my_param}}", id="escaped-braces"),
+    pytest.param("Evaluate {context.my_param", id="malformed-template"),
 ]
 
 _OUTPUT_SCHEMA = {"result": {"type": "string", "description": "result"}}
@@ -46,12 +56,13 @@ def test_llm_evaluator_prompt_valid_variables(prompt):
     assert evaluator.prompt == prompt
 
 
-def test_llm_evaluator_prompt_no_variables_raises():
+@pytest.mark.parametrize("prompt", _INVALID_PROMPTS)
+def test_llm_evaluator_prompt_no_variables_raises(prompt):
     with pytest.raises(ValidationError) as exc_info:
         LlmEvaluator(
             llm_provider_id=1,
             llm_provider_model_id=1,
-            prompt="Evaluate this conversation please.",
+            prompt=prompt,
             output_schema=_OUTPUT_SCHEMA,
         )
     error_message = str(exc_info.value)

--- a/apps/evaluations/tests/test_llm_evaluator.py
+++ b/apps/evaluations/tests/test_llm_evaluator.py
@@ -23,8 +23,13 @@ _VALID_PROMPTS = [
     "Evaluate this: {input.content}",
     "Check the output: {output.content}",
     "Context value: {context.my_param}",
+    "Participant: {participant_data.name}",
+    "State: {session_state.current_step}",
     "Full history: {full_history}",
     "Generated: {generated_response}",
+    # Unadvertised sub-keys stay valid: the validator matches on the root.
+    "Role: {input.role}",
+    "Role: {output.role}",
 ]
 
 _OUTPUT_SCHEMA = {"result": {"type": "string", "description": "result"}}
@@ -350,3 +355,46 @@ def test_evaluators_return_typed_pydantic_model(get_llm_service):
     # Should raise validation error for invalid enum value
     with pytest.raises(ValueError, match="invalid_choice"):
         invalid_structured_llm.invoke("test prompt")
+
+
+@pytest.mark.django_db()
+@mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
+def test_evaluator_interpolates_participant_data_and_session_state(get_llm_service, llm_provider, llm_provider_model):
+    """Both are captured on the message, so the prompt can read them."""
+    response = AIMessage(
+        content="",
+        tool_calls=[{"name": "DynamicModel", "args": {"evaluation": "ok"}, "id": "call_1"}],
+    )
+    service = build_fake_llm_service(responses=[response])
+    get_llm_service.return_value = service
+
+    evaluation_message = EvaluationMessageFactory.create(
+        input={"content": "Am I on track?", "role": "human"},
+        output={"content": "Yes", "role": "ai"},
+        participant_data={"name": "Ada"},
+        session_state={"current_step": "onboarding", "missing": None},
+        create_chat_messages=True,
+    )
+
+    llm_evaluator = LlmEvaluator(
+        llm_provider_id=llm_provider.id,
+        llm_provider_model_id=llm_provider_model.id,
+        prompt=(
+            "Participant {participant_data.name} is at step {session_state.current_step}. "
+            "Absent: [{session_state.not_a_key}]"
+        ),
+        output_schema={"evaluation": {"type": "string", "description": "the evaluation result"}},
+    )
+    evaluator = EvaluatorFactory.create(params=llm_evaluator.model_dump(), type="LlmEvaluator")
+    dataset = EvaluationDatasetFactory.create(messages=[evaluation_message])
+    evaluation_config = cast(EvaluationConfig, EvaluationConfigFactory.create(evaluators=[evaluator], dataset=dataset))
+    evaluation_run = EvaluationRun.objects.create(team=evaluation_config.team, config=evaluation_config)
+
+    evaluate_message(evaluation_run.id, [evaluator.id], evaluation_message.id)
+
+    result = evaluation_run.results.get()
+    assert "error" not in result.output, result.output
+    prompt_sent = service.llm.get_call_messages()[0]
+    assert "Participant Ada is at step onboarding." in str(prompt_sent)
+    # An unknown key resolves to "" rather than raising, as for {context.*}
+    assert "Absent: []" in str(prompt_sent)

--- a/apps/evaluations/tests/test_python_evaluator.py
+++ b/apps/evaluations/tests/test_python_evaluator.py
@@ -144,3 +144,21 @@ def test_python_evaluator_with_missing_output():
 
     evaluator_output = evaluator.run(message, "")
     assert evaluator_output.result == {"has_output": False, "output_value": "NO OUTPUT"}
+
+
+@pytest.mark.django_db()
+def test_python_evaluator_receives_participant_data_and_session_state():
+    """These reach main() through **kwargs, so the existing signature stays valid."""
+    code = textwrap.dedent("""
+        def main(input, output, context, full_history, generated_response, **kwargs):
+            return {
+                "name": kwargs["participant_data"]["name"],
+                "step": kwargs["session_state"]["current_step"],
+            }
+        """)
+    evaluator = PythonEvaluator(code=code)
+    message = EvaluationMessageFactory.create(
+        participant_data={"name": "Ada"},
+        session_state={"current_step": "onboarding"},
+    )
+    assert evaluator.run(message, "").result == {"name": "Ada", "step": "onboarding"}

--- a/apps/evaluations/views/evaluator_views.py
+++ b/apps/evaluations/views/evaluator_views.py
@@ -12,6 +12,11 @@ from django_tables2 import SingleTableView
 
 from apps.annotations.models import Tag
 from apps.evaluations import evaluators
+from apps.evaluations.const import (
+    EVALUATOR_PROMPT_VARIABLES,
+    evaluator_prompt_variable_hints,
+    evaluator_prompt_variable_names,
+)
 from apps.evaluations.exceptions import InFlightRunsError
 from apps.evaluations.forms import EvaluatorForm, EvaluatorTagRuleFormSet
 from apps.evaluations.models import Evaluator
@@ -118,6 +123,14 @@ class EvaluatorFormsetMixin:
             "evaluator_schemas": _evaluator_schemas(),
             "parameter_values": _evaluator_parameter_values(self.request.team, llm_providers, llm_provider_models),
             "llm_provider_selection": _initial_llm_provider_selection(form, self.request.team),
+            # Both modes up front: the form switches between them client-side.
+            "prompt_variables_by_mode": {
+                mode: {
+                    "autocomplete": evaluator_prompt_variable_names(mode),
+                    "hints": evaluator_prompt_variable_hints(mode),
+                }
+                for mode in EVALUATOR_PROMPT_VARIABLES
+            },
         }
 
 

--- a/templates/evaluations/evaluator_form.html
+++ b/templates/evaluations/evaluator_form.html
@@ -144,17 +144,12 @@
             <!-- Mode-specific variable hints -->
             <template x-if="getWidget(field) === 'text_editor_widget'">
                 <div class="mt-1">
-                    <template x-if="evaluationMode === 'session'">
-                        <p class="text-sm text-gray-500">
-                            {% translate "Available variables:" %} <code>{full_history}</code>, <code>{context.[param]}</code>
-                        </p>
-                    </template>
-                    <template x-if="evaluationMode !== 'session'">
-                        <p class="text-sm text-gray-500">
-                            {% translate "Available variables:" %} <code>{input.content}</code>, <code>{output.content}</code>,
-                            <code>{context.[param]}</code>, <code>{full_history}</code>, <code>{generated_response}</code>
-                        </p>
-                    </template>
+                    <p class="text-sm text-gray-500">
+                        {% translate "Available variables:" %}
+                        <template x-for="(hint, i) in promptVariableHints" :key="hint">
+                            <span><template x-if="i > 0"><span>, </span></template><code x-text="hint"></code></span>
+                        </template>
+                    </p>
                 </div>
             </template>
 
@@ -546,12 +541,14 @@
           onload="SiteJS.tagRuleSelect.bootstrapTagRuleSelects();"></script>
   {{ evaluator_schemas|json_script:"evaluator-schemas" }}
   {{ parameter_values|json_script:"parameter-values" }}
+  {{ prompt_variables_by_mode|json_script:"prompt-variables-by-mode" }}
   {% if object.params %}{{ object.params|json_script:"existing-params" }}{% elif form.params.value %}{{ form.params.value|json_script:"existing-params" }}{% endif %}
   <script>
     document.addEventListener('alpine:init', () => {
       Alpine.data('evaluatorForm', () => ({
         evaluatorSchemas: JSON.parse(document.getElementById("evaluator-schemas").textContent),
         parameterValues: JSON.parse(document.getElementById("parameter-values").textContent),
+        promptVariablesByMode: JSON.parse(document.getElementById("prompt-variables-by-mode").textContent),
         selectedType: '{% if object.type %}{{ object.type|escapejs }}{% else %}{{ form.type.value|default:"" }}{% endif %}',
         evaluationMode: '{{ form.evaluation_mode.value|default:"message" }}',
         llmProviderId: '{{ llm_provider_selection.llm_provider_id|default_if_none:""|escapejs }}',
@@ -568,6 +565,9 @@
           evalModeRadios.forEach(radio => {
               radio.addEventListener('change', (e) => {
                   this.evaluationMode = e.target.value;
+                  // data-autocomplete-vars is read once at construction, so the editor must be
+                  // rebuilt to pick up the new mode. Content survives via the hidden textarea.
+                  this.$nextTick(() => this.rebuildPromptEditors());
               });
           });
 
@@ -640,6 +640,12 @@
               }
             });
           }
+        },
+
+        rebuildPromptEditors() {
+          const create = window.SiteJS?.editors?.createPromptEditor;
+          if (!create) return;
+          document.querySelectorAll('.prompt-editor').forEach(el => create(el));
         },
 
         getWidget(field) {
@@ -842,10 +848,16 @@
           }
         },
 
+        get promptVariables() {
+          return this.promptVariablesByMode[this.evaluationMode] || this.promptVariablesByMode.message;
+        },
+
         get autocompleteVars() {
-          return this.evaluationMode === 'session'
-            ? JSON.stringify(['full_history', 'context'])
-            : JSON.stringify(['input.content', 'output.content', 'context', 'full_history', 'generated_response']);
+          return JSON.stringify(this.promptVariables.autocomplete);
+        },
+
+        get promptVariableHints() {
+          return this.promptVariables.hints;
         },
 
         get paramsJson() {


### PR DESCRIPTION
### Product Description
Evaluator prompts can now read `{participant_data.*}` and `{session_state.*}`, and Python evaluators receive both via `**kwargs`.

### Technical Description
Both fields have been on `EvaluationMessage` for a while — populated from sessions, settable through CSV column mapping, rendered as dataset table columns, stored in results — but neither `LlmEvaluator.run` nor `PythonEvaluator.run` ever passed them in. A prompt referencing `{session_state.foo}` raised `KeyError` inside `.format()`, which `tasks._run_evaluator_on_message` catches and writes as a per-message error result, so the run "completed" with an error string in every row instead of failing at save time.

Two things worth a look:

- **`PythonEvaluator` gets the new values through the mandatory `**kwargs`, not new positional args.** `_validate_function_signature` requires an exact positional match against `_get_function_args`, so widening it would invalidate every saved Python evaluator. Existing code keeps working untouched.
- **The prompt validator matches on the variable *root* (`{input`), not the full name (`{input.content`).**

The variable list was previously hardcoded in five places (field description, validator, format call, autocomplete list, mode hints) and is now derived from `EVALUATOR_PROMPT_VARIABLES` in `const.py`. `test_every_offered_variable_is_actually_interpolated` fails if the form offers something `run()` doesn't supply.

Also fixes a pre-existing bug found while verifying: `PromptEditor` reads `data-autocomplete-vars` once at CodeMirror construction, so switching evaluation mode left the editor completing the old mode's variables while the visible hints updated correctly. The mode listener now rebuilds the editor.

### Demo

**Message Mode**
<img width="1216" height="405" alt="Screenshot from 2026-08-28 15-48-19" src="https://github.com/user-attachments/assets/590abfc3-a6f4-4c7a-819c-06d34ed5d4b3" />

**Session Mode**
<img width="1209" height="55" alt="image" src="https://github.com/user-attachments/assets/1925adad-3bc1-436a-9915-bc73f1580f19" />


### Docs and Changelog
- [x] This PR requires docs/changelog update

New evaluator prompt variables: `{participant_data.[key]}` and `{session_state.[key]}`, available in both message and session mode. Python evaluators read them from `kwargs`.

