### PR TITLE
Feat: Adds missing pricing

### DIFF
--- a/apps/cost_tracking/migrations/0003_seed_pricing.py
+++ b/apps/cost_tracking/migrations/0003_seed_pricing.py
@@ -1,13 +1,9 @@
 from django.db import migrations
 
-from apps.cost_tracking.migration_utils import load_pricing_data
-
 
 class Migration(migrations.Migration):
     dependencies = [
         ("cost_tracking", "0002_seed_pricing"),
     ]
 
-    operations = [
-        load_pricing_data(),
-    ]
+    operations = []

--- a/apps/cost_tracking/migrations/0004_rate_update_20260702.py
+++ b/apps/cost_tracking/migrations/0004_rate_update_20260702.py
@@ -1,8 +1,6 @@
 from django.db import migrations
 
-from apps.cost_tracking.migration_utils import load_pricing_data
-
 
 class Migration(migrations.Migration):
     dependencies = [("cost_tracking", "0003_seed_pricing")]
-    operations = [load_pricing_data()]
+    operations = []

--- a/apps/cost_tracking/migrations/0005_rate_update_20260716.py
+++ b/apps/cost_tracking/migrations/0005_rate_update_20260716.py
@@ -1,8 +1,6 @@
 from django.db import migrations
 
-from apps.cost_tracking.migration_utils import load_pricing_data
-
 
 class Migration(migrations.Migration):
     dependencies = [("cost_tracking", "0004_rate_update_20260702")]
-    operations = [load_pricing_data()]
+    operations = []

--- a/apps/cost_tracking/migrations/0007_rate_update_20260731.py
+++ b/apps/cost_tracking/migrations/0007_rate_update_20260731.py
@@ -1,8 +1,6 @@
 from django.db import migrations
 
-from apps.cost_tracking.migration_utils import load_pricing_data
-
 
 class Migration(migrations.Migration):
     dependencies = [("cost_tracking", "0006_usagerecord_evaluation_config_usagerecord_source_and_more")]
-    operations = [load_pricing_data()]
+    operations = []

--- a/apps/cost_tracking/migrations/0008_rate_update_20260904.py
+++ b/apps/cost_tracking/migrations/0008_rate_update_20260904.py
@@ -1,0 +1,8 @@
+from django.db import migrations
+
+from apps.cost_tracking.migration_utils import load_pricing_data
+
+
+class Migration(migrations.Migration):
+    dependencies = [("cost_tracking", "0007_rate_update_20260731")]
+    operations = [load_pricing_data()]

--- a/apps/cost_tracking/seed_data/llm_pricing.json
+++ b/apps/cost_tracking/seed_data/llm_pricing.json
@@ -1540,5 +1540,45 @@
         "unit_price": "0.0012"
       }
     ]
+  },
+  {
+    "provider_type": "anthropic",
+    "model_name": "claude-3-5-haiku-latest",
+    "rules": [
+      {
+        "service_kind": "llm_input",
+        "unit_price": "0.0008"
+      },
+      {
+        "service_kind": "llm_output",
+        "unit_price": "0.004"
+      },
+      {
+        "service_kind": "llm_cached_input",
+        "unit_price": "0.00008"
+      },
+      {
+        "service_kind": "llm_cache_write",
+        "unit_price": "0.001"
+      }
+    ]
+  },
+  {
+    "provider_type": "openai",
+    "model_name": "o4-mini-high",
+    "rules": [
+      {
+        "service_kind": "llm_input",
+        "unit_price": "0.0011"
+      },
+      {
+        "service_kind": "llm_output",
+        "unit_price": "0.0044"
+      },
+      {
+        "service_kind": "llm_cached_input",
+        "unit_price": "0.000275"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->
Fixes cost dashboard accuracy for two models that had no pricing configured: Claude 3.5 Haiku and o4-mini-high. Usage of these models can now be costed exactly instead of falling back to an estimate (or showing no cost at all).

### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->
Adds pricing rows to apps/cost_tracking/seed_data/llm_pricing.json, plus a `new load_pricing_data()` migration (`0008_rate_update_20260904.py`) to load them:
| Provider | Model | Input (/1K) | Output (/1K) | Cached input (/1K) | Cache write (/1K) | Source |
|---|---|---|---|---|---|---|
| anthropic | claude-3-5-haiku-latest | 0.0008 | 0.004 | 0.00008 | 0.001 | Anthropic's published Haiku 3.5 card |
| openai | o4-mini-high | 0.0011 | 0.0044 | 0.000275 | — | Mirrors `o4-mini` — "high" is a reasoning-effort setting on the same priced model, not a separate SKU |

The other 6 models flagged as missing pricing were left as-is: they're already tracked in `test_seed_coverage.py's` KNOWN_UNPRICED allow-list with documented reasons, and groq/whisper-large-v3-turbo can't be priced this way at all since it's billed per audio-minute and there's no per-minute ServiceKind.


### Issue Link
<!--
Link to the issue or doc that prompted this change, if any.
-->

### Migrations
<!--
There may be a potentially long window during the deployment where migrations are applied, but the old code is still running. We need to ensure that migrations can be applied to the current running code without breaking it, to the extent possible.

Delete this section if there are no migration.
 -->
- [ ] The migrations are backwards compatible


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change

<!--
Check the box above if a self-hosted operator has to do something, or would be
surprised on upgrade: migrations, new/renamed/removed settings or env vars, a
change in deployment shape (process types, queues, backing-service versions),
a deprecation or removal, or a security fix needing operator action.

This is separate from the docs/changelog checkbox above, which covers the
user-facing product changelog. If checked, add an entry under `[Unreleased]` in
the repo-root `CHANGELOG.md` in this PR. See RELEASING.md.

Leave unchecked for a change that is purely a feature, improvement or bug fix
with none of the above — those reach operators through the user-facing
changelog. A feature PR that also carries a migration or a settings change is
still operator-impacting: check the box and log the migration.
-->

Resolves #3729 