### PR TITLE
Enum Name Overrides

### DIFF
--- a/api-schemas/export.yml
+++ b/api-schemas/export.yml
@@ -1983,7 +1983,7 @@ components:
           format: date-time
           readOnly: true
         item_type:
-          $ref: '#/components/schemas/ItemTypeEnum'
+          $ref: '#/components/schemas/EvaluationModeEnum'
         status:
           $ref: '#/components/schemas/AnnotationItemDetailStatusEnum'
         review_count:
@@ -3145,16 +3145,6 @@ components:
       - cursor
       - has_more
       - results
-    EmailLevelEnum:
-      enum:
-      - 0
-      - 1
-      - 2
-      type: integer
-      description: |-
-        * `0` - Info
-        * `1` - Warning
-        * `2` - Error
     EmbeddingProviderModelDetail:
       type: object
       properties:
@@ -3173,7 +3163,7 @@ components:
           format: date-time
           readOnly: true
         type:
-          $ref: '#/components/schemas/Type0f6Enum'
+          $ref: '#/components/schemas/LlmProviderTypeEnum'
         name:
           type: string
           description: The name of the model. e.g. 'text-embedding-3-small'
@@ -3301,7 +3291,7 @@ components:
             * `session` - Session
         status:
           allOf:
-          - $ref: '#/components/schemas/StatusA8fEnum'
+          - $ref: '#/components/schemas/JobStatusEnum'
           description: |-
             Status of dataset creation
 
@@ -3398,12 +3388,12 @@ components:
       - results
     EvaluationModeEnum:
       enum:
-      - message
       - session
+      - message
       type: string
       description: |-
-        * `message` - Message
         * `session` - Session
+        * `message` - Message
     EvaluationResultDetail:
       type: object
       properties:
@@ -3528,7 +3518,7 @@ components:
             reversal) landed. Set as soon as the run completes if it has nothing to
             finalize.
         status:
-          $ref: '#/components/schemas/StatusA8fEnum'
+          $ref: '#/components/schemas/JobStatusEnum'
         type:
           $ref: '#/components/schemas/EvaluationRunDetailTypeEnum'
         job_id:
@@ -3777,7 +3767,7 @@ components:
         event_data: {}
         level:
           allOf:
-          - $ref: '#/components/schemas/EmailLevelEnum'
+          - $ref: '#/components/schemas/NotificationLevelEnum'
           minimum: 0
           maximum: 32767
       required:
@@ -3903,7 +3893,7 @@ components:
           nullable: true
         required_auth_level:
           allOf:
-          - $ref: '#/components/schemas/RequiredAuthLevelEnum'
+          - $ref: '#/components/schemas/WidgetAuthLevelEnum'
           description: |-
             Minimum authentication an embedded widget must provide. New widgets (0.9.0+) send a session token; only downgrade this for a channel you know is running an older widget.
 
@@ -3917,7 +3907,7 @@ components:
           minimum: 0
           maximum: 32767
           oneOf:
-          - $ref: '#/components/schemas/PendingAuthLevelEnum'
+          - $ref: '#/components/schemas/WidgetAuthLevelEnum'
           - $ref: '#/components/schemas/NullEnum'
         auth_level_notified_at:
           type: string
@@ -4357,14 +4347,18 @@ components:
       description: |-
         * `email` - Email
         * `text` - Text
-    ItemTypeEnum:
+    JobStatusEnum:
       enum:
-      - session
-      - message
+      - pending
+      - processing
+      - completed
+      - failed
       type: string
       description: |-
-        * `session` - Session
-        * `message` - Message
+        * `pending` - Pending
+        * `processing` - Processing
+        * `completed` - Completed
+        * `failed` - Failed
     LastRunStatusEnum:
       enum:
       - success
@@ -4393,7 +4387,7 @@ components:
           format: date-time
           readOnly: true
         type:
-          $ref: '#/components/schemas/Type0f6Enum'
+          $ref: '#/components/schemas/LlmProviderTypeEnum'
         name:
           type: string
           maxLength: 255
@@ -4440,7 +4434,7 @@ components:
           format: date-time
           readOnly: true
         type:
-          $ref: '#/components/schemas/Type0f6Enum'
+          $ref: '#/components/schemas/LlmProviderTypeEnum'
         name:
           type: string
           description: The name of the model. e.g. 'gpt-4o-mini' or 'claude-3-5-sonnet-20240620'
@@ -4479,6 +4473,32 @@ components:
       - cursor
       - has_more
       - results
+    LlmProviderTypeEnum:
+      enum:
+      - openai
+      - azure
+      - anthropic
+      - groq
+      - perplexity
+      - deepseek
+      - minimax
+      - litellm
+      - google
+      - google_vertex_ai
+      - voyage
+      type: string
+      description: |-
+        * `openai` - OpenAI
+        * `azure` - Azure OpenAI
+        * `anthropic` - Anthropic
+        * `groq` - Groq
+        * `perplexity` - Perplexity
+        * `deepseek` - DeepSeek
+        * `minimax` - MiniMax
+        * `litellm` - LiteLLM
+        * `google` - Google Gemini
+        * `google_vertex_ai` - Google Vertex AI
+        * `voyage` - Voyage AI
     Manifest:
       type: object
       description: 'The sync manifest: the call order and per-model config, plus a
@@ -4723,6 +4743,16 @@ components:
       - cursor
       - has_more
       - results
+    NotificationLevelEnum:
+      enum:
+      - 0
+      - 1
+      - 2
+      type: integer
+      description: |-
+        * `0` - Info
+        * `1` - Warning
+        * `2` - Error
     NullEnum:
       enum:
       - null
@@ -4832,16 +4862,6 @@ components:
       - cursor
       - has_more
       - results
-    PendingAuthLevelEnum:
-      enum:
-      - 0
-      - 1
-      - 2
-      type: integer
-      description: |-
-        * `0` - None (pre-0.5.1 legacy)
-        * `1` - Embed key only (0.5.1 – 0.8.x)
-        * `2` - Session token required (0.9.0+)
     PipelineChatHistoryDetail:
       type: object
       properties:
@@ -5126,16 +5146,6 @@ components:
         * `evaluation_dataset` - Evaluation Dataset
         * `data_export` - Data Export
         * `message_media` - Message Media
-    RequiredAuthLevelEnum:
-      enum:
-      - 0
-      - 1
-      - 2
-      type: integer
-      description: |-
-        * `0` - None (pre-0.5.1 legacy)
-        * `1` - Embed key only (0.5.1 – 0.8.x)
-        * `2` - Session token required (0.9.0+)
     ScheduledMessageDetail:
       type: object
       properties:
@@ -5533,18 +5543,6 @@ components:
       - cursor
       - has_more
       - results
-    StatusA8fEnum:
-      enum:
-      - pending
-      - processing
-      - completed
-      - failed
-      type: string
-      description: |-
-        * `pending` - Pending
-        * `processing` - Processing
-        * `completed` - Completed
-        * `failed` - Failed
     SyncErrorDetail:
       type: object
       properties:
@@ -6002,7 +6000,7 @@ components:
         description:
           type: string
         status:
-          $ref: '#/components/schemas/StatusA8fEnum'
+          $ref: '#/components/schemas/JobStatusEnum'
         query_file:
           type: string
           nullable: true
@@ -6073,32 +6071,6 @@ components:
       - cursor
       - has_more
       - results
-    Type0f6Enum:
-      enum:
-      - openai
-      - azure
-      - anthropic
-      - groq
-      - perplexity
-      - deepseek
-      - minimax
-      - litellm
-      - google
-      - google_vertex_ai
-      - voyage
-      type: string
-      description: |-
-        * `openai` - OpenAI
-        * `azure` - Azure OpenAI
-        * `anthropic` - Anthropic
-        * `groq` - Groq
-        * `perplexity` - Perplexity
-        * `deepseek` - DeepSeek
-        * `minimax` - MiniMax
-        * `litellm` - LiteLLM
-        * `google` - Google Gemini
-        * `google_vertex_ai` - Google Vertex AI
-        * `voyage` - Voyage AI
     UsageRecordDetail:
       type: object
       properties:
@@ -6267,14 +6239,14 @@ components:
           type: boolean
         in_app_level:
           allOf:
-          - $ref: '#/components/schemas/EmailLevelEnum'
+          - $ref: '#/components/schemas/NotificationLevelEnum'
           minimum: 0
           maximum: 32767
         email_enabled:
           type: boolean
         email_level:
           allOf:
-          - $ref: '#/components/schemas/EmailLevelEnum'
+          - $ref: '#/components/schemas/NotificationLevelEnum'
           minimum: 0
           maximum: 32767
         do_not_disturb_until:
@@ -6391,6 +6363,16 @@ components:
         * `always` - Always
         * `reciprocal` - Reciprocal
         * `never` - Never
+    WidgetAuthLevelEnum:
+      enum:
+      - 0
+      - 1
+      - 2
+      type: integer
+      description: |-
+        * `0` - None (pre-0.5.1 legacy)
+        * `1` - Embed key only (0.5.1 – 0.8.x)
+        * `2` - Session token required (0.9.0+)
   securitySchemes:
     apiKeyAuth:
       type: apiKey

--- a/apps/api/tests/test_schema.py
+++ b/apps/api/tests/test_schema.py
@@ -1,9 +1,13 @@
+import os
+
 import pytest
 import yaml
 from django.core.management import call_command
 from django.test import Client
 
 from apps.api.schema import _swap_host
+
+VERSIONS = [pytest.param("v1", id="v1"), pytest.param("v2", id="v2"), pytest.param("export", id="export")]
 
 
 @pytest.mark.django_db()
@@ -53,14 +57,7 @@ def test_served_schema_uses_request_host():
     assert "example.com" not in body
 
 
-@pytest.mark.parametrize(
-    "version",
-    [
-        pytest.param("v1", id="v1"),
-        pytest.param("v2", id="v2"),
-        pytest.param("export", id="export"),
-    ],
-)
+@pytest.mark.parametrize("version", VERSIONS)
 def test_schema_is_up_to_date_and_valid(pytestconfig, tmp_path, version):
     """If this test fails run `inv schema` to update the schema."""
     path = tmp_path / f"{version}.yml"
@@ -72,3 +69,12 @@ def test_schema_is_up_to_date_and_valid(pytestconfig, tmp_path, version):
         old_schema = yaml.safe_load(f)
 
     assert old_schema == new_schema
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_schema_generates_without_warnings(version):
+    """Warnings mean a view or serializer could not be resolved. See `@extend_schema`.
+
+    The emitted warnings are printed to stderr, so pytest shows them on failure.
+    """
+    call_command("spectacular", api_version=version, fail_on_warn=True, file=os.devnull)

--- a/config/settings.py
+++ b/config/settings.py
@@ -491,10 +491,15 @@ SPECTACULAR_SETTINGS = {
     "PREPROCESSING_HOOKS": [
         "apps.api.schema.exclude_legacy_participants_path",
     ],
-    # Give the ExperimentSession ``status`` enum a stable name; otherwise it collides with other
-    # "status" fields and drf-spectacular falls back to a hashed name ("Status490Enum").
+    # Name every choice set that drf-spectacular can't name unambiguously on its own. Without an
+    # entry it either derives the name from a hash of the choices ("Status490Enum")
     "ENUM_NAME_OVERRIDES": {
         "ChatbotSessionStatusEnum": "apps.experiments.models.SessionStatus",
+        "LlmProviderTypeEnum": "apps.service_providers.models.LlmProviderTypes.choices",
+        "JobStatusEnum": "apps.evaluations.models.EvaluationRunStatus",
+        "EvaluationModeEnum": "apps.evaluations.models.EvaluationMode",
+        "WidgetAuthLevelEnum": "apps.channels.models.WidgetAuthLevel",
+        "NotificationLevelEnum": "apps.ocs_notifications.models.LevelChoices",
     },
     "SWAGGER_UI_SETTINGS": {
         "displayOperationId": True,


### PR DESCRIPTION
### Product Description
No change for end users of the app.

For API consumers, six enum components in the published OpenAPI schemas now have stable, meaningful names instead of hash-suffixed ones. On the export surface, `Type0f6Enum` → `LlmProviderTypeEnum`, `StatusA8fEnum` → `JobStatusEnum`, `ItemTypeEnum` → `EvaluationModeEnum`, `EmailLevelEnum` → `NotificationLevelEnum`, and both `RequiredAuthLevelEnum` and `PendingAuthLevelEnum` → a single `WidgetAuthLevelEnum`. Anyone generating a client from `api-schemas/export.yml` will see the corresponding model classes renamed.

### Technical Description
[Link to GitHub issue here](https://github.com/dimagi/open-chat-studio/issues/4256)

drf-spectacular names an enum component after the serializer field it comes from. When the same field name carries different choice sets across components it can't resolve the clash, so it falls back to a name hashed from the choice values, which then churns whenever a choice is added or removed. Five choice sets on the export surface were hitting that: two collided outright and got hashed names, while three were reachable under several names each (`WidgetAuthLevel` appeared as both `RequiredAuthLevel` and `PendingAuthLevel`). Each now has an `ENUM_NAME_OVERRIDES` entry pointing at its source enum, and `api-schemas/export.yml` is regenerated to match.

### Demo
No UI change.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change