### PR TITLE
Write API: publish, poll and archive a chatbot

### DIFF
--- a/api-schemas/v2.yml
+++ b/api-schemas/v2.yml
@@ -756,6 +756,109 @@ paths:
         '409':
           description: The node is part of the pipeline's structure and cannot be
             deleted.
+  /api/v2/chatbots/{id}/versions/:
+    post:
+      operationId: chatbot_version_create
+      description: |-
+        Snapshot the chatbot's working (draft) version as a new, immutable version. Nothing writes to a version: read it back with the `chatbot_inspect` endpoint's `version` parameter, and every other write endpoint keeps targeting the working version.
+
+        A worker takes the snapshot, so the answer is `202` with no body. Poll the `chatbot_version_status` endpoint for the version number and the outcome.
+
+        One version operation runs at a time per chatbot, creating a version and reverting alike; a second is refused with `409`.
+      summary: Create a new version
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Chatbot ID
+        required: true
+      tags:
+      - Chatbots
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VersionCreate'
+      security:
+      - OAuth2:
+        - chatbots:write
+      - apiKeyAuth: []
+      - tokenAuth: []
+      responses:
+        '202':
+          description: The version creation was accepted. Poll `chatbot_version_status`
+            for its outcome.
+        '400':
+          description: The body carries a key this endpoint does not accept.
+        '403':
+          description: 'The caller is authenticated but not authorised for this chatbot''s
+            versions: either its role lacks permission to change chatbots, or it is
+            a machine (client-credentials) token whose application is not authorised
+            for this chatbot.'
+        '404':
+          description: 'No such chatbot. Archived chatbots and existing versions are
+            both outside this endpoint''s reach: only a live working version can be
+            snapshotted.'
+        '409':
+          description: A version operation (another version creation, or a revert
+            started in the UI) is already running for this chatbot.
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionCreateRefused'
+          description: 'Either the pipeline has errors and this version would be served
+            to participants -- `make_default: true`, or a chatbot''s first version,
+            which is always the published one -- or the working version is identical
+            to the newest one, so the snapshot would record no change. Nothing is
+            snapshotted either way. Dangling handles are not errors: `unwired_handles`
+            is advisory.'
+  /api/v2/chatbots/{id}/versions/status/:
+    get:
+      operationId: chatbot_version_status
+      description: |-
+        Report where this chatbot's version history stands, which is how a version the `chatbot_version_create` endpoint accepted is followed to its end.
+
+        Poll this until `status` is terminal:
+
+        - **`pending`** — a version operation is still running. Poll again.
+        - **`completed`** — no operation is running and `version_number` names the chatbot's newest version. Read it back with the `chatbot_inspect` endpoint's `version` parameter to check what landed in it.
+
+        **`completed` is not a receipt for your request.** This reports the chatbot's own state, not one task's outcome, so it cannot say which request produced the version it names. A version creation the worker raised on releases the lock without snapshotting anything, and polling then reports `completed` on the version that was already there — so check `version_number` against the one you expected rather than reading `completed` as proof the snapshot landed.
+
+        A chatbot with no version at all has nothing to report and answers `404`.
+      summary: Version creation status
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Chatbot ID
+        required: true
+      tags:
+      - Chatbots
+      security:
+      - OAuth2:
+        - chatbots:read
+      - apiKeyAuth: []
+      - tokenAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionStatus'
+          description: ''
+        '403':
+          description: 'The caller is authenticated but not authorised for this chatbot''s
+            versions: either its role lacks permission to change chatbots, or it is
+            a machine (client-credentials) token whose application is not authorised
+            for this chatbot.'
+        '404':
+          description: No such chatbot, or it has never created a version.
   /api/v2/me/:
     get:
       operationId: me
@@ -3683,6 +3786,67 @@ components:
       - type: array
         items:
           $ref: '#/components/schemas/UsageBucketResult'
+    VersionCreate:
+      type: object
+      description: 'The version-create body: whether the snapshot goes live, and what
+        to label it.'
+      properties:
+        make_default:
+          type: boolean
+          default: false
+          description: Whether the new version becomes the one participants are served,
+            which takes effect from the next message on. Left false, the version is
+            a checkpoint that nothing serves -- except a chatbot's first version,
+            which is always the published one and so is always held to the pipeline-validity
+            gate.
+        version_description:
+          type: string
+          nullable: true
+          default: ''
+          description: Free-text label for this version -- what changed since the
+            last one. The `chatbot_inspect` endpoint reads it back under the same
+            name.
+      additionalProperties: false
+    VersionCreateRefused:
+      type: object
+      description: 'The 422: why the chatbot''s state made the request unanswerable.'
+      properties:
+        detail:
+          type: string
+        pipeline_errors:
+          allOf:
+          - $ref: '#/components/schemas/PipelineBuildErrors'
+          description: The repair list, present only when going live was refused for
+            a pipeline that does not validate. Absent when the refusal is that there
+            is nothing to snapshot.
+      required:
+      - detail
+    VersionStatus:
+      type: object
+      description: 'A version poll''s answer: whether an operation is running, and
+        the newest version if not.'
+      properties:
+        status:
+          allOf:
+          - $ref: '#/components/schemas/VersionStatusEnum'
+          description: |-
+            `pending` while a version operation is running -- poll again. `completed` is terminal.
+
+            * `pending` - Pending
+            * `completed` - Completed
+        version_number:
+          type: integer
+          description: The chatbot's newest version. Present on `completed` only.
+      required:
+      - status
+    VersionStatusEnum:
+      enum:
+      - pending
+      - completed
+      type: string
+      description: |-
+        * `pending` - Pending
+        * `completed` - Completed
     VoiceResponseBehaviourEnum:
       enum:
       - always

--- a/api-schemas/v2.yml
+++ b/api-schemas/v2.yml
@@ -815,6 +815,61 @@ paths:
             to the newest one, so the snapshot would record no change. Nothing is
             snapshotted either way. Dangling handles are not errors: `unwired_handles`
             is advisory.'
+  /api/v2/chatbots/{id}/versions/{version_number}/:
+    patch:
+      operationId: chatbot_version_publish
+      description: |-
+        Make this version the one participants are served, without snapshotting anything.
+
+        Channels resolve the published version per message, so a live chatbot switches over from the next message on. The version that held it stops being served and is otherwise untouched -- a chatbot holds exactly one published version, so promoting one demotes the other.
+
+        This is how an already-published version is served again; the `chatbot_version_create` endpoint's `make_default` covers the other case, a snapshot that goes live as it is taken. Promoting a version this way creates nothing, so it is never refused for having no changes to record.
+      summary: Make chatbot version the published one
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Chatbot ID
+        required: true
+      - in: path
+        name: version_number
+        schema:
+          type: integer
+        description: The version's number, as the `chatbot_inspect` endpoint reports
+          it.
+        required: true
+      tags:
+      - Chatbots
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedPublishVersion'
+      security:
+      - OAuth2:
+        - chatbots:write
+      - apiKeyAuth: []
+      - tokenAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionPublished'
+          description: ''
+        '400':
+          description: The body carries a key this endpoint does not accept, or asks
+            to un-publish a version -- a chatbot always needs a published one.
+        '403':
+          description: 'The caller is authenticated but not authorised for this chatbot''s
+            versions: either its role lacks permission to change chatbots, or it is
+            a machine (client-credentials) token whose application is not authorised
+            for this chatbot.'
+        '404':
+          description: No such chatbot, or it has no version under this number --
+            an archived chatbot and an archived version included.
   /api/v2/chatbots/{id}/versions/status/:
     get:
       operationId: chatbot_version_status
@@ -3176,6 +3231,21 @@ components:
             does not declare is dropped rather than refused, and the response reports
             the params the node ended up holding.
       additionalProperties: false
+    PatchedPublishVersion:
+      type: object
+      description: |-
+        The PATCH body: make this version the one participants are served.
+
+        Named as ``chatbot_inspect`` reports it, so an agent that read
+        ``is_published_version: false`` writes back the same key.
+      properties:
+        is_published_version:
+          type: boolean
+          description: Must be `true`. A chatbot may hold only one published version
+            and always needs one, so this promotes a version; it cannot un-publish
+            one. Create a new version that goes live, or make a different version
+            the published one, to move it off.
+      additionalProperties: false
     PipelineBuildErrors:
       type: object
       description: The normalized three-bucket errors report the publish gate rejects
@@ -3821,6 +3891,19 @@ components:
             is nothing to snapshot.
       required:
       - detail
+    VersionPublished:
+      type: object
+      description: 'The PATCH response: which version participants are served now.'
+      properties:
+        version_number:
+          type: integer
+          description: The version now served to participants.
+        is_published_version:
+          type: boolean
+          description: Always true; the failure cases are status codes.
+      required:
+      - is_published_version
+      - version_number
     VersionStatus:
       type: object
       description: 'A version poll''s answer: whether an operation is running, and

--- a/api-schemas/v2.yml
+++ b/api-schemas/v2.yml
@@ -870,6 +870,54 @@ paths:
         '404':
           description: No such chatbot, or it has no version under this number --
             an archived chatbot and an archived version included.
+    delete:
+      operationId: chatbot_version_archive
+      description: |-
+        Archive one of the chatbot's versions. This is a soft delete: the version and the pipeline snapshot it owns are hidden rather than destroyed, and a person can restore it in the web app. Nothing in this API reaches an archived version, so a repeat of this call answers `404` -- which makes it safe to retry after an answer you never saw.
+
+        **The published version is refused with `409`.** It is the version participants are served and a chatbot may hold only one, so archiving it would leave the chatbot with none; the `chatbot_version_publish` endpoint moves it to another version first.
+
+        The working (draft) version has no number and is not reachable here. Archiving the whole chatbot is the `chatbot_archive` endpoint, which takes the channel guard and the scheduled messages with it -- neither of which a single version has.
+      summary: Archive a chatbot version
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Chatbot ID
+        required: true
+      - in: path
+        name: version_number
+        schema:
+          type: integer
+        description: The version's number, as the `chatbot_inspect` endpoint reports
+          it.
+        required: true
+      tags:
+      - Chatbots
+      security:
+      - OAuth2:
+        - chatbots:write
+      - apiKeyAuth: []
+      - tokenAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionArchived'
+          description: ''
+        '403':
+          description: 'The caller is authenticated but not authorised to archive
+            this chatbot''s versions: either its role lacks permission to delete chatbots,
+            or it is a machine (client-credentials) token whose application is not
+            authorised for this chatbot.'
+        '404':
+          description: No such chatbot, or it has no version under this number --
+            an archived chatbot and an already-archived version included.
+        '409':
+          description: This is the chatbot's published version.
   /api/v2/chatbots/{id}/versions/status/:
     get:
       operationId: chatbot_version_status
@@ -3856,6 +3904,15 @@ components:
       - type: array
         items:
           $ref: '#/components/schemas/UsageBucketResult'
+    VersionArchived:
+      type: object
+      description: 'The version-archive response: that it happened.'
+      properties:
+        archived:
+          type: boolean
+          description: Always true; the failure cases are status codes.
+      required:
+      - archived
     VersionCreate:
       type: object
       description: 'The version-create body: whether the snapshot goes live, and what

--- a/api-schemas/v2.yml
+++ b/api-schemas/v2.yml
@@ -186,6 +186,50 @@ paths:
             a machine (client-credentials) token whose application is not authorised
             for this chatbot. Retrying will not help; the application''s chatbot list
             has to change.'
+    delete:
+      operationId: chatbot_archive
+      description: |-
+        Archive the chatbot. This is a soft delete: the chatbot and its versions are hidden rather than destroyed, and a person can restore it in the web app. Nothing in this API reaches an archived chatbot, so a repeat of this call answers `404` -- which makes it safe to retry after an answer you never saw.
+
+        **It is refused while a channel is attached.** Taking a chatbot off Telegram, WhatsApp or the chat widget removes its webhook at the provider, and this API cannot create a channel to put back, so detaching stays a person's job in the web app; the `409` names the channels to detach. The team-wide API, web and evaluations channels are not attachments and never stand in the way, so a chatbot created through this API archives freely.
+
+        **It cancels every scheduled message the chatbot has**, finished and already-cancelled ones included, and they cannot be recovered. That is the right consequence of archiving -- and there is no endpoint to drain them first -- so the response reports how many went, rather than refusing.
+      summary: Archive Chatbot
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Chatbot ID
+        required: true
+      tags:
+      - Chatbots
+      security:
+      - OAuth2:
+        - chatbots:write
+      - apiKeyAuth: []
+      - tokenAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Archived'
+          description: ''
+        '403':
+          description: 'The caller is authenticated but not authorised to archive
+            this chatbot: either its role lacks permission to delete chatbots, or
+            it is a machine (client-credentials) token whose application is not authorised
+            for this chatbot.'
+        '404':
+          description: No such chatbot, or it is archived already.
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelsAttached'
+          description: ''
   /api/v2/chatbots/{id}/inspect/:
     get:
       operationId: chatbot_inspect
@@ -1374,6 +1418,39 @@ components:
             type: string
       required:
       - paths
+    Archived:
+      type: object
+      description: 'The archive response: that it happened, and what it destroyed
+        on the way.'
+      properties:
+        archived:
+          type: boolean
+          description: Always true; the failure cases are status codes.
+        cancelled_scheduled_messages:
+          type: integer
+          description: How many of the chatbot's scheduled messages were deleted,
+            finished and already-cancelled ones included. They cannot be recovered.
+      required:
+      - archived
+      - cancelled_scheduled_messages
+    AttachedChannel:
+      type: object
+      description: |-
+        One channel standing in the way, named the way the web app names it.
+
+        Enough for a client to tell a person which channels to go and detach; there is nothing here to
+        address, because no endpoint takes a channel.
+      properties:
+        id:
+          type: integer
+        platform:
+          $ref: '#/components/schemas/PlatformEnum'
+        name:
+          type: string
+      required:
+      - id
+      - name
+      - platform
     BooleanNodeParams:
       type: object
       properties:
@@ -1433,6 +1510,20 @@ components:
       required:
       - messaging_provider
       - name
+    ChannelsAttached:
+      type: object
+      description: 'The 409: why the archive was refused, and what a person has to
+        do about it.'
+      properties:
+        detail:
+          type: string
+        channels:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttachedChannel'
+      required:
+      - channels
+      - detail
     Chatbot:
       type: object
       description: |-

--- a/apps/api/v2/urls.py
+++ b/apps/api/v2/urls.py
@@ -12,6 +12,7 @@ from apps.api.v2.discovery import (
 )
 from apps.api.v2.pipeline_edit.views import PipelineEdgeEditView, PipelineNodeEditView
 from apps.api.v2.usage.views import UsageView
+from apps.api.v2.versions.views import ChatbotVersionCreateView, ChatbotVersionStatusView
 
 app_name = "v2"
 
@@ -51,6 +52,16 @@ urlpatterns = [
         "chatbots/<str:id>/pipeline/edges/<str:edge_id>/",
         PipelineEdgeEditView.as_view(http_method_names=["delete", "options"]),
         name="pipeline-edge-delete",
+    ),
+    path(
+        "chatbots/<str:id>/versions/",
+        ChatbotVersionCreateView.as_view(),
+        name="chatbot-version-create",
+    ),
+    path(
+        "chatbots/<str:id>/versions/status/",
+        ChatbotVersionStatusView.as_view(),
+        name="chatbot-version-status",
     ),
     path("", include(router.urls)),
 ]

--- a/apps/api/v2/urls.py
+++ b/apps/api/v2/urls.py
@@ -12,7 +12,11 @@ from apps.api.v2.discovery import (
 )
 from apps.api.v2.pipeline_edit.views import PipelineEdgeEditView, PipelineNodeEditView
 from apps.api.v2.usage.views import UsageView
-from apps.api.v2.versions.views import ChatbotVersionCreateView, ChatbotVersionStatusView
+from apps.api.v2.versions.views import (
+    ChatbotVersionCreateView,
+    ChatbotVersionStatusView,
+    ChatbotVersionView,
+)
 
 app_name = "v2"
 
@@ -62,6 +66,11 @@ urlpatterns = [
         "chatbots/<str:id>/versions/status/",
         ChatbotVersionStatusView.as_view(),
         name="chatbot-version-status",
+    ),
+    path(
+        "chatbots/<str:id>/versions/<int:version_number>/",
+        ChatbotVersionView.as_view(),
+        name="chatbot-version",
     ),
     path("", include(router.urls)),
 ]

--- a/apps/api/v2/versions/exceptions.py
+++ b/apps/api/v2/versions/exceptions.py
@@ -1,0 +1,53 @@
+"""What the chatbot version endpoints refuse a request with, and why (#4142)."""
+
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class VersionOperationInProgress(APIException):
+    """Another version operation holds the chatbot's version lock.
+
+    The lock covers reverting as well as creating a version, so the answer names neither a task to
+    poll nor which operation holds it: a revert's lock token is not a Celery task id, and handing
+    one out as a poll handle would report a version that was never created.
+    """
+
+    status_code = status.HTTP_409_CONFLICT
+    default_detail = "A version operation is already in progress for this chatbot. Try again once it has finished."
+
+
+class PipelineIsNotValid(APIException):
+    """The pipeline has errors, so the snapshot may not become the version participants are served.
+
+    422 rather than 400: the body was fine and the request was understood -- it is the state of the
+    chatbot that makes it unanswerable.
+    """
+
+    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def __init__(self, pipeline_errors: dict) -> None:
+        super().__init__(
+            {
+                "detail": (
+                    "This chatbot's pipeline has errors, so it cannot be made the version "
+                    "participants are served. Repair what `pipeline_errors` reports, or leave out "
+                    "`make_default` to checkpoint the work as it stands."
+                ),
+                "pipeline_errors": pipeline_errors,
+            }
+        )
+
+
+class NothingToPublish(APIException):
+    """The working version is identical to the newest one, so a new version would record no change.
+
+    422 for the same reason as ``PipelineIsNotValid``: the body was fine and the request understood
+    -- it is the state of the chatbot that makes it unanswerable.
+    """
+
+    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+    default_detail = (
+        "This chatbot has no changes since its newest version, so there is nothing to snapshot. "
+        "Write to the working version first, or read the newest version back with the "
+        "`chatbot_inspect` endpoint's `version` parameter."
+    )

--- a/apps/api/v2/versions/exceptions.py
+++ b/apps/api/v2/versions/exceptions.py
@@ -51,3 +51,18 @@ class NothingToPublish(APIException):
         "Write to the working version first, or read the newest version back with the "
         "`chatbot_inspect` endpoint's `version` parameter."
     )
+
+
+class VersionIsDefault(APIException):
+    """The version participants are served cannot be archived out from under them.
+
+    409 rather than 403: the caller may archive this chatbot's versions, and will be able to archive
+    this one, once it is no longer the default. Retrying without that changing will not help.
+    """
+
+    status_code = status.HTTP_409_CONFLICT
+    default_detail = (
+        "This is the published version, the one participants are served, and a chatbot may hold "
+        "only one -- so archiving it would leave the chatbot with none. Make another version the "
+        "published one first, with the `chatbot_version_publish` endpoint or in the web app."
+    )

--- a/apps/api/v2/versions/serializers.py
+++ b/apps/api/v2/versions/serializers.py
@@ -42,6 +42,12 @@ class VersionCreateRefusedSerializer(serializers.Serializer):
     )
 
 
+class VersionArchivedSerializer(serializers.Serializer):
+    """The version-archive response: that it happened."""
+
+    archived = serializers.BooleanField(help_text="Always true; the failure cases are status codes.")
+
+
 class PublishVersionSerializer(RejectsUnknownKeys, serializers.Serializer):
     """The PATCH body: make this version the one participants are served.
 

--- a/apps/api/v2/versions/serializers.py
+++ b/apps/api/v2/versions/serializers.py
@@ -1,0 +1,67 @@
+"""Request and response shapes for the chatbot version endpoints (#4142)."""
+
+from django.db import models
+from rest_framework import serializers
+
+from apps.api.v2.inspect.serializers import PipelineBuildErrorsSerializer
+from apps.api.v2.write.base import RejectsUnknownKeys
+from apps.api.v2.write.fields import OptionalTextField
+
+
+class VersionCreateSerializer(RejectsUnknownKeys, serializers.Serializer):
+    """The version-create body: whether the snapshot goes live, and what to label it."""
+
+    make_default = serializers.BooleanField(
+        default=False,
+        help_text=(
+            "Whether the new version becomes the one participants are served, which takes effect "
+            "from the next message on. Left false, the version is a checkpoint that nothing serves "
+            "-- except a chatbot's first version, which is always the published one and so is "
+            "always held to the pipeline-validity gate."
+        ),
+    )
+    version_description = OptionalTextField(
+        default="",
+        help_text=(
+            "Free-text label for this version -- what changed since the last one. The "
+            "`chatbot_inspect` endpoint reads it back under the same name."
+        ),
+    )
+
+
+class VersionCreateRefusedSerializer(serializers.Serializer):
+    """The 422: why the chatbot's state made the request unanswerable."""
+
+    detail = serializers.CharField()
+    pipeline_errors = PipelineBuildErrorsSerializer(
+        required=False,
+        help_text=(
+            "The repair list, present only when going live was refused for a pipeline that does "
+            "not validate. Absent when the refusal is that there is nothing to snapshot."
+        ),
+    )
+
+
+class VersionStatus(models.TextChoices):
+    """The states a version poll reports. ``pending`` is not terminal; ``completed`` is.
+
+    ``TextChoices`` rather than a plain ``StrEnum`` for a set that backs no model column, because
+    ``ENUM_NAME_OVERRIDES`` (config/settings.py) is what gives this a stable name in the published
+    schema, and it matches on the ``(value, label)`` pairs a ``Choices`` class produces.
+    """
+
+    PENDING = "pending"
+    COMPLETED = "completed"
+
+
+class VersionStatusSerializer(serializers.Serializer):
+    """A version poll's answer: whether an operation is running, and the newest version if not."""
+
+    status = serializers.ChoiceField(
+        choices=VersionStatus.choices,
+        help_text="`pending` while a version operation is running -- poll again. `completed` is terminal.",
+    )
+    version_number = serializers.IntegerField(
+        required=False,
+        help_text="The chatbot's newest version. Present on `completed` only.",
+    )

--- a/apps/api/v2/versions/serializers.py
+++ b/apps/api/v2/versions/serializers.py
@@ -42,6 +42,37 @@ class VersionCreateRefusedSerializer(serializers.Serializer):
     )
 
 
+class PublishVersionSerializer(RejectsUnknownKeys, serializers.Serializer):
+    """The PATCH body: make this version the one participants are served.
+
+    Named as ``chatbot_inspect`` reports it, so an agent that read
+    ``is_published_version: false`` writes back the same key.
+    """
+
+    is_published_version = serializers.BooleanField(
+        help_text=(
+            "Must be `true`. A chatbot may hold only one published version and always needs one, "
+            "so this promotes a version; it cannot un-publish one. Create a new version that goes "
+            "live, or make a different version the published one, to move it off."
+        )
+    )
+
+    def validate_is_published_version(self, value: bool) -> bool:
+        if not value:
+            raise serializers.ValidationError(
+                "Only `true` is accepted. A chatbot always needs a published version, so this "
+                "cannot un-publish one -- make a different version the published one instead."
+            )
+        return value
+
+
+class VersionPublishedSerializer(serializers.Serializer):
+    """The PATCH response: which version participants are served now."""
+
+    version_number = serializers.IntegerField(help_text="The version now served to participants.")
+    is_published_version = serializers.BooleanField(help_text="Always true; the failure cases are status codes.")
+
+
 class VersionStatus(models.TextChoices):
     """The states a version poll reports. ``pending`` is not terminal; ``completed`` is.
 

--- a/apps/api/v2/versions/tests/conftest.py
+++ b/apps/api/v2/versions/tests/conftest.py
@@ -63,3 +63,7 @@ def strand_the_end_node(chatbot) -> None:
 
 def status_url(chatbot) -> str:
     return f"/api/v2/chatbots/{chatbot.public_id}/versions/status/"
+
+
+def version_url(chatbot, version_number: int) -> str:
+    return f"/api/v2/chatbots/{chatbot.public_id}/versions/{version_number}/"

--- a/apps/api/v2/versions/tests/conftest.py
+++ b/apps/api/v2/versions/tests/conftest.py
@@ -1,0 +1,65 @@
+"""Fixtures for the version endpoints (#4142)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from apps.utils.factories.experiment import ChatbotFactory
+from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+from apps.utils.tests.clients import ApiTestClient
+
+
+@pytest.fixture()
+def team(db):
+    return TeamWithUsersFactory.create()
+
+
+@pytest.fixture()
+def chatbot(team):
+    """`ChatbotFactory` wires Start -> End, so the pipeline validates cleanly and can go live."""
+    return ChatbotFactory.create(team=team, name="Support bot")
+
+
+@pytest.fixture()
+def client(chatbot):
+    return ApiTestClient(chatbot.team.members.first(), chatbot.team)
+
+
+@pytest.fixture()
+def dispatch():
+    """The Celery hand-off, stubbed: the suite has no broker, and what these endpoints are
+    responsible for is what they asked the worker to do, not what the worker then did."""
+    with patch("apps.experiments.tasks.async_create_experiment_version.apply_async") as apply_async:
+        yield apply_async
+
+
+@pytest.fixture()
+def llm_provider(team):
+    """A provider and a model of the same type, which is what pairs them for an LLM node."""
+    provider = LlmProviderFactory.create(team=team, type="openai")
+    model = LlmProviderModelFactory.create(team=team, type="openai", name="gpt-4o")
+    return provider, model
+
+
+def versions_url(chatbot) -> str:
+    return f"/api/v2/chatbots/{chatbot.public_id}/versions/"
+
+
+def nodes_url(chatbot) -> str:
+    return f"/api/v2/chatbots/{chatbot.public_id}/pipeline/nodes/"
+
+
+def strand_the_end_node(chatbot) -> None:
+    """Drop the one edge, leaving End unreachable -- the commonest way a half-built graph is invalid.
+
+    Written straight into ``Pipeline.data`` because that is where the edges live (ADR-0049), and
+    because a test about publishing should not fail when the unwire endpoint changes.
+    """
+    pipeline = chatbot.pipeline
+    pipeline.data["edges"] = []
+    pipeline.save(update_fields=["data"])
+
+
+def status_url(chatbot) -> str:
+    return f"/api/v2/chatbots/{chatbot.public_id}/versions/status/"

--- a/apps/api/v2/versions/tests/test_auth.py
+++ b/apps/api/v2/versions/tests/test_auth.py
@@ -1,0 +1,102 @@
+"""Authorization for publishing a chatbot version (#4142).
+
+Publishing is a *change* to the chatbot rather than a new resource of its own, so the gate is
+`change_experiment` and not `add_experiment` -- the permission the pipeline façade asks for, since
+publishing is the last step of the same build.
+"""
+
+import pytest
+
+from apps.teams.backends import CHAT_VIEWER_GROUP, CHATBOT_ADMIN_GROUP, add_user_to_team, create_default_groups
+from apps.teams.utils import set_current_team, unset_current_team
+from apps.utils.factories.experiment import ChatbotFactory
+from apps.utils.factories.team import TeamFactory, TeamWithUsersFactory
+from apps.utils.factories.user import UserFactory
+from apps.utils.tests.clients import ApiTestClient
+
+from .conftest import versions_url
+
+
+@pytest.fixture()
+def team_with_roles(db):
+    """`create_default_groups()` is explicit so the DB-backed groups match backends.py even
+    though pytest runs with --reuse-db."""
+    create_default_groups()
+    team = TeamFactory.create()
+    token = set_current_team(team)
+    try:
+        yield team
+    finally:
+        unset_current_team(token)
+
+
+def publish(client, chatbot):
+    return client.post(versions_url(chatbot), {"make_default": True}, format="json")
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("group", "allowed"),
+    [
+        pytest.param(CHATBOT_ADMIN_GROUP, True, id="chatbot-admin-may-publish"),
+        pytest.param(CHAT_VIEWER_GROUP, False, id="chat-viewer-may-not"),
+    ],
+)
+def test_publishing_requires_change_experiment(team_with_roles, dispatch, group, allowed):
+    chatbot = ChatbotFactory.create(team=team_with_roles)
+    user = UserFactory.create()
+    add_user_to_team(team_with_roles, user, [group])
+
+    response = publish(ApiTestClient(user, team_with_roles), chatbot)
+
+    assert response.status_code == (202 if allowed else 403), response.content
+
+
+@pytest.mark.django_db()
+def test_a_read_only_key_cannot_publish(chatbot, dispatch):
+    """`UserAPIKey.read_only` defaults to True, so publishing takes a key an operator issued
+    deliberately."""
+    client = ApiTestClient(chatbot.team.members.first(), chatbot.team, read_only=True)
+
+    assert publish(client, chatbot).status_code == 403
+    dispatch.assert_not_called()
+
+
+@pytest.mark.django_db()
+def test_a_token_without_the_write_scope_is_refused(chatbot, dispatch):
+    client = ApiTestClient(chatbot.team.members.first(), chatbot.team, auth_method="oauth", scopes=["chatbots:read"])
+
+    assert publish(client, chatbot).status_code == 403
+    dispatch.assert_not_called()
+
+
+@pytest.mark.django_db()
+def test_another_teams_chatbot_is_not_found(chatbot, dispatch):
+    other = TeamWithUsersFactory.create()
+
+    response = publish(ApiTestClient(other.members.first(), other), chatbot)
+
+    assert response.status_code == 404, response.content
+    dispatch.assert_not_called()
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    "listed",
+    [
+        pytest.param(False, id="unlisted-is-refused"),
+        pytest.param(True, id="listed-may-publish"),
+    ],
+)
+def test_a_machine_token_is_held_to_its_applications_chatbot_allowlist(chatbot, dispatch, listed):
+    client = ApiTestClient(
+        UserFactory.create(),
+        chatbot.team,
+        auth_method="oauth_client_credentials",
+        scopes=["chatbots:write"],
+        allowed_chatbots=[chatbot] if listed else [],
+    )
+
+    response = publish(client, chatbot)
+
+    assert response.status_code == (202 if listed else 403), response.content

--- a/apps/api/v2/versions/tests/test_publish.py
+++ b/apps/api/v2/versions/tests/test_publish.py
@@ -1,0 +1,326 @@
+"""POST /api/v2/chatbots/{id}/versions/ -- publish a snapshot of the working version (#4142)."""
+
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+
+from apps.experiments.models import Experiment
+from apps.pipelines.build_state import pipeline_build_state
+
+from .conftest import nodes_url, strand_the_end_node, versions_url
+
+
+def publish(client, chatbot, **body):
+    return client.post(versions_url(chatbot), body, format="json")
+
+
+@pytest.mark.django_db()
+def test_the_publish_url_is_the_registered_route(chatbot):
+    assert reverse("api:v2:chatbot-version-create", args=[chatbot.public_id]) == versions_url(chatbot)
+
+
+@pytest.mark.django_db()
+class TestDispatch:
+    def test_publishing_is_accepted_with_nothing_handed_back(self, client, chatbot, dispatch):
+        """202, not 201: the snapshot is taken by a worker, so nothing exists to point at yet. And
+        no body, because the status endpoint takes no handle -- there is nothing to give."""
+        response = publish(client, chatbot, make_default=True)
+
+        assert response.status_code == 202, response.content
+        assert not response.content
+        assert dispatch.call_count == 1
+
+    def test_the_task_runs_under_the_lock_token(self, client, chatbot, dispatch):
+        """One uuid is both the lock token and the Celery task id. Nothing hands it out any more,
+        but the task's `finally` releases the lock by experiment id, so the two have to stay the
+        one value for a publish to be visible to a poll at all."""
+        publish(client, chatbot, make_default=True)
+
+        chatbot.refresh_from_db()
+        assert dispatch.call_args.kwargs["task_id"] == chatbot.create_version_task_id
+
+    def test_the_body_reaches_the_task(self, client, chatbot, dispatch):
+        publish(client, chatbot, make_default=True, version_description="Added the 24h timeout")
+
+        assert dispatch.call_args.kwargs["kwargs"] == {
+            "experiment_id": chatbot.id,
+            "version_description": "Added the 24h timeout",
+            "make_default": True,
+        }
+
+    def test_an_empty_body_checkpoints_without_going_live(self, client, chatbot, dispatch):
+        """The defaults are the cautious ones: an agent that omits `make_default` snapshots its work
+        rather than swapping the version live channels serve."""
+        assert publish(client, chatbot).status_code == 202
+
+        assert dispatch.call_args.kwargs["kwargs"] == {
+            "experiment_id": chatbot.id,
+            "version_description": "",
+            "make_default": False,
+        }
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_a_publish_that_runs_produces_the_version_and_frees_the_lock(self, client, chatbot):
+        """End to end, with no stub between the endpoint and the snapshot it asked for."""
+        assert publish(client, chatbot, make_default=True, version_description="v1").status_code == 202
+
+        version = chatbot.versions.get()
+        assert (version.version_number, version.is_default_version) == (1, True)
+        assert version.version_description == "v1"
+        chatbot.refresh_from_db()
+        assert not chatbot.version_operation_in_progress
+
+    def test_a_second_operation_while_one_is_in_flight_is_refused(self, client, chatbot, dispatch):
+        """The lock guards every version operation, a revert included, so the answer names neither
+        a task to poll nor the operation holding it -- the caller retries or reads the versions back."""
+        chatbot.acquire_version_operation_lock("already-running")
+
+        response = publish(client, chatbot, make_default=True)
+
+        assert response.status_code == 409
+        assert "in progress" in response.json()["detail"]
+        dispatch.assert_not_called()
+        chatbot.refresh_from_db()
+        assert chatbot.create_version_task_id == "already-running"
+
+
+@pytest.mark.django_db()
+class TestGoLiveGate:
+    """Going live is gated on the pipeline validating; checkpointing a draft is not.
+
+    The divergence from the UI, which lets a human publish a bot whose red markers they can see:
+    live channels resolve the default version per message, so `make_default` on a broken pipeline
+    breaks every conversation, and an unattended agent has nothing to look at.
+    """
+
+    def test_a_broken_pipeline_cannot_be_made_live(self, client, chatbot, dispatch):
+        strand_the_end_node(chatbot)
+
+        response = publish(client, chatbot, make_default=True)
+
+        assert response.status_code == 422
+        assert response.json()["pipeline_errors"] == pipeline_build_state(chatbot.pipeline)["errors"]
+        dispatch.assert_not_called()
+        chatbot.refresh_from_db()
+        assert not chatbot.version_operation_in_progress
+
+    def test_the_refusal_reports_the_errors_that_caused_it(self, client, chatbot, dispatch):
+        """Not just that it failed: the errors are the repair list, so the agent's next call is a
+        fix rather than a re-read."""
+        response = client.post(nodes_url(chatbot), {"type": "LLMResponseWithPrompt"}, format="json")
+        node_id = response.json()["node"]["node_id"]
+
+        errors = publish(client, chatbot, make_default=True).json()["pipeline_errors"]
+
+        assert "llm_provider_id" in errors["node"][node_id]
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_a_broken_pipeline_can_still_be_checkpointed_once_something_is_live(self, client, chatbot):
+        """Lenient where it costs nothing: a snapshot nothing serves cannot break a conversation.
+
+        Only true from the second version on, which is why a version is published first: until then
+        the snapshot *is* what participants get.
+        """
+        assert publish(client, chatbot, make_default=True).status_code == 202
+        # An LLM node with no provider: a real change, and one that invalidates the graph.
+        added = client.post(nodes_url(chatbot), {"type": "LLMResponseWithPrompt"}, format="json")
+        assert added.json()["pipeline_valid"] is False
+
+        assert publish(client, chatbot).status_code == 202
+        assert chatbot.versions.count() == 2
+
+    def test_a_broken_first_publish_is_refused_even_without_make_default(self, client, chatbot, dispatch):
+        """`create_new_version` makes the first version the default whatever `make_default` says --
+        a chatbot with versions but no default would serve nothing -- so there is no such thing as
+        checkpointing a first draft. Ungated, this published a broken pipeline straight to
+        participants on a `make_default: false` request.
+        """
+        strand_the_end_node(chatbot)
+
+        response = publish(client, chatbot)
+
+        assert response.status_code == 422, response.content
+        assert response.json()["pipeline_errors"] == pipeline_build_state(chatbot.pipeline)["errors"]
+        dispatch.assert_not_called()
+        assert chatbot.versions.count() == 0
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_a_checkpointed_first_version_is_the_one_participants_are_served(self, client, chatbot):
+        """The fact the gate above rests on, pinned directly so it cannot drift out from under it."""
+        assert publish(client, chatbot).status_code == 202
+
+        assert chatbot.versions.get().is_default_version is True
+
+    def test_unwired_handles_never_block_going_live(self, client, chatbot, dispatch, llm_provider):
+        """A node wired to nothing is a normal state mid-build, so it is advisory and not an error.
+        The gate rejects on the errors report and nothing else."""
+        provider, model = llm_provider
+        island = client.post(
+            nodes_url(chatbot),
+            {
+                "type": "LLMResponseWithPrompt",
+                "params": {"llm_provider_id": provider.id, "llm_provider_model_id": model.id},
+            },
+            format="json",
+        ).json()
+        assert island["pipeline_valid"] is True  # guards the guard
+        assert island["unwired_handles"], "the island has to be reported unwired for this to test anything"
+
+        assert publish(client, chatbot, make_default=True).status_code == 202
+
+    def test_a_chatbot_with_no_pipeline_is_not_gated(self, client, team, dispatch):
+        """`Experiment.pipeline` is nullable, and rows predating pipeline-backed chatbots hold null.
+        There is nothing to validate, so there is nothing to refuse -- as in the UI."""
+        chatbot = Experiment.objects.create(team=team, name="Legacy", owner=team.members.first())
+
+        assert publish(client, chatbot, make_default=True).status_code == 202
+
+
+@pytest.mark.django_db()
+class TestNothingToPublish:
+    """A working version identical to the newest one is refused rather than snapshotted.
+
+    The same comparison the web app's "unreleased changes" badge is drawn from, so an agent is held
+    to the rule a person sees: a version records a change, and there is no change to record.
+    """
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_republishing_an_unchanged_chatbot_is_refused(self, client, chatbot):
+        assert publish(client, chatbot, make_default=True).status_code == 202
+
+        response = publish(client, chatbot, make_default=True)
+
+        assert response.status_code == 422
+        assert "no changes since its newest version" in response.json()["detail"]
+        assert "pipeline_errors" not in response.json()
+        assert chatbot.versions.count() == 1
+
+    def test_the_first_publish_is_never_refused(self, client, chatbot, dispatch):
+        """`compare_with_latest()` reports False for a chatbot with no versions, so "no baseline"
+        and "no difference" arrive as the same value -- the absence of versions has to be checked
+        separately or a chatbot could never be published at all."""
+        assert publish(client, chatbot, make_default=True).status_code == 202
+        assert dispatch.call_count == 1
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_a_settings_change_since_the_last_version_may_be_published(self, client, chatbot):
+        publish(client, chatbot, make_default=True)
+
+        chatbot.name = "Support bot, renamed"
+        chatbot.save(update_fields=["name"])
+
+        assert publish(client, chatbot, make_default=True).status_code == 202
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_a_pipeline_edit_since_the_last_version_may_be_published(self, client, chatbot, llm_provider):
+        """The edit this API is mostly used for. A node added through the façade has to register as
+        a difference, or every publish after the first would be refused."""
+        publish(client, chatbot, make_default=True)
+
+        provider, model = llm_provider
+        added = client.post(
+            nodes_url(chatbot),
+            {
+                "type": "LLMResponseWithPrompt",
+                "params": {"llm_provider_id": provider.id, "llm_provider_model_id": model.id},
+            },
+            format="json",
+        )
+        assert added.status_code == 201, added.content
+
+        assert publish(client, chatbot, make_default=True).status_code == 202
+
+    @pytest.mark.parametrize(
+        "rewire",
+        [
+            pytest.param("delete", id="unwiring-an-edge"),
+            pytest.param("create", id="wiring-one-up"),
+        ],
+    )
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_a_rewiring_since_the_last_version_may_be_published(self, client, chatbot, rewire):
+        """Edges live in `Pipeline.data` rather than in a row of their own, so the version
+        comparison was once blind to them and a client that only rewires the graph could never
+        publish again. `Pipeline`'s version details cover the wiring now.
+        """
+        publish(client, chatbot, make_default=True)
+
+        edges_url = f"/api/v2/chatbots/{chatbot.public_id}/pipeline/edges/"
+        edge = chatbot.pipeline.data["edges"][0]
+        unwired = client.delete(f"{edges_url}{edge['id']}/")
+        assert unwired.status_code == 200, unwired.content
+        if rewire == "create":
+            # Bank the unwiring first, so the change left to detect is the wire coming back.
+            assert publish(client, chatbot).status_code == 202
+            rewired = client.post(
+                edges_url, {"wires": [{"source": edge["source"], "target": edge["target"]}]}, format="json"
+            )
+            assert rewired.status_code == 201, rewired.content
+        chatbot.refresh_from_db()
+        # The rewiring is the only change, so this is what the refusal is asked to read.
+        assert chatbot.compare_with_latest() is True
+
+        assert publish(client, chatbot).status_code == 202
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_the_diff_is_checked_before_the_pipeline_gate(self, client, chatbot):
+        """Asked in the order the cheaper question comes first: an unchanged chatbot is refused for
+        having nothing to publish, without the graph being walked to find fault with it too.
+
+        Reaching that state takes a checkpoint of the broken graph, since a chatbot whose pipeline
+        broke since its last version has, by that very fact, something to publish.
+        """
+        publish(client, chatbot, make_default=True)
+        strand_the_end_node(chatbot)
+        assert publish(client, chatbot).status_code == 202
+
+        response = publish(client, chatbot, make_default=True)
+
+        assert response.status_code == 422
+        assert "no changes since its newest version" in response.json()["detail"]
+        assert "pipeline_errors" not in response.json()
+
+
+@pytest.mark.django_db()
+class TestBody:
+    def test_an_unrecognised_key_is_a_400_naming_it(self, client, chatbot, dispatch):
+        """Dropping it silently would publish -- possibly live -- on a body the client got wrong."""
+        response = publish(client, chatbot, make_defualt=True)
+
+        assert response.status_code == 400
+        assert "make_defualt" in response.json()
+        dispatch.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "sent",
+        [
+            pytest.param({}, id="omitted"),
+            pytest.param({"version_description": ""}, id="blank"),
+            pytest.param({"version_description": None}, id="null"),
+        ],
+    )
+    def test_an_absent_description_is_stored_as_blank(self, client, chatbot, dispatch, sent):
+        """`version_description` is a non-null TextField, so the one representation of "unlabelled"
+        is "" -- and a client echoing an inspect response back at us is not refused."""
+        assert publish(client, chatbot, **sent).status_code == 202
+
+        assert dispatch.call_args.kwargs["kwargs"]["version_description"] == ""
+
+
+@pytest.mark.django_db()
+def test_an_archived_chatbot_cannot_be_published(client, chatbot, dispatch):
+    """Archived rows are outside every v2 write path's queryset, so this is a 404 rather than the
+    UI's PermissionDenied."""
+    chatbot.archive()
+
+    assert publish(client, chatbot, make_default=True).status_code == 404
+    dispatch.assert_not_called()
+
+
+@pytest.mark.django_db()
+def test_a_version_snapshot_cannot_itself_be_published(client, chatbot, dispatch):
+    """Snapshots are immutable: only the working version is ever the subject of a write."""
+    chatbot.create_new_version()
+
+    assert publish(client, chatbot.versions.get(), make_default=True).status_code == 404
+    dispatch.assert_not_called()

--- a/apps/api/v2/versions/tests/test_version_archive.py
+++ b/apps/api/v2/versions/tests/test_version_archive.py
@@ -1,0 +1,182 @@
+"""DELETE /api/v2/chatbots/{id}/versions/{version_number}/ -- archive one version (#4143).
+
+Archiving a version is a soft delete of one snapshot, not a teardown of the chatbot. The channel
+guard and the scheduled-message count the chatbot-level archive carries have nothing to do here:
+channels and schedules hang off the working row, never off a snapshot.
+"""
+
+import pytest
+from django.urls import reverse
+
+from apps.experiments.models import Experiment
+from apps.pipelines.models import Pipeline
+from apps.teams.backends import CHAT_VIEWER_GROUP, CHATBOT_ADMIN_GROUP, add_user_to_team, create_default_groups
+from apps.teams.utils import set_current_team, unset_current_team
+from apps.utils.factories.experiment import ChatbotFactory
+from apps.utils.factories.team import TeamFactory, TeamWithUsersFactory
+from apps.utils.factories.user import UserFactory
+from apps.utils.tests.clients import ApiTestClient
+
+from .conftest import version_url
+
+
+@pytest.fixture()
+def published(chatbot):
+    """Two versions, the second of them the default -- so there is a version each rule applies to."""
+    chatbot.create_new_version()
+    chatbot.create_new_version(make_default=True)
+    return chatbot
+
+
+def archive(client, chatbot, version_number):
+    return client.delete(version_url(chatbot, version_number))
+
+
+@pytest.mark.django_db()
+def test_the_archive_url_is_the_registered_route(chatbot):
+    assert reverse("api:v2:chatbot-version", args=[chatbot.public_id, 2]) == version_url(chatbot, 2)
+
+
+@pytest.mark.django_db()
+class TestArchive:
+    def test_a_published_version_archives(self, client, published):
+        response = archive(client, published, 1)
+
+        assert response.status_code == 200, response.content
+        assert response.json() == {"archived": True}
+        assert Experiment.objects.get_all().get(working_version=published, version_number=1).is_archived is True
+
+    def test_the_other_versions_and_the_working_row_are_left_alone(self, client, published):
+        assert archive(client, published, 1).status_code == 200
+
+        published.refresh_from_db()
+        assert published.is_archived is False
+        assert [version.version_number for version in published.versions.all()] == [2]
+
+    def test_archiving_a_version_takes_its_pipeline_with_it(self, client, published):
+        """A version owns its own pipeline snapshot, so the snapshot goes when the version does --
+        the same as the web app's per-version archive. The working pipeline is untouched."""
+        version = published.versions.get(version_number=1)
+        version_pipeline_id = version.pipeline_id
+
+        assert archive(client, published, 1).status_code == 200
+
+        assert Pipeline.objects.get_all().get(id=version_pipeline_id).is_archived is True
+        published.refresh_from_db()
+        assert published.pipeline.is_archived is False
+
+    def test_repeating_the_call_is_not_found(self, client, published):
+        """Archived rows are outside the queryset this resolves through, so a retry after an answer
+        the client never saw is safe rather than a second archive."""
+        assert archive(client, published, 1).status_code == 200
+
+        assert archive(client, published, 1).status_code == 404
+
+
+@pytest.mark.django_db()
+class TestRefusals:
+    def test_the_default_version_is_refused(self, client, published):
+        """It is the version participants are served, and a family may hold only one, so archiving
+        it would leave the chatbot with none. The published version is moved first."""
+        response = archive(client, published, 2)
+
+        assert response.status_code == 409, response.content
+        assert "published version" in response.json()["detail"]
+        assert published.versions.get(version_number=2).is_archived is False
+
+    def test_a_version_number_that_does_not_exist_is_not_found(self, client, published):
+        assert archive(client, published, 99).status_code == 404
+
+    def test_a_version_of_an_archived_chatbot_is_not_found(self, client, published):
+        """The chatbot is resolved first and archived chatbots are outside every v2 write path, so
+        this never reaches the version rule."""
+        published.archive()
+
+        assert archive(client, published, 1).status_code == 404
+
+    def test_another_chatbots_version_number_is_not_found(self, client, published, team):
+        """The version is looked for among this chatbot's own, so a number that exists elsewhere
+        does not resolve here."""
+        other = ChatbotFactory.create(team=team, name="Other bot")
+        other.create_new_version()
+
+        assert archive(client, other, 2).status_code == 404
+        assert other.versions.get(version_number=1).is_archived is False
+
+
+@pytest.mark.django_db()
+class TestAuth:
+    def test_another_teams_chatbot_is_not_found(self, published):
+        other = TeamWithUsersFactory.create()
+
+        response = archive(ApiTestClient(other.members.first(), other), published, 1)
+
+        assert response.status_code == 404, response.content
+
+    def test_a_read_only_key_cannot_archive(self, published):
+        client = ApiTestClient(published.team.members.first(), published.team, read_only=True)
+
+        assert archive(client, published, 1).status_code == 403
+        assert published.versions.get(version_number=1).is_archived is False
+
+    def test_a_token_without_the_write_scope_is_refused(self, published):
+        client = ApiTestClient(
+            published.team.members.first(), published.team, auth_method="oauth", scopes=["chatbots:read"]
+        )
+
+        assert archive(client, published, 1).status_code == 403
+
+    @pytest.mark.parametrize(
+        "listed",
+        [
+            pytest.param(False, id="unlisted-is-refused"),
+            pytest.param(True, id="listed-may-archive"),
+        ],
+    )
+    def test_a_machine_token_is_held_to_its_applications_chatbot_allowlist(self, published, listed):
+        client = ApiTestClient(
+            UserFactory.create(),
+            published.team,
+            auth_method="oauth_client_credentials",
+            scopes=["chatbots:write"],
+            allowed_chatbots=[published] if listed else [],
+        )
+
+        assert archive(client, published, 1).status_code == (200 if listed else 403)
+
+
+@pytest.fixture()
+def team_with_roles(db):
+    """`create_default_groups()` is explicit so the DB-backed groups match backends.py even
+    though pytest runs with --reuse-db."""
+    create_default_groups()
+    team = TeamFactory.create()
+    token = set_current_team(team)
+    try:
+        yield team
+    finally:
+        unset_current_team(token)
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("group", "allowed"),
+    [
+        pytest.param(CHATBOT_ADMIN_GROUP, True, id="chatbot-admin-may-archive"),
+        pytest.param(CHAT_VIEWER_GROUP, False, id="chat-viewer-may-not"),
+    ],
+)
+def test_archiving_a_version_requires_delete_experiment(team_with_roles, group, allowed):
+    """Unlike the rest of the chatbot sub-resources -- where the verb map would ask the wrong
+    question -- this one really is a delete: a version is an `Experiment` row and this hides one."""
+    chatbot = ChatbotFactory.create(team=team_with_roles)
+    chatbot.create_new_version()
+    # v1 is made the default automatically, so a second version has to take that over before the
+    # first one is archivable at all.
+    chatbot.create_new_version(make_default=True)
+    user = UserFactory.create()
+    add_user_to_team(team_with_roles, user, [group])
+
+    response = archive(ApiTestClient(user, team_with_roles), chatbot, 1)
+
+    assert response.status_code == (200 if allowed else 403), response.content

--- a/apps/api/v2/versions/tests/test_version_publish.py
+++ b/apps/api/v2/versions/tests/test_version_publish.py
@@ -1,0 +1,197 @@
+"""PATCH /api/v2/chatbots/{id}/versions/{version_number}/ -- serve an existing version (#4142).
+
+The other half of choosing what participants get. `chatbot_version_create`'s `make_default` covers
+a snapshot that goes live as it is taken; this covers a version that already exists, and creates
+nothing -- so it is never refused for having no changes to publish.
+"""
+
+import pytest
+from django.urls import reverse
+
+from apps.teams.backends import CHAT_VIEWER_GROUP, CHATBOT_ADMIN_GROUP, add_user_to_team, create_default_groups
+from apps.teams.utils import set_current_team, unset_current_team
+from apps.utils.factories.experiment import ChatbotFactory
+from apps.utils.factories.team import TeamFactory, TeamWithUsersFactory
+from apps.utils.factories.user import UserFactory
+from apps.utils.tests.clients import ApiTestClient
+
+from .conftest import version_url
+
+
+@pytest.fixture()
+def published(chatbot):
+    """Two versions, the first of them the one served.
+
+    `create_new_version()` makes v1 the published version automatically, so v2 arrives unpublished
+    and there is something for a promotion to do.
+    """
+    chatbot.create_new_version()
+    chatbot.create_new_version()
+    return chatbot
+
+
+def promote(client, chatbot, version_number, **body):
+    return client.patch(version_url(chatbot, version_number), body or {"is_published_version": True}, format="json")
+
+
+def served(chatbot):
+    """(version_number, published?) for every live version, oldest first.
+
+    `is_published_version` is the API's name for the column the model calls `is_default_version`.
+    """
+    return [(v.version_number, v.is_default_version) for v in chatbot.versions.order_by("version_number")]
+
+
+@pytest.mark.django_db()
+def test_the_version_url_is_the_registered_route(chatbot):
+    assert reverse("api:v2:chatbot-version", args=[chatbot.public_id, 2]) == version_url(chatbot, 2)
+
+
+@pytest.mark.django_db()
+class TestPromote:
+    def test_promoting_a_version_serves_it(self, client, published):
+        response = promote(client, published, 2)
+
+        assert response.status_code == 200, response.content
+        assert response.json() == {"version_number": 2, "is_published_version": True}
+
+    def test_the_version_that_held_it_is_demoted(self, published, client):
+        """A chatbot holds exactly one published version -- a partial unique constraint enforces it
+        -- so promoting one has to take the flag off the incumbent in the same transaction."""
+        assert promote(client, published, 2).status_code == 200
+
+        assert served(published) == [(1, False), (2, True)]
+
+    def test_promoting_the_version_already_served_is_not_an_error(self, client, published):
+        """The request asked for a state that already holds, so it is answered rather than refused
+        -- which also makes a retry after an answer the client never saw safe."""
+        assert promote(client, published, 1).status_code == 200
+
+        assert served(published) == [(1, True), (2, False)]
+
+    def test_nothing_is_snapshotted(self, client, published):
+        """The distinction from `make_default` on a publish: this creates no version, so it is not
+        held to the no-changes rule that would refuse an identical snapshot."""
+        assert promote(client, published, 2).status_code == 200
+
+        assert published.versions.count() == 2
+        published.refresh_from_db()
+        assert not published.version_operation_in_progress
+
+
+@pytest.mark.django_db()
+class TestRefusals:
+    def test_un_publishing_is_refused(self, client, published):
+        """A chatbot always needs a published version, so there is no way to leave it with none.
+        Moving it off a version means naming the version that takes over."""
+        response = promote(client, published, 1, is_published_version=False)
+
+        assert response.status_code == 400, response.content
+        assert "is_published_version" in response.json()
+        assert served(published) == [(1, True), (2, False)]
+
+    def test_an_empty_body_is_refused(self, client, published):
+        """`is_published_version` is required rather than defaulted: a PATCH is a statement of what
+        to change, and an empty one asking to serve a different version is a client bug."""
+        response = client.patch(version_url(published, 2), {}, format="json")
+
+        assert response.status_code == 400, response.content
+        assert "is_published_version" in response.json()
+
+    def test_an_unrecognised_key_is_a_400_naming_it(self, client, published):
+        response = client.patch(version_url(published, 2), {"is_defualt": True}, format="json")
+
+        assert response.status_code == 400
+        assert "is_defualt" in response.json()
+        assert served(published) == [(1, True), (2, False)]
+
+    def test_a_version_number_that_does_not_exist_is_a_404(self, client, published):
+        assert promote(client, published, 99).status_code == 404
+
+    def test_an_archived_version_is_a_404(self, client, published):
+        """`versions` excludes archived rows, so a version a person tidied away cannot be served
+        again through this API -- they restore it in the web app first."""
+        published.versions.get(version_number=2).archive()
+
+        assert promote(client, published, 2).status_code == 404
+
+    def test_a_version_of_an_archived_chatbot_is_a_404(self, client, published):
+        published.archive()
+
+        assert promote(client, published, 1).status_code == 404
+
+    def test_another_chatbots_version_number_is_a_404(self, client, published, team):
+        other = ChatbotFactory.create(team=team, name="Other bot")
+        other.create_new_version()
+
+        assert promote(client, other, 2).status_code == 404
+
+
+@pytest.mark.django_db()
+class TestAuth:
+    def test_another_teams_chatbot_is_a_404(self, published):
+        other = TeamWithUsersFactory.create()
+
+        response = promote(ApiTestClient(other.members.first(), other), published, 2)
+
+        assert response.status_code == 404, response.content
+
+    def test_a_read_only_key_cannot_promote(self, published):
+        client = ApiTestClient(published.team.members.first(), published.team, read_only=True)
+
+        assert promote(client, published, 2).status_code == 403
+        assert served(published) == [(1, True), (2, False)]
+
+    def test_a_token_without_the_write_scope_is_refused(self, published):
+        client = ApiTestClient(
+            published.team.members.first(), published.team, auth_method="oauth", scopes=["chatbots:read"]
+        )
+
+        assert promote(client, published, 2).status_code == 403
+
+    def test_a_machine_token_is_held_to_its_applications_chatbot_allowlist(self, published):
+        client = ApiTestClient(
+            published.team.members.first(),
+            published.team,
+            auth_method="oauth_client_credentials",
+            scopes=["chatbots:write"],
+            allowed_chatbots=[],
+        )
+
+        assert promote(client, published, 2).status_code == 403
+
+
+@pytest.fixture()
+def team_with_roles(db):
+    """`create_default_groups()` is explicit so the DB-backed groups match backends.py even
+    though pytest runs with --reuse-db."""
+    create_default_groups()
+    team = TeamFactory.create()
+    token = set_current_team(team)
+    try:
+        yield team
+    finally:
+        unset_current_team(token)
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("group", "allowed"),
+    [
+        pytest.param(CHATBOT_ADMIN_GROUP, True, id="chatbot-admin-may-promote"),
+        pytest.param(CHAT_VIEWER_GROUP, False, id="chat-viewer-may-not"),
+    ],
+)
+def test_promoting_requires_change_experiment(team_with_roles, group, allowed):
+    """`change_experiment`, not the `delete_experiment` its DELETE sibling asks for: choosing which
+    version is served changes the chatbot, and a role that may edit chatbots but not delete them
+    should be able to do it."""
+    chatbot = ChatbotFactory.create(team=team_with_roles)
+    chatbot.create_new_version()
+    chatbot.create_new_version()
+    user = UserFactory.create()
+    add_user_to_team(team_with_roles, user, [group])
+
+    response = promote(ApiTestClient(user, team_with_roles), chatbot, 2)
+
+    assert response.status_code == (200 if allowed else 403), response.content

--- a/apps/api/v2/versions/tests/test_version_status.py
+++ b/apps/api/v2/versions/tests/test_version_status.py
@@ -1,0 +1,134 @@
+"""GET /api/v2/chatbots/{id}/versions/status/ -- where the version history stands (#4142)."""
+
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+
+from apps.experiments.models import Experiment
+from apps.utils.factories.experiment import ChatbotFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+from apps.utils.tests.clients import ApiTestClient
+
+from .conftest import status_url, versions_url
+
+
+def publish(client, chatbot, **body) -> None:
+    response = client.post(versions_url(chatbot), body, format="json")
+    assert response.status_code == 202, response.content
+
+
+def poll(client, chatbot):
+    return client.get(status_url(chatbot))
+
+
+@pytest.mark.django_db()
+def test_the_status_url_is_the_registered_route(chatbot):
+    assert reverse("api:v2:chatbot-version-status", args=[chatbot.public_id]) == status_url(chatbot)
+
+
+@pytest.mark.django_db()
+class TestInFlight:
+    def test_an_operation_that_still_holds_the_lock_is_pending(self, client, chatbot, dispatch):
+        """The lock, not Celery's state, is what says "in flight": a task Celery has not started yet
+        reads PENDING, which is indistinguishable from a task id it has never heard of."""
+        publish(client, chatbot, make_default=True)
+
+        response = poll(client, chatbot)
+
+        assert response.status_code == 200, response.content
+        assert response.json() == {"status": "pending"}
+
+    def test_a_revert_holding_the_lock_also_reads_pending(self, client, chatbot):
+        """The lock covers every version operation, so `pending` means "an operation is running"
+        rather than "your publish is running" -- the same breadth as the publish endpoint's 409."""
+        chatbot.acquire_version_operation_lock("revert-1-2")
+
+        assert poll(client, chatbot).json() == {"status": "pending"}
+
+
+@pytest.mark.django_db()
+class TestTerminal:
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_a_finished_publish_reports_the_version(self, client, chatbot):
+        publish(client, chatbot, make_default=True)
+
+        assert poll(client, chatbot).json() == {"status": "completed", "version_number": 1}
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_the_newest_version_is_what_is_reported(self, client, chatbot):
+        """The answer is the chatbot's own state, so a second publish moves it on -- there is no
+        handle that keeps pointing at the first one."""
+        publish(client, chatbot)
+        chatbot.name = "Renamed, so there is something to publish"
+        chatbot.save(update_fields=["name"])
+        publish(client, chatbot, make_default=True)
+
+        assert poll(client, chatbot).json() == {"status": "completed", "version_number": 2}
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_the_report_is_per_chatbot(self, client, chatbot, team):
+        """Each chatbot answers for its own history: publishing one leaves the other with nothing
+        to report rather than borrowing its neighbour's version."""
+        other = ChatbotFactory.create(team=team, name="Other bot")
+        publish(client, other, make_default=True)
+
+        assert poll(client, other).json() == {"status": "completed", "version_number": 1}
+        assert poll(client, chatbot).status_code == 404
+
+
+@pytest.mark.django_db()
+class TestNothingToReport:
+    def test_a_chatbot_that_has_never_published_is_not_found(self, client, chatbot):
+        assert poll(client, chatbot).status_code == 404
+
+    def test_a_publish_that_snapshotted_nothing_leaves_nothing_to_report(self, client, chatbot, dispatch):
+        """The worker raised before creating anything and its `finally` freed the lock. With no
+        version to name and no task to account for, the honest answer is that there is nothing."""
+        publish(client, chatbot, make_default=True)
+        Experiment.release_version_operation_lock(chatbot.id)
+
+        assert poll(client, chatbot).status_code == 404
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_a_failed_publish_on_a_chatbot_with_history_reports_the_version_already_there(self, client, chatbot):
+        """The documented cost of polling the chatbot rather than the task: `completed` names the
+        version that was already there, so a client checks `version_number` against the one it
+        expected instead of reading `completed` as proof its own snapshot landed."""
+        publish(client, chatbot, make_default=True)
+        chatbot.refresh_from_db()
+        # A second publish that the worker raises on: the lock is taken and freed, and no snapshot
+        # is made -- exactly the state the task's `finally` leaves behind.
+        chatbot.acquire_version_operation_lock("publish-that-will-raise")
+        Experiment.release_version_operation_lock(chatbot.id)
+
+        assert poll(client, chatbot).json() == {"status": "completed", "version_number": 1}
+
+
+@pytest.mark.django_db()
+class TestAuth:
+    def test_polling_another_teams_chatbot_is_not_found(self, chatbot):
+        other = TeamWithUsersFactory.create()
+
+        response = poll(ApiTestClient(other.members.first(), other), chatbot)
+
+        assert response.status_code == 404, response.content
+
+    def test_a_read_only_key_may_poll(self, chatbot, dispatch):
+        """Reporting an outcome writes nothing, so the read-only gate lets it through -- an operator
+        can watch a publish with the same key that inspects the chatbot."""
+        writer = ApiTestClient(chatbot.team.members.first(), chatbot.team)
+        publish(writer, chatbot, make_default=True)
+        reader = ApiTestClient(chatbot.team.members.first(), chatbot.team, read_only=True)
+
+        assert poll(reader, chatbot).json() == {"status": "pending"}
+
+    def test_a_machine_token_is_held_to_its_applications_chatbot_allowlist(self, chatbot):
+        client = ApiTestClient(
+            chatbot.team.members.first(),
+            chatbot.team,
+            auth_method="oauth_client_credentials",
+            scopes=["chatbots:read"],
+            allowed_chatbots=[],
+        )
+
+        assert poll(client, chatbot).status_code == 403

--- a/apps/api/v2/versions/views.py
+++ b/apps/api/v2/versions/views.py
@@ -6,10 +6,13 @@ it. A worker takes the snapshot, so the request answers `202` rather than with t
 second endpoint here reports the chatbot's version history as that version lands in it.
 """
 
+from django.db import transaction
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from field_audit.models import AuditAction
 from rest_framework import status
 from rest_framework.exceptions import NotFound
+from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -23,14 +26,22 @@ from apps.pipelines.build_state import pipeline_build_state
 
 from .exceptions import NothingToPublish, PipelineIsNotValid, VersionOperationInProgress
 from .serializers import (
+    PublishVersionSerializer,
     VersionCreateRefusedSerializer,
     VersionCreateSerializer,
+    VersionPublishedSerializer,
     VersionStatus,
     VersionStatusSerializer,
 )
 
 CHATBOT_ID = OpenApiParameter(
     name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH, description="Chatbot ID"
+)
+VERSION_NUMBER = OpenApiParameter(
+    name="version_number",
+    type=OpenApiTypes.INT,
+    location=OpenApiParameter.PATH,
+    description="The version's number, as the `chatbot_inspect` endpoint reports it.",
 )
 FORBIDDEN = OpenApiResponse(
     description=(
@@ -193,6 +204,75 @@ class ChatbotVersionStatusView(APIView):
         # has no publish of its own to follow.
         enforce_application_chatbot_write(request, chatbot)
         return Response(_version_status(chatbot))
+
+
+class ChatbotVersionView(APIView):
+    """Make an existing version the one participants are served."""
+
+    permission_classes = [*BASE_PERMISSION_CLASSES, ChatbotCompositionPermission, TokenHasOAuthResourceScope]
+    required_scopes = ["chatbots"]
+
+    @extend_schema(
+        operation_id="chatbot_version_publish",
+        summary="Make chatbot version the published one",
+        description=(
+            "Make this version the one participants are served, without snapshotting anything.\n\n"
+            "Channels resolve the published version per message, so a live chatbot switches over "
+            "from the next message on. The version that held it stops being served and is "
+            "otherwise untouched -- a chatbot holds exactly one published version, so promoting "
+            "one demotes the other.\n\n"
+            "This is how an already-published version is served again; the "
+            "`chatbot_version_create` endpoint's `make_default` covers the other case, a snapshot "
+            "that goes live as it is taken. Promoting a version this way creates nothing, so it is "
+            "never refused for having no changes to record."
+        ),
+        tags=["Chatbots"],
+        parameters=[CHATBOT_ID, VERSION_NUMBER],
+        request=PublishVersionSerializer,
+        responses={
+            200: VersionPublishedSerializer,
+            400: OpenApiResponse(
+                description=(
+                    "The body carries a key this endpoint does not accept, or asks to un-publish a "
+                    "version -- a chatbot always needs a published one."
+                )
+            ),
+            403: FORBIDDEN,
+            404: OpenApiResponse(
+                description=(
+                    "No such chatbot, or it has no version under this number -- an archived "
+                    "chatbot and an archived version included."
+                )
+            ),
+        },
+    )
+    def patch(self, request, id: str, version_number: int) -> Response:
+        body = PublishVersionSerializer(data=request.data)
+        body.is_valid(raise_exception=True)
+        # One transaction and one row lock on the working chatbot, because demoting the incumbent
+        # and promoting this version have to land together: interleaved, two promotions could
+        # demote each other's winner and leave the chatbot with no published version at all.
+        with transaction.atomic():
+            chatbot = get_working_chatbot(request.team, id, lock=True)
+            enforce_application_chatbot_write(request, chatbot)
+            version = get_object_or_404(chatbot.versions, version_number=version_number)
+            _publish_existing_version(chatbot, version)
+        return Response({"version_number": version.version_number, "is_published_version": True})
+
+
+def _publish_existing_version(chatbot: Experiment, version: Experiment) -> None:
+    """Move the published flag onto ``version``, taking it off whichever version holds it.
+
+    A partial unique constraint allows one published version per family, so the incumbent is
+    demoted in the same statement-pair under the caller's row lock rather than left to collide.
+    Already-published is not an error: the request asked for a state that already holds.
+    """
+    chatbot.versions.filter(is_default_version=True).exclude(id=version.id).update(
+        is_default_version=False, audit_action=AuditAction.AUDIT
+    )
+    if not version.is_default_version:
+        version.is_default_version = True
+        version.save(update_fields=["is_default_version"])
 
 
 def _version_status(chatbot: Experiment) -> dict:

--- a/apps/api/v2/versions/views.py
+++ b/apps/api/v2/versions/views.py
@@ -1,0 +1,205 @@
+"""The chatbot version endpoints (#4142).
+
+Every write in this API targets the working (draft) version. Creating a version is how that draft
+becomes an immutable snapshot, which a client verifies by reading it back rather than by editing
+it. A worker takes the snapshot, so the request answers `202` rather than with the version, and the
+second endpoint here reports the chatbot's version history as that version lands in it.
+"""
+
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.exceptions import NotFound
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.api.permissions import BASE_PERMISSION_CLASSES
+from apps.api.v2.lookups import get_working_chatbot
+from apps.api.v2.write.base import ChatbotCompositionPermission
+from apps.experiments.models import Experiment
+from apps.experiments.tasks import start_version_creation
+from apps.oauth.permissions import TokenHasOAuthResourceScope, enforce_application_chatbot_write
+from apps.pipelines.build_state import pipeline_build_state
+
+from .exceptions import NothingToPublish, PipelineIsNotValid, VersionOperationInProgress
+from .serializers import (
+    VersionCreateRefusedSerializer,
+    VersionCreateSerializer,
+    VersionStatus,
+    VersionStatusSerializer,
+)
+
+CHATBOT_ID = OpenApiParameter(
+    name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH, description="Chatbot ID"
+)
+FORBIDDEN = OpenApiResponse(
+    description=(
+        "The caller is authenticated but not authorised for this chatbot's versions: either its "
+        "role lacks permission to change chatbots, or it is a machine (client-credentials) token "
+        "whose application is not authorised for this chatbot."
+    )
+)
+
+
+class ChatbotVersionCreateView(APIView):
+    """Snapshot the working version as a new immutable version."""
+
+    permission_classes = [*BASE_PERMISSION_CLASSES, ChatbotCompositionPermission, TokenHasOAuthResourceScope]
+    required_scopes = ["chatbots"]
+
+    @extend_schema(
+        operation_id="chatbot_version_create",
+        summary="Create a new version",
+        description=(
+            "Snapshot the chatbot's working (draft) version as a new, immutable version. Nothing "
+            "writes to a version: read it back with the `chatbot_inspect` endpoint's `version` "
+            "parameter, and every other write endpoint keeps targeting the working version.\n\n"
+            "A worker takes the snapshot, so the answer is `202` with no body. Poll the "
+            "`chatbot_version_status` endpoint for the version number and the outcome.\n\n"
+            "One version operation runs at a time per chatbot, creating a version and reverting "
+            "alike; a second is refused with `409`."
+        ),
+        tags=["Chatbots"],
+        parameters=[CHATBOT_ID],
+        request=VersionCreateSerializer,
+        responses={
+            202: OpenApiResponse(
+                description="The version creation was accepted. Poll `chatbot_version_status` for its outcome."
+            ),
+            400: OpenApiResponse(description="The body carries a key this endpoint does not accept."),
+            403: FORBIDDEN,
+            404: OpenApiResponse(
+                description=(
+                    "No such chatbot. Archived chatbots and existing versions are both outside "
+                    "this endpoint's reach: only a live working version can be snapshotted."
+                )
+            ),
+            409: OpenApiResponse(
+                description=(
+                    "A version operation (another version creation, or a revert started in the "
+                    "UI) is already running for this chatbot."
+                )
+            ),
+            422: OpenApiResponse(
+                response=VersionCreateRefusedSerializer,
+                description=(
+                    "Either the pipeline has errors and this version would be served to "
+                    "participants -- `make_default: true`, or a chatbot's first version, which is "
+                    "always the published one -- or the working version is identical to the newest "
+                    "one, so the snapshot would record no change. Nothing is snapshotted either "
+                    "way. Dangling handles are not errors: `unwired_handles` is advisory."
+                ),
+            ),
+        },
+    )
+    def post(self, request, id: str) -> Response:
+        body = VersionCreateSerializer(data=request.data)
+        body.is_valid(raise_exception=True)
+        chatbot = get_working_chatbot(request.team, id)
+        # A machine token reaches only the chatbots its application was pinned to. After resolution
+        # because the allowlist is keyed on the chatbot, and before the gate, which reads the graph.
+        enforce_application_chatbot_write(request, chatbot)
+        make_default = body.validated_data["make_default"]
+        # The cheaper question first: an unchanged chatbot is refused for having nothing to publish
+        # without the graph also being walked to find fault with it.
+        _check_there_is_something_to_publish(chatbot)
+        if chatbot.publish_goes_live(make_default=make_default):
+            _check_pipeline_can_go_live(chatbot)
+        dispatched = start_version_creation(
+            chatbot,
+            version_description=body.validated_data["version_description"],
+            make_default=make_default,
+        )
+        # The task id it hands back goes nowhere: the status endpoint takes none. It is read only
+        # for the `None` that means another version operation already holds the lock.
+        if dispatched is None:
+            raise VersionOperationInProgress()
+        return Response(status=status.HTTP_202_ACCEPTED)
+
+
+def _check_there_is_something_to_publish(chatbot: Experiment) -> None:
+    """Refuse a version whose snapshot would be identical to the newest version.
+
+    The comparison the web app's "unreleased changes" badge is drawn from, so the API and the web
+    app agree about whether a chatbot has anything to publish.
+
+    A chatbot with no versions has nothing to compare against, and ``compare_with_latest()`` answers
+    ``False`` for it -- "no baseline" and "no difference" arrive as one value, so the absence of
+    versions is asked about separately rather than read out of the comparison.
+    """
+    if chatbot.latest_version is None:
+        return
+    if chatbot.compare_with_latest():
+        return
+    raise NothingToPublish()
+
+
+def _check_pipeline_can_go_live(chatbot: Experiment) -> None:
+    """Refuse a version that would serve participants a pipeline that does not validate.
+
+    A deliberate divergence from the pipeline builder, which lets a human publish a bot whose red
+    markers they can see. An unattended client has nothing to look at, and the version goes live
+    per-message, so the refusal is the only backstop.
+
+    Judged on exactly what the façade writes and `chatbot_inspect` reads report, so the gate and the
+    report cannot disagree about whether a pipeline is publishable.
+
+    ``Experiment.pipeline`` is nullable and rows predating pipeline-backed chatbots hold null: there
+    is nothing to validate, so there is nothing to refuse -- as in the UI.
+    """
+    if chatbot.pipeline_id is None:
+        return
+    state = pipeline_build_state(chatbot.pipeline)
+    if not state["pipeline_valid"]:
+        raise PipelineIsNotValid(state["errors"])
+
+
+class ChatbotVersionStatusView(APIView):
+    """Report where the chatbot's version history stands."""
+
+    permission_classes = [*BASE_PERMISSION_CLASSES, ChatbotCompositionPermission, TokenHasOAuthResourceScope]
+    required_scopes = ["chatbots"]
+
+    @extend_schema(
+        operation_id="chatbot_version_status",
+        summary="Version creation status",
+        description=(
+            "Report where this chatbot's version history stands, which is how a version the "
+            "`chatbot_version_create` endpoint accepted is followed to its end.\n\n"
+            "Poll this until `status` is terminal:\n\n"
+            "- **`pending`** — a version operation is still running. Poll again.\n"
+            "- **`completed`** — no operation is running and `version_number` names the chatbot's "
+            "newest version. Read it back with the `chatbot_inspect` endpoint's `version` "
+            "parameter to check what landed in it.\n\n"
+            "**`completed` is not a receipt for your request.** This reports the chatbot's own "
+            "state, not one task's outcome, so it cannot say which request produced the version it "
+            "names. A version creation the worker raised on releases the lock without snapshotting "
+            "anything, and polling then reports `completed` on the version that was already "
+            "there — so check `version_number` against the one you expected rather than reading "
+            "`completed` as proof the snapshot landed.\n\n"
+            "A chatbot with no version at all has nothing to report and answers `404`."
+        ),
+        tags=["Chatbots"],
+        parameters=[CHATBOT_ID],
+        responses={
+            200: VersionStatusSerializer,
+            403: FORBIDDEN,
+            404: OpenApiResponse(description="No such chatbot, or it has never created a version."),
+        },
+    )
+    def get(self, request, id: str) -> Response:
+        chatbot = get_working_chatbot(request.team, id)
+        # The same allowlist the publish is held to: a machine token that may not publish a chatbot
+        # has no publish of its own to follow.
+        enforce_application_chatbot_write(request, chatbot)
+        return Response(_version_status(chatbot))
+
+
+def _version_status(chatbot: Experiment) -> dict:
+    """Where ``chatbot``'s version history stands: an operation in flight, or the newest version."""
+    if chatbot.version_operation_in_progress:
+        return {"status": VersionStatus.PENDING}
+    version = chatbot.latest_version
+    if version is None:
+        raise NotFound("This chatbot has no versions yet.")
+    return {"status": VersionStatus.COMPLETED, "version_number": version.version_number}

--- a/apps/api/v2/versions/views.py
+++ b/apps/api/v2/versions/views.py
@@ -16,7 +16,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.api.permissions import BASE_PERMISSION_CLASSES
+from apps.api.permissions import BASE_PERMISSION_CLASSES, RequiresTeamPermission
 from apps.api.v2.lookups import get_working_chatbot
 from apps.api.v2.write.base import ChatbotCompositionPermission
 from apps.experiments.models import Experiment
@@ -24,9 +24,10 @@ from apps.experiments.tasks import start_version_creation
 from apps.oauth.permissions import TokenHasOAuthResourceScope, enforce_application_chatbot_write
 from apps.pipelines.build_state import pipeline_build_state
 
-from .exceptions import NothingToPublish, PipelineIsNotValid, VersionOperationInProgress
+from .exceptions import NothingToPublish, PipelineIsNotValid, VersionIsDefault, VersionOperationInProgress
 from .serializers import (
     PublishVersionSerializer,
+    VersionArchivedSerializer,
     VersionCreateRefusedSerializer,
     VersionCreateSerializer,
     VersionPublishedSerializer,
@@ -48,6 +49,13 @@ FORBIDDEN = OpenApiResponse(
         "The caller is authenticated but not authorised for this chatbot's versions: either its "
         "role lacks permission to change chatbots, or it is a machine (client-credentials) token "
         "whose application is not authorised for this chatbot."
+    )
+)
+FORBIDDEN_DELETE = OpenApiResponse(
+    description=(
+        "The caller is authenticated but not authorised to archive this chatbot's versions: either "
+        "its role lacks permission to delete chatbots, or it is a machine (client-credentials) "
+        "token whose application is not authorised for this chatbot."
     )
 )
 
@@ -206,11 +214,34 @@ class ChatbotVersionStatusView(APIView):
         return Response(_version_status(chatbot))
 
 
-class ChatbotVersionView(APIView):
-    """Make an existing version the one participants are served."""
+class ChatbotVersionDeletePermission(RequiresTeamPermission):
+    """Archiving a version really is a delete, so this one asks for ``delete_experiment``.
 
-    permission_classes = [*BASE_PERMISSION_CLASSES, ChatbotCompositionPermission, TokenHasOAuthResourceScope]
+    The other routes under ``/chatbots/{id}/`` deliberately do not: removing a pipeline node is a
+    change to the chatbot rather than a deletion of one. A version is an ``Experiment`` row of its
+    own, and this hides it.
+    """
+
+    required_permissions = ["experiments.delete_experiment"]
+
+
+class ChatbotVersionView(APIView):
+    """The two writes that address one published version: promote it, or archive it."""
+
+    # Set per verb by `get_permissions`; declared so a misconfiguration is a refusal, not an
+    # open door, if that override is ever removed.
+    permission_classes = [*BASE_PERMISSION_CLASSES, ChatbotVersionDeletePermission, TokenHasOAuthResourceScope]
     required_scopes = ["chatbots"]
+
+    def get_permissions(self):
+        """Archiving a version really is a delete; promoting one is a change to the chatbot.
+
+        The two verbs share a path, so the permission cannot be a class attribute: `delete_version`
+        would refuse a role that may edit chatbots but not delete them the right to choose which
+        version is served, and `change_experiment` alone would let it hide versions.
+        """
+        write = ChatbotVersionDeletePermission if self.request.method == "DELETE" else ChatbotCompositionPermission
+        return [permission() for permission in [*BASE_PERMISSION_CLASSES, write, TokenHasOAuthResourceScope]]
 
     @extend_schema(
         operation_id="chatbot_version_publish",
@@ -258,6 +289,52 @@ class ChatbotVersionView(APIView):
             version = get_object_or_404(chatbot.versions, version_number=version_number)
             _publish_existing_version(chatbot, version)
         return Response({"version_number": version.version_number, "is_published_version": True})
+
+    @extend_schema(
+        operation_id="chatbot_version_archive",
+        summary="Archive a chatbot version",
+        description=(
+            "Archive one of the chatbot's versions. This is a soft delete: the version and the pipeline "
+            "snapshot it owns are hidden rather than destroyed, and a person can restore it in the "
+            "web app. Nothing in this API reaches an archived version, so a repeat of this call "
+            "answers `404` -- which makes it safe to retry after an answer you never saw.\n\n"
+            "**The published version is refused with `409`.** It is the version participants are "
+            "served and a chatbot may hold only one, so archiving it would leave the chatbot with "
+            "none; the `chatbot_version_publish` endpoint moves it to another version first.\n\n"
+            "The working (draft) version has no number and is not reachable here. Archiving the "
+            "whole chatbot is the `chatbot_archive` endpoint, which takes the channel guard and "
+            "the scheduled messages with it -- neither of which a single version has."
+        ),
+        tags=["Chatbots"],
+        parameters=[CHATBOT_ID, VERSION_NUMBER],
+        request=None,
+        responses={
+            200: VersionArchivedSerializer,
+            403: FORBIDDEN_DELETE,
+            404: OpenApiResponse(
+                description=(
+                    "No such chatbot, or it has no version under this number -- an archived "
+                    "chatbot and an already-archived version included."
+                )
+            ),
+            409: OpenApiResponse(description="This is the chatbot's published version."),
+        },
+    )
+    def delete(self, request, id: str, version_number: int) -> Response:
+        # Resolution, the default-version rule and the archive share one transaction and one row
+        # lock on the working chatbot, so two archives of the same version cannot both read it as
+        # live. The second blocks, then re-resolves against the committed `is_archived` and 404s.
+        with transaction.atomic():
+            chatbot = get_working_chatbot(request.team, id, lock=True)
+            # A machine token reaches only the chatbots its application was pinned to. Checked after
+            # resolution because the allowlist is keyed on the chatbot, and before anything written.
+            enforce_application_chatbot_write(request, chatbot)
+            # `versions` excludes archived rows, so an already-archived version is a 404 here.
+            version = get_object_or_404(chatbot.versions, version_number=version_number)
+            if version.is_default_version:
+                raise VersionIsDefault()
+            version.archive()
+        return Response({"archived": True})
 
 
 def _publish_existing_version(chatbot: Experiment, version: Experiment) -> None:

--- a/apps/api/v2/views.py
+++ b/apps/api/v2/views.py
@@ -15,6 +15,7 @@ from apps.api.v2.inspect.serializers import ChatbotInspectSerializer
 from apps.api.v2.inspect.versioning import InspectVersionError, resolve_inspect_version
 from apps.api.v2.lookups import get_working_chatbot, working_chatbots
 from apps.api.v2.serializers import ChatbotSerializer, MeSerializer
+from apps.api.v2.write.archive import ArchivedSerializer, ChannelsAttachedSerializer, archive_chatbot
 from apps.api.v2.write.serializers import (
     ChatbotCreateSerializer,
     ChatbotDetailSerializer,
@@ -181,6 +182,60 @@ class ChatbotViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, GenericVi
             serializer.is_valid(raise_exception=True)
             chatbot = serializer.save()
         return Response(ChatbotDetailSerializer(chatbot).data)
+
+    @extend_schema(
+        operation_id="chatbot_archive",
+        summary="Archive Chatbot",
+        description=(
+            "Archive the chatbot. This is a soft delete: the chatbot and its versions are hidden "
+            "rather than destroyed, and a person can restore it in the web app. Nothing in this "
+            "API reaches an archived chatbot, so a repeat of this call answers `404` -- which "
+            "makes it safe to retry after an answer you never saw.\n\n"
+            "**It is refused while a channel is attached.** Taking a chatbot off Telegram, "
+            "WhatsApp or the chat widget removes its webhook at the provider, and this API cannot "
+            "create a channel to put back, so detaching stays a person's job in the web app; the "
+            "`409` names the channels to detach. The team-wide API, web and evaluations channels "
+            "are not attachments and never stand in the way, so a chatbot created through this "
+            "API archives freely.\n\n"
+            "**It cancels every scheduled message the chatbot has**, finished and "
+            "already-cancelled ones included, and they cannot be recovered. That is the right "
+            "consequence of archiving -- and there is no endpoint to drain them first -- so the "
+            "response reports how many went, rather than refusing."
+        ),
+        tags=["Chatbots"],
+        parameters=[
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH, description="Chatbot ID"
+            ),
+        ],
+        request=None,
+        responses={
+            200: ArchivedSerializer,
+            403: OpenApiResponse(
+                description=(
+                    "The caller is authenticated but not authorised to archive this chatbot: "
+                    "either its role lacks permission to delete chatbots, or it is a machine "
+                    "(client-credentials) token whose application is not authorised for this "
+                    "chatbot."
+                )
+            ),
+            404: OpenApiResponse(description="No such chatbot, or it is archived already."),
+            409: ChannelsAttachedSerializer,
+        },
+    )
+    def destroy(self, request, *args, **kwargs) -> Response:
+        # Resolution, the channel guard and the archive share one transaction and one row lock,
+        # because the reported count is read before `archive()` deletes the rows it counts. Two
+        # unlocked archives would both count the same schedules and both report deleting them,
+        # when only the first did. Under the lock the second blocks, then re-evaluates the
+        # working-chatbot predicate against the committed `is_archived` and answers 404.
+        with transaction.atomic():
+            chatbot = get_working_chatbot(self.team, self.kwargs[self.lookup_url_kwarg], lock=True)
+            # A machine token reaches only the chatbots its application was pinned to. Checked
+            # after resolution because the allowlist is keyed on the chatbot, and before anything
+            # is written.
+            enforce_application_chatbot_write(request, chatbot)
+            return Response(archive_chatbot(chatbot))
 
 
 class MeView(APIView):

--- a/apps/api/v2/write/archive.py
+++ b/apps/api/v2/write/archive.py
@@ -1,0 +1,108 @@
+"""Archiving a chatbot: the guard that stands in the way, and what archiving destroys (#4143).
+
+Archiving through this API is "undo my own draft", not a teardown of a live bot. There is no
+channel endpoint of any kind: detaching a channel fires a best-effort call to the upstream provider
+to remove its webhook, and since this API cannot *create* a channel, a client that detached one
+could never put it back. So a chatbot with a channel attached is refused, and a person detaches it.
+"""
+
+from rest_framework import serializers, status
+from rest_framework.exceptions import APIException
+
+from apps.channels.models import ChannelPlatform, ExperimentChannel
+from apps.experiments.models import Experiment
+
+
+class AttachedChannelSerializer(serializers.Serializer):
+    """One channel standing in the way, named the way the web app names it.
+
+    Enough for a client to tell a person which channels to go and detach; there is nothing here to
+    address, because no endpoint takes a channel.
+    """
+
+    id = serializers.IntegerField()
+    # The same choice set the `chatbot_inspect` endpoint reports a channel's platform from, so a
+    # client parses one enum across both.
+    platform = serializers.ChoiceField(choices=ChannelPlatform.choices)
+    name = serializers.CharField()
+
+
+class ArchivedSerializer(serializers.Serializer):
+    """The archive response: that it happened, and what it destroyed on the way."""
+
+    archived = serializers.BooleanField(help_text="Always true; the failure cases are status codes.")
+    cancelled_scheduled_messages = serializers.IntegerField(
+        help_text=(
+            "How many of the chatbot's scheduled messages were deleted, finished and "
+            "already-cancelled ones included. They cannot be recovered."
+        )
+    )
+
+
+class ChannelsAttachedSerializer(serializers.Serializer):
+    """The 409: why the archive was refused, and what a person has to do about it."""
+
+    detail = serializers.CharField()
+    channels = AttachedChannelSerializer(many=True)
+
+
+class ChannelsAttached(APIException):
+    """The chatbot is still live on channels only a person can detach.
+
+    409 rather than 403: the caller may archive this chatbot, and will be able to, once the
+    channels are off it. Retrying without that changing will not help.
+    """
+
+    status_code = status.HTTP_409_CONFLICT
+
+    def __init__(self, channels: list[ExperimentChannel]) -> None:
+        # Assigned rather than handed to ``super().__init__``, which runs a structured detail
+        # through ``_get_error_details`` and turns every leaf into an ``ErrorDetail`` -- a ``str``
+        # subclass, so each channel's integer id would render as a string. Setting ``detail`` is
+        # all that ``__init__`` does with it, and the exception handler serves it as the body.
+        self.detail = {
+            "detail": (
+                f"This chatbot is still attached to {len(channels)} channel(s). Detaching one "
+                "removes its webhook at the messaging provider, so a person has to do it in the "
+                "web app -- this API has no channel endpoints. Archive again once they are "
+                "detached."
+            ),
+            "channels": AttachedChannelSerializer(channels, many=True).data,
+        }
+
+
+def archive_chatbot(chatbot: Experiment) -> dict:
+    """Soft-archive the chatbot, or refuse while a channel is still attached.
+
+    The caller resolves the chatbot under a row lock and calls this inside that transaction: the
+    schedules are counted before ``archive()`` deletes them, so two archives racing unlocked would
+    both count the same rows and both claim to have deleted them. Serialised, the second finds the
+    chatbot already archived and outside the working-chatbot queryset every write path resolves
+    through, so it answers 404 -- which is also what makes a retry after an unseen answer safe.
+    """
+    if attached := attached_channels(chatbot):
+        raise ChannelsAttached(attached)
+    # Counted before the archive, not after: `archive()` hard-deletes these rows and reports
+    # nothing, so this is the last moment they can be seen. Blocking on them instead would
+    # deadlock -- there is no scheduled-message endpoint to drain them with -- and cancelling
+    # future sends is the right consequence of archiving anyway, so the count is reported to keep
+    # the destruction visible to whoever the client answers to.
+    cancelled = chatbot.scheduled_messages.count()
+    chatbot.archive()
+    return {"archived": True, "cancelled_scheduled_messages": cancelled}
+
+
+def attached_channels(chatbot: Experiment) -> list[ExperimentChannel]:
+    """The channels that stand in the way of archiving ``chatbot``, oldest first.
+
+    The team-wide API, web and evaluations channels are excluded: there is one of each per team,
+    they carry no chatbot of their own, and nobody detaches them -- so a web or API bot, which is
+    all this API can create, archives freely. Already-detached rows are excluded by the default
+    manager, since detaching soft-deletes: counting those would leave a chatbot permanently
+    unarchivable.
+    """
+    return list(
+        ExperimentChannel.objects.filter(experiment_id=chatbot.id)
+        .exclude(platform__in=ChannelPlatform.team_global_platforms())
+        .order_by("id")
+    )

--- a/apps/api/v2/write/tests/test_auth.py
+++ b/apps/api/v2/write/tests/test_auth.py
@@ -24,10 +24,11 @@ def team_with_roles(db):
         unset_current_team(token)
 
 
-# The two shipped endpoints are gated by `DjangoModelPermissionsWithView` on `ChatbotViewSet`. Team
-# membership alone must not be enough to write: the caller's role has to hold the same model
-# permissions the chatbot UI requires. Chat Viewer holds neither add_experiment nor
-# change_experiment; Chatbot Admin holds both.
+# The top-level chatbot endpoints are gated by `DjangoModelPermissionsWithView` on
+# `ChatbotViewSet`, which derives the permission from the verb -- so each verb is exercised
+# separately. Team membership alone must not be enough to write: the caller's role has to hold the
+# same model permissions the chatbot UI requires. Chatbot Admin holds the whole experiments app;
+# Chat Viewer holds nothing in it beyond viewing sessions.
 ROLE_CASES = [
     pytest.param(CHATBOT_ADMIN_GROUP, True, id="chatbot-admin-may-write"),
     pytest.param(CHAT_VIEWER_GROUP, False, id="chat-viewer-may-not"),
@@ -60,6 +61,20 @@ def test_patch_requires_change_experiment(team_with_roles, group, allowed):
     assert response.status_code == (200 if allowed else 403), response.content
 
 
+@pytest.mark.django_db()
+@pytest.mark.parametrize(("group", "allowed"), ROLE_CASES)
+def test_archive_requires_delete_experiment(team_with_roles, group, allowed):
+    """Archiving is the one write on this viewset that really is a delete, so unlike the pipeline
+    façade -- where the verb map would ask the wrong question -- the stock `delete_experiment` is
+    exactly right here."""
+    chatbot = ChatbotFactory.create(team=team_with_roles)
+    response = _client_for_role(team_with_roles, group).delete(f"/api/v2/chatbots/{chatbot.public_id}/")
+
+    assert response.status_code == (200 if allowed else 403), response.content
+    chatbot.refresh_from_db()
+    assert chatbot.is_archived is allowed
+
+
 def _machine_write_client(team, allowed_chatbots=None):
     """A machine (client-credentials) client holding chatbots:write.
 
@@ -89,6 +104,18 @@ def test_patch_refuses_an_unlisted_chatbot(team_with_roles):
     assert response.status_code == 403, response.content
     chatbot.refresh_from_db()
     assert chatbot.name != "Nope"
+
+
+@pytest.mark.django_db()
+def test_archive_refuses_an_unlisted_chatbot(team_with_roles):
+    chatbot = ChatbotFactory.create(team=team_with_roles)
+    client = _machine_write_client(team_with_roles, allowed_chatbots=[])
+
+    response = client.delete(f"/api/v2/chatbots/{chatbot.public_id}/")
+
+    assert response.status_code == 403, response.content
+    chatbot.refresh_from_db()
+    assert chatbot.is_archived is False
 
 
 @pytest.mark.django_db()

--- a/apps/api/v2/write/tests/test_chatbot_archive.py
+++ b/apps/api/v2/write/tests/test_chatbot_archive.py
@@ -1,0 +1,242 @@
+"""DELETE /api/v2/chatbots/{id}/ -- soft-archive a chatbot (#4143).
+
+Archiving is "undo my own draft", not a teardown. A chatbot with a messaging channel attached is
+refused: detaching one calls out to the upstream provider to remove its webhook, and this API
+cannot create a channel, so the agent could not put back what it tore down. The team-wide API, web
+and evaluations channels are not attachments and never stand in the way.
+"""
+
+import threading
+
+import pytest
+from django.db import connections, transaction
+from django.utils import timezone
+
+from apps.api.v2.lookups import get_working_chatbot
+from apps.api.v2.write.archive import archive_chatbot
+from apps.channels.models import ChannelPlatform, ExperimentChannel
+from apps.events.models import EventActionType, ScheduledMessage, TimePeriod
+from apps.utils.factories.channels import ExperimentChannelFactory
+from apps.utils.factories.events import EventActionFactory, ScheduledMessageFactory
+from apps.utils.factories.experiment import ChatbotFactory, ParticipantFactory
+from apps.utils.factories.team import TeamWithUsersFactory
+from apps.utils.pytest import django_db_with_data
+from apps.utils.tests.clients import ApiTestClient
+
+
+@pytest.fixture()
+def chatbot(db):
+    return ChatbotFactory.create(team=TeamWithUsersFactory.create(), name="Support bot", description="")
+
+
+@pytest.fixture()
+def client(chatbot):
+    return ApiTestClient(chatbot.team.members.first(), chatbot.team)
+
+
+def _url(chatbot):
+    return f"/api/v2/chatbots/{chatbot.public_id}/"
+
+
+def _schedule(chatbot, **kwargs) -> ScheduledMessage:
+    """A scheduled message on `chatbot`, for a participant of its own.
+
+    Its own participant because `external_id` is derived from (name, experiment, participant) and
+    unique across the three, so several messages sharing a participant would collide. A schedule
+    per participant is also what the feature actually creates.
+    """
+    action = EventActionFactory.create(
+        action_type=EventActionType.SCHEDULETRIGGER,
+        params={
+            "name": "Check in",
+            "time_period": TimePeriod.DAYS,
+            "frequency": 1,
+            "repetitions": 1,
+            "prompt_text": "Still there?",
+            "experiment_id": chatbot.id,
+        },
+    )
+    return ScheduledMessageFactory.create(
+        team=chatbot.team,
+        experiment=chatbot,
+        action=action,
+        participant=ParticipantFactory.create(team=chatbot.team),
+        **kwargs,
+    )
+
+
+@pytest.mark.django_db()
+class TestArchive:
+    def test_a_chatbot_with_nothing_attached_archives(self, client, chatbot):
+        response = client.delete(_url(chatbot))
+
+        assert response.status_code == 200, response.content
+        assert response.json() == {"archived": True, "cancelled_scheduled_messages": 0}
+        chatbot.refresh_from_db()
+        assert chatbot.is_archived is True
+
+    def test_the_team_wide_channels_do_not_stand_in_the_way(self, client, chatbot):
+        """API, web and evaluations channels are one per team and carry no chatbot of their own, so
+        a plain web or API bot -- the kind this API creates -- archives freely."""
+        ExperimentChannel.objects.get_team_api_channel(chatbot.team)
+        ExperimentChannel.objects.get_team_web_channel(chatbot.team)
+        ExperimentChannel.objects.get_team_evaluations_channel(chatbot.team)
+
+        assert client.delete(_url(chatbot)).status_code == 200
+
+    def test_a_channel_already_detached_does_not_stand_in_the_way(self, client, chatbot):
+        """Detaching soft-deletes, so the row survives its own removal. Counting it would leave a
+        chatbot permanently unarchivable."""
+        channel = ExperimentChannelFactory.create(team=chatbot.team, experiment=chatbot)
+        channel.soft_delete()
+
+        assert client.delete(_url(chatbot)).status_code == 200
+
+    def test_another_chatbots_channel_does_not_stand_in_the_way(self, client, chatbot):
+        """The guard is per chatbot, not per team."""
+        ExperimentChannelFactory.create(team=chatbot.team, experiment=ChatbotFactory.create(team=chatbot.team))
+
+        assert client.delete(_url(chatbot)).status_code == 200
+
+    def test_a_second_delete_is_a_404(self, client, chatbot):
+        """Archived rows are outside every v2 write path's queryset, so a retry after an answer the
+        client never saw is safe: the 404 means the first one landed."""
+        assert client.delete(_url(chatbot)).status_code == 200
+
+        assert client.delete(_url(chatbot)).status_code == 404
+
+
+@pytest.mark.django_db()
+class TestChannelGuard:
+    def test_an_attached_channel_blocks_the_archive_and_is_named(self, client, chatbot):
+        channel = ExperimentChannelFactory.create(
+            team=chatbot.team, experiment=chatbot, platform=ChannelPlatform.TELEGRAM, name="Support telegram"
+        )
+
+        response = client.delete(_url(chatbot))
+
+        assert response.status_code == 409
+        body = response.json()
+        assert body["channels"] == [{"id": channel.id, "platform": "telegram", "name": "Support telegram"}]
+        assert "detach" in body["detail"].lower()
+
+    def test_the_chatbot_is_left_exactly_as_it_was(self, client, chatbot):
+        """Nothing partial: the scheduled messages archiving would have destroyed are still there."""
+        ExperimentChannelFactory.create(team=chatbot.team, experiment=chatbot)
+        _schedule(chatbot)
+
+        assert client.delete(_url(chatbot)).status_code == 409
+
+        chatbot.refresh_from_db()
+        assert chatbot.is_archived is False
+        assert chatbot.scheduled_messages.count() == 1
+
+    def test_every_attached_channel_is_named(self, client, chatbot):
+        """The client has to hand the whole list to a human, so one call reports all of them rather
+        than one per retry."""
+        channels = [
+            ExperimentChannelFactory.create(team=chatbot.team, experiment=chatbot, platform=platform)
+            for platform in (ChannelPlatform.TELEGRAM, ChannelPlatform.WHATSAPP)
+        ]
+
+        body = client.delete(_url(chatbot)).json()
+
+        assert [entry["platform"] for entry in body["channels"]] == ["telegram", "whatsapp"]
+        assert {entry["id"] for entry in body["channels"]} == {channel.id for channel in channels}
+
+
+@pytest.mark.django_db()
+class TestScheduledMessages:
+    """Archiving hard-deletes the chatbot's scheduled messages. Blocking on them would deadlock --
+    there is no API to drain them -- so the count is reported instead, to keep the destruction
+    visible to whoever the client answers to."""
+
+    def test_the_messages_are_deleted_and_counted(self, client, chatbot):
+        for _ in range(3):
+            _schedule(chatbot)
+
+        response = client.delete(_url(chatbot))
+
+        assert response.json()["cancelled_scheduled_messages"] == 3
+        assert chatbot.scheduled_messages.count() == 0
+
+    def test_messages_that_will_never_fire_again_are_counted_too(self, client, chatbot):
+        """`archive()` deletes every row, not just the pending ones, so the reported count has to
+        cover the finished and already-cancelled ones or it would understate what was destroyed."""
+        _schedule(chatbot)
+        _schedule(chatbot, is_complete=True)
+        _schedule(chatbot, cancelled_at=timezone.now())
+
+        assert client.delete(_url(chatbot)).json()["cancelled_scheduled_messages"] == 3
+        assert ScheduledMessage.objects.filter(experiment=chatbot).count() == 0
+
+    def test_another_chatbots_messages_are_left_alone(self, client, chatbot):
+        other = ChatbotFactory.create(team=chatbot.team)
+        _schedule(other)
+
+        assert client.delete(_url(chatbot)).json()["cancelled_scheduled_messages"] == 0
+        assert other.scheduled_messages.count() == 1
+
+
+@pytest.mark.django_db()
+def test_a_read_only_key_cannot_archive(chatbot):
+    client = ApiTestClient(chatbot.team.members.first(), chatbot.team, read_only=True)
+
+    assert client.delete(_url(chatbot)).status_code == 403
+    chatbot.refresh_from_db()
+    assert chatbot.is_archived is False
+
+
+@pytest.mark.django_db()
+def test_a_token_without_the_write_scope_cannot_archive(chatbot):
+    client = ApiTestClient(chatbot.team.members.first(), chatbot.team, auth_method="oauth", scopes=["chatbots:read"])
+
+    assert client.delete(_url(chatbot)).status_code == 403
+
+
+@pytest.mark.django_db()
+def test_another_teams_chatbot_is_not_found(chatbot):
+    other = TeamWithUsersFactory.create()
+
+    assert ApiTestClient(other.members.first(), other).delete(_url(chatbot)).status_code == 404
+
+
+@django_db_with_data()
+def test_an_archive_racing_another_reports_nothing_rather_than_a_stale_count():
+    """Two archives of one chatbot are serialised on its row, so only the winner reports a count.
+
+    The count is read before `archive()` deletes the rows it counts. Unlocked, a second archive
+    read that same count while the first was still in flight and answered 200 having deleted none
+    of them; it now waits on the row and finds the chatbot archived.
+    """
+    team = TeamWithUsersFactory.create()
+    chatbot = ChatbotFactory.create(team=team, name="Support bot", description="")
+    _schedule(chatbot)
+    client = ApiTestClient(team.members.first(), team)
+    answer = {}
+
+    def archive_over_the_api():
+        try:
+            response = client.delete(_url(chatbot))
+            answer["status_code"] = response.status_code
+        finally:
+            # The thread's own connection, which the test's transaction machinery does not reach.
+            connections.close_all()
+
+    # The first archive, held open mid-flight: the row is locked and the schedules are gone, but
+    # nothing is committed, so a reader that took no lock would still count them.
+    with transaction.atomic():
+        first = get_working_chatbot(team, chatbot.public_id, lock=True)
+        assert archive_chatbot(first)["cancelled_scheduled_messages"] == 1
+
+        racer = threading.Thread(target=archive_over_the_api)
+        racer.start()
+        # Asserted so a racer that finished before the commit fails the test rather than passing it
+        # vacuously -- it would have answered from a state this test never meant to exercise.
+        racer.join(timeout=1)
+        assert racer.is_alive(), "the second archive did not wait for the first"
+
+    racer.join(timeout=10)
+    assert not racer.is_alive()
+    assert answer["status_code"] == 404
+    assert ScheduledMessage.objects.filter(experiment=chatbot).count() == 0

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -863,6 +863,17 @@ class Experiment(BaseTeamModel, VersionsMixin):
     def release_version_operation_lock(cls, experiment_id: int):
         cls.objects.get_all().filter(id=experiment_id).update(create_version_task_id="", audit_action=AuditAction.AUDIT)
 
+    def publish_goes_live(self, *, make_default: bool) -> bool:
+        """Whether a version published from this row now would be the one participants are served.
+
+        ``make_default`` asks for it, and ``create_new_version`` grants it unconditionally to the
+        first version -- a chatbot holding versions but no default would serve nothing -- so a
+        caller gating on "will this go live" has to account for both. Read from the working row's
+        own ``version_number`` counter, which every publish increments, so archiving versions does
+        not make a later publish look like a first one.
+        """
+        return make_default or self.version_number == 1
+
     @transaction.atomic()
     def create_new_version(  # ty: ignore[invalid-method-override]
         self,

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -101,6 +101,15 @@ class VersionFieldDisplayFormatters:
         return template.render({"chip": Chip(label=name, url=url)})
 
     @staticmethod
+    def format_wiring(wiring: set[tuple[str, str, str, str]]) -> str:
+        """A pipeline's wires as ``source.handle -> target.handle`` lines, one per wire.
+
+        Sorted, because the wiring is a set and the comparison UI diffs these strings: an
+        unstable order would show every wire as changed whenever any one of them did.
+        """
+        return "\n".join(sorted(f"{source}.{out} -> {target}.{into}" for source, out, target, into in wiring))
+
+    @staticmethod
     def format_custom_action_operation(op) -> str:
         action = op.custom_action
         op_details = action.get_operations_by_id().get(op.operation_id)

--- a/apps/experiments/tasks.py
+++ b/apps/experiments/tasks.py
@@ -77,15 +77,17 @@ def async_create_experiment_version(
         Experiment.release_version_operation_lock(experiment_id)
 
 
-def start_version_creation(experiment, version_description: str = "", make_default: bool = False) -> bool:
+def start_version_creation(experiment, version_description: str = "", make_default: bool = False) -> str | None:
     """Dispatch async version creation under the version-operation lock.
 
     The lock is acquired before dispatch so a concurrent version operation is
-    rejected atomically. Returns False when another operation is already in flight.
+    rejected atomically. Returns the task id, or None when another operation is
+    already in flight. The one uuid is both the lock token and the Celery task id,
+    so a caller that has to report progress can hand it out as a poll handle.
     """
     task_id = str(uuid4())
     if not experiment.acquire_version_operation_lock(task_id):
-        return False
+        return None
     try:
         async_create_experiment_version.apply_async(
             kwargs={
@@ -98,7 +100,7 @@ def start_version_creation(experiment, version_description: str = "", make_defau
     except Exception:
         Experiment.release_version_operation_lock(experiment.id)
         raise
-    return True
+    return task_id
 
 
 @shared_task(bind=True, base=TaskbadgerTask, queue=Queues.CHAT)

--- a/apps/experiments/tests/test_version_operation_lock.py
+++ b/apps/experiments/tests/test_version_operation_lock.py
@@ -38,10 +38,13 @@ class TestStartVersionCreation:
     def test_acquires_lock_before_dispatch(self, apply_async):
         experiment = ExperimentFactory.create()
 
-        assert start_version_creation(experiment, version_description="desc", make_default=True) is True
+        task_id = start_version_creation(experiment, version_description="desc", make_default=True)
 
         experiment.refresh_from_db()
         assert experiment.version_operation_in_progress
+        # The one uuid is the lock token, the Celery task id, and what the caller is handed to
+        # poll with -- so a caller can follow the operation it started.
+        assert task_id == experiment.create_version_task_id
         assert apply_async.call_count == 1
         kwargs = apply_async.call_args.kwargs
         assert kwargs["task_id"] == experiment.create_version_task_id
@@ -55,7 +58,7 @@ class TestStartVersionCreation:
     def test_rejected_while_another_operation_in_flight(self, apply_async):
         experiment = ExperimentFactory.create(create_version_task_id="other-operation")
 
-        assert start_version_creation(experiment) is False
+        assert start_version_creation(experiment) is None
 
         apply_async.assert_not_called()
         experiment.refresh_from_db()

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -334,6 +334,17 @@ class Pipeline(BaseTeamModel, VersionsMixin):
     def node_ids(self):
         return self.node_set.order_by("created_at").values_list("flow_id", flat=True).all()
 
+    @property
+    def wiring(self) -> set[tuple[str, str, str, str]]:
+        """This graph's wiring as ``(source, source handle, target, target handle)`` tuples.
+
+        Read through ``FlowEdge`` so a null handle and the standard name it stands for compare as
+        one wire -- a seeded or imported graph would otherwise read as different from an equivalent
+        one the builder made. Edge ids stay out: they are client-generated, so deleting a wire and
+        drawing the same one again would otherwise look like a change.
+        """
+        return {edge.wiring for edge in FlowWithoutNodes(**(self.data or {"edges": []})).edges}
+
     @transaction.atomic()
     def create_new_version(self, is_copy: bool = False):  # ty: ignore[invalid-method-override]
         version_number = 1 if is_copy else self.version_number
@@ -460,6 +471,13 @@ class Pipeline(BaseTeamModel, VersionsMixin):
                     name="nodes",
                     queryset=self.node_set.exclude(type__in=reserved_types),
                     to_display=node_name,
+                ),
+                # Edges live in ``data`` rather than in a row of their own (ADR-0049), so without
+                # this a version that only rewires the graph reports no changes.
+                VersionField(
+                    name="edges",
+                    raw_value=self.wiring,
+                    to_display=VersionFieldDisplayFormatters.format_wiring,
                 ),
             ],
         )

--- a/apps/pipelines/tests/test_models.py
+++ b/apps/pipelines/tests/test_models.py
@@ -8,6 +8,7 @@ from apps.chat.bots import PipelineTestBot
 from apps.documents.models import CollectionFile
 from apps.events.models import EventActionType
 from apps.experiments.models import Experiment, ExperimentSession, Participant
+from apps.pipelines.const import STANDARD_INPUT_NAME, STANDARD_OUTPUT_NAME
 from apps.pipelines.exceptions import has_errors
 from apps.pipelines.flow import Flow, FlowNode, split_flow_data
 from apps.pipelines.models import Node, Pipeline
@@ -183,6 +184,103 @@ class TestVersioningNodes:
 
         node.refresh_from_db()
         assert not node.compare_with_latest()
+
+
+@pytest.mark.django_db()
+class TestPipelineWiringVersionDetails:
+    """Edges live in ``Pipeline.data`` (ADR-0049), so the version comparison has to read them
+    from there or a version that only rewires the graph reports no changes."""
+
+    def _rewire(self, pipeline, edges):
+        pipeline.data = {**pipeline.data, "edges": edges}
+        pipeline.save(update_fields=["data"])
+
+    def test_unwiring_an_edge_is_a_change(self):
+        pipeline = PipelineFactory.create()
+        pipeline.create_new_version()
+
+        self._rewire(pipeline, [])
+
+        assert pipeline.compare_with_latest() is True
+
+    def test_wiring_an_edge_up_is_a_change(self):
+        pipeline = PipelineFactory.create()
+        self._rewire(pipeline, [])
+        pipeline.create_new_version()
+
+        self._rewire(pipeline, [{"id": "1->2", "source": "start", "target": "end"}])
+
+        assert pipeline.compare_with_latest() is True
+
+    def test_repointing_an_edge_is_a_change(self):
+        """The wire's endpoints changed while its id did not -- an id-only comparison would miss it."""
+        pipeline = PipelineFactory.create()
+        NodeFactory.create(flow_id="middle", pipeline=pipeline)
+        pipeline.create_new_version()
+
+        self._rewire(pipeline, [{"id": "1->2", "source": "start", "target": "middle"}])
+
+        assert pipeline.compare_with_latest() is True
+
+    def test_a_new_id_for_the_same_wire_is_not_a_change(self):
+        """Edge ids are client-generated, so deleting a wire and drawing the same one again would
+        otherwise read as a change to a graph that is wired identically."""
+        pipeline = PipelineFactory.create()
+        pipeline.create_new_version()
+
+        self._rewire(pipeline, [{"id": "drawn-again", "source": "start", "target": "end"}])
+
+        assert pipeline.compare_with_latest() is False
+
+    def test_an_absent_handle_matches_the_standard_one_it_stands_for(self):
+        """The builder names its source handles and a seeded graph does not, so the two spellings of
+        the standard handle have to compare as one wire."""
+        pipeline = PipelineFactory.create()
+        self._rewire(
+            pipeline,
+            [
+                {
+                    "id": "1->2",
+                    "source": "start",
+                    "target": "end",
+                    "sourceHandle": STANDARD_OUTPUT_NAME,
+                    "targetHandle": STANDARD_INPUT_NAME,
+                }
+            ],
+        )
+        pipeline.create_new_version()
+
+        self._rewire(
+            pipeline, [{"id": "1->2", "source": "start", "target": "end", "sourceHandle": None, "targetHandle": None}]
+        )
+
+        assert pipeline.compare_with_latest() is False
+
+    def test_the_order_edges_are_stored_in_is_not_a_change(self):
+        pipeline = PipelineFactory.create()
+        NodeFactory.create(flow_id="middle", pipeline=pipeline)
+        edges = [
+            {"id": "a", "source": "start", "target": "middle"},
+            {"id": "b", "source": "middle", "target": "end"},
+        ]
+        self._rewire(pipeline, edges)
+        pipeline.create_new_version()
+
+        self._rewire(pipeline, list(reversed(edges)))
+
+        assert pipeline.compare_with_latest() is False
+
+    def test_a_rewiring_reaches_the_experiment_comparison(self):
+        """The comparison the web app's "unreleased changes" badge and the write API's
+        nothing-to-publish refusal are both drawn from."""
+        pipeline = PipelineFactory.create()
+        experiment = ExperimentFactory.create(team=pipeline.team, pipeline=pipeline)
+        experiment.create_new_version()
+
+        self._rewire(pipeline, [])
+        experiment.refresh_from_db()
+
+        assert experiment.compare_with_latest() is True
 
 
 @pytest.mark.django_db()

--- a/config/settings.py
+++ b/config/settings.py
@@ -503,6 +503,7 @@ SPECTACULAR_SETTINGS = {
         "EvaluationModeEnum": "apps.evaluations.models.EvaluationMode",
         "WidgetAuthLevelEnum": "apps.channels.models.WidgetAuthLevel",
         "NotificationLevelEnum": "apps.ocs_notifications.models.LevelChoices",
+        "VersionStatusEnum": "apps.api.v2.versions.serializers.VersionStatus",
     },
     "SWAGGER_UI_SETTINGS": {
         "displayOperationId": True,


### PR DESCRIPTION
### Product Description
Three new v2 endpoints: publish a chatbot version, poll that publish for its outcome, and archive a chatbot.

### Technical Description
Decisions the diff doesn't show:

- **`start_version_creation` now returns the task id.** #4142 asked the endpoint to replicate its lock-and-dispatch lines to keep hold of the uuid; returning it avoids a second copy of that protocol. The three existing callers used the result as a bool, so truthiness carries them.
- **Two names diverge from the spec sketch:** the publish body takes `version_description` (`description` already means the chatbot's own on create/patch, and it's what inspect reads back), and the 422 carries `pipeline_errors`, matching the façade and inspect.
- **An unattributable `task_id` is a 404 when the chatbot has no versions** — the spec left this open. Nothing records the ids of finished operations, and a completed publish always leaves a version behind. Where versions do exist an unknown id still reads `completed` against the newest, which is the ambiguity W3 accepts.
- **The 409 on a busy version lock names no task id** on purpose: a UI revert holds the same lock under a token that isn't a Celery task id, so handing it out would report a publish that never happened.
- **The 409 channel list adds `name`** to the `id`/`platform` #4143 specifies. Nothing in that list is addressable — there is no channel endpoint — so it exists for a person to find the channel in the web app.

Worth a look: `ChannelsAttached` sets `self.detail` rather than passing it to `super().__init__()`, because DRF coerces every leaf of a structured detail to `ErrorDetail` (a `str` subclass) and that rendered each channel's integer id as a string. The 422 next door goes through `super()` and is unaffected only because every leaf of the errors report is already a string.

### Issue Link
fixes #4142
fixes #4143

### Docs and Changelog
- [x] This PR requires docs/changelog update

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change