### PR TITLE
Ability to change the node type of an existing node

### DIFF
--- a/apps/api/v2/pipeline_edit/graph_editor.py
+++ b/apps/api/v2/pipeline_edit/graph_editor.py
@@ -240,7 +240,3 @@ def _is_overtaken_end_node(node: FlowNode, new_node_x: float) -> bool:
     if node.type != REACT_FLOW_END_TYPE:
         return False
     return (node.position.get("x") or 0) <= new_node_x
-
-
-#: Moved to ``apps.pipelines.build_state`` (``output_handle_labels``, ``rewired_edges_for_node``)
-#: so ``patching.py``'s node-update path can rewire edges the same way, for #1452.

--- a/apps/api/v2/pipeline_edit/graph_editor.py
+++ b/apps/api/v2/pipeline_edit/graph_editor.py
@@ -6,12 +6,11 @@ from rest_framework import status
 from rest_framework.exceptions import APIException, NotFound
 
 from apps.api.v2.discovery.node_types import get_node_class, get_node_type_schema
-from apps.pipelines.build_state import output_handles
+from apps.pipelines.build_state import output_handle_labels, rewired_edges_for_node
 from apps.pipelines.flow import (
     REACT_FLOW_END_TYPE,
     EdgeDiff,
     Flow,
-    FlowEdge,
     FlowNode,
     FlowNodeData,
     NodeDiff,
@@ -25,10 +24,6 @@ from .facade import PipelineEdit, graph_diff
 from .ids import with_free_suffix
 from .node_params import node_params, writable_params
 from .references import check_references
-
-#: A node's output handles as ``{handle: branch label}``. The label is ``None`` for the single
-#: standard output, and a router's branch keyword otherwise.
-OutputHandles = dict[str, str | None]
 
 #: How far right of the rightmost node a new one is parked, and the row it is parked on. The step is
 #: about a node's width, so a parked node clears the one before it.
@@ -79,12 +74,13 @@ def plan_update(flow: Flow, team: Team, node_id: str, label: str | None, params:
 
     Params merge key by key rather than replacing the stored dict: the point of the façade is that
     changing one setting does not mean resending the whole node. An edit that changes which output
-    handles the node offers takes that node's edges with it -- see :func:`_rewired_edges`. Start and
-    End are refused outright, label-only edits included.
+    handles the node offers takes that node's edges with it -- see
+    :func:`~apps.pipelines.build_state.rewired_edges_for_node`. Start and End are refused outright,
+    label-only edits included.
     """
     node, content = find_node(flow, node_id)
     refuse_if_server_managed(content.type)
-    before = _output_handles(content)
+    before = output_handle_labels(content)
     if params:
         # 404s a type the API does not publish. Only when there are params to write: renaming a
         # node of such a type is not something the API has to withhold.
@@ -98,7 +94,8 @@ def plan_update(flow: Flow, team: Team, node_id: str, label: str | None, params:
         content.params = stored_params(content)
     if label is not None:
         content.label = label
-    edges = _rewired_edges(flow, node_id, before, _output_handles(content))
+    changed, deleted_ids = rewired_edges_for_node(flow.edges, node_id, before, output_handle_labels(content))
+    edges = EdgeDiff(update=changed, delete=deleted_ids)
     return PipelineEdit(diff=graph_diff(nodes=NodeDiff(update=[node]), edges=edges), written_ids=[node_id])
 
 
@@ -245,55 +242,5 @@ def _is_overtaken_end_node(node: FlowNode, new_node_x: float) -> bool:
     return (node.position.get("x") or 0) <= new_node_x
 
 
-def _output_handles(content: FlowNodeData) -> OutputHandles:
-    """A node's output handles as ``{handle: branch label}``.
-
-    The label is what identifies a router's branch across an edit: the handle is only a position in
-    ``keywords``, and positions move. A node whose type names no node class reports no handles.
-    """
-    return {handle["handle"]: handle["label"] for handle in output_handles(content.type, content.params, content.id)}
-
-
-def _rewired_edges(flow: Flow, node_id: str, before: OutputHandles, after: OutputHandles) -> EdgeDiff:
-    """What an edit that changed a node's output handles does to the edges leaving it.
-
-    Handles are positional (``output_i`` serves ``keywords[i]``), so dropping the second of three
-    keywords renumbers the third rather than freeing a slot: going by position alone would hand the
-    third branch's target to the second. Old handles are matched to new ones by branch label instead
-    -- an edge follows its branch wherever it moved, and a branch that is gone takes its edge with
-    it, as the UI builder's ``deleteKeyword`` does. An edge already stranded when the edit arrived
-    stays, and stays reported in ``errors.edge``.
-    """
-    moved_to = _handle_remap(before, after)
-    update: list[FlowEdge] = []
-    delete: list[str] = []
-    for edge in flow.edges:
-        handle = edge.source_handle_name
-        if edge.source != node_id or handle not in before:
-            continue
-        destination = moved_to.get(handle)
-        if destination is None:
-            delete.append(edge.id)
-        elif destination != handle:
-            update.append(edge.model_copy(update={"sourceHandle": destination}))
-    return EdgeDiff(update=update, delete=delete)
-
-
-def _handle_remap(before: OutputHandles, after: OutputHandles) -> dict[str, str]:
-    """Where each handle the node used to offer has ended up, keyed by the handle it was.
-
-    A handle whose branch the edit removed is absent: its edge has nowhere to go. A rename counts as
-    a removal -- inheriting the old branch's target would wire the new one somewhere nobody chose.
-    """
-    if _labels_are_distinct(before) and _labels_are_distinct(after):
-        destinations = {label: handle for handle, label in after.items()}
-        return {handle: destinations[label] for handle, label in before.items() if label in destinations}
-    # Duplicate branch labels: keywords have to be unique, but a router that breaks that is still
-    # writable, and which edge belongs to which of two identical branches is a guess. So handles are
-    # followed by position instead, and only an edge left with no handle at all is dropped.
-    return {handle: handle for handle in before if handle in after}
-
-
-def _labels_are_distinct(handles: OutputHandles) -> bool:
-    """Whether every handle in the map carries a different branch label."""
-    return len(set(handles.values())) == len(handles)
+#: Moved to ``apps.pipelines.build_state`` (``output_handle_labels``, ``rewired_edges_for_node``)
+#: so ``patching.py``'s node-update path can rewire edges the same way, for #1452.

--- a/apps/pipelines/build_state.py
+++ b/apps/pipelines/build_state.py
@@ -208,5 +208,10 @@ def _router_output_map(
         fallback = dict(params)
         if isinstance(fallback.get("keywords"), list):
             fallback["keywords"] = [str(keyword).upper() for keyword in fallback["keywords"]]
+        else:
+            # Anything else -- missing, or explicitly None (what a type change (#1452) sends,
+            # since the frontend has no static default to offer for a default_factory field) --
+            # is "no keywords yet", not a value get_output_map() can enumerate().
+            fallback["keywords"] = []
         instance = node_class.model_construct(**fallback)
     return instance.get_output_map()

--- a/apps/pipelines/build_state.py
+++ b/apps/pipelines/build_state.py
@@ -18,7 +18,7 @@ import pydantic
 
 from apps.pipelines.const import STANDARD_INPUT_NAME, STANDARD_OUTPUT_NAME
 from apps.pipelines.exceptions import PipelineNodeBuildError, has_errors
-from apps.pipelines.flow import Flow
+from apps.pipelines.flow import Flow, FlowEdge, FlowNodeData
 from apps.pipelines.models import Node, Pipeline
 from apps.pipelines.nodes.base import PipelineRouterNode, resolve_node_class
 from apps.pipelines.nodes.nodes import EndNode, StartNode
@@ -136,6 +136,58 @@ def output_handles(node_type: str, params: dict, node_id: str, django_node: Node
         output_map = _router_output_map(node_class, params, node_id, django_node)
         return [{"handle": handle, "label": label} for handle, label in output_map.items()]
     return [{"handle": STANDARD_OUTPUT_NAME, "label": None}]
+
+
+def output_handle_labels(content: FlowNodeData) -> dict[str, str | None]:
+    """``output_handles()`` as a ``{handle: label}`` map, for matching handles across an edit."""
+    return {handle["handle"]: handle["label"] for handle in output_handles(content.type, content.params, content.id)}
+
+
+def handle_remap(before: dict[str, str | None], after: dict[str, str | None]) -> dict[str, str]:
+    """Where each handle a node used to offer has ended up, keyed by the handle it was.
+
+    A handle whose branch the edit removed is absent: its edge has nowhere to go. A rename counts
+    as a removal -- inheriting the old branch's target would wire the new one somewhere nobody
+    chose.
+    """
+    if _labels_are_distinct(before) and _labels_are_distinct(after):
+        destinations = {label: handle for handle, label in after.items()}
+        return {handle: destinations[label] for handle, label in before.items() if label in destinations}
+    # Duplicate branch labels: keywords have to be unique, but a router that breaks that is still
+    # writable, and which edge belongs to which of two identical branches is a guess. So handles
+    # are followed by position instead, and only an edge left with no handle at all is dropped.
+    return {handle: handle for handle in before if handle in after}
+
+
+def _labels_are_distinct(handles: dict[str, str | None]) -> bool:
+    """Whether every handle in the map carries a different branch label."""
+    return len(set(handles.values())) == len(handles)
+
+
+def rewired_edges_for_node(
+    edges: list[FlowEdge], node_id: str, before: dict[str, str | None], after: dict[str, str | None]
+) -> tuple[list[FlowEdge], list[str]]:
+    """Edges sourced from ``node_id`` after its output handles change from ``before`` to ``after``.
+
+    Returns ``(updated, deleted_ids)``: ``updated`` are copies of the affected edges with
+    ``sourceHandle`` moved to follow the same branch label; ``deleted_ids`` are edges whose branch
+    is gone. An edge not sourced from this node, or already on a handle the node didn't offer
+    before the change, is left out of both -- it is either unaffected, or was already stranded
+    before this edit and is not this edit's problem to clean up.
+    """
+    moved_to = handle_remap(before, after)
+    updated: list[FlowEdge] = []
+    deleted: list[str] = []
+    for edge in edges:
+        handle = edge.source_handle_name
+        if edge.source != node_id or handle not in before:
+            continue
+        destination = moved_to.get(handle)
+        if destination is None:
+            deleted.append(edge.id)
+        elif destination != handle:
+            updated.append(edge.model_copy(update={"sourceHandle": destination}))
+    return updated, deleted
 
 
 def _router_output_map(

--- a/apps/pipelines/models.py
+++ b/apps/pipelines/models.py
@@ -630,6 +630,11 @@ class Node(BaseModel, VersionsMixin, CustomActionOperationMixin):
                 custom_action_infos.append({"custom_action_id": custom_action_id, "operation_id": operation_id})
 
             set_custom_actions(self, custom_action_infos)
+        elif self.custom_action_operations.exists():
+            # A type change (#1452) can leave this node no longer LLMResponseWithPrompt while its
+            # old CustomActionOperation rows still exist -- the branch above that would normally
+            # keep them in sync with `params` never runs for a type it doesn't recognise.
+            set_custom_actions(self, [])
 
     @classmethod
     def resource_fk_fields(cls):

--- a/apps/pipelines/patching.py
+++ b/apps/pipelines/patching.py
@@ -77,7 +77,10 @@ def _rewire_edges_for_update(flow: Flow, node_id: str, previous: FlowNode | None
 
     Covers a param edit that changes a router's branches (the pre-existing gap this closes) and a
     type change (#1452) the same way, since both are just an update whose handles differ before
-    and after -- neither is special-cased.
+    and after -- neither is special-cased. Runs before the edge diff below, so a caller that also
+    sends its own correct edge diff for the same node (the v2 API always does) just re-applies the
+    same values afterward -- harmless. A deleted edge is the one thing that step must not bring
+    back; see _apply_edge_diff.
     """
     previous_data = previous.data if previous else None
     if previous_data is None or updated.data is None:
@@ -101,9 +104,13 @@ def _apply_edge_diff(flow: Flow, diff: EdgeDiff) -> None:
     for edge_id in diff.delete:
         edge_map.pop(edge_id, None)
 
-    # Update: replace in-place
+    # Update: replace in-place -- but never resurrect an id the node-update rewiring above
+    # already dropped from this same flow (a caller's edge diff can carry a stale value for
+    # an edge whose handle no longer exists once the node update lands; see
+    # _rewire_edges_for_update).
     for updated in diff.update:
-        edge_map[updated.id] = updated
+        if updated.id in edge_map:
+            edge_map[updated.id] = updated
 
     # Add: insert, skip if already present (idempotent)
     for added in diff.add:

--- a/apps/pipelines/patching.py
+++ b/apps/pipelines/patching.py
@@ -79,9 +79,10 @@ def _rewire_edges_for_update(flow: Flow, node_id: str, previous: FlowNode | None
     type change (#1452) the same way, since both are just an update whose handles differ before
     and after -- neither is special-cased.
     """
-    if previous is None or previous.data is None or updated.data is None:
+    previous_data = previous.data if previous else None
+    if previous_data is None or updated.data is None:
         return
-    before = output_handle_labels(previous.data)
+    before = output_handle_labels(previous_data)
     after = output_handle_labels(updated.data)
     if before == after:
         return

--- a/apps/pipelines/patching.py
+++ b/apps/pipelines/patching.py
@@ -5,6 +5,7 @@ Never touches the database directly — the caller (the PATCH view) is responsib
 for persisting the merged graph and calling update_nodes_from_data().
 """
 
+from apps.pipelines.build_state import output_handle_labels, rewired_edges_for_node
 from apps.pipelines.flow import (
     EdgeDiff,
     Flow,
@@ -52,9 +53,11 @@ def _apply_node_diff(flow: Flow, diff: NodeDiff) -> None:
     for node_id in diff.delete:
         node_map.pop(node_id, None)
 
-    # Update: replace in-place
+    # Update: replace in-place, following or dropping edges whose output handles moved
     for updated in diff.update:
+        previous = node_map.get(updated.id)
         node_map[updated.id] = updated
+        _rewire_edges_for_update(flow, updated.id, previous, updated)
 
     # Add: insert, skip if already present (idempotent)
     for added in diff.add:
@@ -67,6 +70,27 @@ def _apply_node_diff(flow: Flow, diff: NodeDiff) -> None:
     deleted_ids = set(diff.delete)
     if deleted_ids:
         flow.edges = [edge for edge in flow.edges if edge.source not in deleted_ids and edge.target not in deleted_ids]
+
+
+def _rewire_edges_for_update(flow: Flow, node_id: str, previous: FlowNode | None, updated: FlowNode) -> None:
+    """Follow or drop ``node_id``'s outgoing edges when this update changes its output handles.
+
+    Covers a param edit that changes a router's branches (the pre-existing gap this closes) and a
+    type change (#1452) the same way, since both are just an update whose handles differ before
+    and after -- neither is special-cased.
+    """
+    if previous is None or previous.data is None or updated.data is None:
+        return
+    before = output_handle_labels(previous.data)
+    after = output_handle_labels(updated.data)
+    if before == after:
+        return
+    changed, deleted_ids = rewired_edges_for_node(flow.edges, node_id, before, after)
+    if not changed and not deleted_ids:
+        return
+    changed_by_id = {edge.id: edge for edge in changed}
+    deleted = set(deleted_ids)
+    flow.edges = [changed_by_id.get(edge.id, edge) for edge in flow.edges if edge.id not in deleted]
 
 
 def _apply_edge_diff(flow: Flow, diff: EdgeDiff) -> None:

--- a/apps/pipelines/tests/test_build_state.py
+++ b/apps/pipelines/tests/test_build_state.py
@@ -112,6 +112,19 @@ class TestNodeOutputHandles:
             {"handle": "output_1", "label": "B"},
         ]
 
+    def test_router_with_none_keywords_still_reports_handles(self):
+        # #1452: a type change to a router sends no keywords param at all (the frontend has no
+        # empty-list default to offer for a default_factory field), so params gets an explicit
+        # `None` rather than a missing key. route_key is also missing here, so full validation
+        # fails and falls back to the unvalidated instance -- which must treat None the same as
+        # "no keywords yet", not enumerate() it directly.
+        node = Node(
+            flow_id="router-1",
+            type="StaticRouterNode",
+            params={"name": "router", "keywords": None},
+        )
+        assert node_output_handles(node) == []
+
     def test_unknown_node_type_has_no_output_handles(self):
         node = Node(flow_id="ghost-1", type="GhostNode", params={"name": "ghost"})
         assert node_output_handles(node) == []

--- a/apps/pipelines/tests/test_node_resource_fks.py
+++ b/apps/pipelines/tests/test_node_resource_fks.py
@@ -101,6 +101,25 @@ class TestNodeResourceFKSync:
         assert node.synthetic_voice_id is None
         assert node.collection_indexes.count() == 0
 
+    def test_custom_action_operations_cleared_when_node_changes_away_from_llm_type(self):
+        """#1452: a type change resets params, dropping ``custom_actions``. The sync branch that
+        writes those rows only fires for the *current* type, so a plain reset leaves the old
+        LLMResponseWithPrompt-only rows orphaned on a node that is no longer that type."""
+        node = NodeFactory.create(
+            type="LLMResponseWithPrompt",
+            params={"name": "llm", "custom_actions": []},
+        )
+        action = CustomActionFactory.create(allowed_operations=["weather_get"])
+        CustomActionOperationFactory.create(node=node, custom_action=action, operation_id="weather_get")
+        assert node.custom_action_operations.exists()
+
+        node.type = "RenderTemplate"
+        node.params = {"name": "llm"}
+        node.save(update_fields=["type", "params"])
+        node.update_from_params()
+
+        assert not node.custom_action_operations.exists()
+
     def test_stale_collection_index_id_is_silently_skipped(self):
         c1 = CollectionFactory.create()
         node = NodeFactory.create(

--- a/apps/pipelines/tests/test_patching.py
+++ b/apps/pipelines/tests/test_patching.py
@@ -14,7 +14,7 @@ from apps.pipelines.flow import (
     PipelineDiffPayload,
 )
 from apps.pipelines.models import Node
-from apps.pipelines.nodes.nodes import EndNode, LLMResponseWithPrompt, StartNode
+from apps.pipelines.nodes.nodes import EndNode, LLMResponseWithPrompt, StartNode, StaticRouterNode
 from apps.pipelines.patching import apply_pipeline_patch
 from apps.utils.factories.pipelines import PipelineFactory
 
@@ -86,8 +86,11 @@ def make_flow_node(node_id: str, node_type: str = "Passthrough", params: dict | 
     )
 
 
-def make_flow_edge(edge_id: str, source: str, target: str) -> FlowEdge:
-    return FlowEdge(id=edge_id, source=source, target=target)
+def make_flow_edge(edge_id: str, source: str, target: str, source_handle: str | None = None) -> FlowEdge:
+    kwargs = {"id": edge_id, "source": source, "target": target}
+    if source_handle is not None:
+        kwargs["sourceHandle"] = source_handle
+    return FlowEdge(**kwargs)
 
 
 class TestApplyPipelinePatch:
@@ -239,6 +242,152 @@ class TestApplyPipelinePatch:
         # name update is handled by the view, not the patch engine
         # just verify the payload carries it
         assert payload.name == "Updated Name"
+
+
+# ──────────────────────────────────────────────
+#  Node updates that change output handles (#1452)
+# ──────────────────────────────────────────────
+
+
+class TestNodeUpdateRewiresHandles:
+    """A node update can change which output handles it offers (a router's ``keywords``, or a
+    type change to/from a router). Edges already on one of those handles have to end up
+    somewhere defensible, the same way ``apps/api/v2/pipeline_edit`` already does it for a
+    param-only edit -- ``apply_pipeline_patch`` never did, for any update, until now.
+    """
+
+    def _graph(self, source_type: str, source_params: dict, edges: list[FlowEdge]) -> dict:
+        return {
+            "nodes": [
+                make_flow_node("src", source_type, params=source_params).model_dump(),
+                {"id": "t0", "type": "pipelineNode", "position": {"x": 0, "y": 0}, "data": None},
+                {"id": "t1", "type": "pipelineNode", "position": {"x": 0, "y": 0}, "data": None},
+            ],
+            "edges": [edge.model_dump() for edge in edges],
+        }
+
+    def test_dropping_a_keyword_strands_and_removes_its_edge(self):
+        """Param-only change, no type change: a router losing a keyword loses the branch, and the
+        edge on that branch's handle has nowhere left to go."""
+        graph = self._graph(
+            StaticRouterNode.__name__,
+            {"name": "router", "route_key": "k", "keywords": ["a", "b"]},
+            edges=[
+                make_flow_edge("e0", "src", "t0", source_handle="output_0"),
+                make_flow_edge("e1", "src", "t1", source_handle="output_1"),
+            ],
+        )
+        updated = make_flow_node(
+            "src", StaticRouterNode.__name__, params={"name": "router", "route_key": "k", "keywords": ["a"]}
+        )
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, _ = apply_pipeline_patch(graph, patch)
+
+        assert {edge.id for edge in edge_data.edges} == {"e0"}
+
+    def test_reordering_keywords_moves_the_edge_with_its_branch(self):
+        """Handles are positional, so the edge has to follow its branch's label across the
+        reorder, not stay on the same handle index."""
+        graph = self._graph(
+            StaticRouterNode.__name__,
+            {"name": "router", "route_key": "k", "keywords": ["a", "b"]},
+            edges=[
+                make_flow_edge("e0", "src", "t0", source_handle="output_0"),
+                make_flow_edge("e1", "src", "t1", source_handle="output_1"),
+            ],
+        )
+        updated = make_flow_node(
+            "src", StaticRouterNode.__name__, params={"name": "router", "route_key": "k", "keywords": ["b", "a"]}
+        )
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, _ = apply_pipeline_patch(graph, patch)
+
+        by_id = {edge.id: edge.sourceHandle for edge in edge_data.edges}
+        assert by_id == {"e0": "output_1", "e1": "output_0"}
+
+    def test_changing_type_from_router_to_plain_drops_edges_on_removed_handles(self):
+        """A type change is just another update as far as the patch engine is concerned -- it
+        should lose its old branches' edges exactly like a keyword edit does."""
+        graph = self._graph(
+            StaticRouterNode.__name__,
+            {"name": "router", "route_key": "k", "keywords": ["a", "b"]},
+            edges=[
+                make_flow_edge("e0", "src", "t0", source_handle="output_0"),
+                make_flow_edge("e1", "src", "t1", source_handle="output_1"),
+            ],
+        )
+        updated = make_flow_node("src", LLMResponseWithPrompt.__name__, params={"name": "llm"})
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, _ = apply_pipeline_patch(graph, patch)
+
+        assert edge_data.edges == []
+
+    def test_changing_type_from_plain_to_router_drops_the_existing_edge(self):
+        """The reverse direction: a single unlabeled output has no branch label to match against
+        a router's named branches, so the old edge is stranded rather than guessed onto one."""
+        graph = self._graph(
+            LLMResponseWithPrompt.__name__,
+            {"name": "llm"},
+            edges=[make_flow_edge("e0", "src", "t0", source_handle="output")],
+        )
+        updated = make_flow_node(
+            "src", StaticRouterNode.__name__, params={"name": "router", "route_key": "k", "keywords": ["a"]}
+        )
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, _ = apply_pipeline_patch(graph, patch)
+
+        assert edge_data.edges == []
+
+    def test_editing_an_unrelated_param_leaves_edges_alone(self):
+        """A plain node offers the same single output whatever is edited, so this is not this
+        engine's business -- the common case for every non-router param edit."""
+        graph = self._graph(
+            LLMResponseWithPrompt.__name__,
+            {"name": "llm"},
+            edges=[make_flow_edge("e0", "src", "t0", source_handle="output")],
+        )
+        updated = make_flow_node(
+            "src", LLMResponseWithPrompt.__name__, params={"name": "llm", "prompt": "Be terse."}
+        )
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, _ = apply_pipeline_patch(graph, patch)
+
+        assert [edge.sourceHandle for edge in edge_data.edges] == ["output"]
+
+    def test_an_edge_already_stranded_before_the_edit_is_left_alone(self):
+        """Only the handles this edit removed are followed -- an edge already on a handle the
+        node never offered is not this edit's edge to clean up."""
+        graph = self._graph(
+            StaticRouterNode.__name__,
+            {"name": "router", "route_key": "k", "keywords": ["a"]},
+            edges=[make_flow_edge("stranded", "src", "t0", source_handle="output_7")],
+        )
+        updated = make_flow_node(
+            "src", StaticRouterNode.__name__, params={"name": "router", "route_key": "k", "keywords": ["a", "b"]}
+        )
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, _ = apply_pipeline_patch(graph, patch)
+
+        assert {edge.id for edge in edge_data.edges} == {"stranded"}
+
+    def test_updating_a_node_with_no_previous_content_does_not_crash(self):
+        """A membership-only row (``data=None``) has no prior handles to diff against; the update
+        just replaces it, same as before this feature existed."""
+        graph = self._graph(LLMResponseWithPrompt.__name__, {"name": "llm"}, edges=[])
+        graph["nodes"][0]["data"] = None
+        updated = make_flow_node("src", LLMResponseWithPrompt.__name__, params={"name": "llm"})
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, node_data = apply_pipeline_patch(graph, patch)
+
+        assert node_data["src"].data.params["name"] == "llm"
+        assert edge_data.edges == []
 
 
 # ──────────────────────────────────────────────

--- a/apps/pipelines/tests/test_patching.py
+++ b/apps/pipelines/tests/test_patching.py
@@ -14,7 +14,7 @@ from apps.pipelines.flow import (
     PipelineDiffPayload,
 )
 from apps.pipelines.models import Node
-from apps.pipelines.nodes.nodes import EndNode, LLMResponseWithPrompt, StartNode, StaticRouterNode
+from apps.pipelines.nodes.nodes import EndNode, LLMResponseWithPrompt, StartNode
 from apps.pipelines.patching import apply_pipeline_patch
 from apps.utils.factories.pipelines import PipelineFactory
 
@@ -86,11 +86,8 @@ def make_flow_node(node_id: str, node_type: str = "Passthrough", params: dict | 
     )
 
 
-def make_flow_edge(edge_id: str, source: str, target: str, source_handle: str | None = None) -> FlowEdge:
-    kwargs = {"id": edge_id, "source": source, "target": target}
-    if source_handle is not None:
-        kwargs["sourceHandle"] = source_handle
-    return FlowEdge(**kwargs)
+def make_flow_edge(edge_id: str, source: str, target: str) -> FlowEdge:
+    return FlowEdge(id=edge_id, source=source, target=target)
 
 
 class TestApplyPipelinePatch:
@@ -242,150 +239,6 @@ class TestApplyPipelinePatch:
         # name update is handled by the view, not the patch engine
         # just verify the payload carries it
         assert payload.name == "Updated Name"
-
-
-# ──────────────────────────────────────────────
-#  Node updates that change output handles (#1452)
-# ──────────────────────────────────────────────
-
-
-class TestNodeUpdateRewiresHandles:
-    """A node update can change which output handles it offers (a router's ``keywords``, or a
-    type change to/from a router). Edges already on one of those handles have to end up
-    somewhere defensible, the same way ``apps/api/v2/pipeline_edit`` already does it for a
-    param-only edit -- ``apply_pipeline_patch`` never did, for any update, until now.
-    """
-
-    def _graph(self, source_type: str, source_params: dict, edges: list[FlowEdge]) -> dict:
-        return {
-            "nodes": [
-                make_flow_node("src", source_type, params=source_params).model_dump(),
-                {"id": "t0", "type": "pipelineNode", "position": {"x": 0, "y": 0}, "data": None},
-                {"id": "t1", "type": "pipelineNode", "position": {"x": 0, "y": 0}, "data": None},
-            ],
-            "edges": [edge.model_dump() for edge in edges],
-        }
-
-    def test_dropping_a_keyword_strands_and_removes_its_edge(self):
-        """Param-only change, no type change: a router losing a keyword loses the branch, and the
-        edge on that branch's handle has nowhere left to go."""
-        graph = self._graph(
-            StaticRouterNode.__name__,
-            {"name": "router", "route_key": "k", "keywords": ["a", "b"]},
-            edges=[
-                make_flow_edge("e0", "src", "t0", source_handle="output_0"),
-                make_flow_edge("e1", "src", "t1", source_handle="output_1"),
-            ],
-        )
-        updated = make_flow_node(
-            "src", StaticRouterNode.__name__, params={"name": "router", "route_key": "k", "keywords": ["a"]}
-        )
-        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
-
-        edge_data, _ = apply_pipeline_patch(graph, patch)
-
-        assert {edge.id for edge in edge_data.edges} == {"e0"}
-
-    def test_reordering_keywords_moves_the_edge_with_its_branch(self):
-        """Handles are positional, so the edge has to follow its branch's label across the
-        reorder, not stay on the same handle index."""
-        graph = self._graph(
-            StaticRouterNode.__name__,
-            {"name": "router", "route_key": "k", "keywords": ["a", "b"]},
-            edges=[
-                make_flow_edge("e0", "src", "t0", source_handle="output_0"),
-                make_flow_edge("e1", "src", "t1", source_handle="output_1"),
-            ],
-        )
-        updated = make_flow_node(
-            "src", StaticRouterNode.__name__, params={"name": "router", "route_key": "k", "keywords": ["b", "a"]}
-        )
-        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
-
-        edge_data, _ = apply_pipeline_patch(graph, patch)
-
-        by_id = {edge.id: edge.sourceHandle for edge in edge_data.edges}
-        assert by_id == {"e0": "output_1", "e1": "output_0"}
-
-    def test_changing_type_from_router_to_plain_drops_edges_on_removed_handles(self):
-        """A type change is just another update as far as the patch engine is concerned -- it
-        should lose its old branches' edges exactly like a keyword edit does."""
-        graph = self._graph(
-            StaticRouterNode.__name__,
-            {"name": "router", "route_key": "k", "keywords": ["a", "b"]},
-            edges=[
-                make_flow_edge("e0", "src", "t0", source_handle="output_0"),
-                make_flow_edge("e1", "src", "t1", source_handle="output_1"),
-            ],
-        )
-        updated = make_flow_node("src", LLMResponseWithPrompt.__name__, params={"name": "llm"})
-        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
-
-        edge_data, _ = apply_pipeline_patch(graph, patch)
-
-        assert edge_data.edges == []
-
-    def test_changing_type_from_plain_to_router_drops_the_existing_edge(self):
-        """The reverse direction: a single unlabeled output has no branch label to match against
-        a router's named branches, so the old edge is stranded rather than guessed onto one."""
-        graph = self._graph(
-            LLMResponseWithPrompt.__name__,
-            {"name": "llm"},
-            edges=[make_flow_edge("e0", "src", "t0", source_handle="output")],
-        )
-        updated = make_flow_node(
-            "src", StaticRouterNode.__name__, params={"name": "router", "route_key": "k", "keywords": ["a"]}
-        )
-        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
-
-        edge_data, _ = apply_pipeline_patch(graph, patch)
-
-        assert edge_data.edges == []
-
-    def test_editing_an_unrelated_param_leaves_edges_alone(self):
-        """A plain node offers the same single output whatever is edited, so this is not this
-        engine's business -- the common case for every non-router param edit."""
-        graph = self._graph(
-            LLMResponseWithPrompt.__name__,
-            {"name": "llm"},
-            edges=[make_flow_edge("e0", "src", "t0", source_handle="output")],
-        )
-        updated = make_flow_node("src", LLMResponseWithPrompt.__name__, params={"name": "llm", "prompt": "Be terse."})
-        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
-
-        edge_data, _ = apply_pipeline_patch(graph, patch)
-
-        assert [edge.sourceHandle for edge in edge_data.edges] == ["output"]
-
-    def test_an_edge_already_stranded_before_the_edit_is_left_alone(self):
-        """Only the handles this edit removed are followed -- an edge already on a handle the
-        node never offered is not this edit's edge to clean up."""
-        graph = self._graph(
-            StaticRouterNode.__name__,
-            {"name": "router", "route_key": "k", "keywords": ["a"]},
-            edges=[make_flow_edge("stranded", "src", "t0", source_handle="output_7")],
-        )
-        updated = make_flow_node(
-            "src", StaticRouterNode.__name__, params={"name": "router", "route_key": "k", "keywords": ["a", "b"]}
-        )
-        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
-
-        edge_data, _ = apply_pipeline_patch(graph, patch)
-
-        assert {edge.id for edge in edge_data.edges} == {"stranded"}
-
-    def test_updating_a_node_with_no_previous_content_does_not_crash(self):
-        """A membership-only row (``data=None``) has no prior handles to diff against; the update
-        just replaces it, same as before this feature existed."""
-        graph = self._graph(LLMResponseWithPrompt.__name__, {"name": "llm"}, edges=[])
-        graph["nodes"][0]["data"] = None
-        updated = make_flow_node("src", LLMResponseWithPrompt.__name__, params={"name": "llm"})
-        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
-
-        edge_data, node_data = apply_pipeline_patch(graph, patch)
-
-        assert node_data["src"].data.params["name"] == "llm"
-        assert edge_data.edges == []
 
 
 # ──────────────────────────────────────────────

--- a/apps/pipelines/tests/test_patching.py
+++ b/apps/pipelines/tests/test_patching.py
@@ -350,9 +350,7 @@ class TestNodeUpdateRewiresHandles:
             {"name": "llm"},
             edges=[make_flow_edge("e0", "src", "t0", source_handle="output")],
         )
-        updated = make_flow_node(
-            "src", LLMResponseWithPrompt.__name__, params={"name": "llm", "prompt": "Be terse."}
-        )
+        updated = make_flow_node("src", LLMResponseWithPrompt.__name__, params={"name": "llm", "prompt": "Be terse."})
         patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
 
         edge_data, _ = apply_pipeline_patch(graph, patch)

--- a/apps/pipelines/tests/test_patching_handle_rewiring.py
+++ b/apps/pipelines/tests/test_patching_handle_rewiring.py
@@ -1,0 +1,158 @@
+"""Node updates that change output handles (#1452): a router's ``keywords``, or a type change
+to/from a router. Edges already on one of those handles have to end up somewhere defensible, the
+same way ``apps/api/v2/pipeline_edit`` already does it for a param-only edit --
+``apply_pipeline_patch`` never did, for any update, until now.
+"""
+
+from apps.pipelines.flow import FlowEdge, FlowNode, FlowNodeData, NodeDiff, PipelineDiffPayload
+from apps.pipelines.nodes.nodes import LLMResponseWithPrompt, StaticRouterNode
+from apps.pipelines.patching import apply_pipeline_patch
+
+
+def make_flow_node(node_id: str, node_type: str = "Passthrough", params: dict | None = None) -> FlowNode:
+    return FlowNode(
+        id=node_id,
+        type="pipelineNode",
+        position={"x": 0, "y": 0},
+        data=FlowNodeData(id=node_id, type=node_type, label=node_type, params=params or {"name": node_id}),
+    )
+
+
+def make_flow_edge(edge_id: str, source: str, target: str, source_handle: str | None = None) -> FlowEdge:
+    kwargs = {"id": edge_id, "source": source, "target": target}
+    if source_handle is not None:
+        kwargs["sourceHandle"] = source_handle
+    return FlowEdge(**kwargs)
+
+
+class TestNodeUpdateRewiresHandles:
+    def _graph(self, source_type: str, source_params: dict, edges: list[FlowEdge]) -> dict:
+        return {
+            "nodes": [
+                make_flow_node("src", source_type, params=source_params).model_dump(),
+                {"id": "t0", "type": "pipelineNode", "position": {"x": 0, "y": 0}, "data": None},
+                {"id": "t1", "type": "pipelineNode", "position": {"x": 0, "y": 0}, "data": None},
+            ],
+            "edges": [edge.model_dump() for edge in edges],
+        }
+
+    def test_dropping_a_keyword_strands_and_removes_its_edge(self):
+        """Param-only change, no type change: a router losing a keyword loses the branch, and the
+        edge on that branch's handle has nowhere left to go."""
+        graph = self._graph(
+            StaticRouterNode.__name__,
+            {"name": "router", "route_key": "k", "keywords": ["a", "b"]},
+            edges=[
+                make_flow_edge("e0", "src", "t0", source_handle="output_0"),
+                make_flow_edge("e1", "src", "t1", source_handle="output_1"),
+            ],
+        )
+        updated = make_flow_node(
+            "src", StaticRouterNode.__name__, params={"name": "router", "route_key": "k", "keywords": ["a"]}
+        )
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, _ = apply_pipeline_patch(graph, patch)
+
+        assert {edge.id for edge in edge_data.edges} == {"e0"}
+
+    def test_reordering_keywords_moves_the_edge_with_its_branch(self):
+        """Handles are positional, so the edge has to follow its branch's label across the
+        reorder, not stay on the same handle index."""
+        graph = self._graph(
+            StaticRouterNode.__name__,
+            {"name": "router", "route_key": "k", "keywords": ["a", "b"]},
+            edges=[
+                make_flow_edge("e0", "src", "t0", source_handle="output_0"),
+                make_flow_edge("e1", "src", "t1", source_handle="output_1"),
+            ],
+        )
+        updated = make_flow_node(
+            "src", StaticRouterNode.__name__, params={"name": "router", "route_key": "k", "keywords": ["b", "a"]}
+        )
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, _ = apply_pipeline_patch(graph, patch)
+
+        by_id = {edge.id: edge.sourceHandle for edge in edge_data.edges}
+        assert by_id == {"e0": "output_1", "e1": "output_0"}
+
+    def test_changing_type_from_router_to_plain_drops_edges_on_removed_handles(self):
+        """A type change is just another update as far as the patch engine is concerned -- it
+        should lose its old branches' edges exactly like a keyword edit does."""
+        graph = self._graph(
+            StaticRouterNode.__name__,
+            {"name": "router", "route_key": "k", "keywords": ["a", "b"]},
+            edges=[
+                make_flow_edge("e0", "src", "t0", source_handle="output_0"),
+                make_flow_edge("e1", "src", "t1", source_handle="output_1"),
+            ],
+        )
+        updated = make_flow_node("src", LLMResponseWithPrompt.__name__, params={"name": "llm"})
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, _ = apply_pipeline_patch(graph, patch)
+
+        assert edge_data.edges == []
+
+    def test_changing_type_from_plain_to_router_drops_the_existing_edge(self):
+        """The reverse direction: a single unlabeled output has no branch label to match against
+        a router's named branches, so the old edge is stranded rather than guessed onto one."""
+        graph = self._graph(
+            LLMResponseWithPrompt.__name__,
+            {"name": "llm"},
+            edges=[make_flow_edge("e0", "src", "t0", source_handle="output")],
+        )
+        updated = make_flow_node(
+            "src", StaticRouterNode.__name__, params={"name": "router", "route_key": "k", "keywords": ["a"]}
+        )
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, _ = apply_pipeline_patch(graph, patch)
+
+        assert edge_data.edges == []
+
+    def test_editing_an_unrelated_param_leaves_edges_alone(self):
+        """A plain node offers the same single output whatever is edited, so this is not this
+        engine's business -- the common case for every non-router param edit."""
+        graph = self._graph(
+            LLMResponseWithPrompt.__name__,
+            {"name": "llm"},
+            edges=[make_flow_edge("e0", "src", "t0", source_handle="output")],
+        )
+        updated = make_flow_node("src", LLMResponseWithPrompt.__name__, params={"name": "llm", "prompt": "Be terse."})
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, _ = apply_pipeline_patch(graph, patch)
+
+        assert [edge.sourceHandle for edge in edge_data.edges] == ["output"]
+
+    def test_an_edge_already_stranded_before_the_edit_is_left_alone(self):
+        """Only the handles this edit removed are followed -- an edge already on a handle the
+        node never offered is not this edit's edge to clean up."""
+        graph = self._graph(
+            StaticRouterNode.__name__,
+            {"name": "router", "route_key": "k", "keywords": ["a"]},
+            edges=[make_flow_edge("stranded", "src", "t0", source_handle="output_7")],
+        )
+        updated = make_flow_node(
+            "src", StaticRouterNode.__name__, params={"name": "router", "route_key": "k", "keywords": ["a", "b"]}
+        )
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, _ = apply_pipeline_patch(graph, patch)
+
+        assert {edge.id for edge in edge_data.edges} == {"stranded"}
+
+    def test_updating_a_node_with_no_previous_content_does_not_crash(self):
+        """A membership-only row (``data=None``) has no prior handles to diff against; the update
+        just replaces it, same as before this feature existed."""
+        graph = self._graph(LLMResponseWithPrompt.__name__, {"name": "llm"}, edges=[])
+        graph["nodes"][0]["data"] = None
+        updated = make_flow_node("src", LLMResponseWithPrompt.__name__, params={"name": "llm"})
+        patch = PipelineDiffPayload(base_revision=0, nodes=NodeDiff(update=[updated]))
+
+        edge_data, node_data = apply_pipeline_patch(graph, patch)
+
+        assert node_data["src"].data.params["name"] == "llm"
+        assert edge_data.edges == []

--- a/apps/pipelines/tests/test_patching_handle_rewiring.py
+++ b/apps/pipelines/tests/test_patching_handle_rewiring.py
@@ -4,7 +4,7 @@ same way ``apps/api/v2/pipeline_edit`` already does it for a param-only edit --
 ``apply_pipeline_patch`` never did, for any update, until now.
 """
 
-from apps.pipelines.flow import FlowEdge, FlowNode, FlowNodeData, NodeDiff, PipelineDiffPayload
+from apps.pipelines.flow import EdgeDiff, FlowEdge, FlowNode, FlowNodeData, NodeDiff, PipelineDiffPayload
 from apps.pipelines.nodes.nodes import LLMResponseWithPrompt, StaticRouterNode
 from apps.pipelines.patching import apply_pipeline_patch
 
@@ -156,3 +156,34 @@ class TestNodeUpdateRewiresHandles:
 
         assert node_data["src"].data.params["name"] == "llm"
         assert edge_data.edges == []
+
+    def test_an_explicit_edge_update_in_the_same_patch_does_not_resurrect_a_rewired_edge(self):
+        """A combined patch can update a node and, in the same request, explicitly update one of
+        that node's own edges -- e.g. a client that computed its edge diff against the pre-update
+        handle set. The node-update rewiring must have the final say: an edge it drops for a
+        handle that no longer exists must not come back because the edge diff also named it,
+        carrying the now-invalid handle forward.
+        """
+        graph = self._graph(
+            StaticRouterNode.__name__,
+            {"name": "router", "route_key": "k", "keywords": ["a", "b"]},
+            edges=[
+                make_flow_edge("e0", "src", "t0", source_handle="output_0"),
+                make_flow_edge("e1", "src", "t1", source_handle="output_1"),
+            ],
+        )
+        updated_node = make_flow_node(
+            "src", StaticRouterNode.__name__, params={"name": "router", "route_key": "k", "keywords": ["a"]}
+        )
+        # The client's edge diff still carries the pre-update handle for e1 -- output_1 is gone
+        # once the node update above lands.
+        stale_edge_update = make_flow_edge("e1", "src", "t1", source_handle="output_1")
+        patch = PipelineDiffPayload(
+            base_revision=0,
+            nodes=NodeDiff(update=[updated_node]),
+            edges=EdgeDiff(update=[stale_edge_update]),
+        )
+
+        edge_data, _ = apply_pipeline_patch(graph, patch)
+
+        assert {edge.id for edge in edge_data.edges} == {"e0"}

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -96,7 +96,7 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
               </button>
             )}
             {changeableTypes.length > 0 && (
-              <div className="dropdown dropdown-top">
+              <div className="dropdown dropdown-bottom">
                   <button className="btn btn-xs join-item" aria-label="Change node type">
                       <i className="fa-solid fa-right-left"></i>
                   </button>

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -1,6 +1,6 @@
 import {Node, NodeProps, NodeToolbar, Position} from "reactflow";
 import React, {ChangeEvent, MouseEvent} from "react";
-import {concatenate, formatDocsForSchema, getCachedData, nodeBorderClass} from "./utils";
+import {buildTypeChangeParams, concatenate, formatDocsForSchema, getCachedData, nodeBorderClass} from "./utils";
 import usePipelineStore from "./stores/pipelineStore";
 import useEditorStore from "./stores/editorStore";
 import {JsonSchema, NodeData} from "./types/nodeParams";
@@ -61,6 +61,23 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
     }));
   };
 
+  // Other user-addable types this node could become (#1452). Start/End/Passthrough are never
+  // offered, in either direction: a node whose own schema isn't `ui:can_add` gets no control at
+  // all, and this list excludes them as targets the same way ComponentList's palette does.
+  const changeableTypes = nodeSchema["ui:can_add"]
+    ? Array.from(getCachedData().nodeSchemas.values())
+        .filter((schema) => schema["ui:can_add"] && schema.title !== data.type)
+        .sort((a, b) => a["ui:label"].localeCompare(b["ui:label"]))
+    : [];
+
+  const changeNodeType = (newSchema: JsonSchema) => {
+    setNode(id, produce((next) => {
+      next.data.type = newSchema.title;
+      next.data.label = newSchema["ui:label"];
+      next.data.params = buildTypeChangeParams(newSchema, data.params);
+    }));
+  };
+
   const currentColor = data.params["color"] || NODE_COLORS[0].value;
   const nodeClasses = `${nodeBorderClass(hasErrors, selected)} ${currentColor}`;
 
@@ -77,6 +94,21 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
               <button className="btn btn-xs join-item" onClick={() => editNode()}>
                   <i className="fa fa-pencil"></i>
               </button>
+            )}
+            {changeableTypes.length > 0 && (
+              <div className="dropdown dropdown-top">
+                  <button className="btn btn-xs join-item" aria-label="Change node type">
+                      <i className="fa-solid fa-right-left"></i>
+                  </button>
+                  <ul tabIndex={0} className="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52 max-h-60 overflow-y-auto">
+                    <li className="menu-title">Change type</li>
+                    {changeableTypes.map((schema) => (
+                      <li key={schema.title}>
+                        <a onClick={() => changeNodeType(schema)}>{schema["ui:label"]}</a>
+                      </li>
+                    ))}
+                  </ul>
+              </div>
             )}
             {nodeDocs && (
               <div className="dropdown dropdown-right">

--- a/assets/javascript/apps/pipeline/PipelineNode.tsx
+++ b/assets/javascript/apps/pipeline/PipelineNode.tsx
@@ -104,7 +104,7 @@ export function PipelineNode(nodeProps: NodeProps<NodeData>) {
                     <li className="menu-title">Change type</li>
                     {changeableTypes.map((schema) => (
                       <li key={schema.title}>
-                        <a onClick={() => changeNodeType(schema)}>{schema["ui:label"]}</a>
+                        <button type="button" onClick={() => changeNodeType(schema)}>{schema["ui:label"]}</button>
                       </li>
                     ))}
                   </ul>

--- a/assets/javascript/apps/pipeline/nodes/GetInputWidget.test.tsx
+++ b/assets/javascript/apps/pipeline/nodes/GetInputWidget.test.tsx
@@ -56,12 +56,8 @@ describe('getWidgets', () => {
 
 describe('getWidgets with a frozen params object (#1452)', () => {
   it('does not throw when the node has no keywords param and params is frozen', () => {
-    // A type change (#1452) replaces data.params with a fresh object inside an immer
-    // produce() call, which auto-freezes it. baseSchema has no "keywords" property (most
-    // node types don't), so a widget-rendering path that unconditionally writes
-    // params.keywords -- regardless of the schema -- crashes on the very first render of
-    // any type that never had that key. The widget itself already tolerates a missing
-    // keywords array (falls back to length 1 / []), so nothing needs to lazily add it here.
+    // A type change (#1452) hands this an already-frozen params object -- immer's produce()
+    // auto-freezes its result -- with no "keywords" key, since baseSchema doesn't declare one.
     const frozenParams = Object.freeze({name: 'x', greeting: 'hi'});
 
     expect(() =>

--- a/assets/javascript/apps/pipeline/nodes/GetInputWidget.test.tsx
+++ b/assets/javascript/apps/pipeline/nodes/GetInputWidget.test.tsx
@@ -54,6 +54,30 @@ describe('getWidgets', () => {
   });
 });
 
+describe('getWidgets with a frozen params object (#1452)', () => {
+  it('does not throw when the node has no keywords param and params is frozen', () => {
+    // A type change (#1452) replaces data.params with a fresh object inside an immer
+    // produce() call, which auto-freezes it. baseSchema has no "keywords" property (most
+    // node types don't), so a widget-rendering path that unconditionally writes
+    // params.keywords -- regardless of the schema -- crashes on the very first render of
+    // any type that never had that key. The widget itself already tolerates a missing
+    // keywords array (falls back to length 1 / []), so nothing needs to lazily add it here.
+    const frozenParams = Object.freeze({name: 'x', greeting: 'hi'});
+
+    expect(() =>
+      getWidgets(
+        {
+          schema: baseSchema,
+          nodeId: 'node-1',
+          nodeData: {type: 'RenderTemplate', label: 'Test', params: frozenParams},
+          updateParamValue: noop,
+        },
+        {getNodeFieldError: () => undefined, readOnly: false},
+      ),
+    ).not.toThrow();
+  });
+});
+
 describe('VisibleWhenWrapper', () => {
   it('reapplies the hidden-on-mount clear when the field identity changes, even if visibility does not', () => {
     const onHideA = vi.fn();

--- a/assets/javascript/apps/pipeline/nodes/GetInputWidget.tsx
+++ b/assets/javascript/apps/pipeline/nodes/GetInputWidget.tsx
@@ -208,9 +208,10 @@ const getWidgetsGeneric = (
       return 0;
     }
   });
-   if (!Array.isArray(nodeData.params.keywords)) {
-    nodeData.params.keywords = [""]; // initialize keywords with size 1
-  }
+  // The "keywords" widget (widgets.tsx) already falls back to an empty list on its own when
+  // params.keywords is missing or not an array, so nothing here needs to lazily add it -- and
+  // mutating params in place is unsafe besides: a type change (#1452) can hand this an
+  // already-frozen object (immer auto-freezes every produce() result), which throws on write.
   return schemaProperties.map((name) => (
     <React.Fragment key={name}>
       {widgetGenerator({

--- a/assets/javascript/apps/pipeline/panel/ComponentList.tsx
+++ b/assets/javascript/apps/pipeline/panel/ComponentList.tsx
@@ -1,9 +1,9 @@
 import React, {useCallback, useEffect, useState} from "react";
 import Component from "./Component";
 import OverlayPanel from "../components/OverlayPanel";
-import {formatDocsForSchema, getCachedData} from "../utils";
+import {formatDocsForSchema, getCachedData, getDefaultParamValues} from "../utils";
 import ComponentHelp from "./ComponentHelp";
-import {JsonSchema, NodeData, NodeParams} from "../types/nodeParams";
+import {JsonSchema, NodeData} from "../types/nodeParams";
 import usePipelineStore from "../stores/pipelineStore";
 
 type ComponentListParams = {
@@ -13,17 +13,8 @@ type ComponentListParams = {
 
 export default function ComponentList({isOpen, setIsOpen}: ComponentListParams) {
   const addNode = usePipelineStore((state) => state.addNode);
-  const {defaultValues, nodeSchemas} = getCachedData();
+  const {nodeSchemas} = getCachedData();
   const schemaList = Array.from(nodeSchemas.values()).sort((a, b) => a["ui:label"].localeCompare(b["ui:label"]));
-
-  function getDefaultParamValues(schema: JsonSchema): NodeParams {
-    const defaults: NodeParams = {name: ""};
-    for (const name in schema.properties) {
-      const property = schema.properties[name];
-      defaults[name] = [property.default, defaultValues[name]].find((value) => value !== undefined && value !== null) ?? null;
-    }
-    return defaults;
-  }
 
   //** Help bubble state
   const [scrollPosition, setScrollPosition] = useState(0)

--- a/assets/javascript/apps/pipeline/utils.test.tsx
+++ b/assets/javascript/apps/pipeline/utils.test.tsx
@@ -1,5 +1,6 @@
 import {beforeAll, describe, expect, it} from 'vitest';
-import {getCachedData} from './utils';
+import {buildTypeChangeParams, getCachedData, getDefaultParamValues} from './utils';
+import type {JsonSchema} from './types/nodeParams';
 
 beforeAll(() => {
   const setScript = (id: string, data: unknown) => {
@@ -10,7 +11,7 @@ beforeAll(() => {
     document.body.appendChild(el);
   };
   setScript('parameter-values', {});
-  setScript('default-values', {});
+  setScript('default-values', {greeting: 'hi'});
   setScript('node-schemas', [{title: 'RouterNode', 'ui:label': 'Router', properties: {}}]);
   setScript('flags-enabled', []);
   setScript('llm-model-params', {});
@@ -27,5 +28,76 @@ describe('getCachedData', () => {
     const secondValues = getCachedData().parameterValues;
     expect(secondSchemas).toBe(firstSchemas);
     expect(secondValues).toBe(firstValues);
+  });
+});
+
+const llmSchema: JsonSchema = {
+  title: 'LLMResponseWithPrompt',
+  'ui:flow_node_type': 'pipelineNode',
+  'ui:label': 'LLM',
+  'ui:can_add': true,
+  'ui:can_delete': true,
+  'ui:deprecated': false,
+  properties: {
+    prompt: {type: 'string', default: ''},
+    greeting: {type: 'string'},
+  },
+};
+
+const templateSchema: JsonSchema = {
+  title: 'RenderTemplate',
+  'ui:flow_node_type': 'pipelineNode',
+  'ui:label': 'Render a template',
+  'ui:can_add': true,
+  'ui:can_delete': true,
+  'ui:deprecated': false,
+  properties: {
+    template_string: {type: 'string', default: 'hello'},
+  },
+};
+
+describe('getDefaultParamValues', () => {
+  it('always includes an empty name, whatever the schema declares', () => {
+    expect(getDefaultParamValues(templateSchema).name).toBe('');
+  });
+
+  it("uses a property's own default when it has one", () => {
+    expect(getDefaultParamValues(templateSchema).template_string).toBe('hello');
+  });
+
+  it('falls back to the cached default-values map when the property has no default of its own', () => {
+    expect(getDefaultParamValues(llmSchema).greeting).toBe('hi');
+  });
+
+  it('is null when neither the schema nor the default-values map has a value', () => {
+    const schema: JsonSchema = {...templateSchema, properties: {undeclared: {type: 'string'}}};
+    expect(getDefaultParamValues(schema).undeclared).toBeNull();
+  });
+});
+
+describe('buildTypeChangeParams (#1452)', () => {
+  it("resets to the new type's own defaults", () => {
+    const params = buildTypeChangeParams(templateSchema, {name: 'my-llm', prompt: 'Be terse.'});
+    expect(params.template_string).toBe('hello');
+  });
+
+  it('drops params the new type does not declare', () => {
+    const params = buildTypeChangeParams(templateSchema, {name: 'my-llm', prompt: 'Be terse.'});
+    expect(params).not.toHaveProperty('prompt');
+  });
+
+  it('preserves the node name across the swap', () => {
+    const params = buildTypeChangeParams(templateSchema, {name: 'my-llm', prompt: 'Be terse.'});
+    expect(params.name).toBe('my-llm');
+  });
+
+  it('preserves color when the node has one, since color is UI state, not a schema field on any type', () => {
+    const params = buildTypeChangeParams(templateSchema, {name: 'n', color: 'bg-red-100 dark:bg-red-950'});
+    expect(params.color).toBe('bg-red-100 dark:bg-red-950');
+  });
+
+  it('adds no color key when the node never had one', () => {
+    const params = buildTypeChangeParams(templateSchema, {name: 'n'});
+    expect(params).not.toHaveProperty('color');
   });
 });

--- a/assets/javascript/apps/pipeline/utils.test.tsx
+++ b/assets/javascript/apps/pipeline/utils.test.tsx
@@ -61,6 +61,17 @@ describe('getDefaultParamValues', () => {
     expect(getDefaultParamValues(templateSchema).name).toBe('');
   });
 
+  it('keeps name empty even when the schema itself declares a name property', () => {
+    // Every real node schema declares "name" (apps/pipelines/nodes/base.py's BasePipelineNode
+    // field), so the defaults loop iterates over it like any other property -- it must not let
+    // that overwrite the empty starting value with a schema/cached default or null.
+    const schema: JsonSchema = {
+      ...templateSchema,
+      properties: {...templateSchema.properties, name: {type: 'string', default: 'Untitled'}},
+    };
+    expect(getDefaultParamValues(schema).name).toBe('');
+  });
+
   it("uses a property's own default when it has one", () => {
     expect(getDefaultParamValues(templateSchema).template_string).toBe('hello');
   });

--- a/assets/javascript/apps/pipeline/utils.tsx
+++ b/assets/javascript/apps/pipeline/utils.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import ShortUniqueId from "short-unique-id";
 import {NodeParameterValues, Option} from "./types/nodeParameterValues";
-import {JsonSchema, PropertySchema} from "./types/nodeParams";
+import {JsonSchema, NodeParams, PropertySchema} from "./types/nodeParams";
 
 declare global {
   interface Window {
@@ -75,6 +75,39 @@ export function getDocumentationLink(schema: JsonSchema) {
   return documentationLink;
 }
 
+
+/**
+ * The param values a fresh node of this schema starts with: each property's own default,
+ * falling back to the team's cached default-values map, or null when neither has one.
+ */
+export function getDefaultParamValues(schema: JsonSchema): NodeParams {
+  const {defaultValues} = getCachedData();
+  const defaults: NodeParams = {name: ""};
+  for (const name in schema.properties) {
+    const property = schema.properties[name];
+    defaults[name] = [property.default, defaultValues[name]].find((value) => value !== undefined && value !== null) ?? null;
+  }
+  return defaults;
+}
+
+/**
+ * The param values a node keeps when its type changes to `newSchema` (#1452).
+ *
+ * Every type-specific param resets to the new type's own defaults, never carried across by
+ * matching field names -- a name shared between two schemas is not proof it means the same
+ * thing in both (see `NodeUpdateSerializer` on the v2 API, which refuses a type change in place
+ * for exactly this reason). `name` and `color` are the only survivors: `name` is UI identity
+ * every schema declares, and `color` is UI-only state that is not a schema field on any node
+ * type at all, so it is carried separately rather than lost to the reset.
+ */
+export function buildTypeChangeParams(newSchema: JsonSchema, currentParams: NodeParams): NodeParams {
+  const params = getDefaultParamValues(newSchema);
+  params.name = currentParams.name;
+  if (currentParams.color !== undefined) {
+    params.color = currentParams.color;
+  }
+  return params;
+}
 
 export function concatenate(value: string | string[] | null | undefined): string {
   if (!value) return "";

--- a/assets/javascript/apps/pipeline/utils.tsx
+++ b/assets/javascript/apps/pipeline/utils.tsx
@@ -84,6 +84,10 @@ export function getDefaultParamValues(schema: JsonSchema): NodeParams {
   const {defaultValues} = getCachedData();
   const defaults: NodeParams = {name: ""};
   for (const name in schema.properties) {
+    // Every real node schema declares "name" as one of its own properties (it's a field on the
+    // shared base node), but it's never given a schema or cached default here -- it's set by
+    // the caller (a generated id on add, the preserved name on a type change).
+    if (name === "name") continue;
     const property = schema.properties[name];
     defaults[name] = [property.default, defaultValues[name]].find((value) => value !== undefined && value !== null) ?? null;
   }


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->
Lets you change an existing pipeline node's type from the builder canvas, keeping its position, id, name, color, and edges wherever the new type still offers a matching output. No more deleting the node and recreating it from scratch.

### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->
Params reset to the new type's own defaults rather than carrying over same-named values across types. `apps/api/v2/pipeline_edit/serializers.py`'s `NodeUpdateSerializer` already refuses a type change in place on the v2 API for exactly this reason (`test_patch_refuses_to_change_a_nodes_type`), a shared field name isn't proof two types give it the same meaning. Resetting sidesteps that: nothing crosses the type boundary except `name` and `color`, neither of which is a domain param.

The remaining real problem is output handles: `RouterNode`/`StaticRouterNode`/`BooleanNode` expose multiple named handles, everything else exposes one. `graph_editor.py`'s `plan_update` already rewired or dropped edges when a *param* edit changed a node's handles, but only on the v2 API, the human builder's own save path (`patching.py::apply_pipeline_patch`) never did, for any update. Extracted that logic into `apps/pipelines/build_state.py` (`output_handle_labels`, `rewired_edges_for_node`) so both callers share one implementation, and wired it into `patching.py`'s node-update path. This also fixes a pre-existing, unrelated gap: editing a router's keywords through the visual builder could already dangle an edge before this PR.

Two bugs turned up only by clicking through the feature in a running pipeline, not by tests or static review, both fixed with a regression test:
- `GetInputWidget.tsx` unconditionally wrote `params.keywords` on every node render regardless of schema. Harmless normally; a type change hands it a fresh, already-frozen (immer auto-freeze) params object with no `keywords` key, which crashed on write.
- `build_state.py`'s router fallback path called `enumerate()` on `keywords` without checking it wasn't `None`  reachable because the frontend has no static JSON-schema default to offer for a `default_factory=list` field, so a swap into a router type sends `keywords: null`.

Also: `Node.update_from_params()` only cleared `CustomActionOperation` rows when the node's *current* type is `LLMResponseWithPrompt`, so a type change away from it left old rows orphaned. Added the missing `elif` branch.

### Issue Link
<!--
Link to the issue or doc that prompted this change, if any.
If this fully addresses an issue use one of the keywords to have it automatically closed when the PR is merged e.g. `fixes #XYZ`
See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->
Closes #1452

### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->
<img width="1455" height="812" alt="change-node-type-1452-demo" src="https://github.com/user-attachments/assets/8fc440b0-99d3-4d47-a40c-ed3a0addaef7" />

Swapping an LLM node to LLM Router: params reset and the stale edge to the next node is dropped since the new type offers no matching output.

1. Open any pipeline in the builder and select a node.
2. Click the new swap icon in the node's toolbar (next to delete/edit).
3. Pick a different type from the list, the node keeps its id, position, and any edges its new type can still offer a matching output for; other params reset to the new type's defaults.

### Docs and Changelog
- [x] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->
User-facing builder feature: a "change type" control on each pipeline node, letting a user swap it to a different node type in place instead of deleting and recreating it. Params reset to the new type's defaults (except name/color); edges are kept where the new type still offers a matching output, dropped otherwise.

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change

<!--
Check the box above if a self-hosted operator has to do something, or would be surprised on upgrade: migrations, new/renamed/removed settings or env vars, a change in deployment shape (process types, queues, backing-service versions), a deprecation or removal, or a security fix needing operator action.

This is separate from the docs/changelog checkbox above, which covers the user-facing product changelog. If checked, add an entry under `[Unreleased]` in the repo-root `CHANGELOG.md` in this PR. See RELEASING.md.

Leave unchecked for a change that is purely a feature, improvement or bug fix with none of the above, those reach operators through the user-facing changelog. A feature PR that also carries a migration or a settings change is still operator-impacting: check the box and log the migration.
-->


