### PR TITLE
feat: add scrub_participant_data management command

### DIFF
--- a/apps/experiments/management/commands/scrub_participant_data.py
+++ b/apps/experiments/management/commands/scrub_participant_data.py
@@ -1,0 +1,781 @@
+"""Permanently overwrite chosen participant-data values across one chatbot's records.
+
+Two primitives do all the work: a value-based text scan, which searches free text for the
+participant's own values, and a key-based JSON replacement, which rewrites a selected key's
+value at any depth regardless of its type. The key-based pass is what clears short and
+non-string values, which are too ambiguous to search for in prose.
+
+Reached: chat messages, chat names, session state, pipeline chat history, traces, evaluation
+messages, evaluator results, the throwaway sessions bot generation ran the participant's
+messages through, participant names and participant data.
+
+Out of reach: copies held by external trace providers, evaluation messages whose session has
+been deleted (``session`` is SET_NULL and there is no participant to fall back on), and
+anything already exported to a file or a downstream system. Participant identifiers are left
+alone deliberately: they are the participant's identity and unique key.
+
+Nothing is wrapped in a transaction, so each batch commits on its own. A participant's data
+row is written after every other surface of theirs, which makes an interrupted run safely
+re-runnable: the values still to be hunted for are read from that row.
+"""
+
+import logging
+import re
+from collections import Counter
+from dataclasses import dataclass
+from functools import cached_property
+from urllib.parse import urlparse
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import F, Prefetch, Q, QuerySet
+from django.db.models.functions import Coalesce
+from django.http import QueryDict
+
+from apps.chat.models import Chat, ChatMessage
+from apps.evaluations.models import EvaluationMessage, EvaluationResult
+from apps.experiments.filters import ExperimentSessionFilter
+from apps.experiments.models import Experiment, ExperimentSession, Participant, ParticipantData
+from apps.pipelines.models import PipelineChatMessages
+from apps.trace.models import Trace
+from apps.web.dynamic_filters.datastructures import FilterParams
+
+logger = logging.getLogger(__name__)
+
+MIN_SCANNABLE_VALUE_LENGTH = 4
+CHUNK_SIZE = 500
+CONFIRMATION_PHRASE = "SCRUB"
+
+# The annotation every surface carries to say which participant's plan applies to a row.
+OWNER = "scrub_owner"
+
+# Keys that carry the *structure* of the JSON surfaces below, rather than participant data.
+# Key-based replacement matches at any depth, so selecting a participant-data key that happens
+# to share one of these names also blanks the conversation content stored under it.
+STRUCTURAL_JSON_KEYS = frozenset(
+    {
+        "content",
+        "role",
+        "message_type",
+        "summary",
+        "trace_id",
+        "trace_url",
+        "session_id",
+        "experiment_id",
+        "created_mode",
+        # EvaluationResult.output wraps a whole copy of the message, so its field names are
+        # structural keys there too.
+        "message",
+        "generated_response",
+        "result",
+        "input",
+        "output",
+        "context",
+        "history",
+        "metadata",
+        "participant_data",
+        "session_state",
+    }
+)
+
+
+def value_is_scannable(value: object) -> bool:
+    """Whether a value is distinctive enough to search for in free text.
+
+    Short values ("7", "Bob") match far too much unrelated text to be worth scanning for;
+    the key-based pass is what removes those.
+    """
+    return isinstance(value, str) and len(value.strip()) >= MIN_SCANNABLE_VALUE_LENGTH
+
+
+@dataclass
+class ScrubPlan:
+    """What to replace, for one participant.
+
+    ``replacements`` maps a participant-data key to the string that replaces it. ``originals``
+    holds that participant's current values, which is what the text scan searches for. A key
+    with no original still has its value replaced wherever the key appears in JSON.
+    """
+
+    replacements: dict[str, str]
+    originals: dict[str, object]
+
+    @cached_property
+    def text_rule(self) -> tuple[re.Pattern, list[str]] | None:
+        """One alternation over every search term, plus the replacement for each alternative.
+
+        One pattern rather than one per value, so one key's replacement cannot then be
+        re-matched by another key's rule. Values are stripped, so a stored ``" John "`` still
+        matches ``John`` in prose. Longest term first, so a value that is a prefix of another
+        cannot consume the longer match ("John" against "John Smith").
+        """
+        pairs = sorted(
+            (
+                (str(value).strip(), self.replacements[key])
+                for key, value in self.originals.items()
+                if key in self.replacements and value_is_scannable(value)
+            ),
+            key=lambda pair: len(pair[0]),
+            reverse=True,
+        )
+        if not pairs:
+            return None
+        alternatives = "|".join(f"({re.escape(original)})" for original, _ in pairs)
+        pattern = re.compile(rf"(?<!\w)(?:{alternatives})(?!\w)", re.IGNORECASE)
+        return pattern, [replacement for _, replacement in pairs]
+
+
+@dataclass
+class Scope:
+    """The rows one chunk of participants can reach."""
+
+    sessions: QuerySet
+    participant_ids: list[int]
+    experiment_ids: list[int]
+
+
+def scrub_text(text: str, plan: ScrubPlan) -> str:
+    """Replace every occurrence of the participant's values in ``text``."""
+    if plan.text_rule is None:
+        return text
+    pattern, replacements = plan.text_rule
+    # A function replacement, so backslashes in the replacement string stay literal instead of
+    # being read as group references. Only one alternative can match, so its group number
+    # indexes the replacement list.
+    return pattern.sub(lambda match: replacements[match.lastindex - 1], text)
+
+
+def scrub_json(value, plan: ScrubPlan):
+    """Replace selected keys' values, and text-scan every string leaf, at any depth."""
+    if isinstance(value, dict):
+        return {
+            key: plan.replacements[key] if key in plan.replacements else scrub_json(item, plan)
+            for key, item in value.items()
+        }
+    if isinstance(value, list | tuple):
+        return [scrub_json(item, plan) for item in value]
+    if isinstance(value, str):
+        return scrub_text(value, plan)
+    return value
+
+
+def _scrub_fields(row, plan: ScrubPlan, text_fields: tuple[str, ...], json_fields: tuple[str, ...]) -> bool:
+    """Rewrite the named fields in place; return whether anything actually changed."""
+    changed = False
+    for name in text_fields:
+        current = getattr(row, name) or ""
+        scrubbed = scrub_text(current, plan)
+        if scrubbed != current:
+            setattr(row, name, scrubbed)
+            changed = True
+    for name in json_fields:
+        current = getattr(row, name)
+        scrubbed = scrub_json(current, plan)
+        if scrubbed != current:
+            setattr(row, name, scrubbed)
+            changed = True
+    return changed
+
+
+def _apply(
+    queryset,
+    plans: dict[int, ScrubPlan],
+    *,
+    dry_run: bool,
+    text_fields: tuple[str, ...] = (),
+    json_fields: tuple[str, ...] = (),
+) -> int:
+    """Stream ``queryset``, scrub each row with its owner's plan, and write back what changed.
+
+    ``plans`` is keyed by whatever the ``OWNER`` annotation yields, so one query serves a whole
+    chunk of participants rather than one query per participant. A row whose owner is not in
+    ``plans`` is left alone: scrubbing it would mean using someone else's search terms.
+    """
+    model = queryset.model
+    fields = [*text_fields, *json_fields]
+    changed = 0
+    batch = []
+    # only(): a message history is unbounded, and no other column is read or written here.
+    for row in queryset.only(*fields).iterator(chunk_size=CHUNK_SIZE):
+        plan = plans.get(getattr(row, OWNER))
+        if plan is None:
+            continue
+        if _scrub_fields(row=row, plan=plan, text_fields=text_fields, json_fields=json_fields):
+            batch.append(row)
+        if len(batch) >= CHUNK_SIZE:
+            if not dry_run:
+                model.objects.bulk_update(batch, fields)
+            changed += len(batch)
+            batch = []
+    if batch:
+        if not dry_run:
+            model.objects.bulk_update(batch, fields)
+        changed += len(batch)
+    return changed
+
+
+def _owned_by(queryset, owner):
+    """Annotate which participant owns each row, and order for a stable stream."""
+    return queryset.annotate(**{OWNER: owner}).order_by("id")
+
+
+def _scrub_messages(scope: Scope, plans: dict[int, ScrubPlan], dry_run: bool) -> int:
+    """Rewrite the text and translations of every message in the eligible sessions."""
+    queryset = _owned_by(
+        ChatMessage.objects.filter(chat__experiment_session__in=scope.sessions),
+        F("chat__experiment_session__participant_id"),
+    )
+    return _apply(
+        queryset=queryset,
+        plans=plans,
+        dry_run=dry_run,
+        text_fields=("content", "summary"),
+        json_fields=("translations",),
+    )
+
+
+def _scrub_chat_names(scope: Scope, plans: dict[int, ScrubPlan], dry_run: bool) -> int:
+    """Text-scan ``Chat.name``, which is "<identifier> - <channel>".
+
+    Only the text scan can reach it, and identifiers are deliberately preserved, so the name
+    changes only when the identifier is also stored as one of the participant's data values.
+    """
+    if all(plan.text_rule is None for plan in plans.values()):
+        return 0
+    queryset = _owned_by(
+        Chat.objects.filter(experiment_session__in=scope.sessions), F("experiment_session__participant_id")
+    )
+    return _apply(queryset=queryset, plans=plans, dry_run=dry_run, text_fields=("name",))
+
+
+def _scrub_session_state(scope: Scope, plans: dict[int, ScrubPlan], dry_run: bool) -> int:
+    """Rewrite the stored state of every eligible session."""
+    return _apply(
+        queryset=_owned_by(scope.sessions, F("participant_id")), plans=plans, dry_run=dry_run, json_fields=("state",)
+    )
+
+
+def _scrub_pipeline_history(scope: Scope, plans: dict[int, ScrubPlan], dry_run: bool) -> int:
+    """Rewrite the pipeline's own copy of the conversation.
+
+    An LLM node whose history mode is not "global" writes each turn to ``PipelineChatMessages``
+    as well as to ``ChatMessage``, so the transcript exists twice.
+    """
+    queryset = _owned_by(
+        PipelineChatMessages.objects.filter(chat_history__session__in=scope.sessions),
+        F("chat_history__session__participant_id"),
+    )
+    return _apply(
+        queryset=queryset, plans=plans, dry_run=dry_run, text_fields=("human_message", "ai_message", "summary")
+    )
+
+
+def _scrub_traces(scope: Scope, plans: dict[int, ScrubPlan], dry_run: bool) -> int:
+    """Traces on the eligible sessions, plus these participants' traces whose session FK was nulled."""
+    queryset = _owned_by(
+        Trace.objects.filter(
+            Q(session__in=scope.sessions)
+            | Q(
+                session__isnull=True,
+                participant_id__in=scope.participant_ids,
+                experiment_id__in=scope.experiment_ids,
+            )
+        ),
+        # An orphaned trace has only its own participant FK left to identify it by.
+        Coalesce(F("session__participant_id"), F("participant_id")),
+    )
+    return _apply(
+        queryset=queryset,
+        plans=plans,
+        dry_run=dry_run,
+        text_fields=("error",),
+        json_fields=("participant_data", "participant_data_diff", "session_state", "trace_metadata"),
+    )
+
+
+def _scrub_eval_messages(scope: Scope, plans: dict[int, ScrubPlan], dry_run: bool) -> int:
+    """Rewrite the evaluation messages captured from the eligible sessions."""
+    queryset = _owned_by(EvaluationMessage.objects.filter(session__in=scope.sessions), F("session__participant_id"))
+    return _apply(
+        queryset=queryset,
+        plans=plans,
+        dry_run=dry_run,
+        json_fields=("input", "output", "context", "history", "participant_data", "session_state", "metadata"),
+    )
+
+
+def _scrub_eval_results(scope: Scope, plans: dict[int, ScrubPlan], dry_run: bool) -> int:
+    """Rewrite the copy of the message that every evaluator result embeds.
+
+    ``EvaluationResult.output`` holds ``EvaluationMessage.as_result_dict()`` under "message",
+    so each evaluator run against a message keeps a second copy of the participant's data and
+    conversation, alongside whatever a judge quoted back. Reached through the message, because
+    ``EvaluationResult.session`` is the throwaway session the bot generation ran in.
+    """
+    queryset = _owned_by(
+        EvaluationResult.objects.filter(message__session__in=scope.sessions), F("message__session__participant_id")
+    )
+    return _apply(queryset=queryset, plans=plans, dry_run=dry_run, json_fields=("output",))
+
+
+def _generated_session_plans(scope: Scope, plans: dict[int, ScrubPlan]) -> dict[int, ScrubPlan]:
+    """Map each throwaway generation session to the plan of the participant it copied.
+
+    Bot generation copies the participant's session state and history into a session owned by
+    the synthetic "evaluations" participant, on a version row rather than the working version,
+    so neither the participant nor the experiment filter reaches it. The evaluator result the
+    generation fed is the only link back.
+    """
+    rows = EvaluationResult.objects.filter(message__session__in=scope.sessions, session__isnull=False).values_list(
+        "session_id", "message__session__participant_id"
+    )
+    return {session_id: plans[owner] for session_id, owner in rows if owner in plans}
+
+
+def _scrub_generated_sessions(scope: Scope, plans: dict[int, ScrubPlan], dry_run: bool) -> int:
+    """Scrub the throwaway sessions bot generation ran the eligible messages through.
+
+    Keyed by session rather than by participant: these sessions all belong to the same
+    synthetic participant, so only the session id says whose data they hold.
+    """
+    plans_by_session = _generated_session_plans(scope=scope, plans=plans)
+    if not plans_by_session:
+        return 0
+    session_ids = list(plans_by_session)
+    passes = (
+        (ExperimentSession.objects.filter(id__in=session_ids), F("id"), (), ("state",)),
+        (
+            ChatMessage.objects.filter(chat__experiment_session__id__in=session_ids),
+            F("chat__experiment_session__id"),
+            ("content", "summary"),
+            ("translations",),
+        ),
+        (
+            PipelineChatMessages.objects.filter(chat_history__session_id__in=session_ids),
+            F("chat_history__session_id"),
+            ("human_message", "ai_message", "summary"),
+            (),
+        ),
+        (
+            Trace.objects.filter(session_id__in=session_ids),
+            F("session_id"),
+            ("error",),
+            ("participant_data", "participant_data_diff", "session_state", "trace_metadata"),
+        ),
+    )
+    changed = 0
+    for queryset, owner, text_fields, json_fields in passes:
+        changed += _apply(
+            queryset=_owned_by(queryset, owner),
+            plans=plans_by_session,
+            dry_run=dry_run,
+            text_fields=text_fields,
+            json_fields=json_fields,
+        )
+    return changed
+
+
+# Every table one run rewrites, in the order they are scrubbed and reported.
+SURFACE_SCRUBBERS = (
+    ("messages", _scrub_messages),
+    ("chat_names", _scrub_chat_names),
+    ("session_state", _scrub_session_state),
+    ("pipeline_history", _scrub_pipeline_history),
+    ("traces", _scrub_traces),
+    ("evaluation_messages", _scrub_eval_messages),
+    ("evaluation_results", _scrub_eval_results),
+    ("evaluation_sessions", _scrub_generated_sessions),
+)
+
+SURFACES = (*(label for label, _ in SURFACE_SCRUBBERS), "participant_names", "participant_data")
+
+
+def _scrub_participant_names(participants: list[Participant], plans: dict[int, ScrubPlan], dry_run: bool) -> int:
+    """Rewrite ``Participant.name``, which holds a copy of this participant's "name" value.
+
+    Replaced wholesale only when the participant actually holds a selected "name":
+    ``replacements`` is the operator's one global selection while ``originals`` is per
+    participant, and ``Participant.name`` is team-scoped.
+    """
+    changed = []
+    for participant in participants:
+        plan = plans[participant.id]
+        original = participant.name
+        if not original:
+            continue
+        if "name" in plan.replacements and "name" in plan.originals:
+            scrubbed = plan.replacements["name"]
+        else:
+            scrubbed = scrub_text(original, plan)
+        if scrubbed != original:
+            participant.name = scrubbed
+            changed.append(participant)
+    if changed and not dry_run:
+        Participant.objects.bulk_update(changed, ["name"])
+    return len(changed)
+
+
+def _scrub_participant_data(data_rows: dict[int, ParticipantData], plans: dict[int, ScrubPlan], dry_run: bool) -> int:
+    """Rewrite the participant-data rows themselves, the last surface to be touched."""
+    changed = []
+    for participant_id, data_row in data_rows.items():
+        scrubbed = scrub_json(data_row.data, plans[participant_id])
+        if scrubbed != data_row.data:
+            data_row.data = scrubbed
+            changed.append(data_row)
+    if changed and not dry_run:
+        ParticipantData.objects.bulk_update(changed, ["data"])
+    return len(changed)
+
+
+def _version_family_ids(working: Experiment) -> list[int]:
+    """Every id in the chatbot's version family, archived versions included.
+
+    ``Experiment.version_family_ids`` walks the default related manager, which drops archived
+    versions — and an archived version's orphaned traces still hold participant data.
+    """
+    versions = Experiment.objects.get_all().filter(working_version_id=working.id).values_list("id", flat=True)
+    return [working.id, *versions]
+
+
+def _participant_chunks(working: Experiment, participant_ids: list[int]):
+    """Yield the participants CHUNK_SIZE at a time, each with its participant-data row.
+
+    ``ParticipantData.data`` is decrypted on read, so the rows are fetched a chunk at a time
+    rather than all at once.
+    """
+    for start in range(0, len(participant_ids), CHUNK_SIZE):
+        yield list(
+            Participant.objects.filter(id__in=participant_ids[start : start + CHUNK_SIZE])
+            .order_by("id")
+            .prefetch_related(
+                Prefetch(
+                    "data_set",
+                    queryset=ParticipantData.objects.for_experiment(working).order_by("id"),
+                    to_attr="scrub_data",
+                )
+            )
+        )
+
+
+def resolve_selection(answer: str, keys: list[str]) -> list[str]:
+    """Turn a typed answer ("all", or numbers) into the list of keys it names."""
+    answer = answer.strip()
+    if answer.lower() == "all":
+        return keys
+    selected = []
+    for token in (part.strip() for part in answer.split(",")):
+        if not token:
+            continue
+        if not token.isdigit() or not 1 <= int(token) <= len(keys):
+            raise CommandError(f"{token!r} is not one of the listed numbers; nothing was written.")
+        key = keys[int(token) - 1]
+        if key not in selected:
+            selected.append(key)
+    if not selected:
+        raise CommandError("No keys selected; nothing was written.")
+    return selected
+
+
+def parse_filter_query_string(raw: str) -> FilterParams:
+    """Parse a filter query string, tolerating a whole URL or a leading "?"."""
+    raw = (raw or "").strip()
+    if not raw:
+        return FilterParams()
+    if "://" in raw:
+        raw = urlparse(raw).query
+    return FilterParams(QueryDict(raw.lstrip("?")))
+
+
+class Command(BaseCommand):
+    """Interactively scrub a chosen set of participant-data values from one chatbot."""
+
+    help = (
+        "Permanently overwrite participant-data values across a chatbot's messages, chat names, "
+        "session state, pipeline chat history, traces, evaluation messages, evaluator results, "
+        "participant names and participant data. Keys and their replacements are chosen at the "
+        "prompt. Cannot be undone."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("experiment_id", type=int, help="The chatbot's numeric ID, as it appears in its URL")
+        parser.add_argument(
+            "--filter",
+            default="",
+            help=(
+                "Session filter query string copied from the Sessions tab URL (a whole URL is "
+                "also accepted). It selects participants: every session those participants had "
+                "with this chatbot is scrubbed. Empty means every participant of the chatbot."
+            ),
+        )
+        parser.add_argument("--dry-run", action="store_true", help="Report what would change without writing")
+
+    def handle(self, *args, **options):
+        """Resolve the targets, ask what to replace, confirm, then scrub."""
+        dry_run = options["dry_run"]
+        experiment = self._get_experiment(options["experiment_id"])
+        working = experiment.get_working_version()
+        filter_params = self._parse_filter(options["filter"])
+
+        matched_count, participant_ids = self._resolve_matched(working, filter_params)
+        if not participant_ids:
+            self.stdout.write(self.style.WARNING("The filter matched no sessions. Nothing to do."))
+            return
+
+        experiment_ids = _version_family_ids(working)
+        sessions = ExperimentSession.objects.filter(
+            experiment_id__in=experiment_ids, participant_id__in=participant_ids
+        )
+        key_counts, unscannable_counts = self._discover_keys(working, participant_ids)
+
+        self.stdout.write(f'Chatbot: "{working.name}" (id={working.id}, team={working.team.slug})')
+        self.stdout.write(f"Sessions matched by the filter: {matched_count}")
+        self.stdout.write(f"Participants: {len(participant_ids)}")
+        self.stdout.write(f"Sessions to scrub (every session these participants had here): {sessions.count()}")
+
+        if not key_counts:
+            self.stdout.write(self.style.WARNING("These participants hold no participant data. Nothing to scrub."))
+            return
+
+        selected_keys = self._prompt_for_keys(key_counts, unscannable_counts)
+        replacements = self._prompt_for_replacements(selected_keys)
+
+        self._report_plan(replacements, key_counts, unscannable_counts, dry_run=dry_run)
+
+        if not dry_run:
+            self._confirm()
+
+        logger.info(
+            "scrub_participant_data starting: experiment=%s team=%s participants=%s filter=%r keys=%s dry_run=%s",
+            working.id,
+            working.team.slug,
+            len(participant_ids),
+            options["filter"],
+            sorted(replacements),
+            dry_run,
+        )
+        totals = self._scrub(
+            working=working,
+            participant_ids=participant_ids,
+            experiment_ids=experiment_ids,
+            replacements=replacements,
+            dry_run=dry_run,
+        )
+        logger.info(
+            "scrub_participant_data finished: experiment=%s dry_run=%s totals=%s",
+            working.id,
+            dry_run,
+            dict(totals),
+        )
+        self._report_totals(totals, dry_run=dry_run)
+
+    def _get_experiment(self, experiment_id: int) -> Experiment:
+        """Load the chatbot by id, including an archived one."""
+        experiment = Experiment.objects.get_all().filter(id=experiment_id).first()
+        if experiment is None:
+            raise CommandError(f"No chatbot with id={experiment_id}")
+        return experiment
+
+    def _parse_filter(self, raw: str) -> FilterParams:
+        """Parse --filter, refusing anything the session filter would not actually apply."""
+        filter_params = parse_filter_query_string(raw)
+        if raw.strip() and not filter_params.filters:
+            raise CommandError(
+                f"The filter {raw!r} produced no usable filters. Pass an empty --filter to mean "
+                "every session, rather than risking a scrub that is wider than you intended."
+            )
+        self._validate_filter(filter_params)
+        return filter_params
+
+    def _validate_filter(self, filter_params: FilterParams) -> None:
+        """Refuse a column or operator that ExperimentSessionFilter would silently ignore.
+
+        ``MultiColumnFilter.apply`` walks only its own declared columns, and each column only
+        its own ``apply_<operator>`` methods, so an unknown column or operator narrows nothing
+        while still looking like a filter. Here that means scrubbing the whole chatbot.
+        """
+        known = {column.query_param: column for column in ExperimentSessionFilter.filters}
+        for filter_data in filter_params.filters:
+            column = known.get(filter_data.column)
+            if column is None:
+                raise CommandError(
+                    f'"{filter_data.column}" is not a session filter column, so it would narrow '
+                    f"nothing. Available columns: {', '.join(sorted(known))}."
+                )
+            if filter_data.operator not in column.operators:
+                raise CommandError(
+                    f'The "{filter_data.column}" filter does not support the operator '
+                    f'"{filter_data.operator}", so it would narrow nothing. Supported: '
+                    f"{', '.join(column.operators)}."
+                )
+
+    def _resolve_matched(self, working: Experiment, filter_params: FilterParams) -> tuple[int, list[int]]:
+        """Apply the filter and return how many sessions matched, and their participant ids."""
+        base = ExperimentSession.objects.get_table_queryset(working.team, working.id)
+        queryset = ExperimentSessionFilter().apply(base, filter_params=filter_params) if filter_params.filters else base
+        matched_count = queryset.order_by().count()
+        if filter_params.filters and matched_count and matched_count == base.order_by().count():
+            # A filter can narrow nothing without erroring — TimestampFilter swallows an
+            # unparseable date, for one — and matching everything is the only signal.
+            raise CommandError(
+                "The filter matched every session of this chatbot, so it narrowed nothing. "
+                "If you really do mean every participant, pass an empty --filter."
+            )
+        participant_ids = queryset.order_by().values_list("participant_id", flat=True).distinct()
+        return matched_count, sorted(participant_ids)
+
+    def _discover_keys(self, working, participant_ids) -> tuple[Counter, Counter]:
+        """Top-level participant-data keys, with counts only — never a value.
+
+        Decrypting in-process is the only option: `ParticipantData.data` is encrypted at
+        rest, so no SQL can reach inside it.
+        """
+        key_counts: Counter = Counter()
+        unscannable_counts: Counter = Counter()
+        rows = ParticipantData.objects.for_experiment(working).filter(participant_id__in=participant_ids)
+        for row in rows.iterator(chunk_size=CHUNK_SIZE):
+            for key, value in (row.data or {}).items():
+                key_counts[key] += 1
+                if not value_is_scannable(value):
+                    unscannable_counts[key] += 1
+        return key_counts, unscannable_counts
+
+    def _prompt_for_keys(self, key_counts: Counter, unscannable_counts: Counter) -> list[str]:
+        """Offer the discovered keys and read back a selection."""
+        keys = sorted(key_counts)
+        self.stdout.write("\nParticipant-data keys (participant counts only, never values):")
+        for number, key in enumerate(keys, start=1):
+            note = ""
+            if unscannable_counts[key]:
+                note = f" — {unscannable_counts[key]} too short/non-text to scan for in prose"
+            self.stdout.write(f"  {number}. {key}: {key_counts[key]} participant(s){note}")
+        answer = self._ask('\nKeys to scrub (comma-separated numbers, or "all"): ')
+        return resolve_selection(answer=answer, keys=keys)
+
+    def _prompt_for_replacements(self, keys: list[str]) -> dict[str, str]:
+        """Ask for the replacement string for each selected key."""
+        self.stdout.write("\nEnter a replacement for each key. An empty answer clears the value.")
+        return {key: self._ask(f'  Replacement for "{key}": ') for key in keys}
+
+    def _report_plan(
+        self, replacements: dict[str, str], key_counts: Counter, unscannable_counts: Counter, *, dry_run: bool
+    ) -> None:
+        """Print the replacements and, for a real run, what is about to be destroyed."""
+        self.stdout.write("\nReplacements:")
+        for key in sorted(replacements):
+            shown = replacements[key] if replacements[key] else "(cleared)"
+            self.stdout.write(f"  {key} -> {shown}{self._scan_note(key, key_counts, unscannable_counts)}")
+        self.stdout.write(
+            "\nA selected key is cleared wherever it appears in the JSON being rewritten, including "
+            "for in-scope participants who never held it. The counts above are only how many "
+            "participants hold the key today."
+        )
+        self._warn_about_structural_keys(replacements)
+        if dry_run:
+            self.stdout.write(self.style.WARNING("\nDRY RUN — nothing will be written."))
+            return
+        self.stdout.write(
+            self.style.ERROR(
+                "\nThis permanently overwrites messages, chat names, session state, pipeline chat "
+                "history, traces, evaluation messages, evaluator results, evaluation sessions, "
+                "participant names and participant data. It cannot be undone and there is no backup."
+            )
+        )
+        self.stdout.write(
+            self.style.WARNING(
+                "Out of reach from here: copies held by external trace providers (Langfuse and "
+                "friends); evaluation messages whose session has been deleted, which have no "
+                "participant left to find them by; and anything already exported to a file or a "
+                "downstream system.\n"
+                "Participant names are team-scoped, so clearing a name is visible in this team's "
+                "other chatbots as well. Participant identifiers are left alone: they are the "
+                "participant's identity and unique key, so they survive the scrub."
+            )
+        )
+
+    def _scan_note(self, key: str, key_counts: Counter, unscannable_counts: Counter) -> str:
+        """How much of this key's population the text scan will actually hunt for."""
+        unscannable = unscannable_counts[key]
+        if not unscannable:
+            return ""
+        held = key_counts[key]
+        if unscannable == held:
+            return " — cleared by key only, not text-scanned"
+        return f" — text-scanned for {held - unscannable} of {held} participants, key-only for the rest"
+
+    def _warn_about_structural_keys(self, replacements: dict[str, str]) -> None:
+        """Say so when a selected key also names a field of the JSON being rewritten."""
+        collisions = sorted(set(replacements) & STRUCTURAL_JSON_KEYS)
+        if collisions:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"\n{', '.join(collisions)} is also used as a structural key inside stored "
+                    "message translations, evaluation records and trace metadata. Those fields "
+                    "will be overwritten too, not just the participant's own value."
+                )
+            )
+
+    def _confirm(self) -> None:
+        """Require the confirmation phrase to be typed, or abort before writing anything."""
+        answer = self._ask(f'Type "{CONFIRMATION_PHRASE}" to continue, anything else to abort: ')
+        if answer.strip() != CONFIRMATION_PHRASE:
+            raise CommandError("Aborted; nothing was written.")
+
+    def _ask(self, prompt: str) -> str:
+        """Read one answer, failing cleanly when there is no one at the keyboard."""
+        try:
+            return input(prompt)
+        except EOFError:
+            raise CommandError("This command has to be answered interactively; nothing was written.") from None
+
+    def _scrub(self, working, participant_ids, experiment_ids, replacements, *, dry_run: bool) -> Counter:
+        """Scrub a chunk of participants at a time, and report the rows changed per surface.
+
+        Each participant needs its own plan: the values to search for in free text are read
+        from that participant's own data. Rows are fetched for a whole chunk and matched back
+        to their owner, so the query count follows the number of chunks rather than the number
+        of participants. Participant data is written last, because it is where those values
+        were read from, so an interrupted run can still find them.
+        """
+        totals: Counter = Counter()
+        done = 0
+        for chunk in _participant_chunks(working=working, participant_ids=participant_ids):
+            plans = {}
+            data_rows = {}
+            for participant in chunk:
+                data_row = participant.scrub_data[0] if participant.scrub_data else None
+                if data_row is not None:
+                    data_rows[participant.id] = data_row
+                plans[participant.id] = ScrubPlan(
+                    replacements=replacements, originals=(data_row.data or {}) if data_row else {}
+                )
+            scope = Scope(
+                sessions=ExperimentSession.objects.filter(
+                    experiment_id__in=experiment_ids, participant_id__in=list(plans)
+                ),
+                participant_ids=list(plans),
+                experiment_ids=experiment_ids,
+            )
+            for label, scrub in SURFACE_SCRUBBERS:
+                totals[label] += scrub(scope, plans, dry_run)
+            totals["participant_names"] += _scrub_participant_names(participants=chunk, plans=plans, dry_run=dry_run)
+            totals["participant_data"] += _scrub_participant_data(data_rows=data_rows, plans=plans, dry_run=dry_run)
+            done += len(chunk)
+            logger.info(
+                "scrub_participant_data progress: experiment=%s participants=%s/%s totals=%s",
+                working.id,
+                done,
+                len(participant_ids),
+                dict(totals),
+            )
+        return totals
+
+    def _report_totals(self, totals: Counter, *, dry_run: bool) -> None:
+        """Print the per-surface row counts."""
+        verb = "Would change" if dry_run else "Changed"
+        self.stdout.write(f"\n{verb}:")
+        for label in SURFACES:
+            self.stdout.write(f"  {label}: {totals[label]}")
+        if dry_run:
+            self.stdout.write(self.style.WARNING("\nDry run complete; nothing was written."))
+        else:
+            self.stdout.write(self.style.SUCCESS("\nScrub complete."))

--- a/apps/experiments/management/commands/scrub_participant_data.py
+++ b/apps/experiments/management/commands/scrub_participant_data.py
@@ -27,6 +27,7 @@ from functools import cached_property
 from itertools import batched
 from urllib.parse import urlparse
 
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models import F, Prefetch, Q, QuerySet
 from django.db.models.functions import Coalesce
@@ -480,14 +481,80 @@ def resolve_selection(answer: str, keys: list[str]) -> list[str]:
     return selected
 
 
+def _query_string_from(raw: str) -> str:
+    """The query part of what was pasted: a bare query string, or a URL with or without a scheme.
+
+    A URL copied without its scheme still carries a path, and reading that path as a query
+    string turns the first filter in it into an unrecognised key.
+    """
+    if "://" in raw:
+        return urlparse(raw).query
+    head, separator, query = raw.partition("?")
+    return query if separator else head
+
+
+def _plural(number: int, noun: str) -> str:
+    return f"{number} {noun}" if number == 1 else f"{number} {noun}s"
+
+
+def _refuse_unreadable_filters(query_params: QueryDict) -> int:
+    """Refuse a query string whose filters cannot be read back as pasted; count the pairs.
+
+    ``FilterParams`` drops a filter whose value or operator is missing rather than raising,
+    and a dropped filter widens the scrub instead of narrowing it.
+    """
+    columns = {key[2:] for key in query_params if key.startswith("f_") and key != "f_"}
+    for key in query_params:
+        if key.startswith("op_") and key[3:] not in columns:
+            raise CommandError(
+                f'"{key}" names an operator with no value to apply it to, so that filter would be '
+                "dropped and the scrub would be wider than the one you copied."
+            )
+    pairs = 0
+    for column in sorted(columns):
+        values = len(query_params.getlist(f"f_{column}"))
+        operators = len(query_params.getlist(f"op_{column}"))
+        if not operators:
+            raise CommandError(
+                f'The "{column}" filter has a value with no operator, so it would be dropped and '
+                "the scrub would be wider than the one you copied."
+            )
+        if values != operators:
+            raise CommandError(
+                f'The "{column}" filter has {_plural(values, "value")} but '
+                f"{_plural(operators, 'operator')}, so part of it would be dropped and the scrub "
+                "would be wider than the one you copied."
+            )
+        pairs += values
+    return pairs
+
+
 def parse_filter_query_string(raw: str) -> FilterParams:
-    """Parse a filter query string, tolerating a whole URL or a leading "?"."""
+    """Parse a filter query string, tolerating a whole URL, a scheme-less URL or a leading "?".
+
+    Every filter in the string has to survive the parse. Anything that would silently drop one
+    is refused instead: the operator confirms a scope based on what the sessions table showed
+    them, and a filter lost in transit widens that scope irreversibly.
+    """
     raw = (raw or "").strip()
     if not raw:
         return FilterParams()
-    if "://" in raw:
-        raw = urlparse(raw).query
-    return FilterParams(QueryDict(raw.lstrip("?")))
+    if "&amp;" in raw:
+        raise CommandError(
+            'The filter contains "&amp;", so it came from a rendered link rather than the address '
+            "bar and its separators are escaped. Every filter after the first would be dropped. "
+            "Copy the URL from the browser's address bar instead."
+        )
+    query_params = QueryDict(_query_string_from(raw))
+    pairs = _refuse_unreadable_filters(query_params)
+    filter_params = FilterParams(query_params)
+    if len(filter_params.filters) != pairs:
+        raise CommandError(
+            f"Only {len(filter_params.filters)} of the {pairs} filters in this string could be "
+            f"read (at most {settings.MAX_FILTER_PARAMS} apply, and a filter needs a non-empty "
+            "value). Narrow the selection in the UI and copy the URL again."
+        )
+    return filter_params
 
 
 class Command(BaseCommand):
@@ -587,7 +654,9 @@ class Command(BaseCommand):
     def _parse_filter(self, raw: str) -> FilterParams:
         """Parse --filter, refusing anything the session filter would not actually apply."""
         filter_params = parse_filter_query_string(raw)
-        if raw.strip() and not filter_params.filters:
+        # `raw` rather than `raw.strip()`: only a genuinely empty --filter means every
+        # participant, so a value that arrived as whitespace is a mangled paste, not a choice.
+        if raw and not filter_params.filters:
             raise CommandError(
                 f"The filter {raw!r} produced no usable filters. Pass an empty --filter to mean "
                 "every session, rather than risking a scrub that is wider than you intended."

--- a/apps/experiments/management/commands/scrub_participant_data.py
+++ b/apps/experiments/management/commands/scrub_participant_data.py
@@ -24,6 +24,7 @@ import re
 from collections import Counter
 from dataclasses import dataclass
 from functools import cached_property
+from itertools import batched
 from urllib.parse import urlparse
 
 from django.core.management.base import BaseCommand, CommandError
@@ -177,6 +178,21 @@ def _scrub_fields(row, plan: ScrubPlan, text_fields: tuple[str, ...], json_field
     return changed
 
 
+def _scrubbed_rows(
+    queryset, plans: dict[int, ScrubPlan], *, text_fields: tuple[str, ...], json_fields: tuple[str, ...]
+):
+    """Stream the rows the scrub actually altered, each already rewritten in memory.
+
+    A row whose owner is not in ``plans`` is left alone: scrubbing it would mean using someone
+    else's search terms.
+    """
+    # only(): a message history is unbounded, and no other column is read or written here.
+    for row in queryset.only(*text_fields, *json_fields).iterator(chunk_size=CHUNK_SIZE):
+        plan = plans.get(getattr(row, OWNER))
+        if plan is not None and _scrub_fields(row=row, plan=plan, text_fields=text_fields, json_fields=json_fields):
+            yield row
+
+
 def _apply(
     queryset,
     plans: dict[int, ScrubPlan],
@@ -185,31 +201,18 @@ def _apply(
     text_fields: tuple[str, ...] = (),
     json_fields: tuple[str, ...] = (),
 ) -> int:
-    """Stream ``queryset``, scrub each row with its owner's plan, and write back what changed.
+    """Scrub every eligible row of ``queryset``, writing back what changed one batch at a time.
 
     ``plans`` is keyed by whatever the ``OWNER`` annotation yields, so one query serves a whole
-    chunk of participants rather than one query per participant. A row whose owner is not in
-    ``plans`` is left alone: scrubbing it would mean using someone else's search terms.
+    chunk of participants rather than one query per participant.
     """
-    model = queryset.model
     fields = [*text_fields, *json_fields]
+    rows = _scrubbed_rows(queryset=queryset, plans=plans, text_fields=text_fields, json_fields=json_fields)
     changed = 0
-    batch = []
-    # only(): a message history is unbounded, and no other column is read or written here.
-    for row in queryset.only(*fields).iterator(chunk_size=CHUNK_SIZE):
-        plan = plans.get(getattr(row, OWNER))
-        if plan is None:
-            continue
-        if _scrub_fields(row=row, plan=plan, text_fields=text_fields, json_fields=json_fields):
-            batch.append(row)
-        if len(batch) >= CHUNK_SIZE:
-            if not dry_run:
-                model.objects.bulk_update(batch, fields)
-            changed += len(batch)
-            batch = []
-    if batch:
+    # strict=False: the last batch is short whenever the row count is not a whole multiple.
+    for batch in batched(rows, CHUNK_SIZE, strict=False):
         if not dry_run:
-            model.objects.bulk_update(batch, fields)
+            queryset.model.objects.bulk_update(batch, fields)
         changed += len(batch)
     return changed
 
@@ -457,20 +460,21 @@ def _participant_chunks(working: Experiment, participant_ids: list[int]):
         )
 
 
+def _key_for_token(token: str, keys: list[str]) -> str:
+    """Look up the key that one typed number names."""
+    if not token.isdigit() or not 1 <= int(token) <= len(keys):
+        raise CommandError(f"{token!r} is not one of the listed numbers; nothing was written.")
+    return keys[int(token) - 1]
+
+
 def resolve_selection(answer: str, keys: list[str]) -> list[str]:
     """Turn a typed answer ("all", or numbers) into the list of keys it names."""
     answer = answer.strip()
     if answer.lower() == "all":
         return keys
-    selected = []
-    for token in (part.strip() for part in answer.split(",")):
-        if not token:
-            continue
-        if not token.isdigit() or not 1 <= int(token) <= len(keys):
-            raise CommandError(f"{token!r} is not one of the listed numbers; nothing was written.")
-        key = keys[int(token) - 1]
-        if key not in selected:
-            selected.append(key)
+    tokens = [token for token in (part.strip() for part in answer.split(",")) if token]
+    # dict.fromkeys: keeps the typed order while dropping a number listed twice.
+    selected = list(dict.fromkeys(_key_for_token(token, keys) for token in tokens))
     if not selected:
         raise CommandError("No keys selected; nothing was written.")
     return selected

--- a/apps/experiments/management/commands/scrub_participant_data.py
+++ b/apps/experiments/management/commands/scrub_participant_data.py
@@ -445,7 +445,7 @@ def _participant_chunks(working: Experiment, participant_ids: list[int]):
     """
     for start in range(0, len(participant_ids), CHUNK_SIZE):
         yield list(
-            Participant.objects.filter(id__in=participant_ids[start : start + CHUNK_SIZE])
+            Participant.objects.filter(team=working.team, id__in=participant_ids[start : start + CHUNK_SIZE])
             .order_by("id")
             .prefetch_related(
                 Prefetch(
@@ -497,6 +497,7 @@ class Command(BaseCommand):
     )
 
     def add_arguments(self, parser):
+        parser.add_argument("team_slug", help="The slug of the team the chatbot belongs to, as it appears in its URL")
         parser.add_argument("experiment_id", type=int, help="The chatbot's numeric ID, as it appears in its URL")
         parser.add_argument(
             "--filter",
@@ -512,7 +513,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         """Resolve the targets, ask what to replace, confirm, then scrub."""
         dry_run = options["dry_run"]
-        experiment = self._get_experiment(options["experiment_id"])
+        experiment = self._get_experiment(options["team_slug"], options["experiment_id"])
         working = experiment.get_working_version()
         filter_params = self._parse_filter(options["filter"])
 
@@ -523,7 +524,7 @@ class Command(BaseCommand):
 
         experiment_ids = _version_family_ids(working)
         sessions = ExperimentSession.objects.filter(
-            experiment_id__in=experiment_ids, participant_id__in=participant_ids
+            team=working.team, experiment_id__in=experiment_ids, participant_id__in=participant_ids
         )
         key_counts, unscannable_counts = self._discover_keys(working, participant_ids)
 
@@ -568,11 +569,15 @@ class Command(BaseCommand):
         )
         self._report_totals(totals, dry_run=dry_run)
 
-    def _get_experiment(self, experiment_id: int) -> Experiment:
-        """Load the chatbot by id, including an archived one."""
-        experiment = Experiment.objects.get_all().filter(id=experiment_id).first()
+    def _get_experiment(self, team_slug: str, experiment_id: int) -> Experiment:
+        """Load the chatbot by team and id, including an archived one.
+
+        The id alone is a bare number, and a mistyped one names a real chatbot somewhere else.
+        The team is part of the lookup, so a typo finds nothing rather than a stranger's chatbot.
+        """
+        experiment = Experiment.objects.get_all().filter(id=experiment_id, team__slug=team_slug).first()
         if experiment is None:
-            raise CommandError(f"No chatbot with id={experiment_id}")
+            raise CommandError(f"No chatbot with id={experiment_id} in team {team_slug!r}")
         return experiment
 
     def _parse_filter(self, raw: str) -> FilterParams:
@@ -750,7 +755,7 @@ class Command(BaseCommand):
                 )
             scope = Scope(
                 sessions=ExperimentSession.objects.filter(
-                    experiment_id__in=experiment_ids, participant_id__in=list(plans)
+                    team=working.team, experiment_id__in=experiment_ids, participant_id__in=list(plans)
                 ),
                 participant_ids=list(plans),
                 experiment_ids=experiment_ids,

--- a/apps/experiments/management/commands/scrub_participant_data.py
+++ b/apps/experiments/management/commands/scrub_participant_data.py
@@ -31,6 +31,7 @@ from django.db.models import F, Prefetch, Q, QuerySet
 from django.db.models.functions import Coalesce
 from django.http import QueryDict
 
+from apps.channels.models import ChannelPlatform
 from apps.chat.models import Chat, ChatMessage
 from apps.evaluations.models import EvaluationMessage, EvaluationResult
 from apps.experiments.filters import ExperimentSessionFilter
@@ -321,9 +322,8 @@ def _generated_session_plans(scope: Scope, plans: dict[int, ScrubPlan]) -> dict[
     """Map each throwaway generation session to the plan of the participant it copied.
 
     Bot generation copies the participant's session state and history into a session owned by
-    the synthetic "evaluations" participant, on a version row rather than the working version,
-    so neither the participant nor the experiment filter reaches it. The evaluator result the
-    generation fed is the only link back.
+    the synthetic "evaluations" participant, which the match deliberately leaves out. The
+    evaluator result the generation fed is the only link back.
     """
     rows = EvaluationResult.objects.filter(message__session__in=scope.sessions, session__isnull=False).values_list(
         "session_id", "message__session__participant_id"
@@ -614,19 +614,45 @@ class Command(BaseCommand):
                 )
 
     def _resolve_matched(self, working: Experiment, filter_params: FilterParams) -> tuple[int, list[int]]:
-        """Apply the filter and return how many sessions matched, and their participant ids."""
-        base = ExperimentSession.objects.get_table_queryset(working.team, working.id)
-        queryset = ExperimentSessionFilter().apply(base, filter_params=filter_params) if filter_params.filters else base
+        """Apply the filter and return how many sessions matched, and their participant ids.
+
+        Sessions owned by the synthetic evaluations participant are left out. Bot generation
+        runs every evaluation message through one, so together they hold copies of whatever
+        the team's datasets contain. The ones that copied a matched participant are reached
+        through their evaluator result instead.
+        """
+        base = ExperimentSession.objects.get_table_queryset(working.team, working.id).exclude(
+            participant__platform=ChannelPlatform.EVALUATIONS
+        )
+        if not filter_params.filters:
+            queryset = base
+        else:
+            self._refuse_filters_that_narrow_nothing(base, filter_params)
+            queryset = ExperimentSessionFilter().apply(base, filter_params=filter_params)
         matched_count = queryset.order_by().count()
-        if filter_params.filters and matched_count and matched_count == base.order_by().count():
-            # A filter can narrow nothing without erroring — TimestampFilter swallows an
-            # unparseable date, for one — and matching everything is the only signal.
-            raise CommandError(
-                "The filter matched every session of this chatbot, so it narrowed nothing. "
-                "If you really do mean every participant, pass an empty --filter."
-            )
         participant_ids = queryset.order_by().values_list("participant_id", flat=True).distinct()
         return matched_count, sorted(participant_ids)
+
+    def _refuse_filters_that_narrow_nothing(self, base: QuerySet, filter_params: FilterParams) -> None:
+        """Apply each filter on its own and refuse any that matches every session.
+
+        A filter can narrow nothing without erroring — TimestampFilter swallows an unparseable
+        date, a choice filter drops values it cannot parse — and matching everything is the
+        only signal. Each is checked alone, because a real filter beside it would hide the
+        no-op, and the scrub would reach more participants than the operator confirmed.
+        """
+        total = base.order_by().count()
+        if not total:
+            return
+        session_filter = ExperimentSessionFilter()
+        for filter_data in filter_params.filters:
+            alone = session_filter.apply(base, filter_params=FilterParams(column_filters=[filter_data]))
+            if alone.order_by().count() == total:
+                raise CommandError(
+                    f'The filter "{filter_data.column} {filter_data.operator} {filter_data.value}" matched '
+                    "every session of this chatbot, so it narrowed nothing. If you really do mean every "
+                    "participant, pass an empty --filter."
+                )
 
     def _discover_keys(self, working, participant_ids) -> tuple[Counter, Counter]:
         """Top-level participant-data keys, with counts only — never a value.

--- a/apps/experiments/tests/test_scrub_participant_data_command.py
+++ b/apps/experiments/tests/test_scrub_participant_data_command.py
@@ -156,6 +156,19 @@ def _participant_data(chatbot):
     return ParticipantData.objects.get(participant=chatbot["participant"], experiment=chatbot["experiment"])
 
 
+def _totals(printed: str) -> dict[str, int]:
+    """The per-surface counts from the command's closing totals block, as a dict.
+
+    Parsed rather than matched as substrings, so that a count printed for one surface cannot
+    stand in for another ("messages" is a substring of "evaluation_messages").
+    """
+    return {
+        label: int(count)
+        for label, _, count in (line.strip().partition(": ") for line in printed.splitlines())
+        if label in SURFACES
+    }
+
+
 def _other_participant(experiment, *, data=None, name=None, identifier=None, state=None):
     """A second participant of ``experiment``, with their own data, name and session state."""
     session = ExperimentSessionFactory.create(experiment=experiment, team=experiment.team, state=state or {})
@@ -358,8 +371,7 @@ class TestSurfaceCoverage:
         assert _participant_data(chatbot).data == {"name": "[REDACTED]", "age": ""}
 
         printed = output.getvalue()
-        for label in SURFACES:
-            assert f"{label}: 1" in printed
+        assert _totals(printed) == dict.fromkeys(SURFACES, 1)
 
     def test_a_participant_name_holding_another_keys_value_is_text_scanned(self, chatbot, monkeypatch):
         """The name is replaced wholesale when "name" is selected, and scanned otherwise."""
@@ -444,7 +456,7 @@ class TestSurfaceCoverage:
 
         assert not ChatMessage.objects.filter(content__icontains=SECRET).exists()
         # The fixture's own message brings the total to one past two full batches.
-        assert f"messages: {CHUNK_SIZE + 2}" in output.getvalue()
+        assert _totals(output.getvalue())["messages"] == CHUNK_SIZE + 2
 
     @pytest.mark.parametrize("on_working_version", [False, True], ids=["on-a-version", "on-the-working-chatbot"])
     def test_scrubs_the_messages_copied_into_a_generation_session(self, chatbot, monkeypatch, on_working_version):
@@ -961,7 +973,7 @@ class TestSafety:
 
         printed = output.getvalue()
         assert "nothing was written" in printed
-        assert "messages: 1" in printed
+        assert _totals(printed)["messages"] == 1
 
         assert ChatMessage.objects.get(id=chatbot["message"].id).content == f"Hi, {SECRET} here"
         assert ExperimentSession.objects.get(id=chatbot["session"].id).state == {"last_caller": SECRET, "age": 7}
@@ -975,8 +987,7 @@ class TestSafety:
         _scrub(chatbot["experiment"], monkeypatch, stdout=output)
 
         printed = output.getvalue()
-        for label in SURFACES:
-            assert f"{label}: 0" in printed
+        assert _totals(printed) == dict.fromkeys(SURFACES, 0)
         assert _participant_data(chatbot).data == {"name": "[REDACTED]", "age": ""}
 
     def test_the_run_is_logged_without_any_values(self, chatbot, monkeypatch, caplog):

--- a/apps/experiments/tests/test_scrub_participant_data_command.py
+++ b/apps/experiments/tests/test_scrub_participant_data_command.py
@@ -143,7 +143,7 @@ def _scrub(experiment, monkeypatch, *, answers=None, filter_query="", **kwargs):
     """Run the command, answering its prompts from ``answers`` in order."""
     responses = iter(SCRUB_BOTH_KEYS if answers is None else answers)
     monkeypatch.setattr("builtins.input", lambda *_args: next(responses))
-    call_command("scrub_participant_data", str(experiment.id), filter=filter_query, **kwargs)
+    call_command("scrub_participant_data", experiment.team.slug, str(experiment.id), filter=filter_query, **kwargs)
 
 
 def _participant_data(chatbot):
@@ -773,7 +773,7 @@ class TestPromptFlow:
         monkeypatch.setattr("builtins.input", no_answer)
 
         with pytest.raises(CommandError, match="answered interactively"):
-            call_command("scrub_participant_data", str(chatbot["experiment"].id))
+            call_command("scrub_participant_data", chatbot["experiment"].team.slug, str(chatbot["experiment"].id))
 
         assert ChatMessage.objects.get(id=chatbot["message"].id).content == f"Hi, {SECRET} here"
 
@@ -838,7 +838,17 @@ class TestPromptFlow:
         monkeypatch.setattr("builtins.input", lambda *_args: "")
 
         with pytest.raises(CommandError, match="No chatbot with id"):
-            call_command("scrub_participant_data", "123456789")
+            call_command("scrub_participant_data", "some-team", "123456789")
+
+    def test_a_chatbot_in_another_team_is_refused(self, chatbot, monkeypatch):
+        """A mistyped id names a real chatbot somewhere else; the team slug catches that."""
+        monkeypatch.setattr("builtins.input", lambda *_args: "")
+
+        with pytest.raises(CommandError, match="in team 'not-this-team'"):
+            call_command("scrub_participant_data", "not-this-team", str(chatbot["experiment"].id))
+
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == f"Hi, {SECRET} here"
+        assert _participant_data(chatbot).data == {"name": SECRET, "age": 7}
 
 
 class TestFilterArgumentParsing:

--- a/apps/experiments/tests/test_scrub_participant_data_command.py
+++ b/apps/experiments/tests/test_scrub_participant_data_command.py
@@ -1,0 +1,977 @@
+"""Tests for the scrub_participant_data management command."""
+
+import logging
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from apps.annotations.models import UserComment
+from apps.chat.models import Chat, ChatMessage, ChatMessageType
+from apps.evaluations.models import EvaluationMessage
+from apps.experiments.management.commands.scrub_participant_data import (
+    CHUNK_SIZE,
+    SURFACES,
+    ScrubPlan,
+    parse_filter_query_string,
+    resolve_selection,
+    scrub_json,
+    scrub_text,
+    value_is_scannable,
+)
+from apps.experiments.models import ExperimentSession, Participant, ParticipantData
+from apps.pipelines.models import PipelineChatHistory, PipelineChatHistoryTypes, PipelineChatMessages
+from apps.trace.models import Trace
+from apps.utils.factories.evaluations import EvaluationResultFactory
+from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory, ParticipantDataFactory
+from apps.utils.factories.team import TeamFactory
+from apps.utils.factories.traces import TraceFactory
+from apps.utils.factories.user import UserFactory
+from apps.web.dynamic_filters.base import Operators
+
+COMMAND = "apps.experiments.management.commands.scrub_participant_data"
+SECRET = "John Smith"
+
+# The fixture's keys sort to ["age", "name"], so the prompts run in this order: the selection,
+# the replacement for "age", the replacement for "name", then the typed confirmation.
+SCRUB_BOTH_KEYS = ["all", "", "[REDACTED]", "SCRUB"]
+
+
+def _plan(originals: dict, replacements: dict) -> ScrubPlan:
+    return ScrubPlan(replacements=replacements, originals=originals)
+
+
+def _add_records(session, *, participant=None):
+    """Put SECRET (and a short value) on every surface reachable from one session."""
+    participant = participant or session.participant
+    message = ChatMessage.objects.create(
+        chat=session.chat,
+        message_type=ChatMessageType.HUMAN,
+        content=f"Hi, {SECRET} here",
+        summary=f"{SECRET} checked in",
+        translations={"af": f"Haai, {SECRET} hier"},
+    )
+    trace = TraceFactory.create(
+        team=session.team,
+        experiment=session.experiment,
+        session=session,
+        participant=participant,
+        participant_data={"name": SECRET, "age": 7},
+        participant_data_diff=[["change", "name", [SECRET, "J"]]],
+        session_state={"last_caller": SECRET, "age": 7},
+        trace_metadata={"note": SECRET},
+        error=f"{SECRET} timed out",
+    )
+    eval_message = EvaluationMessage.objects.create(
+        session=session,
+        input={"content": f"{SECRET} speaking", "role": "human"},
+        output={"content": f"Hello {SECRET}", "role": "ai"},
+        context={"who": SECRET},
+        history=[{"message_type": "human", "content": f"{SECRET} again", "summary": ""}],
+        participant_data={"name": SECRET, "age": 7},
+        session_state={"last_caller": SECRET},
+        metadata={"note": f"{SECRET} was here"},
+    )
+    pipeline_message = PipelineChatMessages.objects.create(
+        chat_history=PipelineChatHistory.objects.create(
+            session=session, type=PipelineChatHistoryTypes.NAMED, name="node-1"
+        ),
+        node_id="node-1",
+        human_message=f"Hi, {SECRET} here",
+        ai_message=f"Hello {SECRET}",
+        summary=f"{SECRET} checked in",
+    )
+    return {
+        "message": message,
+        "trace": trace,
+        "eval_message": eval_message,
+        "pipeline_message": pipeline_message,
+    }
+
+
+def _add_evaluation_result(eval_message, *, team, generated_session=None):
+    """An evaluator result, holding the copy of the message that `as_result_dict` embeds."""
+    return EvaluationResultFactory.create(
+        team=team,
+        message=eval_message,
+        session=generated_session,
+        evaluator__team=team,
+        run__team=team,
+        output={
+            "message": eval_message.as_result_dict(),
+            "generated_response": f"Hello {SECRET}",
+            "result": {"note": f"{SECRET} sounded upset"},
+        },
+    )
+
+
+def _generated_session(experiment, **kwargs):
+    """The throwaway session bot generation runs an evaluation message through.
+
+    Owned by the synthetic "evaluations" participant and attached to a version row, which is
+    what puts it beyond both the participant and the experiment filter.
+    """
+    version = ExperimentFactory.create(team=experiment.team, working_version=experiment, version_number=99)
+    return ExperimentSessionFactory.create(
+        experiment=version,
+        team=experiment.team,
+        participant__identifier="evaluations",
+        participant__team=experiment.team,
+        **kwargs,
+    )
+
+
+@pytest.fixture()
+def chatbot(db):
+    """One chatbot, one participant, one session, SECRET on every surface."""
+    session = ExperimentSessionFactory.create(state={"last_caller": SECRET, "age": 7})
+    session.participant.name = SECRET
+    session.participant.identifier = "user1@example.com"
+    session.participant.save()
+    ParticipantDataFactory.create(
+        team=session.team,
+        experiment=session.experiment,
+        participant=session.participant,
+        data={"name": SECRET, "age": 7},
+    )
+    records = _add_records(session)
+    return {"session": session, "experiment": session.experiment, "participant": session.participant, **records}
+
+
+def _scrub(experiment, monkeypatch, *, answers=None, filter_query="", **kwargs):
+    """Run the command, answering its prompts from ``answers`` in order."""
+    responses = iter(SCRUB_BOTH_KEYS if answers is None else answers)
+    monkeypatch.setattr("builtins.input", lambda *_args: next(responses))
+    call_command("scrub_participant_data", str(experiment.id), filter=filter_query, **kwargs)
+
+
+def _participant_data(chatbot):
+    return ParticipantData.objects.get(participant=chatbot["participant"], experiment=chatbot["experiment"])
+
+
+def _other_participant(experiment, *, data=None, name=None, identifier=None, state=None):
+    """A second participant of ``experiment``, with their own data, name and session state."""
+    session = ExperimentSessionFactory.create(experiment=experiment, team=experiment.team, state=state or {})
+    if name is not None:
+        session.participant.name = name
+    if identifier is not None:
+        session.participant.identifier = identifier
+    if name is not None or identifier is not None:
+        session.participant.save()
+    if data is not None:
+        ParticipantDataFactory.create(
+            team=experiment.team, experiment=experiment, participant=session.participant, data=data
+        )
+    return session
+
+
+class TestTextReplacement:
+    """The value-based primitive: finding a participant's own values in free text."""
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            pytest.param("John", "X", id="whole-string"),
+            pytest.param("Hi John!", "Hi X!", id="punctuation-is-a-boundary"),
+            pytest.param("name:John", "name:X", id="colon-is-a-boundary"),
+            pytest.param("John-Smith", "X-Smith", id="hyphen-is-a-boundary"),
+            pytest.param("JOHN", "X", id="case-insensitive"),
+            pytest.param("Johnson", "Johnson", id="suffix-is-not-a-match"),
+            pytest.param("stjohn@mail.com", "stjohn@mail.com", id="prefix-is-not-a-match"),
+            pytest.param("John_Smith", "John_Smith", id="underscore-is-a-word-char"),
+            pytest.param("John and John", "X and X", id="every-occurrence"),
+        ],
+    )
+    def test_word_boundaries_and_case(self, text, expected):
+        assert scrub_text(text, _plan({"n": "John"}, {"n": "X"})) == expected
+
+    @pytest.mark.parametrize(
+        ("value", "scannable"),
+        [
+            pytest.param("Bob", False, id="three-chars-too-short"),
+            pytest.param("Bobb", True, id="four-chars-is-enough"),
+            pytest.param(" Bob ", False, id="padding-does-not-count-toward-length"),
+            pytest.param(7, False, id="int-is-never-scanned"),
+            pytest.param(None, False, id="none-is-never-scanned"),
+            pytest.param("", False, id="empty-is-never-scanned"),
+        ],
+    )
+    def test_only_distinctive_values_are_scanned(self, value, scannable):
+        assert value_is_scannable(value) is scannable
+
+    @pytest.mark.parametrize(
+        "value",
+        [pytest.param("Bob", id="too-short-to-hunt-for"), pytest.param(7, id="non-string")],
+    )
+    def test_nothing_scannable_leaves_text_alone(self, value):
+        assert scrub_text("Bob and Bobby", _plan({"n": value}, {"n": "X"})) == "Bob and Bobby"
+
+    def test_stored_value_is_stripped_before_matching(self):
+        """Participant data holding " John " should still clear "John" from prose."""
+        assert scrub_text("a John b", _plan({"n": " John "}, {"n": "X"})) == "a X b"
+
+    def test_longest_value_wins_when_one_is_a_prefix_of_another(self):
+        plan = _plan({"full": "John Smith", "first": "John"}, {"full": "FULL", "first": "FIRST"})
+        assert scrub_text("John Smith here", plan) == "FULL here"
+        assert scrub_text("John alone", plan) == "FIRST alone"
+
+    def test_replacements_do_not_cascade(self):
+        """One key's replacement must not be re-matched by another key's rule.
+
+        Scrubbing "Johnny" to "Robert" while a second key's value *is* "Robert" must leave
+        "Robert" standing, not carry it on into the second rule.
+        """
+        plan = _plan({"a": "Johnny", "b": "Robert"}, {"a": "Robert", "b": "ZZZZ"})
+        assert scrub_text("Johnny called", plan) == "Robert called"
+        assert scrub_text("Robert called", plan) == "ZZZZ called"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("A. Smith (Jr.)", id="dots-and-parens"),
+            pytest.param("foo|bar", id="alternation"),
+            pytest.param("a+b+c", id="quantifier"),
+            pytest.param("[bracketed]", id="character-class"),
+        ],
+    )
+    def test_regex_metacharacters_in_a_value_are_literal(self, value):
+        assert scrub_text(f"call {value} now", _plan({"n": value}, {"n": "X"})) == "call X now"
+
+    @pytest.mark.parametrize(
+        "replacement",
+        [
+            pytest.param(r"\1", id="group-reference"),
+            pytest.param(r"\g<0>", id="named-group-reference"),
+            pytest.param("back\\slash", id="backslash"),
+            pytest.param("$1", id="dollar-one"),
+        ],
+    )
+    def test_replacement_string_is_inserted_literally(self, replacement):
+        assert scrub_text("Hi John", _plan({"n": "John"}, {"n": replacement})) == f"Hi {replacement}"
+
+    def test_empty_replacement_deletes_the_value(self):
+        assert scrub_text("Hi John there", _plan({"n": "John"}, {"n": ""})) == "Hi  there"
+
+
+class TestJsonReplacement:
+    """The key-based primitive: clearing a selected key's value at any depth."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param({"name": "John"}, {"name": "X"}, id="top-level-key"),
+            pytest.param({"a": {"name": "John"}}, {"a": {"name": "X"}}, id="nested-dict"),
+            pytest.param({"a": [{"name": "John"}]}, {"a": [{"name": "X"}]}, id="dict-in-list-in-dict"),
+            pytest.param([{"name": 7}], [{"name": "X"}], id="key-clears-non-string-value"),
+            pytest.param({"other": "John"}, {"other": "X"}, id="unselected-key-still-text-scanned"),
+            pytest.param({"John": "John"}, {"John": "X"}, id="dict-keys-are-never-rewritten"),
+            pytest.param(
+                {"a": 1, "b": 2.5, "c": True, "d": None},
+                {"a": 1, "b": 2.5, "c": True, "d": None},
+                id="non-string-leaves-preserved",
+            ),
+            pytest.param(
+                [["change", "name", ["John", "J"]]],
+                [["change", "name", ["X", "J"]]],
+                id="top-level-list-dictdiffer-shape",
+            ),
+            pytest.param({}, {}, id="empty-dict"),
+            pytest.param({"a": []}, {"a": []}, id="empty-list"),
+        ],
+    )
+    def test_shapes(self, value, expected):
+        assert scrub_json(value, _plan({"name": "John"}, {"name": "X"})) == expected
+
+    def test_tuples_become_lists(self):
+        """JSON has no tuple, so a tuple in a Python-side value round-trips as a list."""
+        assert scrub_json({"a": ("John",)}, _plan({"name": "John"}, {"name": "X"})) == {"a": ["X"]}
+
+    def test_a_selected_key_with_no_original_still_clears_its_value(self):
+        """A key nobody holds is still cleared wherever it appears in stored JSON."""
+        assert scrub_json({"absent": "anything"}, _plan({}, {"absent": "X"})) == {"absent": "X"}
+
+
+@pytest.mark.django_db()
+class TestSurfaceCoverage:
+    """Every field one run rewrites, and the rows it reaches."""
+
+    def test_scrubs_every_surface(self, chatbot, monkeypatch):
+        """One changed row on every surface the command reports, so a new surface has to be covered here."""
+        chat = chatbot["session"].chat
+        chat.name = f"{SECRET} - web"
+        chat.save()
+        generated = _generated_session(chatbot["experiment"], state={"last_caller": SECRET, "age": 7})
+        result = _add_evaluation_result(
+            chatbot["eval_message"], team=chatbot["experiment"].team, generated_session=generated
+        )
+        output = StringIO()
+
+        _scrub(chatbot["experiment"], monkeypatch, stdout=output)
+
+        assert Chat.objects.get(id=chat.id).name == "[REDACTED] - web"
+
+        pipeline_message = PipelineChatMessages.objects.get(id=chatbot["pipeline_message"].id)
+        assert pipeline_message.human_message == "Hi, [REDACTED] here"
+        assert pipeline_message.ai_message == "Hello [REDACTED]"
+        assert pipeline_message.summary == "[REDACTED] checked in"
+
+        result.refresh_from_db()
+        assert result.output["message"]["input"]["content"] == "[REDACTED] speaking"
+        assert result.output["message"]["participant_data"] == {"name": "[REDACTED]", "age": ""}
+        assert result.output["generated_response"] == "Hello [REDACTED]"
+        assert result.output["result"] == {"note": "[REDACTED] sounded upset"}
+
+        assert ExperimentSession.objects.get(id=generated.id).state == {"last_caller": "[REDACTED]", "age": ""}
+
+        message = ChatMessage.objects.get(id=chatbot["message"].id)
+        assert message.content == "Hi, [REDACTED] here"
+        assert message.summary == "[REDACTED] checked in"
+        assert message.translations == {"af": "Haai, [REDACTED] hier"}
+
+        session = ExperimentSession.objects.get(id=chatbot["session"].id)
+        assert session.state == {"last_caller": "[REDACTED]", "age": ""}
+
+        trace = Trace.objects.get(id=chatbot["trace"].id)
+        assert trace.participant_data == {"name": "[REDACTED]", "age": ""}
+        assert trace.participant_data_diff == [["change", "name", ["[REDACTED]", "J"]]]
+        assert trace.session_state == {"last_caller": "[REDACTED]", "age": ""}
+        assert trace.trace_metadata == {"note": "[REDACTED]"}
+        assert trace.error == "[REDACTED] timed out"
+
+        eval_message = EvaluationMessage.objects.get(id=chatbot["eval_message"].id)
+        assert eval_message.input == {"content": "[REDACTED] speaking", "role": "human"}
+        assert eval_message.output == {"content": "Hello [REDACTED]", "role": "ai"}
+        assert eval_message.context == {"who": "[REDACTED]"}
+        assert eval_message.history == [{"message_type": "human", "content": "[REDACTED] again", "summary": ""}]
+        assert eval_message.participant_data == {"name": "[REDACTED]", "age": ""}
+        assert eval_message.session_state == {"last_caller": "[REDACTED]"}
+        assert eval_message.metadata == {"note": "[REDACTED] was here"}
+
+        assert Participant.objects.get(id=chatbot["participant"].id).name == "[REDACTED]"
+        assert _participant_data(chatbot).data == {"name": "[REDACTED]", "age": ""}
+
+        printed = output.getvalue()
+        for label in SURFACES:
+            assert f"{label}: 1" in printed
+
+    def test_a_participant_name_holding_another_keys_value_is_text_scanned(self, chatbot, monkeypatch):
+        """The name is replaced wholesale when "name" is selected, and scanned otherwise."""
+        data = _participant_data(chatbot)
+        data.data = {"name": SECRET, "age": 7, "nickname": "Zedediah"}
+        data.save()
+        chatbot["participant"].name = "Zedediah rocks"
+        chatbot["participant"].save()
+
+        # keys sort to ["age", "name", "nickname"]; select nickname only
+        _scrub(chatbot["experiment"], monkeypatch, answers=["3", "NICK", "SCRUB"])
+
+        assert Participant.objects.get(id=chatbot["participant"].id).name == "NICK rocks"
+
+    def test_an_empty_participant_name_is_left_alone(self, chatbot, monkeypatch):
+        chatbot["participant"].name = ""
+        chatbot["participant"].save()
+        output = StringIO()
+
+        _scrub(chatbot["experiment"], monkeypatch, stdout=output)
+
+        assert Participant.objects.get(id=chatbot["participant"].id).name == ""
+        assert "participant_names: 0" in output.getvalue()
+
+    @pytest.mark.parametrize(
+        ("on_older_version", "archived"),
+        [
+            pytest.param(False, False, id="working-version"),
+            pytest.param(True, False, id="older-version"),
+            pytest.param(True, True, id="archived-older-version"),
+        ],
+    )
+    def test_a_trace_whose_session_was_deleted_is_still_scrubbed(
+        self, chatbot, monkeypatch, on_older_version, archived
+    ):
+        """Trace.session is SET_NULL, so an orphaned trace still holds a copy.
+
+        The orphan clause searches the whole version family, archived versions included: the
+        default related manager drops those, and their traces hold the same data.
+        """
+        experiment = chatbot["experiment"]
+        if on_older_version:
+            experiment = ExperimentFactory.create(
+                team=experiment.team, working_version=experiment, version_number=1, is_archived=archived
+            )
+        orphan = TraceFactory.create(
+            team=chatbot["experiment"].team,
+            experiment=experiment,
+            session=None,
+            participant=chatbot["participant"],
+            participant_data={"name": SECRET},
+            session_state={"last_caller": SECRET},
+        )
+
+        _scrub(chatbot["experiment"], monkeypatch)
+
+        orphan.refresh_from_db()
+        assert orphan.participant_data == {"name": "[REDACTED]"}
+        assert orphan.session_state == {"last_caller": "[REDACTED]"}
+
+    def test_an_evaluation_message_with_no_session_is_out_of_reach(self, chatbot, monkeypatch):
+        """A documented limitation: CSV-imported messages have no session to reach them by."""
+        orphan = EvaluationMessage.objects.create(session=None, input={"content": f"{SECRET} speaking"})
+
+        _scrub(chatbot["experiment"], monkeypatch)
+
+        orphan.refresh_from_db()
+        assert orphan.input == {"content": f"{SECRET} speaking"}
+
+    def test_writes_every_row_past_the_batch_boundary(self, chatbot, monkeypatch):
+        """The write batches flush at CHUNK_SIZE, so the boundary is a real code path."""
+        ChatMessage.objects.bulk_create(
+            [
+                ChatMessage(chat=chatbot["session"].chat, message_type=ChatMessageType.HUMAN, content=f"{SECRET} #{n}")
+                for n in range(CHUNK_SIZE + 1)
+            ]
+        )
+
+        output = StringIO()
+
+        _scrub(chatbot["experiment"], monkeypatch, stdout=output)
+
+        assert not ChatMessage.objects.filter(content__icontains=SECRET).exists()
+        # The fixture's own message brings the total to one past two full batches.
+        assert f"messages: {CHUNK_SIZE + 2}" in output.getvalue()
+
+    def test_scrubs_the_messages_copied_into_a_generation_session(self, chatbot, monkeypatch):
+        """Bot generation replays the participant's history into the throwaway session's chat."""
+        generated = _generated_session(chatbot["experiment"], state={})
+        copied = ChatMessage.objects.create(
+            chat=generated.chat, message_type=ChatMessageType.HUMAN, content=f"{SECRET} again"
+        )
+        _add_evaluation_result(chatbot["eval_message"], team=chatbot["experiment"].team, generated_session=generated)
+
+        _scrub(chatbot["experiment"], monkeypatch)
+
+        assert ChatMessage.objects.get(id=copied.id).content == "[REDACTED] again"
+
+    def test_scrubs_the_chat_name_built_from_the_participant_identifier(self, chatbot, monkeypatch):
+        """`Chat.name` is "<identifier> - <channel>", so it holds a copy of the identifier."""
+        data = _participant_data(chatbot)
+        data.data = {"email": "user1@example.com"}
+        data.save()
+        chat = chatbot["session"].chat
+        chat.name = "user1@example.com - web"
+        chat.save()
+
+        _scrub(chatbot["experiment"], monkeypatch, answers=["1", "[GONE]", "SCRUB"])
+
+        chat.refresh_from_db()
+        assert chat.name == "[GONE] - web"
+
+
+@pytest.mark.django_db()
+class TestScope:
+    """Which participants the filter selects, and which of their sessions get scrubbed."""
+
+    def test_filter_selects_participants_not_sessions(self, chatbot, monkeypatch):
+        """Matching one of a participant's sessions scrubs all of them.
+
+        The values belong to the participant, not the session, so a narrow filter must not
+        leave copies behind in their other conversations with this chatbot.
+        """
+        others = [
+            ExperimentSessionFactory.create(
+                experiment=chatbot["experiment"],
+                team=chatbot["experiment"].team,
+                participant=chatbot["participant"],
+                state={"last_caller": SECRET},
+            )
+            for _ in range(2)
+        ]
+        records = [_add_records(session, participant=chatbot["participant"]) for session in others]
+
+        _scrub(
+            chatbot["experiment"],
+            monkeypatch,
+            filter_query=f"f_session_id={chatbot['session'].external_id}&op_session_id={Operators.EQUALS}",
+        )
+
+        for session, record in zip(others, records, strict=True):
+            assert ExperimentSession.objects.get(id=session.id).state == {"last_caller": "[REDACTED]"}
+            assert SECRET not in ChatMessage.objects.get(id=record["message"].id).content
+
+    def test_unmatched_participants_are_untouched(self, chatbot, monkeypatch):
+        other = _other_participant(chatbot["experiment"], identifier="user2@example.com", name=SECRET)
+        other_records = _add_records(other)
+
+        _scrub(
+            chatbot["experiment"],
+            monkeypatch,
+            filter_query=f"f_participant=user1&op_participant={Operators.CONTAINS}",
+        )
+
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == "Hi, [REDACTED] here"
+        assert ChatMessage.objects.get(id=other_records["message"].id).content == f"Hi, {SECRET} here"
+        assert Participant.objects.get(id=other.participant.id).name == SECRET
+
+    def test_empty_filter_covers_every_participant(self, chatbot, monkeypatch):
+        other = _other_participant(
+            chatbot["experiment"], data={"name": SECRET, "age": 7}, state={"last_caller": SECRET}
+        )
+        other_records = _add_records(other)
+
+        _scrub(chatbot["experiment"], monkeypatch)
+
+        assert SECRET not in ChatMessage.objects.get(id=other_records["message"].id).content
+        assert ExperimentSession.objects.get(id=other.id).state == {"last_caller": "[REDACTED]"}
+
+    def test_the_same_participants_other_chatbots_are_untouched(self, chatbot, monkeypatch):
+        """Participant data is per (participant, experiment), so a second chatbot keeps its copy."""
+        other_session = ExperimentSessionFactory.create(
+            team=chatbot["experiment"].team, participant=chatbot["participant"], state={"last_caller": SECRET}
+        )
+        other_data = ParticipantDataFactory.create(
+            team=chatbot["experiment"].team,
+            experiment=other_session.experiment,
+            participant=chatbot["participant"],
+            data={"name": SECRET, "age": 7},
+        )
+        other_records = _add_records(other_session, participant=chatbot["participant"])
+
+        _scrub(chatbot["experiment"], monkeypatch)
+
+        assert ParticipantData.objects.get(id=other_data.id).data == {"name": SECRET, "age": 7}
+        assert ExperimentSession.objects.get(id=other_session.id).state == {"last_caller": SECRET}
+        assert ChatMessage.objects.get(id=other_records["message"].id).content == f"Hi, {SECRET} here"
+
+    def test_another_teams_records_are_untouched(self, chatbot, monkeypatch):
+        team = TeamFactory.create()
+        foreign = ExperimentSessionFactory.create(team=team, experiment__team=team, state={"last_caller": SECRET})
+        ParticipantDataFactory.create(
+            team=team, experiment=foreign.experiment, participant=foreign.participant, data={"name": SECRET}
+        )
+        foreign_records = _add_records(foreign)
+
+        _scrub(chatbot["experiment"], monkeypatch)
+
+        assert ExperimentSession.objects.get(id=foreign.id).state == {"last_caller": SECRET}
+        assert ChatMessage.objects.get(id=foreign_records["message"].id).content == f"Hi, {SECRET} here"
+
+    def test_a_version_id_resolves_to_the_working_chatbot(self, chatbot, monkeypatch):
+        """Sessions attach to the working version, so a version id must scrub the family's data."""
+        version = ExperimentFactory.create(
+            team=chatbot["experiment"].team, working_version=chatbot["experiment"], version_number=1
+        )
+
+        _scrub(version, monkeypatch)
+
+        assert _participant_data(chatbot).data == {"name": "[REDACTED]", "age": ""}
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == "Hi, [REDACTED] here"
+
+    def test_each_participant_is_scanned_for_only_their_own_values(self, chatbot, monkeypatch):
+        """The plan is rebuilt per participant, so A's value is never hunted in B's records.
+
+        Both participants' messages name both people; only the owner's own value may go.
+        """
+        other = _other_participant(chatbot["experiment"], data={"name": "Mary Jones"}, identifier="user2@example.com")
+        shared_text = f"{SECRET} met Mary Jones"
+        mine = ChatMessage.objects.create(
+            chat=chatbot["session"].chat, message_type=ChatMessageType.HUMAN, content=shared_text
+        )
+        theirs = ChatMessage.objects.create(chat=other.chat, message_type=ChatMessageType.HUMAN, content=shared_text)
+
+        _scrub(chatbot["experiment"], monkeypatch)
+
+        assert ChatMessage.objects.get(id=mine.id).content == "[REDACTED] met Mary Jones"
+        assert ChatMessage.objects.get(id=theirs.id).content == f"{SECRET} met [REDACTED]"
+
+    def test_a_participant_without_data_is_not_text_scanned(self, chatbot, monkeypatch):
+        """The values to search for come from each participant's own data.
+
+        A participant holding no participant data has nothing to scan for, so free text naming
+        someone else is left alone. Only the selected keys are cleared from their JSON.
+        """
+        other = _other_participant(chatbot["experiment"], state={"last_caller": SECRET, "age": 7})
+        other_records = _add_records(other)
+
+        original_name = other.participant.name
+
+        _scrub(chatbot["experiment"], monkeypatch)
+
+        assert ChatMessage.objects.get(id=other_records["message"].id).content == f"Hi, {SECRET} here"
+        assert ExperimentSession.objects.get(id=other.id).state == {"last_caller": SECRET, "age": ""}
+        # The "name" replacement is the global selection; this participant holds no name of
+        # their own, and Participant.name is team-scoped, so it must not be rewritten.
+        assert Participant.objects.get(id=other.participant.id).name == original_name
+
+    def test_a_name_is_only_replaced_for_participants_who_hold_one(self, chatbot, monkeypatch):
+        """Selecting "name" must not blank the name of a participant whose data lacks it."""
+        other = _other_participant(chatbot["experiment"], data={"age": 41}, name="Someone Else")
+
+        _scrub(chatbot["experiment"], monkeypatch)
+
+        assert Participant.objects.get(id=chatbot["participant"].id).name == "[REDACTED]"
+        assert Participant.objects.get(id=other.participant.id).name == "Someone Else"
+
+    def test_another_participants_evaluator_result_is_untouched(self, chatbot, monkeypatch):
+        """An evaluator result is reached through its message, so it follows that participant."""
+        other = _other_participant(chatbot["experiment"], identifier="user2@example.com", data={"name": SECRET})
+        other_records = _add_records(other)
+        team = chatbot["experiment"].team
+        mine = _add_evaluation_result(chatbot["eval_message"], team=team)
+        theirs = _add_evaluation_result(other_records["eval_message"], team=team)
+
+        _scrub(
+            chatbot["experiment"],
+            monkeypatch,
+            filter_query=f"f_participant=user1&op_participant={Operators.CONTAINS}",
+        )
+
+        mine.refresh_from_db()
+        theirs.refresh_from_db()
+        assert mine.output["message"]["input"]["content"] == "[REDACTED] speaking"
+        assert theirs.output["message"]["input"]["content"] == f"{SECRET} speaking"
+
+    def test_another_participants_generation_session_is_untouched(self, chatbot, monkeypatch):
+        """Generation sessions all belong to one synthetic participant, so only the link scopes them."""
+        other = _other_participant(chatbot["experiment"], identifier="user2@example.com", data={"name": SECRET})
+        other_records = _add_records(other)
+        theirs = _generated_session(chatbot["experiment"], state={"last_caller": SECRET})
+        _add_evaluation_result(other_records["eval_message"], team=chatbot["experiment"].team, generated_session=theirs)
+
+        _scrub(
+            chatbot["experiment"],
+            monkeypatch,
+            filter_query=f"f_participant=user1&op_participant={Operators.CONTAINS}",
+        )
+
+        assert ExperimentSession.objects.get(id=theirs.id).state == {"last_caller": SECRET}
+
+
+@pytest.mark.django_db()
+class TestScopeBoundary:
+    """Records sitting next to the scrubbed ones, left alone by decision rather than omission."""
+
+    def test_adjacent_surfaces_are_left_alone(self, chatbot, monkeypatch):
+        """`ChatMessage.metadata` and `Chat.metadata` hold file references and routing state
+        rather than participant prose, and a `UserComment` is a staff user's own words about
+        the conversation, so scrubbing it would destroy someone else's writing.
+        """
+        message = chatbot["message"]
+        message.metadata = {"note": SECRET}
+        message.save()
+        chat = chatbot["session"].chat
+        chat.metadata = {"note": SECRET}
+        chat.save()
+        comment = UserComment.objects.create(
+            content_object=chat, user=UserFactory.create(), comment=f"{SECRET} called in", team=chat.team
+        )
+
+        _scrub(chatbot["experiment"], monkeypatch)
+
+        assert ChatMessage.objects.get(id=message.id).metadata == {"note": SECRET}
+        assert Chat.objects.get(id=chat.id).metadata == {"note": SECRET}
+        assert UserComment.objects.get(id=comment.id).comment == f"{SECRET} called in"
+
+
+class TestKeySelectionPrompt:
+    """Turning the typed answer into a list of keys."""
+
+    @pytest.mark.parametrize(
+        ("answer", "expected"),
+        [
+            pytest.param("all", ["age", "name"], id="all"),
+            pytest.param("ALL", ["age", "name"], id="all-uppercase"),
+            pytest.param("1,2", ["age", "name"], id="both-numbers"),
+            pytest.param(" 1 , 2 ", ["age", "name"], id="whitespace-tolerated"),
+            pytest.param("2", ["name"], id="single"),
+            pytest.param("2,1", ["name", "age"], id="order-follows-the-answer"),
+            pytest.param("1,1", ["age"], id="duplicates-collapse"),
+            pytest.param("1,,2", ["age", "name"], id="empty-token-ignored"),
+        ],
+    )
+    def test_accepted_answers(self, answer, expected):
+        assert resolve_selection(answer, ["age", "name"]) == expected
+
+    @pytest.mark.parametrize(
+        "answer",
+        [
+            pytest.param("", id="empty"),
+            pytest.param("   ", id="whitespace-only"),
+            pytest.param(",", id="only-separators"),
+        ],
+    )
+    def test_selecting_nothing_is_refused(self, answer):
+        with pytest.raises(CommandError, match="No keys selected"):
+            resolve_selection(answer, ["age", "name"])
+
+    @pytest.mark.parametrize(
+        "answer",
+        [
+            pytest.param("0", id="zero"),
+            pytest.param("3", id="past-the-end"),
+            pytest.param("-1", id="negative"),
+            pytest.param("abc", id="not-a-number"),
+            pytest.param("1,99", id="one-good-one-bad"),
+            pytest.param("1.5", id="decimal"),
+        ],
+    )
+    def test_answers_outside_the_list_are_refused(self, answer):
+        with pytest.raises(CommandError, match="not one of the listed numbers"):
+            resolve_selection(answer, ["age", "name"])
+
+
+@pytest.mark.django_db()
+class TestPromptFlow:
+    """What the operator is shown, and what stops the run before it writes."""
+
+    def test_offers_keys_with_counts_and_never_values(self, chatbot, monkeypatch):
+        output = StringIO()
+        _scrub(chatbot["experiment"], monkeypatch, stdout=output)
+
+        printed = output.getvalue()
+        assert "1. age: 1 participant(s) — 1 too short/non-text to scan for in prose" in printed
+        assert "2. name: 1 participant(s)" in printed
+        assert SECRET not in printed
+        assert "also used as a structural key" not in printed
+
+    def test_warns_when_a_selected_key_also_names_a_json_field(self, chatbot, monkeypatch):
+        """Key-based replacement matches at any depth, so "content" also blanks message bodies."""
+        data = _participant_data(chatbot)
+        data.data = {"content": "a private note"}
+        data.save()
+        output = StringIO()
+
+        _scrub(chatbot["experiment"], monkeypatch, answers=["1", "X", "SCRUB"], stdout=output)
+
+        assert "also used as a structural key" in output.getvalue()
+        assert EvaluationMessage.objects.get(id=chatbot["eval_message"].id).input["content"] == "X"
+
+    def test_a_key_only_some_participants_can_be_scanned_for_says_so(self, chatbot, monkeypatch):
+        """A mixed population must not be reported as if nothing gets text-scanned."""
+        _other_participant(chatbot["experiment"], data={"name": "Bo"}, identifier="user2@example.com")
+        output = StringIO()
+
+        _scrub(chatbot["experiment"], monkeypatch, stdout=output)
+
+        printed = output.getvalue()
+        assert "name -> [REDACTED] — text-scanned for 1 of 2 participants, key-only for the rest" in printed
+        assert "age -> (cleared) — cleared by key only, not text-scanned" in printed
+
+    def test_the_plan_says_a_key_is_cleared_even_for_participants_who_never_held_it(self, chatbot, monkeypatch):
+        """The key pass is global, so the participant counts are not the blast radius."""
+        output = StringIO()
+
+        _scrub(chatbot["experiment"], monkeypatch, stdout=output)
+
+        assert "including for in-scope participants who never held it" in output.getvalue()
+
+    def test_a_non_interactive_run_fails_cleanly(self, chatbot, monkeypatch):
+        """A bare EOFError traceback would leave the operator guessing."""
+
+        def no_answer(*_args):
+            raise EOFError
+
+        monkeypatch.setattr("builtins.input", no_answer)
+
+        with pytest.raises(CommandError, match="answered interactively"):
+            call_command("scrub_participant_data", str(chatbot["experiment"].id))
+
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == f"Hi, {SECRET} here"
+
+    def test_selecting_one_key_leaves_the_others_alone(self, chatbot, monkeypatch):
+        _scrub(chatbot["experiment"], monkeypatch, answers=["1", "", "SCRUB"])
+
+        assert _participant_data(chatbot).data == {"name": SECRET, "age": ""}
+        assert Participant.objects.get(id=chatbot["participant"].id).name == SECRET
+
+    def test_each_replacement_is_paired_with_the_key_it_was_asked_for(self, chatbot, monkeypatch):
+        """The prompts follow the selection order, so a mis-pairing would swap the values."""
+        _scrub(chatbot["experiment"], monkeypatch, answers=["2,1", "NAME", "AGE", "SCRUB"])
+
+        assert _participant_data(chatbot).data == {"name": "NAME", "age": "AGE"}
+
+    def test_a_bad_selection_writes_nothing(self, chatbot, monkeypatch):
+        with pytest.raises(CommandError):
+            _scrub(chatbot["experiment"], monkeypatch, answers=["99"])
+
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == f"Hi, {SECRET} here"
+
+    @pytest.mark.parametrize(
+        "confirmation",
+        [
+            pytest.param("nope", id="wrong-word"),
+            pytest.param("", id="empty"),
+            pytest.param("scrub", id="lowercase-is-not-enough"),
+        ],
+    )
+    def test_a_failed_confirmation_writes_nothing(self, chatbot, monkeypatch, confirmation):
+        with pytest.raises(CommandError, match="Aborted"):
+            _scrub(chatbot["experiment"], monkeypatch, answers=["all", "", "[REDACTED]", confirmation])
+
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == f"Hi, {SECRET} here"
+        assert _participant_data(chatbot).data == {"name": SECRET, "age": 7}
+
+    def test_no_participant_data_stops_before_prompting(self, db, monkeypatch):
+        session = ExperimentSessionFactory.create(state={"last_caller": SECRET})
+        _add_records(session)
+        output = StringIO()
+
+        _scrub(session.experiment, monkeypatch, answers=[], stdout=output)
+
+        assert "no participant data" in output.getvalue()
+        assert ExperimentSession.objects.get(id=session.id).state == {"last_caller": SECRET}
+
+    def test_a_filter_matching_nothing_stops_before_prompting(self, chatbot, monkeypatch):
+        output = StringIO()
+
+        _scrub(
+            chatbot["experiment"],
+            monkeypatch,
+            answers=[],
+            filter_query=f"f_participant=nobody-at-all&op_participant={Operators.CONTAINS}",
+            stdout=output,
+        )
+
+        assert "matched no sessions" in output.getvalue()
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == f"Hi, {SECRET} here"
+
+    def test_an_unknown_chatbot_id_is_refused(self, db, monkeypatch):
+        monkeypatch.setattr("builtins.input", lambda *_args: "")
+
+        with pytest.raises(CommandError, match="No chatbot with id"):
+            call_command("scrub_participant_data", "123456789")
+
+
+class TestFilterArgumentParsing:
+    """Reading the query string the operator pasted."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            pytest.param("f_participant=bob&op_participant=contains", id="bare-query-string"),
+            pytest.param("?f_participant=bob&op_participant=contains", id="leading-question-mark"),
+            pytest.param(
+                "http://localhost:8000/a/team/chatbots/36/?f_participant=bob&op_participant=contains",
+                id="whole-url",
+            ),
+        ],
+    )
+    def test_equivalent_forms_produce_the_same_filter(self, raw):
+        filters = parse_filter_query_string(raw).filters
+
+        assert len(filters) == 1
+        assert (filters[0].column, filters[0].value) == ("participant", "bob")
+
+    @pytest.mark.parametrize(
+        "raw",
+        [pytest.param("", id="empty"), pytest.param("   ", id="whitespace"), pytest.param(None, id="none")],
+    )
+    def test_an_empty_string_means_no_filter(self, raw):
+        assert parse_filter_query_string(raw).filters == []
+
+
+@pytest.mark.django_db()
+class TestFilterArgumentGuard:
+    """A filter that would not narrow the scrub is refused rather than silently widened."""
+
+    @pytest.mark.parametrize(
+        ("filter_query", "message"),
+        [
+            pytest.param("page=2&sort=name", "no usable filters", id="unrelated-params"),
+            pytest.param("http://localhost:8000/a/team/chatbots/36/", "no usable filters", id="url-with-no-query"),
+            pytest.param(
+                "filter_0_column=participant&filter_0_operator=contains&filter_0_value=bob",
+                "no usable filters",
+                id="legacy-format",
+            ),
+            pytest.param("f_bogus=x&op_bogus=contains", "not a session filter", id="unknown-column"),
+            pytest.param("f_participant=x&op_participant=is", "does not support", id="unsupported-operator"),
+            pytest.param("f_last_message=yesterday&op_last_message=on", "matched every session", id="unparseable-date"),
+            pytest.param(
+                f"f_participant=user1&op_participant={Operators.CONTAINS}",
+                "pass an empty --filter",
+                id="genuinely-matches-everything",
+            ),
+        ],
+    )
+    def test_a_filter_that_would_not_narrow_the_scrub_is_refused(self, chatbot, monkeypatch, filter_query, message):
+        """An unknown column, operator or value narrows nothing, which would scrub everyone."""
+        with pytest.raises(CommandError, match=message):
+            _scrub(chatbot["experiment"], monkeypatch, answers=[], filter_query=filter_query)
+
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == f"Hi, {SECRET} here"
+
+
+@pytest.mark.django_db()
+class TestSafety:
+    """The properties that make an irreversible command usable."""
+
+    def test_dry_run_changes_nothing_but_reports_the_counts(self, chatbot, monkeypatch):
+        """The answers list holds no confirmation, so a prompt would raise StopIteration."""
+        output = StringIO()
+
+        _scrub(chatbot["experiment"], monkeypatch, answers=["all", "", "[REDACTED]"], stdout=output, dry_run=True)
+
+        printed = output.getvalue()
+        assert "nothing was written" in printed
+        assert "messages: 1" in printed
+
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == f"Hi, {SECRET} here"
+        assert ExperimentSession.objects.get(id=chatbot["session"].id).state == {"last_caller": SECRET, "age": 7}
+        assert Participant.objects.get(id=chatbot["participant"].id).name == SECRET
+        assert _participant_data(chatbot).data == {"name": SECRET, "age": 7}
+
+    def test_running_twice_changes_nothing_the_second_time(self, chatbot, monkeypatch):
+        _scrub(chatbot["experiment"], monkeypatch)
+        output = StringIO()
+
+        _scrub(chatbot["experiment"], monkeypatch, stdout=output)
+
+        printed = output.getvalue()
+        for label in SURFACES:
+            assert f"{label}: 0" in printed
+        assert _participant_data(chatbot).data == {"name": "[REDACTED]", "age": ""}
+
+    def test_the_run_is_logged_without_any_values(self, chatbot, monkeypatch, caplog):
+        """A deletion request has to be evidenced afterwards, and the log is all that survives."""
+        with caplog.at_level(logging.INFO, logger=COMMAND):
+            _scrub(chatbot["experiment"], monkeypatch)
+
+        logged = "\n".join(record.getMessage() for record in caplog.records)
+        assert "scrub_participant_data starting" in logged
+        assert f"experiment={chatbot['experiment'].id}" in logged
+        assert "keys=['age', 'name']" in logged
+        assert "scrub_participant_data finished" in logged
+        assert SECRET not in logged
+
+    def test_an_interrupted_run_is_safely_re_runnable(self, chatbot, monkeypatch):
+        """Participant data is written last, so a crash leaves the search terms readable.
+
+        Without that ordering a half-finished run would have nothing left to hunt for on the
+        surfaces it never reached.
+        """
+
+        def interrupt(**_kwargs):
+            raise RuntimeError("interrupted mid-scrub")
+
+        monkeypatch.setattr(f"{COMMAND}._scrub_participant_data", interrupt)
+
+        with pytest.raises(RuntimeError, match="interrupted mid-scrub"):
+            _scrub(chatbot["experiment"], monkeypatch)
+
+        assert _participant_data(chatbot).data == {"name": SECRET, "age": 7}
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == "Hi, [REDACTED] here"
+
+        monkeypatch.undo()
+        _scrub(chatbot["experiment"], monkeypatch)
+
+        assert _participant_data(chatbot).data == {"name": "[REDACTED]", "age": ""}
+        assert not ChatMessage.objects.filter(content__icontains=SECRET).exists()
+
+    def test_a_replacement_containing_the_original_is_not_reapplied(self, chatbot, monkeypatch):
+        """Replacing "John Smith" with "John Smith (removed)" must not compound on a rerun."""
+        _scrub(chatbot["experiment"], monkeypatch, answers=["2", f"{SECRET} (removed)", "SCRUB"])
+        first = ChatMessage.objects.get(id=chatbot["message"].id).content
+
+        _scrub(chatbot["experiment"], monkeypatch, answers=["2", f"{SECRET} (removed)", "SCRUB"])
+
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == first

--- a/apps/experiments/tests/test_scrub_participant_data_command.py
+++ b/apps/experiments/tests/test_scrub_participant_data_command.py
@@ -8,6 +8,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 
 from apps.annotations.models import UserComment
+from apps.channels.models import ChannelPlatform
 from apps.chat.models import Chat, ChatMessage, ChatMessageType
 from apps.evaluations.models import EvaluationMessage
 from apps.experiments.management.commands.scrub_participant_data import (
@@ -106,17 +107,22 @@ def _add_evaluation_result(eval_message, *, team, generated_session=None):
     )
 
 
-def _generated_session(experiment, **kwargs):
+def _generated_session(experiment, *, on_working_version=False, **kwargs):
     """The throwaway session bot generation runs an evaluation message through.
 
-    Owned by the synthetic "evaluations" participant and attached to a version row, which is
-    what puts it beyond both the participant and the experiment filter.
+    Owned by the synthetic "evaluations" participant. An evaluation configured for a specific
+    or published version attaches it to that version row; one configured for the latest
+    working version attaches it to the working chatbot itself.
     """
-    version = ExperimentFactory.create(team=experiment.team, working_version=experiment, version_number=99)
+    target = experiment
+    if not on_working_version:
+        target = ExperimentFactory.create(team=experiment.team, working_version=experiment, version_number=99)
     return ExperimentSessionFactory.create(
-        experiment=version,
+        experiment=target,
         team=experiment.team,
+        platform=ChannelPlatform.EVALUATIONS,
         participant__identifier="evaluations",
+        participant__platform=ChannelPlatform.EVALUATIONS,
         participant__team=experiment.team,
         **kwargs,
     )
@@ -440,9 +446,10 @@ class TestSurfaceCoverage:
         # The fixture's own message brings the total to one past two full batches.
         assert f"messages: {CHUNK_SIZE + 2}" in output.getvalue()
 
-    def test_scrubs_the_messages_copied_into_a_generation_session(self, chatbot, monkeypatch):
+    @pytest.mark.parametrize("on_working_version", [False, True], ids=["on-a-version", "on-the-working-chatbot"])
+    def test_scrubs_the_messages_copied_into_a_generation_session(self, chatbot, monkeypatch, on_working_version):
         """Bot generation replays the participant's history into the throwaway session's chat."""
-        generated = _generated_session(chatbot["experiment"], state={})
+        generated = _generated_session(chatbot["experiment"], on_working_version=on_working_version, state={})
         copied = ChatMessage.objects.create(
             chat=generated.chat, message_type=ChatMessageType.HUMAN, content=f"{SECRET} again"
         )
@@ -644,6 +651,24 @@ class TestScope:
         )
 
         assert ExperimentSession.objects.get(id=theirs.id).state == {"last_caller": SECRET}
+
+    def test_the_evaluations_participants_own_sessions_are_never_matched(self, chatbot, monkeypatch):
+        """A generation session on the working chatbot is visible to the filter.
+
+        The synthetic participant owns every generation session of every evaluation run, and
+        those hold copies of whatever the dataset contained, from any chatbot in the team. An
+        empty filter must not select it; its sessions are reached only through the evaluator
+        result that links each one to the participant it copied.
+        """
+        theirs = _generated_session(
+            chatbot["experiment"], on_working_version=True, state={"name": "Someone Else", "last_caller": SECRET}
+        )
+        output = StringIO()
+
+        _scrub(chatbot["experiment"], monkeypatch, stdout=output)
+
+        assert ExperimentSession.objects.get(id=theirs.id).state == {"name": "Someone Else", "last_caller": SECRET}
+        assert "Participants: 1" in output.getvalue()
 
 
 @pytest.mark.django_db()
@@ -906,6 +931,19 @@ class TestFilterArgumentGuard:
     def test_a_filter_that_would_not_narrow_the_scrub_is_refused(self, chatbot, monkeypatch, filter_query, message):
         """An unknown column, operator or value narrows nothing, which would scrub everyone."""
         with pytest.raises(CommandError, match=message):
+            _scrub(chatbot["experiment"], monkeypatch, answers=[], filter_query=filter_query)
+
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == f"Hi, {SECRET} here"
+
+    def test_each_filter_must_narrow_on_its_own(self, chatbot, monkeypatch):
+        """A no-op filter hiding behind a real one would scrub more than the operator confirmed."""
+        _other_participant(chatbot["experiment"], identifier="user2@example.com")
+        filter_query = (
+            f"f_participant=user1&op_participant={Operators.CONTAINS}"
+            f"&f_last_message=yesterday&op_last_message={Operators.ON}"
+        )
+
+        with pytest.raises(CommandError, match='"last_message on yesterday" matched every session'):
             _scrub(chatbot["experiment"], monkeypatch, answers=[], filter_query=filter_query)
 
         assert ChatMessage.objects.get(id=chatbot["message"].id).content == f"Hi, {SECRET} here"

--- a/apps/experiments/tests/test_scrub_participant_data_command.py
+++ b/apps/experiments/tests/test_scrub_participant_data_command.py
@@ -157,16 +157,9 @@ def _participant_data(chatbot):
 
 
 def _totals(printed: str) -> dict[str, int]:
-    """The per-surface counts from the command's closing totals block, as a dict.
-
-    Parsed rather than matched as substrings, so that a count printed for one surface cannot
-    stand in for another ("messages" is a substring of "evaluation_messages").
-    """
-    return {
-        label: int(count)
-        for label, _, count in (line.strip().partition(": ") for line in printed.splitlines())
-        if label in SURFACES
-    }
+    """Per-surface counts parsed from the printed totals block ("messages" also matches "evaluation_messages")."""
+    parsed = (line.strip().partition(": ") for line in printed.splitlines())
+    return {label: int(count) for label, _, count in parsed if label in SURFACES}
 
 
 def _other_participant(experiment, *, data=None, name=None, identifier=None, state=None):

--- a/apps/experiments/tests/test_scrub_participant_data_command.py
+++ b/apps/experiments/tests/test_scrub_participant_data_command.py
@@ -893,6 +893,14 @@ class TestFilterArgumentParsing:
                 "http://localhost:8000/a/team/chatbots/36/?f_participant=bob&op_participant=contains",
                 id="whole-url",
             ),
+            pytest.param(
+                "/a/team/chatbots/36/?f_participant=bob&op_participant=contains",
+                id="url-without-a-scheme",
+            ),
+            pytest.param(
+                "localhost:8000/a/team/chatbots/36/?f_participant=bob&op_participant=contains",
+                id="url-without-a-protocol",
+            ),
         ],
     )
     def test_equivalent_forms_produce_the_same_filter(self, raw):
@@ -907,6 +915,40 @@ class TestFilterArgumentParsing:
     )
     def test_an_empty_string_means_no_filter(self, raw):
         assert parse_filter_query_string(raw).filters == []
+
+    def test_every_filter_in_a_pasted_url_survives(self):
+        """A dropped filter widens the scrub, so losing one silently is the dangerous case."""
+        raw = "/a/team/chatbots/36/?f_participant=bob&op_participant=contains&f_state=active&op_state=any of"
+
+        filters = parse_filter_query_string(raw).filters
+
+        assert [(item.column, item.operator) for item in filters] == [
+            ("participant", "contains"),
+            ("state", "any of"),
+        ]
+
+    @pytest.mark.parametrize(
+        ("raw", "message"),
+        [
+            pytest.param(
+                "f_tags=x&op_tags=any of&amp;f_participant=bob&amp;op_participant=contains",
+                "separators are escaped",
+                id="html-escaped-separator",
+            ),
+            pytest.param("f_participant=user1", "with no operator", id="operator-missing"),
+            pytest.param("op_participant=equals", "with no value", id="value-missing"),
+            pytest.param(
+                "f_first_message=2026-01-01&op_first_message=after&f_first_message=2026-02-01",
+                "2 values but 1 operator",
+                id="mismatched-pair-counts",
+            ),
+            pytest.param("f_participant=&op_participant=equals", "Only 0 of the 1 filters", id="empty-value"),
+        ],
+    )
+    def test_a_filter_string_that_cannot_be_read_faithfully_is_refused(self, raw, message):
+        """Refusing beats guessing: every one of these silently drops a filter."""
+        with pytest.raises(CommandError, match=message):
+            parse_filter_query_string(raw)
 
 
 @pytest.mark.django_db()
@@ -939,6 +981,38 @@ class TestFilterArgumentGuard:
             _scrub(chatbot["experiment"], monkeypatch, answers=[], filter_query=filter_query)
 
         assert ChatMessage.objects.get(id=chatbot["message"].id).content == f"Hi, {SECRET} here"
+
+    @pytest.mark.parametrize(
+        "filter_query",
+        [
+            pytest.param("f_participant=user1&amp;op_participant=equals", id="html-escaped-separator"),
+            pytest.param("f_participant=user1", id="operator-missing"),
+            pytest.param("   ", id="whitespace-only"),
+        ],
+    )
+    def test_a_filter_string_that_did_not_survive_being_copied_writes_nothing(self, chatbot, monkeypatch, filter_query):
+        """Each of these would otherwise run with a wider filter than the operator pasted."""
+        with pytest.raises(CommandError):
+            _scrub(chatbot["experiment"], monkeypatch, answers=[], filter_query=filter_query)
+
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == f"Hi, {SECRET} here"
+
+    def test_a_pasted_url_narrows_to_the_participant_it_names(self, chatbot, monkeypatch):
+        """The end-to-end form: a scheme-less URL must not lose its first filter."""
+        other = _other_participant(chatbot["experiment"], identifier="user2@example.com", data={"name": SECRET})
+        other_records = _add_records(other)
+
+        _scrub(
+            chatbot["experiment"],
+            monkeypatch,
+            filter_query=(
+                f"/a/{chatbot['experiment'].team.slug}/chatbots/{chatbot['experiment'].id}/"
+                f"?f_participant=user1&op_participant={Operators.CONTAINS}"
+            ),
+        )
+
+        assert ChatMessage.objects.get(id=chatbot["message"].id).content == "Hi, [REDACTED] here"
+        assert ChatMessage.objects.get(id=other_records["message"].id).content == f"Hi, {SECRET} here"
 
     def test_each_filter_must_narrow_on_its_own(self, chatbot, monkeypatch):
         """A no-op filter hiding behind a real one would scrub more than the operator confirmed."""


### PR DESCRIPTION
### Product Description

A support engineer can now permanently remove a participant's personal details from a chatbot, on request, without deleting the conversations themselves.

The operator names a team and a chatbot, optionally narrows to a set of participants with a filter copied from the Sessions tab, then picks which participant-data keys to scrub and what to replace each one with. Everything is shown and confirmed before anything is written, and `--dry-run` reports the same thing without writing.

The values are overwritten across chat messages, chat names, session state, pipeline chat history, traces, evaluation messages, evaluator results, the throwaway sessions bot generation ran the participant's messages through, participant names and participant data. This cannot be undone.

Participant identifiers are deliberately left alone — they are the participant's identity and unique key. Out of reach: copies held by external trace providers, evaluation messages whose session has been deleted, and anything already exported elsewhere.

### Technical Description

New management command `scrub_participant_data <team_slug> <experiment_id> [--filter ...] [--dry-run]`.

Two primitives do the work:

- **Value-based text scan** — searches free text for the participant's own values. One alternation over all search terms, longest first, so one key's replacement cannot be re-matched by another key's rule and a value that is a prefix of another cannot consume the longer match.
- **Key-based JSON replacement** — rewrites a selected key's value at any depth regardless of type. This is what clears short and non-string values, which are too ambiguous to search for in prose. Because it matches at any depth, the command warns when a selected key collides with a name that carries the *structure* of those JSON blobs.

Notes on the design:

- Nothing is wrapped in a transaction, so each batch commits on its own. A participant's data row is written **after** every other surface of theirs, which makes an interrupted run safely re-runnable: the values still to be hunted for are read from that row.
- Participants are processed in chunks, since `ParticipantData.data` is decrypted on read.
- `--filter` is validated against `ExperimentSessionFilter`'s declared columns and operators. An unknown column or operator narrows nothing while still looking like a filter, which here would mean scrubbing the whole chatbot, so it is refused rather than ignored.
- The team slug is a required positional argument and part of the chatbot lookup; the session and participant querysets are scoped to that same team. The id alone is a bare number, and a mistyped one names a real chatbot in some other team.
- Start, per-chunk progress and completion are logged.

### Issue Link

N/A

### Migrations

- [x] The migrations are backwards compatible

No migrations.

### Demo

https://www.loom.com/share/79329f67908c4eb8b70af94912477bf9

Recorded before the team slug was added as a parameter, so the invocation in the video is missing that first argument.

### Docs and Changelog

- [ ] This PR requires docs/changelog update

### Operator Impact

- [ ] Self-hosted operators must know about or act on this change
