### PR TITLE
Add undo/redo to the pipeline builder

### DIFF
--- a/assets/javascript/apps/pipeline/Pipeline.tsx
+++ b/assets/javascript/apps/pipeline/Pipeline.tsx
@@ -1,9 +1,11 @@
 import "reactflow/dist/style.css";
 import "./styles.css"
 import React, {useCallback, useState, useEffect} from "react";
+import {useStore} from "zustand";
 import ReactFlow, {
   Background,
   BackgroundVariant,
+  ControlButton,
   Controls,
   EdgeTypes,
   FitViewOptions,
@@ -55,6 +57,8 @@ export default function Pipeline() {
   const currentPipeline = usePipelineStore((state) => state.currentPipeline);
   const autoSaveCurrentPipline = usePipelineStore((state) => state.autoSaveCurrentPipline);
   const savePipeline = usePipelineStore((state) => state.savePipeline);
+  const canUndo = useStore(usePipelineStore.temporal, (state) => state.pastStates.length > 0);
+  const canRedo = useStore(usePipelineStore.temporal, (state) => state.futureStates.length > 0);
   const { nodeSchemas } = getCachedData();
 
   const editingNode = useEditorStore((state) => state.currentNode);
@@ -130,6 +134,14 @@ export default function Pipeline() {
 
   useHotkeys(["backspace", "delete"], handleDelete);
   useHotkeys("ctrl+s", () => manualSaveCurrentPipeline(), {preventDefault: true});
+  useHotkeys(["ctrl+z", "meta+z"], () => {
+    if (readOnly) return;
+    usePipelineStore.temporal.getState().undo();
+  }, {preventDefault: true});
+  useHotkeys(["ctrl+shift+z", "meta+shift+z", "ctrl+y"], () => {
+    if (readOnly) return;
+    usePipelineStore.temporal.getState().redo();
+  }, {preventDefault: true});
 
   const onSelectionChange = useCallback(
     (flow: OnSelectionChangeParams): void => {
@@ -190,7 +202,26 @@ export default function Pipeline() {
           </>
         )}
         {editingNode && <EditPanel key={editingNode.id} nodeId={editingNode.id} />}
-        <Controls showZoom showFitView showInteractive position="bottom-left"/>
+        <Controls showZoom showFitView showInteractive position="bottom-left">
+          {!readOnly && (
+            <>
+              <ControlButton
+                title="Undo"
+                disabled={!canUndo}
+                onClick={() => usePipelineStore.temporal.getState().undo()}
+              >
+                <i className="fa-solid fa-rotate-left"></i>
+              </ControlButton>
+              <ControlButton
+                title="Redo"
+                disabled={!canRedo}
+                onClick={() => usePipelineStore.temporal.getState().redo()}
+              >
+                <i className="fa-solid fa-rotate-right"></i>
+              </ControlButton>
+            </>
+          )}
+        </Controls>
         <Background
           variant={BackgroundVariant.Dots}
           gap={12}

--- a/assets/javascript/apps/pipeline/Pipeline.tsx
+++ b/assets/javascript/apps/pipeline/Pipeline.tsx
@@ -57,6 +57,8 @@ export default function Pipeline() {
   const currentPipeline = usePipelineStore((state) => state.currentPipeline);
   const autoSaveCurrentPipline = usePipelineStore((state) => state.autoSaveCurrentPipline);
   const savePipeline = usePipelineStore((state) => state.savePipeline);
+  const undoLastChange = usePipelineStore((state) => state.undoLastChange);
+  const redoLastChange = usePipelineStore((state) => state.redoLastChange);
   const canUndo = useStore(usePipelineStore.temporal, (state) => state.pastStates.length > 0);
   const canRedo = useStore(usePipelineStore.temporal, (state) => state.futureStates.length > 0);
   const { nodeSchemas } = getCachedData();
@@ -136,11 +138,11 @@ export default function Pipeline() {
   useHotkeys("ctrl+s", () => manualSaveCurrentPipeline(), {preventDefault: true});
   useHotkeys(["ctrl+z", "meta+z"], () => {
     if (readOnly) return;
-    usePipelineStore.temporal.getState().undo();
+    undoLastChange();
   }, {preventDefault: true});
   useHotkeys(["ctrl+shift+z", "meta+shift+z", "ctrl+y"], () => {
     if (readOnly) return;
-    usePipelineStore.temporal.getState().redo();
+    redoLastChange();
   }, {preventDefault: true});
 
   const onSelectionChange = useCallback(
@@ -208,14 +210,14 @@ export default function Pipeline() {
               <ControlButton
                 title="Undo"
                 disabled={!canUndo}
-                onClick={() => usePipelineStore.temporal.getState().undo()}
+                onClick={undoLastChange}
               >
                 <i className="fa-solid fa-rotate-left"></i>
               </ControlButton>
               <ControlButton
                 title="Redo"
                 disabled={!canRedo}
-                onClick={() => usePipelineStore.temporal.getState().redo()}
+                onClick={redoLastChange}
               >
                 <i className="fa-solid fa-rotate-right"></i>
               </ControlButton>

--- a/assets/javascript/apps/pipeline/stores/pipelineStore.test.tsx
+++ b/assets/javascript/apps/pipeline/stores/pipelineStore.test.tsx
@@ -1,0 +1,123 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from "vitest";
+import {Edge, Node} from "reactflow";
+import usePipelineStore from "./pipelineStore";
+
+const nodeA: Node = {id: "a", type: "pipelineNode", position: {x: 0, y: 0}, data: {type: "LLMResponse", params: {}}};
+const nodeB: Node = {id: "b", type: "pipelineNode", position: {x: 100, y: 0}, data: {type: "LLMResponse", params: {}}};
+const edgeAB: Edge = {id: "a-b", source: "a", target: "b"};
+
+// handleSet is throttled (see pipelineStore.ts) so a node drag collapses into one history
+// entry instead of one per pointer move. Fake timers make that deterministic here: without
+// them, the throttle's real wall-clock window from one test can still be open when the next
+// test's assertion runs, since the throttled function is a single instance shared for the
+// life of the store.
+function flushThrottle() {
+  vi.advanceTimersByTime(500);
+}
+
+function seed() {
+  usePipelineStore.getState().resetFlow({nodes: [nodeA, nodeB], edges: [edgeAB]});
+  usePipelineStore.temporal.getState().clear();
+}
+
+describe("pipelineStore undo/redo", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    seed();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("undo restores a deleted node and its connected edge", () => {
+    usePipelineStore.getState().deleteNode("b");
+    flushThrottle();
+    expect(usePipelineStore.getState().nodes.map((n) => n.id)).toEqual(["a"]);
+    expect(usePipelineStore.getState().edges).toEqual([]);
+
+    usePipelineStore.temporal.getState().undo();
+
+    expect(usePipelineStore.getState().nodes.map((n) => n.id).sort()).toEqual(["a", "b"]);
+    expect(usePipelineStore.getState().edges).toEqual([edgeAB]);
+  });
+
+  test("redo re-applies an undone node deletion", () => {
+    usePipelineStore.getState().deleteNode("b");
+    flushThrottle();
+    usePipelineStore.temporal.getState().undo();
+    usePipelineStore.temporal.getState().redo();
+
+    expect(usePipelineStore.getState().nodes.map((n) => n.id)).toEqual(["a"]);
+    expect(usePipelineStore.getState().edges).toEqual([]);
+  });
+
+  test("resetFlow does not create an undo step", () => {
+    usePipelineStore.getState().resetFlow({nodes: [nodeA], edges: []});
+    usePipelineStore.getState().resetFlow({nodes: [nodeA, nodeB], edges: [edgeAB]});
+    flushThrottle();
+
+    expect(usePipelineStore.temporal.getState().pastStates).toHaveLength(0);
+  });
+
+  test("undo history only grows from the user edit between two resets, not the resets themselves", () => {
+    usePipelineStore.getState().deleteNode("b");
+    usePipelineStore.getState().resetFlow({nodes: [nodeA], edges: []});
+    flushThrottle();
+
+    expect(usePipelineStore.temporal.getState().pastStates).toHaveLength(1);
+  });
+
+  // React Flow fires onNodesChange/onEdgesChange for its own bookkeeping, not just user
+  // edits: a 'dimensions' change on every node as it first measures itself, and a 'select'
+  // change on every click, including a click that only selects a node without moving it.
+  // Neither is something a user would expect Ctrl+Z to walk back through.
+  test("a node dimensions/select-only change does not create an undo step", () => {
+    usePipelineStore.getState().onNodesChange([
+      {id: "a", type: "dimensions", dimensions: {width: 200, height: 80}},
+    ]);
+    usePipelineStore.getState().onNodesChange([{id: "a", type: "select", selected: true}]);
+    flushThrottle();
+
+    expect(usePipelineStore.temporal.getState().pastStates).toHaveLength(0);
+  });
+
+  test("an edge select-only change does not create an undo step", () => {
+    usePipelineStore.getState().onEdgesChange([{id: "a-b", type: "select", selected: true}]);
+    flushThrottle();
+
+    expect(usePipelineStore.temporal.getState().pastStates).toHaveLength(0);
+  });
+
+  // zundo pushes a history entry on every set() call by default, whether or not the
+  // partialized (nodes/edges) slice actually changed. Without an equality function, a
+  // set() call that touches neither key — isLoading here, but the same is true of
+  // loadPipeline's early currentPipeline/currentRevision writes — would still count as an
+  // undo step.
+  test("a set() call that touches neither nodes nor edges does not create an undo step", () => {
+    usePipelineStore.getState().setIsLoading(true);
+    flushThrottle();
+
+    expect(usePipelineStore.temporal.getState().pastStates).toHaveLength(0);
+  });
+
+  // React Flow sends a 'position' change with no `position` field, just `dragging: false`,
+  // on a plain click that never moved the node — its own drag-end bookkeeping, not a move.
+  test("a position change with no position value (click, no drag) does not create an undo step", () => {
+    usePipelineStore.getState().onNodesChange([{id: "a", type: "position", dragging: false}]);
+    flushThrottle();
+
+    expect(usePipelineStore.temporal.getState().pastStates).toHaveLength(0);
+  });
+
+  test("a real node position change is still trackable", () => {
+    usePipelineStore.getState().onNodesChange([
+      {id: "a", type: "position", position: {x: 50, y: 50}, dragging: false},
+    ]);
+    flushThrottle();
+
+    expect(usePipelineStore.temporal.getState().pastStates).toHaveLength(1);
+    usePipelineStore.temporal.getState().undo();
+    expect(usePipelineStore.getState().nodes.find((n) => n.id === "a")?.position).toEqual({x: 0, y: 0});
+  });
+});

--- a/assets/javascript/apps/pipeline/stores/pipelineStore.test.tsx
+++ b/assets/javascript/apps/pipeline/stores/pipelineStore.test.tsx
@@ -16,8 +16,28 @@ function flushThrottle() {
 }
 
 function seed() {
+  // readOnly is reset explicitly: nothing else in this file resets it after a test sets it,
+  // so without this a read-only test leaks readOnly: true into whatever runs next.
+  usePipelineStore.setState({readOnly: false});
   usePipelineStore.getState().resetFlow({nodes: [nodeA, nodeB], edges: [edgeAB]});
   usePipelineStore.temporal.getState().clear();
+}
+
+// Autosave only fires once a pipeline is loaded (autoSaveCurrentPipline early-returns
+// without one), so the undo/redo-triggers-autosave tests need this seeded too.
+function seedCurrentPipeline() {
+  usePipelineStore.setState({
+    currentPipeline: {
+      id: BigInt(1),
+      team: "test-team",
+      name: "Test Pipeline",
+      data: {nodes: [nodeA, nodeB], edges: [edgeAB]},
+      description: "",
+      errors: {},
+    },
+    currentPipelineId: 1,
+    currentRevision: 0,
+  });
 }
 
 describe("pipelineStore undo/redo", () => {
@@ -119,5 +139,61 @@ describe("pipelineStore undo/redo", () => {
     expect(usePipelineStore.temporal.getState().pastStates).toHaveLength(1);
     usePipelineStore.temporal.getState().undo();
     expect(usePipelineStore.getState().nodes.find((n) => n.id === "a")?.position).toEqual({x: 0, y: 0});
+  });
+
+  // zundo's undo()/redo() call the store's raw set() directly, bypassing setNodes/setEdges —
+  // the only places that call autoSaveCurrentPipline(). Without an explicit trigger, undoing
+  // a change restores the canvas but never tells the server, so a reload right after would
+  // lose it.
+  test("undo triggers an autosave", () => {
+    seedCurrentPipeline();
+
+    usePipelineStore.getState().deleteNode("b");
+    flushThrottle();
+    // deleteNode's own autoSaveCurrentPipline() call already set this; reset it so the
+    // assertion below isolates undo's own trigger, not delete's.
+    usePipelineStore.setState({dirty: false});
+
+    usePipelineStore.getState().undoLastChange();
+
+    expect(usePipelineStore.getState().dirty).toBe(true);
+  });
+
+  test("redo triggers an autosave", () => {
+    seedCurrentPipeline();
+
+    usePipelineStore.getState().deleteNode("b");
+    flushThrottle();
+    usePipelineStore.getState().undoLastChange();
+    usePipelineStore.setState({dirty: false});
+
+    usePipelineStore.getState().redoLastChange();
+
+    expect(usePipelineStore.getState().dirty).toBe(true);
+  });
+
+  // Every other mutator in this store (setNodes, deleteNode, onConnect, ...) guards itself
+  // with `if (get().readOnly) return`, not just relying on the UI to check first. These two
+  // should match that, not just the UI-level check in Pipeline.tsx.
+  test("undoLastChange does nothing in read-only mode", () => {
+    usePipelineStore.getState().deleteNode("b");
+    flushThrottle();
+    usePipelineStore.setState({readOnly: true});
+
+    usePipelineStore.getState().undoLastChange();
+
+    expect(usePipelineStore.getState().nodes.map((n) => n.id)).toEqual(["a"]);
+  });
+
+  test("redoLastChange does nothing in read-only mode", () => {
+    usePipelineStore.getState().deleteNode("b");
+    flushThrottle();
+    usePipelineStore.setState({readOnly: false});
+    usePipelineStore.getState().undoLastChange();
+    usePipelineStore.setState({readOnly: true});
+
+    usePipelineStore.getState().redoLastChange();
+
+    expect(usePipelineStore.getState().nodes.map((n) => n.id).sort()).toEqual(["a", "b"]);
   });
 });

--- a/assets/javascript/apps/pipeline/stores/pipelineStore.ts
+++ b/assets/javascript/apps/pipeline/stores/pipelineStore.ts
@@ -290,6 +290,19 @@ const createPipelineStore: StateCreator<
     });
     usePipelineStore.temporal.getState().resume();
   },
+  undoLastChange: () => {
+    if (get().readOnly) return;
+    usePipelineStore.temporal.getState().undo();
+    // zundo's undo() sets nodes/edges via the store's raw set(), bypassing setNodes/setEdges
+    // — the only places that trigger autoSaveCurrentPipline() — so it has to be called here
+    // explicitly, or an undo restores the canvas without ever telling the server.
+    get().autoSaveCurrentPipline();
+  },
+  redoLastChange: () => {
+    if (get().readOnly) return;
+    usePipelineStore.temporal.getState().redo();
+    get().autoSaveCurrentPipline();
+  },
 })
 
 const createPipelineManagerStore: StateCreator<

--- a/assets/javascript/apps/pipeline/stores/pipelineStore.ts
+++ b/assets/javascript/apps/pipeline/stores/pipelineStore.ts
@@ -9,10 +9,13 @@ import {
   NodeChange,
 } from "reactflow";
 import {create, StateCreator} from "zustand";
+import {shallow} from "zustand/shallow";
+import {temporal} from "zundo";
 import {PipelineStoreType} from "../types/pipelineStore";
 import useEditorStore from "./editorStore";
 import {getNodeId} from "../utils";
 import cloneDeep from "lodash/cloneDeep";
+import throttle from "lodash/throttle";
 import {ErrorsType, PipelineManagerStoreType} from "../types/pipelineManagerStore";
 import {apiClient} from "../api/api";
 import {PipelineDiffPayload, PipelineType, PipelineSaveResponse} from "../types/pipeline";
@@ -84,15 +87,30 @@ const createPipelineStore: StateCreator<
   },
   setReadOnly: (value: boolean) => set({ readOnly: value }),
   onNodesChange: (changes: NodeChange[]) => {
+    // React Flow fires this for its own bookkeeping too, not just user edits: a
+    // 'dimensions' change as every node first measures itself, a 'select' change on every
+    // click, and — on a plain click that never moved the node — a 'position' change
+    // carrying no `position` value, just `dragging: false` (its own drag-end signal, sent
+    // whether or not anything actually moved). None of those are undo-worthy.
+    const isUserEdit = changes.some((change) => {
+      if (change.type === "dimensions" || change.type === "select") return false;
+      if (change.type === "position" && change.position === undefined) return false;
+      return true;
+    });
+    if (!isUserEdit) usePipelineStore.temporal.getState().pause();
     set({
       nodes: applyNodeChanges(changes, get().nodes),
     });
+    if (!isUserEdit) usePipelineStore.temporal.getState().resume();
   },
   onEdgesChange: (changes: EdgeChange[]) => {
     if (get().readOnly) return;
+    const isUserEdit = changes.some((change) => change.type !== "select");
+    if (!isUserEdit) usePipelineStore.temporal.getState().pause();
     set({
       edges: applyEdgeChanges(changes, get().edges),
     });
+    if (!isUserEdit) usePipelineStore.temporal.getState().resume();
   },
   setNodes: (change) => {
     if (get().readOnly) return;
@@ -144,24 +162,27 @@ const createPipelineStore: StateCreator<
     }
 
     useEditorStore.getState().closeEditor();
-    const nodes = get().nodes.filter((node) =>
+    const removedNodes = get().nodes.filter((node) =>
       typeof nodeId === "string"
         ? node.id === nodeId
         : nodeId.includes(node.id)
     )
-    const connectedEdges = getConnectedEdges(nodes, get().edges);
+    const connectedEdges = getConnectedEdges(removedNodes, get().edges);
     const remainingEdges = get().edges.filter(
       (edge) => !connectedEdges.includes(edge),
     );
-    get().setEdges(remainingEdges);
-
-    get().setNodes(
-      get().nodes.filter((node) =>
-        typeof nodeId === "string"
-          ? node.id !== nodeId
-          : !nodeId.includes(node.id)
-      )
+    const remainingNodes = get().nodes.filter((node) =>
+      typeof nodeId === "string"
+        ? node.id !== nodeId
+        : !nodeId.includes(node.id)
     );
+
+    // One set() call, not setEdges() then setNodes(): removing a node and its edges is one
+    // user action, and undo history is recorded per set() call, so splitting this into two
+    // calls would make it take two undos to fully restore, landing on a broken intermediate
+    // state (edges gone, node still present) in between.
+    set({edges: remainingEdges, nodes: remainingNodes});
+    get().autoSaveCurrentPipline();
   },
   deleteEdge: (edgeId) => {
     if (get().readOnly) return;
@@ -261,10 +282,13 @@ const createPipelineStore: StateCreator<
     get().setNodes(newNodes);
   },
   resetFlow: ({nodes, edges}) => {
+    // Loading or reloading a pipeline is not a user edit — don't let it become an undo step.
+    usePipelineStore.temporal.getState().pause();
     set({
       nodes,
       edges,
     });
+    usePipelineStore.temporal.getState().resume();
   },
 })
 
@@ -376,6 +400,8 @@ const createPipelineManagerStore: StateCreator<
           if (saveResponse) {
             saveSucceeded = true;
             pipeline.data = saveResponse.data as PipelineType["data"];
+            // Same reasoning as resetFlow above.
+            usePipelineStore.temporal.getState().pause();
             set({
               currentPipeline: pipeline,
               dirty: false,
@@ -390,6 +416,7 @@ const createPipelineManagerStore: StateCreator<
                 edges: updateEdgeClasses(get().edges, saveResponse.errors as ErrorsType)
               })
             }
+            usePipelineStore.temporal.getState().resume();
             resolve();
           }
         })
@@ -413,7 +440,8 @@ const createPipelineManagerStore: StateCreator<
       const response = await apiClient.patchPipeline(get().currentPipelineId!, diff);
       if (response) {
         patchSucceeded = true;
-        // Update local state with merged data from server
+        // Update local state with merged data from server — same reasoning as resetFlow.
+        usePipelineStore.temporal.getState().pause();
         const edges = response.data?.edges as Edge[] | undefined;
         set({
           currentRevision: response.edit_revision,
@@ -435,6 +463,7 @@ const createPipelineManagerStore: StateCreator<
             },
           });
         }
+        usePipelineStore.temporal.getState().resume();
       }
     } catch (err) {
       if ((err as {status?: number; currentRevision?: number}).status === 409) {
@@ -473,10 +502,29 @@ const createPipelineManagerStore: StateCreator<
 })
 
 
-const usePipelineStore = create<PipelineStoreType & PipelineManagerStoreType>((...a) => ({
-  ...createPipelineStore(...a),
-  ...createPipelineManagerStore(...a),
-}));
+// Undo history is tracked for `nodes`/`edges` only, and only for changes made through the
+// user-facing mutators above (onNodesChange, deleteNode, addNode, onConnect, ...). The
+// server-driven writes in resetFlow/_patchPipeline/savePipeline pause tracking around
+// themselves, so a save or reload never becomes an undo step. `handleSet` is throttled so a
+// node drag — which fires onNodesChange on every pointer move — collapses into one history
+// entry instead of one per pixel.
+const usePipelineStore = create<PipelineStoreType & PipelineManagerStoreType>()(
+  temporal(
+    (...a) => ({
+      ...createPipelineStore(...a),
+      ...createPipelineManagerStore(...a),
+    }),
+    {
+      partialize: (state) => ({nodes: state.nodes, edges: state.edges}),
+      limit: 50,
+      // Without this, zundo pushes a history entry on every set() call regardless of
+      // whether nodes/edges actually changed — a set() that touches neither (isLoading,
+      // errors, currentRevision, ...) would still count as an undo step.
+      equality: shallow,
+      handleSet: (handleSet) => throttle<typeof handleSet>((state) => handleSet(state), 500),
+    }
+  )
+);
 
 export default usePipelineStore;
 

--- a/assets/javascript/apps/pipeline/types/pipelineStore.ts
+++ b/assets/javascript/apps/pipeline/types/pipelineStore.ts
@@ -26,4 +26,6 @@ export type PipelineStoreType = {
     nodes: Node[];
     edges: Edge[];
   }) => void;
+  undoLastChange: () => void;
+  redoLastChange: () => void;
 };

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "short-unique-id": "^5.3.2",
     "tailwindcss": "^4.1.4",
     "tom-select": "^2.6.0",
+    "zundo": "^2.3.0",
     "zustand": "^5.0.13"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       tom-select:
         specifier: ^2.6.0
         version: 2.6.2
+      zundo:
+        specifier: ^2.3.0
+        version: 2.3.0(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
       zustand:
         specifier: ^5.0.13
         version: 5.0.14(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
@@ -3689,6 +3692,11 @@ packages:
 
   zod@4.5.4:
     resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
+
+  zundo@2.3.0:
+    resolution: {integrity: sha512-4GXYxXA17SIKYhVbWHdSEU04P697IMyVGXrC2TnzoyohEAWytFNOKqOp5gTGvaW93F/PM5Y0evbGtOPF0PWQwQ==}
+    peerDependencies:
+      zustand: ^4.3.0 || ^5.0.0
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -7314,6 +7322,10 @@ snapshots:
       zod: 4.5.4
 
   zod@4.5.4: {}
+
+  zundo@2.3.0(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))):
+    dependencies:
+      zustand: 5.0.14(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
 
   zustand@4.5.7(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8):
     dependencies:


### PR DESCRIPTION
### Product Description
Adds undo/redo to the pipeline builder. Ctrl+Z / Ctrl+Shift+Z (or Ctrl+Y), plus toolbar buttons next to the existing zoom/fit-view controls, undo and redo node and edge edits: add, remove, move, connect, and param/label changes.

### Technical Description
Wraps the pipeline store's `nodes`/`edges` in zundo's `temporal` middleware, scoped via `partialize` so only those two keys are tracked.

History is scoped to real user edits, not every store write:
- `resetFlow` and the autosave/save response handlers pause tracking around themselves, reloading a pipeline or reconciling a server response isn't a user edit.
- `onNodesChange`/`onEdgesChange` filter out React Flow's own bookkeeping changes: a `dimensions` change as each node first measures itself, a `select` change on every click, and a `position` change with no `position` value, which React Flow sends on a plain click as its own drag-end signal.
- `equality: shallow` is needed because zundo otherwise pushes a history entry on every `set()` call regardless of whether `nodes`/`edges` actually changed.

`deleteNode` now issues one `set()` call instead of two (edges then nodes), since removing a node and its edges is one user action and undo history is recorded per `set()` call, splitting it made a single undo land on a broken intermediate state instead of the original.

`handleSet` is throttled so a node drag collapses into one history entry instead of one per pointer move.

zundo's `undo()`/`redo()` set `nodes`/`edges` through the store's raw `set()`, bypassing `setNodes`/`setEdges` the only places that call `autoSaveCurrentPipline()`. An undo restored the canvas but never told the server, so a reload right after would lose it. Added `undoLastChange`/`redoLastChange` store actions that call zundo's `undo()`/`redo()` then `autoSaveCurrentPipline()` explicitly, and pointed the hotkeys and toolbar buttons at them. Both guard on `readOnly`, matching every other mutator in this store.

Blast radius: touches `pipelineStore.ts`, which every pipeline builder interaction depends on. The scoped mutators are the same ones the UI already calls for node/edge changes, so wrapping them changes when history is recorded, not what they do. Verified against the full pipeline test suite and a manual pass in the browser: undo during and after an in-flight autosave, and undo triggering a real PATCH that survives a reload, including when the undo happens while a prior save is still in flight, which the existing deferred-save handling (`pendingSave`/`settleDeferredSave`) covers without changes.

Related but separate: `Pipeline.revert_to_version` already exists (reached through a chatbot's published version history) and resets a working pipeline to a prior published snapshot. Different granularity and trigger from this undo stack, so it doesn't overlap.

### Issue Link
Closes #2006

### Demo
Delete a node, click Undo (restores it and its edge), click Redo (re-deletes it):

<img width="1498" height="812" alt="pipeline-undo-redo-demo-final" src="https://github.com/user-attachments/assets/d6452a0c-1fea-41ee-a725-72cf10fa33d9" />

### Docs and Changelog
- [x] This PR requires docs/changelog update

New user-facing feature: undo/redo (Ctrl+Z / Ctrl+Shift+Z, or Ctrl+Y) in the pipeline builder canvas, with toolbar buttons next to the existing zoom/fit-view controls.

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change


