### PR TITLE
remove 'contact' link from prelogin landing page

### DIFF
--- a/templates/prelogin/landing.html
+++ b/templates/prelogin/landing.html
@@ -111,7 +111,6 @@
         <div class="landing-links">
           <a href="https://docs.openchatstudio.com/" target="_blank" rel="noopener">Documentation</a>
           <a href="https://github.com/dimagi/open-chat-studio" target="_blank" rel="noopener">GitHub</a>
-          <a href="{{ project_meta.MARKETING_SITE_URL }}/contact/">Contact</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
**Before**
<img width="502" height="185" alt="image" src="https://github.com/user-attachments/assets/b3198dbc-c453-41b3-992e-e4db72dc84cb" />

**After**
<img width="502" height="185" alt="image" src="https://github.com/user-attachments/assets/cd3525fb-f7b9-4321-91e9-2e7e34557b18" />
