### PR TITLE
fix: show record position in non-lazy table pagination

### DIFF
--- a/apps/web/tests/test_table_pagination_templates.py
+++ b/apps/web/tests/test_table_pagination_templates.py
@@ -1,0 +1,46 @@
+"""The pager's "X of TOTAL" is only replaced by "Page N" for lazily paginated tables.
+
+`render_table` renders its template with a fresh context, so a `{% render_table ... with
+lazy_pagination=True %}` never reaches the template; the two variants must differ by
+template, not by a context flag.
+"""
+
+import django_tables2 as tables
+import pytest
+from django.template.loader import render_to_string
+from django_tables2 import LazyPaginator, RequestConfig
+
+ROWS = [{"name": f"row-{i}"} for i in range(5)]
+
+
+class SimpleTable(tables.Table):
+    name = tables.Column()
+
+
+pytestmark = pytest.mark.django_db()
+
+
+def render(template_name, request, **paginate):
+    table = SimpleTable(ROWS)
+    RequestConfig(request, paginate={"per_page": 2, **paginate}).configure(table)
+    return " ".join(render_to_string(template_name, {"table": table}, request=request).split())
+
+
+def test_standard_table_pager_shows_the_total(rf):
+    assert "2 of 5" in render("table/single_table.html", rf.get("/"))
+
+
+def test_lazy_table_pager_shows_only_the_page_number(rf):
+    html = render("table/single_table_lazy_pagination.html", rf.get("/"), paginator_class=LazyPaginator)
+
+    assert "Page 1" in html
+    assert "of 5" not in html
+
+
+def test_lazy_pager_never_asks_for_a_count(rf):
+    """`LazyPaginator.count` raises, so rendering the total would break the page."""
+    table = SimpleTable(ROWS)
+    RequestConfig(rf.get("/"), paginate={"per_page": 2, "paginator_class": LazyPaginator}).configure(table)
+
+    with pytest.raises(NotImplementedError):
+        table.paginator.count  # noqa: B018

--- a/templates/table/single_table_lazy_pagination.html
+++ b/templates/table/single_table_lazy_pagination.html
@@ -1,5 +1,5 @@
 {% load static %}
 {% load render_table from django_tables2 %}
-{% render_table table "table/tailwind_js_pagination.html" with lazy_pagination=True %}
+{% render_table table "table/tailwind_js_pagination_lazy.html" %}
 {% block modal %}
 {% endblock modal %}

--- a/templates/table/tailwind_js_pagination.html
+++ b/templates/table/tailwind_js_pagination.html
@@ -38,13 +38,3 @@ Override pagination and sorting in base template to use htmx
     hx-target="closest div.table-container"
     hx-swap="outerHTML"
 {% endblock next-page-link-attr %}
-
-{% if lazy_pagination %}
-  {% block pagination_info %}
-    {% with page_number=table.page.number %}
-      {% blocktranslate %}
-        Page {{ page_number }}
-      {% endblocktranslate %}
-    {% endwith %}
-  {% endblock pagination_info %}
-{% endif %}

--- a/templates/table/tailwind_js_pagination_lazy.html
+++ b/templates/table/tailwind_js_pagination_lazy.html
@@ -1,0 +1,9 @@
+{% extends "table/tailwind_js_pagination.html" %}
+{% load i18n %}
+{% comment %}
+A LazyPaginator has no count, so the pager reports the page number alone.
+{% endcomment %}
+
+{% block pagination_info %}
+    {% blocktranslate with page_number=table.page.number %}Page {{ page_number }}{% endblocktranslate %}
+{% endblock pagination_info %}


### PR DESCRIPTION
### Product Description
Most tables (All Sessions, chatbot sessions, team members, integrations, notifications, evaluation runs, pipelines…) showed `Page 1` in the pager instead of `25 of 300`. They now show the position and total again. The three genuinely lazily-paginated tables keep `Page N`.

### Technical Description
`tailwind_js_pagination.html` guarded its `pagination_info` override with `{% if lazy_pagination %}`. That guard never did anything: `ExtendsNode` collects block overrides at compile time via `get_nodes_by_type(BlockNode)`, which descends into the `IfNode`'s branches, and a child template's content outside blocks is discarded at render time. So the override applied to every table using that template.

The flag couldn't have worked in any case — `render_table` renders with a fresh context of `{"table": table}` and ignores trailing tag bits, so `{% render_table ... with lazy_pagination=True %}` passed nothing. Simply moving the `{% if %}` inside the block would have made it always-false and blown up the lazy views, since `LazyPaginator.count` raises `NotImplementedError`.

The two variants now differ by template inheritance rather than a context flag. Nothing else changes: the affected tables were already paying the `COUNT` (default `Paginator` counts whether or not anything reads it), so this is display-only.

### Issue Link
N/A — found while tracing how All Sessions was wired up.

### Demo
N/A — pager text only.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change
