### PR TITLE
Keep pipelines running when their LLM model is deprecated

### DIFF
--- a/api-schemas/v2.yml
+++ b/api-schemas/v2.yml
@@ -1676,11 +1676,20 @@ components:
             every output handle with no outgoing edge and every implicit ``input``
             handle with no incoming edge. Never an error and never blocks a publish.'
           readOnly: true
+        deprecated_models:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/DeprecatedModel'
+          description: Advisory map, keyed by ``node_id``, of nodes referencing a
+            deprecated LLM model. The model keeps working until it is removed, so
+            this is never an error and never blocks a publish.
+          readOnly: true
         events:
           $ref: '#/components/schemas/InspectEvents'
       required:
       - channels
       - consent_form
+      - deprecated_models
       - events
       - id
       - is_published_version

--- a/api-schemas/v2.yml
+++ b/api-schemas/v2.yml
@@ -1859,6 +1859,20 @@ components:
       required:
       - llm_provider_id
       - llm_provider_model_id
+    DeprecatedModel:
+      type: object
+      description: The model a node still points at, and what to move it to.
+      properties:
+        model:
+          type: string
+          description: Name of the deprecated model the node references.
+        replacement:
+          type: string
+          nullable: true
+          description: Name of the model to migrate to, or null where none is declared.
+      required:
+      - model
+      - replacement
     EdgeCreate:
       type: object
       description: |-
@@ -1918,7 +1932,16 @@ components:
           description: 'Advisory ''what still needs wiring'' map, keyed by ``node_id``:
             every output handle with no outgoing edge and every implicit ``input``
             handle with no incoming edge. Never an error and never blocks a publish.'
+        deprecated_models:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/DeprecatedModel'
+          description: Advisory map, keyed by ``node_id``, of nodes referencing a
+            deprecated LLM model. The model keeps working until it is removed, so
+            this is never an error and never blocks a publish -- but a new node may
+            not be pointed at one.
       required:
+      - deprecated_models
       - edges
       - pipeline_errors
       - pipeline_valid
@@ -2854,7 +2877,16 @@ components:
           description: 'Advisory ''what still needs wiring'' map, keyed by ``node_id``:
             every output handle with no outgoing edge and every implicit ``input``
             handle with no incoming edge. Never an error and never blocks a publish.'
+        deprecated_models:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/DeprecatedModel'
+          description: Advisory map, keyed by ``node_id``, of nodes referencing a
+            deprecated LLM model. The model keeps working until it is removed, so
+            this is never an error and never blocks a publish -- but a new node may
+            not be pointed at one.
       required:
+      - deprecated_models
       - node
       - pipeline_errors
       - pipeline_valid
@@ -3103,11 +3135,8 @@ components:
             rule.
     PipelineWrite:
       type: object
-      description: |-
-        What every façade write reports back about the pipeline it just changed.
-
-        The same three fields the `chatbot_inspect` endpoint publishes, so one shape is parsed across
-        read and write.
+      description: What every façade write reports back about the pipeline it just
+        changed.
       properties:
         pipeline_valid:
           type: boolean
@@ -3124,7 +3153,16 @@ components:
           description: 'Advisory ''what still needs wiring'' map, keyed by ``node_id``:
             every output handle with no outgoing edge and every implicit ``input``
             handle with no incoming edge. Never an error and never blocks a publish.'
+        deprecated_models:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/DeprecatedModel'
+          description: Advisory map, keyed by ``node_id``, of nodes referencing a
+            deprecated LLM model. The model keeps working until it is removed, so
+            this is never an error and never blocks a publish -- but a new node may
+            not be pointed at one.
       required:
+      - deprecated_models
       - pipeline_errors
       - pipeline_valid
       - unwired_handles

--- a/apps/api/v2/inspect/serializers.py
+++ b/apps/api/v2/inspect/serializers.py
@@ -741,6 +741,16 @@ class PipelineBuildErrorsSerializer(serializers.Serializer):
     )
 
 
+class DeprecatedModelSerializer(serializers.Serializer):
+    """The model a node still points at, and what to move it to."""
+
+    model = serializers.CharField(help_text="Name of the deprecated model the node references.")
+    replacement = serializers.CharField(
+        allow_null=True,
+        help_text="Name of the model to migrate to, or null where none is declared.",
+    )
+
+
 class ChatbotInspectSerializer(serializers.ModelSerializer):
     """The whole chatbot configuration in one read-only response (ADR-0024).
 
@@ -770,6 +780,7 @@ class ChatbotInspectSerializer(serializers.ModelSerializer):
     pipeline_valid = serializers.SerializerMethodField(help_text=("Whether this chatbot's pipeline validates cleanly"))
     pipeline_errors = serializers.SerializerMethodField()
     unwired_handles = serializers.SerializerMethodField()
+    deprecated_models = serializers.SerializerMethodField()
     events = InspectEventsSerializer(source="*")
 
     class Meta:
@@ -793,6 +804,7 @@ class ChatbotInspectSerializer(serializers.ModelSerializer):
             "pipeline_valid",
             "pipeline_errors",
             "unwired_handles",
+            "deprecated_models",
             "events",
         ]
 
@@ -834,6 +846,19 @@ class ChatbotInspectSerializer(serializers.ModelSerializer):
     )
     def get_unwired_handles(self, experiment) -> dict:
         return self._build_state(experiment)["unwired_handles"]
+
+    @extend_schema_field(
+        serializers.DictField(
+            child=DeprecatedModelSerializer(),
+            help_text=(
+                "Advisory map, keyed by ``node_id``, of nodes referencing a deprecated LLM model. "
+                "The model keeps working until it is removed, so this is never an error and never "
+                "blocks a publish."
+            ),
+        )
+    )
+    def get_deprecated_models(self, experiment) -> dict:
+        return self._build_state(experiment)["deprecated_models"]
 
 
 # ── Schema extensions ──────────────────────────────────────────────────────────────────────────

--- a/apps/api/v2/pipeline_edit/serializers.py
+++ b/apps/api/v2/pipeline_edit/serializers.py
@@ -5,7 +5,11 @@ from typing import Any
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from apps.api.v2.inspect.serializers import OutputHandleSerializer, PipelineBuildErrorsSerializer
+from apps.api.v2.inspect.serializers import (
+    DeprecatedModelSerializer,
+    OutputHandleSerializer,
+    PipelineBuildErrorsSerializer,
+)
 from apps.api.v2.write.base import RejectsUnknownKeys
 from apps.pipelines.build_state import node_output_handles
 from apps.pipelines.models import Node
@@ -120,16 +124,6 @@ class NodeUpdateSerializer(RejectsServerAssignedKeys, RejectsUnknownKeys, serial
         required=False,
         default=dict,
         help_text="The params to change; the ones you leave out are left as they are. " + PARAM_NAMES,
-    )
-
-
-class DeprecatedModelSerializer(serializers.Serializer):
-    """The model a node still points at, and what to move it to."""
-
-    model = serializers.CharField(help_text="Name of the deprecated model the node references.")
-    replacement = serializers.CharField(
-        allow_null=True,
-        help_text="Name of the model to migrate to, or null where none is declared.",
     )
 
 

--- a/apps/api/v2/pipeline_edit/serializers.py
+++ b/apps/api/v2/pipeline_edit/serializers.py
@@ -123,12 +123,18 @@ class NodeUpdateSerializer(RejectsServerAssignedKeys, RejectsUnknownKeys, serial
     )
 
 
-class PipelineWriteSerializer(serializers.Serializer):
-    """What every façade write reports back about the pipeline it just changed.
+class DeprecatedModelSerializer(serializers.Serializer):
+    """The model a node still points at, and what to move it to."""
 
-    The same three fields the `chatbot_inspect` endpoint publishes, so one shape is parsed across
-    read and write.
-    """
+    model = serializers.CharField(help_text="Name of the deprecated model the node references.")
+    replacement = serializers.CharField(
+        allow_null=True,
+        help_text="Name of the model to migrate to, or null where none is declared.",
+    )
+
+
+class PipelineWriteSerializer(serializers.Serializer):
+    """What every façade write reports back about the pipeline it just changed."""
 
     pipeline_valid = serializers.BooleanField(
         help_text="Whether the pipeline validates cleanly: all three error buckets empty, and nothing more."
@@ -140,6 +146,14 @@ class PipelineWriteSerializer(serializers.Serializer):
             "Advisory 'what still needs wiring' map, keyed by ``node_id``: every output handle with "
             "no outgoing edge and every implicit ``input`` handle with no incoming edge. Never an "
             "error and never blocks a publish."
+        ),
+    )
+    deprecated_models = serializers.DictField(
+        child=DeprecatedModelSerializer(),
+        help_text=(
+            "Advisory map, keyed by ``node_id``, of nodes referencing a deprecated LLM model. The "
+            "model keeps working until it is removed, so this is never an error and never blocks a "
+            "publish -- but a new node may not be pointed at one."
         ),
     )
 

--- a/apps/api/v2/pipeline_edit/tests/test_deprecated_models.py
+++ b/apps/api/v2/pipeline_edit/tests/test_deprecated_models.py
@@ -1,0 +1,76 @@
+"""What the façade does about a deprecated LLM model: refuses it as a new value, reports an
+existing one as advisory.
+
+The two halves pull in opposite directions on purpose. A deprecated model is on its way out, so a
+client may not newly point a node at one; but the teams already on one are inside a migration
+window, and a write that refused to touch such a node would trap them in it.
+"""
+
+import pytest
+
+from apps.utils.factories.service_provider_factories import LlmProviderModelFactory
+
+from .conftest import add_llm_node, node_url, nodes_url
+
+
+@pytest.fixture()
+def deprecated_model(team):
+    return LlmProviderModelFactory.create(team=team, type="openai", name="gpt-3.5-turbo", deprecated=True)
+
+
+@pytest.mark.django_db()
+def test_a_new_node_cannot_be_pointed_at_a_deprecated_model(client, chatbot, llm, deprecated_model):
+    provider, _ = llm
+
+    response = client.post(
+        nodes_url(chatbot),
+        {
+            "type": "LLMResponseWithPrompt",
+            "params": {"llm_provider_id": provider.id, "llm_provider_model_id": deprecated_model.id},
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400, response.content
+    assert "llm_provider_model_id" in response.json()["params"]
+
+
+@pytest.mark.django_db()
+def test_an_existing_node_cannot_be_moved_onto_a_deprecated_model(client, chatbot, llm, deprecated_model):
+    node_id = add_llm_node(client, chatbot, llm)
+
+    response = client.patch(
+        node_url(chatbot, node_id), {"params": {"llm_provider_model_id": deprecated_model.id}}, format="json"
+    )
+
+    assert response.status_code == 400, response.content
+    assert "llm_provider_model_id" in response.json()["params"]
+
+
+@pytest.mark.django_db()
+def test_a_node_already_on_a_deprecated_model_stays_writable(client, chatbot, llm, deprecated_model):
+    """The migration window in practice: the model is deprecated under a team that already uses it,
+    and every other edit to that node has to keep working -- including the edit that moves it off."""
+    provider, live_model = llm
+    node_id = add_llm_node(client, chatbot, llm)
+    client.patch(node_url(chatbot, node_id), {"params": {"llm_provider_model_id": live_model.id}}, format="json")
+    replacement = LlmProviderModelFactory.create(team=chatbot.team, type="openai", name="gpt-4.1-mini")
+    live_model.deprecated = True
+    live_model.save()
+
+    renamed = client.patch(node_url(chatbot, node_id), {"label": "Answer the question"}, format="json")
+
+    assert renamed.status_code == 200, renamed.content
+    body = renamed.json()
+    assert body["pipeline_valid"] is True
+    assert body["pipeline_errors"] == {"node": {}, "edge": [], "pipeline": []}
+    assert body["deprecated_models"] == {node_id: {"model": "gpt-4o", "replacement": None}}
+
+    moved = client.patch(
+        node_url(chatbot, node_id),
+        {"params": {"llm_provider_id": provider.id, "llm_provider_model_id": replacement.id}},
+        format="json",
+    )
+
+    assert moved.status_code == 200, moved.content
+    assert moved.json()["deprecated_models"] == {}

--- a/apps/api/v2/pipeline_edit/tests/test_facade.py
+++ b/apps/api/v2/pipeline_edit/tests/test_facade.py
@@ -230,7 +230,9 @@ class TestTheResponseEnvelope:
 #: the locked read and once for the rebuild after the write. They buy ``custom_actions`` being served
 #: from those rows rather than from the copy in params, and the count does not move with the number
 #: of nodes -- without them each node would read the table itself.
-QUERIES_UNDER_THE_LOCK = 29
+#: One is ``deprecated_models``, a single statement for the whole graph that does not move with the
+#: number of nodes.
+QUERIES_UNDER_THE_LOCK = 30
 
 
 #: How many statements a wire may run while it holds the pipeline row, on this test's own graph.
@@ -244,14 +246,14 @@ QUERIES_UNDER_THE_LOCK = 29
 #: 17 is that revert. Every extra node on the fixture graph costs 2 (``pipeline_state`` validates each
 #: one), so a failure at 12 is someone having changed the fixture. Raising it deliberately is a
 #: decision about how long the row is held: say in the commit what the extra statements buy.
-WIRE_QUERIES_UNDER_THE_LOCK = 10
+WIRE_QUERIES_UNDER_THE_LOCK = 11
 
 
 @pytest.mark.django_db()
 def test_wiring_does_not_reconcile_the_node_rows(client, chatbot, llm, start_node, end_node):
     """An edge-only diff cannot change a node row, so ``_persist`` skips the reconcile -- and with
     it the rebuild that would have discarded the ``node_set`` prefetch the locked read just paid for.
-    The absolute count is what pins that: reverting the skip takes it from 10 to 17, while a
+    The absolute count is what pins that: reverting the skip takes it from 11 to 18, while a
     comparison against the node path would not, wiring being cheaper either way.
     """
     node_id = add_llm_node(client, chatbot, llm)

--- a/apps/api/v2/pipeline_edit/views.py
+++ b/apps/api/v2/pipeline_edit/views.py
@@ -17,7 +17,7 @@ from apps.api.permissions import BASE_PERMISSION_CLASSES
 from apps.api.v2.discovery.node_types import get_node_class
 from apps.api.v2.write.base import ChatbotCompositionPermission, DescribesPatch
 from apps.oauth.permissions import TokenHasOAuthResourceScope
-from apps.pipelines.build_state import deprecated_models, pipeline_build_state
+from apps.pipelines.build_state import pipeline_build_state
 from apps.pipelines.flow import FlowEdge
 from apps.pipelines.models import Pipeline
 
@@ -455,5 +455,5 @@ def pipeline_state(pipeline: Pipeline) -> dict:
         "pipeline_valid": state["pipeline_valid"],
         "pipeline_errors": state["errors"],
         "unwired_handles": state["unwired_handles"],
-        "deprecated_models": deprecated_models(pipeline),
+        "deprecated_models": state["deprecated_models"],
     }

--- a/apps/api/v2/pipeline_edit/views.py
+++ b/apps/api/v2/pipeline_edit/views.py
@@ -17,7 +17,7 @@ from apps.api.permissions import BASE_PERMISSION_CLASSES
 from apps.api.v2.discovery.node_types import get_node_class
 from apps.api.v2.write.base import ChatbotCompositionPermission, DescribesPatch
 from apps.oauth.permissions import TokenHasOAuthResourceScope
-from apps.pipelines.build_state import pipeline_build_state
+from apps.pipelines.build_state import deprecated_models, pipeline_build_state
 from apps.pipelines.flow import FlowEdge
 from apps.pipelines.models import Pipeline
 
@@ -449,10 +449,11 @@ class PipelineEdgeEditView(PipelineFacadeView):
 
 
 def pipeline_state(pipeline: Pipeline) -> dict:
-    """The three fields every façade write reports about the pipeline it has just changed."""
+    """The fields every façade write reports about the pipeline it has just changed."""
     state = pipeline_build_state(pipeline)
     return {
         "pipeline_valid": state["pipeline_valid"],
         "pipeline_errors": state["errors"],
         "unwired_handles": state["unwired_handles"],
+        "deprecated_models": deprecated_models(pipeline),
     }

--- a/apps/api/v2/tests/test_chatbots_inspect.py
+++ b/apps/api/v2/tests/test_chatbots_inspect.py
@@ -12,7 +12,7 @@ from apps.channels.models import ChannelPlatform, ExperimentChannel
 from apps.events.models import EventActionType
 from apps.experiments.models import Experiment
 from apps.files.models import File
-from apps.pipelines.tests.utils import create_pipeline_model, end_node, start_node
+from apps.pipelines.tests.utils import create_pipeline_model, end_node, llm_response_node, start_node
 from apps.teams.utils import current_team
 from apps.utils.deletion import delete_object_with_auditing_of_related_objects
 from apps.utils.factories.assistants import OpenAiAssistantFactory
@@ -417,6 +417,27 @@ def test_build_state_valid_and_fully_wired():
     assert payload["pipeline_valid"] is True
     assert payload["pipeline_errors"] == {"node": {}, "edge": [], "pipeline": []}
     assert payload["unwired_handles"] == {}
+
+
+@pytest.mark.django_db()
+def test_build_state_reports_a_nodes_deprecated_model():
+    """Deprecation is a migration window, not a fault, so it rides alongside a clean build state
+    rather than in the errors report. The mapping itself is covered in ``test_build_state``."""
+    team = TeamWithUsersFactory.create()
+    provider = LlmProviderFactory.create(team=team, type="openai")
+    # A name absent from DEFAULT_LLM_PROVIDER_MODELS, so no replacement is declared for it.
+    model = LlmProviderModelFactory.create(team=team, type="openai", name="retired-model", deprecated=True)
+    llm = llm_response_node(str(provider.id), str(model.id))
+    pipeline = PipelineFactory.create(team=team)
+    create_pipeline_model([start_node(), llm, end_node()], pipeline=pipeline)
+    pipeline.save()
+    experiment = ExperimentFactory.create(team=team, pipeline=pipeline)
+
+    payload = _client(experiment).get(_inspect_url(experiment)).json()
+
+    assert payload["deprecated_models"] == {llm["id"]: {"model": "retired-model", "replacement": None}}
+    assert payload["pipeline_valid"] is True
+    assert payload["pipeline_errors"] == {"node": {}, "edge": [], "pipeline": []}
 
 
 @pytest.mark.django_db()
@@ -861,6 +882,7 @@ def _expected_full_response(bot):
         },
         # `assist` has no derivable handles, so nothing of its is reported unwired.
         "unwired_handles": {"llm": [{"handle": "input", "label": None}]},
+        "deprecated_models": {},
         "events": _expected_events(bot),
     }
 
@@ -958,8 +980,9 @@ def _adversarial_bot():
 # every mode, so folding it into the measured block keeps the count constant. The top-level build-state
 # fields run Pipeline.validate(), whose LLM-node validators each look the provider model up through
 # ORMRepository (not the prefetched relation) — the same cost the builder pays on save; that adds a
-# fixed number of queries for this bot's two LLM-bearing nodes.
-EXPECTED_RENDER_QUERIES = 17
+# fixed number of queries for this bot's two LLM-bearing nodes. ``deprecated_models`` adds one more:
+# a single lookup covering every model the graph references, whatever the node fan-out.
+EXPECTED_RENDER_QUERIES = 18
 
 
 @pytest.mark.django_db()

--- a/apps/api/v2/tests/test_inspect_schema.py
+++ b/apps/api/v2/tests/test_inspect_schema.py
@@ -38,6 +38,7 @@ def test_inspect_component_documents_the_payload_envelope(api_schema):
         "pipeline_valid",
         "pipeline_errors",
         "unwired_handles",
+        "deprecated_models",
         "events",
     }
 

--- a/apps/data_migrations/management/commands/notify_deprecated_models.py
+++ b/apps/data_migrations/management/commands/notify_deprecated_models.py
@@ -1,6 +1,6 @@
 from apps.data_migrations.management.commands.base import IdempotentCommand, get_affected_teams_data
 from apps.ocs_notifications.notifications import AffectedResources, deprecated_model_notification
-from apps.service_providers.llm_service.default_models import DEFAULT_LLM_PROVIDER_MODELS
+from apps.service_providers.llm_service.default_models import get_deprecated_models
 from apps.service_providers.models import LlmProviderModel
 from apps.teams.models import Team
 
@@ -11,13 +11,7 @@ class Command(IdempotentCommand):
     disable_audit = True
 
     def perform_migration(self, dry_run=False):
-        # Find all deprecated models (with or without a replacement)
-        deprecated_with_replacement = {}
-        for provider_type, provider_models in DEFAULT_LLM_PROVIDER_MODELS.items():
-            for model in provider_models:
-                if model.deprecated:
-                    deprecated_with_replacement[(provider_type, model.name)] = model.replacement or None
-
+        deprecated_with_replacement = get_deprecated_models()
         if not deprecated_with_replacement:
             self.stdout.write(self.style.SUCCESS("No deprecated models found"))
             return

--- a/apps/data_migrations/tests/test_notify_deprecated_models.py
+++ b/apps/data_migrations/tests/test_notify_deprecated_models.py
@@ -36,7 +36,7 @@ class TestNotifyDeprecatedModelsCommand:
         """If no models are deprecated, nothing happens."""
         no_deprecated = {"openai": [Model("gpt-4o", 128000, is_default=True)]}
         with patch(
-            "apps.data_migrations.management.commands.notify_deprecated_models.DEFAULT_LLM_PROVIDER_MODELS",
+            "apps.service_providers.llm_service.default_models.DEFAULT_LLM_PROVIDER_MODELS",
             no_deprecated,
         ):
             call_command("notify_deprecated_models", force=True)
@@ -53,7 +53,7 @@ class TestNotifyDeprecatedModelsCommand:
         experiment = ExperimentFactory(pipeline=pipeline)
 
         with patch(
-            "apps.data_migrations.management.commands.notify_deprecated_models.DEFAULT_LLM_PROVIDER_MODELS",
+            "apps.service_providers.llm_service.default_models.DEFAULT_LLM_PROVIDER_MODELS",
             FAKE_DEPRECATED_MODELS,
         ):
             call_command("notify_deprecated_models", force=True)
@@ -75,7 +75,7 @@ class TestNotifyDeprecatedModelsCommand:
         experiment = ExperimentFactory(pipeline=pipeline)
 
         with patch(
-            "apps.data_migrations.management.commands.notify_deprecated_models.DEFAULT_LLM_PROVIDER_MODELS",
+            "apps.service_providers.llm_service.default_models.DEFAULT_LLM_PROVIDER_MODELS",
             FAKE_DEPRECATED_NO_REPLACEMENT,
         ):
             call_command("notify_deprecated_models", force=True)
@@ -96,7 +96,7 @@ class TestNotifyDeprecatedModelsCommand:
         evaluator = EvaluatorFactory.create(llm_provider_model=deprecated_model)
 
         with patch(
-            "apps.data_migrations.management.commands.notify_deprecated_models.DEFAULT_LLM_PROVIDER_MODELS",
+            "apps.service_providers.llm_service.default_models.DEFAULT_LLM_PROVIDER_MODELS",
             FAKE_DEPRECATED_MODELS,
         ):
             call_command("notify_deprecated_models", force=True)
@@ -116,7 +116,7 @@ class TestNotifyDeprecatedModelsCommand:
         _make_pipeline_referencing(deprecated_model)
 
         with patch(
-            "apps.data_migrations.management.commands.notify_deprecated_models.DEFAULT_LLM_PROVIDER_MODELS",
+            "apps.service_providers.llm_service.default_models.DEFAULT_LLM_PROVIDER_MODELS",
             FAKE_DEPRECATED_MODELS,
         ):
             call_command("notify_deprecated_models", dry_run=True)
@@ -136,7 +136,7 @@ class TestNotifyDeprecatedModelsCommand:
         user = MembershipFactory(team=experiment.team, groups=get_team_owner_groups).user
 
         with patch(
-            "apps.data_migrations.management.commands.notify_deprecated_models.DEFAULT_LLM_PROVIDER_MODELS",
+            "apps.service_providers.llm_service.default_models.DEFAULT_LLM_PROVIDER_MODELS",
             FAKE_DEPRECATED_MODELS,
         ):
             call_command("notify_deprecated_models", force=True)
@@ -157,7 +157,7 @@ class TestNotifyDeprecatedModelsCommand:
         LlmProviderModelFactory(team=None, type="openai", name="test-deprecated-model", deprecated=True)
 
         with patch(
-            "apps.data_migrations.management.commands.notify_deprecated_models.DEFAULT_LLM_PROVIDER_MODELS",
+            "apps.service_providers.llm_service.default_models.DEFAULT_LLM_PROVIDER_MODELS",
             FAKE_DEPRECATED_MODELS,
         ):
             call_command("notify_deprecated_models", force=True)

--- a/apps/pipelines/build_state.py
+++ b/apps/pipelines/build_state.py
@@ -1,4 +1,4 @@
-"""Build-state reporting for a pipeline: the errors report and the advisory unwired-handles map.
+"""Build-state reporting for a pipeline: the errors report and the advisory maps beside it.
 
 ``Pipeline.validate()`` returns a complete :class:`~apps.pipelines.exceptions.ErrorReport`, which
 this passes through unchanged::
@@ -22,6 +22,8 @@ from apps.pipelines.flow import Flow
 from apps.pipelines.models import Node, Pipeline
 from apps.pipelines.nodes.base import PipelineRouterNode, resolve_node_class
 from apps.pipelines.nodes.nodes import EndNode, StartNode
+from apps.service_providers.llm_service.default_models import get_deprecated_models
+from apps.service_providers.models import LlmProviderModel
 
 
 def pipeline_build_state(pipeline: Pipeline) -> dict:
@@ -32,6 +34,37 @@ def pipeline_build_state(pipeline: Pipeline) -> dict:
         "errors": errors,
         "unwired_handles": unwired_handles(pipeline),
     }
+
+
+def deprecated_models(pipeline: Pipeline) -> dict:
+    """The advisory ``{node_id: {model, replacement}}`` map of nodes pointing at a deprecated model.
+    ``replacement`` is the model the team should move to, or ``None`` where none is declared.
+    """
+    nodes_by_model_id = {}
+    for node in pipeline.node_set.all():
+        model_id = _referenced_model_id(node)
+        if model_id is not None:
+            nodes_by_model_id.setdefault(model_id, []).append(node.flow_id)
+    if not nodes_by_model_id:
+        return {}
+
+    warnings = {}
+    replacements = get_deprecated_models()
+    deprecated = LlmProviderModel.objects.for_team(pipeline.team_id).filter(id__in=nodes_by_model_id, deprecated=True)
+    for model in deprecated.values_list("id", "type", "name", named=True):
+        warning = {"model": model.name, "replacement": replacements.get((model.type, model.name))}
+        for flow_id in nodes_by_model_id[model.id]:
+            warnings[flow_id] = warning
+    return warnings
+
+
+def _referenced_model_id(node: Node) -> int | None:
+    """The LLM model id a node's params name, or None if it names none."""
+    model_id = (node.params or {}).get("llm_provider_model_id")
+    try:
+        return int(model_id)
+    except (TypeError, ValueError):
+        return None
 
 
 def unwired_handles(pipeline: Pipeline) -> dict:

--- a/apps/pipelines/build_state.py
+++ b/apps/pipelines/build_state.py
@@ -8,8 +8,8 @@ this passes through unchanged::
 ``pipeline_valid`` is exactly "all three buckets empty" — nothing more.
 
 Validation never flags an unwired node or branch (the build only checks reachable nodes), so
-:func:`unwired_handles` reports those separately as an advisory "what still needs wiring" map. It
-never blocks anything.
+:func:`unwired_handles` reports those separately as an advisory "what still needs wiring" map, and
+:func:`deprecated_models` reports the models on their way out the same way. Neither blocks anything.
 """
 
 from enum import StrEnum
@@ -27,12 +27,13 @@ from apps.service_providers.models import LlmProviderModel
 
 
 def pipeline_build_state(pipeline: Pipeline) -> dict:
-    """``pipeline_valid`` + ``errors`` + advisory ``unwired_handles`` for a pipeline."""
+    """``pipeline_valid`` + ``errors`` + the advisory ``unwired_handles`` and ``deprecated_models``."""
     errors = pipeline.validate()
     return {
         "pipeline_valid": not has_errors(errors),
         "errors": errors,
         "unwired_handles": unwired_handles(pipeline),
+        "deprecated_models": deprecated_models(pipeline),
     }
 
 

--- a/apps/pipelines/nodes/mixins.py
+++ b/apps/pipelines/nodes/mixins.py
@@ -115,21 +115,14 @@ class LLMResponseMixin(BaseModel):
 
     @model_validator(mode="after")
     def validate_llm_model(self):
-        # Ensure model is not deprecated
         try:
             model = ORMRepository().get_llm_provider_model(self.llm_provider_model_id)
         except RepositoryLookupError as e:
             raise PydanticCustomError(
                 "invalid_model",
                 str(e),
-                {"field": "llm_provider_id"},
+                {"field": "llm_provider_model_id"},
             ) from None
-        if model.deprecated:
-            raise PydanticCustomError(
-                "deprecated_model",
-                f"LLM provider model '{model.name}' is deprecated.",
-                {"field": "llm_provider_id"},
-            )
 
         # Validate model parameters
         if params_cls := LLM_MODEL_PARAMETERS.get(model.name):

--- a/apps/pipelines/nodes/node_metadata.py
+++ b/apps/pipelines/nodes/node_metadata.py
@@ -134,8 +134,8 @@ def _llm_provider_options(llm_providers: list[dict], llm_provider_models: QueryS
             _option(provider["id"], provider["name"], provider["type"]) for provider in llm_providers
         ],
         OptionsSource.llm_provider_model_id: [
-            _option(provider.id, str(provider), provider.type, None, provider.max_token_limit)
-            for provider in llm_provider_models
+            _option(model.id, str(model), model.type, None, model.max_token_limit, model.deprecated)
+            for model in llm_provider_models
         ],
     }
 
@@ -237,12 +237,14 @@ def _option(
     type_: str | None = None,
     edit_url: str | None = None,
     max_token_limit: int | None = None,
+    deprecated: bool = False,
 ) -> dict:
     data = {"value": value, "label": label}
     data = data | ({"type": type_} if type_ else {})
     data = data | ({"edit_url": edit_url} if edit_url else {})
     # 0 is a real limit -- it disables history compression -- so only an absent one is dropped.
     data = data | ({"max_token_limit": max_token_limit} if max_token_limit is not None else {})
+    data = data | ({"deprecated": True} if deprecated else {})
     return data
 
 

--- a/apps/pipelines/tests/test_build_state.py
+++ b/apps/pipelines/tests/test_build_state.py
@@ -243,6 +243,48 @@ class TestPipelineBuildState:
             "unwired_handles": {},
         }
 
+    @pytest.mark.parametrize(
+        ("model_id", "expected"),
+        [
+            pytest.param(
+                0,
+                {"llm_provider_model_id": "LLM provider model with id 0 not found"},
+                id="falsy-id-reaches-the-after-validator",
+            ),
+            pytest.param(
+                999999,
+                {"root": "LLM provider model with id 999999 does not exist"},
+                id="absent-id-is-caught-before-it",
+            ),
+        ],
+    )
+    def test_a_bad_model_id_is_reported_against_the_model_field(self, model_id, expected):
+        """Which validator catches it decides where it lands, and the two differ.
+
+        ``ensure_default_parameters`` runs ``mode="before"`` and raises for an id it cannot look up,
+        so the ordinary dangling reference never reaches ``validate_llm_model`` and reports under
+        ``root``. A falsy-but-present id skips that lookup and does reach it -- the one path on which
+        the ``invalid_model`` error is raised, and it names the model field, not the provider field.
+        """
+        start, end = start_node(), end_node()
+        llm = {
+            "id": "llm-1",
+            "type": "LLMResponseWithPrompt",
+            "params": {
+                "name": "llm-1",
+                "prompt": "hi",
+                "llm_provider_id": 1,
+                "llm_provider_model_id": model_id,
+            },
+        }
+        edges = [
+            {"id": "e1", "source": start["id"], "target": "llm-1"},
+            {"id": "e2", "source": "llm-1", "target": end["id"]},
+        ]
+        pipeline = create_pipeline_model([start, llm, end], edges)
+
+        assert pipeline_build_state(pipeline)["errors"]["node"] == {"llm-1": expected}
+
     def test_node_build_error_is_reported_generically_rather_than_verbatim(self, monkeypatch, caplog):
         """A build-stage node error can wrap a raw pydantic error naming the classes behind the node.
         The report is served over the API, so it carries a generic line and the detail is logged."""

--- a/apps/pipelines/tests/test_build_state.py
+++ b/apps/pipelines/tests/test_build_state.py
@@ -1,12 +1,18 @@
 """Tests for the pipeline build-state helpers: the three-bucket errors report, ``pipeline_valid``,
-the advisory ``unwired_handles`` map, and the stranded-router-edge guard."""
+the advisory ``unwired_handles`` and ``deprecated_models`` maps, and the stranded-router-edge guard."""
 
 import logging
+from unittest.mock import patch
 
 import pytest
 from pydantic import model_validator
 
-from apps.pipelines.build_state import node_output_handles, pipeline_build_state, unwired_handles
+from apps.pipelines.build_state import (
+    deprecated_models,
+    node_output_handles,
+    pipeline_build_state,
+    unwired_handles,
+)
 from apps.pipelines.exceptions import PipelineNodeBuildError
 from apps.pipelines.graph import PipelineGraph
 from apps.pipelines.models import Node, Pipeline
@@ -14,10 +20,15 @@ from apps.pipelines.nodes import nodes as pipeline_nodes
 from apps.pipelines.tests.utils import (
     create_pipeline_model,
     end_node,
+    llm_response_node,
     passthrough_node,
     start_node,
     state_key_router_node,
 )
+from apps.service_providers.llm_service import default_models
+from apps.service_providers.llm_service.default_models import Model
+from apps.utils.factories.pipelines import PipelineFactory
+from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
 
 # ``Node.type`` is graph data, so it can name any module-level attribute of
 # ``apps.pipelines.nodes.nodes`` — not just a node class. None of these are usable node types, so
@@ -530,3 +541,115 @@ class TestPipelineBuildState:
                 end["id"]: [{"handle": "input", "label": None}],
             },
         }
+
+
+@pytest.mark.django_db()
+class TestDeprecatedModels:
+    """The advisory deprecated-model map. Deprecation is a migration window, so none of this may
+    touch ``pipeline_valid`` -- an errored pipeline cannot run, be test-messaged or be versioned."""
+
+    @pytest.fixture(autouse=True)
+    def _model_defaults(self):
+        """Replacements come from ``DEFAULT_LLM_PROVIDER_MODELS``, which is edited every time a real
+        model is deprecated. Stub it so these tests describe the mapping, not the current list."""
+        stub = {
+            "openai": [
+                Model("live-model", 1000),
+                Model("old-model", 1000, deprecated=True, replacement="live-model"),
+                Model("orphan-model", 1000, deprecated=True),
+            ]
+        }
+        with patch.dict(default_models.DEFAULT_LLM_PROVIDER_MODELS, stub, clear=True):
+            yield
+
+    def _pipeline_using(self, model):
+        provider = LlmProviderFactory.create(team=model.team, type=model.type)
+        llm = llm_response_node(str(provider.id), str(model.id))
+        pipeline = create_pipeline_model(
+            [start_node(), llm, end_node()], pipeline=PipelineFactory.create(team=model.team)
+        )
+        return pipeline, llm["id"]
+
+    def test_a_node_on_a_deprecated_model_is_advisory_and_still_valid(self):
+        model = LlmProviderModelFactory.create(type="openai", name="old-model", deprecated=True)
+        pipeline, node_id = self._pipeline_using(model)
+
+        state = pipeline_build_state(pipeline)
+
+        assert state["pipeline_valid"] is True
+        assert state["errors"] == {"node": {}, "edge": [], "pipeline": []}
+        assert deprecated_models(pipeline) == {node_id: {"model": "old-model", "replacement": "live-model"}}
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            pytest.param("orphan-model", id="declared-without-a-replacement"),
+            pytest.param("our-finetune", id="not-in-the-shipped-table"),
+        ],
+    )
+    def test_a_model_with_no_declared_replacement_reports_none(self, name):
+        """The team is still told to migrate; there is just nothing to name as the destination. A
+        team's own model is absent from `DEFAULT_LLM_PROVIDER_MODELS` entirely, so the lookup has to
+        miss rather than raise."""
+        model = LlmProviderModelFactory.create(type="openai", name=name, deprecated=True)
+        pipeline, node_id = self._pipeline_using(model)
+
+        assert deprecated_models(pipeline) == {node_id: {"model": name, "replacement": None}}
+
+    def test_another_teams_model_is_not_reported(self):
+        """Params are just JSON, so a foreign id can sit in one. Echoing the row back would tell
+        this team a model name from another."""
+        model = LlmProviderModelFactory.create(type="openai", name="old-model", deprecated=True)
+        provider = LlmProviderFactory.create(team=model.team, type=model.type)
+        llm = llm_response_node(str(provider.id), str(model.id))
+        pipeline = create_pipeline_model([start_node(), llm, end_node()])
+
+        assert deprecated_models(pipeline) == {}
+
+    def test_a_live_model_is_not_reported(self):
+        model = LlmProviderModelFactory.create(type="openai", name="live-model")
+        pipeline, _ = self._pipeline_using(model)
+
+        assert deprecated_models(pipeline) == {}
+
+    def test_every_node_on_the_same_deprecated_model_is_reported(self):
+        model = LlmProviderModelFactory.create(type="openai", name="old-model", deprecated=True)
+        provider = LlmProviderFactory.create(team=model.team, type=model.type)
+        first = llm_response_node(str(provider.id), str(model.id), name="first")
+        second = llm_response_node(str(provider.id), str(model.id), name="second")
+        pipeline = create_pipeline_model(
+            [start_node(), first, second, end_node()], pipeline=PipelineFactory.create(team=model.team)
+        )
+
+        assert set(deprecated_models(pipeline)) == {first["id"], second["id"]}
+
+    def test_a_pipeline_with_no_llm_nodes_costs_no_query(self, django_assert_num_queries):
+        """Every read of a pipeline pays for this map, and most nodes name no model at all."""
+        pipeline = create_pipeline_model([start_node(), end_node()])
+
+        with django_assert_num_queries(1):
+            assert deprecated_models(pipeline) == {}
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            pytest.param(None, id="null"),
+            pytest.param("", id="empty-string"),
+            pytest.param("not-an-id", id="non-numeric"),
+            pytest.param([7], id="list"),
+            pytest.param(999999, id="absent-row"),
+        ],
+    )
+    def test_junk_in_the_model_param_is_not_a_crash(self, model_id):
+        """Params are unvalidated JSON, and `absent-row` is a node between `remove_deprecated_models`
+        deleting a row and the node being repointed. A bad id is validation's problem to report, not
+        this map's to raise on -- and raising here would take the whole editor read down with it."""
+        pipeline = create_pipeline_model([start_node(), end_node()])
+        Node.objects.create(
+            pipeline=pipeline,
+            flow_id="llm-junk",
+            type="LLMResponse",
+            params={"name": "llm-junk", "llm_provider_model_id": model_id},
+        )
+
+        assert deprecated_models(pipeline) == {}

--- a/apps/pipelines/tests/test_build_state.py
+++ b/apps/pipelines/tests/test_build_state.py
@@ -152,6 +152,7 @@ class TestPipelineBuildState:
             "pipeline_valid": True,
             "errors": {"node": {}, "edge": [], "pipeline": []},
             "unwired_handles": {},
+            "deprecated_models": {},
         }
 
     def test_dangling_router_branch_is_advisory_not_an_error(self):
@@ -170,6 +171,7 @@ class TestPipelineBuildState:
             "pipeline_valid": True,
             "errors": {"node": {}, "edge": [], "pipeline": []},
             "unwired_handles": {router["id"]: [{"handle": "output_1", "label": "B"}]},
+            "deprecated_models": {},
         }
 
     def test_off_graph_island_reports_input_and_output_unwired(self):
@@ -185,6 +187,7 @@ class TestPipelineBuildState:
             "unwired_handles": {
                 island["id"]: [{"handle": "input", "label": None}, {"handle": "output", "label": None}]
             },
+            "deprecated_models": {},
         }
 
     def test_start_input_and_end_output_are_never_reported(self):
@@ -220,6 +223,7 @@ class TestPipelineBuildState:
                 "pipeline": [],
             },
             "unwired_handles": {},
+            "deprecated_models": {},
         }
 
     def test_dangling_provider_model_reference_reports_node_error_instead_of_raising(self):
@@ -252,6 +256,7 @@ class TestPipelineBuildState:
                 "pipeline": [],
             },
             "unwired_handles": {},
+            "deprecated_models": {},
         }
 
     @pytest.mark.parametrize(
@@ -318,6 +323,7 @@ class TestPipelineBuildState:
                 "pipeline": ["This pipeline could not be built. Check the values of its nodes' params."],
             },
             "unwired_handles": {},
+            "deprecated_models": {},
         }
         assert "SecretInternalNode" not in str(state)
         assert "SecretInternalNode" in caplog.text
@@ -347,6 +353,7 @@ class TestPipelineBuildState:
                 ghost["id"]: [{"handle": "input", "label": None}],
                 end["id"]: [{"handle": "input", "label": None}],
             },
+            "deprecated_models": {},
         }
 
     def test_removed_node_type_with_a_named_handle_edge_does_not_raise(self):
@@ -370,6 +377,7 @@ class TestPipelineBuildState:
                 "pipeline": [],
             },
             "unwired_handles": {},
+            "deprecated_models": {},
         }
 
     @pytest.mark.parametrize("node_type", NON_NODE_ATTRIBUTES)
@@ -395,6 +403,7 @@ class TestPipelineBuildState:
                 "pipeline": [],
             },
             "unwired_handles": {},
+            "deprecated_models": {},
         }
 
     def test_stranded_router_edge_lands_in_edge_bucket_without_raising(self):
@@ -420,6 +429,7 @@ class TestPipelineBuildState:
                 "pipeline": ["One or more edges reference a router output that no longer exists"],
             },
             "unwired_handles": {router["id"]: [{"handle": "output_0", "label": "A"}]},
+            "deprecated_models": {},
         }
 
     def test_stranded_edge_on_unreachable_router_does_not_block_the_build(self):
@@ -455,6 +465,7 @@ class TestPipelineBuildState:
                 ],
                 island_target["id"]: [{"handle": "output", "label": None}],
             },
+            "deprecated_models": {},
         }
 
     def test_node_and_graph_errors_are_reported_together(self):
@@ -500,6 +511,7 @@ class TestPipelineBuildState:
             "pipeline_valid": True,
             "errors": {"node": {}, "edge": [], "pipeline": []},
             "unwired_handles": {},
+            "deprecated_models": {},
         }
 
     def test_invalid_router_does_not_have_its_edges_called_stranded(self):
@@ -540,6 +552,7 @@ class TestPipelineBuildState:
                 island["id"]: [{"handle": "output", "label": None}],
                 end["id"]: [{"handle": "input", "label": None}],
             },
+            "deprecated_models": {},
         }
 
 
@@ -578,7 +591,7 @@ class TestDeprecatedModels:
 
         assert state["pipeline_valid"] is True
         assert state["errors"] == {"node": {}, "edge": [], "pipeline": []}
-        assert deprecated_models(pipeline) == {node_id: {"model": "old-model", "replacement": "live-model"}}
+        assert state["deprecated_models"] == {node_id: {"model": "old-model", "replacement": "live-model"}}
 
     @pytest.mark.parametrize(
         "name",

--- a/apps/pipelines/tests/test_deprecated_llm_models.py
+++ b/apps/pipelines/tests/test_deprecated_llm_models.py
@@ -6,9 +6,12 @@ it gives a team a migration window, announced by `notify_deprecated_models`. Del
 may block, and the editor says so out of band instead.
 """
 
+import json
 from unittest import mock
 
 import pytest
+from django.test import Client
+from django.urls import reverse
 
 from apps.chatbots.views import CreateChatbotVersion
 from apps.pipelines.nodes.base import PipelineState
@@ -18,6 +21,7 @@ from apps.pipelines.tests.utils import create_pipeline_model, create_runnable, e
 from apps.utils.factories.experiment import ExperimentFactory
 from apps.utils.factories.pipelines import PipelineFactory
 from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
+from apps.utils.factories.team import TeamWithUsersFactory
 from apps.utils.factories.user import UserFactory
 from apps.utils.tests.langchain import build_fake_llm_service
 
@@ -85,3 +89,69 @@ def test_deprecated_model_does_not_block_version_creation(provider, deprecated_m
     view.object = ExperimentFactory.create(team=provider.team, pipeline=pipeline)
 
     assert view._check_pipleline_for_errors() is None
+
+
+@pytest.mark.django_db()
+class TestEditorEndpoint:
+    """The editor's own read and save. Neither computes anything of its own -- the point is that
+    both responses carry the map, since the badge would silently vanish on whichever one did not."""
+
+    @pytest.fixture()
+    def team(self):
+        return TeamWithUsersFactory.create()
+
+    @pytest.fixture()
+    def provider(self, team):
+        return LlmProviderFactory.create(team=team)
+
+    @pytest.fixture()
+    def authed_client(self, team):
+        client = Client()
+        client.force_login(team.members.first())
+        return client
+
+    def _url(self, pipeline):
+        return reverse("pipelines:pipeline_data", kwargs={"team_slug": pipeline.team.slug, "pk": pipeline.id})
+
+    def test_the_read_reports_the_deprecated_model(self, authed_client, provider, deprecated_model, pipeline):
+        nodes = _nodes(provider, deprecated_model)
+        create_pipeline_model(nodes, pipeline=pipeline).save()
+
+        response = authed_client.get(self._url(pipeline))
+
+        assert response.status_code == 200
+        body = response.json()["pipeline"]
+        assert body["errors"] == {"node": {}, "edge": [], "pipeline": []}
+        assert body["deprecated_models"] == {nodes[1]["id"]: {"model": deprecated_model.name, "replacement": None}}
+
+    def test_a_save_reports_the_deprecated_model(self, authed_client, provider, deprecated_model, pipeline):
+        nodes = _nodes(provider, deprecated_model)
+        create_pipeline_model(nodes, pipeline=pipeline).save()
+
+        response = authed_client.patch(
+            self._url(pipeline),
+            data=json.dumps({"base_revision": pipeline.edit_revision, "name": "Renamed"}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.json()["deprecated_models"] == {
+            nodes[1]["id"]: {"model": deprecated_model.name, "replacement": None}
+        }
+
+    def test_a_full_graph_save_reports_the_deprecated_model(self, authed_client, provider, deprecated_model, pipeline):
+        """The POST path, which the editor still uses for a whole-graph save. It builds its own
+        response dict rather than sharing the PATCH one, so it can carry the key or not on its own."""
+        nodes = _nodes(provider, deprecated_model)
+        create_pipeline_model(nodes, pipeline=pipeline).save()
+
+        response = authed_client.post(
+            self._url(pipeline),
+            data=json.dumps({"name": pipeline.name, "data": pipeline.flow_data}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.json()["deprecated_models"] == {
+            nodes[1]["id"]: {"model": deprecated_model.name, "replacement": None}
+        }

--- a/apps/pipelines/tests/test_deprecated_llm_models.py
+++ b/apps/pipelines/tests/test_deprecated_llm_models.py
@@ -1,0 +1,87 @@
+"""A node pointing at a deprecated LLM model keeps working until the model is deleted.
+
+Deprecation is the warning stage of the model lifecycle (`docs/developer_guides/managing_models.md`):
+it gives a team a migration window, announced by `notify_deprecated_models`. Deletion --
+`remove_deprecated_models` -- is the stage that repoints or clears the references. So nothing here
+may block, and the editor says so out of band instead.
+"""
+
+from unittest import mock
+
+import pytest
+
+from apps.chatbots.views import CreateChatbotVersion
+from apps.pipelines.nodes.base import PipelineState
+from apps.pipelines.repository import ORMRepository
+from apps.pipelines.tasks import get_response_for_pipeline_test_message
+from apps.pipelines.tests.utils import create_pipeline_model, create_runnable, end_node, llm_response_node, start_node
+from apps.utils.factories.experiment import ExperimentFactory
+from apps.utils.factories.pipelines import PipelineFactory
+from apps.utils.factories.service_provider_factories import LlmProviderFactory, LlmProviderModelFactory
+from apps.utils.factories.user import UserFactory
+from apps.utils.tests.langchain import build_fake_llm_service
+
+
+@pytest.fixture()
+def provider():
+    return LlmProviderFactory.create()
+
+
+@pytest.fixture()
+def deprecated_model(provider):
+    return LlmProviderModelFactory.create(team=provider.team, type=provider.type, deprecated=True)
+
+
+@pytest.fixture()
+def pipeline(provider):
+    return PipelineFactory.create(team=provider.team)
+
+
+def _nodes(provider, model):
+    return [start_node(), llm_response_node(str(provider.id), str(model.id)), end_node()]
+
+
+@pytest.mark.django_db()
+@mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
+def test_deprecated_model_still_runs(get_llm_service, provider, deprecated_model, pipeline):
+    """The live-bot case: a deploy that deprecates a model must not take running chatbots down."""
+    get_llm_service.return_value = build_fake_llm_service(responses=["123"])
+
+    state = create_runnable(pipeline, _nodes(provider, deprecated_model)).invoke(
+        PipelineState(messages=["Repeat exactly: 123"]), config={"configurable": {"repo": ORMRepository()}}
+    )
+
+    assert state["messages"][-1] == "123"
+
+
+@pytest.mark.django_db()
+def test_deprecated_model_is_not_a_validation_error(provider, deprecated_model, pipeline):
+    """`validate()` feeds the editor, the test-message run and version creation alike, so a
+    deprecated model reported here blocks all three."""
+    create_pipeline_model(_nodes(provider, deprecated_model), pipeline=pipeline)
+
+    assert pipeline.validate(full=False) == {"node": {}, "edge": [], "pipeline": []}
+
+
+@pytest.mark.django_db()
+@mock.patch("apps.service_providers.models.LlmProvider.get_llm_service")
+def test_deprecated_model_does_not_block_the_test_message(get_llm_service, provider, deprecated_model, pipeline):
+    get_llm_service.return_value = build_fake_llm_service(responses=["123"])
+    create_pipeline_model(_nodes(provider, deprecated_model), pipeline=pipeline).save()
+    user = UserFactory.create()
+    ExperimentFactory.create(team=provider.team, pipeline=pipeline, owner=user)
+
+    response = get_response_for_pipeline_test_message(pipeline.id, "hi", user.id)
+
+    assert "error" not in response
+
+
+@pytest.mark.django_db()
+def test_deprecated_model_does_not_block_version_creation(provider, deprecated_model, pipeline):
+    """`CreateChatbotVersion` refuses to version a pipeline with errors, so a deprecation used to
+    freeze a chatbot's releases as well as its runs."""
+    create_pipeline_model(_nodes(provider, deprecated_model), pipeline=pipeline).save()
+    view = CreateChatbotVersion()
+    view.object = ExperimentFactory.create(team=provider.team, pipeline=pipeline)
+
+    assert view._check_pipleline_for_errors() is None

--- a/apps/pipelines/tests/test_node_options.py
+++ b/apps/pipelines/tests/test_node_options.py
@@ -259,6 +259,21 @@ def test_options_llm_models_are_filtered_by_team_provider_type(team_with_resourc
 
 
 @pytest.mark.django_db()
+def test_the_builder_flags_the_deprecated_models_it_offers(team):
+    """The builder offers deprecated models so an existing node renders its selection; the flag is
+    what lets the node warn about the one it has selected without waiting for a save."""
+    LlmProviderFactory.create(team=team, type="openai")
+    deprecated = LlmProviderModelFactory.create(team=team, type="openai", deprecated=True)
+    live = LlmProviderModelFactory.create(team=team, type="openai")
+
+    options = {option["value"]: option for option in get_node_parameter_values(team)["llm_provider_model_id"]}
+
+    assert options[deprecated.id]["deprecated"] is True
+    # Absent rather than false, so the payload only carries the flag where it means something.
+    assert "deprecated" not in options[live.id]
+
+
+@pytest.mark.django_db()
 def test_options_omit_deprecated_llm_models(team_with_resources):
     """Absent rather than flagged, the same as a deprecated node type. The builder still shows these
     so an existing node keeps rendering; this list is only what a client may build with."""

--- a/apps/pipelines/views.py
+++ b/apps/pipelines/views.py
@@ -19,6 +19,7 @@ from django_tables2 import SingleTableView
 
 from apps.events.models import EventActionType, StaticTrigger, StaticTriggerType, TimeoutTrigger
 from apps.experiments.models import Experiment
+from apps.pipelines.build_state import deprecated_models
 from apps.pipelines.exceptions import MissingNodeDataError
 from apps.pipelines.flow import FlowPipelineData, PipelineDiffPayload, split_flow_data
 from apps.pipelines.jinja_utils import djlint_check, parse_jinja_template
@@ -245,6 +246,7 @@ def pipeline_data(request, team_slug: str, pk: int):
                 "data": pipeline.flow_data,
                 "edit_revision": pipeline.edit_revision,
                 "errors": pipeline.validate(),
+                "deprecated_models": deprecated_models(pipeline),
             }
         }
     )
@@ -278,6 +280,7 @@ def _handle_pipeline_post(request, pk: int, team_slug: str) -> JsonResponse:
         {
             "data": pipeline.flow_data,
             "errors": pipeline.validate(),
+            "deprecated_models": deprecated_models(pipeline),
             "edit_revision": pipeline.edit_revision,
         }
     )
@@ -329,6 +332,7 @@ def _handle_pipeline_patch(request, pk: int, team_slug: str) -> JsonResponse:
         {
             "data": pipeline.flow_data,
             "errors": pipeline.validate(),
+            "deprecated_models": deprecated_models(pipeline),
             "edit_revision": pipeline.edit_revision,
         }
     )

--- a/apps/service_providers/llm_service/default_models.py
+++ b/apps/service_providers/llm_service/default_models.py
@@ -258,6 +258,16 @@ def get_default_model(provider_type: str) -> Model | None:
     return next((m for m in DEFAULT_LLM_PROVIDER_MODELS.get(provider_type, ()) if m.is_default), None)
 
 
+def get_deprecated_models() -> dict[tuple[str, str], str | None]:
+    """``{(provider_type, model_name): replacement}`` for every deprecated model."""
+    return {
+        (provider_type, model.name): model.replacement
+        for provider_type, models in DEFAULT_LLM_PROVIDER_MODELS.items()
+        for model in models
+        if model.deprecated
+    }
+
+
 def get_default_translation_models_by_provider() -> dict:
     """
     Returns a dict mapping provider labels (e.g., "OpenAI") to their default translation model name.

--- a/assets/javascript/apps/pipeline/DeprecationNotice.test.tsx
+++ b/assets/javascript/apps/pipeline/DeprecationNotice.test.tsx
@@ -1,0 +1,40 @@
+import {afterEach, describe, expect, it} from 'vitest';
+import {render} from '@testing-library/react';
+import {DeprecationNotice} from './PipelineNode';
+import type {JsonSchema} from './types/nodeParams';
+import usePipelineStore from './stores/pipelineStore';
+
+const schema = (overrides: Partial<JsonSchema> = {}) => ({properties: {}, ...overrides}) as JsonSchema;
+
+afterEach(() => {
+  usePipelineStore.setState({deprecatedModels: {}});
+});
+
+describe('DeprecationNotice', () => {
+  it('still says where to go when the deprecated model names no replacement', () => {
+    // Most deprecated models declare no replacement, so the branch that reads one is the
+    // exceptional path. Collapsing the two into `{replacement && ...}` leaves those nodes with
+    // a warning badge and no advice, which renders and reads fine — nothing else would fail.
+    usePipelineStore.setState({deprecatedModels: {'node-1': {model: 'gpt-5', replacement: null}}});
+
+    const {container} = render(<DeprecationNotice nodeId="node-1" nodeSchema={schema()} />);
+
+    expect(container.textContent).toContain('gpt-5');
+    expect(container.textContent).toContain('moved to a supported model');
+  });
+
+  it('reports a deprecated type and a deprecated model under one badge', () => {
+    // The two warnings share a badge because a node can carry both at once. A third source
+    // added later is most naturally written as its own badge, which silently gives such a node
+    // two triangles to tell apart rather than failing.
+    usePipelineStore.setState({deprecatedModels: {'node-1': {model: 'gpt-5', replacement: 'gpt-5.4'}}});
+
+    const {getAllByRole, container} = render(
+      <DeprecationNotice nodeId="node-1" nodeSchema={schema({'ui:deprecated': true})} />,
+    );
+
+    expect(getAllByRole('button')).toHaveLength(1);
+    expect(container.textContent).toContain('This node type has been deprecated');
+    expect(container.textContent).toContain('gpt-5.4');
+  });
+});

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -180,7 +180,7 @@ function NodeHeader({
           </ul>
         </div>
         <div className="px-10 m-1 text-lg font-bold text-center align-middle">
-          <DeprecationNotice nodeSchema={nodeSchema}/>
+          <DeprecationNotice nodeId={nodeId} nodeSchema={nodeSchema}/>
           {nodeSchema["ui:removed"] && (
             <span className="badge badge-warning badge-sm mr-2 align-middle">Removed</span>
           )}
@@ -192,28 +192,46 @@ function NodeHeader({
 }
 
 
-function DeprecationNotice({nodeSchema}: {nodeSchema: JsonSchema}) {
-  if (!nodeSchema["ui:deprecated"]) {
+/**
+ * The node's deprecation warnings, sharing one badge: a node can be both a deprecated *type* and
+ * pointing at a deprecated *model*.
+ */
+export function DeprecationNotice({nodeId, nodeSchema}: {nodeId: string; nodeSchema: JsonSchema}) {
+  const deprecatedModel = usePipelineStore((state) => state.getNodeDeprecatedModel(nodeId));
+  const typeDeprecated = !!nodeSchema["ui:deprecated"];
+  if (!typeDeprecated && !deprecatedModel) {
     return <></>;
   }
   const removed = !!nodeSchema["ui:removed"];
   const customMessage = nodeSchema["ui:deprecation_message"] || "";
+  const subject = typeDeprecated ? "node type" : "model";
   return (
     <div className="dropdown">
       <div tabIndex={0} role="button" className="mr-2 text-warning inline-block tooltip hover:cursor-pointer"
-      data-tip={`This node type has been ${removed ? "removed" : "deprecated"}. Click for details`}><i className="fa-solid fa-exclamation-triangle"></i></div>
+      data-tip={`This ${subject} has been ${removed ? "removed" : "deprecated"}. Click for details`}><i className="fa-solid fa-exclamation-triangle"></i></div>
       <div
         tabIndex={0}
         className="dropdown-content card card-sm bg-base-100 z-1 w-64 shadow-md">
         <div className="card-body">
-          <p>
-            {removed
-              // The graph still saves (the editor POSTs and gets the errors back); it is the
-              // build/run that the unknown node type blocks. Don't tell the user saving is off.
-              ? "This node type has been removed. The node no longer runs, and the pipeline will not run until it is deleted."
-              : "This node type has been deprecated and will be removed in future."}
-          </p>
-          {customMessage && <p dangerouslySetInnerHTML={{__html: customMessage}}></p>}
+          {typeDeprecated && (
+            <p>
+              {removed
+                // The graph still saves (the editor POSTs and gets the errors back); it is the
+                // build/run that the unknown node type blocks. Don't tell the user saving is off.
+                ? "This node type has been removed. The node no longer runs, and the pipeline will not run until it is deleted."
+                : "This node type has been deprecated and will be removed in future."}
+            </p>
+          )}
+          {typeDeprecated && customMessage && <p dangerouslySetInnerHTML={{__html: customMessage}}></p>}
+          {deprecatedModel && (
+            <p>
+              The model <span className="font-semibold">{deprecatedModel.model}</span> has been deprecated and
+              will be removed. This node keeps running until then
+              {deprecatedModel.replacement
+                ? <>, but should be moved to <span className="font-semibold">{deprecatedModel.replacement}</span>.</>
+                : <>, but should be moved to a supported model.</>}
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -32,6 +32,7 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
   const hasErrors = usePipelineStore((state) => state.nodeHasErrors(id));
   const nodeError = usePipelineStore((state) => state.getNodeFieldError(id, "root"));
   const getNodeFieldError = usePipelineStore((state) => state.getNodeFieldError);
+  const deprecatedModel = usePipelineStore((state) => state.getNodeDeprecatedModel(id));
   const readOnly = usePipelineStore((state) => state.readOnly);
   const nodeSchema = getCachedData().nodeSchemas.get(data.type)!;
 
@@ -62,7 +63,7 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
   };
 
   const currentColor = data.params["color"] || NODE_COLORS[0].value;
-  const nodeClasses = `${nodeBorderClass(hasErrors, selected)} ${currentColor}`;
+  const nodeClasses = `${nodeBorderClass(hasErrors, selected, !!deprecatedModel)} ${currentColor}`;
 
   return (
     <>

--- a/assets/javascript/apps/pipeline/nodes/widgets.test.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.test.tsx
@@ -1,6 +1,6 @@
 import {beforeAll, describe, expect, it, vi} from 'vitest';
 import {render, fireEvent} from '@testing-library/react';
-import {getWidget as getWidgetUntyped} from './widgets';
+import {getWidget as getWidgetUntyped, InputField} from './widgets';
 import type {WidgetParams} from './widgets';
 import type {ComponentType} from 'react';
 import type {PropertySchema} from '../types/nodeParams';
@@ -132,5 +132,27 @@ describe('BuiltInToolsWidget', () => {
       />,
     );
     expect(checkbox.checked).toBe(true);
+  });
+});
+
+describe('InputField warning slot', () => {
+  it('shows an advisory note under the field', () => {
+    const {container} = render(
+      <InputField label="LLM Model" help_text="" inputWarning="gpt-5 is deprecated">
+        <input />
+      </InputField>,
+    );
+    expect(container.textContent).toContain('gpt-5 is deprecated');
+  });
+
+  it('suppresses the warning while there is an error', () => {
+    // One message per field, and the error is the one that has to be acted on first.
+    const {container} = render(
+      <InputField label="LLM Model" help_text="" inputError="This field is required." inputWarning="gpt-5 is deprecated">
+        <input />
+      </InputField>,
+    );
+    expect(container.textContent).toContain('This field is required.');
+    expect(container.textContent).not.toContain('deprecated');
   });
 });

--- a/assets/javascript/apps/pipeline/nodes/widgets.tsx
+++ b/assets/javascript/apps/pipeline/nodes/widgets.tsx
@@ -921,10 +921,15 @@ export function LlmWidget(props: WidgetParams) {
   } else {
     error = "This field is required."
   }
+  const selectedModel = (parameterValues.llm_provider_model_id as LlmProviderModel[])
+    .find((model) => String(model.value) === String(providerModelId));
+  const warning = selectedModel?.deprecated
+    ? "Deprecated — move to a supported model before it is removed."
+    : undefined;
   const llmModelParamsSchema = getSelectedModelSchema(providerModelId);
   return (
     <>
-      <InputField label={props.label} help_text={props.helpText} inputError={error}>
+      <InputField label={props.label} help_text={props.helpText} inputError={error} inputWarning={warning}>
         <select
           // Add `appearance-none` to work around placement issue: https://github.com/saadeghi/daisyui/discussions/4202
           // Should be resolved in future versions of browsers.
@@ -1099,10 +1104,11 @@ function HelpBubble({ helpText }: { helpText: string }) {
   );
 }
 
-export function InputField({label, help_text, inputError, children}: React.PropsWithChildren<{
+export function InputField({label, help_text, inputError, inputWarning, children}: React.PropsWithChildren<{
   label: string | ReactNode,
   help_text: string,
-  inputError?: string | undefined
+  inputError?: string | undefined,
+  inputWarning?: string | undefined
 }>) {
   return (
     <>
@@ -1115,6 +1121,7 @@ export function InputField({label, help_text, inputError, children}: React.Props
       </div>
       <div>
         <small className="text-red-500">{inputError}</small>
+        {!inputError && inputWarning && <small className="text-warning">{inputWarning}</small>}
       </div>
     </>
   );

--- a/assets/javascript/apps/pipeline/stores/pipelineStore.ts
+++ b/assets/javascript/apps/pipeline/stores/pipelineStore.ts
@@ -280,6 +280,7 @@ const createPipelineManagerStore: StateCreator<
   isSaving: false,
   isLoading: true,
   errors: {},
+  deprecatedModels: {},
   conflictDetected: false,
   currentRevision: 0,
   dismissConflict: () => {
@@ -297,7 +298,7 @@ const createPipelineManagerStore: StateCreator<
           currentPipelineId: pipelineId,
           currentRevision: pipeline.edit_revision ?? 0,
         });
-        set({errors: pipeline.errors});
+        set({errors: pipeline.errors, deprecatedModels: pipeline.deprecated_models ?? {}});
         set({isLoading: false});
         if (get().reactFlowInstance) {
           get().resetFlow({
@@ -380,7 +381,10 @@ const createPipelineManagerStore: StateCreator<
               dirty: false,
               currentRevision: saveResponse.edit_revision,
             });
-            set({errors: saveResponse.errors as ErrorsType});
+            set({
+              errors: saveResponse.errors as ErrorsType,
+              deprecatedModels: saveResponse.deprecated_models ?? {},
+            });
             if (get().reactFlowInstance && saveResponse.errors) {
               set({
                 edges: updateEdgeClasses(get().edges, saveResponse.errors as ErrorsType)
@@ -414,6 +418,7 @@ const createPipelineManagerStore: StateCreator<
         set({
           currentRevision: response.edit_revision,
           errors: response.errors as ErrorsType,
+          deprecatedModels: response.deprecated_models ?? {},
           dirty: false,
         });
         if (edges) {
@@ -461,6 +466,9 @@ const createPipelineManagerStore: StateCreator<
   },
   getPipelineError: () => {
     return get().errors["pipeline"] ?? NO_PIPELINE_ERRORS;
+  },
+  getNodeDeprecatedModel: (nodeId: string) => {
+    return get().deprecatedModels[nodeId];
   },
 })
 

--- a/assets/javascript/apps/pipeline/types/nodeParameterValues.ts
+++ b/assets/javascript/apps/pipeline/types/nodeParameterValues.ts
@@ -19,4 +19,5 @@
 
    export type LlmProviderModel = TypedOption & {
     max_token_limit: number
+    deprecated?: boolean
    };

--- a/assets/javascript/apps/pipeline/types/pipeline.ts
+++ b/assets/javascript/apps/pipeline/types/pipeline.ts
@@ -5,6 +5,17 @@ export type ReactFlowJsonObject<NodeData = any, EdgeData = any> = {
     edges: Edge<EdgeData>[];
 };
 
+/**
+ * A node still pointing at a deprecated LLM model. Advisory: the model keeps working until it is
+ * removed, so this never makes the pipeline invalid. `replacement` is null when none is declared.
+ */
+export type DeprecatedModel = {
+  model: string;
+  replacement: string | null;
+};
+
+export type DeprecatedModelsType = {[nodeId: string]: DeprecatedModel};
+
 export type PipelineType = {
   id: bigint;
   team: string;
@@ -14,6 +25,7 @@ export type PipelineType = {
   date_created?: string;
   updated_at?: string;
   errors: {[nodeId: string]: {[name: string]: string}},
+  deprecated_models?: DeprecatedModelsType;
   edit_revision?: number;
 };
 
@@ -51,5 +63,6 @@ export type PipelineDiffPayload = {
 export type PipelineSaveResponse = {
   data: Record<string, unknown>;
   errors: Record<string, unknown>;
+  deprecated_models?: DeprecatedModelsType;
   edit_revision: number;
 };

--- a/assets/javascript/apps/pipeline/types/pipelineManagerStore.ts
+++ b/assets/javascript/apps/pipeline/types/pipelineManagerStore.ts
@@ -1,4 +1,4 @@
-import {PipelineDiffPayload, PipelineType} from "./pipeline";
+import {DeprecatedModel, DeprecatedModelsType, PipelineDiffPayload, PipelineType} from "./pipeline";
 
 export type PipelineManagerStoreType = {
   currentPipeline: PipelineType | undefined;
@@ -26,6 +26,8 @@ export type PipelineManagerStoreType = {
   getNodeFieldError: (nodeId: string, fieldName: string) => string | undefined;
   edgeHasErrors: (edgeId: string) => boolean;
   getPipelineError: () => string[];
+  deprecatedModels: DeprecatedModelsType;
+  getNodeDeprecatedModel: (nodeId: string) => DeprecatedModel | undefined;
 };
 
 export type ErrorsType = {

--- a/assets/javascript/apps/pipeline/utils.tsx
+++ b/assets/javascript/apps/pipeline/utils.tsx
@@ -19,11 +19,14 @@ export function classNames(...classes: Array<string | null | undefined>): string
   return classes.filter(Boolean).join(" ");
 }
 
-export function nodeBorderClass(nodeErrors : boolean, selected : boolean ): string {
-  const defaultBorder = nodeErrors ? "border-error " : ""
-  const selectedBorder = nodeErrors ? "border-secondary" : "border-primary"
-  const border = selected ? selectedBorder : defaultBorder
-  return classNames(border, "border py-2 shadow-md rounded-xl border-2")
+export function nodeBorderClass(nodeErrors : boolean, selected : boolean, nodeWarnings = false): string {
+  if (nodeErrors) {
+    return classNames(selected ? "border-secondary" : "border-error", "border py-2 shadow-md rounded-xl border-2")
+  }
+  if (nodeWarnings) {
+    return classNames(selected ? "border-warning" : "border-warning/60", "border py-2 shadow-md rounded-xl border-2")
+  }
+  return classNames(selected ? "border-primary" : "", "border py-2 shadow-md rounded-xl border-2")
 }
 
 const localCache = {


### PR DESCRIPTION
### Product Description

Deprecating an LLM model used to break every chatbot using it the moment the deploy landed: bots replied with the canned configuration-error message, and teams could no longer send a test message or version the pipeline. A deprecated model now keeps working until it is actually deleted, which is what the deprecation notice already promised.

Affected nodes carry a warning triangle in the header, naming the model and what to migrate to. Additionally, the node itself will be highlighted with an amber border to indicate it has a warning. If the node has errors the red border colour will take precedence over the warning colour.

<img width="473" height="553" alt="Screenshot_20260909_150508" src="https://github.com/user-attachments/assets/d622b376-df89-4486-8f4b-7634e0f132d8" />

A node that is both a deprecated *type* and on a deprecated model shows one triangle carrying both messages.

<img width="391" height="373" alt="Screenshot_20260909_150558" src="https://github.com/user-attachments/assets/b7174239-2b76-43d5-b229-55cf6ae70b7b" />

Furthermore, the LLM Model field will now also show a deprecated message if the currently selected model is deprecated:
<img width="467" height="111" alt="Screenshot_20260909_150409" src="https://github.com/user-attachments/assets/08120032-d375-41ec-a906-ed37e6637b75" />

### Technical Description

The check lived in pydantic validation, so it failed the node build — one raise took out the run, the editor, the test message and version creation together.

The replacement warning is deliberately not a fourth `ErrorReport` bucket: `has_errors()` is "any bucket non-empty", so anything there would re-block what this fixes. It follows the `unwired_handles` precedent — an advisory map keyed by node id that never feeds `pipeline_valid`. Same reason it is composed in by the editing endpoints rather than returned from `pipeline_build_state()`: it costs a query, and `/inspect/` already publishes the fact as `llm.deprecated`.

The map reads `params`, not the `Node.llm_provider_model` FK column — that column is a mirror, and a stale one would let the warning disagree with the model the node is built from.

### Issue Link

fixes #4430

### Demo
See attached screenshots.

### Docs and Changelog

- [x] This PR requires docs/changelog update

Notes for the changelog: deprecating an LLM model no longer stops chatbots that use it. Bots keep running, and the editor warns on affected nodes naming the model and its replacement so teams can migrate before removal. Previously a deprecation broke those bots immediately and blocked test messages and new versions.

### Operator Impact

- [ ] Self-hosted operators must know about or act on this change
