### PR TITLE
Paginate participant sessions table

### DIFF
--- a/apps/chatbots/tables.py
+++ b/apps/chatbots/tables.py
@@ -248,12 +248,8 @@ class ParticipantSessionsTable(ChatbotSessionsTable):
     """Sessions table for the participant details page.
 
     Adds a "Started" column and a single-version display, and swaps the "Session Details"
-    action for a plain "View" chip. Static, matching the #4231 mockup: no sortable
-    columns and no django-tables2 record-count line (the filter bar's own "N of M
-    sessions" text already covers that).
+    action for a plain "View" chip. Static, matching the #4231 mockup: no sortable columns.
     """
-
-    show_record_count = False
 
     chatbot = columns.Column(verbose_name="Chatbot", accessor="experiment", orderable=False)
     started = columns.Column(accessor="created_at", verbose_name="Started")

--- a/apps/chatbots/tests/test_chatbot_views.py
+++ b/apps/chatbots/tests/test_chatbot_views.py
@@ -567,6 +567,47 @@ def test_participant_scoped_sessions_table_view_ignores_a_non_numeric_chatbot_pa
 
 
 @pytest.mark.django_db()
+def test_participant_scoped_sessions_table_view_paginates(client, team_with_users):
+    """Regression for #4452: this table used to render every session in one response."""
+    team = team_with_users
+    user = team.members.first()
+    client.force_login(user)
+
+    experiment = ExperimentFactory.create(team=team)
+    participant = ParticipantFactory.create(team=team)
+    ExperimentSessionFactory.create_batch(30, team=team, experiment=experiment, participant=participant)
+
+    url = reverse(
+        "chatbots:participant_sessions_list", kwargs={"team_slug": team.slug, "participant_id": participant.id}
+    )
+    response = client.get(url)
+
+    table = response.context_data["table"]
+    assert table.paginator.count == 30
+    assert len(table.page.object_list) < 30
+    assert table.paginator.num_pages > 1
+
+
+@pytest.mark.django_db()
+def test_participant_scoped_sessions_table_view_shows_the_record_count(client, team_with_users):
+    """Regression for #4452: replaces the removed "N of M sessions" pill text."""
+    team = team_with_users
+    user = team.members.first()
+    client.force_login(user)
+
+    experiment = ExperimentFactory.create(team=team)
+    participant = ParticipantFactory.create(team=team)
+    ExperimentSessionFactory.create_batch(3, team=team, experiment=experiment, participant=participant)
+
+    url = reverse(
+        "chatbots:participant_sessions_list", kwargs={"team_slug": team.slug, "participant_id": participant.id}
+    )
+    response = client.get(url)
+
+    assert "3 records" in response.content.decode()
+
+
+@pytest.mark.django_db()
 def test_chatbot_sessions_table_view_applies_both_filters_on_one_column(client, team_with_users):
     """A date range built from two filters on the same column must exclude out-of-range sessions.
 

--- a/apps/participants/tests/test_views.py
+++ b/apps/participants/tests/test_views.py
@@ -102,8 +102,7 @@ def test_edit_participant_data_with_missing_field_does_not_500(client, team_with
 
 @pytest.mark.django_db()
 def test_single_participant_home_with_experiment_renders_session_table(client, team_with_users):
-    """Regression: this page builds ChatbotSessionsTable without RequestConfig, so render_chatbot
-    must not assume self.request is set."""
+    """Regression: the Continue Chat button needs the chat widget launcher partial on the page."""
     participant = ParticipantFactory.create(team=team_with_users)
     session = ExperimentSessionFactory.create(
         participant=participant, team=team_with_users, experiment__team=team_with_users
@@ -127,6 +126,44 @@ def test_single_participant_home_with_experiment_renders_session_table(client, t
 
 
 @pytest.mark.django_db()
+def test_single_participant_home_lazy_loads_the_sessions_table(client, team_with_users):
+    """Regression for #4452: the Sessions tab used to render every session inline, unpaginated."""
+    participant = ParticipantFactory.create(team=team_with_users)
+    experiment = ExperimentFactory.create(team=team_with_users)
+    sessions = ExperimentSessionFactory.create_batch(
+        3, team=team_with_users, experiment=experiment, participant=participant
+    )
+    user = team_with_users.members.first()
+    client.login(username=user.username, password="password")
+
+    url = reverse("participants:single-participant-home", args=[team_with_users.slug, participant.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    # None of the session rows are in the initial HTML -- the table fetches them separately.
+    for session in sessions:
+        assert str(session.external_id) not in content
+    assert reverse("chatbots:participant_sessions_list", args=[team_with_users.slug, participant.id]) in content
+
+
+@pytest.mark.django_db()
+def test_sessions_panel_forwards_the_chatbot_filter_to_the_lazy_load_url(client, team_with_users):
+    """Pill clicks don't remount the Alpine filter widget, so this panel must forward `?chatbot=` itself."""
+    participant = ParticipantFactory.create(team=team_with_users)
+    experiment = ExperimentFactory.create(team=team_with_users)
+    ExperimentSessionFactory.create(team=team_with_users, experiment=experiment, participant=participant)
+    user = team_with_users.members.first()
+    client.login(username=user.username, password="password")
+
+    url = reverse("participants:sessions-panel", args=[team_with_users.slug, participant.id])
+    response = client.get(url, {"chatbot": experiment.id})
+
+    assert response.status_code == 200
+    assert f"chatbot={experiment.id}" in response.content.decode()
+
+
+@pytest.mark.django_db()
 class TestParticipantTabPanelsBuildOnlyTheirOwnContext:
     """A chatbot-pill click re-renders one tab. The context builder used to be shared and
     unconditionally built the session table, aggregated every schedule, and loaded
@@ -143,7 +180,7 @@ class TestParticipantTabPanelsBuildOnlyTheirOwnContext:
         response = client.get(url)
 
         assert response.status_code == 200
-        assert "session_table" in response.context
+        assert "df_filter_data_source_url" in response.context
         assert "participant_schedules" not in response.context
         assert "selected_data_experiment" not in response.context
         assert "participant_data" not in response.context
@@ -158,7 +195,7 @@ class TestParticipantTabPanelsBuildOnlyTheirOwnContext:
 
         assert response.status_code == 200
         assert "participant_schedules" in response.context
-        assert "session_table" not in response.context
+        assert "df_filter_data_source_url" not in response.context
         assert "selected_data_experiment" not in response.context
         assert "participant_data" not in response.context
 
@@ -172,7 +209,7 @@ class TestParticipantTabPanelsBuildOnlyTheirOwnContext:
 
         assert response.status_code == 200
         assert "participant_data" in response.context
-        assert "session_table" not in response.context
+        assert "df_filter_data_source_url" not in response.context
         assert "participant_schedules" not in response.context
 
     def test_full_page_still_carries_every_tab_and_the_header(self, client, team_with_users):
@@ -184,7 +221,7 @@ class TestParticipantTabPanelsBuildOnlyTheirOwnContext:
         response = client.get(url)
 
         assert response.status_code == 200
-        for key in ("session_table", "participant_schedules", "participant_data", "message_trend"):
+        for key in ("df_filter_data_source_url", "participant_schedules", "participant_data", "message_trend"):
             assert key in response.context, key
 
 

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -11,13 +11,11 @@ from django.utils import timezone
 from django.views import View
 from django.views.decorators.http import require_POST
 from django.views.generic import CreateView, TemplateView
-from django_tables2 import RequestConfig, SingleTableView
+from django_tables2 import SingleTableView
 
-from apps.annotations.prefetch import chat_tagged_items_prefetch
 from apps.api.tasks import trigger_bot_message_task
 from apps.api.trigger_bot import TriggerBotMessageError, prepare_trigger_bot_message
 from apps.channels.models import ChannelPlatform
-from apps.chatbots.tables import ParticipantSessionsTable
 from apps.cost_tracking.services.reporting import CostFilters, costs_by_participant
 from apps.experiments.models import Experiment, ExperimentSession, Participant, ParticipantData
 from apps.filters.models import FilterSet
@@ -84,14 +82,6 @@ def _sessions_panel_context(
 ) -> dict:
     team = request.team
     total_session_count = ExperimentSession.objects.filter(team=team, participant=participant).count()
-    sessions = (
-        ExperimentSession.objects.get_table_queryset(team, filter_experiment_id)
-        .filter(participant=participant)
-        .prefetch_related(chat_tagged_items_prefetch())
-    )
-    table = ParticipantSessionsTable(sessions)
-    # set request (no pagination) so the chatbot chip can permission-gate its link
-    session_table = RequestConfig(request, paginate=False).configure(table)
     filter_context = get_filter_context_data(
         team=team,
         columns=ExperimentSessionFilter.columns(team),
@@ -104,7 +94,6 @@ def _sessions_panel_context(
         "participant": participant,
         "experiments": experiments,
         "selected_experiment_id": filter_experiment_id,
-        "session_table": session_table,
         "total_session_count": total_session_count,
         **filter_context,
     }

--- a/templates/participants/partials/participant_sessions_panel.html
+++ b/templates/participants/partials/participant_sessions_panel.html
@@ -1,4 +1,7 @@
 {% include "participants/partials/participant_sessions_pills.html" %}
 <div id="participant-sessions-table" hx-swap-oob="true">
-  {% include "table/single_table.html" with table=session_table %}
+  {% comment %}Pills don't remount the Alpine filter widget, so fetch the table explicitly.{% endcomment %}
+  <div hx-get="{{ df_filter_data_source_url }}{% querystring %}"
+       hx-trigger="load"
+       hx-swap="outerHTML">{% include "table/table_placeholder.html" %}</div>
 </div>

--- a/templates/participants/partials/participant_sessions_pills.html
+++ b/templates/participants/partials/participant_sessions_pills.html
@@ -19,6 +19,4 @@
        class="btn btn-sm rounded-lg no-animation transition-none shadow-none border border-base-300 focus:outline-none focus-visible:outline-none active:outline-none
               {% if selected_experiment_id == experiment.id %}btn-soft btn-primary hover:bg-primary/10 hover:text-primary hover:border-base-300{% else %}bg-base-100{% endif %}">{{ experiment }}</a>
   {% endfor %}
-  <div class="flex-1"></div>
-  <span class="pg-help">{{ session_table.rows|length }} {% translate "of" %} {{ total_session_count }} {% translate "sessions" %}</span>
 </div>

--- a/templates/participants/partials/participant_sessions_table.html
+++ b/templates/participants/partials/participant_sessions_table.html
@@ -4,5 +4,5 @@
     {% include "experiments/filters.html" %}
     {% include "participants/partials/participant_sessions_pills.html" %}
   </div>
-  <div id="participant-sessions-table">{% include "table/single_table.html" with table=session_table %}</div>
+  <div id="participant-sessions-table">{% include "table/table_placeholder.html" %}</div>
 </div>


### PR DESCRIPTION
### Product Description
The Sessions tab on a participant's page now loads 25 sessions at a time with pagination controls, instead of rendering every session the participant has ever had across every chatbot in one response.

### Technical Description
The tab used to build its table inline via `RequestConfig(request, paginate=False)`. It now renders a placeholder and lets the existing `ParticipantScopedSessionsTableView` (added in #4393, previously only used by the dynamic filter widget) fill it in via htmx: on first load through that widget's own init fetch, and on a chatbot-pill click through an explicit `hx-get` since pills don't remount the widget.

`ParticipantSessionsTable` no longer opts out of `show_record_count`, replacing the page's now-redundant "N of M sessions" text with the table's own record count.

Closes #4452
Closes #4441 (superseded, see #4450)

### Migrations
- [ ] The migrations are backwards compatible

N/A, no migrations in this PR.

### Demo
Verified live with 30 sessions for one participant: page 1 shows 25 with "25 of 30" and working prev/next, page 2 shows the remaining 5. Verified the chatbot-pill filter still narrows correctly on a real multi-chatbot participant (18 sessions total, 3 after selecting one chatbot), record count updating to match.

<img width="3000" height="4030" alt="4452-participant-sessions-loaded" src="https://github.com/user-attachments/assets/09927439-51c7-498e-8e64-d032cb58ca94" />

<img width="3000" height="1990" alt="4452-pill-filtered" src="https://github.com/user-attachments/assets/e2ebc77c-42db-421c-88f4-def6958d7326" />


### Docs and Changelog
- [ ] This PR requires docs/changelog update

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change
