### PR TITLE
fix: treat voice notes with no speech as user input, not a fault

### DIFF
--- a/apps/channels/channel_base.py
+++ b/apps/channels/channel_base.py
@@ -15,6 +15,7 @@ from apps.channels.stages.core import (
     ConsentFlowStage,
     DuplicateDeliveryStage,
     MessageTypeValidationStage,
+    NoSpeechGuardStage,
     ParticipantIdentifierStage,
     ParticipantResolverStage,
     QueryExtractionStage,
@@ -142,6 +143,9 @@ class ChannelBase(ABC):
                 MessageTypeValidationStage(),
                 QueryExtractionStage(),
                 ChatMessageCreationStage(),
+                # After the turn is recorded, so a silent voice note still appears in
+                # the history and on the trace.
+                NoSpeechGuardStage(),
                 ConsentFlowStage(),
                 BotInteractionStage(),
                 ResponseFormattingStage(),

--- a/apps/channels/pipeline.py
+++ b/apps/channels/pipeline.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from apps.channels.exceptions import EarlyAbort, EarlyExitResponse
 from apps.chat.bots import EventBot
-from apps.chat.exceptions import ChatException
+from apps.chat.exceptions import ChatException, NoSpeechDetected, NoSpeechReason
 from apps.pipelines.exceptions import (
     CodeNodeRunError,
     NodeUserConfigRunError,
@@ -156,13 +156,30 @@ class MessageProcessingPipeline:
        DEFAULT_ERROR_RESPONSE_TEXT, runs terminal stages, and is logged as
        a warning WITHOUT being re-raised (which would report it to Sentry
        and fail the task with no useful retry).
-    4. Unexpected Exception -- catch-all generates an error message
+    4. NoSpeechDetected -- the transcriber found no speech in the
+       participant's voice note. Replies with a message generated from
+       NO_SPEECH_PROMPTS via EventBot, falls back to
+       DEFAULT_ERROR_RESPONSE_TEXT, runs terminal stages, and is NOT
+       re-raised: it is user input, not a fault.
+    5. Unexpected Exception -- catch-all generates an error message
        via EventBot (preserving ChatException distinction), falls back
        to DEFAULT_ERROR_RESPONSE_TEXT, runs terminal stages, then
        RE-RAISES so the caller knows processing failed.
     """
 
     DEFAULT_ERROR_RESPONSE_TEXT = "Sorry, something went wrong while processing your message. Please try again later"
+
+    # Fed to the error bot, which turns them into advice in the participant's language.
+    NO_SPEECH_PROMPTS = {
+        NoSpeechReason.SILENCE: (
+            "Tell the user that no speech could be heard in the voice message they sent"
+            " and that they should try recording it again."
+        ),
+        NoSpeechReason.NOT_UNDERSTOOD: (
+            "Tell the user that the speech in the voice message they sent could not be made out"
+            " and that they should try recording it again, speaking clearly."
+        ),
+    }
 
     def __init__(
         self,
@@ -189,10 +206,13 @@ class MessageProcessingPipeline:
            error text, log a warning, and set ctx.early_exit_response --
            but do NOT re-raise (misconfiguration is not a bug worth
            reporting).
-        5. If any raises an unexpected exception, generate an error message
+        5. If any raises NoSpeechDetected, reply with a message generated
+           from the reason and set ctx.early_exit_response -- but do NOT
+           re-raise (silence is user input, not a bug).
+        6. If any raises an unexpected exception, generate an error message
            and set ctx.early_exit_response.
-        6. Run terminal stages unconditionally (they always fire).
-        7. If there was an unexpected exception, re-raise it after terminal
+        7. Run terminal stages unconditionally (they always fire).
+        8. If there was an unexpected exception, re-raise it after terminal
            stages complete.
         """
         try:
@@ -248,6 +268,9 @@ class MessageProcessingPipeline:
             logger.warning("Node user config error: %s", e)
             ctx.early_exit_response = self.DEFAULT_ERROR_RESPONSE_TEXT
             ctx.processing_errors.append(str(e))
+        except NoSpeechDetected as e:
+            logger.info("No speech detected in voice message: %s", e.reason)
+            ctx.early_exit_response = self._user_message(ctx, self.NO_SPEECH_PROMPTS[e.reason], e)
         except Exception as e:
             ctx.early_exit_response = self._generate_error_message(ctx, e)
             ctx.processing_errors.append(str(e))
@@ -264,7 +287,6 @@ class MessageProcessingPipeline:
         Maps to the old _inform_user_of_error() but WITHOUT sending --
         sending is ResponseSendingStage's responsibility.
         """
-        trace_info = TraceInfo(name="error", metadata={"error": str(exception)})
         prompt = (
             "Tell the user that something went wrong while processing their message"
             " and that they should try again later."
@@ -275,7 +297,11 @@ class MessageProcessingPipeline:
                 f"they should try again later or adjust the message type or contents "
                 f"according to the following error message: {exception}"
             )
+        return self._user_message(ctx, prompt, exception)
 
+    def _user_message(self, ctx: MessageProcessingContext, prompt: str, exception: Exception) -> str:
+        """Ask EventBot for a participant-facing message, falling back to the canned reply."""
+        trace_info = TraceInfo(name="error", metadata={"error": str(exception)})
         event_bot = EventBot(ctx.experiment_session, ctx.experiment, trace_info, trace_service=ctx.trace_service)
         try:
             return event_bot.get_user_message(prompt)

--- a/apps/channels/pipeline.py
+++ b/apps/channels/pipeline.py
@@ -84,6 +84,12 @@ class MessageProcessingContext:
     # Stages do NOT set this directly; they raise EarlyExitResponse.
     early_exit_response: str | None = None
 
+    # Set by QueryExtractionStage when a voice note held no speech. It defers the
+    # signal rather than raising so ChatMessageCreationStage still records the turn;
+    # NoSpeechGuardStage raises once it has. An empty user_query cannot carry this
+    # on its own -- an attachment-only message with no caption looks identical.
+    no_speech_reason: NoSpeechReason | None = None
+
     # --- Sending errors -----------------------------------------------------
     # Populated by ResponseSendingStage for each send failure (text, voice,
     # or file). SendingErrorHandlerStage processes each one for notifications

--- a/apps/channels/pipeline.py
+++ b/apps/channels/pipeline.py
@@ -156,12 +156,12 @@ class MessageProcessingPipeline:
     2. EarlyAbort -- silent halt; no message, no terminal stages.
        Used when reporting back to the user would be wrong (e.g. platform
        consent withdrawn).
-    3. Pipeline build error -- the pipeline is misconfigured (e.g. a
-       deprecated model, an unreachable node). This is a user
-       configuration problem, not a bug, so it replies with the generic
-       DEFAULT_ERROR_RESPONSE_TEXT, runs terminal stages, and is logged as
-       a warning WITHOUT being re-raised (which would report it to Sentry
-       and fail the task with no useful retry).
+    3. Configuration error -- the chatbot is misconfigured (e.g. a
+       deprecated model, an unreachable node, a broken template, code that
+       raised). This is a user configuration problem, not a bug, so it
+       replies with the generic DEFAULT_ERROR_RESPONSE_TEXT, runs terminal
+       stages, and is logged as a warning WITHOUT being re-raised (which
+       would report it to Sentry and fail the task with no useful retry).
     4. NoSpeechDetected -- the transcriber found no speech in the
        participant's voice note. Replies with a message generated from
        NO_SPEECH_PROMPTS via EventBot, falls back to
@@ -174,6 +174,10 @@ class MessageProcessingPipeline:
     """
 
     DEFAULT_ERROR_RESPONSE_TEXT = "Sorry, something went wrong while processing your message. Please try again later"
+
+    # Errors in how the chatbot was configured, not bugs: they get the canned reply
+    # and are never re-raised.
+    CONFIGURATION_EXCEPTIONS = (PipelineBuildError, PipelineNodeBuildError, CodeNodeRunError, NodeUserConfigRunError)
 
     # Fed to the error bot, which turns them into advice in the participant's language.
     NO_SPEECH_PROMPTS = {
@@ -208,7 +212,7 @@ class MessageProcessingPipeline:
            handling, no terminal stages, no user-facing response.
         3. If any raises a passthrough exception, re-raise immediately
            without error handling or terminal stages.
-        4. If any raises a pipeline build error, reply with the generic
+        4. If any raises a configuration error, reply with the generic
            error text, log a warning, and set ctx.early_exit_response --
            but do NOT re-raise (misconfiguration is not a bug worth
            reporting).
@@ -256,22 +260,16 @@ class MessageProcessingPipeline:
             # Passthrough exceptions (e.g. GenerationCancelled) propagate immediately --
             # no error message generation, no terminal stages.
             raise
-        except (PipelineBuildError, PipelineNodeBuildError) as e:
-            # The pipeline is misconfigured (e.g. a deprecated model). Reply
-            # with the generic message and run terminal stages, but do NOT
-            # re-raise: this is a configuration problem, not a bug, and
-            # re-raising would report it to Sentry and fail the task with no
-            # useful retry. Skip LLM-based message generation -- the LLM may be
-            # the thing that is misconfigured, and a canned reply is enough.
-            logger.warning("Pipeline build error (node=%s): %s", getattr(e, "node_id", None), e)
-            ctx.early_exit_response = self.DEFAULT_ERROR_RESPONSE_TEXT
-            ctx.processing_errors.append(str(e))
-        except (CodeNodeRunError, NodeUserConfigRunError) as e:
-            # User-authored code or user-configured template/email raised an error.
-            # This is a user configuration problem, not a system bug.
-            # Log a warning and return a canned reply without re-raising so that
-            # Sentry does not receive a spurious error report.
-            logger.warning("Node user config error: %s", e)
+        except self.CONFIGURATION_EXCEPTIONS as e:
+            # The chatbot is misconfigured (a deprecated model, a broken template,
+            # user-authored code that raised). Reply with the canned message and run
+            # terminal stages, but do NOT re-raise: this is a configuration problem,
+            # not a bug, and re-raising would report it to Sentry and fail the task
+            # with no useful retry. Skip LLM-based message generation too -- the LLM
+            # may be the thing that is misconfigured.
+            logger.warning(
+                "Chatbot configuration error (%s, node=%s): %s", type(e).__name__, getattr(e, "node_id", None), e
+            )
             ctx.early_exit_response = self.DEFAULT_ERROR_RESPONSE_TEXT
             ctx.processing_errors.append(str(e))
         except NoSpeechDetected as e:

--- a/apps/channels/stages/base.py
+++ b/apps/channels/stages/base.py
@@ -8,15 +8,17 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from django.db.models import Model
 
 from apps.channels.exceptions import EarlyAbort, EarlyExitResponse
+from apps.chat.exceptions import NoSpeechDetected
 from apps.service_providers.llm_service.runnables import GenerationCancelled
 
 if TYPE_CHECKING:
     from apps.channels.pipeline import MessageProcessingContext
 
 # Control-flow signals are not failures: they steer the pipeline (early exit,
-# silent abort, generation cancellation) rather than indicate something broke.
-# They must not mark a stage's span as errored.
-_CONTROL_FLOW_SIGNALS = (EarlyExitResponse, EarlyAbort, GenerationCancelled)
+# silent abort, generation cancellation, a voice note with no speech in it)
+# rather than indicate something broke. They must not mark a stage's span as
+# errored, which would also count them on the operator error-rate charts.
+_CONTROL_FLOW_SIGNALS = (EarlyExitResponse, EarlyAbort, GenerationCancelled, NoSpeechDetected)
 
 # Bounds for span-value serialization -- keep trace payloads small and cheap.
 _SPAN_LIST_LIMIT = 20

--- a/apps/channels/stages/core.py
+++ b/apps/channels/stages/core.py
@@ -571,10 +571,14 @@ class QueryExtractionStage(ProcessingStage):
         if ctx.message.content_type == MESSAGE_TYPES.VOICE:
             try:
                 ctx.user_query = self._transcribe_voice(ctx)
-            except NoSpeechDetected:
-                # The pipeline answers the participant for this one: no team
-                # notification and no processing error recorded against the trace.
-                raise
+            except NoSpeechDetected as e:
+                # Defer to NoSpeechGuardStage so ChatMessageCreationStage records the
+                # turn first: the voice note is real input and belongs in the history
+                # and on the trace, even though there are no words in it. The empty
+                # query is what makes that stage keep the text empty and let the
+                # attachment carry the content.
+                ctx.user_query = ""
+                ctx.no_speech_reason = e.reason
             except Exception as e:
                 # Stage handles its own error
                 audio_transcription_failure_notification(ctx.experiment, platform=ctx.experiment_channel.platform)
@@ -696,6 +700,29 @@ class ChatMessageCreationStage(ProcessingStage):
         )
         ctx.experiment_session.chat.attach_files("voice_message", [file])
         return [file.id]
+
+
+# ---------------------------------------------------------------------------
+# NoSpeechGuardStage
+# ---------------------------------------------------------------------------
+
+
+class NoSpeechGuardStage(ProcessingStage):
+    """Stops a voice note that held no speech, once the turn has been recorded.
+
+    Sits after ChatMessageCreationStage because QueryExtractionStage cannot both
+    record the turn and halt the pipeline. The pipeline answers the participant
+    from the reason.
+    """
+
+    span_input_fields = ("no_speech_reason",)
+
+    def should_run(self, ctx: MessageProcessingContext) -> bool:
+        return ctx.no_speech_reason is not None
+
+    def process(self, ctx: MessageProcessingContext) -> None:
+        assert ctx.no_speech_reason is not None
+        raise NoSpeechDetected(ctx.no_speech_reason)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/channels/stages/core.py
+++ b/apps/channels/stages/core.py
@@ -17,7 +17,7 @@ from apps.channels.stages.base import ProcessingStage
 from apps.channels.text_utils import MARKDOWN_REF_PATTERN, strip_urls_and_emojis
 from apps.chat.bots import EvalsBot, EventBot, get_bot
 from apps.chat.const import STATUSES_FOR_COMPLETE_CHATS
-from apps.chat.exceptions import AudioSynthesizeException, UserReportableError
+from apps.chat.exceptions import AudioSynthesizeException, NoSpeechDetected, UserReportableError
 from apps.chat.models import ChatAttachment, ChatMessage, ChatMessageMetadataKeys, ChatMessageType
 from apps.events.models import StaticTriggerType
 from apps.events.tasks import enqueue_static_triggers
@@ -571,6 +571,10 @@ class QueryExtractionStage(ProcessingStage):
         if ctx.message.content_type == MESSAGE_TYPES.VOICE:
             try:
                 ctx.user_query = self._transcribe_voice(ctx)
+            except NoSpeechDetected:
+                # The pipeline answers the participant for this one: no team
+                # notification and no processing error recorded against the trace.
+                raise
             except Exception as e:
                 # Stage handles its own error
                 audio_transcription_failure_notification(ctx.experiment, platform=ctx.experiment_channel.platform)

--- a/apps/channels/stages/terminal.py
+++ b/apps/channels/stages/terminal.py
@@ -281,54 +281,69 @@ class PersistenceStage(ProcessingStage):
         )
 
     def process(self, ctx: MessageProcessingContext) -> None:
-        # 1. Apply human message tags set by earlier stages
-        if ctx.human_message and ctx.human_message_tags:
-            for tag_name, tag_category in ctx.human_message_tags:
-                ctx.human_message.create_and_add_tag(tag_name, ctx.experiment.team, tag_category)
+        self._apply_human_message_tags(ctx)
+        self._persist_early_exit_response(ctx)
+        self._attach_voice_audio(ctx)
 
-        # 2. Persist early exit response to chat history.
-        #    Skip when ctx.bot_response exists -- bot.process_input() already
-        #    persisted the AI message (e.g. when the catch-all error handler
-        #    set early_exit_response after BotInteractionStage succeeded).
-        if ctx.early_exit_response is not None and ctx.bot_response is None:
-            # Both halves of the link, as the bot path does when it saves a response:
-            # the FK so the trace points at the message, and the metadata the message
-            # renders its own trace icon from. The bot path never ran, so nothing else
-            # sets either.
-            trace_metadata = ctx.trace_service.get_trace_metadata() if ctx.trace_service else {}
-            ai_message = ChatMessage.objects.create(
-                chat=ctx.experiment_session.chat,
-                message_type=ChatMessageType.AI,
-                content=ctx.early_exit_response,
-                metadata=trace_metadata,
+    def _apply_human_message_tags(self, ctx: MessageProcessingContext) -> None:
+        """Apply the tags earlier stages set on the inbound message."""
+        if not (ctx.human_message and ctx.human_message_tags):
+            return
+
+        for tag_name, tag_category in ctx.human_message_tags:
+            ctx.human_message.create_and_add_tag(tag_name, ctx.experiment.team, tag_category)
+
+    def _persist_early_exit_response(self, ctx: MessageProcessingContext) -> None:
+        """Record the early exit response as an AI message.
+
+        Skipped when ctx.bot_response exists -- bot.process_input() already
+        persisted the AI message (e.g. when the catch-all error handler
+        set early_exit_response after BotInteractionStage succeeded).
+        """
+        if ctx.early_exit_response is None or ctx.bot_response is not None:
+            return
+
+        # Both halves of the link, as the bot path does when it saves a response:
+        # the FK so the trace points at the message, and the metadata the message
+        # renders its own trace icon from. The bot path never ran, so nothing else
+        # sets either.
+        trace_metadata = ctx.trace_service.get_trace_metadata() if ctx.trace_service else {}
+        ai_message = ChatMessage.objects.create(
+            chat=ctx.experiment_session.chat,
+            message_type=ChatMessageType.AI,
+            content=ctx.early_exit_response,
+            metadata=trace_metadata,
+        )
+        if ctx.trace_service:
+            ctx.trace_service.set_output_message_id(ai_message.id)
+
+    def _attach_voice_audio(self, ctx: MessageProcessingContext) -> None:
+        """Tag the bot response as voice and attach the synthesized audio."""
+        if ctx.voice_audio is None or ctx.bot_response is None:
+            return
+
+        ctx.bot_response.create_and_add_tag("voice", ctx.experiment.team, TagCategories.MEDIA_TYPE)
+        ctx.voice_audio.audio.seek(0)
+        # Guard against zero-byte / exhausted audio streams. Persisting a
+        # File row without storage leads to ValueError later when the
+        # attachment is downloaded (see OPEN-CHAT-STUDIO-248).
+        if not ctx.voice_audio.audio.read():
+            logger.warning(
+                "Skipping voice_note.ogg attachment for experiment=%s session=%s: empty audio stream",
+                ctx.experiment.id,
+                getattr(ctx.experiment_session, "id", None),
             )
-            if ctx.trace_service:
-                ctx.trace_service.set_output_message_id(ai_message.id)
+            return
 
-        # 3. Tag and save voice attachment on bot response
-        if ctx.voice_audio is not None and ctx.bot_response is not None:
-            ctx.bot_response.create_and_add_tag("voice", ctx.experiment.team, TagCategories.MEDIA_TYPE)
-            ctx.voice_audio.audio.seek(0)
-            # Guard against zero-byte / exhausted audio streams. Persisting a
-            # File row without storage leads to ValueError later when the
-            # attachment is downloaded (see OPEN-CHAT-STUDIO-248).
-            audio_bytes = ctx.voice_audio.audio.read()
-            if not audio_bytes:
-                logger.warning(
-                    "Skipping voice_note.ogg attachment for experiment=%s session=%s: empty audio stream",
-                    ctx.experiment.id,
-                    getattr(ctx.experiment_session, "id", None),
-                )
-            else:
-                ctx.voice_audio.audio.seek(0)
-                file = File.create(
-                    "voice_note.ogg",
-                    ctx.voice_audio.audio,
-                    ctx.experiment.team_id,
-                    purpose=FilePurpose.MESSAGE_MEDIA,
-                    content_type=ctx.voice_audio.content_type,
-                )
-                ctx.bot_response.add_attachment_id(file.id)
+        ctx.voice_audio.audio.seek(0)
+        file = File.create(
+            "voice_note.ogg",
+            ctx.voice_audio.audio,
+            ctx.experiment.team_id,
+            purpose=FilePurpose.MESSAGE_MEDIA,
+            content_type=ctx.voice_audio.content_type,
+        )
+        ctx.bot_response.add_attachment_id(file.id)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/channels/stages/terminal.py
+++ b/apps/channels/stages/terminal.py
@@ -290,8 +290,6 @@ class PersistenceStage(ProcessingStage):
         #    Skip when ctx.bot_response exists -- bot.process_input() already
         #    persisted the AI message (e.g. when the catch-all error handler
         #    set early_exit_response after BotInteractionStage succeeded).
-        print(f"ctx.early_exit_response: {ctx.early_exit_response}")
-        print(f"ctx.bot_response: {ctx.bot_response}")
         if ctx.early_exit_response is not None and ctx.bot_response is None:
             # Both halves of the link, as the bot path does when it saves a response:
             # the FK so the trace points at the message, and the metadata the message

--- a/apps/channels/stages/terminal.py
+++ b/apps/channels/stages/terminal.py
@@ -290,14 +290,20 @@ class PersistenceStage(ProcessingStage):
         #    Skip when ctx.bot_response exists -- bot.process_input() already
         #    persisted the AI message (e.g. when the catch-all error handler
         #    set early_exit_response after BotInteractionStage succeeded).
+        print(f"ctx.early_exit_response: {ctx.early_exit_response}")
+        print(f"ctx.bot_response: {ctx.bot_response}")
         if ctx.early_exit_response is not None and ctx.bot_response is None:
+            # Both halves of the link, as the bot path does when it saves a response:
+            # the FK so the trace points at the message, and the metadata the message
+            # renders its own trace icon from. The bot path never ran, so nothing else
+            # sets either.
+            trace_metadata = ctx.trace_service.get_trace_metadata() if ctx.trace_service else {}
             ai_message = ChatMessage.objects.create(
                 chat=ctx.experiment_session.chat,
                 message_type=ChatMessageType.AI,
                 content=ctx.early_exit_response,
+                metadata=trace_metadata,
             )
-            # Nothing else links this one: the bot path sets it from process_input,
-            # which never ran. Without it the trace has no message to navigate from.
             if ctx.trace_service:
                 ctx.trace_service.set_output_message_id(ai_message.id)
 

--- a/apps/channels/stages/terminal.py
+++ b/apps/channels/stages/terminal.py
@@ -291,11 +291,15 @@ class PersistenceStage(ProcessingStage):
         #    persisted the AI message (e.g. when the catch-all error handler
         #    set early_exit_response after BotInteractionStage succeeded).
         if ctx.early_exit_response is not None and ctx.bot_response is None:
-            ChatMessage.objects.create(
+            ai_message = ChatMessage.objects.create(
                 chat=ctx.experiment_session.chat,
                 message_type=ChatMessageType.AI,
                 content=ctx.early_exit_response,
             )
+            # Nothing else links this one: the bot path sets it from process_input,
+            # which never ran. Without it the trace has no message to navigate from.
+            if ctx.trace_service:
+                ctx.trace_service.set_output_message_id(ai_message.id)
 
         # 3. Tag and save voice attachment on bot response
         if ctx.voice_audio is not None and ctx.bot_response is not None:

--- a/apps/channels/tests/channels/stages/test_persistence.py
+++ b/apps/channels/tests/channels/stages/test_persistence.py
@@ -6,7 +6,7 @@ import pytest
 from apps.channels.stages.terminal import PersistenceStage
 from apps.channels.tests.channels.conftest import make_context
 from apps.channels.tests.message_examples.base_messages import text_message
-from apps.chat.models import ChatMessage, ChatMessageType
+from apps.chat.models import ChatMessage, ChatMessageMetadataKeys, ChatMessageType
 from apps.utils.factories.experiment import ExperimentFactory, ExperimentSessionFactory
 
 
@@ -127,6 +127,24 @@ class TestPersistenceStageDB:
 
         ai_message = ChatMessage.objects.get(chat=session.chat, message_type=ChatMessageType.AI)
         ctx.trace_service.set_output_message_id.assert_called_once_with(ai_message.id)
+
+    def test_early_exit_ai_message_carries_trace_metadata(self):
+        """The message renders its own trace icon from this, so the FK alone is not enough."""
+        experiment = ExperimentFactory()
+        session = ExperimentSessionFactory(experiment=experiment, team=experiment.team)
+        ctx = make_context(
+            experiment=experiment,
+            experiment_session=session,
+            early_exit_response="Not allowed",
+        )
+        ctx.trace_service.get_trace_metadata.return_value = {
+            ChatMessageMetadataKeys.TRACE_INFO: [{"trace_id": 7, "trace_provider": "ocs"}]
+        }
+
+        self.stage(ctx)
+
+        ai_message = ChatMessage.objects.get(chat=session.chat, message_type=ChatMessageType.AI)
+        assert [info["trace_id"] for info in ai_message.trace_info] == [7]
 
     def test_no_trace_link_when_the_bot_already_replied(self):
         """bot.process_input() linked its own message; PersistenceStage must not overwrite it."""

--- a/apps/channels/tests/channels/stages/test_persistence.py
+++ b/apps/channels/tests/channels/stages/test_persistence.py
@@ -112,3 +112,33 @@ class TestPersistenceStageDB:
         bot_msg.refresh_from_db()
         tag_names = list(bot_msg.tags.values_list("name", flat=True))
         assert "voice" in tag_names
+
+    def test_early_exit_ai_message_is_linked_to_the_trace(self):
+        """Only PersistenceStage knows this message exists, so only it can link it."""
+        experiment = ExperimentFactory()
+        session = ExperimentSessionFactory(experiment=experiment, team=experiment.team)
+        ctx = make_context(
+            experiment=experiment,
+            experiment_session=session,
+            early_exit_response="Not allowed",
+        )
+
+        self.stage(ctx)
+
+        ai_message = ChatMessage.objects.get(chat=session.chat, message_type=ChatMessageType.AI)
+        ctx.trace_service.set_output_message_id.assert_called_once_with(ai_message.id)
+
+    def test_no_trace_link_when_the_bot_already_replied(self):
+        """bot.process_input() linked its own message; PersistenceStage must not overwrite it."""
+        experiment = ExperimentFactory()
+        session = ExperimentSessionFactory(experiment=experiment, team=experiment.team)
+        ctx = make_context(
+            experiment=experiment,
+            experiment_session=session,
+            early_exit_response="seed message response",
+            bot_response=MagicMock(),
+        )
+
+        self.stage(ctx)
+
+        ctx.trace_service.set_output_message_id.assert_not_called()

--- a/apps/channels/tests/channels/stages/test_query_extraction.py
+++ b/apps/channels/tests/channels/stages/test_query_extraction.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from apps.channels.stages.core import QueryExtractionStage
+from apps.channels.stages.core import NoSpeechGuardStage, QueryExtractionStage
 from apps.channels.tests.channels.conftest import StubCallbacks, make_context
 from apps.channels.tests.message_examples.base_messages import audio_message, text_message
 from apps.chat.exceptions import NoSpeechDetected, NoSpeechReason
@@ -86,22 +86,51 @@ class TestQueryExtractionStage:
         # The raise tears the span down, which is what marks the trace as errored.
         assert not _span(ctx).set_outputs.called
 
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            pytest.param(NoSpeechReason.SILENCE, id="silence"),
+            pytest.param(NoSpeechReason.NOT_UNDERSTOOD, id="not-understood"),
+        ],
+    )
     @patch("apps.channels.stages.core.audio_transcription_failure_notification")
-    def test_no_speech_is_neither_notified_nor_recorded_as_an_error(self, mock_notification):
+    def test_no_speech_defers_instead_of_raising(self, mock_notification, reason):
+        """Deferred so ChatMessageCreationStage still records the turn."""
         msg = audio_message()
         experiment = MagicMock()
         experiment.voice_provider.get_speech_service.return_value.supports_transcription = True
         experiment.voice_provider.get_speech_service.return_value.transcribe_audio.side_effect = NoSpeechDetected(
-            NoSpeechReason.SILENCE
+            reason
         )
         ctx = make_context(message=msg, callbacks=StubCallbacks(), experiment=experiment)
 
-        with pytest.raises(NoSpeechDetected):
-            self.stage(ctx)
+        self.stage(ctx)
 
+        assert ctx.no_speech_reason == reason
+        # Empty rather than None, so ChatMessageCreationStage runs and keeps the text empty.
+        assert ctx.user_query == ""
         mock_notification.assert_not_called()
         assert ctx.processing_errors == []
-        # Treated as a control-flow signal, so the span closes cleanly and the
-        # trace is not counted on the operator error-rate charts.
         assert _span(ctx).set_outputs.called
         _span(ctx).mark_span_as_error.assert_not_called()
+
+
+class TestNoSpeechGuardStage:
+    def setup_method(self):
+        self.stage = NoSpeechGuardStage()
+
+    def test_raises_the_deferred_reason(self):
+        ctx = make_context(user_query="", no_speech_reason=NoSpeechReason.NOT_UNDERSTOOD)
+
+        with pytest.raises(NoSpeechDetected) as exc_info:
+            self.stage(ctx)
+
+        assert exc_info.value.reason == NoSpeechReason.NOT_UNDERSTOOD
+
+    def test_does_not_run_for_an_ordinary_empty_query(self):
+        """An attachment-only message with no caption reaches this stage with user_query == ""."""
+        ctx = make_context(user_query="")
+
+        self.stage(ctx)
+
+        assert ctx.early_exit_response is None

--- a/apps/channels/tests/channels/stages/test_query_extraction.py
+++ b/apps/channels/tests/channels/stages/test_query_extraction.py
@@ -5,6 +5,12 @@ import pytest
 from apps.channels.stages.core import QueryExtractionStage
 from apps.channels.tests.channels.conftest import StubCallbacks, make_context
 from apps.channels.tests.message_examples.base_messages import audio_message, text_message
+from apps.chat.exceptions import NoSpeechDetected, NoSpeechReason
+
+
+def _span(ctx):
+    """The span mock the stage wrote to, as entered by ProcessingStage.__call__."""
+    return ctx.trace_service.span.return_value.__enter__.return_value
 
 
 class TestQueryExtractionStage:
@@ -77,3 +83,25 @@ class TestQueryExtractionStage:
 
         mock_notification.assert_called_once()
         assert any("Voice transcription failed" in e for e in ctx.processing_errors)
+        # The raise tears the span down, which is what marks the trace as errored.
+        assert not _span(ctx).set_outputs.called
+
+    @patch("apps.channels.stages.core.audio_transcription_failure_notification")
+    def test_no_speech_is_neither_notified_nor_recorded_as_an_error(self, mock_notification):
+        msg = audio_message()
+        experiment = MagicMock()
+        experiment.voice_provider.get_speech_service.return_value.supports_transcription = True
+        experiment.voice_provider.get_speech_service.return_value.transcribe_audio.side_effect = NoSpeechDetected(
+            NoSpeechReason.SILENCE
+        )
+        ctx = make_context(message=msg, callbacks=StubCallbacks(), experiment=experiment)
+
+        with pytest.raises(NoSpeechDetected):
+            self.stage(ctx)
+
+        mock_notification.assert_not_called()
+        assert ctx.processing_errors == []
+        # Treated as a control-flow signal, so the span closes cleanly and the
+        # trace is not counted on the operator error-rate charts.
+        assert _span(ctx).set_outputs.called
+        _span(ctx).mark_span_as_error.assert_not_called()

--- a/apps/channels/tests/channels/test_pipeline_orchestrator.py
+++ b/apps/channels/tests/channels/test_pipeline_orchestrator.py
@@ -7,7 +7,13 @@ from apps.channels.pipeline import (
     EarlyExitResponse,
     MessageProcessingPipeline,
 )
-from apps.chat.exceptions import ChatException
+from apps.chat.exceptions import (
+    AudioTranscriptionException,
+    ChatException,
+    NoSpeechDetected,
+    NoSpeechReason,
+    UserReportableError,
+)
 from apps.pipelines.exceptions import (
     CodeNodeRunError,
     NodeUserConfigRunError,
@@ -255,6 +261,66 @@ class TestUserCausedErrors:
         single test going red.
         """
         assert not issubclass(NodeUserConfigRunError, PipelineNodeRunError)
+
+
+class TestNoSpeechDetected:
+    """A voice note with no recognizable speech is participant input, not a fault."""
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            pytest.param(NoSpeechReason.SILENCE, id="silence"),
+            pytest.param(NoSpeechReason.NOT_UNDERSTOOD, id="not-understood"),
+        ],
+    )
+    @patch("apps.channels.pipeline.MessageProcessingPipeline._user_message")
+    def test_replies_with_the_prompt_for_the_reason_and_does_not_reraise(self, mock_user_message, reason):
+        mock_user_message.return_value = "I could not hear anything in that voice note"
+        error = NoSpeechDetected(reason)
+        s1 = _make_stage(side_effect=error)
+        t1 = _make_stage()
+
+        ctx = make_context()
+        pipeline = _pipeline(core=[s1], terminal=[t1])
+
+        result = pipeline.process(ctx)
+
+        assert result is ctx
+        mock_user_message.assert_called_once_with(ctx, MessageProcessingPipeline.NO_SPEECH_PROMPTS[reason], error)
+        assert ctx.early_exit_response == "I could not hear anything in that voice note"
+        t1.assert_called_once()
+
+    @patch("apps.channels.pipeline.MessageProcessingPipeline._user_message")
+    def test_is_not_recorded_as_a_processing_error(self, mock_user_message):
+        mock_user_message.return_value = "I could not hear anything in that voice note"
+        s1 = _make_stage(side_effect=NoSpeechDetected(NoSpeechReason.SILENCE))
+
+        ctx = make_context()
+        _pipeline(core=[s1], terminal=[_make_stage()]).process(ctx)
+
+        assert ctx.processing_errors == []
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(UserReportableError("Unable to transcribe audio"), id="provider-failure"),
+            pytest.param(AudioTranscriptionException("Azure speech transcription failed"), id="direct-parent"),
+        ],
+    )
+    @patch("apps.channels.pipeline.MessageProcessingPipeline._generate_error_message")
+    def test_real_transcription_failures_are_still_reraised(self, mock_gen, error):
+        """Only the NoSpeechDetected subclass is exempt; its ancestors keep reaching Sentry."""
+        mock_gen.return_value = "something went wrong"
+        s1 = _make_stage(side_effect=error)
+        t1 = _make_stage()
+
+        ctx = make_context()
+        pipeline = _pipeline(core=[s1], terminal=[t1])
+
+        with pytest.raises(type(error)):
+            pipeline.process(ctx)
+
+        t1.assert_called_once()
 
 
 class TestErrorMessageGeneration:

--- a/apps/channels/tests/channels/test_voice_transcription_no_speech.py
+++ b/apps/channels/tests/channels/test_voice_transcription_no_speech.py
@@ -1,0 +1,96 @@
+"""End-to-end behaviour for a voice note the transcriber found no speech in.
+
+Runs a real message through ``ChannelBase.new_user_message`` against the DB, which is
+what checks that the provider, the stage and the pipeline connect. The tests either
+side of this one each mock one of those boundaries.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import azure.cognitiveservices.speech as speechsdk
+import pytest
+
+from apps.channels.pipeline import MessageProcessingPipeline
+from apps.channels.tests.message_examples import base_messages
+from apps.chat.exceptions import NoSpeechReason, UserReportableError
+from apps.ocs_notifications.models import NotificationEvent
+from apps.service_providers.models import VoiceProviderType
+from apps.utils.factories.experiment import ExperimentSessionFactory
+from apps.utils.factories.service_provider_factories import VoiceProviderFactory
+
+from .conftest import StubChannel, make_trace_service
+
+
+@pytest.fixture()
+def azure_voice_session(db):
+    session = ExperimentSessionFactory.create()
+    session.experiment.voice_provider = VoiceProviderFactory.create(
+        team=session.team,
+        type=VoiceProviderType.azure,
+        config={"azure_subscription_key": "key", "azure_region": "eastus"},
+    )
+    session.experiment.save()
+    return session
+
+
+def _channel(session):
+    channel = StubChannel(session.experiment, session.experiment_channel, session)
+    channel.trace_service = make_trace_service()
+    return channel
+
+
+@contextmanager
+def _azure_no_match(reason):
+    """Patch the Azure SDK so recognition returns NoMatch with the given reason."""
+    with (
+        patch.object(speechsdk, "SpeechConfig"),
+        patch.object(speechsdk.audio, "AudioConfig"),
+        patch.object(speechsdk, "SpeechRecognizer") as recognizer_cls,
+    ):
+        recognition = recognizer_cls.return_value.recognize_once_async.return_value.get.return_value
+        recognition.reason = speechsdk.ResultReason.NoMatch
+        recognition.no_match_details.reason = reason
+        yield
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("no_match_reason", "expected_reason"),
+    [
+        pytest.param(speechsdk.NoMatchReason.InitialSilenceTimeout, NoSpeechReason.SILENCE, id="silence"),
+        pytest.param(speechsdk.NoMatchReason.NotRecognized, NoSpeechReason.NOT_UNDERSTOOD, id="not-understood"),
+    ],
+)
+@patch("apps.channels.pipeline.EventBot")
+def test_no_speech_replies_without_erroring_or_notifying(
+    mock_event_bot_cls, azure_voice_session, no_match_reason, expected_reason
+):
+    mock_event_bot_cls.return_value.get_user_message.return_value = "I could not hear anything"
+    channel = _channel(azure_voice_session)
+
+    with _azure_no_match(no_match_reason):
+        channel.new_user_message(base_messages.audio_message())
+
+    assert channel.text_sent == ["I could not hear anything"]
+
+    prompt = mock_event_bot_cls.return_value.get_user_message.call_args.args[0]
+    assert prompt == MessageProcessingPipeline.NO_SPEECH_PROMPTS[expected_reason]
+
+    assert not NotificationEvent.objects.filter(title="Audio Transcription Failed").exists()
+
+
+@pytest.mark.django_db()
+@patch("apps.channels.pipeline.EventBot")
+def test_real_transcription_failure_still_raises_and_notifies(mock_event_bot_cls, azure_voice_session):
+    """The other half of the contract: a genuine Azure fault keeps reaching Sentry and the team."""
+    mock_event_bot_cls.return_value.get_user_message.return_value = "something went wrong"
+    channel = _channel(azure_voice_session)
+
+    with (
+        patch.object(speechsdk, "SpeechConfig", side_effect=RuntimeError("invalid subscription key")),
+        pytest.raises(UserReportableError, match="Unable to transcribe audio"),
+    ):
+        channel.new_user_message(base_messages.audio_message())
+
+    assert NotificationEvent.objects.filter(title="Audio Transcription Failed").exists()

--- a/apps/channels/tests/channels/test_voice_transcription_no_speech.py
+++ b/apps/channels/tests/channels/test_voice_transcription_no_speech.py
@@ -141,6 +141,10 @@ def test_no_speech_records_the_turn_and_links_it_to_the_trace(mock_event_bot_cls
     assert trace.input_message_id == human.id
     assert trace.output_message_id == ai.id
 
+    # The UI renders the trace icon from the AI message's own metadata, not the FK,
+    # so the FK alone leaves the icon disabled with "No trace recorded".
+    assert [info["trace_id"] for info in ai.trace_info] == [trace.id]
+
 
 @pytest.mark.django_db()
 @patch("apps.channels.pipeline.EventBot")

--- a/apps/channels/tests/channels/test_voice_transcription_no_speech.py
+++ b/apps/channels/tests/channels/test_voice_transcription_no_speech.py
@@ -6,18 +6,24 @@ side of this one each mock one of those boundaries.
 """
 
 from contextlib import contextmanager
+from io import BytesIO
 from unittest.mock import patch
 
 import azure.cognitiveservices.speech as speechsdk
 import pytest
 
+from apps.channels.const import MESSAGE_TYPES
+from apps.channels.datamodels import BaseMessage, MediaCache
 from apps.channels.pipeline import MessageProcessingPipeline
 from apps.channels.tests.message_examples import base_messages
 from apps.chat.exceptions import NoSpeechReason, UserReportableError
+from apps.chat.models import ChatMessage, ChatMessageType
 from apps.ocs_notifications.models import NotificationEvent
 from apps.service_providers.models import VoiceProviderType
+from apps.trace.models import Trace
 from apps.utils.factories.experiment import ExperimentSessionFactory
 from apps.utils.factories.service_provider_factories import VoiceProviderFactory
+from apps.utils.llm_messages import EMPTY_MESSAGE_PLACEHOLDER
 
 from .conftest import StubChannel, make_trace_service
 
@@ -38,6 +44,16 @@ def _channel(session):
     channel = StubChannel(session.experiment, session.experiment_channel, session)
     channel.trace_service = make_trace_service()
     return channel
+
+
+def _voice_message(audio: bytes = b"opus-bytes"):
+    """A voice note carrying real bytes, so the attachment is not skipped as zero-length."""
+    return BaseMessage(
+        participant_id="123",
+        message_text="",
+        content_type=MESSAGE_TYPES.VOICE,
+        cached_media_data=MediaCache(content_type="audio/ogg", data=BytesIO(audio)),
+    )
 
 
 @contextmanager
@@ -94,3 +110,48 @@ def test_real_transcription_failure_still_raises_and_notifies(mock_event_bot_cls
         channel.new_user_message(base_messages.audio_message())
 
     assert NotificationEvent.objects.filter(title="Audio Transcription Failed").exists()
+
+
+@pytest.mark.django_db()
+@patch("apps.channels.pipeline.EventBot")
+def test_no_speech_records_the_turn_and_links_it_to_the_trace(mock_event_bot_cls, azure_voice_session):
+    """The turn must be visible in chat history and reachable from the trace both ways.
+
+    Uses the real tracing service rather than the mock, since the linking being asserted
+    is what writes Trace.input_message and Trace.output_message.
+    """
+    mock_event_bot_cls.return_value.get_user_message.return_value = "I could not hear anything"
+    channel = StubChannel(azure_voice_session.experiment, azure_voice_session.experiment_channel, azure_voice_session)
+
+    with _azure_no_match(speechsdk.NoMatchReason.InitialSilenceTimeout):
+        channel.new_user_message(_voice_message())
+
+    chat = azure_voice_session.chat
+    human = ChatMessage.objects.get(chat=chat, message_type=ChatMessageType.HUMAN)
+    ai = ChatMessage.objects.get(chat=chat, message_type=ChatMessageType.AI)
+
+    # The voice note is the content, so the text stays empty rather than becoming the
+    # placeholder -- same rule as an attachment-only message with no caption.
+    assert human.content == ""
+    assert human.get_attached_files().count() == 1
+    assert "voice" in {tag.name for tag in human.tags.all()}
+    assert ai.content == "I could not hear anything"
+
+    trace = Trace.objects.get(session=azure_voice_session)
+    assert trace.input_message_id == human.id
+    assert trace.output_message_id == ai.id
+
+
+@pytest.mark.django_db()
+@patch("apps.channels.pipeline.EventBot")
+def test_no_speech_without_usable_audio_stores_the_placeholder(mock_event_bot_cls, azure_voice_session):
+    """With no attachment to carry the content, empty text would poison later turns."""
+    mock_event_bot_cls.return_value.get_user_message.return_value = "I could not hear anything"
+    channel = _channel(azure_voice_session)
+
+    with _azure_no_match(speechsdk.NoMatchReason.InitialSilenceTimeout):
+        channel.new_user_message(_voice_message(audio=b""))
+
+    human = ChatMessage.objects.get(chat=azure_voice_session.chat, message_type=ChatMessageType.HUMAN)
+    assert human.content == EMPTY_MESSAGE_PLACEHOLDER
+    assert human.get_attached_files().count() == 0

--- a/apps/chat/exceptions.py
+++ b/apps/chat/exceptions.py
@@ -1,3 +1,6 @@
+from enum import StrEnum
+
+
 class ChatException(Exception):
     def __init__(self, message=""):
         self.message = message
@@ -10,6 +13,25 @@ class AudioSynthesizeException(ChatException):
 
 class AudioTranscriptionException(ChatException):
     pass
+
+
+class NoSpeechReason(StrEnum):
+    """Why a transcriber produced no words."""
+
+    SILENCE = "silence"
+    NOT_UNDERSTOOD = "not_understood"
+
+
+class NoSpeechDetected(AudioTranscriptionException):
+    """The transcriber found no speech in the audio: a silent or unintelligible voice note.
+
+    The pipeline answers the participant instead of notifying the team, so each reason
+    needs participant-facing wording in MessageProcessingPipeline.NO_SPEECH_PROMPTS.
+    """
+
+    def __init__(self, reason: NoSpeechReason):
+        self.reason = reason
+        super().__init__(reason.value)
 
 
 class ChannelException(ChatException):

--- a/apps/service_providers/speech_service.py
+++ b/apps/service_providers/speech_service.py
@@ -14,7 +14,13 @@ from openai import OpenAI
 from pydub import AudioSegment
 
 from apps.channels.audio import convert_audio
-from apps.chat.exceptions import AudioSynthesizeException, AudioTranscriptionException, UserReportableError
+from apps.chat.exceptions import (
+    AudioSynthesizeException,
+    AudioTranscriptionException,
+    NoSpeechDetected,
+    NoSpeechReason,
+    UserReportableError,
+)
 from apps.experiments.models import SyntheticVoice
 from apps.service_providers.intron import INTRON_BASE_URL
 from apps.service_providers.minimax import DEFAULT_MINIMAX_TTS_MODEL, MINIMAX_BASE_URL
@@ -61,10 +67,18 @@ class SpeechService(pydantic.BaseModel):
 
     def transcribe_audio(self, audio: IO[bytes]) -> str:
         try:
-            return self._transcribe_audio(audio)
+            transcript = self._transcribe_audio(audio)
+        except NoSpeechDetected:
+            raise
         except Exception as e:
             log.exception(e)
             raise UserReportableError("Unable to transcribe audio") from e
+
+        # Azure reports silence outright; the rest return an empty transcript.
+        if not (transcript or "").strip():
+            log.info("No transcript returned by %s; treating as silence", self._type)
+            raise NoSpeechDetected(NoSpeechReason.SILENCE)
+        return transcript
 
     def _transcribe_audio(self, audio: IO[bytes]) -> str:
         raise NotImplementedError
@@ -199,7 +213,12 @@ class AzureSpeechService(SpeechService):
             return result.text
         elif result.reason == speechsdk.ResultReason.NoMatch:
             reason = result.no_match_details.reason
-            raise AudioTranscriptionException(f"No speech could be recognized: {reason}")
+            log.info("Azure recognized no speech in the audio: %s", reason)
+            # NotRecognized is the only reason that means speech was heard. The rest cover
+            # silence or noise, so an unrecognized future reason gets the safer message.
+            if reason == speechsdk.NoMatchReason.NotRecognized:
+                raise NoSpeechDetected(NoSpeechReason.NOT_UNDERSTOOD)
+            raise NoSpeechDetected(NoSpeechReason.SILENCE)
         elif result.reason == speechsdk.ResultReason.Canceled:
             cancellation_details = result.cancellation_details
             msg = f"Azure speech transcription failed: {cancellation_details.reason.name}"

--- a/apps/service_providers/speech_service.py
+++ b/apps/service_providers/speech_service.py
@@ -120,6 +120,17 @@ class AWSSpeechService(SpeechService):
             return SynthesizedAudio(audio=BytesIO(audio_data), duration=duration_seconds, format="mp3")
 
 
+def _azure_cancellation_message(prefix: str, cancellation_details) -> str:
+    """Azure's cancellation reason, with the error details when it carries them."""
+    # keep heavy imports inline
+    import azure.cognitiveservices.speech as speechsdk  # noqa: PLC0415 - lazy: optional provider dep (Azure speech SDK)
+
+    msg = f"{prefix}: {cancellation_details.reason.name}"
+    if cancellation_details.reason == speechsdk.CancellationReason.Error and cancellation_details.error_details:
+        msg += f". Error details: {cancellation_details.error_details}"
+    return msg
+
+
 class AzureSpeechService(SpeechService):
     _type: ClassVar[str] = SyntheticVoice.Azure
     supports_transcription: ClassVar[bool] = True
@@ -182,12 +193,9 @@ class AzureSpeechService(SpeechService):
 
                 return SynthesizedAudio(audio=BytesIO(file_content), duration=duration_seconds, format="wav")
             elif result.reason == speechsdk.ResultReason.Canceled:
-                cancellation_details = result.cancellation_details
-                msg = f"Azure speech synthesis failed: {cancellation_details.reason.name}"
-                if cancellation_details.reason == speechsdk.CancellationReason.Error:
-                    if cancellation_details.error_details:
-                        msg += f". Error details: {cancellation_details.error_details}"
-                raise AudioSynthesizeException(msg)
+                raise AudioSynthesizeException(
+                    _azure_cancellation_message("Azure speech synthesis failed", result.cancellation_details)
+                )
             raise AudioSynthesizeException(f"Unexpected result: {result}")
         finally:
             if os.path.exists(temp_file_name):
@@ -209,9 +217,16 @@ class AzureSpeechService(SpeechService):
             speech_recognizer = speechsdk.SpeechRecognizer(speech_config=speech_config, audio_config=audio_config)
             result = speech_recognizer.recognize_once_async().get()
 
+        return self._transcript_from_result(result)
+
+    def _transcript_from_result(self, result) -> str:
+        """The recognized text, or the exception saying why there is none."""
+        # keep heavy imports inline
+        import azure.cognitiveservices.speech as speechsdk  # noqa: PLC0415 - lazy: optional provider dep (Azure speech SDK)
+
         if result.reason == speechsdk.ResultReason.RecognizedSpeech:
             return result.text
-        elif result.reason == speechsdk.ResultReason.NoMatch:
+        if result.reason == speechsdk.ResultReason.NoMatch:
             reason = result.no_match_details.reason
             log.info("Azure recognized no speech in the audio: %s", reason)
             # NotRecognized is the only reason that means speech was heard. The rest cover
@@ -219,13 +234,10 @@ class AzureSpeechService(SpeechService):
             if reason == speechsdk.NoMatchReason.NotRecognized:
                 raise NoSpeechDetected(NoSpeechReason.NOT_UNDERSTOOD)
             raise NoSpeechDetected(NoSpeechReason.SILENCE)
-        elif result.reason == speechsdk.ResultReason.Canceled:
-            cancellation_details = result.cancellation_details
-            msg = f"Azure speech transcription failed: {cancellation_details.reason.name}"
-            if cancellation_details.reason == speechsdk.CancellationReason.Error:
-                if cancellation_details.error_details:
-                    msg += f". Error details: {cancellation_details.error_details}"
-            raise AudioTranscriptionException(msg)
+        if result.reason == speechsdk.ResultReason.Canceled:
+            raise AudioTranscriptionException(
+                _azure_cancellation_message("Azure speech transcription failed", result.cancellation_details)
+            )
         raise AudioTranscriptionException(f"Unexpected result: {result}")
 
 

--- a/apps/service_providers/tests/test_speech_transcription.py
+++ b/apps/service_providers/tests/test_speech_transcription.py
@@ -1,0 +1,163 @@
+import logging
+from contextlib import contextmanager
+from io import BytesIO
+from unittest import mock
+
+import azure.cognitiveservices.speech as speechsdk
+import pytest
+
+from apps.chat.exceptions import NoSpeechDetected, NoSpeechReason, UserReportableError
+from apps.service_providers.speech_service import (
+    AzureSpeechService,
+    ElevenLabsSpeechService,
+    OpenAISpeechService,
+    OpenAIVoiceEngineSpeechService,
+    SpeechService,
+)
+
+
+def _azure_service():
+    return AzureSpeechService(azure_subscription_key="key", azure_region="eastus")
+
+
+@contextmanager
+def _azure_returning(result):
+    """Run the Azure recognizer against a canned SpeechRecognitionResult."""
+    with (
+        mock.patch.object(speechsdk, "SpeechConfig"),
+        mock.patch.object(speechsdk.audio, "AudioConfig"),
+        mock.patch.object(speechsdk, "SpeechRecognizer") as recognizer_cls,
+    ):
+        recognizer_cls.return_value.recognize_once_async.return_value.get.return_value = result
+        yield
+
+
+def _no_match_result(reason):
+    result = mock.Mock()
+    result.reason = speechsdk.ResultReason.NoMatch
+    result.no_match_details.reason = reason
+    return result
+
+
+class TestAzureNoMatch:
+    @pytest.mark.parametrize(
+        ("no_match_reason", "expected"),
+        [
+            pytest.param(
+                speechsdk.NoMatchReason.NotRecognized, NoSpeechReason.NOT_UNDERSTOOD, id="not-recognized-speech-heard"
+            ),
+            pytest.param(
+                speechsdk.NoMatchReason.InitialSilenceTimeout, NoSpeechReason.SILENCE, id="initial-silence-timeout"
+            ),
+            pytest.param(speechsdk.NoMatchReason.EndSilenceTimeout, NoSpeechReason.SILENCE, id="end-silence-timeout"),
+            pytest.param(
+                speechsdk.NoMatchReason.InitialBabbleTimeout, NoSpeechReason.SILENCE, id="babble-timeout-only-noise"
+            ),
+            pytest.param(
+                speechsdk.NoMatchReason.KeywordNotRecognized, NoSpeechReason.SILENCE, id="keyword-not-recognized"
+            ),
+        ],
+    )
+    def test_no_match_reasons_map_to_a_speech_reason(self, no_match_reason, expected):
+        with _azure_returning(_no_match_result(no_match_reason)), pytest.raises(NoSpeechDetected) as exc_info:
+            _azure_service().transcribe_audio(BytesIO(b"audio"))
+
+        assert exc_info.value.reason == expected
+
+    def test_every_no_match_reason_is_covered(self):
+        """A new SDK reason should show up here rather than silently take a default."""
+        covered = {
+            speechsdk.NoMatchReason.NotRecognized,
+            speechsdk.NoMatchReason.InitialSilenceTimeout,
+            speechsdk.NoMatchReason.EndSilenceTimeout,
+            speechsdk.NoMatchReason.InitialBabbleTimeout,
+            speechsdk.NoMatchReason.KeywordNotRecognized,
+        }
+        assert set(speechsdk.NoMatchReason) == covered
+
+    def test_recognized_speech_is_returned(self):
+        result = mock.Mock()
+        result.reason = speechsdk.ResultReason.RecognizedSpeech
+        result.text = "hello there"
+
+        with _azure_returning(result):
+            assert _azure_service().transcribe_audio(BytesIO(b"audio")) == "hello there"
+
+    def test_cancelled_is_still_an_unexpected_failure(self):
+        result = mock.Mock()
+        result.reason = speechsdk.ResultReason.Canceled
+        result.cancellation_details.reason = speechsdk.CancellationReason.Error
+        result.cancellation_details.error_details = "Invalid subscription key"
+
+        with _azure_returning(result), pytest.raises(UserReportableError, match="Unable to transcribe audio"):
+            _azure_service().transcribe_audio(BytesIO(b"audio"))
+
+
+class TestBlankTranscript:
+    """Providers that signal silence with an empty transcript rather than an error."""
+
+    @pytest.mark.parametrize(
+        "service",
+        [
+            pytest.param(AzureSpeechService(azure_subscription_key="key", azure_region="eastus"), id="azure"),
+            pytest.param(OpenAISpeechService(openai_api_key="key"), id="openai"),
+            pytest.param(OpenAIVoiceEngineSpeechService(openai_api_key="key"), id="openai-voice-engine"),
+            pytest.param(ElevenLabsSpeechService(elevenlabs_api_key="key"), id="elevenlabs"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "transcript",
+        [pytest.param("", id="empty"), pytest.param("   \n ", id="whitespace"), pytest.param(None, id="none")],
+    )
+    def test_blank_transcript_raises_silence(self, service, transcript):
+        with mock.patch.object(type(service), "_transcribe_audio", return_value=transcript):
+            with pytest.raises(NoSpeechDetected) as exc_info:
+                service.transcribe_audio(BytesIO(b"audio"))
+
+        assert exc_info.value.reason == NoSpeechReason.SILENCE
+
+    def test_blank_transcript_names_the_provider_in_the_log(self, caplog):
+        """The only operator-visible signal that a provider is returning nothing but blanks."""
+        service = OpenAISpeechService(openai_api_key="key")
+
+        with caplog.at_level(logging.INFO, logger="ocs.speech"):
+            with mock.patch.object(OpenAISpeechService, "_transcribe_audio", return_value=""):
+                with pytest.raises(NoSpeechDetected):
+                    service.transcribe_audio(BytesIO(b"audio"))
+
+        assert OpenAISpeechService._type in caplog.text
+
+
+class StubSpeechService(SpeechService):
+    """Base-class behaviour, isolated from any provider SDK."""
+
+    _type = "stub"
+    supports_transcription = True
+    result: object = None
+
+    def _transcribe_audio(self, audio):
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+class TestTranscribeAudioErrorPolicy:
+    def test_no_speech_detected_keeps_its_reason(self):
+        """NoSpeechDetected must survive intact so the pipeline can tell it apart."""
+        service = StubSpeechService(result=NoSpeechDetected(NoSpeechReason.NOT_UNDERSTOOD))
+
+        with pytest.raises(NoSpeechDetected) as exc_info:
+            service.transcribe_audio(BytesIO(b"audio"))
+
+        assert exc_info.value.reason == NoSpeechReason.NOT_UNDERSTOOD
+
+    def test_other_failures_are_still_flattened(self):
+        service = StubSpeechService(result=RuntimeError("connection reset"))
+
+        with pytest.raises(UserReportableError, match="Unable to transcribe audio"):
+            service.transcribe_audio(BytesIO(b"audio"))
+
+    def test_transcript_is_returned_unchanged(self):
+        service = StubSpeechService(result="  hello  ")
+
+        assert service.transcribe_audio(BytesIO(b"audio")) == "  hello  "


### PR DESCRIPTION
### Product Description

A participant who sends a silent or unintelligible voice note now gets a reply telling them what to do differently — "I couldn't hear anything in that voice note, could you record it again?" instead of the generic "something went wrong". The error bot generates it, so it arrives in the participant's own language.

The turn is also recorded properly. Previously the voice note vanished and only the bot's reply was saved, so the session history showed an answer to nothing and the trace had no message to navigate from.

For the team this stops being an incident: no "Audio Transcription Failed" notification, no Sentry event, no failed Celery task, and it no longer counts against the chatbot's error rate. Genuine transcription failures — an invalid key, exhausted quota, a cancelled recognition — behave exactly as before.

### Technical Description

`SpeechService.transcribe_audio` flattened everything into `UserReportableError`, erasing the difference between "the participant sent silence" and "the Azure key is invalid". Both then hit the pipeline's generic `except Exception`, which re-raises after terminal stages, so both reached Sentry.

* **`NoSpeechDetected(AudioTranscriptionException)`** carries a `NoSpeechReason` — `SILENCE` or `NOT_UNDERSTOOD`. `speech_service.py` re-raises it instead of flattening it. Azure's `NoMatch` maps to a reason, and the base class raises `SILENCE` for a blank transcript, which is how OpenAI, ElevenLabs and Voice Engine report silence.
* **`MessageProcessingPipeline`** replies from `NO_SPEECH_PROMPTS[reason]` via the error bot and does not re-raise, matching the existing `PipelineBuildError` / `CodeNodeRunError` precedent. `QueryExtractionStage` skips the failure notification.
* **`NoSpeechDetected` joins `_CONTROL_FLOW_SIGNALS`** so the stage's span closes cleanly. Without this the trace was still written as `TraceStatus.ERROR` and counted on the operator error-rate charts.
* **Recording the turn.** `QueryExtractionStage` sits immediately before `ChatMessageCreationStage`, so raising there skipped the only stage that creates the human message, attaches the voice note and links the trace input. It now defers instead: it sets an empty `user_query`, records the reason on the context, and `NoSpeechGuardStage` raises once the turn exists. The reason needs its own context field — an attachment-only message with no caption produces the same empty query.
* **Linking the AI message.** `PersistenceStage` never called `set_output_message_id` for early-exit replies. That affected every early-exit path, so consent-flow, channel-disabled, unsupported-type and pipeline-build-error replies were all unreachable from their trace. Fixed where the message is created, so all of them benefit.

Two deviations from the issue's sketch, both pinned by tests:

1. **No `ctx.processing_errors` entry.** Its only consumer surfaces recovered errors on the span, and this span is deliberately not marked as errored. The pipeline tier owns the "not a fault" decision.
2. **Azure `NoMatchReason` bucketing is inverted from the obvious reading.** `InitialBabbleTimeout` means noise with no speech, so it maps to `SILENCE`; `NotRecognized` is the only member meaning audio was heard. A test asserts the covered set equals `set(speechsdk.NoMatchReason)`, so an SDK bump that adds a reason fails here rather than silently taking a default.

Not addressed here: **#4467** (unsupported message types have the same missing-human-message shape — the deferral fix does not transfer), and the hardcoded `en-US` recognition language, which makes non-English speech surface as exactly `NotRecognized`. Those participants get a better reply, but their speech still is not transcribable.

Tests: `ruff` and `ty` clean; 3137 passing across `apps/channels/`, `apps/service_providers/`, `apps/chat/`, `apps/experiments/` and `apps/pipelines/`. Both turn-recording defects were pinned with failing tests first.

### Issue Link

Closes #4405

### Migrations

No migrations in this PR.

- [ ] The migrations are backwards compatible

### Demo

Covered by `apps/channels/tests/channels/test_voice_transcription_no_speech.py`, which drives a real voice message through `ChannelBase.new_user_message` against the DB and asserts the participant reply, the error-bot prompt for each reason, the absence of the team notification, and — against the real tracing service rather than a mock — that the human message, its voice attachment and `Trace.input_message` / `Trace.output_message` are all written.

### Docs and Changelog

- [ ] This PR requires docs/changelog update

### Operator Impact

Self-hosted operators will see fewer "Audio Transcription Failed" notifications and a lower chatbot error rate, because silent voice notes stop being counted. They now also create a human message, so the `NEW_HUMAN_MESSAGE` static trigger fires for them where it previously did not — worth knowing if a deployment has triggers wired to it. No action required.

- [ ] Self-hosted operators must know about or act on this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
