### PR TITLE
Style the message time-gap separator as a badge

### DIFF
--- a/templates/experiments/components/session_messages.html
+++ b/templates/experiments/components/session_messages.html
@@ -14,12 +14,8 @@
   <div class="flex flex-col" x-data="{commentsRow: null}">
     {% for message in messages %}
       {% if message.time_gap_text %}
-        <div class="py-3 text-center bg-base-200/50">
-          <div class="flex items-center justify-center gap-2 text-sm text-base-content/60 px-5">
-            <div class="h-px flex-1 bg-base-content/20"></div>
-            <span class="font-medium px-2">{{ message.time_gap_text }}</span>
-            <div class="h-px flex-1 bg-base-content/20"></div>
-          </div>
+        <div class="py-4 text-center bg-base-200/50">
+          <span class="badge badge-success">{{ message.time_gap_text }}</span>
         </div>
       {% endif %}
       <div


### PR DESCRIPTION
### Product Description
The time-gap divider between messages in a session transcript now renders as a single badge (e.g. "5 hours later") instead of plain grey text flanked by two thin lines. Purely visual, no behavior change.

### Technical Description
`templates/experiments/components/session_messages.html`: replaced the two flanking `<div class="h-px flex-1 bg-base-content/20">` lines and the plain `<span class="font-medium px-2">` with a single `<span class="badge badge-success">`, and bumped the row's vertical padding from `py-3` to `py-4` for a bit more breathing room around the badge.

Closes #4398

### Migrations
- [ ] The migrations are backwards compatible

N/A, no migrations in this PR.

### Demo
"5 hours later" badge rendered against a real session with a genuine gap between messages:

<img width="2200" height="732" alt="time-gap separator badge" src="https://github.com/user-attachments/assets/65327eb5-4ba4-4cff-9e43-6f8d0ccd5101" />

### Docs and Changelog
- [ ] This PR requires docs/changelog update

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change
