### PR TITLE
Render removed node types as a Removed Node

### DIFF
--- a/apps/pipelines/nodes/base.py
+++ b/apps/pipelines/nodes/base.py
@@ -566,6 +566,8 @@ class NodeSchema(BaseModel):
     can_add: bool | None = None
     deprecated: bool = False
     deprecation_message: str | None = None
+    removed: bool = False
+    """The node class is gone; this schema is a stub so stored nodes of the type still render."""
     documentation_link: str | None = None
     field_order: list[str] | None = Field(
         None,
@@ -584,7 +586,7 @@ class NodeSchema(BaseModel):
         if self.can_add is None:
             self.can_add = is_pipeline_node
 
-        if self.deprecated:
+        if self.deprecated or self.removed:
             self.can_add = False
         return self
 
@@ -594,6 +596,7 @@ class NodeSchema(BaseModel):
         schema["ui:can_delete"] = self.can_delete
         schema["ui:can_add"] = self.can_add
         schema["ui:deprecated"] = self.deprecated
+        schema["ui:removed"] = self.removed
         if self.deprecated and self.deprecation_message:
             schema["ui:deprecation_message"] = self.deprecation_message
         if self.field_order:

--- a/apps/pipelines/nodes/node_metadata.py
+++ b/apps/pipelines/nodes/node_metadata.py
@@ -17,7 +17,7 @@ from apps.custom_actions.form_utils import get_custom_action_operation_choices
 from apps.documents.models import Collection
 from apps.experiments.models import AgentTools, BuiltInTools, SourceMaterial, SyntheticVoice
 from apps.pipelines.nodes import nodes as pipeline_nodes
-from apps.pipelines.nodes.base import OptionsSource
+from apps.pipelines.nodes.base import NodeSchema, OptionsSource
 from apps.service_providers.models import LlmProvider, LlmProviderModel, VoiceProvider
 from apps.teams.models import Team
 from apps.utils.prompt import PromptVars
@@ -253,6 +253,15 @@ def get_node_default_values(team: Team, usable_models_only: bool = False) -> dic
     }
 
 
+# Node types whose class has been removed, mapped to the message shown on the stored node.
+#
+# Pipelines still holding one have to open in the editor, so the builder is served a stub schema
+# for the type. The stub is built here rather than from a node class, which is the point:
+# resolve_node_class still returns None, so Pipeline.validate keeps reporting "Unknown node type"
+# and the pipeline cannot build. See issue #4254.
+REMOVED_NODE_TYPES: dict[str, str] = {}
+
+
 def get_node_schemas() -> list[dict]:
     schemas = []
 
@@ -265,7 +274,32 @@ def get_node_schemas() -> list[dict]:
     for node_class in node_classes:
         schemas.append(_get_node_schema(node_class))
 
+    schemas.extend(_removed_node_schema(node_type, message) for node_type, message in REMOVED_NODE_TYPES.items())
+
     return schemas
+
+
+def _removed_node_schema(node_type: str, message: str) -> dict:
+    """A stub schema for a node type with no class behind it.
+
+    Shaped like a real node schema so the builder needs no special case: the title matches the
+    stored ``Node.type``, there are no editable params, and it carries the same ``ui:*`` keys
+    every node has.
+    """
+    schema: dict = {
+        "title": node_type,
+        "type": "object",
+        "description": message,
+        "properties": {},
+    }
+    NodeSchema(
+        label="Removed Node",
+        icon="fa-solid fa-circle-xmark",
+        removed=True,
+        deprecated=True,
+        deprecation_message=message,
+    )(schema)
+    return schema
 
 
 def _get_node_schema(node_class: type) -> dict:

--- a/apps/pipelines/tests/node_schemas/AssistantNode.json
+++ b/apps/pipelines/tests/node_schemas/AssistantNode.json
@@ -46,5 +46,6 @@
   "ui:documentation_link": "/concepts/pipelines/nodes/",
   "ui:flow_node_type": "pipelineNode",
   "ui:icon": "fa-solid fa-user-tie",
-  "ui:label": "OpenAI Assistant"
+  "ui:label": "OpenAI Assistant",
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/node_schemas/BooleanNode.json
+++ b/apps/pipelines/tests/node_schemas/BooleanNode.json
@@ -30,5 +30,6 @@
   "ui:deprecated": true,
   "ui:deprecation_message": "Use the 'Router' node instead.",
   "ui:flow_node_type": "pipelineNode",
-  "ui:label": "Conditional Node"
+  "ui:label": "Conditional Node",
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/node_schemas/CodeNode.json
+++ b/apps/pipelines/tests/node_schemas/CodeNode.json
@@ -32,5 +32,6 @@
   "ui:documentation_link": "/concepts/pipelines/nodes/#python-node",
   "ui:flow_node_type": "pipelineNode",
   "ui:icon": "fa-solid fa-file-code",
-  "ui:label": "Python Node"
+  "ui:label": "Python Node",
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/node_schemas/EndNode.json
+++ b/apps/pipelines/tests/node_schemas/EndNode.json
@@ -14,5 +14,6 @@
   "ui:can_delete": false,
   "ui:deprecated": false,
   "ui:flow_node_type": "endNode",
-  "ui:label": "End"
+  "ui:label": "End",
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/node_schemas/ExtractParticipantData.json
+++ b/apps/pipelines/tests/node_schemas/ExtractParticipantData.json
@@ -61,5 +61,6 @@
   "ui:documentation_link": "/concepts/pipelines/nodes/#update-participant-data-node",
   "ui:flow_node_type": "pipelineNode",
   "ui:icon": "fa-solid fa-user-pen",
-  "ui:label": "Update Participant Data"
+  "ui:label": "Update Participant Data",
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/node_schemas/ExtractStructuredData.json
+++ b/apps/pipelines/tests/node_schemas/ExtractStructuredData.json
@@ -55,5 +55,6 @@
   "ui:documentation_link": "/concepts/pipelines/nodes/#extract-structured-data-node",
   "ui:flow_node_type": "pipelineNode",
   "ui:icon": "fa-solid fa-database",
-  "ui:label": "Extract Structured Data"
+  "ui:label": "Extract Structured Data",
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/node_schemas/LLMResponse.json
+++ b/apps/pipelines/tests/node_schemas/LLMResponse.json
@@ -41,5 +41,6 @@
   "ui:deprecated": true,
   "ui:deprecation_message": "Use the 'LLM' node instead.",
   "ui:flow_node_type": "pipelineNode",
-  "ui:label": "LLM response"
+  "ui:label": "LLM response",
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/node_schemas/LLMResponseWithPrompt.json
+++ b/apps/pipelines/tests/node_schemas/LLMResponseWithPrompt.json
@@ -236,5 +236,6 @@
   "ui:documentation_link": "/concepts/pipelines/nodes/#llm-node",
   "ui:flow_node_type": "pipelineNode",
   "ui:icon": "fa-solid fa-wand-magic-sparkles",
-  "ui:label": "LLM"
+  "ui:label": "LLM",
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/node_schemas/Passthrough.json
+++ b/apps/pipelines/tests/node_schemas/Passthrough.json
@@ -17,5 +17,6 @@
   "ui:can_delete": true,
   "ui:deprecated": false,
   "ui:flow_node_type": "pipelineNode",
-  "ui:label": "Do Nothing"
+  "ui:label": "Do Nothing",
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/node_schemas/RenderTemplate.json
+++ b/apps/pipelines/tests/node_schemas/RenderTemplate.json
@@ -33,5 +33,6 @@
   "ui:documentation_link": "/concepts/pipelines/nodes/#template",
   "ui:flow_node_type": "pipelineNode",
   "ui:icon": "fa-solid fa-robot",
-  "ui:label": "Render a template"
+  "ui:label": "Render a template",
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/node_schemas/RouterNode.json
+++ b/apps/pipelines/tests/node_schemas/RouterNode.json
@@ -150,5 +150,6 @@
     "prompt",
     "keywords",
     "tag_output_message"
-  ]
+  ],
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/node_schemas/SendEmail.json
+++ b/apps/pipelines/tests/node_schemas/SendEmail.json
@@ -51,5 +51,6 @@
   "ui:documentation_link": "/concepts/pipelines/nodes/#email-node",
   "ui:flow_node_type": "pipelineNode",
   "ui:icon": "fa-solid fa-envelope",
-  "ui:label": "Send an email"
+  "ui:label": "Send an email",
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/node_schemas/StartNode.json
+++ b/apps/pipelines/tests/node_schemas/StartNode.json
@@ -14,5 +14,6 @@
   "ui:can_delete": false,
   "ui:deprecated": false,
   "ui:flow_node_type": "startNode",
-  "ui:label": "Start"
+  "ui:label": "Start",
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/node_schemas/StaticRouterNode.json
+++ b/apps/pipelines/tests/node_schemas/StaticRouterNode.json
@@ -69,5 +69,6 @@
     "data_source",
     "route_key",
     "keywords"
-  ]
+  ],
+  "ui:removed": false
 }

--- a/apps/pipelines/tests/test_removed_nodes.py
+++ b/apps/pipelines/tests/test_removed_nodes.py
@@ -1,0 +1,119 @@
+"""A pipeline holding a node type whose class has been removed.
+
+When a node class is deleted, rows of that ``type`` stay behind in ``node_set``. Those pipelines
+must keep opening in the editor and must refuse to build. The two halves are deliberately separate
+mechanisms:
+
+* ``resolve_node_class`` returns ``None`` for the stored type, so validation reports it and the
+  graph will not compile. This is the pre-existing "unknown node type" path.
+* ``get_node_schemas`` serves a stub schema for every type in ``REMOVED_NODE_TYPES`` anyway, so the
+  builder has something to render where the node used to be. The stub is built directly rather than
+  from a node class, which is what keeps the first bullet true.
+
+The registry is empty until a node class is actually deleted (``AssistantNode`` is the first, in
+#4254), so these tests register a type of their own rather than depending on whichever types happen
+to be listed.
+"""
+
+from unittest import mock
+
+import pytest
+
+from apps.pipelines.exceptions import has_errors
+from apps.pipelines.models import Node
+from apps.pipelines.nodes.base import resolve_node_class
+from apps.pipelines.nodes.node_metadata import REMOVED_NODE_TYPES, get_node_schemas
+from apps.pipelines.tests.utils import create_pipeline_model, end_node, start_node
+
+REMOVED_TYPE = "RetiredExampleNode"
+REMOVED_MESSAGE = "This node type was removed. Delete it and use an LLM node instead."
+
+
+@pytest.fixture()
+def registered_as_removed():
+    """``REMOVED_TYPE`` is the only entry in the registry for the duration of a test."""
+    with mock.patch.dict(REMOVED_NODE_TYPES, {REMOVED_TYPE: REMOVED_MESSAGE}, clear=True):
+        yield
+
+
+def _pipeline_with_removed_node():
+    """A saved pipeline whose middle node names a type that no longer has a class."""
+    removed = {
+        "id": "removed-1",
+        "type": REMOVED_TYPE,
+        "params": {"name": "My retired step", "some_param": "42"},
+    }
+    pipeline = create_pipeline_model([start_node(), removed, end_node()])
+    pipeline.save(update_fields=["data"])
+    return pipeline, removed
+
+
+@pytest.mark.django_db()
+class TestRemovedNodeIsNotRunnable:
+    def test_stored_type_resolves_to_no_class(self):
+        assert resolve_node_class(REMOVED_TYPE) is None
+
+    def test_validation_reports_the_node_as_unknown(self, registered_as_removed):
+        """Serving a stub schema must not make the pipeline buildable."""
+        pipeline, removed = _pipeline_with_removed_node()
+
+        report = pipeline.validate()
+
+        assert has_errors(report), "a pipeline holding a removed node type must not be valid"
+        assert report["node"][removed["id"]]["root"] == f"Unknown node type: {REMOVED_TYPE}"
+
+    def test_the_node_row_survives_untouched(self):
+        """Nothing rewrites or drops the row — data cleanup is a separate, later decision."""
+        pipeline, removed = _pipeline_with_removed_node()
+
+        node = Node.objects.get(pipeline=pipeline, flow_id=removed["id"])
+        assert node.type == REMOVED_TYPE
+        assert node.params["some_param"] == "42"
+
+    def test_node_reports_no_parameters(self):
+        """``has_parameter`` is driven by the node class, so a removed type declares nothing."""
+        assert Node(type=REMOVED_TYPE).has_parameter("some_param") is False
+
+
+@pytest.mark.django_db()
+class TestRemovedNodeStillLoadsInTheEditor:
+    def test_flow_data_renders_the_node(self):
+        """The editor is served ``flow_data``; it must include the node rather than raise."""
+        pipeline, removed = _pipeline_with_removed_node()
+
+        flow_nodes = {node["id"]: node for node in pipeline.flow_data["nodes"]}
+
+        assert removed["id"] in flow_nodes
+        assert flow_nodes[removed["id"]]["data"]["type"] == REMOVED_TYPE
+
+    def test_a_stub_schema_is_served_for_the_removed_type(self, registered_as_removed):
+        """Without this the builder's ``nodeSchemas.get(type)`` is undefined and the editor throws."""
+        schemas = {schema["title"]: schema for schema in get_node_schemas()}
+
+        assert REMOVED_TYPE in schemas, "the builder needs a schema for every stored node type"
+        stub = schemas[REMOVED_TYPE]
+        assert stub["ui:label"] == "Removed Node"
+        assert stub["ui:removed"] is True
+        assert stub["ui:can_add"] is False, "a removed type must not be offered in the palette"
+        assert stub["ui:can_delete"] is True, "the user has to be able to delete it"
+        assert stub["properties"] == {}, "a stub has no editable params"
+
+    def test_the_stub_carries_a_deprecation_message(self, registered_as_removed):
+        """The existing DeprecationNotice component renders this; no new UI needed for the text."""
+        stub = next(s for s in get_node_schemas() if s["title"] == REMOVED_TYPE)
+
+        assert stub["ui:deprecated"] is True
+        assert stub["ui:deprecation_message"] == REMOVED_MESSAGE
+
+    def test_live_node_types_get_no_stub_treatment(self, registered_as_removed):
+        """Only types in the registry are stubbed; everything else keeps its real schema."""
+        schemas = {schema["title"]: schema for schema in get_node_schemas()}
+
+        assert "LLMResponseWithPrompt" not in REMOVED_NODE_TYPES
+        assert schemas["LLMResponseWithPrompt"].get("ui:removed", False) is False
+        assert schemas["LLMResponseWithPrompt"]["properties"] != {}
+
+    def test_no_stub_is_served_while_the_registry_is_empty(self):
+        """The mechanism is inert until a class is actually deleted."""
+        assert REMOVED_NODE_TYPES == {}
+        assert all(schema.get("ui:removed") is False for schema in get_node_schemas())

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -190,18 +190,21 @@ function DeprecationNotice({nodeSchema}: {nodeSchema: JsonSchema}) {
   if (!nodeSchema["ui:deprecated"]) {
     return <></>;
   }
+  const removed = !!nodeSchema["ui:removed"];
   const customMessage = nodeSchema["ui:deprecation_message"] || "";
   return (
     <div className="dropdown">
       <div tabIndex={0} role="button" className="mr-2 text-warning inline-block tooltip hover:cursor-pointer"
-      data-tip="This node type has been deprecated. Click for details"><i className="fa-solid fa-exclamation-triangle"></i></div>
+      data-tip={`This node type has been ${removed ? "removed" : "deprecated"}. Click for details`}><i className="fa-solid fa-exclamation-triangle"></i></div>
       <div
         tabIndex={0}
         className="dropdown-content card card-sm bg-base-100 z-1 w-64 shadow-md">
         <div className="card-body">
           <p>
-            {nodeSchema["ui:removed"]
-              ? "This node type has been removed. The node no longer runs and the pipeline cannot be saved until it is deleted."
+            {removed
+              // The graph still saves (the editor POSTs and gets the errors back); it is the
+              // build/run that the unknown node type blocks. Don't tell the user saving is off.
+              ? "This node type has been removed. The node no longer runs, and the pipeline will not run until it is deleted."
               : "This node type has been deprecated and will be removed in future."}
           </p>
           {customMessage && <p dangerouslySetInnerHTML={{__html: customMessage}}></p>}

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -175,6 +175,9 @@ function NodeHeader({
         </div>
         <div className="px-10 m-1 text-lg font-bold text-center align-middle">
           <DeprecationNotice nodeSchema={nodeSchema}/>
+          {nodeSchema["ui:removed"] && (
+            <span className="badge badge-warning badge-sm mr-2 align-middle">Removed</span>
+          )}
           {header}
           <p className="text-xs font-light text-gray-500 dark:text-gray-600">{nodeId}</p>
         </div>
@@ -196,7 +199,11 @@ function DeprecationNotice({nodeSchema}: {nodeSchema: JsonSchema}) {
         tabIndex={0}
         className="dropdown-content card card-sm bg-base-100 z-1 w-64 shadow-md">
         <div className="card-body">
-          <p>This node type has been deprecated and will be removed in future.</p>
+          <p>
+            {nodeSchema["ui:removed"]
+              ? "This node type has been removed. The node no longer runs and the pipeline cannot be saved until it is deleted."
+              : "This node type has been deprecated and will be removed in future."}
+          </p>
           {customMessage && <p dangerouslySetInnerHTML={{__html: customMessage}}></p>}
         </div>
       </div>

--- a/assets/javascript/apps/pipeline/types/nodeParams.ts
+++ b/assets/javascript/apps/pipeline/types/nodeParams.ts
@@ -34,6 +34,7 @@ export type JsonSchema = {
   "ui:can_add": boolean;
   "ui:can_delete": boolean;
   "ui:deprecated": boolean;
+  "ui:removed"?: boolean;
   "ui:deprecation_message"?: string;
   "ui:documentation_link"?: string;
   "ui:order"?: string[];

--- a/assets/javascript/apps/pipeline/utils.tsx
+++ b/assets/javascript/apps/pipeline/utils.tsx
@@ -85,13 +85,18 @@ export function concatenate(value: string | string[] | null | undefined): string
  * If the schema has a `ui:optionsSource`, it fetches the options from the cached parameter values.
  * Otherwise, it constructs options from the schema's enum values and their labels.
  *
+ * A named source with nothing behind it yields no options rather than `undefined`: the backend
+ * stops serving a source as soon as the resource it lists is removed, while nodes already stored
+ * with that `ui:optionsSource` keep rendering. Callers map over the result, so returning
+ * `undefined` here throws and takes the whole editor down with it.
+ *
  * @param {PropertySchema} schema - The schema defining the options.
  * @returns {Option[]} - An array of options for the select input.
  */
 export function getSelectOptions(schema: PropertySchema): Option[] {
   const {parameterValues} = getCachedData();
   if (schema["ui:optionsSource"]) {
-    return parameterValues[schema["ui:optionsSource"]];
+    return parameterValues[schema["ui:optionsSource"]] ?? [];
   }
 
   const enums = schema.enum || [];


### PR DESCRIPTION
Part of splitting #4305 (OpenAI Assistants removal, phase 1). 

### Product Description
No change. The mechanism this adds is inert — the registry it introduces ships empty — and it exists so the *next* PRs can delete a node class without breaking the pipeline editor for anyone still holding one.

### Technical Description
Two independent halves, both prerequisites for the removal PRs behind them:

**A stub schema for node types with no class.** The builder looks a node's schema up by its stored `type` and asserts the result is non-null, so a deleted class means a stored node throws on load. `get_node_schemas()` now appends a stub for every entry in a new `REMOVED_NODE_TYPES` registry (empty here; `AssistantNode` registers in the same commit that deletes its class). The stub is built directly rather than from a node class, which is deliberate: `resolve_node_class()` keeps returning `None`, so `Pipeline.validate` still reports `"Unknown node type"` and the pipeline still refuses to build. `NodeHeader` grows a "Removed" badge, because it prefers a node's custom name over `ui:label` and the stub alone would render the user's own name with nothing explaining it.

**`getSelectOptions` no longer returns `undefined`.** A param declaring a `ui:optionsSource` the backend has stopped serving got `undefined`, and every caller maps or searches the result — `SelectWidget` threw and React unmounted the whole editor. The two sides come apart whenever a resource is removed: the backend drops the source as soon as its model goes, while nodes stored with that `ui:optionsSource` keep rendering until their class is deleted. An absent source now yields an empty select. `apps/pipelines/tests/test_node_options.py::test_every_declared_options_source_has_a_list_to_draw_on` guards the backend side of this invariant; the guard is the client-side backstop.

Tests register a removed type of their own rather than depending on whichever types happen to be listed, so they keep working as real entries come and go. The `ui:removed: false` churn across `node_schemas/*.json` is the regenerated snapshots.

### Demo
Not applicable — nothing renders differently until a node class is actually removed.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change
