### PR TITLE
Make the flag everyone field a tri-state with an explicit off

### DIFF
--- a/apps/admin/forms.py
+++ b/apps/admin/forms.py
@@ -80,9 +80,12 @@ class DateRangeForm(forms.Form):
 
 class FlagUpdateForm(forms.Form):
     """A flag decision is `everyone` or `teams`; the request-only waffle inputs
-    (`superusers`, `testing`, `rollout`, `percent`, `users`) are not accepted."""
+    (`superusers`, `testing`, `rollout`, `percent`, `users`) are not accepted.
 
-    everyone = forms.BooleanField(required=False)
+    `everyone` is a tri-state: on for everyone, off for everyone, or `None` to defer
+    to the team list. An absent key means `None`, never a hard off."""
+
+    everyone = forms.NullBooleanField(required=False)
     teams = forms.ModelMultipleChoiceField(
         queryset=Team.objects.all(), required=False, widget=forms.MultipleHiddenInput()
     )

--- a/apps/admin/tests/test_flag_update.py
+++ b/apps/admin/tests/test_flag_update.py
@@ -28,13 +28,33 @@ class TestUpdateFlag:
 
         response = superuser_client.post(
             reverse("ocs_admin:update_flag", args=[flag.name]),
-            {"everyone": "on", "teams": [team.id]},
+            {"everyone": "true", "teams": [team.id]},
         )
 
         assert response.status_code == 200
         flag.refresh_from_db()
         assert flag.everyone is True
         assert list(flag.teams.all()) == [team]
+
+    @pytest.mark.parametrize(
+        ("posted", "expected"),
+        [
+            pytest.param({"everyone": "true"}, True, id="on-for-everyone"),
+            pytest.param({"everyone": "false"}, False, id="off-for-everyone"),
+            pytest.param({"everyone": "unknown"}, None, id="use-teams"),
+            pytest.param({}, None, id="absent-key-means-use-teams"),
+        ],
+    )
+    def test_everyone_is_written_as_a_tri_state(self, superuser_client, posted, expected):
+        """`everyone` is on for everyone, off for everyone, or defer to the team list;
+        an absent key must mean "use teams", not silently coerce to a hard off."""
+        flag = Flag.objects.create(name="flag_update_probe", everyone=None if expected is True else True)
+
+        response = superuser_client.post(reverse("ocs_admin:update_flag", args=[flag.name]), posted)
+
+        assert response.status_code == 200
+        flag.refresh_from_db()
+        assert flag.everyone is expected
 
     def test_request_only_inputs_are_ignored(self, superuser_client):
         """Posting the dropped fields leaves them untouched rather than writing them back."""
@@ -66,6 +86,8 @@ class TestFlagPages:
         content = response.content.decode()
         assert "formData.everyone" in content
         assert "teams-select" in content
+        for tri_state_option in ('value="true"', 'value="false"', 'value="unknown"'):
+            assert tri_state_option in content, "the everyone control must offer all three states"
         for dropped_control in (
             "formData.testing",
             "formData.superusers",
@@ -74,6 +96,27 @@ class TestFlagPages:
             "users-select",
         ):
             assert dropped_control not in content
+
+    @pytest.mark.parametrize(
+        ("everyone", "on_badge", "off_badge"),
+        [
+            pytest.param(True, True, False, id="globally-on"),
+            pytest.param(False, False, True, id="globally-off"),
+            pytest.param(None, False, False, id="use-teams-has-no-global-badge"),
+        ],
+    )
+    def test_list_page_badges_reflect_the_tri_state(self, superuser_client, everyone, on_badge, off_badge):
+        """A hard off is as much a global decision as a rollout, so it gets its own badge;
+        only the deferred state renders without one."""
+        flag = Flag.objects.create(name="flag_tristate_badge_probe", everyone=everyone)
+
+        response = superuser_client.get(reverse("ocs_admin:flags_home"))
+
+        content = response.content.decode()
+        list_item_start = content.index(f'id="flag-{flag.id}"')
+        list_item = content[list_item_start : content.index("</li>", list_item_start)]
+        assert ("Off for everyone" in list_item) is off_badge
+        assert ("Everyone" in list_item.replace("Off for everyone", "")) is on_badge
 
     def test_list_page_shows_only_the_everyone_badge(self, superuser_client):
         """Request-only field values still stored on a flag no longer render as badges."""

--- a/apps/api/tests/test_throttling.py
+++ b/apps/api/tests/test_throttling.py
@@ -156,9 +156,7 @@ def test_api_over_limit_logs_would_block_in_log_only_mode(experiment, caplog):
 @pytest.mark.django_db()
 def test_exempt_team_is_never_blocked(experiment):
     """The flag_ignore_rate_limiting flag bypasses enforcement."""
-    flag, _ = get_waffle_flag_model().objects.update_or_create(
-        name=RATE_LIMIT_EXEMPT_FLAG, defaults={"everyone": False}
-    )
+    flag, _ = get_waffle_flag_model().objects.update_or_create(name=RATE_LIMIT_EXEMPT_FLAG, defaults={"everyone": None})
     flag.teams.add(experiment.team)
     user = experiment.team.members.first()
     client = ApiTestClient(user, experiment.team)

--- a/apps/banners/tests/test_banners.py
+++ b/apps/banners/tests/test_banners.py
@@ -19,7 +19,7 @@ class BannerServiceTests(TestCase):
         cls.team_with_flag = TeamFactory.create(name="Team With Flag")
         cls.team_without_flag = TeamFactory.create(name="Team Without Flag")
 
-        cls.test_flag = Flag.objects.create(name="flag_test_banner", everyone=False)
+        cls.test_flag = Flag.objects.create(name="flag_test_banner", everyone=None)
         cls.test_flag.teams.add(cls.team_with_flag)
 
         cls.active_global_banner = Banner.objects.create(

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -15,7 +15,8 @@ from apps.channels import widget_versions
 from apps.experiments import model_audit_fields
 from apps.experiments.exceptions import ChannelAlreadyUtilizedException
 from apps.experiments.models import Experiment, ExperimentSession, SessionStatus
-from apps.teams.models import BaseTeamModel, Flag
+from apps.teams.models import BaseTeamModel
+from apps.teams.utils import flag_is_active_for_team
 from apps.web.meta import absolute_url
 
 if TYPE_CHECKING:
@@ -71,9 +72,7 @@ class ChannelPlatform(models.TextChoices):
         if not settings.SLACK_ENABLED:
             platform_availability.pop(cls.SLACK)
 
-        flag = Flag.get("flag_commcare_connect")
-        commcare_connect_flag_enabled = flag.is_active_for_team(team)
-        if not commcare_connect_flag_enabled:
+        if not flag_is_active_for_team(team, "flag_commcare_connect"):
             platform_availability.pop(cls.COMMCARE_CONNECT)
         elif settings.COMMCARE_CONNECT_ENABLED:
             platform_availability[cls.COMMCARE_CONNECT] = True
@@ -90,7 +89,7 @@ class ChannelPlatform(models.TextChoices):
     @classmethod
     def _gate_by_flag(cls, platform_availability: dict, team, platform, flag_name: str) -> None:
         """Offer `platform` only when its flag is on for the team (and, for email, domains are configured)."""
-        offered = Flag.get(flag_name).is_active_for_team(team)
+        offered = flag_is_active_for_team(team, flag_name)
         if platform == cls.EMAIL:
             offered = offered and bool(settings.EMAIL_CHANNEL_ALLOWED_DOMAINS)
         if offered:

--- a/apps/chatbots/views.py
+++ b/apps/chatbots/views.py
@@ -63,6 +63,7 @@ from apps.pipelines.views import get_widget_page_context, llm_model_parameter_co
 from apps.teams.decorators import login_and_team_required, team_required
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 from apps.teams.models import Flag
+from apps.teams.utils import flag_is_active_for_team
 from apps.trace.models import Trace
 from apps.utils.search import similarity_search
 from apps.web.dynamic_filters.datastructures import FilterParams
@@ -400,7 +401,11 @@ class EditChatbot(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateVi
             "default_values": get_node_default_values(self.request.team),
             "origin": "chatbots",
             "allow_edit_name": False,
-            "flags_enabled": [flag.name for flag in Flag.objects.all() if flag.is_active_for_team(self.request.team)],
+            "flags_enabled": [
+                name
+                for name in Flag.objects.values_list("name", flat=True)
+                if flag_is_active_for_team(self.request.team, name)
+            ],
             "widget_page_context": get_widget_page_context(experiment.pipeline, experiment),
             **llm_model_parameter_context(),
         }

--- a/apps/conftest.py
+++ b/apps/conftest.py
@@ -34,18 +34,19 @@ def team():
 def team_flag():
     """Enable a feature flag for one specific team.
 
-    Writes the row the way the team settings screen does: `everyone=False` plus the team M2M.
+    Writes the row the way the team settings screen does: `everyone=None` plus the team M2M.
     For a flag that should simply be on, use `waffle.testutils.override_flag` instead. Flags are
     flushed again on teardown because waffle's cache outlives the test transaction.
     """
     flags = []
 
     def _enable(flag_name, team):
-        flag, _ = Flag.objects.get_or_create(name=flag_name, defaults={"everyone": False})
-        if flag.everyone:
+        flag, _ = Flag.objects.get_or_create(name=flag_name, defaults={"everyone": None})
+        if flag.everyone is not None:
             raise RuntimeError(
-                f"{flag_name} is already on for everyone, so pinning it to a team would not scope "
-                "anything. Drop the override_flag / everyone=True setup or use a different flag."
+                f"{flag_name} is already globally {'on' if flag.everyone else 'off'}, so pinning it "
+                "to a team would not scope anything. Drop the everyone=True/False setup or use a "
+                "different flag."
             )
         flag.teams.add(team)
         flag.flush()

--- a/apps/documents/tests/test_retrieval.py
+++ b/apps/documents/tests/test_retrieval.py
@@ -291,8 +291,8 @@ class TestSearchCollection:
     def test_team_screen_enabled_flag_reaches_hybrid_search(self, team_flag):
         """A flag row shaped the way the team settings screen writes it must enable hybrid search.
 
-        The screen creates the row with `everyone=False` and adds the team to the M2M (#4321);
-        the stored `False` means "no global override", not "off for everyone".
+        The screen creates the row with `everyone=None` and adds the team to the M2M (#4321);
+        only an explicit `True`/`False` is a global decision.
         """
         collection = CollectionFactory.create(is_index=True)
         team_flag(HYBRID_FLAG, collection.team)

--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -36,6 +36,7 @@ from apps.service_providers.llm_service.model_parameters import LLM_MODEL_PARAME
 from apps.teams.decorators import login_and_team_required
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 from apps.teams.models import Flag
+from apps.teams.utils import flag_is_active_for_team
 from apps.web.waf import WafRule, waf_allow
 
 from ..generics.chips import Chip
@@ -177,7 +178,11 @@ class EditPipeline(LoginAndTeamRequiredMixin, PermissionRequiredMixin, TemplateV
             ),
             "default_values": get_node_default_values(self.request.team),
             "allow_edit_name": True,
-            "flags_enabled": [flag.name for flag in Flag.objects.all() if flag.is_active_for_team(self.request.team)],
+            "flags_enabled": [
+                name
+                for name in Flag.objects.values_list("name", flat=True)
+                if flag_is_active_for_team(self.request.team, name)
+            ],
             "read_only": pipeline.is_a_version,
             "widget_page_context": get_widget_page_context(pipeline),
             **llm_model_parameter_context(),

--- a/apps/teams/migrations/0010_create_flag_ai_cost_monitoring.py
+++ b/apps/teams/migrations/0010_create_flag_ai_cost_monitoring.py
@@ -11,7 +11,7 @@ FLAG_NAME = "flag_ai_cost_monitoring"
 
 def forwards(apps, schema_editor):
     Flag = apps.get_model("teams", "Flag")
-    Flag.objects.get_or_create(name=FLAG_NAME, defaults={"everyone": False})
+    Flag.objects.get_or_create(name=FLAG_NAME, defaults={"everyone": None, "superusers": False})
 
 
 def backwards(apps, schema_editor):

--- a/apps/teams/migrations/0017_everyone_false_to_none.py
+++ b/apps/teams/migrations/0017_everyone_false_to_none.py
@@ -1,0 +1,49 @@
+from django.db import migrations
+from waffle.utils import get_cache
+
+from apps.teams.models import Flag as LiveFlag
+
+NEUTRALISED_FIELDS = {
+    "superusers": False,
+    "staff": False,
+    "authenticated": False,
+    "testing": False,
+    "rollout": False,
+    "percent": None,
+    "languages": "",
+}
+
+
+def convert_everyone_false_to_none(apps, schema_editor):
+    """`everyone=False` historically meant "no global override, use teams"; the tri-state
+    admin gives `False` a hard-off meaning, so stored `False` values become `None`.
+
+    Rows created since 0016 carry waffle's field defaults (notably `superusers=True`), so
+    the request-only neutralisation runs again on every row. The reverse is a noop because
+    the old values are deliberately unrecoverable. Cache flushing works as in 0016: flush
+    keys derive from the flag name alone, so an unsaved live-model instance can compute
+    them for the historical rows.
+    """
+    flag_model = apps.get_model("teams", "Flag")
+    flush_keys = set()
+    for flag in flag_model.objects.all():
+        if flag.everyone is False:
+            flag.everyone = None
+        for field, value in NEUTRALISED_FIELDS.items():
+            setattr(flag, field, value)
+        flag.save(update_fields=["everyone", *NEUTRALISED_FIELDS])
+        flag.users.clear()
+        flag.groups.clear()
+        flush_keys.update(LiveFlag(name=flag.name).get_flush_keys())
+    if flush_keys:
+        get_cache().delete_many(flush_keys)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("teams", "0016_neutralise_request_only_flag_fields"),
+    ]
+
+    operations = [
+        migrations.RunPython(convert_everyone_false_to_none, migrations.RunPython.noop, elidable=True),
+    ]

--- a/apps/teams/models.py
+++ b/apps/teams/models.py
@@ -232,6 +232,11 @@ class Flag(AbstractUserFlag):
         return flush_keys
 
     def is_active(self, request, read_only=False):
+        """Minting happens before delegating: waffle's own missing-flag branch stores
+        `everyone=FLAG_DEFAULT` (`False`), which is a hard off under the tri-state."""
+        if not self.pk and get_setting("CREATE_MISSING_FLAGS"):
+            self._mint_missing_flag()
+
         is_active = super().is_active(request, read_only)
         if is_active:
             return is_active
@@ -244,26 +249,33 @@ class Flag(AbstractUserFlag):
         return self.is_active_for_team(team)
 
     def is_active_for_team(self, team):
-        if self.everyone:
-            return True
+        """Tri-state global override: `everyone` set means on or off for every team,
+        `None` defers to the team M2M."""
+        if self.everyone is not None:
+            return self.everyone
 
         if not team:
             return False
 
         if not self.pk:
             if get_setting("CREATE_MISSING_FLAGS"):
-                flag, _created = Flag.objects.get_or_create(
-                    name=self.name, defaults={"everyone": get_setting("FLAG_DEFAULT")}
-                )
-                self.id = flag.id
-                self.refresh_from_db()
-                cache = get_cache()
-                cache.set(self._cache_key(self.name), self)
+                self._mint_missing_flag()
 
             return get_setting("FLAG_DEFAULT")
 
         team_ids = self._get_team_ids()
         return team.pk in team_ids
+
+    def _mint_missing_flag(self):
+        """Create the missing row with no global decision and no superuser grant, and adopt it.
+
+        The model defaults would store `superusers=True`, handing superusers blanket
+        access on request paths; superuser-only surfaces gate on `is_superuser` instead.
+        """
+        flag, _created = Flag.objects.get_or_create(name=self.name, defaults={"everyone": None, "superusers": False})
+        self.id = flag.id
+        self.refresh_from_db()
+        get_cache().set(self._cache_key(self.name), self)
 
     def _get_team_ids(self):
         cache = get_cache()

--- a/apps/teams/tests/test_flags.py
+++ b/apps/teams/tests/test_flags.py
@@ -5,6 +5,7 @@ from apps.teams.models import Flag
 from apps.teams.utils import flag_is_active_for_team
 from apps.teams.views.feature_flags import FeatureFlagForm
 from apps.utils.factories.team import TeamFactory
+from apps.utils.factories.user import UserFactory
 
 
 @pytest.mark.django_db()
@@ -13,18 +14,15 @@ from apps.utils.factories.team import TeamFactory
     [
         pytest.param("flag_precedence_1", True, False, True, id="everyone-true-wins-without-membership"),
         pytest.param("flag_precedence_2", True, True, True, id="everyone-true-wins-with-membership"),
-        pytest.param("flag_precedence_3", False, True, True, id="everyone-false-defers-to-membership"),
+        pytest.param("flag_precedence_3", False, True, False, id="everyone-false-beats-membership"),
         pytest.param("flag_precedence_4", False, False, False, id="everyone-false-without-membership-is-off"),
         pytest.param("flag_precedence_5", None, True, True, id="unset-defers-to-membership"),
         pytest.param("flag_precedence_6", None, False, False, id="unset-without-membership-is-off"),
     ],
 )
 def test_is_active_for_team_everyone_precedence(request, flag_name, everyone, team_in_m2m, expected):
-    """`everyone=True` is a global rollout and wins over team membership.
-
-    `everyone=False` is the value every flag-creation path stores for "no global override"
-    (see #4321), so it defers to the team M2M rather than switching the flag off.
-    """
+    """`everyone` is a tri-state global override: `True` is on for everyone, `False` is
+    off for everyone, and only `None` defers to the team M2M (see #4321)."""
     team = TeamFactory.create()
     flag = Flag.objects.create(name=flag_name, everyone=everyone)
     request.addfinalizer(flag.flush)
@@ -40,6 +38,27 @@ def test_everyone_true_applies_when_no_team_is_given(request):
     flag = Flag.objects.create(name="flag_precedence_no_team", everyone=True)
     request.addfinalizer(flag.flush)
     assert flag.is_active_for_team(None) is True
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("flag_name", "everyone", "expected"),
+    [
+        pytest.param("flag_request_hard_off", False, False, id="everyone-false-beats-membership-on-request-path"),
+        pytest.param("flag_request_teams", None, True, id="unset-defers-to-membership-on-request-path"),
+    ],
+)
+def test_is_active_everyone_precedence_on_request_path(request, rf, flag_name, everyone, expected):
+    """`is_active` applies the same tri-state as `is_active_for_team`: an explicit
+    `everyone=False` switches the flag off even for a team in the M2M."""
+    team = TeamFactory.create()
+    flag = Flag.objects.create(name=flag_name, everyone=everyone)
+    request.addfinalizer(flag.flush)
+    flag.teams.add(team)
+    flag.flush()
+    http_request = rf.get("/")
+    http_request.team = team
+    assert flag.is_active(http_request) is expected
 
 
 @pytest.mark.django_db()
@@ -76,6 +95,18 @@ class TestFeatureFlagFormSave:
         form.save()
         assert flag.teams.filter(pk=team_with_users.pk).exists()
 
+    def test_checking_a_missing_flag_creates_it_without_global_override(self, request, team_with_users):
+        """A row minted by the team screen must not carry a global `everyone` decision:
+        `False` is now a hard off, so the created row stores `None` and defers to teams."""
+        form = FeatureFlagForm({"flag_events": "on"}, team=team_with_users)
+        assert form.is_valid()
+        form.save()
+        flag = Flag.objects.get(name="flag_events")
+        request.addfinalizer(flag.flush)
+        assert flag.everyone is None
+        assert flag.superusers is False
+        assert flag.teams.filter(pk=team_with_users.pk).exists()
+
     def test_unchecking_a_flag_removes_the_team(self, request, team_with_users):
         flag = self._flag(request)
         flag.teams.add(team_with_users)
@@ -84,6 +115,38 @@ class TestFeatureFlagFormSave:
         assert form.is_valid()
         form.save()
         assert not flag.teams.filter(pk=team_with_users.pk).exists()
+
+
+@pytest.mark.django_db()
+def test_create_missing_flags_row_carries_no_global_override(request, settings):
+    """`CREATE_MISSING_FLAGS` mints the row with `everyone=None` (no global decision);
+    the check itself still answers with `FLAG_DEFAULT` for the missing flag."""
+    settings.WAFFLE_CREATE_MISSING_FLAGS = True
+    team = TeamFactory.create()
+    unsaved = Flag.get("flag_minted_on_demand")
+    request.addfinalizer(unsaved.flush)
+    assert unsaved.is_active_for_team(team) is False
+    row = Flag.objects.get(name="flag_minted_on_demand")
+    assert row.everyone is None
+    assert row.superusers is False
+
+
+@pytest.mark.django_db()
+def test_create_missing_flags_on_request_path_carries_no_global_override(request, rf, settings):
+    """waffle's own mint stores `everyone=FLAG_DEFAULT` (`False`), which is now a hard off
+    that would kill later team grants; the model's `superusers=True` default would grant
+    superusers blanket access. The minted row must carry neither."""
+    settings.WAFFLE_CREATE_MISSING_FLAGS = True
+    team = TeamFactory.create()
+    unsaved = Flag.get("flag_minted_on_request")
+    request.addfinalizer(unsaved.flush)
+    http_request = rf.get("/")
+    http_request.team = team
+    http_request.user = UserFactory.create(is_superuser=True)
+    assert unsaved.is_active(http_request) is False
+    row = Flag.objects.get(name="flag_minted_on_request")
+    assert row.everyone is None
+    assert row.superusers is False
 
 
 @pytest.mark.django_db()

--- a/apps/teams/tests/test_migration_0010_create_flag_ai_cost_monitoring.py
+++ b/apps/teams/tests/test_migration_0010_create_flag_ai_cost_monitoring.py
@@ -1,0 +1,44 @@
+import importlib
+
+import pytest
+from django.db import connection
+from django.db.migrations.loader import MigrationLoader
+from field_audit.models import AuditAction
+
+from apps.teams.models import Flag
+
+_migration = importlib.import_module("apps.teams.migrations.0010_create_flag_ai_cost_monitoring")
+forwards = _migration.forwards
+FLAG_NAME = _migration.FLAG_NAME
+
+
+class FakeSchemaEditor:
+    """Stands in for the schema editor a RunPython operation receives."""
+
+    connection = connection
+
+
+@pytest.fixture(autouse=True)
+def _requires_migrations(requires_migrations):
+    """Every test here loads historical state via the migration graph."""
+
+
+def _run():
+    """Run against the app state the migration actually receives, not the live registry."""
+    state = MigrationLoader(None).project_state([("teams", "0009_merge_pipeline_admin_into_experiment_admin")])
+    forwards(state.apps, FakeSchemaEditor())
+
+
+@pytest.mark.django_db()
+def test_pre_created_flag_carries_no_global_override(request):
+    """The pre-created row must be off by absence, not by a stored `everyone=False`:
+    this operation is not elidable, so a squash that drops 0016 and 0017 would leave a
+    hard off no team grant could turn on."""
+    Flag.objects.filter(name=FLAG_NAME).delete(audit_action=AuditAction.IGNORE)
+    request.addfinalizer(Flag(name=FLAG_NAME).flush)
+
+    _run()
+
+    flag = Flag.objects.get(name=FLAG_NAME)
+    assert flag.everyone is None
+    assert flag.superusers is False

--- a/apps/teams/tests/test_migration_0017_everyone_false_to_none.py
+++ b/apps/teams/tests/test_migration_0017_everyone_false_to_none.py
@@ -1,0 +1,99 @@
+import importlib
+
+import pytest
+from django.contrib.auth.models import Group
+from django.db import connection
+from django.db.migrations.loader import MigrationLoader
+from waffle.utils import get_cache
+
+from apps.teams.models import Flag
+from apps.utils.factories.team import TeamFactory
+from apps.utils.factories.user import UserFactory
+
+_migration = importlib.import_module("apps.teams.migrations.0017_everyone_false_to_none")
+convert_everyone_false_to_none = _migration.convert_everyone_false_to_none
+
+
+class FakeSchemaEditor:
+    """Stands in for the schema editor a RunPython operation receives."""
+
+    connection = connection
+
+
+@pytest.fixture(autouse=True)
+def _requires_migrations(requires_migrations):
+    """Every test here loads historical state via the migration graph."""
+
+
+def _run():
+    """Run against the app state the migration actually receives, not the live registry."""
+    state = MigrationLoader(None).project_state([("teams", "0016_neutralise_request_only_flag_fields")])
+    convert_everyone_false_to_none(state.apps, FakeSchemaEditor())
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        pytest.param(False, None, id="false-becomes-none"),
+        pytest.param(True, True, id="true-survives"),
+        pytest.param(None, None, id="none-survives"),
+    ],
+)
+def test_everyone_false_becomes_none(stored, expected):
+    """`everyone=False` historically meant "no global override, use teams", so it becomes
+    `None` before the tri-state gives `False` its hard-off meaning. Team grants survive."""
+    team = TeamFactory.create()
+    flag = Flag.objects.create(name="flag_migration_probe", everyone=stored)
+    flag.teams.add(team)
+
+    _run()
+
+    flag.refresh_from_db()
+    assert flag.everyone is expected
+    assert list(flag.teams.all()) == [team]
+
+
+@pytest.mark.django_db()
+def test_reneutralises_request_only_inputs():
+    """A row minted between 0016 and this migration carries waffle's field defaults
+    (notably `superusers=True`), so the 0016 neutralisation runs again."""
+    flag = Flag.objects.create(
+        name="flag_migration_probe",
+        superusers=True,
+        staff=True,
+        authenticated=True,
+        testing=True,
+        rollout=True,
+        percent=30,
+        languages="en",
+    )
+    flag.users.add(UserFactory.create())
+    flag.groups.add(Group.objects.create(name="migration-probe-group"))
+
+    _run()
+
+    flag.refresh_from_db()
+    assert flag.superusers is False
+    assert flag.staff is False
+    assert flag.authenticated is False
+    assert flag.testing is False
+    assert flag.rollout is False
+    assert flag.percent is None
+    assert flag.languages == ""
+    assert not flag.users.exists()
+    assert not flag.groups.exists()
+
+
+@pytest.mark.django_db()
+def test_flushes_the_waffle_cache_per_flag():
+    """Waffle caches whole Flag instances, so without a flush a stale copy with
+    `everyone=False` would keep hard-switching the flag off until its TTL."""
+    flag = Flag.objects.create(name="flag_migration_probe", everyone=False)
+    cache = get_cache()
+    cache_key = flag._cache_key(flag.name)
+    cache.set(cache_key, flag)
+
+    _run()
+
+    assert cache.get(cache_key) is None

--- a/apps/teams/utils.py
+++ b/apps/teams/utils.py
@@ -15,7 +15,8 @@ log = logging.getLogger("ocs.teams")
 def flag_is_active_for_team(team, flag_name):
     """The team-scoped counterpart of `waffle.flag_is_active(request, flag_name)`.
 
-    `everyone=True` wins; otherwise the flag is active when `team` is in its team M2M.
+    A set `everyone` wins either way (on or off for every team); `None` defers to the
+    flag's team M2M.
     """
     return Flag.get(flag_name).is_active_for_team(team)
 

--- a/apps/teams/views/feature_flags.py
+++ b/apps/teams/views/feature_flags.py
@@ -81,7 +81,9 @@ class FeatureFlagForm(forms.Form):
             self._all_flags = {flag.name: flag for flag in Flag.get_all()}
 
         if flag_name not in self._all_flags:
-            flag, _created = Flag.objects.get_or_create(name=flag_name, defaults={"everyone": False})
+            flag, _created = Flag.objects.get_or_create(
+                name=flag_name, defaults={"everyone": None, "superusers": False}
+            )
             self._all_flags[flag_name] = flag
         return self._all_flags[flag_name]
 

--- a/apps/utils/tests/test_rate_limit.py
+++ b/apps/utils/tests/test_rate_limit.py
@@ -285,9 +285,7 @@ def test_exempt_flag_slugs_match():
 @pytest.mark.django_db()
 def test_is_exempt_for_flagged_team():
     """A team with the flag enabled is exempt; others are not."""
-    flag, _ = get_waffle_flag_model().objects.update_or_create(
-        name=RATE_LIMIT_EXEMPT_FLAG, defaults={"everyone": False}
-    )
+    flag, _ = get_waffle_flag_model().objects.update_or_create(name=RATE_LIMIT_EXEMPT_FLAG, defaults={"everyone": None})
     exempt_team = TeamFactory()
     other_team = TeamFactory()
     flag.teams.add(exempt_team)

--- a/templates/admin/flags/detail.html
+++ b/templates/admin/flags/detail.html
@@ -54,7 +54,7 @@
               flagId: {{ flag.id }},
               flagName: '{{ flag.name }}',
               initialData: {
-              everyone: {{ flag.everyone|yesno:'true,false' }},
+              everyone: '{{ flag.everyone|yesno:'true,false,unknown' }}',
               teams: [{% for team in flag.teams.all %}{{ team.id }}{% if not forloop.last %},{% endif %}{% endfor %}]
               }
               })"
@@ -70,15 +70,15 @@
             </h3>
 
             <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <label class="flex items-center">
-                <input
-                  type="checkbox"
-                  x-model="formData.everyone"
-                  class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
-                />
-                <span class="ml-2 text-sm text-base-content">
-                  {% translate "Everyone" %}
-                  <span class="block text-xs text-base-content/70">{% translate "Enable for all users" %}</span>
+              <label class="flex flex-col gap-1">
+                <span class="text-sm text-base-content">{% translate "Everyone" %}</span>
+                <select x-model="formData.everyone" class="select select-bordered w-full">
+                  <option value="unknown">{% translate "Use team list" %}</option>
+                  <option value="true">{% translate "On for everyone" %}</option>
+                  <option value="false">{% translate "Off for everyone" %}</option>
+                </select>
+                <span class="text-xs text-base-content/70">
+                  {% translate "A global on or off overrides the team list below" %}
                 </span>
               </label>
             </div>
@@ -265,7 +265,7 @@
           }
           formData.append('csrfmiddlewaretoken', csrfToken.value);
 
-          if (this.formData.everyone) formData.append('everyone', 'on');
+          formData.append('everyone', this.formData.everyone);
           this.formData.teams.forEach(id => formData.append('teams', id));
 
           return formData;

--- a/templates/admin/flags/flag_list.html
+++ b/templates/admin/flags/flag_list.html
@@ -35,6 +35,10 @@
                       <span class="badge badge-success">
                         Everyone
                       </span>
+                    {% elif flag.everyone == False %}
+                      <span class="badge badge-error">
+                        Off for everyone
+                      </span>
                     {% endif %}
                   </div>
                   <div class="flex items-center space-x-2">


### PR DESCRIPTION
### Product Description

Feature flags gain a real off switch. A flag is now either on for everyone, off for everyone, or left to the team list, and the admin screen offers those three choices where it previously had a single Everyone checkbox.

Before this change there was no way to say "off for everyone": the stored `False` value meant "no global override, use the team list", so a team grant still turned the feature on. Anyone who wanted a feature globally dark had to empty the team list and hope nothing re-added a team.

Fixes #4321. Third and last PR of the sequence agreed on the issue; based on #4369 (step 2), which is based on #4359 (step 1, merged).

### Technical Description

`Flag.everyone` is a `NullBooleanField`, so the tri-state already existed in the database and only the reads and writes treated it as a boolean.

- `Flag.is_active_for_team` returns `everyone` whenever it is set, so both `True` and `False` beat the team M2M. `Flag.is_active` inherits this through its existing delegation: waffle returns `False` for `everyone=False`, and the OCS override no longer resurrects the flag from the team list.
- Migration `0017_everyone_false_to_none` converts stored `False` to `None` before `False` takes on its new meaning, and re-runs the `0016` request-only neutralisation because rows created between the two migrations carry waffle's field defaults. It follows `0016`: historical model for row writes, per-flag waffle cache flush via an unsaved live `Flag(name=...)`, `elidable=True`, and a noop reverse.
- Every flag-creating path now writes `everyone=None` and `superusers=False`: both `CREATE_MISSING_FLAGS` mint paths and the team settings screen. The `superusers` part is load-bearing rather than tidiness. With `everyone=None` waffle carries on to its superuser branch, so a superuser's first request-path check of a missing flag returned `True` and, among other things, made superusers rate-limit exempt. The previous `everyone=False` had been masking that by short-circuiting the evaluation.
- Migration `0010` pre-creates `flag_ai_cost_monitoring` and is not elidable, unlike `0016` and `0017`. A future squash would drop the two conversions and keep `0010`, so its defaults move to `everyone=None` and `superusers=False` as well. The edit is a no-op wherever the migration has already run.
- `FlagUpdateForm.everyone` becomes a `NullBooleanField`, and the admin detail screen posts an explicit `true` / `false` / `unknown`. A plain `BooleanField` coerces an absent key to `False`, which under the new semantics is exactly the bug being removed. The flag list gains an "Off for everyone" badge; the deferred state shows no global badge.
- Deferred cleanup from #4359's review: `apps/channels/models.py` and the two `flags_enabled` context entries now go through `flag_is_active_for_team`.

One payload change worth flagging for reviewers: a legacy `everyone=on` POST to `update_flag` now cleans to `None` ("use the team list") rather than `True`, because `NullBooleanField.to_python` does not recognise `on`. The endpoint is superuser-only and its sole caller is updated in the same diff, so the exposure is a stale browser tab, and the failure direction narrows access rather than widening it.

### Migrations

- [x] The migrations are backwards compatible

No schema change. `0017` rewrites data only, and code from before this PR reads the resulting `None` exactly as it read the old `False` ("use the team list"), so a rollback of the application code is safe. The data conversion itself is deliberately one-way: the old `False` values are indistinguishable from the ones that meant "use teams", which is why the reverse is a noop.

### Demo

Both badges appear on the flag list; `flag_events` defers to its team list, so it carries no global badge. The `Off for everyone` row is the state that was previously unexpressible, and its change history records the transition as `Everyone: None -> False`.

| State | Screenshot |
| --- | --- |
| **Flag list** | <img width="720" alt="Flag list showing Everyone and Off for everyone badges" src="https://github.com/user-attachments/assets/a3400382-bdc7-4605-8351-2db4fc201c73" /> |
| **On for everyone**<br>`everyone=True` | <img width="720" alt="Flag detail with Everyone set to On for everyone" src="https://github.com/user-attachments/assets/419ad1c2-9c3d-46c7-9b4f-b0f264b087aa" /> |
| **Off for everyone**<br>`everyone=False` | <img width="720" alt="Flag detail with Everyone set to Off for everyone" src="https://github.com/user-attachments/assets/14df1774-7610-43ed-80eb-df81b2159fcc" /> |
| **Use team list**<br>`everyone=None` | <img width="720" alt="Flag detail with Everyone set to Use team list" src="https://github.com/user-attachments/assets/5b971aa3-0c4b-4e0e-9834-5157a2d26e04" /> |

### Docs and Changelog

- [x] This PR requires docs/changelog update

`docs/developer_guides/code_systems/feature_flags.md` describes `everyone` as a boolean.

### Operator Impact

- [x] Self-hosted operators must know about or act on this change

Two behaviour changes land with the migration:

1. Flags stored as `everyone=False` with teams attached had their team grants ignored by team-scoped checks. After the conversion those grants apply. This is the restoration the issue asks for, since `False` has always meant "use teams" in practice, but an operator who genuinely intended "off for everyone" must now select that state explicitly.
2. Newly created flags no longer grant superusers automatic access on request paths. Surfaces that should always be visible to superusers gate on `is_superuser` instead.
