### PR TITLE
session details follow-up fixes

### DIFF
--- a/apps/chat/tests/test_participant_data_diff.py
+++ b/apps/chat/tests/test_participant_data_diff.py
@@ -1,6 +1,7 @@
 import pytest
 from django.urls import reverse
 
+from apps.annotations.models import Tag, TagCategories
 from apps.chat.models import ChatMessageType
 from apps.utils.factories.experiment import (
     ChatMessageFactory,
@@ -68,3 +69,42 @@ class TestParticipantDataDiffInSessionMessages:
         assert page_messages[2].participant_data_diff_from_trace is None
         assert page_messages[3].participant_data_diff_from_trace == diff_2
         assert page_messages[4].participant_data_diff_from_trace is None
+
+
+@pytest.mark.django_db()
+class TestTagFilterInSessionMessages:
+    def test_selecting_multiple_tags_keeps_all_of_them(self, client, experiment):
+        """The tag_filter checkboxes all share the same field name, so multiple selections arrive
+        as repeated query params. Reading it with QueryDict.get() silently keeps only the last one.
+        """
+        session = ExperimentSessionFactory.create(
+            experiment=experiment,
+            participant=ParticipantFactory.create(team=experiment.team, user=experiment.owner),
+        )
+        billing_tag = Tag.objects.create(name="billing", team=experiment.team, category=TagCategories.BOT_RESPONSE)
+        urgent_tag = Tag.objects.create(name="urgent", team=experiment.team, category=TagCategories.BOT_RESPONSE)
+
+        billing_message = ChatMessageFactory.create(
+            chat=session.chat, message_type=ChatMessageType.AI, content="Billing message"
+        )
+        billing_message.add_tag(billing_tag, team=experiment.team, added_by=None)
+        urgent_message = ChatMessageFactory.create(
+            chat=session.chat, message_type=ChatMessageType.AI, content="Urgent message"
+        )
+        urgent_message.add_tag(urgent_tag, team=experiment.team, added_by=None)
+        ChatMessageFactory.create(chat=session.chat, message_type=ChatMessageType.AI, content="Untagged message")
+
+        client.force_login(experiment.owner)
+        url = reverse(
+            "experiments:experiment_session_messages_view",
+            kwargs={
+                "team_slug": experiment.team.slug,
+                "experiment_id": experiment.public_id,
+                "session_id": session.external_id,
+            },
+        )
+        response = client.get(f"{url}?show_all=on&tag_filter=billing&tag_filter=urgent")
+        assert response.status_code == 200
+        page_messages = response.context["messages"]
+
+        assert {message.id for message in page_messages} == {billing_message.id, urgent_message.id}

--- a/apps/experiments/views/experiment.py
+++ b/apps/experiments/views/experiment.py
@@ -553,7 +553,7 @@ def experiment_session_messages_view(request, team_slug: str, experiment_id: uui
     session = request.experiment_session
     experiment = request.experiment
     page = int(request.GET.get("page", 1))
-    selected_tags = list(filter(None, request.GET.get("tag_filter", "").split(",")))
+    selected_tags = list(filter(None, request.GET.getlist("tag_filter")))
     language = request.GET.get("language", "")
     show_original_translation = request.GET.get("show_original_translation") == "on" and language
     try:

--- a/templates/annotations/tag_ui.html
+++ b/templates/annotations/tag_ui.html
@@ -18,7 +18,7 @@
     {% endfor %}
     {% if not label_text %}<i class="fa-solid fa-tags"></i>{% endif %}
     {% if allow_edit|default_if_none:True and perms.annotations.add_customtaggeditem %}
-    <button class="btn btn-xs btn-ghost {% if not label_text %}btn-square{% endif %}" title="Edit tags"
+    <button class="btn btn-xs btn-ghost {% if not label_text %}btn-square{% endif %}{% if hover_reveal_edit %} opacity-0 group-hover:opacity-100 focus:opacity-100 [@media(hover:none)]:opacity-100 transition-opacity{% endif %}" title="Edit tags"
             hx-get="{% url 'annotations:tag_ui' request.team.slug %}?edit=1"
             hx-vals='{{ object.object_info }}'
             hx-target="#tag-ui-{{ object.id }}"

--- a/templates/chatbots/chatbot_session_view.html
+++ b/templates/chatbots/chatbot_session_view.html
@@ -284,7 +284,7 @@
           <h3 class="pg-subtitle">{% translate "Participant data" %}</h3>
           <p class="pg-help mb-2">{% translate "As of the last message in this session" %}</p>
           <div class="p-3 border border-base-300 rounded-lg bg-base-200">
-            <pre class="text-sm whitespace-pre-wrap"><code>{{ experiment_session.latest_participant_data|to_json }}</code></pre>
+            <pre class="text-sm whitespace-pre-wrap wrap-break-word"><code>{{ experiment_session.latest_participant_data|to_json }}</code></pre>
           </div>
         </div>
       </div>
@@ -297,7 +297,7 @@
         <h3 class="pg-subtitle">{% translate "Session state" %}</h3>
         <p class="pg-help mb-2">{% translate "Read-only snapshot of the pipeline state for this session." %}</p>
         <div class="p-3 border border-base-300 rounded-lg bg-base-200">
-          <pre class="text-sm whitespace-pre-wrap"><code>{{ experiment_session.state|to_json }}</code></pre>
+          <pre class="text-sm whitespace-pre-wrap wrap-break-word"><code>{{ experiment_session.state|to_json }}</code></pre>
         </div>
       </div>
     </div>

--- a/templates/chatbots/chatbot_session_view.html
+++ b/templates/chatbots/chatbot_session_view.html
@@ -283,8 +283,8 @@
         <div class="app-card">
           <h3 class="pg-subtitle">{% translate "Participant data" %}</h3>
           <p class="pg-help mb-2">{% translate "As of the last message in this session" %}</p>
-          <div class="mt-2 p-3 border rounded-lg border-neutral-500">
-            <pre><code>{{ experiment_session.latest_participant_data|to_json }}</code></pre>
+          <div class="p-3 border border-base-300 rounded-lg bg-base-200">
+            <pre class="text-sm whitespace-pre-wrap"><code>{{ experiment_session.latest_participant_data|to_json }}</code></pre>
           </div>
         </div>
       </div>
@@ -297,7 +297,7 @@
         <h3 class="pg-subtitle">{% translate "Session state" %}</h3>
         <p class="pg-help mb-2">{% translate "Read-only snapshot of the pipeline state for this session." %}</p>
         <div class="p-3 border border-base-300 rounded-lg bg-base-200">
-          <pre><code class="text-sm">{{ experiment_session.state|to_json }}</code></pre>
+          <pre class="text-sm whitespace-pre-wrap"><code>{{ experiment_session.state|to_json }}</code></pre>
         </div>
       </div>
     </div>

--- a/templates/experiments/components/session_messages.html
+++ b/templates/experiments/components/session_messages.html
@@ -134,15 +134,15 @@
                 {{ message.created_at|date:"DATETIME_FORMAT" }}
               </time>
             </span>
+            {% if message.is_ai_message %}
+              {% include "experiments/chat/components/participant_data_diff_popover.html" with message=message %}
+            {% endif %}
+            {% if perms.annotations.add_usercomment %}
+              {% include "annotations/tag_ui.html" with object=message allow_edit=experiment.is_editable hover_reveal_edit=True %}
+            {% endif %}
             <div class="flex items-center gap-0 opacity-0 group-hover:opacity-100 focus-within:opacity-100 [@media(hover:none)]:opacity-100 transition-opacity">
               {% include "experiments/chat/components/trace_icons.html" with trace_infos=message.trace_info %}
-              {% if message.is_ai_message %}
-                {% include "experiments/chat/components/participant_data_diff_popover.html" with message=message %}
-              {% endif %}
               {% include "experiments/chat/components/copy_message_link.html" with message=message session_detail_url=session_detail_url %}
-              {% if perms.annotations.add_usercomment %}
-                {% include "annotations/tag_ui.html" with object=message allow_edit=experiment.is_editable %}
-              {% endif %}
             </div>
             {% if perms.annotations.add_usercomment %}
               <button class="ml-auto whitespace-nowrap btn btn-ghost btn-xs" @click="commentsRow = (commentsRow === {{ forloop.counter }} ? null : {{ forloop.counter }})">


### PR DESCRIPTION
### Product Description
Five small fixes to the redesigned session details page (#4379): selecting more than one tag filter now keeps every selection instead of only the last one, the participant-data-changed marker and message tags are visible without hovering, the Participant Data and Session State panels share the same styling, and long JSON values wrap instead of forcing a horizontal scroll.

### Technical Description
1. `apps/experiments/views/experiment.py` — `experiment_session_messages_view` read the tag filter with `request.GET.get("tag_filter", "")`. The checkboxes all share `name="tag_filter"`, so selecting more than one sends repeated query params and `.get()` silently kept only the last one. Switched to `request.GET.getlist("tag_filter")`.
2. `templates/chatbots/chatbot_session_view.html` — the Participant Data panel had its own one-off border/background instead of matching the Session State panel. Unified both on the Session State styling and added `whitespace-pre-wrap` to both `<pre>` blocks so a long value wraps instead of scrolling.
3. `templates/experiments/components/session_messages.html` — the participant-data-diff marker and the tag badges were both inside the same `opacity-0 group-hover:opacity-100` wrapper as the trace/copy-link icons, so they were invisible until hovering a row. Moved the diff marker out of that wrapper entirely, since it's informational (shows only on messages where data changed) rather than an action.
4. `templates/annotations/tag_ui.html` — tag badges needed to stay visible while only the edit button stays hover-gated, but this template is also used by 3 other pages (`apps/chatbots/tables.py`, `experiment_details.html`, `chatbot_session_view.html`'s own tags row) that show it fully visible with no hover-gating at all. Added an opt-in `hover_reveal_edit` param, applied only to the edit button's classes, defaulting to off so the other 3 callers are unaffected. `session_messages.html` is the only caller that passes `hover_reveal_edit=True`.

resolves #4415

### Migrations
<!-- none -->

### Demo
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="2000" height="1380" alt="before-messages" src="https://github.com/user-attachments/assets/057f11c6-19a9-4f20-8d81-c5ca8f8d6f21" />

</td>
<td>
<img width="2000" height="1380" alt="after-messages" src="https://github.com/user-attachments/assets/fa703239-3779-4469-89f0-63c58c672ec0" />
</td>
</tr>
<tr>
<td>
<img width="3388" height="430" alt="before-participant-data" src="https://github.com/user-attachments/assets/e497ad94-55a5-4e6d-8454-2ff9dbdd9290" />
</td>
<td>
<img width="2430" height="430" alt="after-participant-data" src="https://github.com/user-attachments/assets/ba3e2c63-a48b-45c1-a63c-429032701baa" />
</td>
</tr>
</table>

Tag badges and the participant-data-changed marker (message 4) are visible without hovering in the "after" screenshots. The Participant Data panel also matches Session State's styling now, and the long `escalation_notes` value wraps instead of forcing the whole page to scroll horizontally.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change
