### PR TITLE
Feat: Updates session mode eval

### DIFF
--- a/apps/evaluations/models.py
+++ b/apps/evaluations/models.py
@@ -293,6 +293,15 @@ class EvaluationMessage(BaseModel):
             additional_kwargs={"id": self.id, "chat_message_id": self.expected_output_chat_message_id},
         )
 
+    def _format_history_lines(self, entries) -> list[str]:
+        lines = []
+        for message in entries:
+            message_type = message.get("message_type", "")
+            content = message.get("content", "")
+            display_type = ChatMessageType(message_type).role
+            lines.append(f"{display_type}: {content}")
+        return lines
+
     @property
     def full_history(self) -> str:
         """
@@ -301,15 +310,13 @@ class EvaluationMessage(BaseModel):
         """
         if not self.history:
             return ""
+        return "\n".join(self._format_history_lines(self.history))
 
-        history_lines = []
-        for message in self.history:
-            message_type = message.get("message_type", "")
-            content = message.get("content", "")
-            display_type = ChatMessageType(message_type).role
-            history_lines.append(f"{display_type}: {content}")
-
-        return "\n".join(history_lines)
+    def history_preview(self, num_exchanges: int = 3) -> str:
+        """First `num_exchanges` human/AI turns, for a compact session-mode row preview."""
+        if not self.history:
+            return ""
+        return "\n".join(self._format_history_lines(self.history[: num_exchanges * 2]))
 
     def as_result_dict(self) -> dict:
         """Returns a dict representation to be stored in any evaluator result"""

--- a/apps/evaluations/tests/test_evaluation_dataset_session_clone.py
+++ b/apps/evaluations/tests/test_evaluation_dataset_session_clone.py
@@ -210,6 +210,37 @@ def test_create_messages_from_sessions_includes_history():
     assert eval_messages[3].full_history == "assistant: session2 message0 ai"
 
 
+@pytest.mark.parametrize(
+    ("history", "num_exchanges", "expected"),
+    [
+        pytest.param([], 3, "", id="empty-history"),
+        pytest.param(
+            [
+                {"message_type": ChatMessageType.HUMAN, "content": "hi"},
+                {"message_type": ChatMessageType.AI, "content": "hello"},
+            ],
+            3,
+            "user: hi\nassistant: hello",
+            id="fewer-entries-than-requested",
+        ),
+        pytest.param(
+            [
+                {"message_type": ChatMessageType.HUMAN, "content": "one"},
+                {"message_type": ChatMessageType.AI, "content": "two"},
+                {"message_type": ChatMessageType.HUMAN, "content": "three"},
+                {"message_type": ChatMessageType.AI, "content": "four"},
+            ],
+            1,
+            "user: one\nassistant: two",
+            id="truncates-to-requested-exchanges",
+        ),
+    ],
+)
+def test_history_preview(history, num_exchanges, expected):
+    message = EvaluationMessage(history=history)
+    assert message.history_preview(num_exchanges=num_exchanges) == expected
+
+
 @pytest.mark.django_db()
 def test_create_messages_from_sessions_includes_comments(team_with_users):
     session_1 = ExperimentSessionFactory.create(team=team_with_users)

--- a/apps/evaluations/tests/test_evaluation_result_home_view.py
+++ b/apps/evaluations/tests/test_evaluation_result_home_view.py
@@ -1,0 +1,36 @@
+"""Tests for EvaluationResultHome: the run-details disclosure hides the Generation
+chatbot field for session-mode runs, where generation never applies.
+"""
+
+import pytest
+from django.urls import reverse
+
+from apps.evaluations.models import EvaluationRunStatus
+from apps.utils.factories.evaluations import EvaluationConfigFactory, EvaluationDatasetFactory, EvaluationRunFactory
+
+
+@pytest.mark.django_db()
+class TestGenerationChatbotVisibility:
+    def test_shown_for_message_mode_run(self, client, team_with_users):
+        dataset = EvaluationDatasetFactory.create(team=team_with_users, evaluation_mode="message")
+        config = EvaluationConfigFactory.create(team=team_with_users, dataset=dataset)
+        run = EvaluationRunFactory.create(team=team_with_users, config=config, status=EvaluationRunStatus.COMPLETED)
+        client.force_login(team_with_users.members.first())
+
+        url = reverse("evaluations:evaluation_results_home", args=[team_with_users.slug, config.id, run.id])
+        response = client.get(url)
+
+        assert response.context["is_session_mode"] is False
+        assert "Generation chatbot" in response.content.decode()
+
+    def test_hidden_for_session_mode_run(self, client, team_with_users):
+        dataset = EvaluationDatasetFactory.create(team=team_with_users, evaluation_mode="session")
+        config = EvaluationConfigFactory.create(team=team_with_users, dataset=dataset)
+        run = EvaluationRunFactory.create(team=team_with_users, config=config, status=EvaluationRunStatus.COMPLETED)
+        client.force_login(team_with_users.members.first())
+
+        url = reverse("evaluations:evaluation_results_home", args=[team_with_users.slug, config.id, run.id])
+        response = client.get(url)
+
+        assert response.context["is_session_mode"] is True
+        assert "Generation chatbot" not in response.content.decode()

--- a/apps/evaluations/tests/test_results_table_view.py
+++ b/apps/evaluations/tests/test_results_table_view.py
@@ -14,10 +14,13 @@ from apps.evaluations.views.evaluation_config_views import ResultFilterPill, _bu
 from apps.utils.factories.cost_tracking import UsageRecordFactory
 from apps.utils.factories.evaluations import (
     EvaluationConfigFactory,
+    EvaluationDatasetFactory,
+    EvaluationMessageFactory,
     EvaluationResultFactory,
     EvaluationRunFactory,
     EvaluatorFactory,
 )
+from apps.utils.factories.experiment import ExperimentSessionFactory
 
 
 def _sentiment_result(run, evaluator, *, sentiment):
@@ -307,3 +310,99 @@ class TestResultsTableCuratedColumns:
 
         assert response.status_code == 200
         assert "$1.50" in response.content.decode()
+
+
+@pytest.mark.django_db()
+class TestResultsTableSessionMode:
+    """A session-mode dataset's results table swaps Dataset Input/Generated Response for
+    a Links column (Session/Message) and a session-history preview - there's no single
+    message to show input/output/generated-response for.
+    """
+
+    def _build_session_mode_run(self, team):
+        session = ExperimentSessionFactory.create(team=team)
+        message = EvaluationMessageFactory.create(
+            session=session,
+            input={},
+            output={},
+            history=[
+                {"message_type": "human", "content": "hi there"},
+                {"message_type": "ai", "content": "hello!"},
+            ],
+        )
+        dataset = EvaluationDatasetFactory.create(team=team, evaluation_mode="session", messages=[message])
+        evaluator = EvaluatorFactory.create(team=team, name="Sentiment Judge")
+        config = EvaluationConfigFactory.create(team=team, dataset=dataset, evaluators=[evaluator])
+        run = EvaluationRunFactory.create(team=team, config=config, evaluator_ids=[evaluator.id])
+        output = EvaluatorResult(
+            message={
+                "input": {},
+                "output": {},
+                "context": {},
+                "history": message.history,
+                "metadata": {},
+            },
+            result={"sentiment": "positive"},
+            generated_response="",
+        ).model_dump()
+        EvaluationResultFactory.create(output=output, team=team, run=run, evaluator=evaluator, message=message)
+        return session, run, config
+
+    def test_column_set_swaps_message_columns_for_links_and_preview(self, client, team_with_users):
+        session, run, config = self._build_session_mode_run(team_with_users)
+        client.force_login(team_with_users.members.first())
+
+        url = reverse("evaluations:evaluation_results_table", args=[team_with_users.slug, config.id, run.id])
+        response = client.get(url)
+
+        column_names = list(response.context["table"].columns.columns)
+        assert column_names == [
+            "#",
+            "Links",
+            "Session Preview",
+            f"score ({config.evaluators.first().name})",
+            f"sentiment ({config.evaluators.first().name})",
+            "Cost",
+        ]
+
+    def test_session_chip_enabled_message_chip_disabled(self, client, team_with_users):
+        session, run, config = self._build_session_mode_run(team_with_users)
+        client.force_login(team_with_users.members.first())
+
+        url = reverse("evaluations:evaluation_results_table", args=[team_with_users.slug, config.id, run.id])
+        response = client.get(url)
+        content = response.content.decode()
+
+        session_url = reverse(
+            "chatbots:chatbot_session_view",
+            args=[team_with_users.slug, session.experiment.public_id, session.external_id],
+        )
+        assert f'href="{session_url}"' in content
+        assert "Session" in content
+        assert "Message" in content
+        # The Message chip is always disabled for a session-mode row.
+        assert 'aria-disabled="true"' in content
+
+    def test_links_column_stops_click_bubbling_to_the_row(self, client, team_with_users):
+        """Every row has its own hx-get (opens the detail panel on click, see
+        `_row_hx_get_factory`). Without stopping propagation here, clicking a chip in the
+        Links column would bubble up and trigger that too, on top of the chip's own
+        navigation."""
+        session, run, config = self._build_session_mode_run(team_with_users)
+        client.force_login(team_with_users.members.first())
+
+        url = reverse("evaluations:evaluation_results_table", args=[team_with_users.slug, config.id, run.id])
+        response = client.get(url)
+        content = response.content.decode()
+
+        assert 'onclick="event.stopPropagation()"' in content
+
+    def test_preview_shows_session_history(self, client, team_with_users):
+        session, run, config = self._build_session_mode_run(team_with_users)
+        client.force_login(team_with_users.members.first())
+
+        url = reverse("evaluations:evaluation_results_table", args=[team_with_users.slug, config.id, run.id])
+        response = client.get(url)
+
+        assert "user: hi there" in response.content.decode()
+        assert "assistant: hello!" in response.content.decode()

--- a/apps/evaluations/views/evaluation_config_views.py
+++ b/apps/evaluations/views/evaluation_config_views.py
@@ -42,6 +42,8 @@ from apps.evaluations.export import (
 from apps.evaluations.forms import EvaluationConfigForm, get_experiment_version_choices
 from apps.evaluations.models import (
     EvaluationConfig,
+    EvaluationMessage,
+    EvaluationMode,
     EvaluationResult,
     EvaluationRun,
     EvaluationRunStatus,
@@ -57,6 +59,8 @@ from apps.evaluations.tasks import (
 )
 from apps.evaluations.utils import build_trend_data, filter_aggregates_for_display, get_evaluators_with_schema
 from apps.experiments.models import Experiment
+from apps.generics import actions
+from apps.generics.actions import chip_action
 from apps.teams.decorators import login_and_team_required
 from apps.teams.mixins import LoginAndTeamRequiredMixin
 from apps.trace.models import Trace
@@ -288,7 +292,10 @@ class EvaluationResultHome(LoginAndTeamRequiredMixin, PermissionRequiredMixin, T
 
     def get_context_data(self, team_slug: str, **kwargs):  # ty: ignore[invalid-method-override]
         evaluation_run = get_object_or_404(
-            EvaluationRun, id=kwargs["evaluation_run_pk"], config_id=kwargs["evaluation_pk"], team=self.request.team
+            EvaluationRun.objects.select_related("config__dataset"),
+            id=kwargs["evaluation_run_pk"],
+            config_id=kwargs["evaluation_pk"],
+            team=self.request.team,
         )
 
         title = (
@@ -302,6 +309,7 @@ class EvaluationResultHome(LoginAndTeamRequiredMixin, PermissionRequiredMixin, T
             "evaluation_run": evaluation_run,
             "allow_new": False,
             "run_cost": run_cost,
+            "is_session_mode": evaluation_run.config.dataset.evaluation_mode == EvaluationMode.SESSION,
         }
 
         # Calculate duration if finished
@@ -428,9 +436,29 @@ class EvaluationResultDataMixin:
     @cached_property
     def evaluation_run(self) -> EvaluationRun:
         return get_object_or_404(
-            EvaluationRun.objects.select_related("generation_experiment").filter(team=self.request.team),
+            EvaluationRun.objects.select_related("generation_experiment", "config__dataset").filter(
+                team=self.request.team
+            ),
             pk=self.kwargs["evaluation_run_pk"],
         )
+
+    @cached_property
+    def is_session_mode(self) -> bool:
+        return self.evaluation_run.config.dataset.evaluation_mode == EvaluationMode.SESSION
+
+    @cached_property
+    def session_previews(self) -> dict[int, str]:
+        """message_id -> a short session-history preview, for session-mode rows.
+
+        Queried independently of `_table_rows` (not derived from it) - `_table_rows`
+        stamps this dict's values onto each row, so deriving message ids from it here
+        would recurse.
+        """
+        if not self.is_session_mode:
+            return {}
+        message_ids = self.evaluation_run.results.values_list("message_id", flat=True).distinct()
+        messages = EvaluationMessage.objects.filter(id__in=message_ids).only("id", "history")
+        return {message.id: message.history_preview() for message in messages}
 
     @cached_property
     def evaluators(self) -> list[Evaluator]:
@@ -487,6 +515,7 @@ class EvaluationResultDataMixin:
         for row in data:
             row["Tokens"] = self.tokens_by_message.get(row.get("id"))
             row["Cost"] = self.cost_by_message.get(row.get("id"))
+            row["Session Preview"] = self.session_previews.get(row.get("id"), "")
         return data
 
     def get_table_data(self):
@@ -561,7 +590,10 @@ class EvaluationResultTableView(EvaluationResultDataMixin, PermissionRequiredMix
         filter_field = self.get_filter_field()
         filter_value = self.get_filter_value()
 
-        column_keys = ["#", "Dataset Input", "Generated Response"]
+        if self.is_session_mode:
+            column_keys = ["#", "Links", "Session Preview"]
+        else:
+            column_keys = ["#", "Dataset Input", "Generated Response"]
         column_keys += [key for key, _label in self.dynamic_columns]
         column_keys.append("Cost")
         attrs = {key: self.get_column(key) for key in column_keys}
@@ -657,6 +689,43 @@ class EvaluationResultTableView(EvaluationResultDataMixin, PermissionRequiredMix
                     template_code="{{ value|add:1 }}",
                     verbose_name="#",
                     orderable=False,
+                )
+            case "Links":
+                # Session-mode row: the source session (always known), and a
+                # permanently-disabled "Message" chip - a session-mode result has no
+                # single message to jump to.
+                def _session_url(_, request, record, __):
+                    return reverse(
+                        "chatbots:chatbot_session_view",
+                        args=[request.team.slug, record.get("source_experiment_id"), record.get("source_session")],
+                    )
+
+                return actions.ActionsColumn(
+                    actions=[
+                        chip_action(
+                            label="Session",
+                            url_factory=_session_url,
+                            enabled_condition=lambda _, record: bool(record.get("source_session")),
+                            open_url_in_new_tab=True,
+                        ),
+                        chip_action(
+                            label="Message",
+                            url_factory=_session_url,
+                            enabled_condition=lambda _, record: False,
+                        ),
+                    ],
+                    align="left",
+                    verbose_name="Links",
+                    extra_context={"join_class": "join join-vertical"},
+                    # The row itself opens the detail panel on click (see the hx-get row
+                    # attrs below) - without this, clicking a chip both follows its link
+                    # and triggers that row-level hx-get.
+                    attrs={"td": {"onclick": "event.stopPropagation()"}},
+                )
+            case "Session Preview":
+                return columns.TemplateColumn(
+                    template_name="evaluations/components/truncated_text_column.html",
+                    verbose_name="Preview",
                 )
             case "Dataset Input" | "Generated Response":
                 # Clamped to 2 lines - these are free-text dataset/model output and can run

--- a/templates/evaluations/evaluation_result_home.html
+++ b/templates/evaluations/evaluation_result_home.html
@@ -142,19 +142,21 @@
                 {% endfor %}
               </div>
             </div>
-            <div>
-              <div class="text-xs uppercase tracking-wide text-base-content/60 mb-1">Generation chatbot</div>
-              {% if evaluation_run.generation_experiment %}
-                <div class="flex items-center gap-1">
-                  {% include "generic/chip.html" with chip=evaluation_run.generation_experiment.as_chatbot_chip %}
-                  {% if evaluation_run.generation_experiment.version_display %}
-                    <span class="text-xs text-base-content/60">{{ evaluation_run.generation_experiment.version_display }}</span>
-                  {% endif %}
-                </div>
-              {% else %}
-                <span class="text-sm text-base-content/40">None configured</span>
-              {% endif %}
-            </div>
+            {% if not is_session_mode %}
+              <div>
+                <div class="text-xs uppercase tracking-wide text-base-content/60 mb-1">Generation chatbot</div>
+                {% if evaluation_run.generation_experiment %}
+                  <div class="flex items-center gap-1">
+                    {% include "generic/chip.html" with chip=evaluation_run.generation_experiment.as_chatbot_chip %}
+                    {% if evaluation_run.generation_experiment.version_display %}
+                      <span class="text-xs text-base-content/60">{{ evaluation_run.generation_experiment.version_display }}</span>
+                    {% endif %}
+                  </div>
+                {% else %}
+                  <span class="text-sm text-base-content/40">None configured</span>
+                {% endif %}
+              </div>
+            {% endif %}
             {% if evaluation_run.error_message %}
               <div class="w-full">
                 <div class="text-xs uppercase tracking-wide text-base-content/60 mb-1">Error</div>


### PR DESCRIPTION
<!--
NOTES
* Change to the chat widget should be kept separate from changes to the OCS code for the sake of the changelog and docs automation.
-->
### Product Description
<!--
A short summary of the change from a user perspective.
For non-user facing changes write 'no change'.
-->

Session-mode evaluation runs shared the same results table as message-mode runs, showing `"Dataset Input"`/`"Dataset Output"`/`"Generated Response"` columns that are always empty for a session, and a `"Generation chatbot"` field that's always `"None configured"` since generation doesn't apply to session-mode runs.

This PR makes the results page mode-aware for session-mode datasets:

Replaces the empty input/output/response columns with a Links column that opens the source conversation, and a disabled `"Message"` chip (_there's no single message to jump to_) and a Session Preview column showing the first few exchanges of the conversation.

Message-mode runs are unaffected.

### Technical Description
<!--
The primary goal of this section is to provide information to the reviewer to make it easier to review the PR.

Include technical details about the change and highlight the primary code changes and any decisions or design points
that the reviewer should be made aware of.

This should NOT be a summary of the every change. Focus on decisions and outcomes.
-->

### Issue Link
<!--
Link to the issue or doc that prompted this change, if any.
If this fully addresses an issue use one of the keywords to have it automatically closed when the PR is merged e.g. `fixes #XYZ`
See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->
Resolves #3214 


### Demo
<!--
If relevant, include screenshots or a loom video to demonstrate the new behaviour
**Include step-by-step instructions to enable functionality of the change
-->

https://github.com/user-attachments/assets/ec2d2672-cca2-43c2-a617-a00e79a1fae3



### Docs and Changelog
- [ ] This PR requires docs/changelog update

<!--
Note: When this PR is merged and the checkbox above is checked, Claude will automatically analyze it and create a changelog entry in the docs repository.

Add any notes here that will help Claude write the changelog and docs.
-->

### Operator Impact
- [ ] Self-hosted operators must know about or act on this change

<!--
Check the box above if a self-hosted operator has to do something, or would be
surprised on upgrade: migrations, new/renamed/removed settings or env vars, a
change in deployment shape (process types, queues, backing-service versions),
a deprecation or removal, or a security fix needing operator action.

This is separate from the docs/changelog checkbox above, which covers the
user-facing product changelog. If checked, add an entry under `[Unreleased]` in
the repo-root `CHANGELOG.md` in this PR. See RELEASING.md.

Leave unchecked for a change that is purely a feature, improvement or bug fix
with none of the above — those reach operators through the user-facing
changelog. A feature PR that also carries a migration or a settings change is
still operator-impacting: check the box and log the migration.
-->
