### PR TITLE
Make External IDs Field Nullable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ Tests and typecheck are necessary but not sufficient. For any change with a runt
 * Prefer `pytest.mark.parametrize` for tests over enumerated data (same assertion, varying inputs); give each case a readable ID with `pytest.param(..., id="...")` rather than an inline comment
 * Always use @.github/pull_request_template.md as the template for pull request descriptions
 * A comment earns its place by carrying context the file cannot show — keep it when a reader of this file alone could not work out why the code is the way it is. Default docstrings to a single line
+* A migration must run correctly against **both** the old code and the new code: the deploy applies migrations to completion while the previous release is still serving. Adding a `NOT NULL` column is the usual trap — Django's `AddField` drops the DB default afterwards, so the running release's inserts, which omit the column, fail. Add it `null=True`, or keep a DB-level default
 * Catch database exceptions *outside* `transaction.atomic()`, or wrap the failing code in a nested `atomic()` savepoint — a DB error caught inside the block leaves an aborted transaction that raises on the next query or on block exit. Enforced by `scripts/check_atomic_exception_handling.py` (pre-commit hook `atomic-exception-handling`)
 
 ## Ask first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,6 @@ version section when a release is cut.
 
 ### Migrations
 <!-- One line per migration. Omit the section if there are none. -->
-- `0028_alter_chatmessage_external_ids`: reversible, metadata-only (`DROP NOT
-  NULL`; brief `ACCESS EXCLUSIVE` lock, no table rewrite), no manual steps.
-  Makes `chat_chatmessage.external_ids` nullable so that the release running
-  during a deploy, which predates the column, can still insert chat messages.
-  (#4387)
 
 ### Configuration
 <!-- New, renamed, retyped or removed environment variables and settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ version section when a release is cut.
 
 ### Migrations
 <!-- One line per migration. Omit the section if there are none. -->
+- `0028_alter_chatmessage_external_ids`: reversible, metadata-only (`DROP NOT
+  NULL`; brief `ACCESS EXCLUSIVE` lock, no table rewrite), no manual steps.
+  Makes `chat_chatmessage.external_ids` nullable so that the release running
+  during a deploy, which predates the column, can still insert chat messages.
+  (#4387)
 
 ### Configuration
 <!-- New, renamed, retyped or removed environment variables and settings.

--- a/api-schemas/export.yml
+++ b/api-schemas/export.yml
@@ -2418,6 +2418,7 @@ components:
           items:
             type: string
             maxLength: 600
+          nullable: true
           description: Provider message IDs this message was built from, namespaced
             by platform.
         chat:

--- a/apps/channels/tests/test_deduplication.py
+++ b/apps/channels/tests/test_deduplication.py
@@ -72,3 +72,15 @@ class TestChatbotScope:
 
         assert is_duplicate_delivery(external_ids_for("telegram", bot_b.id, 55501, 1), bot_a.team_id) is False
         assert is_duplicate_delivery(external_ids_for("telegram", bot_a.id, 55501, 1), bot_a.team_id) is True
+
+
+@pytest.mark.django_db()
+def test_rows_with_no_external_ids_are_ignored(record_delivery):
+    """`external_ids` is nullable so the previous release's inserts survive a deploy's migration
+    step; those NULL rows must be invisible to the lookup rather than crashing it."""
+    team = TeamFactory()
+    record_delivery(team, None)
+    record_delivery(team, [])
+
+    assert _unseen_message_ids(["connect:a"], team.id) == {"connect:a"}
+    assert is_duplicate_delivery(["connect:a"], team.id) is False

--- a/apps/chat/migrations/0028_alter_chatmessage_external_ids.py
+++ b/apps/chat/migrations/0028_alter_chatmessage_external_ids.py
@@ -1,0 +1,23 @@
+import django.contrib.postgres.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("chat", "0027_chatmessage_external_ids_idx"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="chatmessage",
+            name="external_ids",
+            field=django.contrib.postgres.fields.ArrayField(
+                base_field=models.CharField(max_length=600),
+                blank=True,
+                default=list,
+                help_text="Provider message IDs this message was built from, namespaced by platform.",
+                null=True,
+                size=None,
+            ),
+        ),
+    ]

--- a/apps/chat/models.py
+++ b/apps/chat/models.py
@@ -182,6 +182,7 @@ class ChatMessage(BaseModel, TaggedModelMixin, UserCommentsMixin):
         models.CharField(max_length=EXTERNAL_ID_MAX_LENGTH),
         default=list,
         blank=True,
+        null=True,
         help_text="Provider message IDs this message was built from, namespaced by platform.",
     )
 


### PR DESCRIPTION
### Product Description
No change — a deploy-safety fix with no user-visible behaviour change.

### Technical Description
`ChatMessage.external_ids` (added in [#4288](https://github.com/dimagi/open-chat-studio/pull/4288)) shipped as a `NOT NULL` column. Django's `AddField` backfills using a temporary DB default and then drops it, so once the migration task finished, the still-running previous release — which has no such field on its model — inserted chat messages with the column omitted and hit `IntegrityError: null value in column "external_ids" of relation "chat_chatmessage" violates not-null constraint`. It appeared in Sentry on `get_response_for_webchat_task` within minutes of #4288 merging and stopped once the rollout completed, but the same trap awaits the next deploy of any lagging service.

Migration 0028 makes the column nullable: a single `ALTER COLUMN ... DROP NOT NULL`, metadata-only, no table rewrite. `null=True` sits alongside the existing `default=list`, so nothing in the current code writes NULL — only a release predating the field can. The alternative, keeping a DB-level default (`SET DEFAULT '{}'`), would have kept the column two-valued; nullable is the more conventional Django expression of the same guarantee, at the cost of NULL now meaning "written by a release predating the field".

`AGENTS.md` gains a rule about migrations having to work against both the old and the new code, since the PR-template checkbox stated the principle but nothing tied it to this concrete case. A new test asserts NULL and empty rows are invisible to the lookup rather than crashing it.

### Migrations
- [x] The migrations are backwards compatible

### Demo
N/A — no user-facing change.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change



