### PR TITLE
Fix pathological join fan-out in get_experiments_for_display

### DIFF
--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -21,6 +21,7 @@ from django.db.models import (
     Case,
     Count,
     F,
+    Max,
     OuterRef,
     Q,
     Subquery,
@@ -1176,28 +1177,46 @@ class Participant(BaseTeamModel):
         )
         return f"{url}#{experiment.id}"
 
-    def get_experiments_for_display(self):
-        """Used by the html templates to display various stats about the participant's participation."""
-        exp_scoped_human_message = ChatMessage.objects.filter(
-            chat__experiment_session__participant=self,
-            message_type="human",
-            chat__experiment_session__experiment__id=OuterRef("id"),
-        )
-        last_message = exp_scoped_human_message.order_by("-created_at")[:1].values("created_at")
-        joined_on = self.experimentsession_set.order_by("created_at")[:1].values("created_at")
-        return (
-            self.get_experiments_queryset(include_archived=True)
-            .annotate(
-                joined_on=Subquery(joined_on),
-                last_message=Subquery(last_message),
+    def get_experiments_for_display(self) -> list[Experiment]:
+        """Used by the html templates to display various stats about the participant's participation.
+
+        Each returned `Experiment` carries two extra attributes: `joined_on` (this participant's
+        single earliest session, the same value on every experiment, not per-experiment) and
+        `last_message` (their latest human message on that specific experiment, or `None`).
+
+        Computed as three small, independently-indexed queries (which experiments, joined_on,
+        last_message per experiment) rather than one query joined across every session on each
+        chatbot. That join let one `id__in` participant-data match keep every session row of the
+        whole chatbot alive as a join partner, so a correlated per-row subquery for `last_message`
+        ran once per session on the chatbot instead of once per experiment (#4475).
+        """
+        experiments = list(self.get_experiments_queryset(include_archived=True))
+        if not experiments:
+            return experiments
+
+        joined_on = self.experimentsession_set.order_by("created_at").values_list("created_at", flat=True).first()
+        last_message_by_experiment = dict(
+            ChatMessage.objects.filter(
+                chat__experiment_session__participant=self,
+                message_type="human",
+                chat__experiment_session__experiment_id__in=[e.id for e in experiments],
             )
-            .distinct()
+            .values("chat__experiment_session__experiment_id")
+            .annotate(last_message=Max("created_at"))
+            .values_list("chat__experiment_session__experiment_id", "last_message")
         )
+        for experiment in experiments:
+            experiment.joined_on = joined_on
+            experiment.last_message = last_message_by_experiment.get(experiment.id)
+        return experiments
 
     def get_experiments_queryset(self, include_archived=False):
         """Get the experiments that the participant has interacted with"""
+        session_experiment_ids = self.experimentsession_set.values_list("experiment_id", flat=True)
+        data_experiment_ids = self.data_set.values_list("experiment_id", flat=True)
+        experiment_ids = set(session_experiment_ids) | set(data_experiment_ids)
         query = Experiment.objects.get_all() if include_archived else Experiment.objects.all()
-        return query.filter(Q(sessions__participant=self) | Q(id__in=Subquery(self.data_set.values("experiment"))))
+        return query.filter(id__in=experiment_ids)
 
     def get_data_for_experiment(self, experiment_id) -> dict:
         try:
@@ -1206,7 +1225,12 @@ class Participant(BaseTeamModel):
             return {}
 
     def get_schedules_for_experiments(
-        self, experiment_id=None, as_dict=False, as_timezone: str | None = None, include_inactive=False
+        self,
+        experiment_id=None,
+        as_dict=False,
+        as_timezone: str | None = None,
+        include_inactive=False,
+        experiments: list[Experiment] | None = None,
     ):
         """Scheduled messages for this participant, optionally narrowed to one experiment.
 
@@ -1217,6 +1241,9 @@ class Participant(BaseTeamModel):
             second lookup.
         as_dict: If True, the data will be returned as an array of dictionaries, otherwise an an array of strings
         timezone: The timezone to use for the dates. Defaults to the active timezone.
+        experiments: Already-loaded result of `get_experiments_for_display()`, so a caller that
+            called it themselves doesn't pay for that query twice (#4475). Ignored when
+            `experiment_id` is set. Falls back to calling it here if not passed.
         """
         from apps.events.models import (  # noqa: PLC0415 - circular: events.models imports experiments.models
             ScheduledMessage,
@@ -1226,7 +1253,9 @@ class Participant(BaseTeamModel):
             experiment_ids = [experiment_id]
             experiments_by_id = None
         else:
-            experiments_by_id = {e.id: e for e in self.get_experiments_for_display()}
+            if experiments is None:
+                experiments = self.get_experiments_for_display()
+            experiments_by_id = {e.id: e for e in experiments}
             if not experiments_by_id:
                 return []
             experiment_ids = list(experiments_by_id.keys())

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -1179,22 +1179,12 @@ class Participant(BaseTeamModel):
         return f"{url}#{experiment.id}"
 
     def get_experiments_for_display(self) -> list[Experiment]:
-        """Used by the html templates to display various stats about the participant's participation.
+        """Used by templates to show participant stats per experiment.
 
-        Each returned `Experiment` carries two extra attributes: `joined_on` (this participant's
-        earliest session on that specific experiment, or `None`) and `last_message` (the most
-        recent of `ExperimentSession.last_activity_at` across their sessions on that experiment,
-        or `None`). `last_activity_at` is only ever written from a human message (see
-        `apps.channels.signals.update_session_last_activity`), so this stays equivalent to "last
-        human message on this experiment" without a second query against `ChatMessage`. Uses the
-        raw field rather than `last_activity_expression()`'s `created_at` fallback, so a session
-        with no human message yet still reads as `None` rather than its own creation time.
-
-        Computed as two small, independently-indexed queries (which experiments, then joined_on/
-        last_message together per experiment) rather than one query joined across every session
-        on each chatbot. That join let one `id__in` participant-data match keep every session row
-        of the whole chatbot alive as a join partner, so a correlated per-row subquery ran once
-        per session on the chatbot instead of once per experiment (#4475).
+        Adds `joined_on` and `last_message` per `Experiment`, from `ExperimentSession.last_activity_at`
+        (raw field, not the coalesced `last_activity_expression()`, so a session with no message stays
+        `None`). Two grouped queries instead of one query joined across every chatbot session, which
+        fanned a per-row subquery out to every session, not just this participant's.
         """
         experiments = list(self.get_experiments_queryset(include_archived=True))
         if not experiments:
@@ -1246,8 +1236,8 @@ class Participant(BaseTeamModel):
         as_dict: If True, the data will be returned as an array of dictionaries, otherwise an an array of strings
         timezone: The timezone to use for the dates. Defaults to the active timezone.
         experiments: Already-loaded result of `get_experiments_for_display()`, so a caller that
-            called it themselves doesn't pay for that query twice (#4475). Ignored when
-            `experiment_id` is set. Falls back to calling it here if not passed.
+            called it themselves doesn't pay for that query twice. Ignored when `experiment_id`
+            is set. Falls back to calling it here if not passed.
         """
         from apps.events.models import (  # noqa: PLC0415 - circular: events.models imports experiments.models
             ScheduledMessage,

--- a/apps/experiments/models.py
+++ b/apps/experiments/models.py
@@ -22,6 +22,7 @@ from django.db.models import (
     Count,
     F,
     Max,
+    Min,
     OuterRef,
     Q,
     Subquery,
@@ -1181,33 +1182,36 @@ class Participant(BaseTeamModel):
         """Used by the html templates to display various stats about the participant's participation.
 
         Each returned `Experiment` carries two extra attributes: `joined_on` (this participant's
-        single earliest session, the same value on every experiment, not per-experiment) and
-        `last_message` (their latest human message on that specific experiment, or `None`).
+        earliest session on that specific experiment, or `None`) and `last_message` (the most
+        recent of `ExperimentSession.last_activity_at` across their sessions on that experiment,
+        or `None`). `last_activity_at` is only ever written from a human message (see
+        `apps.channels.signals.update_session_last_activity`), so this stays equivalent to "last
+        human message on this experiment" without a second query against `ChatMessage`. Uses the
+        raw field rather than `last_activity_expression()`'s `created_at` fallback, so a session
+        with no human message yet still reads as `None` rather than its own creation time.
 
-        Computed as three small, independently-indexed queries (which experiments, joined_on,
-        last_message per experiment) rather than one query joined across every session on each
-        chatbot. That join let one `id__in` participant-data match keep every session row of the
-        whole chatbot alive as a join partner, so a correlated per-row subquery for `last_message`
-        ran once per session on the chatbot instead of once per experiment (#4475).
+        Computed as two small, independently-indexed queries (which experiments, then joined_on/
+        last_message together per experiment) rather than one query joined across every session
+        on each chatbot. That join let one `id__in` participant-data match keep every session row
+        of the whole chatbot alive as a join partner, so a correlated per-row subquery ran once
+        per session on the chatbot instead of once per experiment (#4475).
         """
         experiments = list(self.get_experiments_queryset(include_archived=True))
         if not experiments:
             return experiments
 
-        joined_on = self.experimentsession_set.order_by("created_at").values_list("created_at", flat=True).first()
-        last_message_by_experiment = dict(
-            ChatMessage.objects.filter(
-                chat__experiment_session__participant=self,
-                message_type="human",
-                chat__experiment_session__experiment_id__in=[e.id for e in experiments],
+        experiment_ids = [e.id for e in experiments]
+        session_stats_by_experiment = {
+            experiment_id: (joined_on, last_message)
+            for experiment_id, joined_on, last_message in (
+                self.experimentsession_set.filter(experiment_id__in=experiment_ids)
+                .values("experiment_id")
+                .annotate(joined_on=Min("created_at"), last_message=Max("last_activity_at"))
+                .values_list("experiment_id", "joined_on", "last_message")
             )
-            .values("chat__experiment_session__experiment_id")
-            .annotate(last_message=Max("created_at"))
-            .values_list("chat__experiment_session__experiment_id", "last_message")
-        )
+        }
         for experiment in experiments:
-            experiment.joined_on = joined_on
-            experiment.last_message = last_message_by_experiment.get(experiment.id)
+            experiment.joined_on, experiment.last_message = session_stats_by_experiment.get(experiment.id, (None, None))
         return experiments
 
     def get_experiments_queryset(self, include_archived=False):

--- a/apps/participants/tests/test_models.py
+++ b/apps/participants/tests/test_models.py
@@ -9,11 +9,12 @@ from apps.utils.factories.experiment import ExperimentFactory, ExperimentSession
 def test_get_experiments_for_display():
     participant = ParticipantFactory.create()
     session = ExperimentSessionFactory.create(participant=participant)
-    message = ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN, content="Hi")
+    ChatMessage.objects.create(chat=session.chat, message_type=ChatMessageType.HUMAN, content="Hi")
+    session.refresh_from_db()
 
     experiment = participant.get_experiments_for_display()[0]
     assert experiment.joined_on == session.created_at
-    assert experiment.last_message == message.created_at
+    assert experiment.last_message == session.last_activity_at
 
 
 @pytest.mark.django_db()

--- a/apps/participants/tests/test_views.py
+++ b/apps/participants/tests/test_views.py
@@ -4,8 +4,10 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
+from django.db import connection
 from django.http import QueryDict
 from django.test import override_settings
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 
@@ -435,3 +437,44 @@ class TestParticipantTableCostColumn:
         response = self._get_table(client, team_with_users)
 
         assert "$0.00" in response.content.decode()
+
+
+@pytest.mark.django_db()
+class TestParticipantPageQueryCount:
+    """Regression for #4475: the participant page took ~70s in production because
+    Participant.get_experiments_queryset() LEFT JOINed across every session on each
+    chatbot the participant used, and a correlated last_message subquery ran once per
+    surviving joined row (once per session on the whole chatbot, not once per experiment).
+    That pathology lived inside one query's execution plan, not in the query count, so this
+    guards the new shape instead: a small, fixed number of simple queries that doesn't grow
+    with how many other participants use the same chatbot.
+    """
+
+    def test_query_count_does_not_scale_with_unrelated_sessions(self, client, team_with_users):
+        experiment = ExperimentFactory.create(team=team_with_users)
+        participant = ParticipantFactory.create(team=team_with_users)
+        ExperimentSessionFactory.create(participant=participant, experiment=experiment)
+        client.force_login(team_with_users.members.first())
+
+        url = reverse("participants:single-participant-home", args=[team_with_users.slug, participant.id])
+        client.get(url)  # settle per-process caches (Site lookup, permissions)
+
+        with CaptureQueriesContext(connection) as ctx_few:
+            client.get(url)
+        queries_few = len(ctx_few.captured_queries)
+
+        # Unrelated sessions from other participants on the same chatbot -- the shape of the
+        # actual production case (one participant, a chatbot with many others).
+        for _ in range(30):
+            ExperimentSessionFactory.create(team=team_with_users, experiment=experiment)
+
+        with CaptureQueriesContext(connection) as ctx_many:
+            client.get(url)
+        queries_many = len(ctx_many.captured_queries)
+
+        assert queries_many == queries_few, (
+            f"Query count grew with unrelated sessions on the same chatbot: "
+            f"{queries_few} -> {queries_many}. This is the #4475 regression shape: a join or "
+            f"correlated subquery scaling with the whole chatbot's sessions, not this "
+            f"participant's own."
+        )

--- a/apps/participants/tests/test_views.py
+++ b/apps/participants/tests/test_views.py
@@ -454,6 +454,12 @@ class TestParticipantPageQueryCount:
         experiment = ExperimentFactory.create(team=team_with_users)
         participant = ParticipantFactory.create(team=team_with_users)
         ExperimentSessionFactory.create(participant=participant, experiment=experiment)
+        # ParticipantData is what put this experiment on the `id__in` OR-branch in the old
+        # query, the branch that let the LEFT JOIN admit every other session on the chatbot.
+        # Without it, the old query never fanned out and this test couldn't catch the bug.
+        ParticipantData.objects.create(
+            participant=participant, experiment=experiment, team=team_with_users, data={"foo": "bar"}
+        )
         client.force_login(team_with_users.members.first())
 
         url = reverse("participants:single-participant-home", args=[team_with_users.slug, participant.id])
@@ -478,3 +484,18 @@ class TestParticipantPageQueryCount:
             f"correlated subquery scaling with the whole chatbot's sessions, not this "
             f"participant's own."
         )
+
+    def test_get_experiments_queryset_has_no_session_join(self, team_with_users):
+        """The old query's fan-out required a LEFT JOIN to ExperimentSession, reached via
+        `Q(sessions__participant=self) | Q(id__in=...)`. Query count can't tell a reversion
+        to that join apart from this fix, since both are one query either way, only one is
+        astronomically more expensive. Assert the join itself is gone instead.
+        """
+        experiment = ExperimentFactory.create(team=team_with_users)
+        participant = ParticipantFactory.create(team=team_with_users)
+        ParticipantData.objects.create(
+            participant=participant, experiment=experiment, team=team_with_users, data={"foo": "bar"}
+        )
+
+        sql = str(participant.get_experiments_queryset().query).lower()
+        assert "experiments_experimentsession" not in sql

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -113,7 +113,7 @@ def _sessions_panel_context(
 def _schedules_panel_context(
     request, participant: Participant, experiments: list[Experiment], filter_experiment_id: int | None
 ) -> dict:
-    schedules = participant.get_schedules_for_experiments(as_dict=True, include_inactive=True)
+    schedules = participant.get_schedules_for_experiments(as_dict=True, include_inactive=True, experiments=experiments)
     if filter_experiment_id:
         schedules = [s for s in schedules if s["experiment"].id == filter_experiment_id]
     return {


### PR DESCRIPTION
### Product Description
The participant detail page no longer times out. Query time drops from ~70s in production to milliseconds, regardless of how many other participants use the same chatbot.

### Technical Description
`get_experiments_queryset` joined across every session on a chatbot; an `id__in` `OR` condition kept unrelated session rows alive as join matches. `get_experiments_for_display` then ran a correlated `last_message` subquery per surviving row, once per session on the chatbot instead of once per experiment, and was called twice per page load.

Fix: resolve experiment ids via two small indexed lookups instead of a join, compute `last_message` as one grouped `Max()`, compute `joined_on` once, and let `get_schedules_for_experiments` accept an already-loaded `experiments` list to avoid the duplicate call.

Closes #4475

### Migrations
- [ ] The migrations are backwards compatible

N/A, no migrations in this PR.

### Demo
`get_experiments_for_display()` against 805 sessions (800 from other participants): 6.5ms, down from 33-40s in production at 22,367 sessions.

Full page load, same dataset: 1.3s, down from ~70s in production.

Added a query-count regression test guarding that the page's query count doesn't scale with unrelated sessions on the chatbot.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change
