### PR TITLE
fix: don't abort a team sync when a reset email is rejected

### DIFF
--- a/apps/teams/export/importer.py
+++ b/apps/teams/export/importer.py
@@ -253,17 +253,21 @@ class Importer:
             self.set_target_team(instance)
 
     def safe_on_user_created(self, user) -> None:
-        """Run the new-user hook, collecting a failure instead of raising it.
+        """Run the new-user hook, reporting a failure instead of raising it.
 
         The user row and its checkpoint are committed before the hook runs, so raising here aborts
         the sync on a row a rerun then skips -- the user stays imported and is never notified, with
-        nothing recording it. The collected failures are listed in the sync report instead."""
+        nothing recording it. The failure is printed as it happens as well as collected: the sync
+        report is only reached once every resource has been imported, so an abort in a later one
+        would otherwise take the collected addresses with it."""
         if self.on_user_created is None:
             return
         try:
             self.on_user_created(user)
         except Exception as exc:
-            self.notification_failures.append((user.email or user.username, str(exc)))
+            identifier = user.email or user.username
+            print(f"could not send a password-reset email to {identifier}: {exc}")
+            self.notification_failures.append((identifier, str(exc)))
 
     def set_target_team(self, team) -> None:
         """Adopt ``team`` as the anchor every team-scoped row is reassigned to, and make it the current

--- a/apps/teams/export/importer.py
+++ b/apps/teams/export/importer.py
@@ -206,6 +206,8 @@ class Importer:
         self.on_user_created = on_user_created
         self.fetch_file_content = fetch_file_content
         self.missing_files: list[str] = []
+        # (user identifier, error) for every on_user_created call that raised -- see safe_on_user_created.
+        self.notification_failures: list[tuple[str, str]] = []
         # The single team every resource is imported into. Captured from the team row (first in the
         # manifest) and assigned to every team-scoped row, since the per-row team FK isn't exported.
         self.target_team = None
@@ -245,11 +247,23 @@ class Importer:
         # filled last: if anything before it fails, the row rolls back with it.
         instance, created = self._import_team_owned_row(model_label, model, source_pk, row)
 
-        if created:
-            if model_label == "users.customuser" and self.on_user_created:
-                self.on_user_created(instance)
+        if created and model_label == "users.customuser":
+            self.safe_on_user_created(instance)
         if model_label == "teams.team":
             self.set_target_team(instance)
+
+    def safe_on_user_created(self, user) -> None:
+        """Run the new-user hook, collecting a failure instead of raising it.
+
+        The user row and its checkpoint are committed before the hook runs, so raising here aborts
+        the sync on a row a rerun then skips -- the user stays imported and is never notified, with
+        nothing recording it. The collected failures are listed in the sync report instead."""
+        if self.on_user_created is None:
+            return
+        try:
+            self.on_user_created(user)
+        except Exception as exc:
+            self.notification_failures.append((user.email or user.username, str(exc)))
 
     def set_target_team(self, team) -> None:
         """Adopt ``team`` as the anchor every team-scoped row is reassigned to, and make it the current

--- a/apps/teams/export/tests/test_command.py
+++ b/apps/teams/export/tests/test_command.py
@@ -1,8 +1,11 @@
+import io
+
 import pytest
 import requests
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from django.core import mail
+from django.core.mail.backends.base import BaseEmailBackend
 from django.core.management.base import CommandError
 
 from apps.api.export.serializers import build_resource_serializer
@@ -21,6 +24,7 @@ from apps.teams.management.commands.sync_team import (
     run_sync,
 )
 from apps.teams.models import Team
+from apps.users.models import CustomUser
 from apps.utils.factories.service_provider_factories import LlmProviderFactory
 
 pytestmark = pytest.mark.django_db
@@ -220,7 +224,8 @@ def test_files_confirmation_fails_cleanly_without_a_terminal(tmp_path, keypair, 
         check_sync_preconditions(FakeClient(*_scenario(keypair[0])), keypair[1], store=store)
 
 
-def test_new_users_receive_a_password_reset_email(tmp_path, keypair):
+def _new_user_scenario():
+    """A manifest and rows whose only entry is a single user the target does not have yet."""
     entries = [
         {"model": "users.customuser", "resource": "user", "cursor": "pk", "secret": False},
     ]
@@ -252,12 +257,40 @@ def test_new_users_receive_a_password_reset_email(tmp_path, keypair):
             }
         ],
     }
+    return entries, rows
+
+
+def test_new_users_receive_a_password_reset_email(tmp_path, keypair):
+    entries, rows = _new_user_scenario()
     store = FKTranslationStore(tmp_path / "t.sqlite")
     mail.outbox.clear()
 
     run_sync(FakeClient(_manifest(entries), rows), store, keypair[1])
 
     assert any("added@example.com" in message.to for message in mail.outbox)
+
+
+class _RejectingEmailBackend(BaseEmailBackend):
+    """Stands in for SES in sandbox mode, which refuses any recipient it hasn't verified."""
+
+    def send_messages(self, email_messages):
+        raise RuntimeError("Email address is not verified")
+
+
+def test_a_rejected_password_reset_email_is_reported_instead_of_aborting_the_sync(tmp_path, monkeypatch, settings):
+    """A recipient the mail provider rejects must not take the sync down; the run finishes and the
+    report names them so the reset can be sent by hand."""
+    entries, rows = _new_user_scenario()
+    settings.EMAIL_BACKEND = f"{__name__}._RejectingEmailBackend"
+    monkeypatch.setattr(sync_team, "ResourceFetcher", lambda *a, **k: FakeClient(_manifest(entries), rows))
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "yes")
+    report = io.StringIO()
+
+    Command(stdout=report).handle(**_sync_options(tmp_path))
+
+    assert CustomUser.objects.filter(email="added@example.com").exists()
+    assert "added@example.com" in report.getvalue()
+    assert "Email address is not verified" in report.getvalue()
 
 
 def test_run_sync_builds_team_and_resolves_secret_provider(tmp_path, keypair):
@@ -482,7 +515,7 @@ def test_force_delete_team_is_a_no_op_when_team_missing(tmp_path):
     force_delete_team("never-synced", tmp_path)  # no team, no state DB -- must not raise
 
 
-def _force_delete_options(tmp_path, **overrides):
+def _sync_options(tmp_path, **overrides):
     options = {
         "source_url": "http://src",
         "api_key": "k",
@@ -491,10 +524,14 @@ def _force_delete_options(tmp_path, **overrides):
         "state_dir": str(tmp_path),
         "limit": 100,
         "skip_schema_check": False,
-        "force_delete": True,
+        "force_delete": False,
     }
     options.update(overrides)
     return options
+
+
+def _force_delete_options(tmp_path, **overrides):
+    return _sync_options(tmp_path, force_delete=True, **overrides)
 
 
 def test_force_delete_aborts_when_confirmation_declined(tmp_path, monkeypatch):

--- a/apps/teams/export/tests/test_importer.py
+++ b/apps/teams/export/tests/test_importer.py
@@ -1082,3 +1082,20 @@ def test_a_failing_on_user_created_hook_is_recorded_rather_than_aborting_the_imp
         ("one@example.com", "Email address is not verified"),
         ("two@example.com", "Email address is not verified"),
     ]
+
+
+def test_a_failing_on_user_created_hook_is_announced_as_it_happens(store, capsys):
+    """The collected failures reach the operator only if the whole sync finishes, so the address is
+    printed at the point of failure too -- an abort in a later resource would otherwise take it."""
+
+    def reject(user):
+        raise RuntimeError("Email address is not verified")
+
+    importer = Importer(store, on_user_created=reject)
+    importer.import_rows("teams.team", [_team_row()])
+
+    importer.import_rows("users.customuser", [_user_row(51, "one@example.com")])
+
+    output = capsys.readouterr().out
+    assert "one@example.com" in output
+    assert "Email address is not verified" in output

--- a/apps/teams/export/tests/test_importer.py
+++ b/apps/teams/export/tests/test_importer.py
@@ -1063,3 +1063,22 @@ def test_every_manifest_entry_imports(store, keypair):
             not_imported.append(f"{entry.model}: target {target} not in the database")
     assert not not_imported, "Manifest entries that failed to import:\n" + "\n".join(not_imported)
     assert store.has_unfilled_targets() is False
+
+
+def test_a_failing_on_user_created_hook_is_recorded_rather_than_aborting_the_import(store):
+    """A rejected reset email must not take the sync down with it. The user row is committed before
+    the hook runs, so raising would strand an imported user that a rerun then skips."""
+
+    def reject(user):
+        raise RuntimeError("Email address is not verified")
+
+    importer = Importer(store, on_user_created=reject)
+    importer.import_rows("teams.team", [_team_row()])
+
+    importer.import_rows("users.customuser", [_user_row(51, "one@example.com"), _user_row(52, "two@example.com")])
+
+    assert CustomUser.objects.filter(username__in=["one@example.com", "two@example.com"]).count() == 2
+    assert importer.notification_failures == [
+        ("one@example.com", "Email address is not verified"),
+        ("two@example.com", "Email address is not verified"),
+    ]

--- a/apps/teams/management/commands/sync_team.py
+++ b/apps/teams/management/commands/sync_team.py
@@ -197,7 +197,7 @@ def _committed_team(store) -> Team | None:
     return team
 
 
-def load_team(importer, client, store, write):
+def load_team(importer, client, store):
     """Set the importer's target team, doing the least work needed to anchor the sync.
 
     Three cases, by where the team is already known:
@@ -222,7 +222,6 @@ def load_team(importer, client, store, write):
         )
     importer.import_rows(TEAM_MODEL, [team_row])
     _enable_target_migration_mode(importer.target_team)
-    write("synced team")
 
 
 def _enable_target_migration_mode(team: Team) -> None:
@@ -255,7 +254,7 @@ def run_sync(
     )
     try:
         with mute_signals():
-            load_team(importer, client, store, write)
+            load_team(importer, client, store)
             for entry in manifest["entries"]:
                 model_label, resource, cursor_type = entry["model"], entry["resource"], entry["cursor"]
                 model = entry_model(model_label)

--- a/apps/teams/management/commands/sync_team.py
+++ b/apps/teams/management/commands/sync_team.py
@@ -5,6 +5,10 @@
 The command is a thin shell: it wires the resource fetcher to the import engine and the local FK
 translation store. Each run makes one pass over the manifest and exits; rerun to pick up new data.
 
+Every user the sync creates is sent a password-reset email, since passwords are hashed and never
+migrated. A failed send doesn't stop the sync; the addresses are listed in the sync report instead,
+to be followed up by hand.
+
 Run this against the latest code on both the source and target servers. Compatibility is verified
 by comparing checksums of the two servers' export OpenAPI schemas -- the exact shape of the data
 being transferred -- rather than their migration history, which is a poor proxy (a squash or rename
@@ -346,6 +350,7 @@ class Command(BaseCommand):
             team_slug=options["team_slug"],
             duration=duration,
             missing_files=importer.missing_files,
+            notification_failures=importer.notification_failures,
         )
 
     def _run_force_delete(self, options):
@@ -365,6 +370,7 @@ class Command(BaseCommand):
         team_slug: str,
         duration: timedelta | None = None,
         missing_files: Sequence[str] = (),
+        notification_failures: Sequence[tuple[str, str]] = (),
     ) -> None:
         """Print everything the operator needs after a sync, so ``handle`` stays a thin wiring shell:
         which resources need manual setup, which files the source had no content for, whether the sync
@@ -387,6 +393,15 @@ class Command(BaseCommand):
             )
             for name in missing_files:
                 self.stdout.write(f"  - {name}")
+
+        if notification_failures:
+            self.stdout.write("")
+            self.stdout.write(
+                self.style.WARNING(f"{len(notification_failures)} user(s) could not be sent a password-reset email:")
+            )
+            for identifier, error in notification_failures:
+                self.stdout.write(f"  - {identifier}: {error}")
+            self.stdout.write("  They were imported, and a rerun won't retry the email; send theirs by hand.")
 
         self.stdout.write("")
         self.stdout.write(self.style.WARNING("Channel webhooks were not re-registered."))


### PR DESCRIPTION
### Product Description
None — this only affects the operator-run `sync_team` management command.

### Technical Description
A `sync_team` run died partway through with `MessageRejected: Email address is not verified`: the target's SES account is in sandbox mode in `eu-west-1`, so it refuses any recipient it hasn't verified. `sync_team` sends a password-reset email for every user it creates, inline in the import loop with nothing catching delivery failures, so one rejected address aborted the whole migration.

It's worse than a noisy abort. `Importer._import_team_owned_row` commits the user row *and fills its sync checkpoint* before `on_user_created` runs, so raising there stops the sync on a row a rerun then skips — the person is migrated and never notified, with nothing recording it.

`Importer.safe_on_user_created` now runs the hook, catches whatever it raises, and collects `(address, error)` in `notification_failures`, which the sync report lists at the end:

```
1 user(s) could not be sent a password-reset email:
  - someone@example.com: An error occurred (MessageRejected) when calling the SendEmail operation: ...
  They were imported, and a rerun won't retry the email; send theirs by hand.
```

Verifying the SES identity (or leaving sandbox) is still the fix for the emails themselves; this only stops a rejection from taking the migration with it.

Also drops the `synced team` progress line, which only printed on a first-time import — a rerun loads the team from the sync store and printed nothing — so it said less than it appeared to.

#### Note: why not just skip users with an unverified email?

Considered and rejected — it isn't safe to do:

- Unverified users are ordinary users. `ACCOUNT_EMAIL_VERIFICATION` defaults to `optional`, and `accept_invitation` ignores verification on purpose, so they join teams and own content like anyone else.
- "Unverified" also covers users with no allauth `EmailAddress` row at all — including every user `sync_team` imports, since `EmailAddress` isn't in `MANIFEST_ENTRIES`.
- Six synced models hold **non-nullable** FKs to `CustomUser` (`sourcematerial.owner`, `usercomment.user`, `annotation.reviewer`, `transcriptanalysis.created_by`, `eventuser.user`, `usernotificationpreferences.user`). The last is per-user, so skipping a team member breaks the import outright rather than rarely.

### Issue Link
N/A

### Migrations
No migrations.

- [ ] The migrations are backwards compatible


### Demo
N/A — the report section is shown above.

### Docs and Changelog
- [ ] This PR requires docs/changelog update

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
