### PR TITLE
Accept .xlsm chat attachments and collection uploads

### DIFF
--- a/apps/api/tests/test_chat_file_upload_api.py
+++ b/apps/api/tests/test_chat_file_upload_api.py
@@ -208,6 +208,20 @@ class TestFileValidationAPI:
 
         assert response.status_code == status.HTTP_201_CREATED
 
+    def test_macro_enabled_workbook_upload_accepted(self, api_client, session):
+        """.xlsm is an ordinary spreadsheet to us: markitdown reads it as xlsx and macros never run."""
+        url = reverse("api:chat:upload-file", kwargs={"session_id": session.external_id})
+        test_file = create_test_file(
+            "workbook.xlsm",
+            b"PK\x03\x04",
+            content_type="application/vnd.ms-excel.sheet.macroEnabled.12",
+        )
+
+        response = api_client.post(url, {"files": test_file}, format="multipart")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["files"][0]["name"] == "workbook.xlsm"
+
     def test_second_bad_file_rejects_whole_upload(self, api_client, session):
         """Validation covers every file; no File rows are created on rejection."""
         url = reverse("api:chat:upload-file", kwargs={"session_id": session.external_id})

--- a/config/settings.py
+++ b/config/settings.py
@@ -1027,8 +1027,8 @@ SUPPORTED_FILE_TYPES = {
         ".c,.cs,.cpp,.doc,.docx,.html,.java,.json,.md,.pdf,.php,.pptx,.py,.py,.rb,.tex,.txt,.css,.js,.sh,.ts"
     ),
     "collections": (
-        ".txt,.pdf,.doc,.docx,.xls,.xlsx,.csv,.jpg,.jpeg,.png,.gif,.bmp,.webp,.svg,.mp4,.mov,.avi,.mp3,.wav,.html,.htm,"
-        ".css,.js,.xml,.md,.ics,.vcf,.rtf,.tsv,.yaml,.yml,.py,.c"
+        ".txt,.pdf,.doc,.docx,.xls,.xlsx,.xlsm,.csv,.jpg,.jpeg,.png,.gif,.bmp,.webp,.svg,.mp4,.mov,.avi,.mp3,.wav,"
+        ".html,.htm,.css,.js,.xml,.md,.ics,.vcf,.rtf,.tsv,.yaml,.yml,.py,.c"
     ),
 }
 


### PR DESCRIPTION
### Product Description

`.xlsm` (macro-enabled Excel) files can now be attached to chats and uploaded to collections. Previously they were rejected with "File type '.xlsm' is not supported".

This also closes a gap for widget users: chat widget 0.12.0 already listed `.xlsm` as an accepted extension and its release notes announced the support, so the widget would let a participant pick an `.xlsm` and the API would then reject the upload.

### Technical Description

`.xlsm` was absent from the allowlist for no technical or policy reason — it was simply never added.

- Extraction already works. `Document.from_file` hands markitdown raw bytes (`apps/documents/readers.py`), magic sniffing places `.xlsm` in the xlsx family, and openpyxl reads it natively. markitdown's `XlsxConverter.accepts()` does not list `.xlsm`, but that path is never taken.
- Macros are not a reason to exclude it: `.doc` and `.xls` are already allowed and can also carry macros. OCS never executes the file — only extracted text reaches the LLM.

`SUPPORTED_FILE_TYPES["chat_attachments"]` is derived from `collections` (minus `.bmp`/`.svg`), and `templates/documents/file_upload_modal.html` gets its `accept` attributes from settings via `apps/documents/views.py`, so a single addition to `collections` covers the chat upload API, collection uploads, and both `accept` lists.

The issue also named the Django chat template and the chat widget, both of which are already resolved on `main`: the widget lists `.xlsm` (`ocs-chat.tsx`, asserted in `ocs-chat.spec.tsx`) and shipped in 0.12.0, and the template's out-of-sync `accept` lists were removed with the assistant-gated upload UI in fdac916c9 — the remaining file input has no `accept` attribute.

The string is rewrapped because the addition pushed the first line to 126 columns. ruff's E501 skips unbroken tokens so it was not flagged, but it was over the configured 120 limit.

Tested with a new API test in `TestFileValidationAPI`, written first and confirmed failing (`assert 400 == 201`) before the settings change.

### Migrations
- [x] The migrations are backwards compatible

No migrations.

### Demo

Not applicable — no UI change. Behaviour is covered by `test_macro_enabled_workbook_upload_accepted`.

### Docs and Changelog
- [x] This PR requires docs/changelog update

The list of supported chat attachment / collection file types gains `.xlsm`.

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
