### PR TITLE
Add connection test for LLM providers

### DIFF
--- a/apps/service_providers/exceptions.py
+++ b/apps/service_providers/exceptions.py
@@ -18,3 +18,11 @@ class NoTestableModelError(Exception):
     """Raised when a provider has no configured model to test a connection with."""
 
     pass
+
+
+class ConnectionTestNotSupportedError(Exception):
+    """Raised when a provider type doesn't support the connection test at all (e.g. Voyage
+    AI, which is embeddings-only). Deliberately distinct from ServiceProviderConfigError,
+    which represents an invalid configuration for a type that does support the test."""
+
+    pass

--- a/apps/service_providers/exceptions.py
+++ b/apps/service_providers/exceptions.py
@@ -12,3 +12,9 @@ class MessageMediaError(Exception):
     """Raised when fetching, resolving, or interpreting inbound message media fails."""
 
     pass
+
+
+class NoTestableModelError(Exception):
+    """Raised when a provider has no configured model to test a connection with."""
+
+    pass

--- a/apps/service_providers/models.py
+++ b/apps/service_providers/models.py
@@ -26,7 +26,7 @@ from apps.teams.models import BaseTeamModel, Team
 from apps.utils.deletion import get_related_objects, has_related_objects
 
 from ..teams.utils import get_slug_for_team
-from .exceptions import NoTestableModelError, ServiceProviderConfigError
+from .exceptions import ConnectionTestNotSupportedError, NoTestableModelError, ServiceProviderConfigError
 
 if TYPE_CHECKING:
     from apps.service_providers import llm_service, messaging_service, speech_service, tracing
@@ -208,14 +208,15 @@ class LlmProvider(BaseTeamModel, ProviderMixin):
     def test_connection(self) -> None:
         """Send one minimal chat request to verify the provider's credentials work.
 
-        Raises `ServiceProviderConfigError` for provider types, like Voyage AI, that don't
-        support chat completions at all, and `NoTestableModelError` if the team has no model
-        configured to test with. Callers classify and report both.
+        Raises `ConnectionTestNotSupportedError` for provider types, like Voyage AI, that
+        don't support chat completions at all; `NoTestableModelError` if the team has no
+        model configured to test with; `ServiceProviderConfigError` if the saved config is
+        invalid for a type that does support the test. Callers classify and report all three.
         """
         from langchain_core.messages import HumanMessage  # noqa: PLC0415 - heavy lib, slow startup
 
         if self.type_enum == LlmProviderTypes.voyage:
-            raise ServiceProviderConfigError(self.type, "does not support chat completions")
+            raise ConnectionTestNotSupportedError(self.type)
 
         # A team-configured model wins over a global default, same priority as pricing-rule
         # resolution elsewhere in this app.
@@ -234,19 +235,22 @@ class LlmProvider(BaseTeamModel, ProviderMixin):
     def run_connection_test_hook(self) -> list[str]:
         """Automatically verify credentials after every save (create and update).
 
-        Runs inside a nested savepoint, mirroring VoiceProvider.run_post_save_hook, so a
-        failed API call can't abort the outer save transaction. Returns a list of user-facing
-        warning messages the caller should surface (e.g. via Django's messages framework);
-        empty on success. Two failure cases stay silent here specifically, since they're
-        expected setup state rather than actionable problems: no model configured yet, and a
-        provider type (Voyage AI) that doesn't support this test at all. The manual "Test
-        Connection" button still reports both explicitly.
+        The caller runs this after the save's own transaction has already committed (an
+        external LLM call can take several seconds; holding the save's DB connection open
+        for that long, or repeating the call if the save transaction were retried or rolled
+        back, would be worse than treating the save and the test as two separate steps).
+        Returns a list of user-facing warning messages the caller should surface (e.g. via
+        Django's messages framework); empty on success. Two failure cases stay silent here
+        specifically, since they're expected setup state rather than actionable problems: no
+        model configured yet, and a provider type (Voyage AI) that doesn't support this test
+        at all. A genuinely invalid configuration is not one of those two, and does produce a
+        warning. The manual "Test Connection" button reports all of these explicitly.
         """
         warnings: list[str] = []
         try:
-            with transaction.atomic(savepoint=True):
+            with transaction.atomic():
                 self.test_connection()
-        except (NoTestableModelError, ServiceProviderConfigError):
+        except (NoTestableModelError, ConnectionTestNotSupportedError):
             pass
         except Exception:
             log.exception("Automatic connection test failed for LLM provider %s", self.pk)

--- a/apps/service_providers/models.py
+++ b/apps/service_providers/models.py
@@ -231,6 +231,28 @@ class LlmProvider(BaseTeamModel, ProviderMixin):
         chat_model = self.get_llm_service().get_chat_model(model.name, timeout=CONNECTION_TEST_TIMEOUT_SECONDS)
         chat_model.invoke([HumanMessage(content="Hello")])
 
+    def run_connection_test_hook(self) -> list[str]:
+        """Automatically verify credentials after every save (create and update).
+
+        Runs inside a nested savepoint, mirroring VoiceProvider.run_post_save_hook, so a
+        failed API call can't abort the outer save transaction. Returns a list of user-facing
+        warning messages the caller should surface (e.g. via Django's messages framework);
+        empty on success. Two failure cases stay silent here specifically, since they're
+        expected setup state rather than actionable problems: no model configured yet, and a
+        provider type (Voyage AI) that doesn't support this test at all. The manual "Test
+        Connection" button still reports both explicitly.
+        """
+        warnings: list[str] = []
+        try:
+            with transaction.atomic(savepoint=True):
+                self.test_connection()
+        except (NoTestableModelError, ServiceProviderConfigError):
+            pass
+        except Exception:
+            log.exception("Automatic connection test failed for LLM provider %s", self.pk)
+            warnings.append("Provider saved, but the connection test failed. Use Test Connection below to retry.")
+        return warnings
+
 
 class LlmProviderModelManager(models.Manager):
     def get_or_create_for_team(self, team, name, type, max_token_limit=8192):

--- a/apps/service_providers/models.py
+++ b/apps/service_providers/models.py
@@ -26,7 +26,7 @@ from apps.teams.models import BaseTeamModel, Team
 from apps.utils.deletion import get_related_objects, has_related_objects
 
 from ..teams.utils import get_slug_for_team
-from .exceptions import ServiceProviderConfigError
+from .exceptions import NoTestableModelError, ServiceProviderConfigError
 
 if TYPE_CHECKING:
     from apps.service_providers import llm_service, messaging_service, speech_service, tracing
@@ -164,6 +164,9 @@ class LlmProviderTypes(LlmProviderType, Enum):
         return None
 
 
+CONNECTION_TEST_TIMEOUT_SECONDS = 10
+
+
 @audit_fields(*model_audit_fields.LLM_PROVIDER_FIELDS, audit_special_queryset_writes=True)
 class LlmProvider(BaseTeamModel, ProviderMixin):
     objects = LlmProviderObjectManagerObjectManager()
@@ -201,6 +204,32 @@ class LlmProvider(BaseTeamModel, ProviderMixin):
         If file_ids are provided, they will be linked to the index.
         """
         return self.get_llm_service().create_remote_index(name, file_ids)
+
+    def test_connection(self) -> None:
+        """Send one minimal chat request to verify the provider's credentials work.
+
+        Raises `ServiceProviderConfigError` for provider types, like Voyage AI, that don't
+        support chat completions at all, and `NoTestableModelError` if the team has no model
+        configured to test with. Callers classify and report both.
+        """
+        from langchain_core.messages import HumanMessage  # noqa: PLC0415 - heavy lib, slow startup
+
+        if self.type_enum == LlmProviderTypes.voyage:
+            raise ServiceProviderConfigError(self.type, "does not support chat completions")
+
+        # A team-configured model wins over a global default, same priority as pricing-rule
+        # resolution elsewhere in this app.
+        model = (
+            LlmProviderModel.objects.for_team(self.team)
+            .filter(type=self.type)
+            .order_by(models.F("team_id").desc(nulls_last=True))
+            .first()
+        )
+        if model is None:
+            raise NoTestableModelError(self.type)
+
+        chat_model = self.get_llm_service().get_chat_model(model.name, timeout=CONNECTION_TEST_TIMEOUT_SECONDS)
+        chat_model.invoke([HumanMessage(content="Hello")])
 
 
 class LlmProviderModelManager(models.Manager):

--- a/apps/service_providers/tests/test_models.py
+++ b/apps/service_providers/tests/test_models.py
@@ -181,3 +181,44 @@ def test_test_connection_raises_config_error_for_voyage_with_no_models():
 
     with pytest.raises(ServiceProviderConfigError):
         provider.test_connection()
+
+
+@pytest.mark.django_db()
+def test_run_connection_test_hook_success_returns_no_warnings():
+    """A successful automatic test stays silent, matching the rest of the save flow."""
+    provider = LlmProviderFactory()
+    with mock.patch.object(LlmProvider, "test_connection"):
+        warnings = provider.run_connection_test_hook()
+    assert warnings == []
+
+
+@pytest.mark.django_db()
+def test_run_connection_test_hook_returns_warning_on_failure():
+    """A real failure produces one warning pointing at the manual retry button, without
+    raising, so it can never abort the save it runs alongside."""
+    provider = LlmProviderFactory()
+    with mock.patch.object(LlmProvider, "test_connection", side_effect=RuntimeError("boom")):
+        warnings = provider.run_connection_test_hook()
+    assert len(warnings) == 1
+    assert "test connection" in warnings[0].lower()
+
+
+@pytest.mark.django_db()
+def test_run_connection_test_hook_silent_when_no_model_configured():
+    """No models configured yet is expected setup state right after creating a provider,
+    not a problem worth warning about on every save."""
+    provider = LlmProviderFactory()
+    with mock.patch.object(LlmProvider, "test_connection", side_effect=NoTestableModelError(provider.type)):
+        warnings = provider.run_connection_test_hook()
+    assert warnings == []
+
+
+@pytest.mark.django_db()
+def test_run_connection_test_hook_silent_for_unsupported_provider():
+    """Voyage AI's lack of chat support is inherent to the type, not an actionable problem."""
+    provider = LlmProviderFactory(type=str(LlmProviderTypes.voyage))
+    with mock.patch.object(
+        LlmProvider, "test_connection", side_effect=ServiceProviderConfigError(provider.type, "not supported")
+    ):
+        warnings = provider.run_connection_test_hook()
+    assert warnings == []

--- a/apps/service_providers/tests/test_models.py
+++ b/apps/service_providers/tests/test_models.py
@@ -1,8 +1,16 @@
+from unittest import mock
+
 import pytest
 from django.core.exceptions import ValidationError
 
 from apps.pipelines.tests.utils import content_flow_node
-from apps.service_providers.models import LlmProviderModel
+from apps.service_providers.exceptions import NoTestableModelError, ServiceProviderConfigError
+from apps.service_providers.models import (
+    CONNECTION_TEST_TIMEOUT_SECONDS,
+    LlmProvider,
+    LlmProviderModel,
+    LlmProviderTypes,
+)
 from apps.utils.factories.assistants import OpenAiAssistantFactory
 from apps.utils.factories.evaluations import EvaluatorFactory
 from apps.utils.factories.pipelines import PipelineFactory
@@ -100,3 +108,76 @@ class TestServiceProviderModel:
         # global provider models can be deleted
         global_llm_provider_model = LlmProviderModelFactory.create(team=None)
         global_llm_provider_model.delete()
+
+
+@pytest.mark.django_db()
+def test_test_connection_raises_when_no_model_configured():
+    """A provider with zero LlmProviderModel rows for its type has nothing to test against.
+
+    Deletes any migration-seeded global defaults for this type first: per this app's own
+    AGENTS.md, tests must not depend on how many global rows happen to exist.
+    """
+    provider = LlmProviderFactory()
+    LlmProviderModel.objects.filter(type=provider.type).delete()
+    with pytest.raises(NoTestableModelError):
+        provider.test_connection()
+
+
+@pytest.mark.django_db()
+def test_test_connection_invokes_chat_model_with_the_configured_model():
+    """The test call should use a model the provider already has configured, not a hardcoded one."""
+    provider = LlmProviderFactory()
+    LlmProviderModel.objects.filter(type=provider.type).delete()
+    provider_model = LlmProviderModelFactory(team=provider.team, type=provider.type, name="gpt-4o-mini")
+
+    mock_chat_model = mock.Mock()
+    mock_service = mock.Mock()
+    mock_service.get_chat_model.return_value = mock_chat_model
+
+    with mock.patch.object(LlmProvider, "get_llm_service", return_value=mock_service):
+        provider.test_connection()
+
+    mock_service.get_chat_model.assert_called_once_with(provider_model.name, timeout=CONNECTION_TEST_TIMEOUT_SECONDS)
+    mock_chat_model.invoke.assert_called_once()
+
+
+@pytest.mark.django_db()
+def test_test_connection_prefers_team_model_over_global_default():
+    """When both a global default and a team-scoped model exist for the type, use the team's own."""
+    provider = LlmProviderFactory()
+    LlmProviderModel.objects.filter(type=provider.type).delete()
+    LlmProviderModelFactory(team=None, type=provider.type, name="global-default")
+    team_model = LlmProviderModelFactory(team=provider.team, type=provider.type, name="team-custom")
+
+    mock_chat_model = mock.Mock()
+    mock_service = mock.Mock()
+    mock_service.get_chat_model.return_value = mock_chat_model
+
+    with mock.patch.object(LlmProvider, "get_llm_service", return_value=mock_service):
+        provider.test_connection()
+
+    mock_service.get_chat_model.assert_called_once_with(team_model.name, timeout=CONNECTION_TEST_TIMEOUT_SECONDS)
+
+
+@pytest.mark.django_db()
+def test_test_connection_raises_for_voyage_regardless_of_configured_models():
+    """Voyage AI can't do chat completions at all, so it should fail the same way whether or
+    not a model happens to be configured, not flip between error messages depending on that."""
+    provider = LlmProviderFactory(type=str(LlmProviderTypes.voyage))
+    LlmProviderModelFactory(team=provider.team, type=provider.type, name="voyage-3")
+
+    with pytest.raises(ServiceProviderConfigError):
+        provider.test_connection()
+
+
+@pytest.mark.django_db()
+def test_test_connection_raises_config_error_for_voyage_with_no_models():
+    """Voyage AI with zero configured models must still raise ServiceProviderConfigError, not
+    NoTestableModelError. The two failure cases could otherwise be conflated silently: without
+    the type-based short-circuit, hitting the model-lookup check first (which also finds
+    nothing for Voyage) would raise the wrong exception and show the wrong message."""
+    provider = LlmProviderFactory(type=str(LlmProviderTypes.voyage))
+    LlmProviderModel.objects.filter(type=provider.type).delete()
+
+    with pytest.raises(ServiceProviderConfigError):
+        provider.test_connection()

--- a/apps/service_providers/tests/test_models.py
+++ b/apps/service_providers/tests/test_models.py
@@ -4,7 +4,11 @@ import pytest
 from django.core.exceptions import ValidationError
 
 from apps.pipelines.tests.utils import content_flow_node
-from apps.service_providers.exceptions import NoTestableModelError, ServiceProviderConfigError
+from apps.service_providers.exceptions import (
+    ConnectionTestNotSupportedError,
+    NoTestableModelError,
+    ServiceProviderConfigError,
+)
 from apps.service_providers.models import (
     CONNECTION_TEST_TIMEOUT_SECONDS,
     LlmProvider,
@@ -166,20 +170,20 @@ def test_test_connection_raises_for_voyage_regardless_of_configured_models():
     provider = LlmProviderFactory(type=str(LlmProviderTypes.voyage))
     LlmProviderModelFactory(team=provider.team, type=provider.type, name="voyage-3")
 
-    with pytest.raises(ServiceProviderConfigError):
+    with pytest.raises(ConnectionTestNotSupportedError):
         provider.test_connection()
 
 
 @pytest.mark.django_db()
-def test_test_connection_raises_config_error_for_voyage_with_no_models():
-    """Voyage AI with zero configured models must still raise ServiceProviderConfigError, not
-    NoTestableModelError. The two failure cases could otherwise be conflated silently: without
-    the type-based short-circuit, hitting the model-lookup check first (which also finds
-    nothing for Voyage) would raise the wrong exception and show the wrong message."""
+def test_test_connection_raises_not_supported_for_voyage_with_no_models():
+    """Voyage AI with zero configured models must still raise ConnectionTestNotSupportedError,
+    not NoTestableModelError. The two failure cases could otherwise be conflated silently:
+    without the type-based short-circuit, hitting the model-lookup check first (which also
+    finds nothing for Voyage) would raise the wrong exception and show the wrong message."""
     provider = LlmProviderFactory(type=str(LlmProviderTypes.voyage))
     LlmProviderModel.objects.filter(type=provider.type).delete()
 
-    with pytest.raises(ServiceProviderConfigError):
+    with pytest.raises(ConnectionTestNotSupportedError):
         provider.test_connection()
 
 
@@ -217,8 +221,19 @@ def test_run_connection_test_hook_silent_when_no_model_configured():
 def test_run_connection_test_hook_silent_for_unsupported_provider():
     """Voyage AI's lack of chat support is inherent to the type, not an actionable problem."""
     provider = LlmProviderFactory(type=str(LlmProviderTypes.voyage))
-    with mock.patch.object(
-        LlmProvider, "test_connection", side_effect=ServiceProviderConfigError(provider.type, "not supported")
-    ):
+    with mock.patch.object(LlmProvider, "test_connection", side_effect=ConnectionTestNotSupportedError(provider.type)):
         warnings = provider.run_connection_test_hook()
     assert warnings == []
+
+
+@pytest.mark.django_db()
+def test_run_connection_test_hook_warns_on_invalid_configuration():
+    """A genuinely invalid configuration is not the same as an unsupported provider type or a
+    missing model: it's a real, actionable problem, and must produce a warning rather than
+    being silently swallowed alongside the two expected setup-state cases."""
+    provider = LlmProviderFactory()
+    with mock.patch.object(
+        LlmProvider, "test_connection", side_effect=ServiceProviderConfigError(provider.type, "bad config")
+    ):
+        warnings = provider.run_connection_test_hook()
+    assert len(warnings) == 1

--- a/apps/service_providers/tests/test_views.py
+++ b/apps/service_providers/tests/test_views.py
@@ -1,11 +1,15 @@
 from unittest import mock
 
 import pytest
+from django.contrib import messages as django_messages
+from django.contrib.messages import get_messages
 from django.urls import reverse
 
+from apps.service_providers.exceptions import NoTestableModelError, ServiceProviderConfigError
 from apps.service_providers.models import (
     AuthProvider,
     LlmProvider,
+    LlmProviderTypes,
     MessagingProvider,
     TraceProvider,
     VoiceProvider,
@@ -127,6 +131,97 @@ def test_sync_voices_endpoint(team_with_users, authed_client):
 
     assert response.status_code == 302
     mock_sync.assert_called_once()
+
+
+@pytest.mark.django_db()
+def test_test_llm_connection_endpoint_success(team_with_users, authed_client):
+    """POST to the test-connection endpoint should call test_connection on the provider and report success."""
+    provider = LlmProviderFactory(team=team_with_users)
+    url = reverse(
+        "service_providers:test_llm_connection",
+        kwargs={
+            "team_slug": team_with_users.slug,
+            "provider_type": "llm",
+            "pk": provider.pk,
+        },
+    )
+    with mock.patch.object(LlmProvider, "test_connection") as mock_test:
+        response = authed_client.post(url)
+
+    assert response.status_code == 302
+    mock_test.assert_called_once()
+
+
+def _test_connection_url(team, provider):
+    return reverse(
+        "service_providers:test_llm_connection",
+        kwargs={"team_slug": team.slug, "provider_type": "llm", "pk": provider.pk},
+    )
+
+
+class _FakeTransientError(Exception):
+    """Stands in for a provider SDK error carrying an HTTP status code, without needing
+    to construct a real openai/anthropic exception in the test."""
+
+    status_code = 429
+
+
+@pytest.mark.django_db()
+def test_test_llm_connection_endpoint_no_models_configured(team_with_users, authed_client):
+    """No LlmProviderModel for the provider's type should produce a warning, not a crash."""
+    provider = LlmProviderFactory(team=team_with_users)
+    url = _test_connection_url(team_with_users, provider)
+
+    with mock.patch.object(LlmProvider, "test_connection", side_effect=NoTestableModelError(provider.type)):
+        response = authed_client.post(url)
+
+    assert response.status_code == 302
+    [msg] = list(get_messages(response.wsgi_request))
+    assert msg.level == django_messages.WARNING
+
+
+@pytest.mark.django_db()
+def test_test_llm_connection_endpoint_unsupported_provider(team_with_users, authed_client):
+    """A provider type that can't do chat completions (e.g. Voyage AI) should say so, not error out."""
+    provider = LlmProviderFactory(team=team_with_users, type=str(LlmProviderTypes.voyage))
+    url = _test_connection_url(team_with_users, provider)
+
+    with mock.patch.object(
+        LlmProvider, "test_connection", side_effect=ServiceProviderConfigError(provider.type, "not supported")
+    ):
+        response = authed_client.post(url)
+
+    assert response.status_code == 302
+    [msg] = list(get_messages(response.wsgi_request))
+    assert msg.level == django_messages.INFO
+
+
+@pytest.mark.django_db()
+def test_test_llm_connection_endpoint_transient_failure(team_with_users, authed_client):
+    """A rate-limit/timeout style failure should be reported as temporary, not a credentials problem."""
+    provider = LlmProviderFactory(team=team_with_users)
+    url = _test_connection_url(team_with_users, provider)
+
+    with mock.patch.object(LlmProvider, "test_connection", side_effect=_FakeTransientError()):
+        response = authed_client.post(url)
+
+    assert response.status_code == 302
+    [msg] = list(get_messages(response.wsgi_request))
+    assert msg.level == django_messages.WARNING
+
+
+@pytest.mark.django_db()
+def test_test_llm_connection_endpoint_credential_failure(team_with_users, authed_client):
+    """A non-retryable failure (bad API key, etc.) should be reported as an error, not a warning."""
+    provider = LlmProviderFactory(team=team_with_users)
+    url = _test_connection_url(team_with_users, provider)
+
+    with mock.patch.object(LlmProvider, "test_connection", side_effect=ValueError("invalid api key")):
+        response = authed_client.post(url)
+
+    assert response.status_code == 302
+    [msg] = list(get_messages(response.wsgi_request))
+    assert msg.level == django_messages.ERROR
 
 
 @pytest.mark.django_db()

--- a/apps/service_providers/tests/test_views.py
+++ b/apps/service_providers/tests/test_views.py
@@ -225,6 +225,27 @@ def test_test_llm_connection_endpoint_credential_failure(team_with_users, authed
 
 
 @pytest.mark.django_db()
+def test_updating_llm_provider_runs_automatic_connection_test(team_with_users, authed_client):
+    """Saving an LlmProvider through the real edit view should trigger the automatic
+    post-save connection test and surface its warning on failure, without blocking the save."""
+    provider = LlmProviderFactory(team=team_with_users, name="Old Name")
+    url = reverse(
+        "service_providers:edit",
+        kwargs={"team_slug": team_with_users.slug, "provider_type": "llm", "pk": provider.pk},
+    )
+
+    with mock.patch.object(LlmProvider, "test_connection", side_effect=RuntimeError("boom")):
+        response = authed_client.post(url, data={"name": "New Name", "openai_api_key": "new-key"}, follow=True)
+
+    assert response.status_code == 200
+    messages_seen = [str(m) for m in response.context["messages"]]
+    assert any("connection test failed" in m.lower() for m in messages_seen)
+
+    provider.refresh_from_db()
+    assert provider.name == "New Name"
+
+
+@pytest.mark.django_db()
 def test_delete_llm_provider_referenced_by_pipeline_nullifies_node_fk(team_with_users, authed_client):
     """Deleting an LLM provider referenced by a pipeline node succeeds (SET_NULL): the node's
     llm_provider FK is nulled, while params (authoritative) is left untouched.

--- a/apps/service_providers/tests/test_views.py
+++ b/apps/service_providers/tests/test_views.py
@@ -1,11 +1,17 @@
 from unittest import mock
 
+import httpx
+import openai
 import pytest
 from django.contrib import messages as django_messages
 from django.contrib.messages import get_messages
 from django.urls import reverse
 
-from apps.service_providers.exceptions import NoTestableModelError, ServiceProviderConfigError
+from apps.service_providers.exceptions import (
+    ConnectionTestNotSupportedError,
+    NoTestableModelError,
+    ServiceProviderConfigError,
+)
 from apps.service_providers.models import (
     AuthProvider,
     LlmProvider,
@@ -186,14 +192,29 @@ def test_test_llm_connection_endpoint_unsupported_provider(team_with_users, auth
     provider = LlmProviderFactory(team=team_with_users, type=str(LlmProviderTypes.voyage))
     url = _test_connection_url(team_with_users, provider)
 
-    with mock.patch.object(
-        LlmProvider, "test_connection", side_effect=ServiceProviderConfigError(provider.type, "not supported")
-    ):
+    with mock.patch.object(LlmProvider, "test_connection", side_effect=ConnectionTestNotSupportedError(provider.type)):
         response = authed_client.post(url)
 
     assert response.status_code == 302
     [msg] = list(get_messages(response.wsgi_request))
     assert msg.level == django_messages.INFO
+
+
+@pytest.mark.django_db()
+def test_test_llm_connection_endpoint_invalid_configuration(team_with_users, authed_client):
+    """A genuinely invalid configuration is not the same as an unsupported provider type, and
+    must not be reported as one (it's a real, actionable problem)."""
+    provider = LlmProviderFactory(team=team_with_users)
+    url = _test_connection_url(team_with_users, provider)
+
+    with mock.patch.object(
+        LlmProvider, "test_connection", side_effect=ServiceProviderConfigError(provider.type, "bad config")
+    ):
+        response = authed_client.post(url)
+
+    assert response.status_code == 302
+    [msg] = list(get_messages(response.wsgi_request))
+    assert msg.level != django_messages.INFO
 
 
 @pytest.mark.django_db()
@@ -203,6 +224,23 @@ def test_test_llm_connection_endpoint_transient_failure(team_with_users, authed_
     url = _test_connection_url(team_with_users, provider)
 
     with mock.patch.object(LlmProvider, "test_connection", side_effect=_FakeTransientError()):
+        response = authed_client.post(url)
+
+    assert response.status_code == 302
+    [msg] = list(get_messages(response.wsgi_request))
+    assert msg.level == django_messages.WARNING
+
+
+@pytest.mark.django_db()
+def test_test_llm_connection_endpoint_timeout_is_temporary_not_credential_failure(team_with_users, authed_client):
+    """A timeout isn't in RATE_LIMIT_EXCEPTIONS or carrying a 429/503 status code, so
+    should_retry_exception alone misses it. It must still be reported as temporary, not
+    mistaken for bad credentials."""
+    provider = LlmProviderFactory(team=team_with_users)
+    url = _test_connection_url(team_with_users, provider)
+    timeout_error = openai.APITimeoutError(httpx.Request("POST", "https://api.openai.com/v1/chat/completions"))
+
+    with mock.patch.object(LlmProvider, "test_connection", side_effect=timeout_error):
         response = authed_client.post(url)
 
     assert response.status_code == 302

--- a/apps/service_providers/urls.py
+++ b/apps/service_providers/urls.py
@@ -39,4 +39,5 @@ urlpatterns = [
     path("<slug:provider_type>/<int:pk>/remove-file/<int:file_id>", views.remove_file, name="delete_file"),
     path("<slug:provider_type>/<int:pk>/upload-file/", views.AddFileToProvider.as_view(), name="add_file"),
     path("<slug:provider_type>/<int:pk>/sync-voices/", views.sync_voices, name="sync_voices"),
+    path("<slug:provider_type>/<int:pk>/test-connection/", views.test_llm_connection, name="test_llm_connection"),
 ]

--- a/apps/service_providers/views.py
+++ b/apps/service_providers/views.py
@@ -22,9 +22,12 @@ from apps.evaluations.models import Evaluator
 from apps.experiments.models import Experiment
 from apps.files.forms import get_file_formset
 from apps.files.views import BaseAddFileHtmxView
+from apps.service_providers.exceptions import NoTestableModelError, ServiceProviderConfigError
 from apps.service_providers.forms import LlmProviderModelForm, PricingOverrideForm
+from apps.service_providers.llm_service.retry import should_retry_exception
 from apps.service_providers.models import (
     EmbeddingProviderModel,
+    LlmProvider,
     LlmProviderModel,
     VoiceProvider,
     VoiceProviderType,
@@ -308,6 +311,15 @@ class CreateServiceProvider(
                     "pk": instance.pk,
                 },
             )
+        if self.provider_type == ServiceProvider.llm and instance:
+            ctx["test_llm_connection_url"] = reverse(
+                "service_providers:test_llm_connection",
+                kwargs={
+                    "team_slug": self.request.team.slug,
+                    "provider_type": "llm",
+                    "pk": instance.pk,
+                },
+            )
         if self.provider_type == ServiceProvider.llm:
             default_llm_models_by_type = _get_models_by_type(LlmProviderModel.objects.filter(team=None))
             embedding_models_by_type = _get_models_by_type(EmbeddingProviderModel.objects.filter(team=None))
@@ -556,4 +568,28 @@ def sync_voices(request, team_slug: str, provider_type: str, pk: int):
     except Exception:
         log.exception("Failed to sync voices for provider %s", pk)
         messages.error(request, "Voice sync failed. Please check your API key and try again.")
+    return redirect("service_providers:edit", team_slug=team_slug, provider_type=provider_type, pk=pk)
+
+
+@require_POST
+@login_and_team_required
+@permission_required("service_providers.change_llmprovider", raise_exception=True)
+def test_llm_connection(request, team_slug: str, provider_type: str, pk: int):
+    provider = get_object_or_404(LlmProvider, team=request.team, pk=pk)
+    try:
+        provider.test_connection()
+    except NoTestableModelError:
+        messages.warning(request, "No models configured to test. Add a model first.")
+    except ServiceProviderConfigError:
+        messages.info(request, "Connection testing isn't supported for this provider type.")
+    except Exception as exc:
+        log.exception("LLM connection test failed for provider %s", pk)
+        if should_retry_exception(exc):
+            messages.warning(
+                request, "Test failed due to a temporary issue (rate limit or timeout). Try again shortly."
+            )
+        else:
+            messages.error(request, "Test failed. Check your credentials and try again.")
+    else:
+        messages.success(request, "Connection test succeeded.")
     return redirect("service_providers:edit", team_slug=team_slug, provider_type=provider_type, pk=pk)

--- a/apps/service_providers/views.py
+++ b/apps/service_providers/views.py
@@ -22,7 +22,7 @@ from apps.evaluations.models import Evaluator
 from apps.experiments.models import Experiment
 from apps.files.forms import get_file_formset
 from apps.files.views import BaseAddFileHtmxView
-from apps.service_providers.exceptions import NoTestableModelError, ServiceProviderConfigError
+from apps.service_providers.exceptions import ConnectionTestNotSupportedError, NoTestableModelError
 from apps.service_providers.forms import LlmProviderModelForm, PricingOverrideForm
 from apps.service_providers.llm_service.retry import should_retry_exception
 from apps.service_providers.models import (
@@ -285,9 +285,13 @@ class CreateServiceProvider(
             if isinstance(obj, VoiceProvider):
                 for warning in obj.run_post_save_hook():
                     messages.warning(request, warning)
-            if isinstance(obj, LlmProvider):
-                for warning in obj.run_connection_test_hook():
-                    messages.warning(request, warning)
+        # Runs after the save transaction commits, not inside it: an external LLM call can
+        # take several seconds, and holding the save's DB connection/locks open for that long
+        # (or repeating the call if the transaction were retried or rolled back) is worse than
+        # the save and the test being two separate steps.
+        if isinstance(obj, LlmProvider):
+            for warning in obj.run_connection_test_hook():
+                messages.warning(request, warning)
         for warning in config_form.warnings:
             messages.warning(request, warning)
 
@@ -574,6 +578,20 @@ def sync_voices(request, team_slug: str, provider_type: str, pk: int):
     return redirect("service_providers:edit", team_slug=team_slug, provider_type=provider_type, pk=pk)
 
 
+def _is_timeout_exception(exc: Exception) -> bool:
+    """Recognizes provider-SDK timeout exceptions for classification purposes here.
+
+    Kept local rather than added to retry.py's RATE_LIMIT_EXCEPTIONS, since that list drives
+    retry behavior for all live LLM traffic, not just this connection test. Covers OpenAI
+    (and every OpenAI-compatible type built on it: Groq, Perplexity, DeepSeek, MiniMax,
+    Azure) and Google/Vertex; Anthropic's timeout is already in RATE_LIMIT_EXCEPTIONS.
+    """
+    import openai  # noqa: PLC0415 - heavy lib, slow startup
+    from google.api_core import exceptions as google_exceptions  # noqa: PLC0415 - heavy lib, slow startup
+
+    return isinstance(exc, (openai.APITimeoutError, google_exceptions.DeadlineExceeded))
+
+
 @require_POST
 @login_and_team_required
 @permission_required("service_providers.change_llmprovider", raise_exception=True)
@@ -583,11 +601,11 @@ def test_llm_connection(request, team_slug: str, provider_type: str, pk: int):
         provider.test_connection()
     except NoTestableModelError:
         messages.warning(request, "No models configured to test. Add a model first.")
-    except ServiceProviderConfigError:
+    except ConnectionTestNotSupportedError:
         messages.info(request, "Connection testing isn't supported for this provider type.")
     except Exception as exc:
         log.exception("LLM connection test failed for provider %s", pk)
-        if should_retry_exception(exc):
+        if should_retry_exception(exc) or _is_timeout_exception(exc):
             messages.warning(
                 request, "Test failed due to a temporary issue (rate limit or timeout). Try again shortly."
             )

--- a/apps/service_providers/views.py
+++ b/apps/service_providers/views.py
@@ -285,6 +285,9 @@ class CreateServiceProvider(
             if isinstance(obj, VoiceProvider):
                 for warning in obj.run_post_save_hook():
                     messages.warning(request, warning)
+            if isinstance(obj, LlmProvider):
+                for warning in obj.run_connection_test_hook():
+                    messages.warning(request, warning)
         for warning in config_form.warnings:
             messages.warning(request, warning)
 

--- a/templates/service_providers/provider_form.html
+++ b/templates/service_providers/provider_form.html
@@ -59,6 +59,12 @@
           <button type="submit" class="btn btn-outline">Sync Voices from ElevenLabs</button>
         </form>
       {% endif %}
+      {% if test_llm_connection_url %}
+        <form method="post" action="{{ test_llm_connection_url }}" class="mt-4">
+          {% csrf_token %}
+          <button type="submit" class="btn btn-outline">Test Connection</button>
+        </form>
+      {% endif %}
     {% endblock post_form %}
   </div>
 {% endblock app %}


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->
Adds a way to verify an LLM provider's credentials actually work, instead of only finding out when a bot's first real chat fails. A "Test Connection" button on the provider edit page sends one minimal message and reports success or a specific failure reason. The same check also runs automatically every time a provider is saved (created or updated), surfacing a non-blocking warning on failure.

Closes #449

### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->
Design doc, including two open questions and the reasoning behind building both manual and automatic instead of one: #449 (comment).

Two decisions worth flagging directly:

- The automatic check runs inline (nested savepoint, same shape as `VoiceProvider.run_post_save_hook`), not as a Celery task. Happy to move it async if the 10s worst case proves too slow in practice — noted as a real option in the design doc, not built here.
- Voyage AI is excluded from the test entirely (embeddings-only, can't run a chat completion). Caught a real bug here during self-review: the original `self.type == LlmProviderTypes.voyage.value` comparison was always `False` (comparing a string to a dataclass instance), silently letting the short-circuit never fire. Fixed to `self.type_enum == LlmProviderTypes.voyage`, matching the pattern already used elsewhere in this file, with a regression test that fails without the fix.

The test call uses a model the provider already has configured (preferring a team-scoped model over a global default, same priority as pricing-rule resolution elsewhere in this app) rather than a hardcoded per-type model list.

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
1. Edit an existing LLM provider, scroll to the bottom, click "Test Connection".
<img width="2782" height="1548" alt="image" src="https://github.com/user-attachments/assets/c4891ebd-8822-4cfe-8d1f-f6437c530e28" />

2. With bad/fake credentials: a "Test failed. Check your credentials and try again." message appears; the page doesn't crash.
<img width="2240" height="1166" alt="image" src="https://github.com/user-attachments/assets/42e30164-b500-47c1-89ec-1c6010974697" />

3. Change the provider's name (no credential change) and click Update: the same test runs automatically, same failure message appears, and the name change still saves (non-blocking).
<img width="2216" height="1516" alt="image" src="https://github.com/user-attachments/assets/0aa52789-e252-4ca6-9da8-b7ea99b57510" />


Verified both in a local browser session against a provider seeded with fake test credentials.

### Docs and Changelog
- [x] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
New: a "Test Connection" button on LLM provider settings, plus an automatic check on save.

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change.

<!--
Check the box above if a self-hosted operator has to do something or would be
surprised on upgrade: migrations, new/renamed/removed settings or env vars, a
change in deployment shape (process types, queues, backing-service versions),
a deprecation or removal, or a security fix needing operator action.

This is separate from the docs/changelog checkbox above, which covers the
user-facing product changelog. If checked, add an entry under `[Unreleased]` in
the repo root `CHANGELOG.md` in this PR. See RELEASING.md.

Leave unchecked for a change that is purely a feature, improvement or bug fix.
with none of the above — those reach operators through the user-facing
changelog. A feature PR that also carries a migration or a settings change is
still operator-impacting: check the box and log the migration.
-->
