### PR TITLE
Make ColumnFilter.prepare() stateless

### DIFF
--- a/apps/experiments/filters.py
+++ b/apps/experiments/filters.py
@@ -96,8 +96,9 @@ class ChatMessageTagsFilter(ChoiceColumnFilter):
     type: str = TYPE_CHOICE
     description: str = "Filter by tags on sessions or messages"
 
-    def prepare(self, team, **_):
-        self.options = [tag.name for tag in team.tag_set.filter(is_system_tag=False)]
+    def prepare(self, team, **_) -> "ChatMessageTagsFilter":
+        options = [tag.name for tag in team.tag_set.filter(is_system_tag=False)]
+        return self.model_copy(update={"options": options})
 
     def _chat_or_message_tag_exists(self, tag_names):
         """Match outer rows whose chat, or any of the chat's messages, carries one of ``tag_names``.
@@ -161,8 +162,9 @@ class MessageTagsFilter(ChoiceColumnFilter):
     type: str = TYPE_CHOICE
     description: str = "Filter by tags on messages"
 
-    def prepare(self, team, **_):
-        self.options = [tag.name for tag in team.tag_set.filter(is_system_tag=False)]
+    def prepare(self, team, **_) -> "MessageTagsFilter":
+        options = [tag.name for tag in team.tag_set.filter(is_system_tag=False)]
+        return self.model_copy(update={"options": options})
 
     def apply_any_of(self, queryset, value, timezone=None):
         return queryset.filter(_message_tag_exists(value))
@@ -181,9 +183,10 @@ class VersionsFilter(ChoiceColumnFilter):
     label: str = "Versions"
     description: str = "Filter by chatbot version (e.g. v1, v2)"
 
-    def prepare(self, team, **kwargs):
+    def prepare(self, team, **kwargs) -> "VersionsFilter":
         single_experiment = kwargs.get("single_experiment")
-        self.options = Experiment.objects.get_version_names(team, working_version=single_experiment)  # ty: ignore[invalid-assignment]
+        options = Experiment.objects.get_version_names(team, working_version=single_experiment)
+        return self.model_copy(update={"options": options})
 
     def _get_version_numbers(self, version_names):
         """Convert version names to numbers removing the 'v' prefix from 'v1'."""
@@ -214,9 +217,10 @@ class MessageVersionsFilter(ChoiceColumnFilter):
     label: str = "Versions"
     description: str = "Filter by message version"
 
-    def prepare(self, team, **kwargs):
+    def prepare(self, team, **kwargs) -> "MessageVersionsFilter":
         single_experiment = kwargs.get("single_experiment")
-        self.options = Experiment.objects.get_version_names(team, working_version=single_experiment)  # ty: ignore[invalid-assignment]
+        options = Experiment.objects.get_version_names(team, working_version=single_experiment)
+        return self.model_copy(update={"options": options})
 
     def apply_any_of(self, queryset, value, timezone=None):
         return queryset.filter(_message_tag_exists(value, category=Chat.MetadataKeys.EXPERIMENT_VERSION))
@@ -237,12 +241,12 @@ class ChannelsFilter(ChoiceColumnFilter):
     description: str = "Filter by messaging platform/channel"
     exclude_platforms: list[str] = []
 
-    def prepare(self, team, **_):
+    def prepare(self, team, **_) -> "ChannelsFilter":
         options = ChannelPlatform.for_filter(team)
         if self.exclude_platforms:
             excluded_labels = {ChannelPlatform(p).label for p in self.exclude_platforms}
             options = [o for o in options if o not in excluded_labels]
-        self.options = options  # ty: ignore[invalid-assignment]
+        return self.model_copy(update={"options": options})
 
     def parse_query_value(self, query_value) -> any:
         selected_display_names = self.values_list(query_value)

--- a/apps/help/agents/filter.py
+++ b/apps/help/agents/filter.py
@@ -59,8 +59,7 @@ def make_get_options_tool(filter_class, team):
 
         if param not in _options_cache:
             try:
-                instance = filter_component.model_copy(deep=True)
-                instance.prepare(team)
+                instance = filter_component.prepare(team)
 
                 normalized = []
                 for opt in instance.options:

--- a/apps/help/tests/test_filter_agent.py
+++ b/apps/help/tests/test_filter_agent.py
@@ -157,21 +157,24 @@ class TestMakeGetOptionsTool:
 
         assert "error" in result
 
-    def test_prepare_is_called_with_team(self):
-        """prepare(team) must be called so DB-backed filters load options."""
+    def test_prepare_is_called_with_team_and_its_return_value_is_used(self):
+        """prepare(team) must be called, and the filter it *returns* (not the original instance)
+        must supply the options -- prepare() no longer mutates in place. See #4363."""
         choice_filter = mock.Mock(spec=ChoiceColumnFilter)
         choice_filter.query_param = "experiment"
-        choice_filter.options = [{"id": 99, "label": "Mocked"}]
-        # model_copy(deep=True) should return the mock itself for simplicity
-        choice_filter.model_copy.return_value = choice_filter
+        prepared = mock.Mock(spec=ChoiceColumnFilter)
+        prepared.options = [{"id": 99, "label": "Mocked"}]
+        choice_filter.prepare.return_value = prepared
 
         filter_class = self._make_filter_class([choice_filter])
         team = mock.Mock()
 
         tool_fn = make_get_options_tool(filter_class, team)
-        tool_fn.invoke({"param": "experiment"})
+        result = tool_fn.invoke({"param": "experiment"})
 
         choice_filter.prepare.assert_called_once_with(team)
+        choice_filter.model_copy.assert_not_called()
+        assert result["options"] == [{"id": 99, "label": "Mocked"}]
 
 
 class TestFilterAgentRun:

--- a/apps/human_annotations/filters.py
+++ b/apps/human_annotations/filters.py
@@ -41,7 +41,7 @@ class ReviewerFilter(ChoiceColumnFilter):
     label: str = "Reviewer"
     description: str = "Filter by reviewer who annotated the item"
 
-    def prepare(self, team, **kwargs):
+    def prepare(self, team, **kwargs) -> "ReviewerFilter":
         reviewers = (
             User.objects.filter(
                 annotations__item__queue__team=team,
@@ -50,10 +50,11 @@ class ReviewerFilter(ChoiceColumnFilter):
             .distinct()
             .values("id", "username", "first_name", "last_name")
         )
-        self.options = [
+        options = [
             {"id": str(r["id"]), "label": r["first_name"] + " " + r["last_name"] if r["first_name"] else r["username"]}
             for r in reviewers
         ]
+        return self.model_copy(update={"options": options})
 
     def parse_query_value(self, query_value):
         values = self.values_list(query_value)

--- a/apps/ocs_notifications/filters.py
+++ b/apps/ocs_notifications/filters.py
@@ -64,10 +64,11 @@ class TeamFilter(ChoiceColumnFilter):
     column: str = "team_id"
     label: str = "Team"
 
-    def prepare(self, team, **kwargs):
+    def prepare(self, team, **kwargs) -> "TeamFilter":
         user = kwargs.get("user")
         teams = user.teams.all().order_by("name") if user else []
-        self.options = [{"id": t.id, "label": t.name} for t in teams]
+        options = [{"id": t.id, "label": t.name} for t in teams]
+        return self.model_copy(update={"options": options})
 
     def parse_query_value(self, value) -> list[int] | None:  # ty: ignore[invalid-method-override]
         values = []

--- a/apps/ocs_notifications/tests/test_filters.py
+++ b/apps/ocs_notifications/tests/test_filters.py
@@ -6,6 +6,8 @@ from django.test import RequestFactory
 from apps.ocs_notifications.filters import (
     EXPLICIT_FILTERS_PARAM,
     SeverityLevelFilter,
+    TeamFilter,
+    UserNotificationFilter,
     build_toggle_options,
     resolve_notification_filter_params,
 )
@@ -103,3 +105,27 @@ class TestResolveNotificationFilterParams:
         filter_params = resolve_notification_filter_params(request)
 
         assert [f.column for f in filter_params.filters] == ["read"]
+
+
+@pytest.mark.django_db()
+class TestTeamFilterPrepare:
+    """TeamFilter.prepare() must return a new, populated instance and leave both the original
+    and the UserNotificationFilter.filters singleton untouched. See #4363."""
+
+    def test_prepare_returns_a_new_instance_with_the_users_teams(self, team_with_users):
+        user = team_with_users.members.first()
+        original = TeamFilter()
+
+        prepared = original.prepare(team_with_users, user=user)
+
+        assert prepared is not original
+        assert original.options == []
+        assert [opt["id"] for opt in prepared.options] == [team_with_users.id]
+
+    def test_columns_leaves_the_shared_team_filter_singleton_untouched(self, team_with_users):
+        user = team_with_users.members.first()
+        shared_team_filter = next(f for f in UserNotificationFilter.filters if isinstance(f, TeamFilter))
+
+        UserNotificationFilter.columns(team=team_with_users, user=user)
+
+        assert shared_team_filter.options == []

--- a/apps/ocs_notifications/views.py
+++ b/apps/ocs_notifications/views.py
@@ -47,11 +47,10 @@ def get_notification_toggle_context(request) -> dict:
     # response (for the out-of-band button refresh), and the pushed URL must always be the
     # notifications page, not wherever the request that built it happened to land.
     context = {"notifications_home_url": reverse("ocs_notifications:notifications_home")}
-    level_filter = SeverityLevelFilter().model_copy(deep=True)
+    level_filter = SeverityLevelFilter()
     context["level_toggle_options"] = build_toggle_options(level_filter, request)
 
-    team_filter = TeamFilter().model_copy(deep=True)
-    team_filter.prepare(request.team, user=request.user)
+    team_filter = TeamFilter().prepare(request.team, user=request.user)
     if len(team_filter.options) < TEAM_TOGGLE_BUTTON_THRESHOLD:
         context["team_toggle_options"] = build_toggle_options(team_filter, request)
 

--- a/apps/trace/filters.py
+++ b/apps/trace/filters.py
@@ -41,10 +41,11 @@ class MessageTagsFilter(ChoiceColumnFilter):
     label: str = "Message Tags"
     type: str = TYPE_CHOICE
 
-    def prepare(self, team, **_):
-        self.options = list(
+    def prepare(self, team, **_) -> "MessageTagsFilter":
+        options = list(
             team.tag_set.filter(is_system_tag=False).values_list("name", flat=True).order_by("name").distinct()
         )
+        return self.model_copy(update={"options": options})
 
     def _input_or_output_message_tag_exists(self, tag_names: list[str]):
         """Build a Q matching traces whose input or output message carries one of ``tag_names``."""
@@ -84,8 +85,8 @@ class ExperimentVersionsFilter(ChoiceColumnFilter):
         # versions are returned as strings like "v1", "v2", so we need to strip the "v" and convert to int
         return [int(v[1:]) for v in values if "v" in v]
 
-    def prepare(self, team, **kwargs):
-        self.options = Experiment.objects.get_version_names(team)  # ty: ignore[invalid-assignment]
+    def prepare(self, team, **kwargs) -> "ExperimentVersionsFilter":
+        return self.model_copy(update={"options": Experiment.objects.get_version_names(team)})
 
 
 class TraceStatusFilter(ChoiceColumnFilter):

--- a/apps/web/dynamic_filters/base.py
+++ b/apps/web/dynamic_filters/base.py
@@ -92,10 +92,7 @@ class MultiColumnFilter:
 
     @classmethod
     def columns(cls, team, **kwargs) -> dict[str, dict]:
-        # Create per-call copies to avoid mutating shared instances
-        instances = [f.model_copy(deep=True) for f in cls.filters]
-        for filter_component in instances:
-            filter_component.prepare(team, **kwargs)
+        instances = [f.prepare(team, **kwargs) for f in cls.filters]
         return {filter_component.query_param: filter_component.model_dump() for filter_component in instances}
 
     def prepare_queryset(self, queryset):
@@ -147,8 +144,10 @@ class ColumnFilter(BaseModel):
     def operators(self) -> list[Operators]:
         return FIELD_TYPE_FILTERS[self.type]
 
-    def prepare(self, team, **kwargs):
-        pass
+    def prepare(self, team, **kwargs) -> ColumnFilter:
+        """Return this filter, or a copy with options set -- `filters` lists on
+        MultiColumnFilter subclasses are shared, so a subclass must not mutate `self` here."""
+        return self
 
     def values_list(self, json_value: str) -> list[str]:
         try:

--- a/apps/web/dynamic_filters/column_filters.py
+++ b/apps/web/dynamic_filters/column_filters.py
@@ -24,11 +24,12 @@ class ExperimentFilter(ChoiceColumnFilter):
         "to look up the ID for a chatbot name. Do NOT use the chatbot name string as a value."
     )
 
-    def prepare(self, team, **_):
+    def prepare(self, team, **_) -> "ExperimentFilter":
         experiments = (
             Experiment.objects.working_versions_queryset().filter(team=team).values("id", "name").order_by("name")
         )
-        self.options = [{"id": exp["id"], "label": exp["name"]} for exp in experiments]
+        options = [{"id": exp["id"], "label": exp["name"]} for exp in experiments]
+        return self.model_copy(update={"options": options})
 
     def parse_query_value(self, value) -> list[int]:  # ty: ignore[invalid-method-override]
         values = []

--- a/apps/web/dynamic_filters/tests/test_base.py
+++ b/apps/web/dynamic_filters/tests/test_base.py
@@ -2,6 +2,7 @@ import pytest
 
 from apps.experiments.filters import ExperimentSessionFilter
 from apps.utils.factories.experiment import ExperimentSessionFactory
+from apps.web.dynamic_filters.base import ChoiceColumnFilter
 from apps.web.dynamic_filters.datastructures import FilterParams
 
 
@@ -13,3 +14,21 @@ def test_apply_does_not_emit_distinct_when_no_filters_applied():
     filtered = ExperimentSessionFilter().apply(queryset, FilterParams())
     sql = str(filtered.query).upper()
     assert "DISTINCT" not in sql, sql
+
+
+def test_prepare_default_returns_self():
+    """A filter with no prepare() override (most of them) must still satisfy the contract that
+    .prepare() returns a filter, not None. See #4363."""
+    f = ChoiceColumnFilter(query_param="x", label="X")
+
+    assert f.prepare(team=None) is f
+
+
+@pytest.mark.django_db()
+def test_columns_handles_a_mix_of_overridden_and_default_prepare(team):
+    """ExperimentSessionFilter.filters mixes filters that override prepare() (VersionsFilter,
+    ChannelsFilter, ...) with ones that rely on the base no-op. columns() must not crash on
+    either kind. See #4363."""
+    columns = ExperimentSessionFilter.columns(team)
+
+    assert set(columns) == {f.query_param for f in ExperimentSessionFilter.filters}


### PR DESCRIPTION
### Product Description

No user-facing change. Internal refactor of the dynamic-filter API.

### Technical Description

`ColumnFilter.prepare()` used to mutate `self.options` and return `None`, relying on every caller to copy the instance first since `MultiColumnFilter.filters` lists are shared `ClassVar` instances. Two of three callers did; the third copied an already-unshared instance for no reason.

`prepare()` now returns a new instance (`self.model_copy(update={"options": [...]})`) instead of mutating. The base no-op and all 9 overrides are converted, and the three callers (`MultiColumnFilter.columns()`, `get_notification_toggle_context`, the help-bot's `get_filter_options` tool) are updated to use the return value instead of the old mutated variable.

Full design doc: #4363 (comment).

### Issue Link

Closes #4363

### Demo

No UI change, verified via Django's test client and manual DB inspection that `columns()`, the notifications toggle context, and the help-bot's filter tool all still populate real options correctly (experiments, tags, versions, channels, teams).

### Docs and Changelog
- [ ] This PR requires docs/changelog update

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change
