### PR TITLE
Link tool-call error notifications to their trace

### DIFF
--- a/apps/channels/tests/channels/test_tool_error_trace_notification.py
+++ b/apps/channels/tests/channels/test_tool_error_trace_notification.py
@@ -1,0 +1,110 @@
+"""Regression coverage for dimagi/open-chat-studio#4420.
+
+Unit tests elsewhere prove the two halves in isolation: `CustomBaseTool._run` now lets
+exceptions propagate (apps/chat/tests/test_tools.py), and `OCSCallbackHandler.on_tool_error`
+records the error on the tracer (apps/service_providers/tests/test_ocs_tracer.py). Neither
+proves what actually happens during a real pipeline run. This does: a real `CustomBaseTool`
+raising inside a real agent turn now aborts the turn instead of being swallowed -- exercising
+the same pipeline catch-all an LLM/chain failure already uses -- and still produces a
+trace-linked notification via the pre-existing `on_tool_error` path, not a new mechanism.
+"""
+
+from typing import ClassVar
+from unittest import mock
+
+import pytest
+from langchain_core.messages import AIMessage, ToolCall
+
+from apps.channels.pipeline import MessageProcessingPipeline
+from apps.channels.stages.core import BotInteractionStage
+from apps.channels.tests.channels.conftest import StubCallbacks, make_context
+from apps.chat.agent import tools
+from apps.chat.bots import PipelineBot
+from apps.experiments.models import AgentTools
+from apps.ocs_notifications.models import NotificationEvent
+from apps.pipelines.tests.utils import create_pipeline_model, end_node, llm_response_with_prompt_node, start_node
+from apps.service_providers.tracing import TracingService
+from apps.utils.factories.experiment import ExperimentSessionFactory, VersionedExperimentFactory
+from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
+from apps.utils.tests.langchain import build_fake_llm_service
+
+
+def _tool_call(name, args):
+    return AIMessage(tool_calls=[ToolCall(name=name, args=args, id="call-1")], content="")
+
+
+@pytest.mark.django_db()
+@mock.patch("apps.chat.bots.EventBot.get_user_message")
+@mock.patch("apps.pipelines.nodes.llm_node._get_configured_tools")
+@mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
+def test_tool_error_aborts_turn_and_creates_trace_linked_notification(
+    get_llm_service, get_configured_tools, mock_event_bot_message
+):
+    provider = LlmProviderFactory.create()
+    provider_model = LlmProviderModelFactory.create()
+    # Force the pipeline catch-all's EventBot path to fail over to its default text, so the
+    # assertion below doesn't depend on a second fake LLM call.
+    mock_event_bot_message.side_effect = RuntimeError("EventBot unavailable in test")
+
+    class RaisingTool(tools.CustomBaseTool):
+        name: str = AgentTools.UPDATE_PARTICIPANT_DATA
+        description: str = "Raises to exercise the real trace-error notification path"
+        requires_callbacks: ClassVar[bool] = False
+
+        def action(self, *args, **kwargs):
+            raise ValueError("simulated tool failure for #4420 regression test")
+
+    get_configured_tools.return_value = [RaisingTool()]
+    get_llm_service.return_value = build_fake_llm_service(
+        responses=[_tool_call(AgentTools.UPDATE_PARTICIPANT_DATA, {"key": "k", "value": "v"})]
+    )
+
+    # A published version -- trace-error notifications only fire for one (matches
+    # pipeline/span-error behaviour, see OCSTracer._fire_error_notification_if_needed).
+    experiment = VersionedExperimentFactory.create()
+    create_pipeline_model(
+        [
+            start_node(),
+            llm_response_with_prompt_node(
+                str(provider.id),
+                str(provider_model.id),
+                prompt="Be helpful. {participant_data}",
+                tools=[AgentTools.UPDATE_PARTICIPANT_DATA],
+            ),
+            end_node(),
+        ],
+        pipeline=experiment.pipeline,
+    )
+    session = ExperimentSessionFactory.create(experiment=experiment)
+    bot = PipelineBot(session, experiment, TracingService.create_for_experiment(experiment))
+    ctx = make_context(
+        experiment=experiment,
+        experiment_session=session,
+        bot=bot,
+        trace_service=bot.trace_service,
+        user_query="hi",
+        callbacks=StubCallbacks(),
+    )
+    pipeline = MessageProcessingPipeline(core_stages=[BotInteractionStage()], terminal_stages=[])
+
+    before_ids = set(NotificationEvent.objects.filter(team=experiment.team).values_list("id", flat=True))
+
+    with bot.trace_service.trace("test-trace", session=session, inputs={}):
+        with pytest.raises(ValueError, match="simulated tool failure"):
+            pipeline.process(ctx)
+
+    # The pre-existing pipeline catch-all still delivered a graceful reply -- the turn aborts,
+    # but the user isn't left with a raw error.
+    assert ctx.early_exit_response == MessageProcessingPipeline.DEFAULT_ERROR_RESPONSE_TEXT
+
+    # The failure still produced a trace-linked notification, the same mechanism pipeline/span
+    # errors already use -- this is the actual behaviour #4420 asked for.
+    notification = (
+        NotificationEvent.objects.filter(team=experiment.team)
+        .exclude(id__in=before_ids)
+        .order_by("-created_at")
+        .first()
+    )
+    assert notification is not None
+    assert notification.title.startswith("Tool Error Failed")
+    assert notification.links.get("View Trace")

--- a/apps/channels/tests/channels/test_tool_error_trace_notification.py
+++ b/apps/channels/tests/channels/test_tool_error_trace_notification.py
@@ -24,6 +24,7 @@ from apps.experiments.models import AgentTools
 from apps.ocs_notifications.models import NotificationEvent
 from apps.pipelines.tests.utils import create_pipeline_model, end_node, llm_response_with_prompt_node, start_node
 from apps.service_providers.tracing import TracingService
+from apps.trace.models import Trace
 from apps.utils.factories.experiment import ExperimentSessionFactory, VersionedExperimentFactory
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 from apps.utils.tests.langchain import build_fake_llm_service
@@ -88,6 +89,7 @@ def test_tool_error_aborts_turn_and_creates_trace_linked_notification(
     pipeline = MessageProcessingPipeline(core_stages=[BotInteractionStage()], terminal_stages=[])
 
     before_ids = set(NotificationEvent.objects.filter(team=experiment.team).values_list("id", flat=True))
+    before_trace_ids = set(Trace.objects.values_list("id", flat=True))
 
     with bot.trace_service.trace("test-trace", session=session, inputs={}):
         with pytest.raises(ValueError, match="simulated tool failure"):
@@ -107,4 +109,9 @@ def test_tool_error_aborts_turn_and_creates_trace_linked_notification(
     )
     assert notification is not None
     assert notification.title.startswith("Tool Error Failed")
-    assert notification.links.get("View Trace")
+
+    # The link points at this run's own trace, not just any trace -- and that trace carries
+    # the tool's error, confirming the two are actually connected, not incidentally both present.
+    trace = Trace.objects.exclude(id__in=before_trace_ids).get()
+    assert notification.links.get("View Trace") == trace.get_absolute_url()
+    assert "simulated tool failure" in trace.error

--- a/apps/channels/tests/channels/test_tool_error_trace_notification.py
+++ b/apps/channels/tests/channels/test_tool_error_trace_notification.py
@@ -1,12 +1,14 @@
 """Regression coverage for dimagi/open-chat-studio#4420.
 
-Unit tests elsewhere prove the two halves in isolation: `CustomBaseTool._run` now lets
-exceptions propagate (apps/chat/tests/test_tools.py), and `OCSCallbackHandler.on_tool_error`
-records the error on the tracer (apps/service_providers/tests/test_ocs_tracer.py). Neither
-proves what actually happens during a real pipeline run. This does: a real `CustomBaseTool`
-raising inside a real agent turn now aborts the turn instead of being swallowed -- exercising
-the same pipeline catch-all an LLM/chain failure already uses -- and still produces a
-trace-linked notification via the pre-existing `on_tool_error` path, not a new mechanism.
+Unit tests elsewhere prove the pieces in isolation: `CustomBaseTool._run` lets exceptions
+propagate (apps/chat/tests/test_tools.py), `OCSCallbackHandler.on_tool_error` records the
+error on the tracer (apps/service_providers/tests/test_ocs_tracer.py), and
+`get_agent_middleware` attaches `ToolErrorMiddleware` (apps/pipelines/tests/test_node_helpers.py).
+Neither proves what happens during a real pipeline run. This does: a real `CustomBaseTool`
+raising inside a real agent turn is caught by `ToolErrorMiddleware` and turned into a
+soft-fail `ToolMessage`, so the turn completes normally instead of aborting -- while still
+producing a trace-linked notification via the pre-existing `on_tool_error` path, which fires
+during tool execution itself, before the middleware ever sees the exception.
 """
 
 from typing import ClassVar
@@ -35,17 +37,11 @@ def _tool_call(name, args):
 
 
 @pytest.mark.django_db()
-@mock.patch("apps.chat.bots.EventBot.get_user_message")
 @mock.patch("apps.pipelines.nodes.llm_node._get_configured_tools")
 @mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
-def test_tool_error_aborts_turn_and_creates_trace_linked_notification(
-    get_llm_service, get_configured_tools, mock_event_bot_message
-):
+def test_tool_error_completes_turn_and_creates_trace_linked_notification(get_llm_service, get_configured_tools):
     provider = LlmProviderFactory.create()
     provider_model = LlmProviderModelFactory.create()
-    # Force the pipeline catch-all's EventBot path to fail over to its default text, so the
-    # assertion below doesn't depend on a second fake LLM call.
-    mock_event_bot_message.side_effect = RuntimeError("EventBot unavailable in test")
 
     class RaisingTool(tools.CustomBaseTool):
         name: str = AgentTools.UPDATE_PARTICIPANT_DATA
@@ -57,7 +53,10 @@ def test_tool_error_aborts_turn_and_creates_trace_linked_notification(
 
     get_configured_tools.return_value = [RaisingTool()]
     get_llm_service.return_value = build_fake_llm_service(
-        responses=[_tool_call(AgentTools.UPDATE_PARTICIPANT_DATA, {"key": "k", "value": "v"})]
+        responses=[
+            _tool_call(AgentTools.UPDATE_PARTICIPANT_DATA, {"key": "k", "value": "v"}),
+            AIMessage(content="Sorry, that didn't work."),
+        ]
     )
 
     # A published version -- trace-error notifications only fire for one (matches
@@ -92,12 +91,12 @@ def test_tool_error_aborts_turn_and_creates_trace_linked_notification(
     before_trace_ids = set(Trace.objects.values_list("id", flat=True))
 
     with bot.trace_service.trace("test-trace", session=session, inputs={}):
-        with pytest.raises(ValueError, match="simulated tool failure"):
-            pipeline.process(ctx)
+        pipeline.process(ctx)
 
-    # The pre-existing pipeline catch-all still delivered a graceful reply -- the turn aborts,
-    # but the user isn't left with a raw error.
-    assert ctx.early_exit_response == MessageProcessingPipeline.DEFAULT_ERROR_RESPONSE_TEXT
+    # The turn completes normally -- ToolErrorMiddleware turned the exception into a soft-fail
+    # ToolMessage instead of letting it abort the run, so the pipeline's catch-all never engages.
+    assert ctx.early_exit_response is None
+    assert ctx.bot_response.content == "Sorry, that didn't work."
 
     # The failure still produced a trace-linked notification, the same mechanism pipeline/span
     # errors already use -- this is the actual behaviour #4420 asked for.

--- a/apps/chat/agent/tools.py
+++ b/apps/chat/agent/tools.py
@@ -28,13 +28,12 @@ from apps.events.forms import ScheduledMessageConfigForm
 from apps.events.models import ScheduledMessage, TimePeriod
 from apps.experiments.models import AgentTools, Experiment, ExperimentSession
 from apps.files.models import File, FileChunkEmbedding
-from apps.ocs_notifications.notifications import tool_error_notification
 from apps.pipelines.models import Node
 from apps.pipelines.nodes.base import Intents
 from apps.pipelines.nodes.tool_callbacks import ToolCallbacks
 from apps.service_providers.llm_service.prompt_context import ParticipantDataProxy
 from apps.teams.models import Team
-from apps.teams.utils import get_current_team, get_slug_for_team
+from apps.teams.utils import get_slug_for_team
 from apps.utils.time import pretty_date
 
 if TYPE_CHECKING:
@@ -246,18 +245,7 @@ class CustomBaseTool(BaseTool):
     def _run(self, *args, **kwargs):
         if self.requires_session and not self.experiment_session:
             return "I am unable to do this"
-        try:
-            return self.action(*args, **kwargs)
-        except Exception as e:
-            logger.exception("Error executing tool: %s", self.name)
-            tool_error_notification(
-                team=get_current_team(),
-                tool_name=self.name,
-                error_message=str(e),
-                session=self.experiment_session,
-            )
-
-            return "Something went wrong"
+        return self.action(*args, **kwargs)
 
     async def _arun(self, *args, **kwargs) -> str:
         """Use the tool asynchronously."""

--- a/apps/chat/tests/test_tools.py
+++ b/apps/chat/tests/test_tools.py
@@ -864,8 +864,11 @@ class TestAttachMediaTool(BaseTestAgentTool):
 
 
 @pytest.mark.django_db()
-class TestNotificationOnToolError:
-    def test_tool_error_triggers_notification(self, team):
+class TestToolErrorPropagation:
+    def test_tool_error_propagates_instead_of_being_swallowed(self, team):
+        """CustomBaseTool._run must not catch tool exceptions itself -- BaseTool.run() needs
+        the real exception to reach it so it can fire on_tool_error (the same trace-capture
+        path pipeline/span errors use) before ToolNode turns it into an error ToolMessage."""
         set_current_team(team)
 
         class CustomBaseTool(tools.CustomBaseTool):
@@ -874,13 +877,12 @@ class TestNotificationOnToolError:
             requires_callbacks: ClassVar[bool] = False
 
             def action(self, *args, **kwargs):
-                raise Exception("Test error")
+                raise ValueError("Test error")
 
         tool = CustomBaseTool()
 
-        with mock.patch("apps.ocs_notifications.notifications.create_notification") as mock_create_notification:
+        with pytest.raises(ValueError, match="Test error"):
             tool.run(tool_input="tool_input")
-            mock_create_notification.assert_called_once()
 
 
 def _get_tool_schema_cls(tool_cls):

--- a/apps/ocs_notifications/notifications.py
+++ b/apps/ocs_notifications/notifications.py
@@ -198,28 +198,6 @@ def message_delivery_failure_notification(
     )
 
 
-@silence_exceptions(logger, log_message="Failed to create tool error notification")
-def tool_error_notification(team, tool_name: str, error_message: str, session=None) -> None:
-    """Create notification when a tool execution fails."""
-    event_data = {"tool_name": tool_name, "error_message": error_message}
-    links = {}
-
-    if session:
-        links["View Bot"] = session.experiment.get_absolute_url()
-        links["View Session"] = session.get_absolute_url()
-
-    create_notification(
-        title="Tool Error Detected",
-        message=error_message,
-        level=LevelChoices.ERROR,
-        team=team,
-        slug="tool-error",
-        event_data=event_data,
-        permissions=None,
-        links=links,
-    )
-
-
 @dataclass(frozen=True)
 class AffectedResources:
     """The resources referencing an LLM model, grouped by kind as ``{name: url}`` maps.

--- a/apps/ocs_notifications/tests/test_notifications.py
+++ b/apps/ocs_notifications/tests/test_notifications.py
@@ -14,7 +14,6 @@ from apps.ocs_notifications.notifications import (
     deprecated_model_notification,
     file_delivery_failure_notification,
     message_delivery_failure_notification,
-    tool_error_notification,
     trace_error_notification,
 )
 from apps.utils.factories.custom_actions import CustomActionFactory
@@ -256,77 +255,6 @@ class TestMessageDeliveryFailureNotification:
         kwargs = mock_create_notification.call_args.kwargs
         assert "+27820001111" in kwargs["message"]
         assert kwargs["links"] == {"View Bot": experiment.get_absolute_url()}
-
-
-class TestToolErrorNotification:
-    @pytest.mark.django_db()
-    @patch("apps.ocs_notifications.notifications.create_notification")
-    def test_creates_notification_with_session(self, mock_create_notification):
-        # Arrange
-        team = TeamFactory.create()
-        tool_name = "weather_api"
-        error_message = "API rate limit exceeded"
-        session = ExperimentSessionFactory.create()
-
-        # Act
-        tool_error_notification(team, tool_name, error_message, session)
-
-        # Assert
-        expected_event_data = {"tool_name": tool_name, "error_message": error_message}
-        expected_links = {
-            "View Bot": session.experiment.get_absolute_url(),
-            "View Session": session.get_absolute_url(),
-        }
-        mock_create_notification.assert_called_once_with(
-            title="Tool Error Detected",
-            message=error_message,
-            level=LevelChoices.ERROR,
-            team=team,
-            slug="tool-error",
-            event_data=expected_event_data,
-            permissions=None,
-            links=expected_links,
-        )
-
-    @pytest.mark.django_db()
-    @patch("apps.ocs_notifications.notifications.create_notification")
-    def test_creates_notification_without_session(self, mock_create_notification):
-        # Arrange
-        team = TeamFactory.create()
-        tool_name = "database_connector"
-        error_message = "Connection timeout"
-
-        # Act
-        tool_error_notification(team, tool_name, error_message)
-
-        # Assert
-        expected_event_data = {"tool_name": tool_name, "error_message": error_message}
-        expected_links = {}
-        mock_create_notification.assert_called_once_with(
-            title="Tool Error Detected",
-            message=error_message,
-            level=LevelChoices.ERROR,
-            team=team,
-            slug="tool-error",
-            event_data=expected_event_data,
-            permissions=None,
-            links=expected_links,
-        )
-
-    @pytest.mark.django_db()
-    @patch("apps.ocs_notifications.notifications.create_notification")
-    def test_handles_none_session(self, mock_create_notification):
-        # Arrange
-        team = TeamFactory.create()
-        tool_name = "test_tool"
-        error_message = "Test error"
-
-        # Act
-        tool_error_notification(team, tool_name, error_message, session=None)
-
-        # Assert
-        call_args = mock_create_notification.call_args[1]
-        assert call_args["links"] == {}
 
 
 class TestTraceErrorNotification:

--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -67,7 +67,7 @@ def _on_tool_error(exc: Exception, request: ToolCallRequest) -> str:
     notification before this runs, since that happens inside tool execution itself.
     """
     tool_name = request.tool_call["name"]
-    return f"The '{tool_name}' tool failed to run ({type(exc).__name__}). Let the user know something went wrong."
+    return f"The '{tool_name}' tool failed to run ({type(exc).__name__})."
 
 
 def get_agent_middleware(node, system_message: SystemMessage) -> list:

--- a/apps/pipelines/nodes/helpers.py
+++ b/apps/pipelines/nodes/helpers.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from string import Formatter
 
 from django.db import transaction
+from langchain.agents.middleware import ToolCallRequest, ToolErrorMiddleware
 from langchain_core.messages import SystemMessage
 
 from apps.channels.models import ChannelPlatform, ExperimentChannel
@@ -60,11 +61,20 @@ def get_system_message(prompt_template: str, prompt_context: PromptTemplateConte
         raise PipelineNodeRunError(str(e)) from e
 
 
+def _on_tool_error(exc: Exception, request: ToolCallRequest) -> str:
+    """Turn a tool exception into a soft-fail ToolMessage so it doesn't abort the turn.
+    The tracer's on_tool_error callback still fires and creates a trace-linked
+    notification before this runs, since that happens inside tool execution itself.
+    """
+    tool_name = request.tool_call["name"]
+    return f"The '{tool_name}' tool failed to run ({type(exc).__name__}). Let the user know something went wrong."
+
+
 def get_agent_middleware(node, system_message: SystemMessage) -> list:
     """Returns the common agent middleware for nodes that build LLM agents:
-    history compression and provider prompt caching.
+    history compression, provider prompt caching, and graceful tool-error handling.
     """
-    middleware = []
+    middleware = [ToolErrorMiddleware(on_error=_on_tool_error)]
     if history_middleware := node.build_history_middleware(system_message=system_message):
         middleware.append(history_middleware)
     if caching_middleware := node.get_llm_service().get_prompt_caching_middleware():

--- a/apps/pipelines/tests/test_node_helpers.py
+++ b/apps/pipelines/tests/test_node_helpers.py
@@ -1,8 +1,12 @@
+from unittest.mock import Mock
+
 import pytest
+from langchain.agents.middleware import ToolErrorMiddleware
+from langchain_core.messages import SystemMessage
 
 from apps.chat.models import ChatMessage, ChatMessageType
 from apps.experiments.models import ExperimentSession
-from apps.pipelines.nodes.helpers import temporary_session
+from apps.pipelines.nodes.helpers import get_agent_middleware, temporary_session
 from apps.utils.factories.team import TeamFactory, UserFactory
 
 
@@ -30,3 +34,27 @@ def test_temporary_session_rolls_back_on_error():
         _run_with_temp_session()
 
     assert ExperimentSession.objects.count() == 0
+
+
+class TestGetAgentMiddlewareToolErrorHandling:
+    """A tool exception should degrade to a soft-fail ToolMessage, not abort the turn."""
+
+    def _build_middleware(self):
+        node = Mock()
+        node.build_history_middleware.return_value = None
+        node.get_llm_service.return_value.get_prompt_caching_middleware.return_value = None
+        return get_agent_middleware(node, SystemMessage(content="prompt"))
+
+    def test_includes_tool_error_middleware(self):
+        middleware = self._build_middleware()
+        assert any(isinstance(m, ToolErrorMiddleware) for m in middleware)
+
+    def test_on_error_returns_content_instead_of_propagating(self):
+        (tool_error_middleware,) = [m for m in self._build_middleware() if isinstance(m, ToolErrorMiddleware)]
+        request = Mock(tool_call={"name": "test_tool"})
+
+        content = tool_error_middleware.on_error(ValueError("boom"), request)
+
+        assert content is not None
+        assert "boom" not in content
+        assert "ValueError" in content

--- a/apps/service_providers/tests/test_ocs_tracer.py
+++ b/apps/service_providers/tests/test_ocs_tracer.py
@@ -130,6 +130,22 @@ class TestOCSCallbackHandler:
         assert tracer.error_detected is True
         assert tracer.error_message == error_message
 
+    def test_on_tool_error_records_error(self):
+        """Tool error handler records the error on the tracer, same path as LLM/chain errors."""
+        experiment = Mock(id=456)
+        tracer = OCSTracer(experiment, team_id=123)
+        tracer.trace_id = str(uuid4())  # ty: ignore[invalid-assignment]
+        tracer.session = Mock()
+
+        callback_handler = OCSCallbackHandler(tracer=tracer)
+
+        error_message = "API rate limit exceeded"
+        callback_handler.on_tool_error(error=Exception(error_message))
+
+        assert tracer.error_detected is True
+        assert tracer.error_message == error_message
+        assert tracer.error_span_name == "Tool Error"
+
 
 @pytest.mark.django_db()
 class TestOCSTracerNotifications:


### PR DESCRIPTION
### Product Description
Tool-call error notifications link to their trace, like pipeline and span errors already do.

### Technical Description
`CustomBaseTool._run` caught its own exceptions and returned "Something went wrong" with no trace link. Removed that. The exception reaches `on_tool_error` on `OCSCallbackHandler`, the same path that already fires trace-linked notifications for LLM and chain errors.

A tool exception degrades gracefully. The turn continues with a soft-fail message instead of aborting, via a ToolErrorMiddleware on the agent. The trace-linked notification still fires, since that happens inside tool execution, before the middleware sees the exception.

### Issue Link
Closes #4420

### Demo
Verified against a real pipeline run: a tool failure produces a notification titled "Tool Error Failed for '\<bot\>'" with a working View Trace link, and the same generic error reply an LLM failure produces.

### Docs and Changelog
- [x] This PR requires docs/changelog update

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change

